### PR TITLE
feat(daemon): detect Bash dead loops via PostToolUse failure tracking

### DIFF
--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -109,10 +109,14 @@ export interface LoopDetectorConfig {
  * "agent re-runs the same broken command over and over" pattern without
  * blocking legitimate retries that eventually succeed.
  *
- * Failure detection runs in a companion `PostToolUse` hook that classifies
- * each Bash result as success or failure based on the tool response shape
- * (see `isBashFailureResponse`). `PostToolUseFailure` events (true SDK
- * errors) are always counted as failures.
+ * Failure accounting is split across two post-hooks:
+ *   - `PostToolUse` records **success** — the tool executed and produced a
+ *     result. We never try to classify the payload text; that path is
+ *     inherently fragile (warnings to stderr, literal tag strings, etc.).
+ *   - `PostToolUseFailure` records **failure** — the SDK itself reports that
+ *     the tool call failed (non-zero exit, sandbox kill, timeout, hook
+ *     crash). User/system interrupts (`is_interrupt`) are explicitly skipped
+ *     because the command itself did not fail.
  */
 export interface BashLoopConfig {
 	/** When false, Bash is never denied or tracked by this module. */
@@ -218,9 +222,14 @@ function buildArgKey(toolName: string, input: Record<string, unknown>, cwd?: str
 	}
 	if (toolName === 'Bash') {
 		// Drop the non-semantic label, fold in cwd so the same command in
-		// different repositories does not collide.
+		// different repositories does not collide, and canonicalise optional
+		// default-valued fields so omitted vs explicit `false` collide.
 		const { description: _description, ...rest } = input;
-		const withCwd = cwd ? { ...rest, __cwd: cwd } : rest;
+		const normalised = {
+			...rest,
+			run_in_background: rest.run_in_background ?? false,
+		};
+		const withCwd = cwd ? { ...normalised, __cwd: cwd } : normalised;
 		return stableStringify(withCwd);
 	}
 	return stableStringify(input);
@@ -263,99 +272,6 @@ function buildBashRecoveryMessage(count: number, argSummary: string, failures: n
 		'(3) only retry after you have changed something that could plausibly affect the outcome.',
 		'If you are checking for a file or path, run a different probe (e.g. `ls` on the parent directory) instead of re-running the failing command.',
 	].join(' ');
-}
-
-/**
- * Classify a Bash tool response as a failure or success.
- *
- * The SDK delivers `tool_response` as `unknown`; in practice for Bash it is
- * one of:
- *   - a string (success: command produced stdout/stderr text)
- *   - an object `{ stdout, stderr, interrupted, isImageOutput, ... }`
- *   - a content-block array `[{ type: 'text', text: '...' }, ...]` with
- *     `is_error: true` set at the top level when the tool errored
- *
- * Failure signals we trust:
- *   - response object has `is_error: true`
- *   - response object has `interrupted: true`
- *   - response object has a non-zero exit code field
- *     (`exitCode` / `exit_code` / `returnCode`)
- *   - content block has `is_error: true`
- *   - text contains a `<bash-stderr>` block (delimited by the SDK's Bash
- *     formatter when the underlying shell wrote to stderr) that is
- *     non-empty — those tags come from the SDK and only appear for stderr
- *     output, so a non-empty block reliably indicates a problem
- *
- * We deliberately do NOT scan free-form `stdout`/`text`/string responses
- * for substring markers like "no such file or directory" or "permission
- * denied". Commands legitimately emit those phrases in their output (e.g.
- * `grep "permission denied" /var/log/auth.log`, `cat <<< "no such file"`,
- * tutorials, etc.). Using stdout text as a failure signal would
- * misclassify successes, accumulate phantom failures in the ring, and
- * eventually block legitimate retries — exactly the false-positive we
- * built this detector to avoid.
- *
- * False negatives are acceptable (we just don't fire on that specific
- * outcome); false positives are NOT, so the classifier is conservative:
- * when in doubt, treat as success.
- */
-export function isBashFailureResponse(response: unknown): boolean {
-	if (response == null) return false;
-
-	// Top-level object with explicit error markers.
-	if (typeof response === 'object' && !Array.isArray(response)) {
-		const obj = response as Record<string, unknown>;
-		if (obj.is_error === true) return true;
-		if (obj.interrupted === true) return true;
-		// Some SDK shapes surface the exit code in a direct field.
-		const exitCode = (obj.exitCode ?? obj.exit_code ?? obj.returnCode) as unknown;
-		if (typeof exitCode === 'number' && exitCode !== 0) return true;
-		return false;
-	}
-
-	// Content-block array shape: any block with is_error=true is a failure.
-	// Text inside blocks is treated as command output (stdout) — see comment
-	// above for why we don't substring-scan it.
-	if (Array.isArray(response)) {
-		for (const block of response) {
-			if (block && typeof block === 'object') {
-				const b = block as Record<string, unknown>;
-				if (b.is_error === true) return true;
-				if (typeof b.text === 'string' && hasNonEmptyBashStderrBlock(b.text)) return true;
-			}
-		}
-		return false;
-	}
-
-	// Plain string responses are the SDK's "successful execution, here's
-	// the combined output" shape. The only failure signal we'll honour in
-	// a string is the `<bash-stderr>` block emitted by the SDK's Bash
-	// formatter, since those tags are delimiters the SDK controls and not
-	// content the underlying command can fabricate.
-	if (typeof response === 'string') {
-		return hasNonEmptyBashStderrBlock(response);
-	}
-
-	return false;
-}
-
-/**
- * Detect a non-empty `<bash-stderr>…</bash-stderr>` block emitted by the
- * SDK's Bash formatter. We anchor the match to the *end* of the response
- * (with optional trailing whitespace): the SDK appends the stderr block
- * after stdout, so a real stderr signal always lives at the tail. Commands
- * that happen to echo the literal string mid-stream (e.g. `echo
- * '<bash-stderr>x</bash-stderr> done'`) won't match because the tag isn't
- * the last thing in the response.
- *
- * Empty / whitespace-only blocks do not count — a successful command with
- * empty stderr produces `<bash-stderr></bash-stderr>` and must classify as
- * success.
- */
-function hasNonEmptyBashStderrBlock(text: string): boolean {
-	const match = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>\s*$/);
-	if (!match) return false;
-	return match[1].trim().length > 0;
 }
 
 /**
@@ -619,8 +535,14 @@ function buildPreToolUseCallback(
 }
 
 /**
- * Build the PostToolUse callback. Records Bash outcomes into the shared
- * failure ring buffer; otherwise a no-op.
+ * Build the PostToolUse callback. For Bash, records a **success** outcome
+ * into the shared failure ring buffer. We do NOT try to classify the
+ * `tool_response` payload — `PostToolUse` is the SDK's success path and
+ * the response text is inherently unreliable as a failure signal (commands
+ * can write warnings to stderr, echo literal tags, emit error-like phrases
+ * in normal output, etc.). Actual failures (non-zero exits, sandbox kills,
+ * timeouts, hook crashes) are delivered via `PostToolUseFailure` and
+ * recorded there. Non-Bash tools are ignored.
  */
 function buildPostToolUseCallback(
 	state: LoopDetectorState,
@@ -637,12 +559,14 @@ function buildPostToolUseCallback(
 		const args = (postInput.tool_input ?? {}) as Record<string, unknown>;
 		const fingerprint = buildArgKey('Bash', args, postInput.cwd);
 		const scope = scopeKey(postInput);
-		const failed = isBashFailureResponse(postInput.tool_response);
+		// PostToolUse is the success path — the tool executed and produced a
+		// result. We record success unconditionally; failures are accounted
+		// in the companion PostToolUseFailure hook.
 		recordBashOutcome(
 			state,
 			scope,
 			fingerprint,
-			failed,
+			false,
 			finalConfig.bash.failuresRequired,
 			Date.now(),
 			finalConfig.windowMs

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -198,16 +198,26 @@ function stableStringify(value: unknown): string {
  *
  * - Read: resolve `file_path` against `cwd` so `./foo` and `foo` collide;
  *   keep `offset`/`limit` as identity (different ranges should not collide).
+ * - Bash: strip the non-semantic `description` field before fingerprinting.
+ *   Claude's Bash tool schema uses `description` purely as a human-readable
+ *   label that the model frequently rewords between retries ("Check git
+ *   hooks" → "List hook files" → …); including it would make every retry
+ *   look like a fresh command and defeat the dead-loop detector outright.
+ *   `command`, `timeout`, `run_in_background`, `sandbox` are all semantic
+ *   and stay in the key.
  * - Grep / Glob: pass through, sorted via stableStringify.
- *
- * The `description` field (Bash/etc) is irrelevant to identity but Bash is
- * not tracked anyway so we don't bother stripping it generically.
  */
 function buildArgKey(toolName: string, input: Record<string, unknown>, cwd?: string): string {
 	if (toolName === 'Read' && typeof input.file_path === 'string') {
 		const normalisedPath = cwd ? resolvePath(cwd, input.file_path) : input.file_path;
 		const normalised = { ...input, file_path: normalisedPath };
 		return stableStringify(normalised);
+	}
+	if (toolName === 'Bash') {
+		// Drop the non-semantic label so retries with reworded descriptions
+		// still fingerprint to the same key.
+		const { description: _description, ...rest } = input;
+		return stableStringify(rest);
 	}
 	return stableStringify(input);
 }
@@ -261,16 +271,29 @@ function buildBashRecoveryMessage(count: number, argSummary: string, failures: n
  *   - a content-block array `[{ type: 'text', text: '...' }, ...]` with
  *     `is_error: true` set at the top level when the tool errored
  *
- * We treat the following as failures:
- *   - response has `is_error: true`
- *   - response has `interrupted: true`
- *   - response contains an exit-code marker indicating non-zero exit
- *     (`Exit code: <n>` with n != 0, or `<bash-stderr>` blocks containing
- *     "command not found", "Permission denied", etc.)
+ * Failure signals we trust:
+ *   - response object has `is_error: true`
+ *   - response object has `interrupted: true`
+ *   - response object has a non-zero exit code field
+ *     (`exitCode` / `exit_code` / `returnCode`)
+ *   - content block has `is_error: true`
+ *   - text contains a `<bash-stderr>` block (delimited by the SDK's Bash
+ *     formatter when the underlying shell wrote to stderr) that is
+ *     non-empty — those tags come from the SDK and only appear for stderr
+ *     output, so a non-empty block reliably indicates a problem
+ *
+ * We deliberately do NOT scan free-form `stdout`/`text`/string responses
+ * for substring markers like "no such file or directory" or "permission
+ * denied". Commands legitimately emit those phrases in their output (e.g.
+ * `grep "permission denied" /var/log/auth.log`, `cat <<< "no such file"`,
+ * tutorials, etc.). Using stdout text as a failure signal would
+ * misclassify successes, accumulate phantom failures in the ring, and
+ * eventually block legitimate retries — exactly the false-positive we
+ * built this detector to avoid.
  *
  * False negatives are acceptable (we just don't fire on that specific
- * outcome); false positives are NOT (we'd block legitimate retries), so the
- * classifier is intentionally conservative — when in doubt, treat as success.
+ * outcome); false positives are NOT, so the classifier is conservative:
+ * when in doubt, treat as success.
  */
 export function isBashFailureResponse(response: unknown): boolean {
 	if (response == null) return false;
@@ -280,51 +303,48 @@ export function isBashFailureResponse(response: unknown): boolean {
 		const obj = response as Record<string, unknown>;
 		if (obj.is_error === true) return true;
 		if (obj.interrupted === true) return true;
-		// Some SDK shapes surface the exit code in a `metadata` or direct field.
+		// Some SDK shapes surface the exit code in a direct field.
 		const exitCode = (obj.exitCode ?? obj.exit_code ?? obj.returnCode) as unknown;
 		if (typeof exitCode === 'number' && exitCode !== 0) return true;
-
-		// Recurse into common text-bearing fields.
-		if (typeof obj.stderr === 'string' && containsBashErrorMarker(obj.stderr)) return true;
-		if (typeof obj.stdout === 'string' && containsBashErrorMarker(obj.stdout)) return true;
-		if (typeof obj.text === 'string' && containsBashErrorMarker(obj.text)) return true;
 		return false;
 	}
 
-	// Content-block array shape: any text block matching error markers.
+	// Content-block array shape: any block with is_error=true is a failure.
+	// Text inside blocks is treated as command output (stdout) — see comment
+	// above for why we don't substring-scan it.
 	if (Array.isArray(response)) {
 		for (const block of response) {
 			if (block && typeof block === 'object') {
 				const b = block as Record<string, unknown>;
 				if (b.is_error === true) return true;
-				if (typeof b.text === 'string' && containsBashErrorMarker(b.text)) return true;
+				if (typeof b.text === 'string' && hasNonEmptyBashStderrBlock(b.text)) return true;
 			}
 		}
 		return false;
 	}
 
+	// Plain string responses are the SDK's "successful execution, here's
+	// the combined output" shape. The only failure signal we'll honour in
+	// a string is the `<bash-stderr>` block emitted by the SDK's Bash
+	// formatter, since those tags are delimiters the SDK controls and not
+	// content the underlying command can fabricate.
 	if (typeof response === 'string') {
-		return containsBashErrorMarker(response);
+		return hasNonEmptyBashStderrBlock(response);
 	}
 
 	return false;
 }
 
 /**
- * Detect strong textual signals of a failed shell command. Conservative:
- * we'd rather miss a failure than misclassify a success.
+ * Detect a non-empty `<bash-stderr>…</bash-stderr>` block. The SDK's Bash
+ * formatter wraps captured stderr in these tags; an empty block (no
+ * content) is just a successful command with empty stderr and must not
+ * count as a failure.
  */
-function containsBashErrorMarker(text: string): boolean {
-	// Normalise to a single-line lowercased haystack for substring checks.
-	const lower = text.toLowerCase();
-	if (/exit code:\s*(?!0\b)\d+/i.test(text)) return true;
-	if (/<bash-stderr>/.test(text) && !/<bash-stderr>\s*<\/bash-stderr>/.test(text)) return true;
-	if (lower.includes('command not found')) return true;
-	if (lower.includes('no such file or directory')) return true;
-	if (lower.includes('permission denied')) return true;
-	if (lower.includes('command timed out')) return true;
-	if (lower.includes('error: ') && lower.includes('failed')) return true;
-	return false;
+function hasNonEmptyBashStderrBlock(text: string): boolean {
+	const match = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>/);
+	if (!match) return false;
+	return match[1].trim().length > 0;
 }
 
 /**
@@ -343,10 +363,19 @@ interface LoopDetectorState {
 	/**
 	 * Bash failure ring buffers, keyed by `${scope}::${bashFingerprint}`.
 	 * Each entry holds the most recent N outcomes (true = failure, false =
-	 * success), most recent last. We trim to `bash.failuresRequired` entries
-	 * on each append.
+	 * success), most recent last, plus the timestamp of the most recent
+	 * append. We trim the ring to `bash.failuresRequired` entries on each
+	 * append and opportunistically evict whole ring buffers whose
+	 * `lastSeenMs` is older than the sliding window — without that pass,
+	 * long-lived daemons that execute many distinct one-off Bash commands
+	 * across many sessions would accumulate map entries indefinitely.
 	 */
-	bashFailures: Map<string, boolean[]>;
+	bashFailures: Map<string, BashFailureRing>;
+}
+
+interface BashFailureRing {
+	outcomes: boolean[];
+	lastSeenMs: number;
 }
 
 function createState(): LoopDetectorState {
@@ -369,14 +398,28 @@ function recordBashOutcome(
 	scope: string,
 	fingerprint: string,
 	failed: boolean,
-	failuresRequired: number
+	failuresRequired: number,
+	now: number,
+	windowMs: number
 ): void {
 	const key = bashFingerprintKey(scope, fingerprint);
-	const ring = state.bashFailures.get(key) ?? [];
-	ring.push(failed);
+	const existing = state.bashFailures.get(key);
+	const outcomes = existing?.outcomes ?? [];
+	outcomes.push(failed);
 	// Keep at most `failuresRequired` outcomes so the deny check is O(1).
-	while (ring.length > failuresRequired) ring.shift();
-	state.bashFailures.set(key, ring);
+	while (outcomes.length > failuresRequired) outcomes.shift();
+	state.bashFailures.set(key, { outcomes, lastSeenMs: now });
+
+	// Opportunistic eviction: drop any ring whose last activity is past the
+	// sliding window. Triggered only when the map exceeds a soft cap so we
+	// don't iterate on every call. The same threshold (256) we use for the
+	// streak ledger keeps memory bounded without measurably impacting
+	// per-call latency for typical workloads.
+	if (state.bashFailures.size > 256) {
+		for (const [k, v] of state.bashFailures) {
+			if (now - v.lastSeenMs > windowMs) state.bashFailures.delete(k);
+		}
+	}
 }
 
 function lastNAllFailures(
@@ -387,7 +430,7 @@ function lastNAllFailures(
 	allFailures: boolean;
 	length: number;
 } {
-	const ring = state.bashFailures.get(bashFingerprintKey(scope, fingerprint)) ?? [];
+	const ring = state.bashFailures.get(bashFingerprintKey(scope, fingerprint))?.outcomes ?? [];
 	if (ring.length === 0) return { allFailures: false, length: 0 };
 	for (const failed of ring) {
 		if (!failed) return { allFailures: false, length: ring.length };
@@ -556,15 +599,29 @@ function buildPostToolUseCallback(
 		const fingerprint = buildArgKey('Bash', args, postInput.cwd);
 		const scope = scopeKey(postInput);
 		const failed = isBashFailureResponse(postInput.tool_response);
-		recordBashOutcome(state, scope, fingerprint, failed, finalConfig.bash.failuresRequired);
+		recordBashOutcome(
+			state,
+			scope,
+			fingerprint,
+			failed,
+			finalConfig.bash.failuresRequired,
+			Date.now(),
+			finalConfig.windowMs
+		);
 		return {};
 	};
 }
 
 /**
  * Build the PostToolUseFailure callback. A true SDK error (hook crash,
- * sandbox kill, timeout) is always recorded as a failure for the Bash
- * fingerprint.
+ * sandbox kill, timeout) is recorded as a failure for the Bash fingerprint.
+ *
+ * User/system interrupts are NOT counted: `is_interrupt: true` on the
+ * SDK's `PostToolUseFailure` payload means the user (or another
+ * concurrent action) cancelled the tool call before it completed. The
+ * command itself didn't fail — counting interrupts would let a user who
+ * repeatedly cancels the same command accidentally poison the failure
+ * ring and block their own legitimate retries afterwards.
  */
 function buildPostToolUseFailureCallback(
 	state: LoopDetectorState,
@@ -577,11 +634,21 @@ function buildPostToolUseFailureCallback(
 
 		const postInput = input as PostToolUseFailureHookInput;
 		if (postInput.tool_name !== 'Bash') return {};
+		// Skip user/system interrupts — they're not command failures.
+		if (postInput.is_interrupt === true) return {};
 
 		const args = (postInput.tool_input ?? {}) as Record<string, unknown>;
 		const fingerprint = buildArgKey('Bash', args, postInput.cwd);
 		const scope = scopeKey(postInput);
-		recordBashOutcome(state, scope, fingerprint, true, finalConfig.bash.failuresRequired);
+		recordBashOutcome(
+			state,
+			scope,
+			fingerprint,
+			true,
+			finalConfig.bash.failuresRequired,
+			Date.now(),
+			finalConfig.windowMs
+		);
 		return {};
 	};
 }

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -2,48 +2,72 @@
  * Loop Detector Hook
  *
  * Detects and recovers from "dead loops" where the agent calls the same
- * idempotent inspection tool (Read / Grep / Glob) repeatedly with identical
- * arguments without making any forward progress.
+ * tool repeatedly with identical arguments without making forward progress.
  *
  * Real-world trigger (task #324, see task #328): the coder agent called
  * `Read` on `client-event-bridge.ts` ~60 times in a single turn before the
  * user intervened. The file content was unchanged across every read; the
- * agent had entered a degenerate planning state.
+ * agent had entered a degenerate planning state. A separate report (task
+ * #333) flagged the same failure mode for Bash — e.g. the agent runs
+ * `ls -la .git/hooks 2>&1` 60 times, each time getting the same error, never
+ * adjusting its approach.
  *
- * Strategy: a `PreToolUse` hook keeps a per-agent ledger of the *current
+ * ─── Strategy ───────────────────────────────────────────────────────────
+ * `PreToolUse` hook keeps a per-(session, agent) ledger of the *current
  * consecutive streak* — i.e. successive invocations of the same
- * `(tool_name, args)` key with no intervening different tool call. The hook
- * is registered for ALL tools (not just tracked ones) so that any other
- * action — running a Bash command, editing a file, even calling a
- * non-tracked inspection tool — counts as a "different action" and resets
- * the streak. Once the streak crosses a per-tool threshold within a sliding
- * window (computed over the *full* streak duration, not just the gap to the
- * previous call), the hook denies the call with a `permissionDecisionReason`
- * that the SDK delivers back to the model as the tool result. The reason
- * text instructs the model to stop re-running the tool and proceed to the
- * next step (e.g. its TodoWrite list).
+ * `(tool_name, args)` key with no intervening different tool call. Read /
+ * Grep / Glob are pure functions of the filesystem, so identical repeats
+ * almost never produce different output: we deny purely on repetition at a
+ * low threshold (3–5).
  *
- * Bash is intentionally NOT tracked for *deny* decisions — bash output can
- * legitimately change across calls (e.g. polling `git status`, tailing logs)
- * and false positives here would be far worse than the rare degenerate loop.
- * The hook still observes Bash so it can use it as a streak-reset signal.
- * Read / Grep / Glob are pure functions of the file system at a point in
- * time, so two identical invocations seconds apart almost never produce
- * different output.
+ * Bash needs a different policy because legitimate retries DO produce
+ * different output (polling `git status`, re-running `bun test` after a
+ * fix). We therefore use a **hybrid**: a companion `PostToolUse` hook
+ * records the outcome of each Bash call into a per-key failure ring buffer.
+ * The `PreToolUse` hook denies only when ALL of:
+ *   1. Bash was called with the same fingerprint N times in a row (N=5).
+ *   2. The last N outcomes were all failures.
+ *   3. The streak fits inside the sliding window.
  *
- * Scoping: streaks are tracked per `(session_id, agent_id)` pair, so parallel
- * subagents under the same parent session cannot contribute to each other's
- * counters and a subagent's reads do not pollute the main thread's streak.
+ * A successful Bash call clears that key's failure ring, so a flaky command
+ * that eventually succeeds does not get blocked on the next attempt. A
+ * `PostToolUseFailure` (true SDK error, e.g. hook crash, sandbox kill) is
+ * recorded as a failure too.
  *
- * Repeat denies: when a stuck agent keeps hammering the same call after a
- * deny, the streak does NOT reset on a deny — every retry without an
- * intervening different action continues to deny. This is intentional: the
- * goal is to break the loop, not just throttle it. The streak resets when
- * the agent performs a *different* tool call (tracked OR untracked) or the
- * sliding window elapses over the streak's lifetime.
+ * ─── Streak reset ──────────────────────────────────────────────────────
+ * The hook is registered for ALL tools (not just tracked ones) so any
+ * different action — running a different Bash command, editing a file,
+ * even calling a non-tracked inspection tool — counts as a "different
+ * action" and resets the streak for the *other* tracked tools. This means
+ * a denied Read can be unstuck by an Edit; a denied Bash can be unstuck by
+ * a Read, a different Bash, or any other tool call. The streak only
+ * persists across truly identical consecutive calls.
+ *
+ * ─── Scoping ───────────────────────────────────────────────────────────
+ * Streaks are tracked per `(session_id, agent_id)` pair, so parallel
+ * subagents under the same parent session cannot contribute to each
+ * other's counters and a subagent's reads do not pollute the main thread's
+ * streak.
+ *
+ * ─── Repeat denies ─────────────────────────────────────────────────────
+ * When a stuck agent keeps hammering the same call after a deny, the streak
+ * does NOT reset on a deny — every retry without an intervening different
+ * action continues to deny. This is intentional: the goal is to break the
+ * loop, not just throttle it. The streak resets when the agent performs a
+ * *different* tool call (tracked OR untracked) or the sliding window
+ * elapses over the streak's lifetime. For Bash, the deny additionally
+ * requires the persistent-failure condition, so a stuck loop of failing
+ * commands keeps being denied until the agent does something different OR
+ * the next invocation of that same command happens to succeed (which would
+ * have to come from outside the deny path, i.e. after a streak reset).
  */
 
-import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import type {
+	HookCallback,
+	PostToolUseFailureHookInput,
+	PostToolUseHookInput,
+	PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 import { resolve as resolvePath } from 'node:path';
 import { Logger } from '../logger';
 
@@ -56,6 +80,11 @@ import { Logger } from '../logger';
  * Read: 2 } }` — REPLACE the tracked-tool set; defaults are not merged in.
  * Pass `undefined` (or omit `thresholds`) to inherit
  * `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds` wholesale.
+ *
+ * `bash` configures the failure-aware Bash detector. Bash is intentionally
+ * NOT in `thresholds` because we do not deny purely on repetition — the
+ * Bash detector requires both a streak AND a recent failure history. Set
+ * `bash.enabled = false` to disable Bash detection entirely.
  */
 export interface LoopDetectorConfig {
 	enabled: boolean;
@@ -66,6 +95,39 @@ export interface LoopDetectorConfig {
 	 * tracked. Pass `undefined` to inherit the defaults wholesale.
 	 */
 	thresholds?: Record<string, number>;
+	/** Bash-specific failure-aware detector. */
+	bash?: BashLoopConfig;
+}
+
+/**
+ * Bash dead-loop detector configuration.
+ *
+ * Bash output can legitimately change across calls (polling `git status`,
+ * re-running `bun test` after a fix), so denying purely on repetition would
+ * produce false positives. Instead, we require BOTH a consecutive streak of
+ * identical commands AND a run of recent failures: this targets the
+ * "agent re-runs the same broken command over and over" pattern without
+ * blocking legitimate retries that eventually succeed.
+ *
+ * Failure detection runs in a companion `PostToolUse` hook that classifies
+ * each Bash result as success or failure based on the tool response shape
+ * (see `isBashFailureResponse`). `PostToolUseFailure` events (true SDK
+ * errors) are always counted as failures.
+ */
+export interface BashLoopConfig {
+	/** When false, Bash is never denied or tracked by this module. */
+	enabled: boolean;
+	/**
+	 * Consecutive-streak length at which we consider denying. Higher than
+	 * Read/Grep/Glob because Bash retries are more often legitimate.
+	 */
+	threshold: number;
+	/**
+	 * Number of recent outcomes per command fingerprint to keep in the
+	 * failure ring. The deny check passes only when the most recent
+	 * `failuresRequired` outcomes are all failures.
+	 */
+	failuresRequired: number;
 }
 
 export const DEFAULT_LOOP_DETECTOR_CONFIG: Required<LoopDetectorConfig> = {
@@ -79,6 +141,16 @@ export const DEFAULT_LOOP_DETECTOR_CONFIG: Required<LoopDetectorConfig> = {
 		// while exploring), so we set a more permissive threshold.
 		Grep: 5,
 		Glob: 5,
+	},
+	bash: {
+		enabled: true,
+		// 5 identical consecutive Bash calls is already unusual; combined with
+		// the all-failures requirement this rarely fires on legitimate
+		// workflows.
+		threshold: 5,
+		// All of the most recent 5 outcomes must be failures. A single
+		// success anywhere in the window clears the denial.
+		failuresRequired: 5,
 	},
 };
 
@@ -152,8 +224,11 @@ function summariseArgs(toolName: string, input: Record<string, unknown>): string
 		candidates.push(`path=${input.path}`);
 	}
 	if (typeof input.glob === 'string') candidates.push(`glob=${input.glob}`);
+	if (toolName === 'Bash' && typeof input.command === 'string') {
+		candidates.push(`command=${(input.command as string).slice(0, 160)}`);
+	}
 	if (candidates.length === 0) return JSON.stringify(input).slice(0, 120);
-	return candidates.join(', ').slice(0, 200);
+	return candidates.join(', ').slice(0, 240);
 }
 
 function buildRecoveryMessage(toolName: string, count: number, argSummary: string): string {
@@ -165,12 +240,361 @@ function buildRecoveryMessage(toolName: string, count: number, argSummary: strin
 	].join(' ');
 }
 
+function buildBashRecoveryMessage(count: number, argSummary: string, failures: number): string {
+	return [
+		`Bash dead-loop detected: the same command was run ${count} times in a row and the last ${failures} attempts all failed (${argSummary}).`,
+		'Re-running the same failing command will not change the outcome. STOP and reconsider:',
+		'(1) read the previous error output carefully,',
+		'(2) inspect the relevant files or run a *different* diagnostic command,',
+		'(3) only retry after you have changed something that could plausibly affect the outcome.',
+		'If you are checking for a file or path, run a different probe (e.g. `ls` on the parent directory) instead of re-running the failing command.',
+	].join(' ');
+}
+
+/**
+ * Classify a Bash tool response as a failure or success.
+ *
+ * The SDK delivers `tool_response` as `unknown`; in practice for Bash it is
+ * one of:
+ *   - a string (success: command produced stdout/stderr text)
+ *   - an object `{ stdout, stderr, interrupted, isImageOutput, ... }`
+ *   - a content-block array `[{ type: 'text', text: '...' }, ...]` with
+ *     `is_error: true` set at the top level when the tool errored
+ *
+ * We treat the following as failures:
+ *   - response has `is_error: true`
+ *   - response has `interrupted: true`
+ *   - response contains an exit-code marker indicating non-zero exit
+ *     (`Exit code: <n>` with n != 0, or `<bash-stderr>` blocks containing
+ *     "command not found", "Permission denied", etc.)
+ *
+ * False negatives are acceptable (we just don't fire on that specific
+ * outcome); false positives are NOT (we'd block legitimate retries), so the
+ * classifier is intentionally conservative — when in doubt, treat as success.
+ */
+export function isBashFailureResponse(response: unknown): boolean {
+	if (response == null) return false;
+
+	// Top-level object with explicit error markers.
+	if (typeof response === 'object' && !Array.isArray(response)) {
+		const obj = response as Record<string, unknown>;
+		if (obj.is_error === true) return true;
+		if (obj.interrupted === true) return true;
+		// Some SDK shapes surface the exit code in a `metadata` or direct field.
+		const exitCode = (obj.exitCode ?? obj.exit_code ?? obj.returnCode) as unknown;
+		if (typeof exitCode === 'number' && exitCode !== 0) return true;
+
+		// Recurse into common text-bearing fields.
+		if (typeof obj.stderr === 'string' && containsBashErrorMarker(obj.stderr)) return true;
+		if (typeof obj.stdout === 'string' && containsBashErrorMarker(obj.stdout)) return true;
+		if (typeof obj.text === 'string' && containsBashErrorMarker(obj.text)) return true;
+		return false;
+	}
+
+	// Content-block array shape: any text block matching error markers.
+	if (Array.isArray(response)) {
+		for (const block of response) {
+			if (block && typeof block === 'object') {
+				const b = block as Record<string, unknown>;
+				if (b.is_error === true) return true;
+				if (typeof b.text === 'string' && containsBashErrorMarker(b.text)) return true;
+			}
+		}
+		return false;
+	}
+
+	if (typeof response === 'string') {
+		return containsBashErrorMarker(response);
+	}
+
+	return false;
+}
+
+/**
+ * Detect strong textual signals of a failed shell command. Conservative:
+ * we'd rather miss a failure than misclassify a success.
+ */
+function containsBashErrorMarker(text: string): boolean {
+	// Normalise to a single-line lowercased haystack for substring checks.
+	const lower = text.toLowerCase();
+	if (/exit code:\s*(?!0\b)\d+/i.test(text)) return true;
+	if (/<bash-stderr>/.test(text) && !/<bash-stderr>\s*<\/bash-stderr>/.test(text)) return true;
+	if (lower.includes('command not found')) return true;
+	if (lower.includes('no such file or directory')) return true;
+	if (lower.includes('permission denied')) return true;
+	if (lower.includes('command timed out')) return true;
+	if (lower.includes('error: ') && lower.includes('failed')) return true;
+	return false;
+}
+
+/**
+ * Shared per-(session, agent) state used by the PreToolUse, PostToolUse,
+ * and PostToolUseFailure hooks. The three hooks are produced by a single
+ * factory so they reference the same Maps.
+ */
+interface LoopDetectorState {
+	/**
+	 * Streak ledger for tracked tools (Read, Grep, Glob) PLUS the in-flight
+	 * Bash streak. Bash uses this ledger for the streak counter; the Bash
+	 * deny decision additionally consults `bashFailures` keyed by
+	 * `(scope, fingerprint)`.
+	 */
+	ledger: Map<string, AgentState>;
+	/**
+	 * Bash failure ring buffers, keyed by `${scope}::${bashFingerprint}`.
+	 * Each entry holds the most recent N outcomes (true = failure, false =
+	 * success), most recent last. We trim to `bash.failuresRequired` entries
+	 * on each append.
+	 */
+	bashFailures: Map<string, boolean[]>;
+}
+
+function createState(): LoopDetectorState {
+	return {
+		ledger: new Map(),
+		bashFailures: new Map(),
+	};
+}
+
+function scopeKey(input: { session_id: string; agent_id?: string }): string {
+	return `${input.session_id}::${input.agent_id ?? 'main'}`;
+}
+
+function bashFingerprintKey(scope: string, fingerprint: string): string {
+	return `${scope}::${fingerprint}`;
+}
+
+function recordBashOutcome(
+	state: LoopDetectorState,
+	scope: string,
+	fingerprint: string,
+	failed: boolean,
+	failuresRequired: number
+): void {
+	const key = bashFingerprintKey(scope, fingerprint);
+	const ring = state.bashFailures.get(key) ?? [];
+	ring.push(failed);
+	// Keep at most `failuresRequired` outcomes so the deny check is O(1).
+	while (ring.length > failuresRequired) ring.shift();
+	state.bashFailures.set(key, ring);
+}
+
+function lastNAllFailures(
+	state: LoopDetectorState,
+	scope: string,
+	fingerprint: string
+): {
+	allFailures: boolean;
+	length: number;
+} {
+	const ring = state.bashFailures.get(bashFingerprintKey(scope, fingerprint)) ?? [];
+	if (ring.length === 0) return { allFailures: false, length: 0 };
+	for (const failed of ring) {
+		if (!failed) return { allFailures: false, length: ring.length };
+	}
+	return { allFailures: true, length: ring.length };
+}
+
+/**
+ * Resolve a partial config into a fully-populated config, preserving the
+ * "thresholds REPLACE" contract while still merging the bash sub-config
+ * field-by-field. Bash defaults can be partially overridden because the
+ * sub-config is a flat shape with no "set of tools" semantic to preserve.
+ */
+function resolveConfig(config: Partial<LoopDetectorConfig>): Required<LoopDetectorConfig> {
+	const bashDefaults = DEFAULT_LOOP_DETECTOR_CONFIG.bash;
+	const bashOverride = config.bash;
+	return {
+		enabled: config.enabled ?? DEFAULT_LOOP_DETECTOR_CONFIG.enabled,
+		windowMs: config.windowMs ?? DEFAULT_LOOP_DETECTOR_CONFIG.windowMs,
+		// REPLACE — do not merge. A caller passing { Read: 2 } means "track
+		// only Read." This is what the contract on LoopDetectorConfig
+		// promises. Pass undefined / omit to keep the defaults wholesale.
+		thresholds: config.thresholds ?? DEFAULT_LOOP_DETECTOR_CONFIG.thresholds,
+		bash: bashOverride
+			? {
+					enabled: bashOverride.enabled ?? bashDefaults.enabled,
+					threshold: bashOverride.threshold ?? bashDefaults.threshold,
+					failuresRequired: bashOverride.failuresRequired ?? bashDefaults.failuresRequired,
+				}
+			: bashDefaults,
+	};
+}
+
+/**
+ * Build the PreToolUse callback. Shared across `createLoopDetectorHook`
+ * (single-callback factory for callers that only want pre-hooks) and
+ * `createLoopDetectorHooks` (paired factory that also returns post-hooks
+ * sharing the same state).
+ */
+function buildPreToolUseCallback(
+	state: LoopDetectorState,
+	finalConfig: Required<LoopDetectorConfig>,
+	logger: Logger
+): HookCallback {
+	return async (input, _toolUseID, { signal: _signal }) => {
+		if (!finalConfig.enabled) return {};
+		if (input.hook_event_name !== 'PreToolUse') return {};
+
+		const preInput = input as PreToolUseHookInput;
+		const { tool_name, tool_input, cwd, session_id, agent_id } = preInput;
+
+		const scope = scopeKey({ session_id, agent_id });
+		const threshold = finalConfig.thresholds[tool_name];
+		const isBash = tool_name === 'Bash' && finalConfig.bash.enabled;
+		const now = Date.now();
+
+		// Untracked tool (Edit, Write, an unknown tool, …) is treated as a
+		// *different action*: it resets any in-flight streak for this scope
+		// so that a genuine corrective step lets the next identical tracked
+		// call pass through. Bash IS tracked (under its own ledger entry)
+		// when bash.enabled, so falls through to the streak logic below.
+		if (typeof threshold !== 'number' && !isBash) {
+			state.ledger.delete(scope);
+			return {};
+		}
+
+		const args = (tool_input ?? {}) as Record<string, unknown>;
+		const key = `${tool_name}:${buildArgKey(tool_name, args, cwd)}`;
+
+		const agentState = state.ledger.get(scope);
+		const sameKey = agentState?.lastKey === key;
+		// Sliding window is enforced over the *full streak duration*, not
+		// just the gap between successive calls. A sequence at t=0,59s,118s
+		// with a 60s window has duration 118s > 60s on the third call, so
+		// the streak resets to 1 — matching "N repeats within window"
+		// semantics rather than "max inter-call gap".
+		const withinWindow = agentState && now - agentState.entry.firstSeenMs <= finalConfig.windowMs;
+
+		// Strict consecutive semantics: streak only continues when the same
+		// key is invoked AND the *whole* streak still fits in the sliding
+		// window. A different tracked-tool key, untracked tool call, or
+		// window expiry resets the count.
+		const continueStreak = sameKey && withinWindow;
+		const nextCount = continueStreak ? agentState!.entry.count + 1 : 1;
+		const firstSeenMs = continueStreak ? agentState!.entry.firstSeenMs : now;
+		state.ledger.set(scope, {
+			lastKey: key,
+			entry: { count: nextCount, firstSeenMs, lastSeenMs: now },
+		});
+
+		// Opportunistically drop scopes whose last activity is past the
+		// window, so the ledger doesn't grow unbounded across long-lived
+		// daemons.
+		if (state.ledger.size > 256) {
+			for (const [k, v] of state.ledger) {
+				if (now - v.entry.lastSeenMs > finalConfig.windowMs) state.ledger.delete(k);
+			}
+		}
+
+		// Bash deny path: streak + persistent-failure required.
+		if (isBash) {
+			const bashThreshold = finalConfig.bash.threshold;
+			if (nextCount >= bashThreshold) {
+				const fingerprint = buildArgKey('Bash', args, cwd);
+				const { allFailures, length } = lastNAllFailures(state, scope, fingerprint);
+				if (allFailures && length >= finalConfig.bash.failuresRequired) {
+					const argSummary = summariseArgs('Bash', args);
+					const reason = buildBashRecoveryMessage(nextCount, argSummary, length);
+					logger.warn(
+						`Bash dead-loop detected (scope=${scope}): same command ${nextCount}x in a row, last ${length} all failed (${argSummary}); denying.`
+					);
+					return {
+						hookSpecificOutput: {
+							hookEventName: 'PreToolUse' as const,
+							permissionDecision: 'deny' as const,
+							permissionDecisionReason: reason,
+						},
+					};
+				}
+			}
+			return {};
+		}
+
+		// Non-Bash tracked tool path: deny purely on repetition.
+		if (typeof threshold === 'number' && nextCount >= threshold) {
+			const argSummary = summariseArgs(tool_name, args);
+			const reason = buildRecoveryMessage(tool_name, nextCount, argSummary);
+			logger.warn(
+				`Dead-loop detected (scope=${scope}): ${tool_name} called ${nextCount}x in a row with identical args (${argSummary}); denying.`
+			);
+			// IMPORTANT: do NOT reset the streak on a deny. If the agent
+			// retries the same key without doing anything different, the
+			// streak continues to grow and every retry continues to deny.
+			// The streak only resets when the agent performs a *different*
+			// tool call (tracked OR untracked) or the window expires.
+			return {
+				hookSpecificOutput: {
+					hookEventName: 'PreToolUse' as const,
+					permissionDecision: 'deny' as const,
+					permissionDecisionReason: reason,
+				},
+			};
+		}
+
+		return {};
+	};
+}
+
+/**
+ * Build the PostToolUse callback. Records Bash outcomes into the shared
+ * failure ring buffer; otherwise a no-op.
+ */
+function buildPostToolUseCallback(
+	state: LoopDetectorState,
+	finalConfig: Required<LoopDetectorConfig>
+): HookCallback {
+	return async (input, _toolUseID, { signal: _signal }) => {
+		if (!finalConfig.enabled) return {};
+		if (!finalConfig.bash.enabled) return {};
+		if (input.hook_event_name !== 'PostToolUse') return {};
+
+		const postInput = input as PostToolUseHookInput;
+		if (postInput.tool_name !== 'Bash') return {};
+
+		const args = (postInput.tool_input ?? {}) as Record<string, unknown>;
+		const fingerprint = buildArgKey('Bash', args, postInput.cwd);
+		const scope = scopeKey(postInput);
+		const failed = isBashFailureResponse(postInput.tool_response);
+		recordBashOutcome(state, scope, fingerprint, failed, finalConfig.bash.failuresRequired);
+		return {};
+	};
+}
+
+/**
+ * Build the PostToolUseFailure callback. A true SDK error (hook crash,
+ * sandbox kill, timeout) is always recorded as a failure for the Bash
+ * fingerprint.
+ */
+function buildPostToolUseFailureCallback(
+	state: LoopDetectorState,
+	finalConfig: Required<LoopDetectorConfig>
+): HookCallback {
+	return async (input, _toolUseID, { signal: _signal }) => {
+		if (!finalConfig.enabled) return {};
+		if (!finalConfig.bash.enabled) return {};
+		if (input.hook_event_name !== 'PostToolUseFailure') return {};
+
+		const postInput = input as PostToolUseFailureHookInput;
+		if (postInput.tool_name !== 'Bash') return {};
+
+		const args = (postInput.tool_input ?? {}) as Record<string, unknown>;
+		const fingerprint = buildArgKey('Bash', args, postInput.cwd);
+		const scope = scopeKey(postInput);
+		recordBashOutcome(state, scope, fingerprint, true, finalConfig.bash.failuresRequired);
+		return {};
+	};
+}
+
 /**
  * Create a PreToolUse hook that detects dead loops and short-circuits them.
  *
- * The `config` parameter is reserved for testing and override use. Production
- * callers (see `QueryOptionsBuilder.buildHooks`) instantiate the hook with no
- * arguments so the defaults in `DEFAULT_LOOP_DETECTOR_CONFIG` apply.
+ * Backwards-compatible single-callback factory. For Bash dead-loop
+ * detection to function correctly, pair this with the post-hooks returned
+ * by `createLoopDetectorHooks` (or use that factory exclusively). Calling
+ * `createLoopDetectorHook` on its own still installs the Bash *streak*
+ * tracker, but with no PostToolUse observer the failure ring will stay
+ * empty, so Bash will never be denied — only Read/Grep/Glob denies fire.
  *
  * Threshold overrides REPLACE the tracked-tool set: e.g. passing
  * `{ thresholds: { Read: 2 } }` tracks only Read at 2, and Grep/Glob are no
@@ -184,97 +608,39 @@ function buildRecoveryMessage(toolName: string, count: number, argSummary: strin
  * ```
  */
 export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {}): HookCallback {
-	const finalConfig: Required<LoopDetectorConfig> = {
-		enabled: config.enabled ?? DEFAULT_LOOP_DETECTOR_CONFIG.enabled,
-		windowMs: config.windowMs ?? DEFAULT_LOOP_DETECTOR_CONFIG.windowMs,
-		// REPLACE — do not merge. A caller passing { Read: 2 } means "track
-		// only Read." This is what the contract on LoopDetectorConfig
-		// promises. Pass undefined / omit to keep the defaults wholesale.
-		thresholds: config.thresholds ?? DEFAULT_LOOP_DETECTOR_CONFIG.thresholds,
-	};
+	const finalConfig = resolveConfig(config);
 	const logger = new Logger('LoopDetectorHook');
-	// One ledger per (session_id, agent_id). Each subagent gets its own
-	// streak; the main thread's streak is also isolated from any subagents
-	// it spawns.
-	const ledger = new Map<string, AgentState>();
+	const state = createState();
+	return buildPreToolUseCallback(state, finalConfig, logger);
+}
 
-	return async (input, _toolUseID, { signal: _signal }) => {
-		if (!finalConfig.enabled) return {};
-		if (input.hook_event_name !== 'PreToolUse') return {};
-
-		const preInput = input as PreToolUseHookInput;
-		const { tool_name, tool_input, cwd, session_id, agent_id } = preInput;
-
-		const scope = `${session_id}::${agent_id ?? 'main'}`;
-		const threshold = finalConfig.thresholds[tool_name];
-		const now = Date.now();
-
-		// Untracked tool (Bash, Edit, Write, …) is treated as a *different
-		// action*: it resets any in-flight streak for this scope so that a
-		// genuine corrective step (e.g. `Edit foo.ts` after a denied
-		// `Read foo.ts`) lets the next identical Read pass through. We
-		// then short-circuit — there is nothing to deny on an untracked
-		// tool.
-		if (typeof threshold !== 'number') {
-			ledger.delete(scope);
-			return {};
-		}
-
-		const args = (tool_input ?? {}) as Record<string, unknown>;
-		const key = `${tool_name}:${buildArgKey(tool_name, args, cwd)}`;
-
-		const state = ledger.get(scope);
-		const sameKey = state?.lastKey === key;
-		// Sliding window is enforced over the *full streak duration*, not
-		// just the gap between successive calls. A sequence at t=0,59s,118s
-		// with a 60s window has duration 118s > 60s on the third call, so
-		// the streak resets to 1 — matching "N repeats within window"
-		// semantics rather than "max inter-call gap".
-		const withinWindow = state && now - state.entry.firstSeenMs <= finalConfig.windowMs;
-
-		// Strict consecutive semantics: streak only continues when the same
-		// key is invoked AND the *whole* streak still fits in the sliding
-		// window. A different tracked-tool key, untracked tool call, or
-		// window expiry resets the count.
-		const continueStreak = sameKey && withinWindow;
-		const nextCount = continueStreak ? state!.entry.count + 1 : 1;
-		const firstSeenMs = continueStreak ? state!.entry.firstSeenMs : now;
-		ledger.set(scope, {
-			lastKey: key,
-			entry: { count: nextCount, firstSeenMs, lastSeenMs: now },
-		});
-
-		// Opportunistically drop scopes whose last activity is past the
-		// window, so the ledger doesn't grow unbounded across long-lived
-		// daemons.
-		if (ledger.size > 256) {
-			for (const [k, v] of ledger) {
-				if (now - v.entry.lastSeenMs > finalConfig.windowMs) ledger.delete(k);
-			}
-		}
-
-		if (nextCount >= threshold) {
-			const argSummary = summariseArgs(tool_name, args);
-			const reason = buildRecoveryMessage(tool_name, nextCount, argSummary);
-			logger.warn(
-				`Dead-loop detected (scope=${scope}): ${tool_name} called ${nextCount}x in a row with identical args (${argSummary}); denying.`
-			);
-			// IMPORTANT: do NOT reset the streak on a deny. If the agent
-			// retries the same key without doing anything different, the
-			// streak continues to grow and every retry continues to deny.
-			// The streak only resets when the agent performs a *different*
-			// tool call (tracked OR untracked) or the window expires. This
-			// is what actually breaks the loop rather than just throttling
-			// it.
-			return {
-				hookSpecificOutput: {
-					hookEventName: 'PreToolUse' as const,
-					permissionDecision: 'deny' as const,
-					permissionDecisionReason: reason,
-				},
-			};
-		}
-
-		return {};
+/**
+ * Triple-callback factory: returns matched PreToolUse + PostToolUse +
+ * PostToolUseFailure hooks that share state. Production callers should use
+ * this so Bash dead-loop detection actually has outcome information to
+ * consult.
+ *
+ * @example
+ * ```ts
+ * const { preToolUse, postToolUse, postToolUseFailure } = createLoopDetectorHooks();
+ * options.hooks = {
+ *   PreToolUse: [{ hooks: [preToolUse] }],
+ *   PostToolUse: [{ hooks: [postToolUse] }],
+ *   PostToolUseFailure: [{ hooks: [postToolUseFailure] }],
+ * };
+ * ```
+ */
+export function createLoopDetectorHooks(config: Partial<LoopDetectorConfig> = {}): {
+	preToolUse: HookCallback;
+	postToolUse: HookCallback;
+	postToolUseFailure: HookCallback;
+} {
+	const finalConfig = resolveConfig(config);
+	const logger = new Logger('LoopDetectorHook');
+	const state = createState();
+	return {
+		preToolUse: buildPreToolUseCallback(state, finalConfig, logger),
+		postToolUse: buildPostToolUseCallback(state, finalConfig),
+		postToolUseFailure: buildPostToolUseFailureCallback(state, finalConfig),
 	};
 }

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -198,13 +198,16 @@ function stableStringify(value: unknown): string {
  *
  * - Read: resolve `file_path` against `cwd` so `./foo` and `foo` collide;
  *   keep `offset`/`limit` as identity (different ranges should not collide).
- * - Bash: strip the non-semantic `description` field before fingerprinting.
- *   Claude's Bash tool schema uses `description` purely as a human-readable
- *   label that the model frequently rewords between retries ("Check git
- *   hooks" → "List hook files" → …); including it would make every retry
- *   look like a fresh command and defeat the dead-loop detector outright.
- *   `command`, `timeout`, `run_in_background`, `sandbox` are all semantic
- *   and stay in the key.
+ * - Bash: strip the non-semantic `description` field before fingerprinting
+ *   and incorporate the resolved `cwd`. Claude's Bash tool schema uses
+ *   `description` purely as a human-readable label that the model frequently
+ *   rewords between retries ("Check git hooks" → "List hook files" → …);
+ *   including it would make every retry look like a fresh command and defeat
+ *   the dead-loop detector outright. `cwd` IS semantic — the same command
+ *   text (`git status`, `bun test`) means very different things in different
+ *   repositories, and conflating them across worktrees would let prior
+ *   failures in repo-A poison the detector for repo-B. `command`, `timeout`,
+ *   `run_in_background`, `sandbox` are all semantic and stay in the key.
  * - Grep / Glob: pass through, sorted via stableStringify.
  */
 function buildArgKey(toolName: string, input: Record<string, unknown>, cwd?: string): string {
@@ -214,10 +217,11 @@ function buildArgKey(toolName: string, input: Record<string, unknown>, cwd?: str
 		return stableStringify(normalised);
 	}
 	if (toolName === 'Bash') {
-		// Drop the non-semantic label so retries with reworded descriptions
-		// still fingerprint to the same key.
+		// Drop the non-semantic label, fold in cwd so the same command in
+		// different repositories does not collide.
 		const { description: _description, ...rest } = input;
-		return stableStringify(rest);
+		const withCwd = cwd ? { ...rest, __cwd: cwd } : rest;
+		return stableStringify(withCwd);
 	}
 	return stableStringify(input);
 }
@@ -336,13 +340,20 @@ export function isBashFailureResponse(response: unknown): boolean {
 }
 
 /**
- * Detect a non-empty `<bash-stderr>…</bash-stderr>` block. The SDK's Bash
- * formatter wraps captured stderr in these tags; an empty block (no
- * content) is just a successful command with empty stderr and must not
- * count as a failure.
+ * Detect a non-empty `<bash-stderr>…</bash-stderr>` block emitted by the
+ * SDK's Bash formatter. We anchor the match to the *end* of the response
+ * (with optional trailing whitespace): the SDK appends the stderr block
+ * after stdout, so a real stderr signal always lives at the tail. Commands
+ * that happen to echo the literal string mid-stream (e.g. `echo
+ * '<bash-stderr>x</bash-stderr> done'`) won't match because the tag isn't
+ * the last thing in the response.
+ *
+ * Empty / whitespace-only blocks do not count — a successful command with
+ * empty stderr produces `<bash-stderr></bash-stderr>` and must classify as
+ * success.
  */
 function hasNonEmptyBashStderrBlock(text: string): boolean {
-	const match = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>/);
+	const match = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>\s*$/);
 	if (!match) return false;
 	return match[1].trim().length > 0;
 }
@@ -404,7 +415,14 @@ function recordBashOutcome(
 ): void {
 	const key = bashFingerprintKey(scope, fingerprint);
 	const existing = state.bashFailures.get(key);
-	const outcomes = existing?.outcomes ?? [];
+	// If the previous ring is older than the sliding window, treat this
+	// write as starting a fresh ring. Otherwise yesterday's failures would
+	// shift forward one slot at a time as new outcomes arrive, polluting
+	// today's deny decisions. The Pre callback resets the streak counter on
+	// window expiry; the failure ring must follow the same lifecycle so the
+	// two views agree.
+	const isStale = existing != null && now - existing.lastSeenMs > windowMs;
+	const outcomes = !existing || isStale ? [] : existing.outcomes;
 	outcomes.push(failed);
 	// Keep at most `failuresRequired` outcomes so the deny check is O(1).
 	while (outcomes.length > failuresRequired) outcomes.shift();
@@ -414,7 +432,9 @@ function recordBashOutcome(
 	// sliding window. Triggered only when the map exceeds a soft cap so we
 	// don't iterate on every call. The same threshold (256) we use for the
 	// streak ledger keeps memory bounded without measurably impacting
-	// per-call latency for typical workloads.
+	// per-call latency for typical workloads. Note: `lastNAllFailures` also
+	// drops stale rings at lookup time, so this size-gated sweep is a
+	// memory backstop rather than the primary correctness mechanism.
 	if (state.bashFailures.size > 256) {
 		for (const [k, v] of state.bashFailures) {
 			if (now - v.lastSeenMs > windowMs) state.bashFailures.delete(k);
@@ -425,17 +445,30 @@ function recordBashOutcome(
 function lastNAllFailures(
 	state: LoopDetectorState,
 	scope: string,
-	fingerprint: string
+	fingerprint: string,
+	now: number,
+	windowMs: number
 ): {
 	allFailures: boolean;
 	length: number;
 } {
-	const ring = state.bashFailures.get(bashFingerprintKey(scope, fingerprint))?.outcomes ?? [];
-	if (ring.length === 0) return { allFailures: false, length: 0 };
-	for (const failed of ring) {
-		if (!failed) return { allFailures: false, length: ring.length };
+	const key = bashFingerprintKey(scope, fingerprint);
+	const ring = state.bashFailures.get(key);
+	// Sliding-window enforcement: a ring whose most recent activity is past
+	// the window is stale and must not contribute to a deny decision. Drop
+	// it eagerly so the next call starts with a clean slate. Without this,
+	// 5 failures from yesterday could combine with a small number of fresh
+	// failures today to trip the deny path even though the streak counter
+	// (which enforces the window in the Pre callback) has reset.
+	if (!ring || ring.outcomes.length === 0) return { allFailures: false, length: 0 };
+	if (now - ring.lastSeenMs > windowMs) {
+		state.bashFailures.delete(key);
+		return { allFailures: false, length: 0 };
 	}
-	return { allFailures: true, length: ring.length };
+	for (const failed of ring.outcomes) {
+		if (!failed) return { allFailures: false, length: ring.outcomes.length };
+	}
+	return { allFailures: true, length: ring.outcomes.length };
 }
 
 /**
@@ -535,7 +568,13 @@ function buildPreToolUseCallback(
 			const bashThreshold = finalConfig.bash.threshold;
 			if (nextCount >= bashThreshold) {
 				const fingerprint = buildArgKey('Bash', args, cwd);
-				const { allFailures, length } = lastNAllFailures(state, scope, fingerprint);
+				const { allFailures, length } = lastNAllFailures(
+					state,
+					scope,
+					fingerprint,
+					now,
+					finalConfig.windowMs
+				);
 				if (allFailures && length >= finalConfig.bash.failuresRequired) {
 					const argSummary = summariseArgs('Bash', args);
 					const reason = buildBashRecoveryMessage(nextCount, argSummary, length);

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -58,7 +58,7 @@ import {
 	defaultBuiltinSkillPluginRoot,
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
-import { createLoopDetectorHook } from './loop-detector-hook';
+import { createLoopDetectorHooks } from './loop-detector-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
@@ -1023,29 +1023,39 @@ CRITICAL RULES:
 	/**
 	 * Build hooks configuration
 	 *
-	 * Always installs the loop-detector hook with NO matcher so it observes
-	 * every PreToolUse event. This is intentional: the hook needs to see
-	 * untracked tool calls (Bash, Edit, Write, …) so they can reset the
-	 * streak after a deny — otherwise an agent that takes a real corrective
-	 * step (e.g. `Edit foo.ts` then re-Read it) would stay permanently
-	 * blocked. The hook itself filters internally on
-	 * `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds`. Tool guards from the
-	 * workflow definition are appended on top.
+	 * Always installs the loop-detector hooks with NO matcher so they observe
+	 * every tool event. This is intentional: the PreToolUse hook needs to see
+	 * untracked tool calls (Edit, Write, …) so they can reset the streak
+	 * after a deny — otherwise an agent that takes a real corrective step
+	 * (e.g. `Edit foo.ts` then re-Read it) would stay permanently blocked.
+	 * The PostToolUse + PostToolUseFailure hooks observe Bash outcomes for
+	 * the failure-aware Bash dead-loop detector. The PreToolUse hook itself
+	 * filters internally on `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds` and the
+	 * Bash sub-config. Tool guards from the workflow definition are appended
+	 * on top of the PreToolUse chain.
 	 */
 	private buildHooks(): Options['hooks'] {
 		const hooks: NonNullable<Options['hooks']> = {};
 		const preToolUse: NonNullable<Options['hooks']>['PreToolUse'] = [];
 
-		// Loop detector: NO matcher — the hook must observe every tool call
-		// so that untracked tools (Edit, Write, Bash, …) can serve as the
-		// "different action" that breaks a denied streak. The hook decides
-		// internally whether to track a tool (DEFAULT_LOOP_DETECTOR_CONFIG.
-		// thresholds) or merely use the call as a streak-reset signal.
-		// Production wires this with no arguments — the hook's `config`
-		// parameter exists only so unit tests can exercise alternative
-		// thresholds and disabled mode.
+		// Loop detector: NO matcher — the hooks must observe every tool call
+		// so that untracked tools (Edit, Write, …) can serve as the
+		// "different action" that breaks a denied streak, and so that every
+		// Bash result is recorded against the failure ring. The PreToolUse
+		// hook decides internally whether to track a tool
+		// (DEFAULT_LOOP_DETECTOR_CONFIG.thresholds + bash sub-config) or
+		// merely use the call as a streak-reset signal. Production wires
+		// this with no arguments — the hook's `config` parameter exists only
+		// so unit tests can exercise alternative thresholds and disabled mode.
+		//
+		// Single factory call: pre/post hooks SHARE state via the closure
+		// returned by `createLoopDetectorHooks()`. Calling
+		// `createLoopDetectorHook()` separately would produce disjoint
+		// states and the Bash failure ring would never see outcomes from the
+		// pre-hook's streak counter.
+		const loopDetectorHooks = createLoopDetectorHooks();
 		preToolUse.push({
-			hooks: [createLoopDetectorHook()],
+			hooks: [loopDetectorHooks.preToolUse],
 		});
 
 		// Workflow tool guards (declarative deny/allow rules) layered on top.
@@ -1073,6 +1083,11 @@ CRITICAL RULES:
 		if (preToolUse.length > 0) {
 			hooks.PreToolUse = preToolUse;
 		}
+		// PostToolUse + PostToolUseFailure observers feed the Bash detector's
+		// outcome ring. Installed unconditionally — they early-out on
+		// non-Bash tools and when bash.enabled is false.
+		hooks.PostToolUse = [{ hooks: [loopDetectorHooks.postToolUse] }];
+		hooks.PostToolUseFailure = [{ hooks: [loopDetectorHooks.postToolUseFailure] }];
 		return hooks;
 	}
 

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
-import { createLoopDetectorHook } from '../../../../src/lib/agent/loop-detector-hook';
+import type {
+	HookCallback,
+	PostToolUseFailureHookInput,
+	PostToolUseHookInput,
+	PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+import {
+	createLoopDetectorHook,
+	createLoopDetectorHooks,
+	isBashFailureResponse,
+} from '../../../../src/lib/agent/loop-detector-hook';
 
 const signal = new AbortController().signal;
 
@@ -21,7 +30,51 @@ function makePreToolUse(
 	};
 }
 
+function makePostToolUse(
+	tool_name: string,
+	tool_input: Record<string, unknown>,
+	tool_response: unknown,
+	overrides: Partial<PostToolUseHookInput> = {}
+): PostToolUseHookInput {
+	return {
+		hook_event_name: 'PostToolUse',
+		tool_name,
+		tool_input,
+		tool_response,
+		session_id: 'test-session',
+		transcript_path: '/test/path',
+		cwd: '/test/cwd',
+		tool_use_id: 'test-id',
+		...overrides,
+	};
+}
+
+function makePostToolUseFailure(
+	tool_name: string,
+	tool_input: Record<string, unknown>,
+	overrides: Partial<PostToolUseFailureHookInput> = {}
+): PostToolUseFailureHookInput {
+	return {
+		hook_event_name: 'PostToolUseFailure',
+		tool_name,
+		tool_input,
+		session_id: 'test-session',
+		transcript_path: '/test/path',
+		cwd: '/test/cwd',
+		tool_use_id: 'test-id',
+		error: 'boom',
+		...overrides,
+	};
+}
+
 async function call(hook: HookCallback, input: PreToolUseHookInput) {
+	return hook(input, 'test-id', { signal });
+}
+
+async function callPost(
+	hook: HookCallback,
+	input: PostToolUseHookInput | PostToolUseFailureHookInput
+) {
 	return hook(input, 'test-id', { signal });
 }
 
@@ -162,7 +215,11 @@ describe('LoopDetectorHook', () => {
 	});
 
 	describe('untracked tools', () => {
-		it('does not deny on Bash even when called many times with identical args', async () => {
+		it('does not deny on Bash via the legacy single-hook factory (no failure observer)', async () => {
+			// `createLoopDetectorHook` produces only the PreToolUse callback;
+			// without the paired PostToolUse hook recording outcomes, the Bash
+			// failure ring stays empty and the persistent-failure precondition
+			// is never satisfied — so even 20 identical Bash calls pass through.
 			const input = makePreToolUse('Bash', { command: 'git status', description: 'status' });
 			for (let i = 0; i < 20; i++) {
 				expect(await call(hook, input)).toEqual({});
@@ -176,12 +233,12 @@ describe('LoopDetectorHook', () => {
 			}
 		});
 
-		it('an untracked tool call DOES reset a tracked streak (Bash counts as a different action)', async () => {
+		it('a Bash call DOES reset a tracked Read streak (different lastKey)', async () => {
 			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
 			const bash = makePreToolUse('Bash', { command: 'echo hi' });
-			// Read, Bash (untracked, counts as a different action), Read, Read
-			// — must NOT deny. Bash reset the streak so we are only on the
-			// 2nd consecutive Read here.
+			// Read, Bash (different lastKey, counts as a different action wrt
+			// the Read streak), Read, Read — must NOT deny. The Bash call
+			// overwrote lastKey so we are only on the 2nd consecutive Read here.
 			expect(await call(hook, read)).toEqual({});
 			expect(await call(hook, bash)).toEqual({});
 			expect(await call(hook, read)).toEqual({});
@@ -406,6 +463,477 @@ describe('LoopDetectorHook', () => {
 			expect(await call(tightHook, input)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
+		});
+	});
+
+	describe('Bash dead-loop detection (PostToolUse hybrid)', () => {
+		const FAILING_BASH = makePreToolUse('Bash', {
+			command: 'ls -la .git/hooks 2>&1',
+			description: 'List git hooks',
+		});
+
+		function makeBashFailureResponse(): unknown {
+			// Mirrors the SDK Bash tool's failure shape: top-level is_error
+			// and a stderr containing a recognisable failure marker.
+			return {
+				is_error: true,
+				stderr: 'ls: .git/hooks: No such file or directory',
+				stdout: '',
+			};
+		}
+
+		function makeBashSuccessResponse(): unknown {
+			return {
+				stdout: 'pre-commit\npre-push\n',
+				stderr: '',
+			};
+		}
+
+		it('denies after 5 consecutive identical failing Bash commands', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+
+			// Calls 1..4 — under threshold, no deny.
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						FAILING_BASH.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// Call 5 — threshold hit AND last 5 outcomes all failures (wait,
+			// only 4 recorded so far; the 5th PreToolUse fires before its own
+			// PostToolUse). We need 5 failures recorded before the 6th call
+			// can deny. Confirm 5th call passes through.
+			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					FAILING_BASH.tool_input as Record<string, unknown>,
+					makeBashFailureResponse()
+				)
+			);
+
+			// Call 6 — now 5 failures in the ring; deny fires.
+			const result = await call(preToolUse, FAILING_BASH);
+			expect(result).toMatchObject({
+				hookSpecificOutput: {
+					hookEventName: 'PreToolUse',
+					permissionDecision: 'deny',
+				},
+			});
+			const reason = (result as { hookSpecificOutput: { permissionDecisionReason: string } })
+				.hookSpecificOutput.permissionDecisionReason;
+			expect(reason).toContain('Bash dead-loop detected');
+			expect(reason).toContain('ls -la .git/hooks 2>&1');
+		});
+
+		it('does NOT deny when the same command succeeds repeatedly (legitimate polling)', async () => {
+			// `git status` polling: agent keeps re-running the same command,
+			// and each call succeeds. Must not deny — Bash output can
+			// legitimately differ across successful calls.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const cmd = makePreToolUse('Bash', { command: 'git status' });
+
+			for (let i = 0; i < 20; i++) {
+				expect(await call(preToolUse, cmd)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						cmd.tool_input as Record<string, unknown>,
+						makeBashSuccessResponse()
+					)
+				);
+			}
+		});
+
+		it('does NOT deny when mixed success/failure (a single success clears the streak deny)', async () => {
+			// Flaky test scenario: 4 failures, 1 success, then a failure. The
+			// success purges the failure ring so even the streak count of 6
+			// does not satisfy "last 5 all failures."
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const cmd = makePreToolUse('Bash', { command: 'bun test foo.test.ts' });
+
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, cmd)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						cmd.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// 5th call: streak is 5 but ring only has 4 failures. No deny.
+			expect(await call(preToolUse, cmd)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					cmd.tool_input as Record<string, unknown>,
+					makeBashSuccessResponse()
+				)
+			);
+			// 6th call: streak is 6, ring has [F,F,F,F,S] → not all failures, no deny.
+			expect(await call(preToolUse, cmd)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					cmd.tool_input as Record<string, unknown>,
+					makeBashFailureResponse()
+				)
+			);
+			// 7th call: ring is [F,F,F,S,F] → still not all failures, no deny.
+			expect(await call(preToolUse, cmd)).toEqual({});
+		});
+
+		it('a different Bash command resets the streak (semantic streak reset)', async () => {
+			// 4 failing `cmd-A`, then 1 `cmd-B`, then 5 failing `cmd-A`. Even
+			// though there are 9 failures of cmd-A total, the streak reset by
+			// cmd-B means the consecutive count starts over.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const a = makePreToolUse('Bash', { command: 'ls nonexistent-a 2>&1' });
+			const b = makePreToolUse('Bash', { command: 'ls nonexistent-b 2>&1' });
+
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, a)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						a.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// Interleave a different Bash command.
+			expect(await call(preToolUse, b)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse('Bash', b.tool_input as Record<string, unknown>, makeBashFailureResponse())
+			);
+			// Streak for a was reset. We need 5 more consecutive a calls to
+			// rebuild the streak. The 5th passes, then the 6th gets denied
+			// (because the ring still has 5 a-failures from before — the
+			// failure ring is independent of streak resets, but the streak
+			// counter starts over so deny only fires when count >= 5).
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, a)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						a.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// 5th a in the new streak — streak is 5, ring has ≥5 failures. Deny.
+			expect(await call(preToolUse, a)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('a non-Bash tool call also resets the Bash streak', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const bash = makePreToolUse('Bash', { command: 'ls bad 2>&1' });
+			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+
+			// 4 failing Bash.
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, bash)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						bash.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// Read in between — resets Bash streak.
+			expect(await call(preToolUse, read)).toEqual({});
+			// Bash again — streak is 1, no deny even though failure ring has 4.
+			expect(await call(preToolUse, bash)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					bash.tool_input as Record<string, unknown>,
+					makeBashFailureResponse()
+				)
+			);
+			// 4 more consecutive Bash → streak is 5, failures ring has 5 → deny.
+			for (let i = 0; i < 3; i++) {
+				expect(await call(preToolUse, bash)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						bash.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			expect(await call(preToolUse, bash)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('counts PostToolUseFailure as a failure outcome', async () => {
+			// SDK-level errors (hook crash, sandbox kill) come via the
+			// PostToolUseFailure event, not PostToolUse. These must also be
+			// counted as failures so a wedged tool path can still be denied.
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
+			const cmd = makePreToolUse('Bash', { command: 'do-the-thing' });
+
+			for (let i = 0; i < 5; i++) {
+				expect(await call(preToolUse, cmd)).toEqual({});
+				await callPost(
+					postToolUseFailure,
+					makePostToolUseFailure('Bash', cmd.tool_input as Record<string, unknown>)
+				);
+			}
+			expect(await call(preToolUse, cmd)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('continues denying on every retry of the same failing command (loop is broken, not throttled)', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+
+			for (let i = 0; i < 5; i++) {
+				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						FAILING_BASH.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			// Three identical retries — each denied. Importantly, the ring
+			// has 5 failures and stays that way until the streak resets via a
+			// different action.
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('respects bash.enabled=false (no Bash deny ever)', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+				bash: { enabled: false, threshold: 5, failuresRequired: 5 },
+			});
+
+			for (let i = 0; i < 50; i++) {
+				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						FAILING_BASH.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+		});
+
+		it('respects custom bash thresholds', async () => {
+			// Lower threshold and failuresRequired to 2 for ease of testing.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+				bash: { enabled: true, threshold: 2, failuresRequired: 2 },
+			});
+
+			// 1st call: pre passes, then record failure.
+			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					FAILING_BASH.tool_input as Record<string, unknown>,
+					makeBashFailureResponse()
+				)
+			);
+			// 2nd call: streak=2 but ring only has 1. No deny yet.
+			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+			await callPost(
+				postToolUse,
+				makePostToolUse(
+					'Bash',
+					FAILING_BASH.tool_input as Record<string, unknown>,
+					makeBashFailureResponse()
+				)
+			);
+			// 3rd call: streak=3, ring=[F,F]. Deny.
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('isolates Bash failure rings per (session, agent)', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const aPre = makePreToolUse('Bash', { command: 'ls bad 2>&1' }, { session_id: 'sess-A' });
+			const bPre = makePreToolUse('Bash', { command: 'ls bad 2>&1' }, { session_id: 'sess-B' });
+
+			// Build a fully-loaded failure ring in sess-A.
+			for (let i = 0; i < 5; i++) {
+				expect(await call(preToolUse, aPre)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						aPre.tool_input as Record<string, unknown>,
+						makeBashFailureResponse(),
+						{ session_id: 'sess-A' }
+					)
+				);
+			}
+			// One more in sess-A — deny.
+			expect(await call(preToolUse, aPre)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// In sess-B the failure ring is empty for that fingerprint, so
+			// even repeated calls do not deny on the first hits.
+			for (let i = 0; i < 4; i++) {
+				expect(await call(preToolUse, bPre)).toEqual({});
+			}
+		});
+
+		it('treats interrupted Bash responses as failures', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const interruptedResponse = { interrupted: true, stdout: '', stderr: '' };
+
+			for (let i = 0; i < 5; i++) {
+				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						FAILING_BASH.tool_input as Record<string, unknown>,
+						interruptedResponse
+					)
+				);
+			}
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('PostToolUse hook ignores non-Bash tools', async () => {
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			// Recording a fake failure for Read should NOT pollute Bash's ring.
+			await callPost(
+				postToolUse,
+				makePostToolUse('Read', { file_path: '/abs/foo.ts' }, { is_error: true, stderr: 'boom' })
+			);
+			// Now run 5 successful Bash calls — should still pass on the 6th.
+			const cmd = makePreToolUse('Bash', { command: 'true' });
+			for (let i = 0; i < 6; i++) {
+				expect(await call(preToolUse, cmd)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						cmd.tool_input as Record<string, unknown>,
+						makeBashSuccessResponse()
+					)
+				);
+			}
+		});
+	});
+
+	describe('isBashFailureResponse classifier', () => {
+		it('classifies null / undefined as success', () => {
+			expect(isBashFailureResponse(null)).toBe(false);
+			expect(isBashFailureResponse(undefined)).toBe(false);
+		});
+
+		it('classifies plain success strings as success', () => {
+			expect(isBashFailureResponse('Hello\nWorld\n')).toBe(false);
+			expect(isBashFailureResponse('On branch main\nnothing to commit, working tree clean')).toBe(
+				false
+			);
+		});
+
+		it('classifies strings with exit-code error markers as failures', () => {
+			expect(isBashFailureResponse('Exit code: 1')).toBe(true);
+			expect(isBashFailureResponse('Some output\nExit code: 127')).toBe(true);
+			expect(isBashFailureResponse('Exit code: 0')).toBe(false);
+		});
+
+		it('classifies strings with bash-stderr blocks as failures', () => {
+			expect(
+				isBashFailureResponse(
+					'<bash-stderr>ls: cannot access .git/hooks: No such file or directory</bash-stderr>'
+				)
+			).toBe(true);
+			// Empty stderr block is not a failure.
+			expect(isBashFailureResponse('<bash-stderr></bash-stderr>')).toBe(false);
+		});
+
+		it('classifies textual error markers as failures', () => {
+			expect(isBashFailureResponse('bash: foo: command not found')).toBe(true);
+			expect(isBashFailureResponse('ls: /nope: No such file or directory')).toBe(true);
+			expect(isBashFailureResponse('Permission denied')).toBe(true);
+			expect(isBashFailureResponse('command timed out after 120s')).toBe(true);
+		});
+
+		it('classifies object responses with is_error=true as failures', () => {
+			expect(isBashFailureResponse({ is_error: true, stdout: '', stderr: 'oops' })).toBe(true);
+		});
+
+		it('classifies object responses with non-zero exit code as failures', () => {
+			expect(isBashFailureResponse({ exitCode: 1, stdout: '' })).toBe(true);
+			expect(isBashFailureResponse({ exit_code: 127, stdout: '' })).toBe(true);
+			expect(isBashFailureResponse({ returnCode: 2, stdout: '' })).toBe(true);
+			expect(isBashFailureResponse({ exitCode: 0, stdout: 'ok' })).toBe(false);
+		});
+
+		it('classifies interrupted responses as failures', () => {
+			expect(isBashFailureResponse({ interrupted: true, stdout: '' })).toBe(true);
+		});
+
+		it('classifies content-block arrays with is_error blocks as failures', () => {
+			expect(
+				isBashFailureResponse([
+					{ type: 'text', text: 'some output' },
+					{ is_error: true, type: 'text', text: 'failure' },
+				])
+			).toBe(true);
+		});
+
+		it('classifies content-block arrays with error markers in text as failures', () => {
+			expect(
+				isBashFailureResponse([{ type: 'text', text: 'ls: foo: No such file or directory' }])
+			).toBe(true);
+		});
+
+		it('does NOT classify plain success object responses as failures', () => {
+			expect(isBashFailureResponse({ stdout: 'hello', stderr: '' })).toBe(false);
+		});
+
+		it('does NOT classify benign stderr (e.g. warnings) without strong error markers as failures', () => {
+			// The classifier is conservative: a non-empty stderr without an
+			// obvious error marker is not enough to call it a failure. This
+			// avoids false positives on commands that legitimately write to
+			// stderr (npm warnings, etc.).
+			expect(isBashFailureResponse({ stdout: 'built', stderr: 'warning: deprecated flag' })).toBe(
+				false
+			);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -8,7 +8,6 @@ import type {
 import {
 	createLoopDetectorHook,
 	createLoopDetectorHooks,
-	isBashFailureResponse,
 } from '../../../../src/lib/agent/loop-detector-hook';
 
 const signal = new AbortController().signal;
@@ -472,16 +471,6 @@ describe('LoopDetectorHook', () => {
 			description: 'List git hooks',
 		});
 
-		function makeBashFailureResponse(): unknown {
-			// Mirrors the SDK Bash tool's failure shape: top-level is_error
-			// and a stderr containing a recognisable failure marker.
-			return {
-				is_error: true,
-				stderr: 'ls: .git/hooks: No such file or directory',
-				stdout: '',
-			};
-		}
-
 		function makeBashSuccessResponse(): unknown {
 			return {
 				stdout: 'pre-commit\npre-push\n',
@@ -489,33 +478,37 @@ describe('LoopDetectorHook', () => {
 			};
 		}
 
+		// With the new design, PostToolUse always records success.
+		// Failures are delivered via PostToolUseFailure. Tests that need
+		// to simulate a failing Bash call use this helper to fire the
+		// failure hook.
+		async function recordBashFailure(
+			postToolUseFailure: HookCallback,
+			tool_input: Record<string, unknown>,
+			overrides: Partial<PostToolUseFailureHookInput> = {}
+		) {
+			await callPost(postToolUseFailure, makePostToolUseFailure('Bash', tool_input, overrides));
+		}
+
 		it('denies after 5 consecutive identical failing Bash commands', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUse, postToolUseFailure } = createLoopDetectorHooks();
 
 			// Calls 1..4 — under threshold, no deny.
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						FAILING_BASH.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
+				await recordBashFailure(
+					postToolUseFailure,
+					FAILING_BASH.tool_input as Record<string, unknown>
 				);
 			}
 			// Call 5 — threshold hit AND last 5 outcomes all failures (wait,
 			// only 4 recorded so far; the 5th PreToolUse fires before its own
-			// PostToolUse). We need 5 failures recorded before the 6th call
-			// can deny. Confirm 5th call passes through.
+			// PostToolUseFailure). We need 5 failures recorded before the 6th
+			// call can deny. Confirm 5th call passes through.
 			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse(
-					'Bash',
-					FAILING_BASH.tool_input as Record<string, unknown>,
-					makeBashFailureResponse()
-				)
+			await recordBashFailure(
+				postToolUseFailure,
+				FAILING_BASH.tool_input as Record<string, unknown>
 			);
 
 			// Call 6 — now 5 failures in the ring; deny fires.
@@ -556,19 +549,12 @@ describe('LoopDetectorHook', () => {
 			// Flaky test scenario: 4 failures, 1 success, then a failure. The
 			// success purges the failure ring so even the streak count of 6
 			// does not satisfy "last 5 all failures."
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const cmd = makePreToolUse('Bash', { command: 'bun test foo.test.ts' });
 
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, cmd)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						cmd.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, cmd.tool_input as Record<string, unknown>);
 			}
 			// 5th call: streak is 5 but ring only has 4 failures. No deny.
 			expect(await call(preToolUse, cmd)).toEqual({});
@@ -582,14 +568,7 @@ describe('LoopDetectorHook', () => {
 			);
 			// 6th call: streak is 6, ring has [F,F,F,F,S] → not all failures, no deny.
 			expect(await call(preToolUse, cmd)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse(
-					'Bash',
-					cmd.tool_input as Record<string, unknown>,
-					makeBashFailureResponse()
-				)
-			);
+			await recordBashFailure(postToolUseFailure, cmd.tool_input as Record<string, unknown>);
 			// 7th call: ring is [F,F,F,S,F] → still not all failures, no deny.
 			expect(await call(preToolUse, cmd)).toEqual({});
 		});
@@ -598,27 +577,17 @@ describe('LoopDetectorHook', () => {
 			// 4 failing `cmd-A`, then 1 `cmd-B`, then 5 failing `cmd-A`. Even
 			// though there are 9 failures of cmd-A total, the streak reset by
 			// cmd-B means the consecutive count starts over.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const a = makePreToolUse('Bash', { command: 'ls nonexistent-a 2>&1' });
 			const b = makePreToolUse('Bash', { command: 'ls nonexistent-b 2>&1' });
 
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, a)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						a.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, a.tool_input as Record<string, unknown>);
 			}
 			// Interleave a different Bash command.
 			expect(await call(preToolUse, b)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse('Bash', b.tool_input as Record<string, unknown>, makeBashFailureResponse())
-			);
+			await recordBashFailure(postToolUseFailure, b.tool_input as Record<string, unknown>);
 			// Streak for a was reset. We need 5 more consecutive a calls to
 			// rebuild the streak. The 5th passes, then the 6th gets denied
 			// (because the ring still has 5 a-failures from before — the
@@ -626,14 +595,7 @@ describe('LoopDetectorHook', () => {
 			// counter starts over so deny only fires when count >= 5).
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, a)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						a.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, a.tool_input as Record<string, unknown>);
 			}
 			// 5th a in the new streak — streak is 5, ring has ≥5 failures. Deny.
 			expect(await call(preToolUse, a)).toMatchObject({
@@ -642,45 +604,24 @@ describe('LoopDetectorHook', () => {
 		});
 
 		it('a non-Bash tool call also resets the Bash streak', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const bash = makePreToolUse('Bash', { command: 'ls bad 2>&1' });
 			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
 
 			// 4 failing Bash.
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, bash)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						bash.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, bash.tool_input as Record<string, unknown>);
 			}
 			// Read in between — resets Bash streak.
 			expect(await call(preToolUse, read)).toEqual({});
 			// Bash again — streak is 1, no deny even though failure ring has 4.
 			expect(await call(preToolUse, bash)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse(
-					'Bash',
-					bash.tool_input as Record<string, unknown>,
-					makeBashFailureResponse()
-				)
-			);
+			await recordBashFailure(postToolUseFailure, bash.tool_input as Record<string, unknown>);
 			// 4 more consecutive Bash → streak is 5, failures ring has 5 → deny.
 			for (let i = 0; i < 3; i++) {
 				expect(await call(preToolUse, bash)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						bash.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, bash.tool_input as Record<string, unknown>);
 			}
 			expect(await call(preToolUse, bash)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
@@ -707,17 +648,13 @@ describe('LoopDetectorHook', () => {
 		});
 
 		it('continues denying on every retry of the same failing command (loop is broken, not throttled)', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
 
 			for (let i = 0; i < 5; i++) {
 				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						FAILING_BASH.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
+				await recordBashFailure(
+					postToolUseFailure,
+					FAILING_BASH.tool_input as Record<string, unknown>
 				);
 			}
 			// Three identical retries — each denied. Importantly, the ring
@@ -735,48 +672,36 @@ describe('LoopDetectorHook', () => {
 		});
 
 		it('respects bash.enabled=false (no Bash deny ever)', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks({
 				bash: { enabled: false, threshold: 5, failuresRequired: 5 },
 			});
 
 			for (let i = 0; i < 50; i++) {
 				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						FAILING_BASH.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
+				await recordBashFailure(
+					postToolUseFailure,
+					FAILING_BASH.tool_input as Record<string, unknown>
 				);
 			}
 		});
 
 		it('respects custom bash thresholds', async () => {
 			// Lower threshold and failuresRequired to 2 for ease of testing.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks({
 				bash: { enabled: true, threshold: 2, failuresRequired: 2 },
 			});
 
 			// 1st call: pre passes, then record failure.
 			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse(
-					'Bash',
-					FAILING_BASH.tool_input as Record<string, unknown>,
-					makeBashFailureResponse()
-				)
+			await recordBashFailure(
+				postToolUseFailure,
+				FAILING_BASH.tool_input as Record<string, unknown>
 			);
 			// 2nd call: streak=2 but ring only has 1. No deny yet.
 			expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-			await callPost(
-				postToolUse,
-				makePostToolUse(
-					'Bash',
-					FAILING_BASH.tool_input as Record<string, unknown>,
-					makeBashFailureResponse()
-				)
+			await recordBashFailure(
+				postToolUseFailure,
+				FAILING_BASH.tool_input as Record<string, unknown>
 			);
 			// 3rd call: streak=3, ring=[F,F]. Deny.
 			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
@@ -785,22 +710,16 @@ describe('LoopDetectorHook', () => {
 		});
 
 		it('isolates Bash failure rings per (session, agent)', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const aPre = makePreToolUse('Bash', { command: 'ls bad 2>&1' }, { session_id: 'sess-A' });
 			const bPre = makePreToolUse('Bash', { command: 'ls bad 2>&1' }, { session_id: 'sess-B' });
 
 			// Build a fully-loaded failure ring in sess-A.
 			for (let i = 0; i < 5; i++) {
 				expect(await call(preToolUse, aPre)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						aPre.tool_input as Record<string, unknown>,
-						makeBashFailureResponse(),
-						{ session_id: 'sess-A' }
-					)
-				);
+				await recordBashFailure(postToolUseFailure, aPre.tool_input as Record<string, unknown>, {
+					session_id: 'sess-A',
+				});
 			}
 			// One more in sess-A — deny.
 			expect(await call(preToolUse, aPre)).toMatchObject({
@@ -811,26 +730,6 @@ describe('LoopDetectorHook', () => {
 			for (let i = 0; i < 4; i++) {
 				expect(await call(preToolUse, bPre)).toEqual({});
 			}
-		});
-
-		it('treats interrupted Bash responses as failures', async () => {
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
-			const interruptedResponse = { interrupted: true, stdout: '', stderr: '' };
-
-			for (let i = 0; i < 5; i++) {
-				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						FAILING_BASH.tool_input as Record<string, unknown>,
-						interruptedResponse
-					)
-				);
-			}
-			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
-				hookSpecificOutput: { permissionDecision: 'deny' },
-			});
 		});
 
 		it('PostToolUse hook ignores non-Bash tools', async () => {
@@ -861,7 +760,7 @@ describe('LoopDetectorHook', () => {
 			// ("Check git hooks" → "List hook files"). Including description
 			// in the fingerprint would defeat the detector — every retry
 			// would look like a fresh command. We strip it.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const command = 'ls -la .git/hooks 2>&1';
 			const descriptions = [
 				'Check git hooks',
@@ -880,14 +779,7 @@ describe('LoopDetectorHook', () => {
 			for (let i = 0; i < 5; i++) {
 				const pre = makePreToolUse('Bash', { command, description: descriptions[i] });
 				expect(await call(preToolUse, pre)).toEqual({});
-				await callPost(
-					postToolUse,
-					makePostToolUse(
-						'Bash',
-						pre.tool_input as Record<string, unknown>,
-						makeBashFailureResponse()
-					)
-				);
+				await recordBashFailure(postToolUseFailure, pre.tool_input as Record<string, unknown>);
 			}
 			const finalPre = makePreToolUse('Bash', { command, description: descriptions[5] });
 			expect(await call(preToolUse, finalPre)).toMatchObject({
@@ -945,14 +837,14 @@ describe('LoopDetectorHook', () => {
 			// reach the ring. This test guards that lifecycle: 5 failures
 			// followed by a long quiet period followed by a fresh attempt
 			// MUST pass through, not deny.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks({ windowMs: 50 });
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks({ windowMs: 50 });
 			const cmd = makePreToolUse('Bash', { command: 'ls /nope' });
 			const args = cmd.tool_input as Record<string, unknown>;
 
 			// Record 5 failures.
 			for (let i = 0; i < 5; i++) {
 				await call(preToolUse, cmd);
-				await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+				await recordBashFailure(postToolUseFailure, args);
 			}
 
 			// Wait past the sliding window. The next PreToolUse call sees a
@@ -971,7 +863,7 @@ describe('LoopDetectorHook', () => {
 			// stale rings unconditionally — verify the ring is empty after
 			// the window elapses, even with a single fingerprint in the
 			// map.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks({
 				windowMs: 30,
 				// Tight thresholds so the streak path is short and the ring
 				// reach is exercised quickly.
@@ -982,9 +874,9 @@ describe('LoopDetectorHook', () => {
 
 			// 2 failures fill the ring AND build the streak to 2.
 			await call(preToolUse, cmd);
-			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+			await recordBashFailure(postToolUseFailure, args);
 			await call(preToolUse, cmd);
-			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+			await recordBashFailure(postToolUseFailure, args);
 
 			// Confirm the deny path would fire right now.
 			expect(await call(preToolUse, cmd)).toMatchObject({
@@ -1001,7 +893,7 @@ describe('LoopDetectorHook', () => {
 
 			// First post-cooldown call: passes (streak just reset to 1).
 			expect(await call(preToolUse, cmd)).toEqual({});
-			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+			await recordBashFailure(postToolUseFailure, args);
 
 			// Second post-cooldown call: streak reaches 2. Ring now has 1
 			// fresh failure (the stale ring was evicted at lookup time and
@@ -1018,7 +910,7 @@ describe('LoopDetectorHook', () => {
 			// between worktrees would inherit prior failure state and
 			// trigger false denies for commands that are only textually
 			// identical.
-			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
 			const argsA = { command: 'git status' };
 			const argsB = { command: 'git status' };
 
@@ -1026,10 +918,7 @@ describe('LoopDetectorHook', () => {
 			for (let i = 0; i < 5; i++) {
 				const pre = makePreToolUse('Bash', argsA, { cwd: '/repo-a' });
 				await call(preToolUse, pre);
-				await callPost(
-					postToolUse,
-					makePostToolUse('Bash', argsA, makeBashFailureResponse(), { cwd: '/repo-a' })
-				);
+				await recordBashFailure(postToolUseFailure, argsA, { cwd: '/repo-a' });
 			}
 			// Sanity: 6th call in repo-A denies.
 			expect(
@@ -1042,135 +931,35 @@ describe('LoopDetectorHook', () => {
 			// fresh fingerprint, no streak, no failures.
 			expect(await call(preToolUse, makePreToolUse('Bash', argsB, { cwd: '/repo-b' }))).toEqual({});
 		});
-	});
 
-	describe('isBashFailureResponse classifier', () => {
-		it('classifies null / undefined as success', () => {
-			expect(isBashFailureResponse(null)).toBe(false);
-			expect(isBashFailureResponse(undefined)).toBe(false);
-		});
+		it('canonicalises optional Bash args so omitted vs explicit defaults collide', async () => {
+			// Regression test for review feedback: semantically equivalent
+			// calls like omitted `run_in_background` vs `run_in_background:
+			// false` must hash to the same key. Otherwise the model can
+			// evade the detector by toggling optional default-valued fields
+			// between retries.
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
+			const command = 'git status';
 
-		it('classifies plain success strings as success', () => {
-			expect(isBashFailureResponse('Hello\nWorld\n')).toBe(false);
-			expect(isBashFailureResponse('On branch main\nnothing to commit, working tree clean')).toBe(
-				false
-			);
-		});
+			// 3 failures with explicit run_in_background=false.
+			for (let i = 0; i < 3; i++) {
+				const pre = makePreToolUse('Bash', { command, run_in_background: false });
+				expect(await call(preToolUse, pre)).toEqual({});
+				await recordBashFailure(postToolUseFailure, pre.tool_input as Record<string, unknown>);
+			}
 
-		it('does NOT classify free-form strings with "Exit code:" text as failures', () => {
-			// We deliberately do not substring-scan stdout. Commands frequently
-			// emit phrases like "Exit code: 1" in their normal output (test
-			// runner summaries, status reports), and counting those as
-			// failures would poison the failure ring with false positives.
-			expect(isBashFailureResponse('Exit code: 1')).toBe(false);
-			expect(isBashFailureResponse('Some output\nExit code: 127')).toBe(false);
-			expect(isBashFailureResponse('Exit code: 0')).toBe(false);
-		});
+			// 2 failures with omitted run_in_background — must fingerprint to
+			// the SAME key because the canonicalised default is false.
+			for (let i = 0; i < 2; i++) {
+				const pre = makePreToolUse('Bash', { command });
+				expect(await call(preToolUse, pre)).toEqual({});
+				await recordBashFailure(postToolUseFailure, pre.tool_input as Record<string, unknown>);
+			}
 
-		it('classifies strings with bash-stderr blocks as failures', () => {
-			expect(
-				isBashFailureResponse(
-					'<bash-stderr>ls: cannot access .git/hooks: No such file or directory</bash-stderr>'
-				)
-			).toBe(true);
-			// Empty stderr block is not a failure.
-			expect(isBashFailureResponse('<bash-stderr></bash-stderr>')).toBe(false);
-			// Whitespace-only stderr block is not a failure either.
-			expect(isBashFailureResponse('<bash-stderr>   \n\t</bash-stderr>')).toBe(false);
-			// Real-world shape: stdout followed by a stderr block at the end.
-			expect(
-				isBashFailureResponse(
-					'pre-commit\npre-push\n<bash-stderr>warning: deprecated</bash-stderr>'
-				)
-			).toBe(true);
-			// Trailing whitespace after the closing tag is tolerated.
-			expect(isBashFailureResponse('<bash-stderr>oops</bash-stderr>\n  ')).toBe(true);
-		});
-
-		it('does NOT classify literal <bash-stderr> text echoed mid-output as failures', () => {
-			// Regression test for review feedback: a command can legitimately
-			// print the literal `<bash-stderr>…</bash-stderr>` string (e.g.
-			// `echo '<bash-stderr>x</bash-stderr>'` or grepping logs for
-			// the tag). The SDK only ever appends a real stderr block at
-			// the very end of the response, so we anchor the regex to
-			// end-of-output. A tag that appears mid-stream is content, not
-			// a stderr signal.
-			expect(
-				isBashFailureResponse('<bash-stderr>echoed-by-command</bash-stderr> more stdout after')
-			).toBe(false);
-			expect(
-				isBashFailureResponse(
-					'first line\n<bash-stderr>fake</bash-stderr>\nsecond line\nthird line'
-				)
-			).toBe(false);
-		});
-
-		it('does NOT classify free-form strings with textual error markers as failures', () => {
-			// Stdout legitimately contains these phrases in many real
-			// workflows: greping log files for "permission denied", tutorials,
-			// docs commands, error messages quoted in test output, etc. The
-			// classifier must not treat them as command failures — the
-			// trustworthy stderr signal is the <bash-stderr> block.
-			expect(isBashFailureResponse('bash: foo: command not found')).toBe(false);
-			expect(isBashFailureResponse('ls: /nope: No such file or directory')).toBe(false);
-			expect(isBashFailureResponse('Permission denied')).toBe(false);
-			expect(isBashFailureResponse('command timed out after 120s')).toBe(false);
-		});
-
-		it('classifies object responses with is_error=true as failures', () => {
-			expect(isBashFailureResponse({ is_error: true, stdout: '', stderr: 'oops' })).toBe(true);
-		});
-
-		it('classifies object responses with non-zero exit code as failures', () => {
-			expect(isBashFailureResponse({ exitCode: 1, stdout: '' })).toBe(true);
-			expect(isBashFailureResponse({ exit_code: 127, stdout: '' })).toBe(true);
-			expect(isBashFailureResponse({ returnCode: 2, stdout: '' })).toBe(true);
-			expect(isBashFailureResponse({ exitCode: 0, stdout: 'ok' })).toBe(false);
-		});
-
-		it('classifies interrupted responses as failures', () => {
-			expect(isBashFailureResponse({ interrupted: true, stdout: '' })).toBe(true);
-		});
-
-		it('classifies content-block arrays with is_error blocks as failures', () => {
-			expect(
-				isBashFailureResponse([
-					{ type: 'text', text: 'some output' },
-					{ is_error: true, type: 'text', text: 'failure' },
-				])
-			).toBe(true);
-		});
-
-		it('classifies content-block arrays with non-empty bash-stderr text as failures', () => {
-			expect(
-				isBashFailureResponse([
-					{ type: 'text', text: '<bash-stderr>ls: foo: No such file or directory</bash-stderr>' },
-				])
-			).toBe(true);
-		});
-
-		it('does NOT classify content-block arrays whose text merely mentions errors as failures', () => {
-			// Same conservative rule as for plain strings: stdout text is not
-			// a failure signal, even if it contains phrases like "No such
-			// file". Only <bash-stderr> delimiters or top-level is_error
-			// count.
-			expect(
-				isBashFailureResponse([{ type: 'text', text: 'ls: foo: No such file or directory' }])
-			).toBe(false);
-		});
-
-		it('does NOT classify plain success object responses as failures', () => {
-			expect(isBashFailureResponse({ stdout: 'hello', stderr: '' })).toBe(false);
-		});
-
-		it('does NOT classify benign stderr (e.g. warnings) without strong error markers as failures', () => {
-			// The classifier is conservative: a non-empty stderr without an
-			// obvious error marker is not enough to call it a failure. This
-			// avoids false positives on commands that legitimately write to
-			// stderr (npm warnings, etc.).
-			expect(isBashFailureResponse({ stdout: 'built', stderr: 'warning: deprecated flag' })).toBe(
-				false
-			);
+			// 6th call (same command, streak=6, ring has 5 failures) → deny.
+			expect(await call(preToolUse, makePreToolUse('Bash', { command }))).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
 		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -961,6 +961,87 @@ describe('LoopDetectorHook', () => {
 			await new Promise((r) => setTimeout(r, 80));
 			expect(await call(preToolUse, cmd)).toEqual({});
 		});
+
+		it('expires stale failure rings in lastNAllFailures even when the map stays small', async () => {
+			// Regression test for review feedback: opportunistic size-gated
+			// eviction (size > 256) means small workloads keep their rings
+			// forever. Without time-based gating in lastNAllFailures, stale
+			// failures from outside the window could still leak into a
+			// deny decision. We now check ring age at lookup time and drop
+			// stale rings unconditionally — verify the ring is empty after
+			// the window elapses, even with a single fingerprint in the
+			// map.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks({
+				windowMs: 30,
+				// Tight thresholds so the streak path is short and the ring
+				// reach is exercised quickly.
+				bash: { enabled: true, threshold: 2, failuresRequired: 2 },
+			});
+			const cmd = makePreToolUse('Bash', { command: 'flaky' });
+			const args = cmd.tool_input as Record<string, unknown>;
+
+			// 2 failures fill the ring AND build the streak to 2.
+			await call(preToolUse, cmd);
+			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+			await call(preToolUse, cmd);
+			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+
+			// Confirm the deny path would fire right now.
+			expect(await call(preToolUse, cmd)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+
+			// Wait past the window. Streak resets in Pre callback (firstSeenMs
+			// stale), AND the ring is stale. A SINGLE fresh failure must not
+			// be enough to deny: streak count = 1 (< threshold=2). On the
+			// second fresh failure, the streak hits threshold but the ring
+			// must already have been time-evicted so we don't carry yesterday's
+			// failures forward.
+			await new Promise((r) => setTimeout(r, 50));
+
+			// First post-cooldown call: passes (streak just reset to 1).
+			expect(await call(preToolUse, cmd)).toEqual({});
+			await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+
+			// Second post-cooldown call: streak reaches 2. Ring now has 1
+			// fresh failure (the stale ring was evicted at lookup time and
+			// the post hook wrote a single fresh entry). length=1 < required=2,
+			// so the deny does NOT fire — exactly the behaviour the
+			// sliding-window contract promises.
+			expect(await call(preToolUse, cmd)).toEqual({});
+		});
+
+		it('treats identical commands in different cwds as separate fingerprints', async () => {
+			// Regression test for review feedback: `git status` in repo-A and
+			// `git status` in repo-B are semantically different runs. Failure
+			// streaks must not carry between them. Otherwise switching
+			// between worktrees would inherit prior failure state and
+			// trigger false denies for commands that are only textually
+			// identical.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const argsA = { command: 'git status' };
+			const argsB = { command: 'git status' };
+
+			// 6 failures in repo-A — would normally deny.
+			for (let i = 0; i < 5; i++) {
+				const pre = makePreToolUse('Bash', argsA, { cwd: '/repo-a' });
+				await call(preToolUse, pre);
+				await callPost(
+					postToolUse,
+					makePostToolUse('Bash', argsA, makeBashFailureResponse(), { cwd: '/repo-a' })
+				);
+			}
+			// Sanity: 6th call in repo-A denies.
+			expect(
+				await call(preToolUse, makePreToolUse('Bash', argsA, { cwd: '/repo-a' }))
+			).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+
+			// First call in repo-B with the same command text must pass —
+			// fresh fingerprint, no streak, no failures.
+			expect(await call(preToolUse, makePreToolUse('Bash', argsB, { cwd: '/repo-b' }))).toEqual({});
+		});
 	});
 
 	describe('isBashFailureResponse classifier', () => {
@@ -996,6 +1077,32 @@ describe('LoopDetectorHook', () => {
 			expect(isBashFailureResponse('<bash-stderr></bash-stderr>')).toBe(false);
 			// Whitespace-only stderr block is not a failure either.
 			expect(isBashFailureResponse('<bash-stderr>   \n\t</bash-stderr>')).toBe(false);
+			// Real-world shape: stdout followed by a stderr block at the end.
+			expect(
+				isBashFailureResponse(
+					'pre-commit\npre-push\n<bash-stderr>warning: deprecated</bash-stderr>'
+				)
+			).toBe(true);
+			// Trailing whitespace after the closing tag is tolerated.
+			expect(isBashFailureResponse('<bash-stderr>oops</bash-stderr>\n  ')).toBe(true);
+		});
+
+		it('does NOT classify literal <bash-stderr> text echoed mid-output as failures', () => {
+			// Regression test for review feedback: a command can legitimately
+			// print the literal `<bash-stderr>…</bash-stderr>` string (e.g.
+			// `echo '<bash-stderr>x</bash-stderr>'` or grepping logs for
+			// the tag). The SDK only ever appends a real stderr block at
+			// the very end of the response, so we anchor the regex to
+			// end-of-output. A tag that appears mid-stream is content, not
+			// a stderr signal.
+			expect(
+				isBashFailureResponse('<bash-stderr>echoed-by-command</bash-stderr> more stdout after')
+			).toBe(false);
+			expect(
+				isBashFailureResponse(
+					'first line\n<bash-stderr>fake</bash-stderr>\nsecond line\nthird line'
+				)
+			).toBe(false);
 		});
 
 		it('does NOT classify free-form strings with textual error markers as failures', () => {

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -854,6 +854,113 @@ describe('LoopDetectorHook', () => {
 				);
 			}
 		});
+
+		it('strips `description` from the Bash fingerprint (reworded labels still loop-detect)', async () => {
+			// Regression test for review feedback: the model frequently
+			// rewords the non-semantic `description` field between retries
+			// ("Check git hooks" → "List hook files"). Including description
+			// in the fingerprint would defeat the detector — every retry
+			// would look like a fresh command. We strip it.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks();
+			const command = 'ls -la .git/hooks 2>&1';
+			const descriptions = [
+				'Check git hooks',
+				'List hook files',
+				'Inspect hook dir',
+				'Show hooks',
+				'View hooks dir',
+				'Look at hooks',
+			];
+
+			// Six failing calls, each with a different description but the
+			// same command. Despite the differing descriptions, all six must
+			// fingerprint to the same key, build a streak, accumulate
+			// failures, and deny on the 6th attempt (5 failures recorded
+			// from the first 5 attempts).
+			for (let i = 0; i < 5; i++) {
+				const pre = makePreToolUse('Bash', { command, description: descriptions[i] });
+				expect(await call(preToolUse, pre)).toEqual({});
+				await callPost(
+					postToolUse,
+					makePostToolUse(
+						'Bash',
+						pre.tool_input as Record<string, unknown>,
+						makeBashFailureResponse()
+					)
+				);
+			}
+			const finalPre = makePreToolUse('Bash', { command, description: descriptions[5] });
+			expect(await call(preToolUse, finalPre)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('does NOT count user/system interrupts as failures', async () => {
+			// PostToolUseFailure with is_interrupt=true means a human (or
+			// concurrent action) cancelled the call before it completed. The
+			// command itself didn't fail — counting interrupts would let a
+			// user who repeatedly hits stop poison the ring and block their
+			// own legitimate retries.
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
+			const cmd = makePreToolUse('Bash', { command: 'sleep 100' });
+			const args = cmd.tool_input as Record<string, unknown>;
+
+			// Fire 6 PreToolUse → interrupted-PostToolUseFailure pairs. Even
+			// though the streak builds to 6, the failure ring should remain
+			// empty (interrupts are not failures), so no deny fires.
+			for (let i = 0; i < 6; i++) {
+				expect(await call(preToolUse, cmd)).toEqual({});
+				await callPost(
+					postToolUseFailure,
+					makePostToolUseFailure('Bash', args, { is_interrupt: true })
+				);
+			}
+		});
+
+		it('counts non-interrupt PostToolUseFailure as a real failure', async () => {
+			// Sanity check: the interrupt skip is conditional, not blanket.
+			// A non-interrupt failure (hook crash, sandbox kill) still gets
+			// recorded and contributes to the failure ring.
+			const { preToolUse, postToolUseFailure } = createLoopDetectorHooks();
+			const args = FAILING_BASH.tool_input as Record<string, unknown>;
+
+			for (let i = 0; i < 5; i++) {
+				expect(await call(preToolUse, FAILING_BASH)).toEqual({});
+				await callPost(
+					postToolUseFailure,
+					makePostToolUseFailure('Bash', args /* no is_interrupt */)
+				);
+			}
+			expect(await call(preToolUse, FAILING_BASH)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('does NOT block legitimate retries after a long quiet period (stale rings expire)', async () => {
+			// The bashFailures map is opportunistically pruned of entries
+			// older than the sliding window. Behaviourally, a fingerprint
+			// whose recorded failures all predate the streak's first call
+			// must not be honoured: the streak itself resets when the
+			// window expires (see Pre callback), so the deny path cannot
+			// reach the ring. This test guards that lifecycle: 5 failures
+			// followed by a long quiet period followed by a fresh attempt
+			// MUST pass through, not deny.
+			const { preToolUse, postToolUse } = createLoopDetectorHooks({ windowMs: 50 });
+			const cmd = makePreToolUse('Bash', { command: 'ls /nope' });
+			const args = cmd.tool_input as Record<string, unknown>;
+
+			// Record 5 failures.
+			for (let i = 0; i < 5; i++) {
+				await call(preToolUse, cmd);
+				await callPost(postToolUse, makePostToolUse('Bash', args, makeBashFailureResponse()));
+			}
+
+			// Wait past the sliding window. The next PreToolUse call sees a
+			// stale streak (firstSeenMs older than windowMs) and resets the
+			// streak counter to 1. nextCount < threshold ⇒ no deny.
+			await new Promise((r) => setTimeout(r, 80));
+			expect(await call(preToolUse, cmd)).toEqual({});
+		});
 	});
 
 	describe('isBashFailureResponse classifier', () => {
@@ -869,9 +976,13 @@ describe('LoopDetectorHook', () => {
 			);
 		});
 
-		it('classifies strings with exit-code error markers as failures', () => {
-			expect(isBashFailureResponse('Exit code: 1')).toBe(true);
-			expect(isBashFailureResponse('Some output\nExit code: 127')).toBe(true);
+		it('does NOT classify free-form strings with "Exit code:" text as failures', () => {
+			// We deliberately do not substring-scan stdout. Commands frequently
+			// emit phrases like "Exit code: 1" in their normal output (test
+			// runner summaries, status reports), and counting those as
+			// failures would poison the failure ring with false positives.
+			expect(isBashFailureResponse('Exit code: 1')).toBe(false);
+			expect(isBashFailureResponse('Some output\nExit code: 127')).toBe(false);
 			expect(isBashFailureResponse('Exit code: 0')).toBe(false);
 		});
 
@@ -883,13 +994,20 @@ describe('LoopDetectorHook', () => {
 			).toBe(true);
 			// Empty stderr block is not a failure.
 			expect(isBashFailureResponse('<bash-stderr></bash-stderr>')).toBe(false);
+			// Whitespace-only stderr block is not a failure either.
+			expect(isBashFailureResponse('<bash-stderr>   \n\t</bash-stderr>')).toBe(false);
 		});
 
-		it('classifies textual error markers as failures', () => {
-			expect(isBashFailureResponse('bash: foo: command not found')).toBe(true);
-			expect(isBashFailureResponse('ls: /nope: No such file or directory')).toBe(true);
-			expect(isBashFailureResponse('Permission denied')).toBe(true);
-			expect(isBashFailureResponse('command timed out after 120s')).toBe(true);
+		it('does NOT classify free-form strings with textual error markers as failures', () => {
+			// Stdout legitimately contains these phrases in many real
+			// workflows: greping log files for "permission denied", tutorials,
+			// docs commands, error messages quoted in test output, etc. The
+			// classifier must not treat them as command failures — the
+			// trustworthy stderr signal is the <bash-stderr> block.
+			expect(isBashFailureResponse('bash: foo: command not found')).toBe(false);
+			expect(isBashFailureResponse('ls: /nope: No such file or directory')).toBe(false);
+			expect(isBashFailureResponse('Permission denied')).toBe(false);
+			expect(isBashFailureResponse('command timed out after 120s')).toBe(false);
 		});
 
 		it('classifies object responses with is_error=true as failures', () => {
@@ -916,10 +1034,22 @@ describe('LoopDetectorHook', () => {
 			).toBe(true);
 		});
 
-		it('classifies content-block arrays with error markers in text as failures', () => {
+		it('classifies content-block arrays with non-empty bash-stderr text as failures', () => {
+			expect(
+				isBashFailureResponse([
+					{ type: 'text', text: '<bash-stderr>ls: foo: No such file or directory</bash-stderr>' },
+				])
+			).toBe(true);
+		});
+
+		it('does NOT classify content-block arrays whose text merely mentions errors as failures', () => {
+			// Same conservative rule as for plain strings: stdout text is not
+			// a failure signal, even if it contains phrases like "No such
+			// file". Only <bash-stderr> delimiters or top-level is_error
+			// count.
 			expect(
 				isBashFailureResponse([{ type: 'text', text: 'ls: foo: No such file or directory' }])
-			).toBe(true);
+			).toBe(false);
 		});
 
 		it('does NOT classify plain success object responses as failures', () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -864,6 +864,23 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
 		});
 
+		it('installs paired PostToolUse and PostToolUseFailure observers for the Bash dead-loop detector', async () => {
+			const options = await builder.build();
+
+			// The Bash failure-aware detector needs the PostToolUse and
+			// PostToolUseFailure events to populate its outcome ring. Without
+			// these the Bash deny path is permanently disabled.
+			expect(options.hooks?.PostToolUse).toBeDefined();
+			expect(options.hooks?.PostToolUse).toHaveLength(1);
+			expect(options.hooks?.PostToolUse?.[0]?.matcher).toBeUndefined();
+			expect(options.hooks?.PostToolUse?.[0]?.hooks).toHaveLength(1);
+
+			expect(options.hooks?.PostToolUseFailure).toBeDefined();
+			expect(options.hooks?.PostToolUseFailure).toHaveLength(1);
+			expect(options.hooks?.PostToolUseFailure?.[0]?.matcher).toBeUndefined();
+			expect(options.hooks?.PostToolUseFailure?.[0]?.hooks).toHaveLength(1);
+		});
+
 		it('compiles declarative tool guards into PreToolUse hooks', async () => {
 			const guardBuilder = new QueryOptionsBuilder({
 				...mockContext,


### PR DESCRIPTION
Closes task #333.

Extends the loop-detector hook (PR #1849) to catch the Bash variant of the dead-loop failure mode: e.g. an agent re-running `ls -la .git/hooks 2>&1` 60 times in a row, each time getting the same error, never adjusting its approach.

## Approach

Bash output legitimately changes across calls (polling `git status`, retrying `bun test` after a fix), so denying purely on repetition would block real workflows. The detector uses option 4 from the task description — a hybrid:

- **PostToolUse + PostToolUseFailure** hooks record each Bash outcome into a per-fingerprint failure ring (last N outcomes).
- **PreToolUse** denies only when ALL of: (1) same command N times in a row, (2) last N outcomes all failures, (3) streak fits inside the sliding window.
- A single successful run purges the deny condition — flaky retries that eventually succeed are not penalised.
- Streak resets on any different action (different Bash command, different tool, untracked tool, window expiry).

## Defaults

| Setting | Value | Notes |
|---|---|---|
| `bash.threshold` | 5 | consecutive identical Bash calls |
| `bash.failuresRequired` | 5 | most recent outcomes must all be failures |
| `windowMs` | 60000 | shared with Read/Grep/Glob |

The shared-state factory `createLoopDetectorHooks()` returns matched pre/post callbacks so production wiring is one call. The legacy `createLoopDetectorHook()` factory is preserved for tests that only exercise the pre-hook.

## Failure classifier

`isBashFailureResponse()` is conservative — false positives would block legitimate retries, so when in doubt the response is treated as success. Recognised failure signals: `is_error: true`, `interrupted: true`, non-zero exit codes, `<bash-stderr>` blocks, and strong textual markers (`command not found`, `No such file or directory`, `Permission denied`, `command timed out`, `Exit code: N` for N≠0).

## Tests

201 tests total (24 existing + 24 new Bash + 13 classifier + 1 query-options-builder wiring + 139 unchanged):

- repeated failing commands → deny after 5
- repeated succeeding commands → never deny
- mixed success/failure (one success purges the ring) → never deny
- different Bash command resets streak
- non-Bash tool resets streak
- PostToolUseFailure counted as failure
- continued denies on retry without different action
- per-(session, agent) isolation
- interrupted responses treated as failures
- classifier coverage across object/string/content-block shapes