### PR TITLE
perf(daemon): index-targeted lookups for hot sdk_messages LiveQueries

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -735,14 +735,26 @@ all_sessions AS (
 unique_session_ids AS (
   SELECT DISTINCT session_id FROM all_sessions
 ),
+-- Per-session message count + lastMessageAt. Phrased as two correlated scalar
+-- subqueries over unique_session_ids so SQLite picks the (session_id, ...)
+-- covering indexes per-session-lookup instead of full-scanning
+-- idx_sdk_messages_session_id to satisfy a GROUP BY join. On the live
+-- daemon DB the GROUP BY form was ~280 ms (full index scan of 1.68M rows);
+-- the per-session lookup form is sub-millisecond.
 message_stats AS (
   SELECT
-    sm.session_id,
-    COUNT(*) AS messageCount,
-    MAX(CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER)) AS lastMessageAt
-  FROM sdk_messages sm
-  JOIN unique_session_ids usi ON usi.session_id = sm.session_id
-  GROUP BY sm.session_id
+    usi.session_id AS session_id,
+    (
+      SELECT COUNT(*)
+      FROM sdk_messages sm
+      WHERE sm.session_id = usi.session_id
+    ) AS messageCount,
+    (
+      SELECT CAST((julianday(MAX(sm.timestamp)) - 2440587.5) * 86400000 AS INTEGER)
+      FROM sdk_messages sm
+      WHERE sm.session_id = usi.session_id
+    ) AS lastMessageAt
+  FROM unique_session_ids usi
 )
 SELECT
   ase.session_id AS id,
@@ -919,12 +931,33 @@ sdk_rows_with_pos AS (
     ROW_NUMBER() OVER (
       PARTITION BY r.sessionId
       ORDER BY r.createdAt ASC, r.id ASC
-    ) AS rowPos
+    ) AS rowPos,
+    -- Mark this row's own rowPos as the carry-forward sentinel when it's a
+    -- user row; otherwise NULL. Combined with the MAX() window below this
+    -- lets us forward-fill the latest user-row position per session without
+    -- a per-row correlated subquery.
+    CASE WHEN r.messageType = 'user' THEN
+      ROW_NUMBER() OVER (PARTITION BY r.sessionId ORDER BY r.createdAt ASC, r.id ASC)
+      ELSE NULL END AS thisUserRowPos
   FROM sdk_rows_raw r
 ),
+-- Forward-fill the latest user-row position seen in each session up to and
+-- including the current row. SQLite ignores NULLs in MAX(), so this carries
+-- the most recent user thisUserRowPos through subsequent rows.
+sdk_rows_with_turn AS (
+  SELECT
+    p.*,
+    MAX(p.thisUserRowPos) OVER (
+      PARTITION BY p.sessionId
+      ORDER BY p.rowPos
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS turnUserRowPos
+  FROM sdk_rows_with_pos p
+),
 user_row_starts AS (
-  -- For each user row, capture (sessionId, rowPos) and its own id. Non-user
-  -- rows pick up the most recent user-row id by joining on rowPos <= current.
+  -- For each user row, capture (sessionId, rowPos) and its own id. The
+  -- per-row carry-forward is computed in sdk_rows_with_turn; this lookup
+  -- maps that rowPos back to the user message id with a single join.
   SELECT
     sessionId,
     rowPos AS userRowPos,
@@ -934,30 +967,26 @@ user_row_starts AS (
 ),
 sdk_rows AS (
   SELECT
-    p.id,
-    p.sessionId,
-    p.kind,
-    p.role,
-    p.label,
-    p.nodeExecutionId,
-    p.taskId,
-    p.taskTitle,
-    p.messageType,
-    p.content,
-    p.origin,
-    p.createdAt,
-    p.parentToolUseId,
-    p.isRenderable,
-    p.isTerminal,
-    (
-      SELECT urs.userMessageId
-      FROM user_row_starts urs
-      WHERE urs.sessionId = p.sessionId
-        AND urs.userRowPos <= p.rowPos
-      ORDER BY urs.userRowPos DESC
-      LIMIT 1
-    ) AS turnUserMessageId
-  FROM sdk_rows_with_pos p
+    t.id,
+    t.sessionId,
+    t.kind,
+    t.role,
+    t.label,
+    t.nodeExecutionId,
+    t.taskId,
+    t.taskTitle,
+    t.messageType,
+    t.content,
+    t.origin,
+    t.createdAt,
+    t.parentToolUseId,
+    t.isRenderable,
+    t.isTerminal,
+    urs.userMessageId AS turnUserMessageId
+  FROM sdk_rows_with_turn t
+  LEFT JOIN user_row_starts urs
+    ON urs.sessionId = t.sessionId
+   AND urs.userRowPos = t.turnUserRowPos
 ),
 joined AS (
   SELECT * FROM github_events

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -750,7 +750,7 @@ message_stats AS (
       WHERE sm.session_id = usi.session_id
     ) AS messageCount,
     (
-      SELECT CAST((julianday(MAX(sm.timestamp)) - 2440587.5) * 86400000 AS INTEGER)
+      SELECT MAX(CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER))
       FROM sdk_messages sm
       WHERE sm.session_id = usi.session_id
     ) AS lastMessageAt

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -925,21 +925,24 @@ sdk_rows_raw AS (
   LEFT JOIN space_agents sa ON sa.id = sne.agent_id
   WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 ),
-sdk_rows_with_pos AS (
+sdk_rows_numbered AS (
   SELECT
     r.*,
     ROW_NUMBER() OVER (
       PARTITION BY r.sessionId
       ORDER BY r.createdAt ASC, r.id ASC
-    ) AS rowPos,
-    -- Mark this row's own rowPos as the carry-forward sentinel when it's a
-    -- user row; otherwise NULL. Combined with the MAX() window below this
-    -- lets us forward-fill the latest user-row position per session without
-    -- a per-row correlated subquery.
-    CASE WHEN r.messageType = 'user' THEN
-      ROW_NUMBER() OVER (PARTITION BY r.sessionId ORDER BY r.createdAt ASC, r.id ASC)
-      ELSE NULL END AS thisUserRowPos
+    ) AS rowPos
   FROM sdk_rows_raw r
+),
+sdk_rows_with_pos AS (
+  -- Mark this row's own rowPos as the carry-forward sentinel when it's a
+  -- user row; otherwise NULL. Combined with the MAX() window below this
+  -- lets us forward-fill the latest user-row position per session without
+  -- a per-row correlated subquery or a second ROW_NUMBER() pass.
+  SELECT
+    n.*,
+    CASE WHEN n.messageType = 'user' THEN n.rowPos ELSE NULL END AS thisUserRowPos
+  FROM sdk_rows_numbered n
 ),
 -- Forward-fill the latest user-row position seen in each session up to and
 -- including the current row. SQLite ignores NULLs in MAX(), so this carries

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -657,28 +657,33 @@ export class SDKMessageRepository {
 	 * Used by rewind to look up a specific checkpoint/message.
 	 *
 	 * The previous implementation loaded every user row for the session and
-	 * scanned in JS — O(N) per lookup. The current form pushes the UUID
-	 * predicate into SQL and uses `idx_sdk_messages_uuid_status`
-	 * `(session_id, send_status, json_extract uuid)` for a full 3-column
-	 * index seek.
+	 * scanned in JS — O(N) per lookup. The current form uses
+	 * `idx_sdk_messages_uuid_status (session_id, send_status,
+	 * json_extract uuid)` for a full 3-column index seek.
 	 *
-	 * Strategy: try `send_status = 'consumed'` first (the >99% case — see
-	 * the established rewind predicate elsewhere in this file:
-	 * `COALESCE(send_status, 'consumed') IN ('consumed', 'failed')`), then
-	 * `'failed'`. Rewindable user messages are always consumed or failed;
-	 * deferred/enqueued user messages haven't been sent yet and are not
-	 * rewind targets. A final fallback scan covers legacy rows with NULL
-	 * `send_status` (none observed in production but kept for safety).
+	 * Coverage must match `getUserMessages` (which returns user rows of
+	 * every `send_status`), otherwise rewind would surface a checkpoint
+	 * it then can't resolve. We probe each known status in turn — the
+	 * planner only picks the full 3-column seek when `send_status` is
+	 * constrained to a single value, so `IN (…)` is not enough — and a
+	 * final fallback covers legacy rows with NULL `send_status` (none
+	 * observed in the current production DB but historically possible).
 	 *
-	 * If duplicate uuids exist within the same session (no DB-level
-	 * uniqueness constraint on the json_extract'd uuid), we preserve the
-	 * previous implementation's earliest-wins tiebreak via
-	 * `ORDER BY timestamp ASC LIMIT 1` on the fallback path. The indexed
-	 * seeks return LIMIT 1 directly — duplicates within the same
-	 * (session_id, send_status, uuid) are not expected.
+	 * Determinism: if duplicate uuids exist within the same session
+	 * (no DB-level uniqueness constraint on the json_extract'd uuid),
+	 * the previous implementation returned the chronologically earliest
+	 * row across the whole session. We preserve that by collecting every
+	 * matching row from each per-status seek (via `.all()` rather than
+	 * `LIMIT 1`) and picking the overall earliest in JS. The NULL
+	 * fallback is only consulted when no indexed-status seek matched,
+	 * so legacy and modern data don't compete on every call — a
+	 * duplicate uuid co-existing across NULL and a known status in the
+	 * same session is not a real-world case.
 	 *
-	 * Benchmark on a 42 061-row session: ~280 ms (before) → ~0.05 ms
-	 * (indexed seek path) — ~3000x speedup.
+	 * Benchmark on a 42 061-row session: ~300 ms (before) → ~0.04 ms
+	 * (4 indexed seeks, no NULL fallback) — ~7500x speedup. NULL
+	 * fallback alone is ~220 ms but only runs when no indexed status
+	 * matched, which the production DB has never been observed to need.
 	 *
 	 * @param sessionId - The session ID
 	 * @param uuid - The message UUID
@@ -688,44 +693,64 @@ export class SDKMessageRepository {
 		sessionId: string,
 		uuid: string
 	): { uuid: string; timestamp: number; content: string } | undefined {
-		// Fast path: indexed seek against idx_sdk_messages_uuid_status, one
-		// send_status at a time so the planner picks the 3-column seek.
+		// Fast path: indexed seek against idx_sdk_messages_uuid_status. We
+		// probe each known send_status separately because the planner only
+		// picks the 3-column index when send_status is constrained to a
+		// single value; `IN (…)` falls back to a session-partition scan.
+		// We deliberately omit `ORDER BY` here — adding one causes the
+		// planner to switch to `idx_sdk_messages_session (session_id,
+		// timestamp)` and lose the indexed seek (~0.01 ms → ~200 ms).
+		// In-bucket determinism is recovered by collecting all matches per
+		// bucket and picking the earliest in JS below.
 		const indexedStmt = this.db.prepare(
 			`SELECT sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
          AND send_status = ?
          AND message_type = 'user'
-         AND json_extract(sdk_message, '$.uuid') = ?
-       LIMIT 1`
+         AND json_extract(sdk_message, '$.uuid') = ?`
 		);
 
-		for (const status of ['consumed', 'failed']) {
-			const row = indexedStmt.get(sessionId, status, uuid) as
-				| { sdk_message: string; timestamp: string }
-				| undefined;
-			if (row) {
-				return this.parseUserMessageRow(row, uuid);
-			}
+		const STATUSES_TO_PROBE: SendStatus[] = ['consumed', 'failed', 'enqueued', 'deferred'];
+		const candidates: Array<{ sdk_message: string; timestamp: string }> = [];
+		for (const status of STATUSES_TO_PROBE) {
+			const rows = indexedStmt.all(sessionId, status, uuid) as Array<{
+				sdk_message: string;
+				timestamp: string;
+			}>;
+			for (const r of rows) candidates.push(r);
 		}
 
-		// Fallback: legacy rows with NULL send_status (not observed in
-		// production but kept for safety). This path scans the session
-		// partition; ORDER BY preserves the earliest-match tiebreak the
-		// pre-optimization implementation used.
-		const fallbackStmt = this.db.prepare(
-			`SELECT sdk_message, timestamp FROM sdk_messages
+		// Fallback: legacy rows with NULL send_status. Not observed in the
+		// current production DB but historically possible. This path scans
+		// the session partition rather than seeking the index, so only run
+		// it when no indexed status seek matched — otherwise it would
+		// dominate the cost on every call.
+		if (candidates.length === 0) {
+			const fallbackStmt = this.db.prepare(
+				`SELECT sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
          AND send_status IS NULL
          AND message_type = 'user'
          AND json_extract(sdk_message, '$.uuid') = ?
        ORDER BY timestamp ASC
        LIMIT 1`
-		);
-		const row = fallbackStmt.get(sessionId, uuid) as
-			| { sdk_message: string; timestamp: string }
-			| undefined;
-		if (!row) return undefined;
-		return this.parseUserMessageRow(row, uuid);
+			);
+			const nullRow = fallbackStmt.get(sessionId, uuid) as
+				| { sdk_message: string; timestamp: string }
+				| undefined;
+			if (nullRow) candidates.push(nullRow);
+		}
+
+		if (candidates.length === 0) return undefined;
+
+		// Pick the chronologically earliest match — matches the previous
+		// full-session ORDER BY timestamp ASC scan + first-match behavior
+		// that rewind timestamp math depends on.
+		let earliest = candidates[0];
+		for (let i = 1; i < candidates.length; i++) {
+			if (candidates[i].timestamp < earliest.timestamp) earliest = candidates[i];
+		}
+		return this.parseUserMessageRow(earliest, uuid);
 	}
 
 	private parseUserMessageRow(

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -656,11 +656,18 @@ export class SDKMessageRepository {
 	 *
 	 * Used by rewind to look up a specific checkpoint/message.
 	 *
-	 * Filters on `json_extract(sdk_message, '$.uuid')` directly so SQLite can
-	 * use `idx_sdk_messages_uuid_status` (covering: session_id, send_status,
-	 * uuid-expr) instead of materialising every user message and scanning in
-	 * JS. On busy sessions with tens of thousands of user rows the JS-scan
-	 * shape was ~400 ms; the indexed lookup is sub-millisecond.
+	 * The previous implementation loaded every user row for the session and
+	 * scanned in JS — O(N) per lookup. The current form pushes the UUID
+	 * predicate into SQL with `LIMIT 1` so SQLite stops at the first match.
+	 *
+	 * Index use: with the predicate set we have here (no `send_status`),
+	 * SQLite can only use the `session_id` prefix of
+	 * `idx_sdk_messages_uuid_status` — not a full 3-column seek. The win
+	 * comes from partition-pruning to one session plus early termination
+	 * via `LIMIT 1`, not from a UUID-column index lookup. We deliberately
+	 * don't add a `send_status` predicate because rewind callers don't
+	 * care about send_status (a pending user message is still a valid
+	 * rewind target). Benchmark: ~400ms → sub-ms on busy sessions.
 	 *
 	 * `ORDER BY timestamp ASC LIMIT 1` matches the previous implementation's
 	 * behavior of returning the earliest matching row when (unexpectedly)

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -662,6 +662,12 @@ export class SDKMessageRepository {
 	 * JS. On busy sessions with tens of thousands of user rows the JS-scan
 	 * shape was ~400 ms; the indexed lookup is sub-millisecond.
 	 *
+	 * `ORDER BY timestamp ASC LIMIT 1` matches the previous implementation's
+	 * behavior of returning the earliest matching row when (unexpectedly)
+	 * multiple user messages share the same uuid — there is no DB-level
+	 * uniqueness constraint on the json_extract'd uuid, so callers like
+	 * `getRewindPoint` rely on the earliest-wins tiebreak.
+	 *
 	 * @param sessionId - The session ID
 	 * @param uuid - The message UUID
 	 * @returns The message data or undefined
@@ -675,6 +681,7 @@ export class SDKMessageRepository {
        WHERE session_id = ?
          AND message_type = 'user'
          AND json_extract(sdk_message, '$.uuid') = ?
+       ORDER BY timestamp ASC
        LIMIT 1`
 		);
 		const row = stmt.get(sessionId, uuid) as { sdk_message: string; timestamp: string } | undefined;

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -680,10 +680,13 @@ export class SDKMessageRepository {
 	 * duplicate uuid co-existing across NULL and a known status in the
 	 * same session is not a real-world case.
 	 *
-	 * Benchmark on a 42 061-row session: ~300 ms (before) → ~0.04 ms
-	 * (4 indexed seeks, no NULL fallback) — ~7500x speedup. NULL
-	 * fallback alone is ~220 ms but only runs when no indexed status
-	 * matched, which the production DB has never been observed to need.
+	 * Benchmark on the largest production session (3 335 user rows in a
+	 * 42 061-row table): ~294 ms (before, full-function wall-clock) →
+	 * ~0.95 ms (after, full-function wall-clock) — ~310x speedup. The
+	 * raw 4-seek SQLite cost is only ~0.04 ms; the remainder is
+	 * JSON.parse + content extraction on the matched row. NULL fallback
+	 * alone is ~220 ms but only runs when no indexed status matched,
+	 * which the production DB has never been observed to need.
 	 *
 	 * @param sessionId - The session ID
 	 * @param uuid - The message UUID

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -656,6 +656,12 @@ export class SDKMessageRepository {
 	 *
 	 * Used by rewind to look up a specific checkpoint/message.
 	 *
+	 * Filters on `json_extract(sdk_message, '$.uuid')` directly so SQLite can
+	 * use `idx_sdk_messages_uuid_status` (covering: session_id, send_status,
+	 * uuid-expr) instead of materialising every user message and scanning in
+	 * JS. On busy sessions with tens of thousands of user rows the JS-scan
+	 * shape was ~400 ms; the indexed lookup is sub-millisecond.
+	 *
 	 * @param sessionId - The session ID
 	 * @param uuid - The message UUID
 	 * @returns The message data or undefined
@@ -666,40 +672,38 @@ export class SDKMessageRepository {
 	): { uuid: string; timestamp: number; content: string } | undefined {
 		const stmt = this.db.prepare(
 			`SELECT sdk_message, timestamp FROM sdk_messages
-       WHERE session_id = ? AND message_type = 'user'
-       ORDER BY timestamp ASC`
+       WHERE session_id = ?
+         AND message_type = 'user'
+         AND json_extract(sdk_message, '$.uuid') = ?
+       LIMIT 1`
 		);
-		const rows = stmt.all(sessionId) as Array<{ sdk_message: string; timestamp: string }>;
+		const row = stmt.get(sessionId, uuid) as { sdk_message: string; timestamp: string } | undefined;
 
-		for (const row of rows) {
-			const message = JSON.parse(row.sdk_message) as SDKMessage;
-			if (message.uuid === uuid) {
-				const timestamp = new Date(row.timestamp).getTime();
+		if (!row) return undefined;
 
-				// Extract text content from message
-				// User messages have a specific structure with nested message.content
-				let content = '';
-				const userMessage = message as {
-					message?: { content?: string | Array<{ type: string; text?: string }> };
-					uuid?: string;
-				};
-				if (userMessage.message?.content) {
-					if (typeof userMessage.message.content === 'string') {
-						content = userMessage.message.content;
-					} else if (Array.isArray(userMessage.message.content)) {
-						// Find first text block
-						const textBlock = userMessage.message.content.find(
-							(block): block is { type: 'text'; text: string } => block.type === 'text'
-						);
-						content = textBlock?.text || '';
-					}
-				}
+		const message = JSON.parse(row.sdk_message) as SDKMessage;
+		const timestamp = new Date(row.timestamp).getTime();
 
-				return { uuid, timestamp, content };
+		// Extract text content from message
+		// User messages have a specific structure with nested message.content
+		let content = '';
+		const userMessage = message as {
+			message?: { content?: string | Array<{ type: string; text?: string }> };
+			uuid?: string;
+		};
+		if (userMessage.message?.content) {
+			if (typeof userMessage.message.content === 'string') {
+				content = userMessage.message.content;
+			} else if (Array.isArray(userMessage.message.content)) {
+				// Find first text block
+				const textBlock = userMessage.message.content.find(
+					(block): block is { type: 'text'; text: string } => block.type === 'text'
+				);
+				content = textBlock?.text || '';
 			}
 		}
 
-		return undefined;
+		return { uuid, timestamp, content };
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -658,22 +658,27 @@ export class SDKMessageRepository {
 	 *
 	 * The previous implementation loaded every user row for the session and
 	 * scanned in JS — O(N) per lookup. The current form pushes the UUID
-	 * predicate into SQL with `LIMIT 1` so SQLite stops at the first match.
+	 * predicate into SQL and uses `idx_sdk_messages_uuid_status`
+	 * `(session_id, send_status, json_extract uuid)` for a full 3-column
+	 * index seek.
 	 *
-	 * Index use: with the predicate set we have here (no `send_status`),
-	 * SQLite can only use the `session_id` prefix of
-	 * `idx_sdk_messages_uuid_status` — not a full 3-column seek. The win
-	 * comes from partition-pruning to one session plus early termination
-	 * via `LIMIT 1`, not from a UUID-column index lookup. We deliberately
-	 * don't add a `send_status` predicate because rewind callers don't
-	 * care about send_status (a pending user message is still a valid
-	 * rewind target). Benchmark: ~400ms → sub-ms on busy sessions.
+	 * Strategy: try `send_status = 'consumed'` first (the >99% case — see
+	 * the established rewind predicate elsewhere in this file:
+	 * `COALESCE(send_status, 'consumed') IN ('consumed', 'failed')`), then
+	 * `'failed'`. Rewindable user messages are always consumed or failed;
+	 * deferred/enqueued user messages haven't been sent yet and are not
+	 * rewind targets. A final fallback scan covers legacy rows with NULL
+	 * `send_status` (none observed in production but kept for safety).
 	 *
-	 * `ORDER BY timestamp ASC LIMIT 1` matches the previous implementation's
-	 * behavior of returning the earliest matching row when (unexpectedly)
-	 * multiple user messages share the same uuid — there is no DB-level
-	 * uniqueness constraint on the json_extract'd uuid, so callers like
-	 * `getRewindPoint` rely on the earliest-wins tiebreak.
+	 * If duplicate uuids exist within the same session (no DB-level
+	 * uniqueness constraint on the json_extract'd uuid), we preserve the
+	 * previous implementation's earliest-wins tiebreak via
+	 * `ORDER BY timestamp ASC LIMIT 1` on the fallback path. The indexed
+	 * seeks return LIMIT 1 directly — duplicates within the same
+	 * (session_id, send_status, uuid) are not expected.
+	 *
+	 * Benchmark on a 42 061-row session: ~280 ms (before) → ~0.05 ms
+	 * (indexed seek path) — ~3000x speedup.
 	 *
 	 * @param sessionId - The session ID
 	 * @param uuid - The message UUID
@@ -683,18 +688,50 @@ export class SDKMessageRepository {
 		sessionId: string,
 		uuid: string
 	): { uuid: string; timestamp: number; content: string } | undefined {
-		const stmt = this.db.prepare(
+		// Fast path: indexed seek against idx_sdk_messages_uuid_status, one
+		// send_status at a time so the planner picks the 3-column seek.
+		const indexedStmt = this.db.prepare(
 			`SELECT sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
+         AND send_status = ?
+         AND message_type = 'user'
+         AND json_extract(sdk_message, '$.uuid') = ?
+       LIMIT 1`
+		);
+
+		for (const status of ['consumed', 'failed']) {
+			const row = indexedStmt.get(sessionId, status, uuid) as
+				| { sdk_message: string; timestamp: string }
+				| undefined;
+			if (row) {
+				return this.parseUserMessageRow(row, uuid);
+			}
+		}
+
+		// Fallback: legacy rows with NULL send_status (not observed in
+		// production but kept for safety). This path scans the session
+		// partition; ORDER BY preserves the earliest-match tiebreak the
+		// pre-optimization implementation used.
+		const fallbackStmt = this.db.prepare(
+			`SELECT sdk_message, timestamp FROM sdk_messages
+       WHERE session_id = ?
+         AND send_status IS NULL
          AND message_type = 'user'
          AND json_extract(sdk_message, '$.uuid') = ?
        ORDER BY timestamp ASC
        LIMIT 1`
 		);
-		const row = stmt.get(sessionId, uuid) as { sdk_message: string; timestamp: string } | undefined;
-
+		const row = fallbackStmt.get(sessionId, uuid) as
+			| { sdk_message: string; timestamp: string }
+			| undefined;
 		if (!row) return undefined;
+		return this.parseUserMessageRow(row, uuid);
+	}
 
+	private parseUserMessageRow(
+		row: { sdk_message: string; timestamp: string },
+		uuid: string
+	): { uuid: string; timestamp: number; content: string } {
 		const message = JSON.parse(row.sdk_message) as SDKMessage;
 		const timestamp = new Date(row.timestamp).getTime();
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -678,11 +678,12 @@ describe('SDKMessageRepository', () => {
 		});
 
 		// Regression: the original implementation loaded every user row for the
-		// session and scanned in JS — O(N) per lookup. The current impl pushes
-		// the uuid match into SQL with LIMIT 1, so SQLite stops at the first
-		// matching row (and in production can use idx_sdk_messages_uuid_status
-		// for an indexed prefix scan). The test schema mirrors the core
-		// migrations but omits that index; correctness is still validated here.
+		// session and scanned in JS — O(N) per lookup. The current impl uses
+		// indexed seeks against (session_id, send_status, json_extract uuid)
+		// for messages saved via saveUserMessage (the production path), with a
+		// fallback scan for legacy NULL-send_status rows. The test schema
+		// mirrors the core migrations but omits idx_sdk_messages_uuid_status;
+		// correctness is still validated here.
 		it('should find the right message among many user rows in the same session', () => {
 			const sessionId = 'session-busy';
 			for (let i = 0; i < 50; i++) {
@@ -694,6 +695,42 @@ describe('SDKMessageRepository', () => {
 			expect(message).toBeDefined();
 			expect(message?.uuid).toBe('uuid-37');
 			expect(message?.content).toBe('Message 37');
+		});
+
+		// Exercises the fast indexed-seek path: messages persisted via
+		// saveUserMessage have send_status set ('consumed' by default), which
+		// is what production rewind targets always look like.
+		it('should find consumed user messages via the indexed path', () => {
+			const sessionId = 'session-consumed';
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Consumed message', 'uuid-consumed'),
+				'consumed'
+			);
+
+			const message = repository.getUserMessageByUuid(sessionId, 'uuid-consumed');
+
+			expect(message).toBeDefined();
+			expect(message?.uuid).toBe('uuid-consumed');
+			expect(message?.content).toBe('Consumed message');
+		});
+
+		// Exercises the fast path for the failed-send_status branch — also a
+		// valid rewind target (see the `(send_status, 'consumed') IN
+		// ('consumed', 'failed')` predicate used elsewhere).
+		it('should find failed user messages via the indexed path', () => {
+			const sessionId = 'session-failed';
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Failed message', 'uuid-failed'),
+				'failed'
+			);
+
+			const message = repository.getUserMessageByUuid(sessionId, 'uuid-failed');
+
+			expect(message).toBeDefined();
+			expect(message?.uuid).toBe('uuid-failed');
+			expect(message?.content).toBe('Failed message');
 		});
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -676,6 +676,24 @@ describe('SDKMessageRepository', () => {
 
 			expect(message).toBeUndefined();
 		});
+
+		// Regression: the original implementation loaded every user row for the
+		// session and scanned in JS — O(N) per lookup. The current impl filters
+		// on json_extract(sdk_message, '$.uuid') so SQLite can serve the lookup
+		// from idx_sdk_messages_uuid_status. This test exercises a busy session
+		// and asserts we still return only the matching row.
+		it('should find the right message among many user rows in the same session', () => {
+			const sessionId = 'session-busy';
+			for (let i = 0; i < 50; i++) {
+				repository.saveSDKMessage(sessionId, createUserMessage(`Message ${i}`, `uuid-${i}`));
+			}
+
+			const message = repository.getUserMessageByUuid(sessionId, 'uuid-37');
+
+			expect(message).toBeDefined();
+			expect(message?.uuid).toBe('uuid-37');
+			expect(message?.content).toBe('Message 37');
+		});
 	});
 
 	describe('origin field persistence and retrieval', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -678,10 +678,11 @@ describe('SDKMessageRepository', () => {
 		});
 
 		// Regression: the original implementation loaded every user row for the
-		// session and scanned in JS — O(N) per lookup. The current impl filters
-		// on json_extract(sdk_message, '$.uuid') so SQLite can serve the lookup
-		// from idx_sdk_messages_uuid_status. This test exercises a busy session
-		// and asserts we still return only the matching row.
+		// session and scanned in JS — O(N) per lookup. The current impl pushes
+		// the uuid match into SQL with LIMIT 1, so SQLite stops at the first
+		// matching row (and in production can use idx_sdk_messages_uuid_status
+		// for an indexed prefix scan). The test schema mirrors the core
+		// migrations but omits that index; correctness is still validated here.
 		it('should find the right message among many user rows in the same session', () => {
 			const sessionId = 'session-busy';
 			for (let i = 0; i < 50; i++) {

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -732,6 +732,67 @@ describe('SDKMessageRepository', () => {
 			expect(message?.uuid).toBe('uuid-failed');
 			expect(message?.content).toBe('Failed message');
 		});
+
+		// Coverage must match getUserMessages (which returns user rows of
+		// every send_status), otherwise rewind would surface a checkpoint
+		// from a manual/queued flow that it then can't resolve.
+		it('should find enqueued user messages via the indexed path', () => {
+			const sessionId = 'session-enqueued';
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Enqueued message', 'uuid-enqueued'),
+				'enqueued'
+			);
+
+			const message = repository.getUserMessageByUuid(sessionId, 'uuid-enqueued');
+
+			expect(message).toBeDefined();
+			expect(message?.uuid).toBe('uuid-enqueued');
+		});
+
+		it('should find deferred user messages via the indexed path', () => {
+			const sessionId = 'session-deferred';
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Deferred message', 'uuid-deferred'),
+				'deferred'
+			);
+
+			const message = repository.getUserMessageByUuid(sessionId, 'uuid-deferred');
+
+			expect(message).toBeDefined();
+			expect(message?.uuid).toBe('uuid-deferred');
+		});
+
+		// If duplicate user rows share a uuid across different send_status
+		// buckets within the same session (no DB-level uniqueness on the
+		// json_extract'd uuid), the function must return the
+		// chronologically earliest row — rewind's deletion-bound math
+		// depends on the timestamp being the earliest occurrence.
+		it('should return the earliest match across send_status buckets', async () => {
+			const sessionId = 'session-dup';
+
+			// 'failed' message persisted first (earliest timestamp)
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Earliest failed copy', 'shared-uuid'),
+				'failed'
+			);
+
+			// Force a later timestamp on the second insert
+			await new Promise((r) => setTimeout(r, 5));
+
+			repository.saveUserMessage(
+				sessionId,
+				createUserMessage('Later consumed copy', 'shared-uuid'),
+				'consumed'
+			);
+
+			const message = repository.getUserMessageByUuid(sessionId, 'shared-uuid');
+
+			expect(message).toBeDefined();
+			expect(message?.content).toBe('Earliest failed copy');
+		});
 	});
 
 	describe('origin field persistence and retrieval', () => {


### PR DESCRIPTION
Follow-up to #1853. Three remaining hot paths on `sdk_messages` rewritten to use indexes / window functions instead of full scans.

## Changes

1. **`getUserMessageByUuid`** (`sdk-message-repository.ts`) — was loading every user row for the session and scanning in JS. Now four indexed seeks against `idx_sdk_messages_uuid_status (session_id, send_status, json_extract uuid)` — one per known `send_status` (`consumed`, `failed`, `enqueued`, `deferred`) — collected via `.all()` and the chronologically earliest match across buckets wins (preserves the pre-optimisation determinism). A fallback scan for legacy NULL-send_status rows runs only when no indexed seek matched. Hit on every rewind/checkpoint click. (We deliberately omit `ORDER BY` from the per-status SQL — adding it makes SQLite switch from the 3-column UUID index to the timestamp index and regresses to ~200 ms.)
2. **`SPACE_TASK_ACTIVITY_BY_TASK_SQL` `message_stats` CTE** — the `GROUP BY sm.session_id` join was forcing a full scan of `idx_sdk_messages_session_id`. Rewritten as two correlated scalar subqueries over `unique_session_ids` so SQLite picks per-session lookups.
3. **`SPACE_TASK_MESSAGES_BASE_CTE` `turnUserMessageId`** — the per-row correlated subquery was O(N×U). Replaced with `MAX() OVER` window function + LEFT JOIN to `user_row_starts`. SQLite has no `LAST_VALUE IGNORE NULLS` so we carry `rowPos` as an integer surrogate and resolve back to the user message id via the join.

## Benchmarks

### `getUserMessageByUuid` — busiest session in `~/.neokai/data/daemon.db` (uuid taken from middle of timeline, 10 runs, warmup excluded)

Full-function wall-clock (includes JSON.parse + content extraction). Raw 4-seek SQLite cost is ~0.04 ms; the rest is JSON work on the matched row.

| query                | user rows | before (ms) | after (ms) | speedup |
| -------------------- | --------: | ----------: | ---------: | ------: |
| getUserMessageByUuid |      3335 |      294.00 |       0.95 |    310x |

### LiveQueries — 5 representative tasks (3 runs each, warmup excluded)

| query        | task     | rows | before (ms) | after (ms) | speedup |
| ------------ | -------- | ---: | ----------: | ---------: | ------: |
| activity     | 9f7038f7 |    3 |       319.9 |        0.9 |  363x   |
| compact      | 9f7038f7 | 1537 |      1406.4 |      323.5 |   4.3x  |
| active-turn  | 9f7038f7 | 1421 |      1361.6 |      302.3 |   4.5x  |
| activity     | c1525ca4 |    2 |       289.5 |        0.7 |  413x   |
| compact      | c1525ca4 |  864 |      1981.6 |      418.6 |   4.7x  |
| active-turn  | c1525ca4 |  792 |      1878.0 |      423.7 |   4.4x  |
| activity     | 31ba3d09 |    1 |       292.6 |        0.7 |  418x   |
| compact      | 31ba3d09 |  728 |      1135.5 |      271.6 |   4.2x  |
| active-turn  | 31ba3d09 |  709 |      1098.1 |      256.4 |   4.3x  |
| activity     | 485f6fec |    1 |       280.8 |        0.8 |  351x   |
| compact      | 485f6fec |  812 |      1421.2 |      342.7 |   4.1x  |
| active-turn  | 485f6fec |  784 |      1390.7 |      330.6 |   4.2x  |
| activity     | 00071b14 |    1 |       275.6 |        0.7 |  394x   |
| compact      | 00071b14 |  691 |      1209.3 |      292.4 |   4.1x  |
| active-turn  | 00071b14 |  673 |      1163.7 |      278.5 |   4.2x  |

Row-by-row equality verified between BEFORE and AFTER SQL across 8 tasks — output is identical.

## Tests

- Tests in `sdk-message-repository.test.ts` for `getUserMessageByUuid`: 50-row scan regression, indexed-seek paths for `consumed`/`failed`/`enqueued`/`deferred`, and cross-bucket earliest-match determinism.
- Full daemon suite (65 tests in this file) and `bun run check` pass.