### PR TITLE
fix(daemon): add pr_url field to review-posted-gate

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -226,7 +226,8 @@ const PR_READY_BASH_SCRIPT = [
  * evidence is accepted only when the authenticated GitHub user is the PR author.
  *
  * Environment variables:
- *   NEOKAI_GATE_DATA_JSON       — current gate data; may contain `pr_url` or `review_url`
+ *   NEOKAI_GATE_DATA_JSON       — current gate data; contains `pr_url` (PR URL, preferred)
+ *                                 and `review_url` (review permalink, fallback)
  *   NEOKAI_WORKFLOW_START_ISO   — ISO8601 timestamp of workflowRun.createdAt,
  *                                 injected by the gate script runner
  */
@@ -721,6 +722,12 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 				'PR conversation comments for same-account setups where GitHub blocks self-reviews. ' +
 				'Blocks the Review → Coding feedback channel until review evidence is visible on the PR.',
 			fields: [
+				{
+					name: 'pr_url',
+					type: 'string',
+					writers: ['Review'],
+					check: { op: 'exists' },
+				},
 				{
 					name: 'review_url',
 					type: 'string',

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -162,17 +162,26 @@ describe('CODING_WORKFLOW template', () => {
 		expect(CODING_WORKFLOW.gates).toHaveLength(2);
 		const gateIds = CODING_WORKFLOW.gates!.map((g) => g.id).sort();
 		expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate']);
-		for (const gate of CODING_WORKFLOW.gates!) {
-			expect(gate.fields).toHaveLength(1);
-		}
+		// code-ready-gate has 1 field (pr_url); review-posted-gate has 2 fields (pr_url + review_url)
+		const codeReadyGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
+		expect(codeReadyGate.fields).toHaveLength(1);
+		const reviewPostedGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		expect(reviewPostedGate.fields).toHaveLength(2);
 	});
 
-	test('review-posted-gate has review_url field writable only by Review node', () => {
+	test('review-posted-gate has pr_url and review_url fields writable only by Review node', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-		const field = gate.fields.find((f) => f.name === 'review_url')!;
-		expect(field.type).toBe('string');
-		expect(field.writers).toEqual(['Review']);
-		expect(field.check.op).toBe('exists');
+		expect(gate.fields).toHaveLength(2);
+
+		const prField = gate.fields.find((f) => f.name === 'pr_url')!;
+		expect(prField.type).toBe('string');
+		expect(prField.writers).toEqual(['Review']);
+		expect(prField.check.op).toBe('exists');
+
+		const reviewField = gate.fields.find((f) => f.name === 'review_url')!;
+		expect(reviewField.type).toBe('string');
+		expect(reviewField.writers).toEqual(['Review']);
+		expect(reviewField.check.op).toBe('exists');
 	});
 
 	test('review-posted-gate has bash script verifying a review submitted after workflow start', () => {
@@ -357,6 +366,58 @@ describe('CODING_WORKFLOW template', () => {
 			});
 			expect(readFileSync(logPath, 'utf8').trim()).toBe(
 				`pr view ${reviewUrl} --json reviews,comments,author`
+			);
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
+	test('review-posted-gate prefers pr_url over review_url when both are in gate data', async () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-prefers-pr-url-'));
+		const binDir = join(workspace, 'bin');
+		const ghPath = join(binDir, 'gh');
+		const logPath = join(workspace, 'gh-args.log');
+		const prUrl = 'https://github.com/test/repo/pull/42';
+		const reviewUrl = 'https://github.com/test/repo/pull/42#pullrequestreview-123';
+
+		try {
+			mkdirSync(binDir);
+			writeFileSync(
+				ghPath,
+				[
+					'#!/usr/bin/env bash',
+					`printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
+					`  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"CHANGES_REQUESTED"}],"comments":[],"author":{"login":"other"}}'`,
+					'  exit 0',
+					'fi',
+					'printf "unexpected gh args: %s\\n" "$*" >&2',
+					'exit 2',
+				].join('\n')
+			);
+			chmodSync(ghPath, 0o755);
+
+			const result = await executeGateScript(
+				gate.script!,
+				{
+					workspacePath: workspace,
+					gateId: 'review-posted-gate',
+					runId: 'run-1',
+					gateData: { pr_url: prUrl, review_url: reviewUrl },
+					workflowStartIso: '2026-05-01T00:00:00Z',
+				},
+				{ PATH: `${binDir}:${process.env.PATH ?? ''}` }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				pr_url: prUrl,
+				review_count: 1,
+				review_evidence: 'formal_review',
+			});
+			expect(readFileSync(logPath, 'utf8').trim()).toBe(
+				`pr view ${prUrl} --json reviews,comments,author`
 			);
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });


### PR DESCRIPTION
The review-posted-gate script was failing with \"No PR URL available to verify review\" because the gate only declared a `review_url` field. When the Review node sent `data: { pr_url, review_url }`, the `pr_url` was stripped during gate write authorization (only declared fields are written), leaving only `review_url` in gate data.

The script tried `.pr_url // .review_url` from gate data, but `review_url` is often a review permalink that `gh pr view` may not handle correctly. The fallback `gh pr view --json url` also fails when not on the PR branch.

**Fix:** add `pr_url` as a declared field on `review-posted-gate` (writable by Review). Now both `pr_url` and `review_url` are persisted to gate data, and the script can read the clean PR URL directly.

- Add `pr_url` field to `review-posted-gate` fields array
- Update gate field count test
- Add test verifying script prefers `pr_url` over `review_url` when both present