### PR TITLE
feat(daemon): add migration M127 to backfill pr_url onto review-posted-gate

### DIFF
--- a/packages/daemon/src/storage/schema/m127-backfill-review-posted-gate-pr-url.ts
+++ b/packages/daemon/src/storage/schema/m127-backfill-review-posted-gate-pr-url.ts
@@ -1,0 +1,114 @@
+/**
+ * Migration 127 — Backfill `pr_url` field onto existing `review-posted-gate` definitions.
+ *
+ * Context: the built-in Coding Workflow's `review-posted-gate` previously declared
+ * only a `review_url` field. The gate script needs a clean PR URL to verify reviews
+ * via `gh pr view`, but `review_url` is often a review permalink (with
+ * `#pullrequestreview-...`) that `gh` may not handle correctly. The fix adds `pr_url`
+ * as a second field on the gate, but `seedBuiltInWorkflows` does NOT re-stamp `gates`
+ * on existing rows — it only updates `completionAutonomyLevel`, `postApproval`,
+ * `templateHash`, and `toolGuards`. Without this migration, existing spaces keep the
+ * stale single-field gate definition forever.
+ *
+ * What this migration does:
+ *   For each `space_workflows` row whose `gates` JSON contains a `review-posted-gate`
+ *   with a `review_url` field but no `pr_url` field, insert `pr_url` as an additional
+ *   field with the same shape (type: 'string', writers: ['Review'], check: exists).
+ *   Gates that lack `review_url` are left untouched — the migration only handles the
+ *   expected historical shape.
+ *
+ * Self-contained by design — migrations must not depend on runtime app logic that may
+ * drift over time. The gate shape is inlined here so the migration's behaviour is
+ * frozen at the time it was authored.
+ *
+ * Idempotent: re-running on a DB whose gates already have `pr_url` is a no-op.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Frozen gate field shape — matches the built-in-workflows.ts definition at
+// the time M127 was authored.
+// ---------------------------------------------------------------------------
+
+const PR_URL_FIELD: GateField = {
+	name: 'pr_url',
+	type: 'string',
+	writers: ['Review'],
+	check: { op: 'exists' },
+};
+
+interface GateField {
+	name: string;
+	type: string;
+	writers: string[];
+	check:
+		| { op: string }
+		| { op: string; value?: unknown }
+		| { op: string; match: string; min: number };
+}
+
+interface Gate {
+	id?: string;
+	fields?: GateField[];
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+// ---------------------------------------------------------------------------
+// Migration entrypoint
+// ---------------------------------------------------------------------------
+
+export function runMigration127(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+
+	// Select rows that have a non-null gates column.
+	const rows = db
+		.prepare(`SELECT id, gates FROM space_workflows WHERE gates IS NOT NULL`)
+		.all() as Array<{ id: string; gates: string | null }>;
+
+	const update = db.prepare(`UPDATE space_workflows SET gates = ? WHERE id = ?`);
+
+	for (const row of rows) {
+		if (!row.gates) continue;
+
+		let parsed: Gate[];
+		try {
+			parsed = JSON.parse(row.gates) as Gate[];
+		} catch {
+			continue; // skip unparseable JSON
+		}
+		if (!Array.isArray(parsed)) continue;
+
+		let modified = false;
+
+		for (const gate of parsed) {
+			if (gate.id !== 'review-posted-gate') continue;
+			if (!Array.isArray(gate.fields)) continue;
+
+			// Already has pr_url — skip this gate
+			const hasPrUrl = gate.fields.some((f) => f.name === 'pr_url');
+			if (hasPrUrl) continue;
+
+			// Insert pr_url before review_url so the script's `.pr_url // .review_url`
+			// jq fallback reads pr_url first when both are present.
+			const reviewUrlIndex = gate.fields.findIndex((f) => f.name === 'review_url');
+			if (reviewUrlIndex === -1) continue; // unexpected shape — leave alone
+			gate.fields.splice(reviewUrlIndex, 0, { ...PR_URL_FIELD });
+			modified = true;
+		}
+
+		if (modified) {
+			update.run(JSON.stringify(parsed), row.id);
+		}
+	}
+}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -12,6 +12,7 @@
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { runMigration94 as runMigration94External } from './m94-backfill-workflow-templates';
 import { runMigration106 as runMigration106External } from './m106-backfill-agent-templates';
+import { runMigration127 as runMigration127External } from './m127-backfill-review-posted-gate-pr-url';
 
 /**
  * Run all database migrations
@@ -609,6 +610,14 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   call sites — keeping both costs write throughput without buying lookup
 	//   speed.
 	runMigration126(db);
+
+	// Migration 127: Backfill `pr_url` field onto existing `review-posted-gate`
+	//   definitions in `space_workflows.gates`. The built-in Coding Workflow's
+	//   `review-posted-gate` previously declared only `review_url`; the gate script
+	//   needs a clean PR URL to verify reviews. `seedBuiltInWorkflows` does NOT
+	//   re-stamp `gates` on existing rows, so this migration is required for
+	//   existing spaces to receive the fix.
+	runMigration127(db);
 }
 
 /**
@@ -1593,6 +1602,15 @@ function quoteSqlIdent(identifier: string): string {
 
 function quoteSqlString(value: string): string {
 	return `'${value.replaceAll("'", "''")}'`;
+}
+
+/**
+ * Migration 127 — delegated to m127-backfill-review-posted-gate-pr-url.ts so the
+ * backfill block doesn't bloat this file. The behaviour is documented in that
+ * module. Exported for direct invocation from tests.
+ */
+export function runMigration127(db: BunDatabase): void {
+	runMigration127External(db);
 }
 
 function tableColumnNames(db: BunDatabase, tableName: string): string[] {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-127_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-127_test.ts
@@ -1,0 +1,305 @@
+/**
+ * Migration 127 Tests — Backfill `pr_url` field onto existing `review-posted-gate` definitions.
+ *
+ * Migration 127 walks every `space_workflows` row with a non-null `gates` column
+ * and, when a gate has `id === 'review-posted-gate'` with only a `review_url`
+ * field (no `pr_url`), inserts `pr_url` as an additional field.
+ *
+ * Covers:
+ *   - Gate with only `review_url` → `pr_url` inserted before `review_url`
+ *   - Gate already has `pr_url` → idempotent (no change)
+ *   - Multiple workflows — only matching gates are touched
+ *   - Workflow without `review-posted-gate` → untouched
+ *   - Workflow with null gates → skipped
+ *   - Gate with no fields array → skipped
+ *   - Re-running migration is a no-op
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration127 } from '../../../../../src/storage/schema/migrations.ts';
+
+interface WorkflowRow {
+	id: string;
+	gates: string | null;
+}
+
+function insertSpace(db: BunDatabase, id: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, id, `/ws/${id}`, id, now, now);
+}
+
+function insertWorkflow(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		name: string;
+		gates?: unknown[] | null;
+	}
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflows (
+			id, space_id, name, description, start_node_id, end_node_id,
+			channels, gates, created_at, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		opts.id,
+		opts.spaceId,
+		opts.name,
+		'',
+		'node-start',
+		'node-end',
+		'[]',
+		opts.gates ? JSON.stringify(opts.gates) : null,
+		now,
+		now
+	);
+}
+
+function readWorkflow(db: BunDatabase, id: string): WorkflowRow | undefined {
+	return db.prepare(`SELECT id, gates FROM space_workflows WHERE id = ?`).get(id) as
+		| WorkflowRow
+		| undefined;
+}
+
+describe('Migration 127: backfill pr_url onto review-posted-gate', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-127',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		insertSpace(db, 'sp-1');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('gate with only review_url → pr_url inserted before review_url', () => {
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: [
+				{
+					id: 'code-ready-gate',
+					fields: [
+						{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } },
+					],
+				},
+				{
+					id: 'review-posted-gate',
+					fields: [
+						{ name: 'review_url', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+					],
+				},
+			],
+		});
+
+		runMigration127(db);
+
+		const row = readWorkflow(db, 'wf-1')!;
+		const gates = JSON.parse(row.gates!);
+		expect(gates).toHaveLength(2);
+
+		const reviewGate = gates.find((g: { id: string }) => g.id === 'review-posted-gate');
+		expect(reviewGate.fields).toHaveLength(2);
+		expect(reviewGate.fields[0].name).toBe('pr_url');
+		expect(reviewGate.fields[0].type).toBe('string');
+		expect(reviewGate.fields[0].writers).toEqual(['Review']);
+		expect(reviewGate.fields[0].check).toEqual({ op: 'exists' });
+		expect(reviewGate.fields[1].name).toBe('review_url');
+	});
+
+	test('gate already has pr_url → idempotent (no change)', () => {
+		const originalGates = [
+			{
+				id: 'review-posted-gate',
+				fields: [
+					{ name: 'pr_url', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+					{ name: 'review_url', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+				],
+			},
+		];
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: originalGates,
+		});
+
+		runMigration127(db);
+
+		const row = readWorkflow(db, 'wf-1')!;
+		const gates = JSON.parse(row.gates!);
+		expect(gates).toEqual(originalGates);
+	});
+
+	test('workflow without review-posted-gate → untouched', () => {
+		const originalGates = [
+			{
+				id: 'code-ready-gate',
+				fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+			},
+		];
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Research Workflow',
+			gates: originalGates,
+		});
+
+		runMigration127(db);
+
+		const row = readWorkflow(db, 'wf-1')!;
+		const gates = JSON.parse(row.gates!);
+		expect(gates).toEqual(originalGates);
+	});
+
+	test('workflow with null gates → skipped', () => {
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Custom Workflow',
+			gates: null,
+		});
+
+		expect(() => runMigration127(db)).not.toThrow();
+
+		const row = readWorkflow(db, 'wf-1')!;
+		expect(row.gates).toBeNull();
+	});
+
+	test('gate with no fields array → skipped', () => {
+		const originalGates = [
+			{
+				id: 'review-posted-gate',
+				// no fields array
+			},
+		];
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: originalGates,
+		});
+
+		runMigration127(db);
+
+		const row = readWorkflow(db, 'wf-1')!;
+		const gates = JSON.parse(row.gates!);
+		expect(gates).toEqual(originalGates);
+	});
+
+	test('gate with fields array but no review_url → left untouched', () => {
+		const originalGates = [
+			{
+				id: 'review-posted-gate',
+				fields: [
+					{ name: 'other_field', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+				],
+			},
+		];
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: originalGates,
+		});
+
+		runMigration127(db);
+
+		const row = readWorkflow(db, 'wf-1')!;
+		const gates = JSON.parse(row.gates!);
+		expect(gates).toEqual(originalGates);
+	});
+
+	test('multiple workflows — only matching gates are touched', () => {
+		insertWorkflow(db, {
+			id: 'wf-coding',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: [
+				{
+					id: 'review-posted-gate',
+					fields: [
+						{ name: 'review_url', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+					],
+				},
+			],
+		});
+		insertWorkflow(db, {
+			id: 'wf-research',
+			spaceId: 'sp-1',
+			name: 'Research Workflow',
+			gates: [
+				{
+					id: 'research-ready-gate',
+					fields: [{ name: 'pr_url', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+				},
+			],
+		});
+
+		runMigration127(db);
+
+		const codingRow = readWorkflow(db, 'wf-coding')!;
+		const codingGates = JSON.parse(codingRow.gates!);
+		const reviewGate = codingGates.find((g: { id: string }) => g.id === 'review-posted-gate');
+		expect(reviewGate.fields).toHaveLength(2);
+		expect(reviewGate.fields[0].name).toBe('pr_url');
+
+		const researchRow = readWorkflow(db, 'wf-research')!;
+		const researchGates = JSON.parse(researchRow.gates!);
+		expect(researchGates[0].fields).toHaveLength(1);
+	});
+
+	test('re-running migration is a no-op', () => {
+		insertWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			gates: [
+				{
+					id: 'review-posted-gate',
+					fields: [
+						{ name: 'review_url', type: 'string', writers: ['Review'], check: { op: 'exists' } },
+					],
+				},
+			],
+		});
+
+		runMigration127(db);
+		const after1 = readWorkflow(db, 'wf-1')!;
+
+		runMigration127(db);
+		const after2 = readWorkflow(db, 'wf-1')!;
+
+		expect(after2.gates).toBe(after1.gates);
+	});
+});


### PR DESCRIPTION
Follow-up to #1856 — the original fix added `pr_url` as a field on `review-posted-gate` in the built-in Coding Workflow template, but `seedBuiltInWorkflows` does NOT re-stamp `gates` on existing rows during drift detection. Without this migration, existing spaces keep the stale single-field gate definition forever.

**What this migration does:**
- Walks every `space_workflows` row with a non-null `gates` column
- For any `review-posted-gate` that has `review_url` but lacks `pr_url`, inserts `pr_url` as an additional field (same shape: type='string', writers=['Review'], check=exists)
- Idempotent — re-running is a no-op

**Files changed:**
- `packages/daemon/src/storage/schema/m127-backfill-review-posted-gate-pr-url.ts` — new migration
- `packages/daemon/src/storage/schema/migrations.ts` — wired into registry
- `packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-127_test.ts` — 7 unit tests