### PR TITLE
feat(daemon): normalize Space runtime notifications via InternalEventBus (M6)

### DIFF
--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -380,6 +380,193 @@ export interface ApiConnectionEvents {
 	'api.connection': { sessionId: string } & import('@neokai/shared').ApiConnectionState;
 }
 
+// ---------------------------------------------------------------------------
+// Space runtime events — migrated from NotificationSink to InternalEventBus in M6.
+// Naming: dot-separated, lower camelCase per segment, fact/state-change wording.
+// ---------------------------------------------------------------------------
+
+/** A task has transitioned to `blocked` and requires judgment. */
+export interface SpaceTaskBlockedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A task has been unblocked and is resuming. */
+export interface SpaceTaskUnblockedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A task has reached a terminal state (completed, failed, or cancelled). */
+export interface SpaceTaskCompletedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	status: 'done' | 'cancelled' | 'blocked';
+	timestamp: string;
+}
+
+/** A task has failed with an unrecoverable error. */
+export interface SpaceTaskFailedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A Task Agent session crashed unexpectedly. */
+export interface SpaceAgentCrashedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	timestamp: string;
+}
+
+/** A crashed agent has been recovered (e.g. after retry). */
+export interface SpaceAgentRecoveredEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	timestamp: string;
+}
+
+/** A stuck agent was auto-completed by the runtime after timeout. */
+export interface SpaceAgentAutoCompletedEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	elapsedMs: number;
+	timestamp: string;
+}
+
+/** A node agent went idle without a terminal SDK message or reported status. */
+export interface SpaceAgentIdleNonTerminalEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	runId: string;
+	executionId: string;
+	nodeId: string;
+	agentName: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A workflow run has reached a terminal state. */
+export interface SpaceWorkflowRunCompletedEvent {
+	sessionId: string;
+	spaceId: string;
+	runId: string;
+	status: 'done' | 'cancelled' | 'blocked';
+	summary?: string;
+	timestamp: string;
+}
+
+/** A workflow run has failed with an unrecoverable error. */
+export interface SpaceWorkflowRunFailedEvent {
+	sessionId: string;
+	spaceId: string;
+	runId: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A workflow run has transitioned to `blocked`. */
+export interface SpaceWorkflowRunBlockedEvent {
+	sessionId: string;
+	spaceId: string;
+	runId: string;
+	reason: string;
+	timestamp: string;
+}
+
+/** A previously-terminal workflow run has been reopened back to `in_progress`. */
+export interface SpaceWorkflowRunReopenedEvent {
+	sessionId: string;
+	spaceId: string;
+	runId: string;
+	fromStatus: 'done' | 'cancelled';
+	reason: string;
+	by: string;
+	timestamp: string;
+}
+
+/** A blocked execution is being automatically retried by the runtime. */
+export interface SpaceWorkflowRunRetryEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	runId: string;
+	originalReason: string;
+	attemptNumber: number;
+	maxAttempts: number;
+	timestamp: string;
+}
+
+/** A blocked workflow run has exhausted automatic retries and needs attention. */
+export interface SpaceWorkflowRunNeedsAttentionEvent {
+	sessionId: string;
+	spaceId: string;
+	runId: string;
+	taskId: string;
+	reason: string;
+	retriesExhausted: number;
+	timestamp: string;
+}
+
+/** A task has paused at a completion action that requires approval. */
+export interface SpaceTaskAwaitingApprovalEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	actionId: string;
+	actionName: string;
+	actionDescription?: string;
+	actionType: 'script' | 'instruction' | 'mcp_call';
+	requiredLevel: number;
+	spaceLevel: number;
+	autonomyLevel: number;
+	timestamp: string;
+}
+
+/** A task has been running longer than the configured timeout threshold. */
+export interface SpaceTaskTimeoutEvent {
+	sessionId: string;
+	spaceId: string;
+	taskId: string;
+	elapsedMs: number;
+	timestamp: string;
+}
+
+/**
+ * Space domain events — migrated from NotificationSink to InternalEventBus in M6.
+ */
+export interface SpaceEvents {
+	'space.task.blocked': SpaceTaskBlockedEvent;
+	'space.task.unblocked': SpaceTaskUnblockedEvent;
+	'space.task.completed': SpaceTaskCompletedEvent;
+	'space.task.failed': SpaceTaskFailedEvent;
+	'space.agent.crashed': SpaceAgentCrashedEvent;
+	'space.agent.recovered': SpaceAgentRecoveredEvent;
+	'space.agent.autoCompleted': SpaceAgentAutoCompletedEvent;
+	'space.agent.idleNonTerminal': SpaceAgentIdleNonTerminalEvent;
+	'space.workflowRun.completed': SpaceWorkflowRunCompletedEvent;
+	'space.workflowRun.failed': SpaceWorkflowRunFailedEvent;
+	'space.workflowRun.blocked': SpaceWorkflowRunBlockedEvent;
+	'space.workflowRun.reopened': SpaceWorkflowRunReopenedEvent;
+	'space.workflowRun.retry': SpaceWorkflowRunRetryEvent;
+	'space.workflowRun.needsAttention': SpaceWorkflowRunNeedsAttentionEvent;
+	'space.task.awaitingApproval': SpaceTaskAwaitingApprovalEvent;
+	'space.task.timeout': SpaceTaskTimeoutEvent;
+}
+
 /**
  * Canonical daemon internal event map.
  *
@@ -395,7 +582,8 @@ export interface DaemonInternalEventMap
 	extends SettingsEvents,
 		ExternalEventEvents,
 		SessionEvents,
-		ApiConnectionEvents {}
+		ApiConnectionEvents,
+		SpaceEvents {}
 
 /**
  * Convenience factory typed with the canonical daemon internal event map.

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -394,7 +394,12 @@ export interface SpaceTaskBlockedEvent {
 	timestamp: string;
 }
 
-/** A task has been unblocked and is resuming. */
+/**
+ * A task has been unblocked and is resuming.
+ *
+ * Reserved: defined in the event map for forward compatibility, but not yet
+ * emitted by any publisher. Will be wired when the runtime adds an unblock path.
+ */
 export interface SpaceTaskUnblockedEvent {
 	sessionId: string;
 	spaceId: string;
@@ -403,7 +408,13 @@ export interface SpaceTaskUnblockedEvent {
 	timestamp: string;
 }
 
-/** A task has reached a terminal state (completed, failed, or cancelled). */
+/**
+ * A task has reached a terminal state (completed, failed, or cancelled).
+ *
+ * Reserved: defined in the event map for forward compatibility, but not yet
+ * emitted by any publisher. The runtime currently emits `workflowRun.completed`
+ * for terminal runs rather than per-task completion events.
+ */
 export interface SpaceTaskCompletedEvent {
 	sessionId: string;
 	spaceId: string;
@@ -412,7 +423,13 @@ export interface SpaceTaskCompletedEvent {
 	timestamp: string;
 }
 
-/** A task has failed with an unrecoverable error. */
+/**
+ * A task has failed with an unrecoverable error.
+ *
+ * Reserved: defined in the event map for forward compatibility, but not yet
+ * emitted by any publisher. Task failures are currently surfaced via
+ * `space.task.blocked` with the failure reason.
+ */
 export interface SpaceTaskFailedEvent {
 	sessionId: string;
 	spaceId: string;
@@ -429,7 +446,13 @@ export interface SpaceAgentCrashedEvent {
 	timestamp: string;
 }
 
-/** A crashed agent has been recovered (e.g. after retry). */
+/**
+ * A crashed agent has been recovered (e.g. after retry).
+ *
+ * Reserved: defined in the event map for forward compatibility, but not yet
+ * emitted by any publisher. Recovery is currently silent; agents are retried
+ * without emitting a dedicated recovery event.
+ */
 export interface SpaceAgentRecoveredEvent {
 	sessionId: string;
 	spaceId: string;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -449,6 +449,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		artifactRepo,
 		pendingMessageRepo,
 		scheduleService,
+		internalEventBus: deps.internalEventBus,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -556,6 +556,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		pendingMessageRepo,
 		spaceAgentInjector,
 		scheduleService,
+		internalEventBus: deps.internalEventBus,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -43,6 +43,9 @@ export { SessionNotificationSink, formatEventMessage } from './runtime/session-n
 export type { SessionNotificationSinkConfig } from './runtime/session-notification-sink';
 export { SpaceRuntimeService } from './runtime/space-runtime-service';
 export type { SpaceRuntimeServiceConfig } from './runtime/space-runtime-service';
+export { SpaceAgentNotificationService } from './runtime/space-agent-notification-service';
+export type { SpaceAgentNotificationServiceConfig } from './runtime/space-agent-notification-service';
+export type { SessionFactory } from './runtime/types';
 export { TaskAgentManager } from './runtime/task-agent-manager';
 export type { TaskAgentManagerConfig } from './runtime/task-agent-manager';
 

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -57,6 +57,11 @@ import type { GateScriptContext } from './gate-script-executor';
 import { executeGateScript } from './gate-script-executor';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import type { NotificationSink, SpaceNotificationEvent } from './notification-sink';
+import type {
+	InternalEventBus,
+	DaemonInternalEventMap,
+	InternalEventPayload,
+} from '../../internal-event-bus';
 import { Logger } from '../../logger';
 import {
 	PermanentSpawnError,
@@ -240,8 +245,18 @@ export interface ChannelRouterConfig {
 	 *
 	 * Failures from `notify()` are caught and logged; notification errors never
 	 * propagate into message delivery / activation paths.
+	 *
+	 * @deprecated Use `internalEventBus` instead. NotificationSink is a short-lived
+	 * compatibility adapter. See M6 migration in internal-event-command-query-architecture.md.
 	 */
 	notificationSink?: NotificationSink;
+	/**
+	 * Optional InternalEventBus for publishing domain events. When provided,
+	 * ChannelRouter publishes typed events alongside the legacy NotificationSink path.
+	 *
+	 * This is the preferred integration point for M6+.
+	 */
+	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
 	/**
 	 * Called when a gate is actively waiting for human approval (gate data was
 	 * written, but the gate is still not open because `approved` has not been set).
@@ -1204,18 +1219,80 @@ export class ChannelRouter {
 	}
 
 	/**
-	 * Invoke the configured notification sink, swallowing any errors so a
-	 * faulty consumer cannot break message delivery or node activation.
+	 * Invoke the configured notification sink and optionally publish to
+	 * InternalEventBus, swallowing any errors so a faulty consumer cannot
+	 * break message delivery or node activation.
 	 *
 	 * When no sink is configured (e.g. unit tests), this is a no-op.
 	 */
 	private async safeNotify(event: SpaceNotificationEvent): Promise<void> {
+		// New path — publish to InternalEventBus FIRST so bus subscribers
+		// are never delayed by a slow or failing legacy sink.
+		if (this.config.internalEventBus) {
+			const mapped = this.mapNotificationEventToInternalEvent(event);
+			if (mapped) {
+				this.publishToInternalEventBus(mapped.event, mapped.payload);
+			}
+		}
+
+		// Legacy path — keep until all subscribers migrate off NotificationSink.
 		if (!this.config.notificationSink) return;
 		try {
 			await this.config.notificationSink.notify(event);
 		} catch {
 			// Intentionally swallow — the runtime must remain resilient to
 			// consumer failures. A separate telemetry layer can log these.
+		}
+	}
+
+	/**
+	 * Type-safe helper that publishes a mapped event to InternalEventBus.
+	 *
+	 * Uses a generic helper to preserve the correlated event→payload type
+	 * relationship without an unsafe cast.
+	 */
+	private publishToInternalEventBus<K extends keyof DaemonInternalEventMap & string>(
+		event: K,
+		payload: DaemonInternalEventMap[K]
+	): void {
+		if (!this.config.internalEventBus) return;
+		try {
+			// All mapped events carry sessionId and satisfy InternalEventPayload.
+			this.config.internalEventBus.publishAsync(
+				event,
+				payload as DaemonInternalEventMap[K] & InternalEventPayload
+			);
+		} catch {
+			// Swallow — bus errors must not break message delivery.
+		}
+	}
+
+	/**
+	 * Map a legacy NotificationSink event to a typed InternalEventBus event.
+	 *
+	 * Returns `null` for events that don't have a corresponding internal event.
+	 */
+	private mapNotificationEventToInternalEvent(event: SpaceNotificationEvent): {
+		event: keyof DaemonInternalEventMap;
+		payload: DaemonInternalEventMap[keyof DaemonInternalEventMap];
+	} | null {
+		const sessionId = 'global';
+		switch (event.kind) {
+			case 'workflow_run_reopened':
+				return {
+					event: 'space.workflowRun.reopened',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						runId: event.runId,
+						fromStatus: event.fromStatus,
+						reason: event.reason,
+						by: event.by,
+						timestamp: event.timestamp,
+					},
+				};
+			default:
+				return null;
 		}
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -7,6 +7,12 @@
  * a workflow run completes, or a task times out).
  *
  * Consumers that don't need notifications can use `NullNotificationSink`.
+ *
+ * @deprecated This is a short-lived compatibility adapter for M6 migration.
+ * Use `InternalEventBus` with typed `SpaceEvents` instead. SpaceRuntime now
+ * publishes both to NotificationSink (legacy) and InternalEventBus (new).
+ * Once all subscribers migrate, this interface and its implementations will
+ * be removed. See docs/plans/internal-event-command-query-architecture.md.
  */
 
 // ---------------------------------------------------------------------------
@@ -288,6 +294,8 @@ export type SpaceNotificationEvent =
  * Implementations must be non-blocking from the runtime's perspective —
  * the runtime awaits the returned promise but does not retry on failure.
  * Implementations should handle their own errors internally.
+ *
+ * @deprecated Use `InternalEventBus` subscribers instead. See M6 migration plan.
  */
 export interface NotificationSink {
 	/**
@@ -309,6 +317,8 @@ export interface NotificationSink {
  * Use this as the default when no real consumer is connected (e.g. in unit
  * tests that don't care about notifications, or before the Space Agent session
  * has been provisioned).
+ *
+ * @deprecated Use `InternalEventBus` without a subscriber instead.
  */
 export class NullNotificationSink implements NotificationSink {
 	notify(_event: SpaceNotificationEvent): Promise<void> {

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -27,20 +27,8 @@
 
 import type { NotificationSink, SpaceNotificationEvent } from './notification-sink';
 import type { SpaceAutonomyLevel } from '@neokai/shared/types/space';
-import type { MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
 import { Logger } from '../../logger';
-
-/**
- * Minimal interface for injecting messages into a session.
- * Used by SessionNotificationSink to forward notification events to the Space Agent session.
- */
-interface SessionFactory {
-	injectMessage(
-		sessionId: string,
-		message: string,
-		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
-	): Promise<void>;
-}
+import type { SessionFactory } from './types';
 
 const log = new Logger('session-notification-sink');
 

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -39,6 +39,12 @@ export interface SpaceAgentNotificationServiceConfig {
 	 */
 	sessionId: string;
 	/**
+	 * The space ID this service is scoped to. Only events whose `spaceId` matches
+	 * this value are processed; events for other spaces are silently ignored.
+	 * This prevents cross-space notification leakage when multiple spaces are active.
+	 */
+	spaceId: string;
+	/**
 	 * The autonomy level for this space. Included in every notification message
 	 * so the agent has context for how much it can act without human approval.
 	 *
@@ -58,6 +64,7 @@ export class SpaceAgentNotificationService {
 	private readonly internalEventBus: InternalEventBus<DaemonInternalEventMap>;
 	private readonly sessionFactory: SessionFactory;
 	private readonly sessionId: string;
+	private readonly spaceId: string;
 	private readonly autonomyLevel: SpaceAutonomyLevel;
 	private unsubscribers: Array<() => void> = [];
 
@@ -65,6 +72,7 @@ export class SpaceAgentNotificationService {
 		this.internalEventBus = config.internalEventBus;
 		this.sessionFactory = config.sessionFactory;
 		this.sessionId = config.sessionId;
+		this.spaceId = config.spaceId;
 		this.autonomyLevel = config.autonomyLevel ?? 1;
 	}
 
@@ -85,58 +93,105 @@ export class SpaceAgentNotificationService {
 		this.unsubscribers = [
 			this.internalEventBus.subscribe(
 				'space.task.blocked',
-				(event) => this.notify(formatTaskBlocked(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.task.blocked' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatTaskBlocked(event, this.autonomyLevel));
+				},
+				{ subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.task.blocked` }
 			),
 			this.internalEventBus.subscribe(
 				'space.workflowRun.blocked',
-				(event) => this.notify(formatWorkflowRunBlocked(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.blocked' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatWorkflowRunBlocked(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.blocked`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.task.timeout',
-				(event) => this.notify(formatTaskTimeout(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.task.timeout' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatTaskTimeout(event, this.autonomyLevel));
+				},
+				{ subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.task.timeout` }
 			),
 			this.internalEventBus.subscribe(
 				'space.workflowRun.completed',
-				(event) => this.notify(formatWorkflowRunCompleted(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.completed' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatWorkflowRunCompleted(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.completed`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.workflowRun.reopened',
-				(event) => this.notify(formatWorkflowRunReopened(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.reopened' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatWorkflowRunReopened(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.reopened`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.agent.autoCompleted',
-				(event) => this.notify(formatAgentAutoCompleted(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.agent.autoCompleted' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatAgentAutoCompleted(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.agent.autoCompleted`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.agent.crashed',
-				(event) => this.notify(formatAgentCrash(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.agent.crashed' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatAgentCrash(event, this.autonomyLevel));
+				},
+				{ subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.agent.crashed` }
 			),
 			this.internalEventBus.subscribe(
 				'space.agent.idleNonTerminal',
-				(event) => this.notify(formatAgentIdleNonTerminal(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.agent.idleNonTerminal' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatAgentIdleNonTerminal(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.agent.idleNonTerminal`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.workflowRun.retry',
-				(event) => this.notify(formatTaskRetry(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.retry' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatTaskRetry(event, this.autonomyLevel));
+				},
+				{ subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.retry` }
 			),
 			this.internalEventBus.subscribe(
 				'space.workflowRun.needsAttention',
-				(event) => this.notify(formatWorkflowRunNeedsAttention(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.needsAttention' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatWorkflowRunNeedsAttention(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.needsAttention`,
+				}
 			),
 			this.internalEventBus.subscribe(
 				'space.task.awaitingApproval',
-				(event) => this.notify(formatTaskAwaitingApproval(event, this.autonomyLevel)),
-				{ subscriberName: 'SpaceAgentNotificationService:space.task.awaitingApproval' }
+				(event) => {
+					if (event.spaceId !== this.spaceId) return;
+					void this.notify(formatTaskAwaitingApproval(event, this.autonomyLevel));
+				},
+				{
+					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.task.awaitingApproval`,
+				}
 			),
 		];
 

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -22,21 +22,9 @@
  */
 
 import type { SpaceAutonomyLevel } from '@neokai/shared/types/space';
-import type { MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
 import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
 import { Logger } from '../../logger';
-
-/**
- * Minimal interface for injecting messages into a session.
- * Used by SpaceAgentNotificationService to forward notification events to the Space Agent session.
- */
-interface SessionFactory {
-	injectMessage(
-		sessionId: string,
-		message: string,
-		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
-	): Promise<void>;
-}
+import type { SessionFactory } from './types';
 
 const log = new Logger('space-agent-notification-service');
 
@@ -85,8 +73,15 @@ export class SpaceAgentNotificationService {
 	 *
 	 * Call this once after construction. The returned unsubscribe function
 	 * tears down all subscriptions.
+	 *
+	 * Safe to call multiple times — any existing subscriptions are torn down
+	 * before the new set is registered.
 	 */
 	subscribe(): () => void {
+		// Tear down any existing subscriptions to prevent leaks on re-init.
+		for (const unsub of this.unsubscribers) {
+			unsub();
+		}
 		this.unsubscribers = [
 			this.internalEventBus.subscribe(
 				'space.task.blocked',
@@ -443,7 +438,7 @@ function formatTaskAwaitingApproval(
 		autonomyLevel: number;
 		timestamp: string;
 	},
-	_spaceAutonomyLevel: SpaceAutonomyLevel
+	autonomyLevel: SpaceAutonomyLevel
 ): string {
 	const descPart = event.actionDescription ? ` — ${event.actionDescription}` : '';
 	const humanReadable =
@@ -461,7 +456,7 @@ function formatTaskAwaitingApproval(
 		requiredLevel: event.requiredLevel,
 		spaceLevel: event.spaceLevel,
 		timestamp: event.timestamp,
-		autonomyLevel: event.autonomyLevel,
+		autonomyLevel,
 	};
 	if (event.actionDescription !== undefined) {
 		payload['actionDescription'] = event.actionDescription;

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -1,0 +1,488 @@
+/**
+ * SpaceAgentNotificationService — InternalEventBus subscriber for Space runtime events.
+ *
+ * Listens to selected `SpaceEvents` on the `InternalEventBus` and formats them
+ * into structured `[TASK_EVENT]` messages for injection into the Space Agent
+ * session. This replaces the legacy `SessionNotificationSink` / `NotificationSink`
+ * integration path.
+ *
+ * ## Migration note
+ *
+ * This service subscribes to `InternalEventBus` events (e.g. `space.task.blocked`,
+ * `space.workflowRun.completed`) rather than receiving `SpaceNotificationEvent`
+ * objects through `NotificationSink.notify()`. The formatting logic is kept
+ * compatible with `SessionNotificationSink` so the Space Agent sees identical
+ * messages.
+ *
+ * ## Subscribed events
+ *
+ * All events that previously flowed through `NotificationSink` are now handled
+ * here. Events that do not require agent notification (e.g. internal bookkeeping)
+ * are silently ignored.
+ */
+
+import type { SpaceAutonomyLevel } from '@neokai/shared/types/space';
+import type { MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
+import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
+import { Logger } from '../../logger';
+
+/**
+ * Minimal interface for injecting messages into a session.
+ * Used by SpaceAgentNotificationService to forward notification events to the Space Agent session.
+ */
+interface SessionFactory {
+	injectMessage(
+		sessionId: string,
+		message: string,
+		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
+	): Promise<void>;
+}
+
+const log = new Logger('space-agent-notification-service');
+
+export interface SpaceAgentNotificationServiceConfig {
+	/** The InternalEventBus to subscribe to. */
+	internalEventBus: InternalEventBus<DaemonInternalEventMap>;
+	/** The SessionFactory used to inject messages into sessions. */
+	sessionFactory: SessionFactory;
+	/**
+	 * The session ID of the Space Agent's global session (e.g. the `spaces:global`
+	 * session that receives coordination notifications).
+	 */
+	sessionId: string;
+	/**
+	 * The autonomy level for this space. Included in every notification message
+	 * so the agent has context for how much it can act without human approval.
+	 *
+	 * Defaults to `1` (most supervised) if not provided.
+	 */
+	autonomyLevel?: SpaceAutonomyLevel;
+}
+
+/**
+ * Production subscriber that turns Space runtime domain events into agent-facing
+ * messages and injects them into the Space Agent session.
+ *
+ * Use this instead of `SessionNotificationSink` when wiring through
+ * `InternalEventBus`.
+ */
+export class SpaceAgentNotificationService {
+	private readonly internalEventBus: InternalEventBus<DaemonInternalEventMap>;
+	private readonly sessionFactory: SessionFactory;
+	private readonly sessionId: string;
+	private readonly autonomyLevel: SpaceAutonomyLevel;
+	private unsubscribers: Array<() => void> = [];
+
+	constructor(config: SpaceAgentNotificationServiceConfig) {
+		this.internalEventBus = config.internalEventBus;
+		this.sessionFactory = config.sessionFactory;
+		this.sessionId = config.sessionId;
+		this.autonomyLevel = config.autonomyLevel ?? 1;
+	}
+
+	/**
+	 * Subscribe to all Space runtime events that require agent notification.
+	 *
+	 * Call this once after construction. The returned unsubscribe function
+	 * tears down all subscriptions.
+	 */
+	subscribe(): () => void {
+		this.unsubscribers = [
+			this.internalEventBus.subscribe(
+				'space.task.blocked',
+				(event) => this.notify(formatTaskBlocked(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.task.blocked' }
+			),
+			this.internalEventBus.subscribe(
+				'space.workflowRun.blocked',
+				(event) => this.notify(formatWorkflowRunBlocked(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.blocked' }
+			),
+			this.internalEventBus.subscribe(
+				'space.task.timeout',
+				(event) => this.notify(formatTaskTimeout(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.task.timeout' }
+			),
+			this.internalEventBus.subscribe(
+				'space.workflowRun.completed',
+				(event) => this.notify(formatWorkflowRunCompleted(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.completed' }
+			),
+			this.internalEventBus.subscribe(
+				'space.workflowRun.reopened',
+				(event) => this.notify(formatWorkflowRunReopened(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.reopened' }
+			),
+			this.internalEventBus.subscribe(
+				'space.agent.autoCompleted',
+				(event) => this.notify(formatAgentAutoCompleted(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.agent.autoCompleted' }
+			),
+			this.internalEventBus.subscribe(
+				'space.agent.crashed',
+				(event) => this.notify(formatAgentCrash(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.agent.crashed' }
+			),
+			this.internalEventBus.subscribe(
+				'space.agent.idleNonTerminal',
+				(event) => this.notify(formatAgentIdleNonTerminal(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.agent.idleNonTerminal' }
+			),
+			this.internalEventBus.subscribe(
+				'space.workflowRun.retry',
+				(event) => this.notify(formatTaskRetry(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.retry' }
+			),
+			this.internalEventBus.subscribe(
+				'space.workflowRun.needsAttention',
+				(event) => this.notify(formatWorkflowRunNeedsAttention(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.workflowRun.needsAttention' }
+			),
+			this.internalEventBus.subscribe(
+				'space.task.awaitingApproval',
+				(event) => this.notify(formatTaskAwaitingApproval(event, this.autonomyLevel)),
+				{ subscriberName: 'SpaceAgentNotificationService:space.task.awaitingApproval' }
+			),
+		];
+
+		return () => {
+			for (const unsub of this.unsubscribers) {
+				unsub();
+			}
+			this.unsubscribers = [];
+		};
+	}
+
+	private async notify(message: string): Promise<void> {
+		try {
+			await this.sessionFactory.injectMessage(this.sessionId, message, {
+				deliveryMode: 'defer',
+				origin: 'system',
+			});
+		} catch (err) {
+			// Session not found or unavailable — log warning, do not propagate.
+			// The notification service must not fail the caller's event handler.
+			log.warn(
+				`[SpaceAgentNotificationService] Failed to inject notification into session ${this.sessionId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Message formatters — kept compatible with SessionNotificationSink output.
+// ---------------------------------------------------------------------------
+
+function formatTaskBlocked(
+	event: {
+		spaceId: string;
+		taskId: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable = `Task ${event.taskId} in space ${event.spaceId} is blocked: ${event.reason}`;
+	const payload = {
+		kind: 'task_blocked',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage('task_blocked', humanReadable, payload);
+}
+
+function formatWorkflowRunBlocked(
+	event: {
+		spaceId: string;
+		runId: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable = `Workflow run ${event.runId} in space ${event.spaceId} is blocked: ${event.reason}`;
+	const payload = {
+		kind: 'workflow_run_blocked',
+		spaceId: event.spaceId,
+		runId: event.runId,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage('workflow_run_blocked', humanReadable, payload);
+}
+
+function formatTaskTimeout(
+	event: {
+		spaceId: string;
+		taskId: string;
+		elapsedMs: number;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const elapsedMin = Math.round(event.elapsedMs / 60000);
+	const humanReadable = `Task ${event.taskId} in space ${event.spaceId} has been running for ${elapsedMin} minute(s) and may be stuck.`;
+	const payload = {
+		kind: 'task_timeout',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		elapsedMs: event.elapsedMs,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage('task_timeout', humanReadable, payload);
+}
+
+function formatWorkflowRunCompleted(
+	event: {
+		spaceId: string;
+		runId: string;
+		status: 'done' | 'cancelled' | 'blocked';
+		summary?: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const statusLabel =
+		event.status === 'done'
+			? 'completed successfully'
+			: event.status === 'cancelled'
+				? 'was cancelled'
+				: 'ended and is blocked';
+	const summaryPart = event.summary ? ` Summary: ${event.summary}` : '';
+	const humanReadable = `Workflow run ${event.runId} in space ${event.spaceId} ${statusLabel}.${summaryPart}`;
+	const payload: Record<string, unknown> = {
+		kind: 'workflow_run_completed',
+		spaceId: event.spaceId,
+		runId: event.runId,
+		status: event.status,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	if (event.summary !== undefined) {
+		payload['summary'] = event.summary;
+	}
+	return buildMessage('workflow_run_completed', humanReadable, payload);
+}
+
+function formatWorkflowRunReopened(
+	event: {
+		spaceId: string;
+		runId: string;
+		fromStatus: 'done' | 'cancelled';
+		reason: string;
+		by: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Workflow run ${event.runId} in space ${event.spaceId} was reopened from '${event.fromStatus}' ` +
+		`back to 'in_progress' (by: ${event.by}). Reason: ${event.reason}. ` +
+		`A previously-finished task is active again; completion actions will not re-fire.`;
+	const payload = {
+		kind: 'workflow_run_reopened',
+		spaceId: event.spaceId,
+		runId: event.runId,
+		fromStatus: event.fromStatus,
+		reason: event.reason,
+		by: event.by,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage('workflow_run_reopened', humanReadable, payload);
+}
+
+function formatAgentAutoCompleted(
+	event: {
+		spaceId: string;
+		taskId: string;
+		elapsedMs: number;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const elapsedMinutes = Math.round(event.elapsedMs / 60_000);
+	const humanReadable =
+		`Task ${event.taskId} in space ${event.spaceId} was auto-completed after ${elapsedMinutes} minute(s) ` +
+		`because the agent did not set task.reportedStatus within the configured timeout.`;
+	return buildMessage('agent_auto_completed', humanReadable, {
+		kind: 'agent_auto_completed',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		elapsedMs: event.elapsedMs,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
+}
+
+function formatAgentCrash(
+	event: {
+		spaceId: string;
+		taskId: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Task ${event.taskId} in space ${event.spaceId} encountered an agent crash. ` +
+		`The task has been marked as blocked. ` +
+		`Please investigate and retry the task when ready.`;
+	const payload = {
+		kind: 'agent_crash',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		failureReason: 'agentCrash',
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	return buildMessage('agent_crash', humanReadable, payload);
+}
+
+function formatAgentIdleNonTerminal(
+	event: {
+		spaceId: string;
+		taskId: string;
+		runId: string;
+		executionId: string;
+		nodeId: string;
+		agentName: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Node ${event.nodeId} (${event.agentName}) in workflow run ${event.runId} went idle with a non-terminal last message. ` +
+		`The runtime will not advance the workflow from this idle state. Reason: ${event.reason}`;
+	return buildMessage('agent_idle_non_terminal', humanReadable, {
+		kind: 'agent_idle_non_terminal',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		runId: event.runId,
+		executionId: event.executionId,
+		nodeId: event.nodeId,
+		agentName: event.agentName,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
+}
+
+function formatTaskRetry(
+	event: {
+		spaceId: string;
+		taskId: string;
+		runId: string;
+		originalReason: string;
+		attemptNumber: number;
+		maxAttempts: number;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Task ${event.taskId} in space ${event.spaceId} was blocked (reason: ${event.originalReason}). ` +
+		`The runtime is automatically retrying (attempt ${event.attemptNumber}/${event.maxAttempts}). ` +
+		`The blocked node execution has been reset to pending and will be re-spawned.`;
+	return buildMessage('task_retry', humanReadable, {
+		kind: 'task_retry',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		runId: event.runId,
+		originalReason: event.originalReason,
+		attemptNumber: event.attemptNumber,
+		maxAttempts: event.maxAttempts,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
+}
+
+function formatWorkflowRunNeedsAttention(
+	event: {
+		spaceId: string;
+		runId: string;
+		taskId: string;
+		reason: string;
+		retriesExhausted: number;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Workflow run ${event.runId} in space ${event.spaceId} needs attention. ` +
+		`The runtime exhausted ${event.retriesExhausted} automatic retry attempt(s). ` +
+		`Reason: ${event.reason}. ` +
+		`Please investigate and take action: retry with updated instructions, reassign, cancel, or escalate to the human.`;
+	return buildMessage('workflow_run_needs_attention', humanReadable, {
+		kind: 'workflow_run_needs_attention',
+		spaceId: event.spaceId,
+		runId: event.runId,
+		taskId: event.taskId,
+		reason: event.reason,
+		retriesExhausted: event.retriesExhausted,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
+}
+
+function formatTaskAwaitingApproval(
+	event: {
+		spaceId: string;
+		taskId: string;
+		actionId: string;
+		actionName: string;
+		actionDescription?: string;
+		actionType: 'script' | 'instruction' | 'mcp_call';
+		requiredLevel: number;
+		spaceLevel: number;
+		autonomyLevel: number;
+		timestamp: string;
+	},
+	_spaceAutonomyLevel: SpaceAutonomyLevel
+): string {
+	const descPart = event.actionDescription ? ` — ${event.actionDescription}` : '';
+	const humanReadable =
+		`Task ${event.taskId} in space ${event.spaceId} is awaiting approval for completion action ` +
+		`'${event.actionName}' (type: ${event.actionType})${descPart}. ` +
+		`Requires autonomy ${event.requiredLevel}, space is at ${event.spaceLevel}. ` +
+		`Review the action and approve or reject to resume the task.`;
+	const payload: Record<string, unknown> = {
+		kind: 'task_awaiting_approval',
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		actionId: event.actionId,
+		actionName: event.actionName,
+		actionType: event.actionType,
+		requiredLevel: event.requiredLevel,
+		spaceLevel: event.spaceLevel,
+		timestamp: event.timestamp,
+		autonomyLevel: event.autonomyLevel,
+	};
+	if (event.actionDescription !== undefined) {
+		payload['actionDescription'] = event.actionDescription;
+	}
+	return buildMessage('task_awaiting_approval', humanReadable, payload);
+}
+
+function buildMessage(
+	kind: string,
+	humanReadable: string,
+	payload: Record<string, unknown>
+): string {
+	return [
+		`[TASK_EVENT] ${kind}`,
+		'',
+		humanReadable,
+		'',
+		`Autonomy level: ${payload['autonomyLevel']}`,
+		'',
+		'```json',
+		JSON.stringify(payload, null, 2),
+		'```',
+	].join('\n');
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -481,6 +481,68 @@ export class SpaceRuntimeService {
 		});
 		this.unsubscribers.push(unsubSessionDeleted);
 
+		// When a space is archived or deleted, tear down its notification service
+		// so stale subscribers don't accumulate and fan-out to non-existent sessions.
+		const unsubSpaceArchived = daemonHub.on(
+			'space.archived',
+			(event) => {
+				const unsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
+				if (unsub) {
+					try {
+						unsub();
+					} catch {
+						log.warn(
+							`Failed to unsubscribe SpaceAgentNotificationService for archived space ${event.spaceId}:`
+						);
+					}
+					this.spaceAgentNotificationUnsubs.delete(event.spaceId);
+				}
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubSpaceArchived);
+
+		const unsubSpaceDeleted = daemonHub.on(
+			'space.deleted',
+			(event) => {
+				const unsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
+				if (unsub) {
+					try {
+						unsub();
+					} catch {
+						log.warn(
+							`Failed to unsubscribe SpaceAgentNotificationService for deleted space ${event.spaceId}:`
+						);
+					}
+					this.spaceAgentNotificationUnsubs.delete(event.spaceId);
+				}
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubSpaceDeleted);
+
+		// When a space is updated, refresh the autonomy level in its notification
+		// service so [TASK_EVENT] messages report the current level.
+		const unsubSpaceUpdated = daemonHub.on(
+			'space.updated',
+			(event) => {
+				const existingUnsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
+				if (!existingUnsub) return;
+
+				// Re-provision the space chat session, which re-creates the
+				// SpaceAgentNotificationService with the updated autonomy level.
+				if (event.space) {
+					void this.setupSpaceAgentSession(event.space as Space).catch(() => {
+						log.error(
+							`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`
+						);
+					});
+				}
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubSpaceUpdated);
+
 		// Hard resets replace the cached AgentSession with a fresh instance built
 		// only from persisted DB state, so runtime-only MCP servers, Space prompts,
 		// and self-heal callbacks must be re-attached before replay restarts a query.
@@ -894,6 +956,7 @@ export class SpaceRuntimeService {
 				internalEventBus: this.config.internalEventBus,
 				sessionFactory: sessionManager,
 				sessionId: spaceChatSessionId,
+				spaceId: space.id,
 				autonomyLevel: space.autonomyLevel ?? 1,
 			} as SpaceAgentNotificationServiceConfig);
 			const unsub = notificationService.subscribe();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -36,6 +36,11 @@ import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
+import {
+	SpaceAgentNotificationService,
+	type SpaceAgentNotificationServiceConfig,
+} from './space-agent-notification-service';
+import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
 
 const log = new Logger('space-runtime-service');
 
@@ -104,6 +109,15 @@ export interface SpaceRuntimeServiceConfig {
 	 * scheduled tasks via the same code path as the RPC handlers. Optional.
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
+	/**
+	 * Optional InternalEventBus for publishing Space runtime domain events.
+	 * When provided, SpaceRuntime publishes typed events alongside the legacy
+	 * NotificationSink path, and SpaceAgentNotificationService is wired per-space
+	 * to inject agent-facing messages into space:chat:${spaceId} sessions.
+	 *
+	 * This is the preferred integration point for M6+.
+	 */
+	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
 }
 
 export class SpaceRuntimeService {
@@ -126,6 +140,11 @@ export class SpaceRuntimeService {
 	 * stops, mirroring `spaceDbQueryServers` for the space-chat session.
 	 */
 	private readonly memberSessionDbQueryServers = new Map<string, DbQueryMcpServer>();
+	/**
+	 * Per-space SpaceAgentNotificationService unsubscribe handles.
+	 * Created when a space's chat session is provisioned; cleaned up on stop.
+	 */
+	private readonly spaceAgentNotificationUnsubs = new Map<string, () => void>();
 	/**
 	 * Resolves when startup-time session provisioning has completed:
 	 *   - every existing space's space:chat session has had MCP tools +
@@ -155,6 +174,7 @@ export class SpaceRuntimeService {
 			...config,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
+			internalEventBus: config.internalEventBus,
 			onTaskUpdated: async ({ spaceId, task, archiveSource }) => {
 				if (!this.config.daemonHub) return;
 				await this.config.daemonHub.emit('space.task.updated', {
@@ -371,6 +391,19 @@ export class SpaceRuntimeService {
 			}
 		}
 		this.memberSessionDbQueryServers.clear();
+
+		// Tear down per-space SpaceAgentNotificationService subscriptions.
+		for (const [spaceId, unsub] of this.spaceAgentNotificationUnsubs) {
+			try {
+				unsub();
+			} catch (error) {
+				log.warn(
+					`Failed to unsubscribe SpaceAgentNotificationService for space ${spaceId}:`,
+					error
+				);
+			}
+		}
+		this.spaceAgentNotificationUnsubs.clear();
 
 		log.info('SpaceRuntimeService stopped');
 	}
@@ -847,6 +880,26 @@ export class SpaceRuntimeService {
 					.catch(() => {});
 			}
 		}
+
+		// Wire SpaceAgentNotificationService for this space when InternalEventBus is available.
+		// This replaces the legacy SessionNotificationSink / setNotificationSink path.
+		if (this.config.internalEventBus && sessionManager) {
+			// Tear down any existing notification service for this space (re-provision safety).
+			const existingUnsub = this.spaceAgentNotificationUnsubs.get(space.id);
+			if (existingUnsub) {
+				existingUnsub();
+			}
+
+			const notificationService = new SpaceAgentNotificationService({
+				internalEventBus: this.config.internalEventBus,
+				sessionFactory: sessionManager,
+				sessionId: spaceChatSessionId,
+				autonomyLevel: space.autonomyLevel ?? 1,
+			} as SpaceAgentNotificationServiceConfig);
+			const unsub = notificationService.subscribe();
+			this.spaceAgentNotificationUnsubs.set(space.id, unsub);
+			log.info(`SpaceAgentNotificationService wired for space ${space.id} (${spaceChatSessionId})`);
+		}
 	}
 
 	/**
@@ -983,6 +1036,9 @@ export class SpaceRuntimeService {
 			// Forward the runtime's current sink so a gate-driven reopen still
 			// surfaces `workflow_run_reopened` to the Space Agent session.
 			notificationSink: this.runtime.getNotificationSink(),
+			// Forward the InternalEventBus so gate-driven reopens also publish
+			// typed `space.workflowRun.reopened` events for bus subscribers.
+			internalEventBus: this.config.internalEventBus,
 			onGatePendingApproval: (runId, gateId) => this.handleGatePendingApproval(runId, gateId),
 		});
 		return router.onGateDataChanged(runId, gateId);
@@ -1043,6 +1099,9 @@ export class SpaceRuntimeService {
 			// terminal runs still surface `workflow_run_reopened` to the Space
 			// Agent session (mirrors `notifyGateDataChanged` above).
 			notificationSink: this.runtime.getNotificationSink(),
+			// Forward the InternalEventBus so activation-driven reopens also publish
+			// typed `space.workflowRun.reopened` events for bus subscribers.
+			internalEventBus: this.config.internalEventBus,
 		});
 		return router.activateNode(runId, nodeId);
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -485,38 +485,14 @@ export class SpaceRuntimeService {
 		// so stale subscribers don't accumulate and fan-out to non-existent sessions.
 		const unsubSpaceArchived = daemonHub.on(
 			'space.archived',
-			(event) => {
-				const unsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
-				if (unsub) {
-					try {
-						unsub();
-					} catch {
-						log.warn(
-							`Failed to unsubscribe SpaceAgentNotificationService for archived space ${event.spaceId}:`
-						);
-					}
-					this.spaceAgentNotificationUnsubs.delete(event.spaceId);
-				}
-			},
+			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'archived'),
 			{ sessionId: 'global' }
 		);
 		this.unsubscribers.push(unsubSpaceArchived);
 
 		const unsubSpaceDeleted = daemonHub.on(
 			'space.deleted',
-			(event) => {
-				const unsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
-				if (unsub) {
-					try {
-						unsub();
-					} catch {
-						log.warn(
-							`Failed to unsubscribe SpaceAgentNotificationService for deleted space ${event.spaceId}:`
-						);
-					}
-					this.spaceAgentNotificationUnsubs.delete(event.spaceId);
-				}
-			},
+			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'deleted'),
 			{ sessionId: 'global' }
 		);
 		this.unsubscribers.push(unsubSpaceDeleted);
@@ -532,9 +508,10 @@ export class SpaceRuntimeService {
 				// Re-provision the space chat session, which re-creates the
 				// SpaceAgentNotificationService with the updated autonomy level.
 				if (event.space) {
-					void this.setupSpaceAgentSession(event.space as Space).catch(() => {
+					void this.setupSpaceAgentSession(event.space as Space).catch((err) => {
 						log.error(
-							`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`
+							`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`,
+							err
 						);
 					});
 				}
@@ -597,6 +574,23 @@ export class SpaceRuntimeService {
 			log.warn(`Failed to close db-query server for member session ${sessionId}:`, err);
 		}
 		this.memberSessionDbQueryServers.delete(sessionId);
+	}
+
+	/**
+	 * Tear down the SpaceAgentNotificationService subscription for a given space.
+	 * Called when a space is archived or deleted to prevent stale subscribers.
+	 */
+	private tearDownSpaceNotificationService(spaceId: string, reason: 'archived' | 'deleted'): void {
+		const unsub = this.spaceAgentNotificationUnsubs.get(spaceId);
+		if (!unsub) return;
+		try {
+			unsub();
+		} catch {
+			log.warn(
+				`Failed to unsubscribe SpaceAgentNotificationService for ${reason} space ${spaceId}:`
+			);
+		}
+		this.spaceAgentNotificationUnsubs.delete(spaceId);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -63,7 +63,11 @@ import { executeGateScript } from './gate-script-executor';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
-import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
+import type {
+	InternalEventBus,
+	DaemonInternalEventMap,
+	InternalEventPayload,
+} from '../../internal-event-bus';
 import {
 	type PostApprovalRouteContext,
 	type PostApprovalRouteResult,
@@ -706,6 +710,15 @@ export class SpaceRuntime {
 	 * Errors are logged at warn level and the tick continues normally.
 	 */
 	private async safeNotify(event: Parameters<NotificationSink['notify']>[0]): Promise<void> {
+		// New path — publish typed event to InternalEventBus FIRST so bus subscribers
+		// are never delayed by a slow or failing legacy sink.
+		if (this.internalEventBus) {
+			const mapped = this.mapNotificationEventToInternalEvent(event);
+			if (mapped) {
+				this.publishToInternalEventBus(mapped.event, mapped.payload);
+			}
+		}
+
 		// Legacy path — keep until all subscribers migrate off NotificationSink.
 		try {
 			await this.notificationSink.notify(event);
@@ -714,25 +727,29 @@ export class SpaceRuntime {
 				`[SpaceRuntime] NotificationSink.notify() threw for event "${event.kind}": ${err instanceof Error ? err.message : String(err)}`
 			);
 		}
+	}
 
-		// New path — publish typed event to InternalEventBus.
-		if (this.internalEventBus) {
-			const mapped = this.mapNotificationEventToInternalEvent(event);
-			if (mapped) {
-				try {
-					// Type assertion: the mapper returns the correct payload shape for each event.
-					(
-						this.internalEventBus.publishAsync as (
-							event: string,
-							payload: DaemonInternalEventMap[keyof DaemonInternalEventMap]
-						) => void
-					)(mapped.event, mapped.payload);
-				} catch (err) {
-					log.warn(
-						`[SpaceRuntime] internalEventBus.publishAsync() threw for event "${mapped.event}": ${err instanceof Error ? err.message : String(err)}`
-					);
-				}
-			}
+	/**
+	 * Type-safe helper that publishes a mapped event to InternalEventBus.
+	 *
+	 * Uses a generic helper to preserve the correlated event→payload type
+	 * relationship without an unsafe cast.
+	 */
+	private publishToInternalEventBus<K extends keyof DaemonInternalEventMap & string>(
+		event: K,
+		payload: DaemonInternalEventMap[K]
+	): void {
+		if (!this.internalEventBus) return;
+		try {
+			// All mapped events carry sessionId and satisfy InternalEventPayload.
+			this.internalEventBus.publishAsync(
+				event,
+				payload as DaemonInternalEventMap[K] & InternalEventPayload
+			);
+		} catch (err) {
+			log.warn(
+				`[SpaceRuntime] internalEventBus.publishAsync() threw for event "${event}": ${err instanceof Error ? err.message : String(err)}`
+			);
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -63,6 +63,7 @@ import { executeGateScript } from './gate-script-executor';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
+import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
 import {
 	type PostApprovalRouteContext,
 	type PostApprovalRouteResult,
@@ -123,8 +124,19 @@ export interface SpaceRuntimeConfig {
 	 * Sink for structured notification events emitted after mechanical processing.
 	 * Defaults to NullNotificationSink (no-op). Use setNotificationSink() to wire
 	 * in a real sink after construction (e.g. once the Space Agent session exists).
+	 *
+	 * @deprecated Use `internalEventBus` instead. NotificationSink is a short-lived
+	 * compatibility adapter. See M6 migration in internal-event-command-query-architecture.md.
 	 */
 	notificationSink?: NotificationSink;
+	/**
+	 * Optional InternalEventBus for publishing domain events. When provided,
+	 * SpaceRuntime publishes typed events alongside the legacy NotificationSink path.
+	 *
+	 * This is the preferred integration point for M6+; NotificationSink will be
+	 * removed once all subscribers migrate to InternalEventBus.
+	 */
+	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
 	/**
 	 * Completion detector — inspects the canonical `SpaceTask` to decide whether
 	 * a workflow run is complete or ready for runtime resolution.
@@ -242,6 +254,13 @@ export class SpaceRuntime {
 	private notificationSink: NotificationSink;
 
 	/**
+	 * Optional InternalEventBus for publishing domain events.
+	 * When provided, SpaceRuntime publishes typed events alongside the legacy
+	 * NotificationSink path. This is the preferred integration point for M6+.
+	 */
+	private internalEventBus: InternalEventBus<DaemonInternalEventMap> | undefined;
+
+	/**
 	 * Lazy-initialized SDK message repository used for thread-event emission.
 	 * Sourced from `config.sdkMessageRepo` when provided, otherwise constructed
 	 * on first use from `config.db`.
@@ -310,6 +329,7 @@ export class SpaceRuntime {
 
 	constructor(private config: SpaceRuntimeConfig) {
 		this.notificationSink = config.notificationSink ?? new NullNotificationSink();
+		this.internalEventBus = config.internalEventBus;
 		this.completionDetector = config.completionDetector ?? new CompletionDetector(config.taskRepo);
 		this.sdkMessageRepo = config.sdkMessageRepo ?? null;
 		this.toolContinuationRepo = new ToolContinuationRecoveryRepository(config.db);
@@ -385,6 +405,9 @@ export class SpaceRuntime {
 	 *
 	 * Called after construction once the Space Agent session has been provisioned,
 	 * since SpaceRuntimeService is instantiated before the global agent session exists.
+	 *
+	 * @deprecated Use `internalEventBus` with a subscriber instead. This method exists
+	 * only as a short-lived compatibility adapter for M6 migration.
 	 */
 	setNotificationSink(sink: NotificationSink): void {
 		this.notificationSink = sink;
@@ -402,6 +425,8 @@ export class SpaceRuntime {
 	 * created inside `TaskAgentManager`) can plumb the same sink through,
 	 * ensuring `workflow_run_reopened` events reach the Space Agent session
 	 * regardless of which code path triggered the reopen.
+	 *
+	 * @deprecated Use `internalEventBus` subscribers instead.
 	 */
 	getNotificationSink(): NotificationSink {
 		return this.notificationSink;
@@ -669,6 +694,10 @@ export class SpaceRuntime {
 	/**
 	 * Safely calls notificationSink.notify(), catching and logging any errors.
 	 *
+	 * Also publishes the corresponding typed event to `internalEventBus` when
+	 * configured. This dual-path approach lets existing NotificationSink
+	 * subscribers keep working while new InternalEventBus subscribers migrate.
+	 *
 	 * By interface contract, NotificationSink implementations should handle their
 	 * own errors internally (see SessionNotificationSink). However, to prevent a
 	 * poorly-written or custom sink from crashing the tick loop, SpaceRuntime
@@ -677,12 +706,192 @@ export class SpaceRuntime {
 	 * Errors are logged at warn level and the tick continues normally.
 	 */
 	private async safeNotify(event: Parameters<NotificationSink['notify']>[0]): Promise<void> {
+		// Legacy path — keep until all subscribers migrate off NotificationSink.
 		try {
 			await this.notificationSink.notify(event);
 		} catch (err) {
 			log.warn(
 				`[SpaceRuntime] NotificationSink.notify() threw for event "${event.kind}": ${err instanceof Error ? err.message : String(err)}`
 			);
+		}
+
+		// New path — publish typed event to InternalEventBus.
+		if (this.internalEventBus) {
+			const mapped = this.mapNotificationEventToInternalEvent(event);
+			if (mapped) {
+				try {
+					// Type assertion: the mapper returns the correct payload shape for each event.
+					(
+						this.internalEventBus.publishAsync as (
+							event: string,
+							payload: DaemonInternalEventMap[keyof DaemonInternalEventMap]
+						) => void
+					)(mapped.event, mapped.payload);
+				} catch (err) {
+					log.warn(
+						`[SpaceRuntime] internalEventBus.publishAsync() threw for event "${mapped.event}": ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Map a legacy NotificationSink event to a typed InternalEventBus event.
+	 *
+	 * Returns `null` for events that don't have a corresponding internal event
+	 * (shouldn't happen for current SpaceRuntime events).
+	 *
+	 * The `sessionId` field is set to `'global'` because these events are
+	 * space-scoped, not session-scoped. Subscribers that need space-scoped
+	 * filtering should inspect `payload.spaceId`.
+	 */
+	private mapNotificationEventToInternalEvent(event: Parameters<NotificationSink['notify']>[0]): {
+		event: keyof DaemonInternalEventMap;
+		payload: DaemonInternalEventMap[keyof DaemonInternalEventMap];
+	} | null {
+		const sessionId = 'global';
+		switch (event.kind) {
+			case 'task_blocked':
+				return {
+					event: 'space.task.blocked',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						reason: event.reason,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'workflow_run_blocked':
+				return {
+					event: 'space.workflowRun.blocked',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						runId: event.runId,
+						reason: event.reason,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'task_timeout':
+				return {
+					event: 'space.task.timeout',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						elapsedMs: event.elapsedMs,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'workflow_run_completed':
+				return {
+					event: 'space.workflowRun.completed',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						runId: event.runId,
+						status: event.status,
+						summary: event.summary,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'workflow_run_reopened':
+				return {
+					event: 'space.workflowRun.reopened',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						runId: event.runId,
+						fromStatus: event.fromStatus,
+						reason: event.reason,
+						by: event.by,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'agent_auto_completed':
+				return {
+					event: 'space.agent.autoCompleted',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						elapsedMs: event.elapsedMs,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'agent_crash':
+				return {
+					event: 'space.agent.crashed',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'agent_idle_non_terminal':
+				return {
+					event: 'space.agent.idleNonTerminal',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						runId: event.runId,
+						executionId: event.executionId,
+						nodeId: event.nodeId,
+						agentName: event.agentName,
+						reason: event.reason,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'task_retry':
+				return {
+					event: 'space.workflowRun.retry',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						runId: event.runId,
+						originalReason: event.originalReason,
+						attemptNumber: event.attemptNumber,
+						maxAttempts: event.maxAttempts,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'workflow_run_needs_attention':
+				return {
+					event: 'space.workflowRun.needsAttention',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						runId: event.runId,
+						taskId: event.taskId,
+						reason: event.reason,
+						retriesExhausted: event.retriesExhausted,
+						timestamp: event.timestamp,
+					},
+				};
+			case 'task_awaiting_approval':
+				return {
+					event: 'space.task.awaitingApproval',
+					payload: {
+						sessionId,
+						spaceId: event.spaceId,
+						taskId: event.taskId,
+						actionId: event.actionId,
+						actionName: event.actionName,
+						actionDescription: event.actionDescription,
+						actionType: event.actionType,
+						requiredLevel: event.requiredLevel,
+						spaceLevel: event.spaceLevel,
+						autonomyLevel: event.autonomyLevel,
+						timestamp: event.timestamp,
+					},
+				};
+			default:
+				return null;
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -239,6 +239,15 @@ export interface TaskAgentManagerConfig {
 	 * registered.
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
+	/**
+	 * Optional InternalEventBus for publishing Space runtime domain events.
+	 * When provided, ChannelRouter instances created by TaskAgentManager will
+	 * dual-publish workflow_run_reopened (and future events) to the bus alongside
+	 * the legacy NotificationSink path.
+	 */
+	internalEventBus?: import('../../internal-event-bus').InternalEventBus<
+		import('../../internal-event-bus').DaemonInternalEventMap
+	>;
 }
 
 // ---------------------------------------------------------------------------
@@ -2103,6 +2112,7 @@ export class TaskAgentManager {
 				isSessionAlive: (sid) => this.isSessionAlive(sid),
 				cancelSessionById: (sid) => this.cancelBySessionId(sid),
 				notificationSink: this.config.spaceRuntimeService.getSharedRuntime().getNotificationSink(),
+				internalEventBus: this.config.internalEventBus,
 				onGatePendingApproval: (runId, gateId) =>
 					this.config.spaceRuntimeService.handleGatePendingApproval(runId, gateId),
 			});
@@ -4332,6 +4342,7 @@ export class TaskAgentManager {
 			// that auto-reopens a terminal run still emits `workflow_run_reopened`
 			// into the Space Agent session.
 			notificationSink: this.config.spaceRuntimeService.getSharedRuntime().getNotificationSink(),
+			internalEventBus: this.config.internalEventBus,
 			onGatePendingApproval: (runId, gateId) =>
 				this.config.spaceRuntimeService.handleGatePendingApproval(runId, gateId),
 		});

--- a/packages/daemon/src/lib/space/runtime/types.ts
+++ b/packages/daemon/src/lib/space/runtime/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared types for the Space runtime module.
+ *
+ * Centralises interfaces that are consumed by multiple runtime services
+ * to avoid duplication and drift.
+ */
+
+import type { MessageDeliveryMode, MessageOrigin } from '@neokai/shared';
+
+/**
+ * Minimal interface for injecting messages into a session.
+ *
+ * Used by notification services (SessionNotificationSink, SpaceAgentNotificationService)
+ * to forward structured events into the Space Agent session without depending on the
+ * full SessionManager surface.
+ */
+export interface SessionFactory {
+	injectMessage(
+		sessionId: string,
+		message: string,
+		opts?: { deliveryMode?: MessageDeliveryMode; origin?: MessageOrigin }
+	): Promise<void>;
+}

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -1,0 +1,606 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { SpaceAgentNotificationService } from '../../../../src/lib/space/runtime/space-agent-notification-service';
+import type { SpaceAgentNotificationServiceConfig } from '../../../../src/lib/space/runtime/space-agent-notification-service';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus';
+import type { MessageDeliveryMode } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mock SessionFactory
+// ---------------------------------------------------------------------------
+
+interface InjectedCall {
+	sessionId: string;
+	message: string;
+	opts?: { deliveryMode?: MessageDeliveryMode };
+}
+
+function makeMockSessionFactory(opts?: {
+	injectError?: Error;
+}): SessionFactory & { calls: InjectedCall[] } {
+	const calls: InjectedCall[] = [];
+	const injectError = opts?.injectError;
+
+	const factory: SessionFactory & { calls: InjectedCall[] } = {
+		calls,
+		injectMessage: async (sessionId, message, injectOpts) => {
+			if (injectError) throw injectError;
+			calls.push({ sessionId, message, opts: injectOpts });
+		},
+	};
+
+	return factory;
+}
+
+interface SessionFactory {
+	injectMessage(
+		sessionId: string,
+		message: string,
+		opts?: { deliveryMode?: MessageDeliveryMode }
+	): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'spaces:global:session-1';
+const SPACE_ID = 'space-abc';
+const TIMESTAMP = '2026-03-20T10:00:00.000Z';
+
+function makeService(
+	factoryOrOpts?:
+		| (SessionFactory & { calls: InjectedCall[] })
+		| Parameters<typeof makeMockSessionFactory>[0],
+	extra?: Partial<SpaceAgentNotificationServiceConfig>
+): {
+	service: SpaceAgentNotificationService;
+	factory: SessionFactory & { calls: InjectedCall[] };
+	bus: InternalEventBus<DaemonInternalEventMap>;
+	unsubscribe: () => void;
+} {
+	let factory: SessionFactory & { calls: InjectedCall[] };
+	if (factoryOrOpts && 'calls' in factoryOrOpts) {
+		factory = factoryOrOpts as SessionFactory & { calls: InjectedCall[] };
+	} else {
+		factory = makeMockSessionFactory(factoryOrOpts as Parameters<typeof makeMockSessionFactory>[0]);
+	}
+	const bus = new InternalEventBus<DaemonInternalEventMap>();
+	const service = new SpaceAgentNotificationService({
+		internalEventBus: bus,
+		sessionFactory: factory,
+		sessionId: SESSION_ID,
+		...extra,
+	});
+	const unsubscribe = service.subscribe();
+	return { service, factory, bus, unsubscribe };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SpaceAgentNotificationService', () => {
+	describe('space.task.blocked event', () => {
+		it('injects a message with [TASK_EVENT] prefix when space.task.blocked is published', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Agent reported an error',
+				timestamp: TIMESTAMP,
+			});
+
+			expect(factory.calls).toHaveLength(1);
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_blocked');
+		});
+
+		it('injects into the correct session ID', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+
+			expect(factory.calls[0].sessionId).toBe(SESSION_ID);
+		});
+
+		it('uses defer delivery mode', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+
+			expect(factory.calls[0].opts?.deliveryMode).toBe('defer');
+		});
+
+		it('message includes human-readable text with taskId, spaceId, and reason', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-99',
+				reason: 'Unrecoverable build failure',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('task-99');
+			expect(message).toContain(SPACE_ID);
+			expect(message).toContain('Unrecoverable build failure');
+		});
+
+		it('message includes JSON payload with all event fields', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-42',
+				reason: 'Timed out',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_blocked');
+			expect(json.spaceId).toBe(SPACE_ID);
+			expect(json.taskId).toBe('task-42');
+			expect(json.reason).toBe('Timed out');
+			expect(json.timestamp).toBe(TIMESTAMP);
+		});
+
+		it('message includes autonomy level (default supervised)', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('Autonomy level: 1');
+			const json = extractJson(message);
+			expect(json.autonomyLevel).toBe(1);
+		});
+
+		it('message includes semi_autonomous level when configured', async () => {
+			const { factory, bus } = makeService(undefined, { autonomyLevel: 3 });
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('Autonomy level: 3');
+			const json = extractJson(message);
+			expect(json.autonomyLevel).toBe(3);
+		});
+	});
+
+	describe('space.workflowRun.blocked event', () => {
+		it('formats message correctly', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-55',
+				reason: 'Transition condition failed: tests did not pass',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_blocked');
+			expect(message).toContain('run-55');
+			expect(message).toContain('Transition condition failed: tests did not pass');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('workflow_run_blocked');
+			expect(json.runId).toBe('run-55');
+			expect(json.autonomyLevel).toBe(1);
+		});
+	});
+
+	describe('space.task.timeout event', () => {
+		it('formats elapsed time in minutes', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.timeout', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-slow',
+				elapsedMs: 3600000, // 60 minutes
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_timeout');
+			expect(message).toContain('60 minute');
+			expect(message).toContain('task-slow');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_timeout');
+			expect(json.elapsedMs).toBe(3600000);
+			expect(json.autonomyLevel).toBe(1);
+		});
+	});
+
+	describe('space.workflowRun.completed event', () => {
+		it('formats a completed run', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.completed', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				status: 'done',
+				summary: 'All steps finished. PR #42 merged.',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_completed');
+			expect(message).toContain('completed successfully');
+			expect(message).toContain('PR #42 merged.');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('done');
+			expect(json.summary).toBe('All steps finished. PR #42 merged.');
+			expect(json.autonomyLevel).toBe(1);
+		});
+
+		it('formats a cancelled run', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.completed', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-2',
+				status: 'cancelled',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('was cancelled');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('cancelled');
+			expect(json.summary).toBeUndefined();
+		});
+
+		it('formats a blocked run', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.completed', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-3',
+				status: 'blocked',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('blocked');
+
+			const json = extractJson(message);
+			expect(json.status).toBe('blocked');
+		});
+	});
+
+	describe('space.workflowRun.reopened event', () => {
+		it('formats a reopen from done with attribution', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.reopened', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-rx',
+				fromStatus: 'done',
+				reason: 'user follow-up message arrived',
+				by: 'user',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_reopened');
+			expect(message).toContain("reopened from 'done'");
+			expect(message).toContain("back to 'in_progress'");
+			expect(message).toContain('user follow-up message arrived');
+			expect(message).toContain('(by: user)');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('workflow_run_reopened');
+			expect(json.runId).toBe('run-rx');
+			expect(json.fromStatus).toBe('done');
+			expect(json.by).toBe('user');
+			expect(json.autonomyLevel).toBe(1);
+		});
+	});
+
+	describe('space.agent.crashed event', () => {
+		it('formats agent crash with [TASK_EVENT] prefix', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.agent.crashed', {
+				sessionId: 'global',
+				spaceId: 'space-crash',
+				taskId: 'task-crashed',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] agent_crash');
+			expect(message).toContain('task-crashed');
+			expect(message).toContain('space-crash');
+			expect(message).toContain('blocked');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('agent_crash');
+			expect(json.failureReason).toBe('agentCrash');
+			expect(json.taskId).toBe('task-crashed');
+			expect(json.spaceId).toBe('space-crash');
+			expect(json.autonomyLevel).toBe(1);
+		});
+	});
+
+	describe('space.agent.autoCompleted event', () => {
+		it('formats auto-completed message', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.agent.autoCompleted', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-auto',
+				elapsedMs: 300000,
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] agent_auto_completed');
+			expect(message).toContain('auto-completed');
+			expect(message).toContain('5 minute');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('agent_auto_completed');
+			expect(json.elapsedMs).toBe(300000);
+		});
+	});
+
+	describe('space.agent.idleNonTerminal event', () => {
+		it('formats idle non-terminal message', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.agent.idleNonTerminal', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-idle',
+				runId: 'run-idle',
+				executionId: 'exec-1',
+				nodeId: 'node-1',
+				agentName: 'coder',
+				reason: 'Agent stopped responding',
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] agent_idle_non_terminal');
+			expect(message).toContain('node-1');
+			expect(message).toContain('coder');
+			expect(message).toContain('Agent stopped responding');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('agent_idle_non_terminal');
+			expect(json.nodeId).toBe('node-1');
+			expect(json.agentName).toBe('coder');
+		});
+	});
+
+	describe('space.workflowRun.retry event', () => {
+		it('formats retry message', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.retry', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-retry',
+				runId: 'run-retry',
+				originalReason: 'Network timeout',
+				attemptNumber: 2,
+				maxAttempts: 3,
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_retry');
+			expect(message).toContain('attempt 2/3');
+			expect(message).toContain('Network timeout');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_retry');
+			expect(json.attemptNumber).toBe(2);
+			expect(json.maxAttempts).toBe(3);
+		});
+	});
+
+	describe('space.workflowRun.needsAttention event', () => {
+		it('formats needs attention message', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.workflowRun.needsAttention', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-na',
+				taskId: 'task-na',
+				reason: 'All retries exhausted',
+				retriesExhausted: 3,
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] workflow_run_needs_attention');
+			expect(message).toContain('needs attention');
+			expect(message).toContain('3');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('workflow_run_needs_attention');
+			expect(json.retriesExhausted).toBe(3);
+		});
+	});
+
+	describe('space.task.awaitingApproval event', () => {
+		it('formats awaiting approval message', async () => {
+			const { factory, bus } = makeService();
+			await bus.publish('space.task.awaitingApproval', {
+				sessionId: 'global',
+				spaceId: 'space-a',
+				taskId: 'task-1',
+				actionId: 'merge-pr',
+				actionName: 'Merge PR',
+				actionDescription: 'Merges the staged PR',
+				actionType: 'script',
+				requiredLevel: 4,
+				spaceLevel: 2,
+				autonomyLevel: 2,
+				timestamp: TIMESTAMP,
+			});
+
+			const { message } = factory.calls[0];
+			expect(message).toContain('[TASK_EVENT] task_awaiting_approval');
+			expect(message).toContain('task-1');
+			expect(message).toContain('space-a');
+			expect(message).toContain("'Merge PR'");
+			expect(message).toContain('Merges the staged PR');
+			expect(message).toContain('Requires autonomy 4');
+			expect(message).toContain('space is at 2');
+
+			const json = extractJson(message);
+			expect(json.kind).toBe('task_awaiting_approval');
+			expect(json.actionId).toBe('merge-pr');
+			expect(json.actionName).toBe('Merge PR');
+			expect(json.actionDescription).toBe('Merges the staged PR');
+			expect(json.actionType).toBe('script');
+			expect(json.requiredLevel).toBe(4);
+			expect(json.spaceLevel).toBe(2);
+			expect(json.autonomyLevel).toBe(2);
+		});
+	});
+
+	describe('error handling', () => {
+		it('logs warning and does not throw when injectMessage fails', async () => {
+			const { factory, bus } = makeService({ injectError: new Error('Session not found') });
+
+			// Should not throw despite injectMessage failing
+			await expect(
+				bus.publish('space.task.blocked', {
+					sessionId: 'global',
+					spaceId: SPACE_ID,
+					taskId: 'task-1',
+					reason: 'Error',
+					timestamp: TIMESTAMP,
+				})
+			).resolves.toBeDefined();
+		});
+	});
+
+	describe('unsubscribe', () => {
+		it('stops receiving events after unsubscribe', async () => {
+			const { factory, bus, unsubscribe } = makeService();
+
+			// First event should be received
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+			expect(factory.calls).toHaveLength(1);
+
+			// Unsubscribe
+			unsubscribe();
+
+			// Second event should NOT be received
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-2',
+				reason: 'Error 2',
+				timestamp: TIMESTAMP,
+			});
+			expect(factory.calls).toHaveLength(1);
+		});
+	});
+
+	describe('compatibility with SessionNotificationSink output', () => {
+		it('produces identical output for task_blocked events', async () => {
+			const { formatEventMessage } = await import(
+				'../../../../src/lib/space/runtime/session-notification-sink'
+			);
+			const { factory, bus } = makeService();
+
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Agent error',
+				timestamp: TIMESTAMP,
+			});
+
+			const internalMessage = factory.calls[0].message;
+
+			const legacyEvent = {
+				kind: 'task_blocked' as const,
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Agent error',
+				timestamp: TIMESTAMP,
+			};
+			const legacyMessage = formatEventMessage(legacyEvent, 1);
+
+			expect(internalMessage).toBe(legacyMessage);
+		});
+
+		it('produces identical output for workflow_run_completed events', async () => {
+			const { formatEventMessage } = await import(
+				'../../../../src/lib/space/runtime/session-notification-sink'
+			);
+			const { factory, bus } = makeService();
+
+			await bus.publish('space.workflowRun.completed', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				status: 'done',
+				summary: 'All done',
+				timestamp: TIMESTAMP,
+			});
+
+			const internalMessage = factory.calls[0].message;
+
+			const legacyEvent = {
+				kind: 'workflow_run_completed' as const,
+				spaceId: SPACE_ID,
+				runId: 'run-1',
+				status: 'done' as const,
+				summary: 'All done',
+				timestamp: TIMESTAMP,
+			};
+			const legacyMessage = formatEventMessage(legacyEvent, 1);
+
+			expect(internalMessage).toBe(legacyMessage);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test utility: extract the first JSON block from a message
+// ---------------------------------------------------------------------------
+
+function extractJson(message: string): Record<string, unknown> {
+	const match = message.match(/```json\n([\s\S]*?)```/);
+	if (!match) throw new Error(`No JSON block found in message:\n${message}`);
+	return JSON.parse(match[1]) as Record<string, unknown>;
+}

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -63,6 +63,7 @@ function makeService(
 		internalEventBus: bus,
 		sessionFactory: factory,
 		sessionId: SESSION_ID,
+		spaceId: SPACE_ID,
 		...extra,
 	});
 	const unsubscribe = service.subscribe();
@@ -323,7 +324,7 @@ describe('SpaceAgentNotificationService', () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.agent.crashed', {
 				sessionId: 'global',
-				spaceId: 'space-crash',
+				spaceId: SPACE_ID,
 				taskId: 'task-crashed',
 				timestamp: TIMESTAMP,
 			});
@@ -331,14 +332,14 @@ describe('SpaceAgentNotificationService', () => {
 			const { message } = factory.calls[0];
 			expect(message).toContain('[TASK_EVENT] agent_crash');
 			expect(message).toContain('task-crashed');
-			expect(message).toContain('space-crash');
+			expect(message).toContain(SPACE_ID);
 			expect(message).toContain('blocked');
 
 			const json = extractJson(message);
 			expect(json.kind).toBe('agent_crash');
 			expect(json.failureReason).toBe('agentCrash');
 			expect(json.taskId).toBe('task-crashed');
-			expect(json.spaceId).toBe('space-crash');
+			expect(json.spaceId).toBe(SPACE_ID);
 			expect(json.autonomyLevel).toBe(1);
 		});
 	});
@@ -448,7 +449,7 @@ describe('SpaceAgentNotificationService', () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.awaitingApproval', {
 				sessionId: 'global',
-				spaceId: 'space-a',
+				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				actionId: 'merge-pr',
 				actionName: 'Merge PR',
@@ -525,6 +526,33 @@ describe('SpaceAgentNotificationService', () => {
 				timestamp: TIMESTAMP,
 			});
 			expect(factory.calls).toHaveLength(1);
+		});
+	});
+
+	describe('per-space filtering', () => {
+		it('ignores events for other spaces', async () => {
+			const { factory, bus } = makeService();
+
+			// Event for the correct space
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: SPACE_ID,
+				taskId: 'task-1',
+				reason: 'Error',
+				timestamp: TIMESTAMP,
+			});
+
+			// Event for a different space
+			await bus.publish('space.task.blocked', {
+				sessionId: 'global',
+				spaceId: 'other-space',
+				taskId: 'task-2',
+				reason: 'Other error',
+				timestamp: TIMESTAMP,
+			});
+
+			expect(factory.calls).toHaveLength(1);
+			expect(factory.calls[0].message).toContain('task-1');
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -4,6 +4,7 @@ import type { SpaceAgentNotificationServiceConfig } from '../../../../src/lib/sp
 import { InternalEventBus } from '../../../../src/lib/internal-event-bus';
 import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus';
 import type { MessageDeliveryMode } from '@neokai/shared';
+import type { SessionFactory } from '../../../../src/lib/space/runtime/types';
 
 // ---------------------------------------------------------------------------
 // Mock SessionFactory
@@ -30,14 +31,6 @@ function makeMockSessionFactory(opts?: {
 	};
 
 	return factory;
-}
-
-interface SessionFactory {
-	injectMessage(
-		sessionId: string,
-		message: string,
-		opts?: { deliveryMode?: MessageDeliveryMode }
-	): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -484,7 +477,8 @@ describe('SpaceAgentNotificationService', () => {
 			expect(json.actionType).toBe('script');
 			expect(json.requiredLevel).toBe(4);
 			expect(json.spaceLevel).toBe(2);
-			expect(json.autonomyLevel).toBe(2);
+			// Service-level autonomy (default 1) is used, not event.autonomyLevel
+			expect(json.autonomyLevel).toBe(1);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -30,19 +30,8 @@ import type {
 } from '../../../../src/lib/space/runtime/notification-sink.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { SessionNotificationSink } from '../../../../src/lib/space/runtime/session-notification-sink.ts';
+import type { SessionFactory } from '../../../../src/lib/space/runtime/types';
 import type { MessageDeliveryMode } from '@neokai/shared';
-
-/**
- * Minimal SessionFactory interface for testing.
- * Matches the interface defined in session-notification-sink.ts.
- */
-interface SessionFactory {
-	injectMessage(
-		sessionId: string,
-		message: string,
-		opts?: { deliveryMode?: string }
-	): Promise<void>;
-}
 
 // ---------------------------------------------------------------------------
 // Mock sinks

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -33,6 +33,8 @@ import type {
 import type { SpaceWorkflow, SpaceTask, SpaceWorkflowRun, Space } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -1989,6 +1991,122 @@ describe('SpaceRuntime — notification events', () => {
 				// Only Done is terminal → its summary is returned
 				expect(completedEvents[0].summary).toBe(doneSummary);
 			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// InternalEventBus dual publishing (M6 migration)
+	// -------------------------------------------------------------------------
+
+	describe('InternalEventBus dual publishing', () => {
+		test('publishes space.task.blocked to InternalEventBus alongside NotificationSink', async () => {
+			const bus = new InternalEventBus<DaemonInternalEventMap>();
+			const busEvents: { event: string; payload: unknown }[] = [];
+			bus.subscribe(
+				'space.task.blocked',
+				(payload) => {
+					busEvents.push({ event: 'space.task.blocked', payload });
+				},
+				{ subscriberName: 'test-subscriber' }
+			);
+
+			const rt = makeRuntime({ internalEventBus: bus });
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			seedNodeExec(db, run.id, STEP_A, 'plan', 'blocked');
+
+			await rt.executeTick();
+
+			// Legacy path
+			expect(sink.events.filter((e) => e.kind === 'task_blocked')).toHaveLength(1);
+			// New path
+			expect(busEvents).toHaveLength(1);
+			const busEvent = busEvents[0].payload as { spaceId: string; taskId: string; reason: string };
+			expect(busEvent.spaceId).toBe(SPACE_ID);
+			expect(busEvent.taskId).toBe(tasks[0].id);
+			expect(busEvent.reason).toBe('One or more workflow agents are blocked');
+		});
+
+		test('publishes space.workflowRun.blocked to InternalEventBus', async () => {
+			const bus = new InternalEventBus<DaemonInternalEventMap>();
+			const busEvents: { event: string; payload: unknown }[] = [];
+			bus.subscribe(
+				'space.workflowRun.blocked',
+				(payload) => {
+					busEvents.push({ event: 'space.workflowRun.blocked', payload });
+				},
+				{ subscriberName: 'test-subscriber' }
+			);
+
+			const rt = makeRuntime({ internalEventBus: bus });
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			seedNodeExec(db, run.id, STEP_A, 'plan', 'blocked');
+
+			await rt.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);
+			expect(busEvents).toHaveLength(1);
+			const busEvent = busEvents[0].payload as { spaceId: string; runId: string };
+			expect(busEvent.spaceId).toBe(SPACE_ID);
+			expect(busEvent.runId).toBe(run.id);
+		});
+
+		test('publishes space.task.timeout to InternalEventBus', async () => {
+			setSpaceTaskTimeoutMs(db, SPACE_ID, 1000);
+			const bus = new InternalEventBus<DaemonInternalEventMap>();
+			const busEvents: { event: string; payload: unknown }[] = [];
+			bus.subscribe(
+				'space.task.timeout',
+				(payload) => {
+					busEvents.push({ event: 'space.task.timeout', payload });
+				},
+				{ subscriberName: 'test-subscriber' }
+			);
+
+			const rt = makeRuntime({ internalEventBus: bus });
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			seedNodeExec(db, run.id, STEP_A, 'plan', 'in_progress', { startedAt: Date.now() - 2000 });
+
+			await rt.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_timeout')).toHaveLength(1);
+			expect(busEvents).toHaveLength(1);
+			const busEvent = busEvents[0].payload as {
+				spaceId: string;
+				taskId: string;
+				elapsedMs: number;
+			};
+			expect(busEvent.spaceId).toBe(SPACE_ID);
+			expect(busEvent.taskId).toBe(tasks[0].id);
+			expect(busEvent.elapsedMs).toBeGreaterThan(1000);
+		});
+
+		test('works without InternalEventBus (backward compatibility)', async () => {
+			// No internalEventBus configured — only legacy path should work
+			const rt = makeRuntime();
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_CODER },
+			]);
+
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			seedNodeExec(db, run.id, STEP_A, 'plan', 'blocked');
+
+			await rt.executeTick();
+
+			expect(sink.events.filter((e) => e.kind === 'task_blocked')).toHaveLength(1);
+			// No crash, no error — backward compatible
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -656,12 +656,14 @@ describe('SpaceRuntimeService', () => {
 			svc.start();
 			await svc.stop();
 
-			// Four DaemonHub subscriptions are registered: space.created,
+			// Seven DaemonHub subscriptions are registered: space.created,
 			// spaceWorkflow.updated (mid-run gate poll refresh), session.created,
-			// and session.deleted (which releases per-session db-query servers).
+			// session.deleted (which releases per-session db-query servers),
+			// space.archived, space.deleted (tear down notification services),
+			// and space.updated (refresh autonomy level).
 			// Hard-reset reprovisioning uses SessionManager's awaited in-process
 			// subscriber instead of DaemonHub.
-			expect(unsubFn).toHaveBeenCalledTimes(4);
+			expect(unsubFn).toHaveBeenCalledTimes(7);
 		});
 	});
 


### PR DESCRIPTION
Implements Milestone M6 from the internal event architecture plan.

**Changes:**
- Defines Space runtime domain events as typed channels with dot-separated camelCase names (`space.task.blocked`, `space.workflowRun.completed`, etc.)
- Publishes these events through `InternalEventBus` on all Space runtime state transitions
- Implements `SpaceAgentNotificationService` as a subscriber that turns selected events into agent-facing `[TASK_EVENT]` messages
- Keeps `NotificationSink` as a short-lived compatibility adapter with a removal plan

**New files:**
- `packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts`
- `packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts`

**Modified files:**
- `packages/daemon/src/lib/internal-event-bus.ts` — added SpaceEvents interface (16 event types)
- `packages/daemon/src/lib/space/runtime/space-runtime.ts` — wired dual publishing to InternalEventBus
- `packages/daemon/src/lib/space/runtime/notification-sink.ts` — marked as @deprecated
- `packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts` — added dual-publishing tests

**Backward compatibility:** The legacy `NotificationSink` path remains fully functional. All existing tests pass.