### PR TITLE
refactor(daemon): rename InternalEventBus sessionId to namespaceId

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -339,13 +339,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// and broadcast read.
 	const unsubSessionCreated = daemonHub.on('session.created', (data) => {
 		void internalEventBus.publish('session.created', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 			session: data.session,
 		});
 	});
 	const unsubSessionUpdated = daemonHub.on('session.updated', (data) => {
 		void internalEventBus.publish('session.updated', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 			source: data.source,
 			session: data.session,
 			processingState: data.processingState,
@@ -353,31 +353,32 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	});
 	const unsubSessionDeleted = daemonHub.on('session.deleted', (data) => {
 		void internalEventBus.publish('session.deleted', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 		});
 	});
 	const unsubCommandsUpdated = daemonHub.on('commands.updated', (data) => {
 		void internalEventBus.publish('commands.updated', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 			commands: data.commands,
 		});
 	});
 	const unsubSessionError = daemonHub.on('session.error', (data) => {
 		void internalEventBus.publish('session.error', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 			error: data.error,
 			details: data.details,
 		});
 	});
 	const unsubSessionErrorClear = daemonHub.on('session.errorClear', (data) => {
 		void internalEventBus.publish('session.errorClear', {
-			sessionId: data.sessionId,
+			namespaceId: data.sessionId,
 		});
 	});
 	const unsubApiConnection = daemonHub.on('api.connection', (data) => {
 		// Forward the complete payload so diagnostic fields (errorCount,
 		// lastError, lastSuccessfulCall) are preserved in projections.
 		void internalEventBus.publish('api.connection', {
+			namespaceId: data.sessionId,
 			...data,
 		});
 	});

--- a/packages/daemon/src/lib/external-events/external-event-service.ts
+++ b/packages/daemon/src/lib/external-events/external-event-service.ts
@@ -35,7 +35,7 @@ export interface PublishResult {
  * matching/routing without an extra store lookup.
  */
 export interface ExternalEventPublishedPayload {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	eventId: string;
 	source: string;
@@ -123,7 +123,7 @@ export class ExternalEventService implements ExternalEventPublisher {
 	 */
 	private async _publishBusEvent(event: ExternalEvent): Promise<void> {
 		await this.bus.publish('externalEvent.published', {
-			sessionId: event.spaceId,
+			namespaceId: event.spaceId,
 			spaceId: event.spaceId,
 			eventId: event.id,
 			source: event.source,

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -68,12 +68,12 @@ export class InternalEventBusPublishError extends Error {
 
 /**
  * Generic constraint for event-map entries.
- * All events must be plain objects so we can safely read `sessionId` for
+ * All events must be plain objects so we can safely read `namespaceId` for
  * scoped routing.
  */
 export interface InternalEventPayload {
-	/** Session-scoped routing key.  Use `'global'` for app-wide events. */
-	sessionId: string;
+	/** Namespace routing key.  Use `'global'` for app-wide events. */
+	namespaceId: string;
 
 	[key: string]: unknown;
 }
@@ -90,9 +90,9 @@ export interface SubscribeOptions {
 
 	/**
 	 * When provided, the handler only receives events whose payload carries
-	 * the matching `sessionId`.  Omit for a global subscription.
+	 * the matching `namespaceId`.  Omit for a global subscription.
 	 */
-	sessionId?: string;
+	namespaceId?: string;
 }
 
 export type InternalEventHandler<TPayload> = (data: TPayload) => void | Promise<void>;
@@ -102,7 +102,7 @@ interface RegisteredHandler {
 	handler: (data: unknown) => void | Promise<void>;
 }
 
-const GLOBAL_SESSION_KEY = '__global__';
+const GLOBAL_NAMESPACE_KEY = '__global__';
 
 /**
  * InternalEventBus
@@ -110,7 +110,7 @@ const GLOBAL_SESSION_KEY = '__global__';
  * @template TEventMap — map of dot-separated event names to payload shapes.
  */
 export class InternalEventBus<TEventMap extends object = Record<string, InternalEventPayload>> {
-	// event → sessionId → handlers
+	// event → namespaceId → handlers
 	private handlers = new Map<string, Map<string, Set<RegisteredHandler>>>();
 
 	/**
@@ -118,7 +118,7 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 	 *
 	 * @param event     — typed event name
 	 * @param handler   — callback invoked when the event is published
-	 * @param options   — must include `subscriberName`; optional `sessionId` filter
+	 * @param options   — must include `subscriberName`; optional `namespaceId` filter
 	 * @returns unsubscribe function
 	 */
 	subscribe<K extends keyof TEventMap & string>(
@@ -127,11 +127,11 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 		options: SubscribeOptions
 	): () => void {
 		const eventKey = event;
-		const sessionKey = options.sessionId ?? GLOBAL_SESSION_KEY;
+		const namespaceKey = options.namespaceId ?? GLOBAL_NAMESPACE_KEY;
 
-		if (options.sessionId === GLOBAL_SESSION_KEY) {
+		if (options.namespaceId === GLOBAL_NAMESPACE_KEY) {
 			throw new Error(
-				`'${GLOBAL_SESSION_KEY}' is a reserved session key and cannot be used as an explicit sessionId`
+				`'${GLOBAL_NAMESPACE_KEY}' is a reserved namespace key and cannot be used as an explicit namespaceId`
 			);
 		}
 
@@ -139,16 +139,16 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 			throw new Error('InternalEventBus.subscribe requires a non-empty subscriberName');
 		}
 
-		let sessionMap = this.handlers.get(eventKey);
-		if (!sessionMap) {
-			sessionMap = new Map();
-			this.handlers.set(eventKey, sessionMap);
+		let namespaceMap = this.handlers.get(eventKey);
+		if (!namespaceMap) {
+			namespaceMap = new Map();
+			this.handlers.set(eventKey, namespaceMap);
 		}
 
-		let handlerSet = sessionMap.get(sessionKey);
+		let handlerSet = namespaceMap.get(namespaceKey);
 		if (!handlerSet) {
 			handlerSet = new Set();
-			sessionMap.set(sessionKey, handlerSet);
+			namespaceMap.set(namespaceKey, handlerSet);
 		}
 
 		const registered: RegisteredHandler = {
@@ -161,10 +161,10 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 		return () => {
 			const map = this.handlers.get(eventKey);
 			if (!map) return;
-			const set = map.get(sessionKey);
+			const set = map.get(namespaceKey);
 			if (!set) return;
 			set.delete(registered);
-			if (set.size === 0) map.delete(sessionKey);
+			if (set.size === 0) map.delete(namespaceKey);
 			if (map.size === 0) this.handlers.delete(eventKey);
 		};
 	}
@@ -185,28 +185,28 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 		data: TEventMap[K] & InternalEventPayload
 	): Promise<PublishResult> {
 		const eventKey = event;
-		const sessionMap = this.handlers.get(eventKey);
+		const namespaceMap = this.handlers.get(eventKey);
 
-		if (!sessionMap || sessionMap.size === 0) {
+		if (!namespaceMap || namespaceMap.size === 0) {
 			return { delivered: 0, failures: [] };
 		}
 
-		const sessionId = data.sessionId;
+		const namespaceId = data.namespaceId;
 		const failures: HandlerFailure[] = [];
 		let delivered = 0;
 
 		const targets: RegisteredHandler[] = [];
 
-		// Session-scoped handlers
-		const scoped = sessionMap.get(sessionId);
+		// Namespace-scoped handlers
+		const scoped = namespaceMap.get(namespaceId);
 		if (scoped) {
 			for (const h of scoped) targets.push(h);
 		}
 
-		// Global handlers — only add when sessionId is not the global sentinel
+		// Global handlers — only add when namespaceId is not the global sentinel
 		// to prevent double-delivery of the same handler set.
-		if (sessionId !== GLOBAL_SESSION_KEY) {
-			const global = sessionMap.get(GLOBAL_SESSION_KEY);
+		if (namespaceId !== GLOBAL_NAMESPACE_KEY) {
+			const global = namespaceMap.get(GLOBAL_NAMESPACE_KEY);
 			if (global) {
 				for (const h of global) targets.push(h);
 			}
@@ -264,7 +264,7 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 	}
 
 	/**
-	 * Remove every handler for the given event (all sessions).
+	 * Remove every handler for the given event (all namespaces).
 	 */
 	off<K extends keyof TEventMap & string>(event: K): void {
 		this.handlers.delete(event);
@@ -279,28 +279,28 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 
 	/**
 	 * Return the total number of registered handlers for an event
-	 * across all session scopes.
+	 * across all namespace scopes.
 	 */
 	getHandlerCount<K extends keyof TEventMap & string>(event: K): number {
-		const sessionMap = this.handlers.get(event);
-		if (!sessionMap) return 0;
+		const namespaceMap = this.handlers.get(event);
+		if (!namespaceMap) return 0;
 		let total = 0;
-		for (const set of sessionMap.values()) {
+		for (const set of namespaceMap.values()) {
 			total += set.size;
 		}
 		return total;
 	}
 
 	/**
-	 * Return the number of registered handlers for a specific session scope.
+	 * Return the number of registered handlers for a specific namespace scope.
 	 */
-	getHandlerCountForSession<K extends keyof TEventMap & string>(
+	getHandlerCountForNamespace<K extends keyof TEventMap & string>(
 		event: K,
-		sessionId: string
+		namespaceId: string
 	): number {
-		const sessionMap = this.handlers.get(event);
-		if (!sessionMap) return 0;
-		return sessionMap.get(sessionId)?.size ?? 0;
+		const namespaceMap = this.handlers.get(event);
+		if (!namespaceMap) return 0;
+		return namespaceMap.get(namespaceId)?.size ?? 0;
 	}
 }
 
@@ -334,10 +334,10 @@ export function createInternalEventBus<
  * `.mcp.json` import refresh. Subscribers (e.g. StateProjectionService) re-broadcast
  * the latest settings to clients on the global settings channel.
  *
- * Always carries `sessionId: 'global'` — settings are application-wide.
+ * Always carries `namespaceId: 'global'` — settings are application-wide.
  */
 export interface SettingsUpdatedEvent {
-	sessionId: string;
+	namespaceId: string;
 	settings: GlobalSettings;
 }
 
@@ -360,24 +360,24 @@ export interface ExternalEventEvents {
  * These events drive StateProjectionService cache updates.
  */
 export interface SessionEvents {
-	'session.created': { sessionId: string; session: import('@neokai/shared').Session };
+	'session.created': { namespaceId: string; session: import('@neokai/shared').Session };
 	'session.updated': {
-		sessionId: string;
+		namespaceId: string;
 		source?: string;
 		session?: Partial<import('@neokai/shared').Session>;
 		processingState?: import('@neokai/shared').AgentProcessingState;
 	};
-	'session.deleted': { sessionId: string };
-	'commands.updated': { sessionId: string; commands: string[] };
-	'session.error': { sessionId: string; error: string; details?: unknown };
-	'session.errorClear': { sessionId: string };
+	'session.deleted': { namespaceId: string };
+	'commands.updated': { namespaceId: string; commands: string[] };
+	'session.error': { namespaceId: string; error: string; details?: unknown };
+	'session.errorClear': { namespaceId: string };
 }
 
 /**
  * API connection events — migrated from DaemonHub to InternalEventBus in M5.
  */
 export interface ApiConnectionEvents {
-	'api.connection': { sessionId: string } & import('@neokai/shared').ApiConnectionState;
+	'api.connection': { namespaceId: string } & import('@neokai/shared').ApiConnectionState;
 }
 
 // ---------------------------------------------------------------------------
@@ -387,7 +387,7 @@ export interface ApiConnectionEvents {
 
 /** A task has transitioned to `blocked` and requires judgment. */
 export interface SpaceTaskBlockedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	reason: string;
@@ -401,7 +401,7 @@ export interface SpaceTaskBlockedEvent {
  * emitted by any publisher. Will be wired when the runtime adds an unblock path.
  */
 export interface SpaceTaskUnblockedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	reason: string;
@@ -416,7 +416,7 @@ export interface SpaceTaskUnblockedEvent {
  * for terminal runs rather than per-task completion events.
  */
 export interface SpaceTaskCompletedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	status: 'done' | 'cancelled' | 'blocked';
@@ -431,7 +431,7 @@ export interface SpaceTaskCompletedEvent {
  * `space.task.blocked` with the failure reason.
  */
 export interface SpaceTaskFailedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	reason: string;
@@ -440,7 +440,7 @@ export interface SpaceTaskFailedEvent {
 
 /** A Task Agent session crashed unexpectedly. */
 export interface SpaceAgentCrashedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	timestamp: string;
@@ -454,7 +454,7 @@ export interface SpaceAgentCrashedEvent {
  * without emitting a dedicated recovery event.
  */
 export interface SpaceAgentRecoveredEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	timestamp: string;
@@ -462,7 +462,7 @@ export interface SpaceAgentRecoveredEvent {
 
 /** A stuck agent was auto-completed by the runtime after timeout. */
 export interface SpaceAgentAutoCompletedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	elapsedMs: number;
@@ -471,7 +471,7 @@ export interface SpaceAgentAutoCompletedEvent {
 
 /** A node agent went idle without a terminal SDK message or reported status. */
 export interface SpaceAgentIdleNonTerminalEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	runId: string;
@@ -484,7 +484,7 @@ export interface SpaceAgentIdleNonTerminalEvent {
 
 /** A workflow run has reached a terminal state. */
 export interface SpaceWorkflowRunCompletedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	runId: string;
 	status: 'done' | 'cancelled' | 'blocked';
@@ -494,7 +494,7 @@ export interface SpaceWorkflowRunCompletedEvent {
 
 /** A workflow run has failed with an unrecoverable error. */
 export interface SpaceWorkflowRunFailedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	runId: string;
 	reason: string;
@@ -503,7 +503,7 @@ export interface SpaceWorkflowRunFailedEvent {
 
 /** A workflow run has transitioned to `blocked`. */
 export interface SpaceWorkflowRunBlockedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	runId: string;
 	reason: string;
@@ -512,7 +512,7 @@ export interface SpaceWorkflowRunBlockedEvent {
 
 /** A previously-terminal workflow run has been reopened back to `in_progress`. */
 export interface SpaceWorkflowRunReopenedEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	runId: string;
 	fromStatus: 'done' | 'cancelled';
@@ -523,7 +523,7 @@ export interface SpaceWorkflowRunReopenedEvent {
 
 /** A blocked execution is being automatically retried by the runtime. */
 export interface SpaceWorkflowRunRetryEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	runId: string;
@@ -535,7 +535,7 @@ export interface SpaceWorkflowRunRetryEvent {
 
 /** A blocked workflow run has exhausted automatic retries and needs attention. */
 export interface SpaceWorkflowRunNeedsAttentionEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	runId: string;
 	taskId: string;
@@ -546,7 +546,7 @@ export interface SpaceWorkflowRunNeedsAttentionEvent {
 
 /** A task has paused at a completion action that requires approval. */
 export interface SpaceTaskAwaitingApprovalEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	actionId: string;
@@ -561,7 +561,7 @@ export interface SpaceTaskAwaitingApprovalEvent {
 
 /** A task has been running longer than the configured timeout threshold. */
 export interface SpaceTaskTimeoutEvent {
-	sessionId: string;
+	namespaceId: string;
 	spaceId: string;
 	taskId: string;
 	elapsedMs: number;

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -72,7 +72,7 @@ export function registerSettingsHandlers(
 			}
 			// Emit event for StateManager to broadcast (global event)
 			internalEventBus.publishAsync('settings.updated', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				settings: updated,
 			});
 
@@ -92,7 +92,7 @@ export function registerSettingsHandlers(
 		}
 		// Emit event for StateManager to broadcast (global event)
 		internalEventBus.publishAsync('settings.updated', {
-			sessionId: 'global',
+			namespaceId: 'global',
 			settings: data.settings,
 		});
 		return { success: true };
@@ -162,7 +162,7 @@ export function registerSettingsHandlers(
 		// already calls `reactiveDb.notifyChange('app_mcp_servers')` on every
 		// insert/update/delete; this event is for UI-level toast/status messaging.
 		internalEventBus.publishAsync('settings.updated', {
-			sessionId: 'global',
+			namespaceId: 'global',
 			settings: settingsManager.getGlobalSettings(),
 		});
 		return { results };

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -1257,7 +1257,7 @@ export class ChannelRouter {
 	): void {
 		if (!this.config.internalEventBus) return;
 		try {
-			// All mapped events carry sessionId and satisfy InternalEventPayload.
+			// All mapped events carry namespaceId and satisfy InternalEventPayload.
 			this.config.internalEventBus.publishAsync(
 				event,
 				payload as DaemonInternalEventMap[K] & InternalEventPayload
@@ -1276,13 +1276,13 @@ export class ChannelRouter {
 		event: keyof DaemonInternalEventMap;
 		payload: DaemonInternalEventMap[keyof DaemonInternalEventMap];
 	} | null {
-		const sessionId = 'global';
+		const namespaceId = 'global';
 		switch (event.kind) {
 			case 'workflow_run_reopened':
 				return {
 					event: 'space.workflowRun.reopened',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						runId: event.runId,
 						fromStatus: event.fromStatus,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -741,7 +741,7 @@ export class SpaceRuntime {
 	): void {
 		if (!this.internalEventBus) return;
 		try {
-			// All mapped events carry sessionId and satisfy InternalEventPayload.
+			// All mapped events carry namespaceId and satisfy InternalEventPayload.
 			this.internalEventBus.publishAsync(
 				event,
 				payload as DaemonInternalEventMap[K] & InternalEventPayload
@@ -759,7 +759,7 @@ export class SpaceRuntime {
 	 * Returns `null` for events that don't have a corresponding internal event
 	 * (shouldn't happen for current SpaceRuntime events).
 	 *
-	 * The `sessionId` field is set to `'global'` because these events are
+	 * The `namespaceId` field is set to `'global'` because these events are
 	 * space-scoped, not session-scoped. Subscribers that need space-scoped
 	 * filtering should inspect `payload.spaceId`.
 	 */
@@ -767,13 +767,13 @@ export class SpaceRuntime {
 		event: keyof DaemonInternalEventMap;
 		payload: DaemonInternalEventMap[keyof DaemonInternalEventMap];
 	} | null {
-		const sessionId = 'global';
+		const namespaceId = 'global';
 		switch (event.kind) {
 			case 'task_blocked':
 				return {
 					event: 'space.task.blocked',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						reason: event.reason,
@@ -784,7 +784,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.workflowRun.blocked',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						runId: event.runId,
 						reason: event.reason,
@@ -795,7 +795,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.task.timeout',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						elapsedMs: event.elapsedMs,
@@ -806,7 +806,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.workflowRun.completed',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						runId: event.runId,
 						status: event.status,
@@ -818,7 +818,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.workflowRun.reopened',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						runId: event.runId,
 						fromStatus: event.fromStatus,
@@ -831,7 +831,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.agent.autoCompleted',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						elapsedMs: event.elapsedMs,
@@ -842,7 +842,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.agent.crashed',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						timestamp: event.timestamp,
@@ -852,7 +852,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.agent.idleNonTerminal',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						runId: event.runId,
@@ -867,7 +867,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.workflowRun.retry',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						runId: event.runId,
@@ -881,7 +881,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.workflowRun.needsAttention',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						runId: event.runId,
 						taskId: event.taskId,
@@ -894,7 +894,7 @@ export class SpaceRuntime {
 				return {
 					event: 'space.task.awaitingApproval',
 					payload: {
-						sessionId,
+						namespaceId,
 						spaceId: event.spaceId,
 						taskId: event.taskId,
 						actionId: event.actionId,

--- a/packages/daemon/src/lib/state-projection-service.ts
+++ b/packages/daemon/src/lib/state-projection-service.ts
@@ -180,8 +180,8 @@ export class StateProjectionService {
 		this.internalEventBus.subscribe(
 			'session.updated',
 			async (data) => {
-				const { sessionId, session, processingState } = data as unknown as {
-					sessionId: string;
+				const { namespaceId, session, processingState } = data as unknown as {
+					namespaceId: string;
 					session?: Partial<Session>;
 					processingState?: AgentProcessingState;
 				};
@@ -191,19 +191,19 @@ export class StateProjectionService {
 				// This prevents sidebar cost display from resetting to $0.00 when clicking sessions.
 				// Initial full session data comes from getSessionsState() which reads from DB.
 				if (session) {
-					const existing = this.sessionCache.get(sessionId);
+					const existing = this.sessionCache.get(namespaceId);
 					if (existing) {
-						this.sessionCache.set(sessionId, { ...existing, ...session });
+						this.sessionCache.set(namespaceId, { ...existing, ...session });
 					}
 					// Skip storing partial session data if no existing entry - broadcastSessionUpdateFromCache
 					// will handle this case by skipping the broadcast
 				}
 				if (processingState) {
-					this.processingStateCache.set(sessionId, processingState);
+					this.processingStateCache.set(namespaceId, processingState);
 				}
 
 				// Trigger broadcast via separate subscriber path
-				await this.broadcastSessionUpdateFromCache(sessionId);
+				await this.broadcastSessionUpdateFromCache(namespaceId);
 			},
 			{ subscriberName: 'StateProjectionService.sessionUpdated' }
 		);
@@ -212,18 +212,18 @@ export class StateProjectionService {
 		this.internalEventBus.subscribe(
 			'session.deleted',
 			(data) => {
-				const { sessionId } = data as unknown as { sessionId: string };
+				const { namespaceId } = data as unknown as { namespaceId: string };
 
 				// Clear caches
-				this.sessionCache.delete(sessionId);
-				this.processingStateCache.delete(sessionId);
-				this.commandsCache.delete(sessionId);
-				this.errorCache.delete(sessionId);
+				this.sessionCache.delete(namespaceId);
+				this.processingStateCache.delete(namespaceId);
+				this.commandsCache.delete(namespaceId);
+				this.errorCache.delete(namespaceId);
 
 				// FIX: Clean up channelVersions for deleted session
-				this.channelVersions.delete(`${STATE_CHANNELS.SESSION}:${sessionId}`);
-				this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}:${sessionId}`);
-				this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}.delta:${sessionId}`);
+				this.channelVersions.delete(`${STATE_CHANNELS.SESSION}:${namespaceId}`);
+				this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}:${namespaceId}`);
+				this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}.delta:${namespaceId}`);
 			},
 			{ subscriberName: 'StateProjectionService.sessionDeleted' }
 		);
@@ -241,11 +241,11 @@ export class StateProjectionService {
 		this.internalEventBus.subscribe(
 			'commands.updated',
 			(data) => {
-				const { sessionId, commands } = data as unknown as {
-					sessionId: string;
+				const { namespaceId, commands } = data as unknown as {
+					namespaceId: string;
 					commands: string[];
 				};
-				this.commandsCache.set(sessionId, commands);
+				this.commandsCache.set(namespaceId, commands);
 			},
 			{ subscriberName: 'StateProjectionService.commandsUpdated' }
 		);
@@ -254,12 +254,12 @@ export class StateProjectionService {
 		this.internalEventBus.subscribe(
 			'session.error',
 			(data) => {
-				const { sessionId, error, details } = data as unknown as {
-					sessionId: string;
+				const { namespaceId, error, details } = data as unknown as {
+					namespaceId: string;
 					error: string;
 					details?: unknown;
 				};
-				this.errorCache.set(sessionId, {
+				this.errorCache.set(namespaceId, {
 					message: error,
 					details,
 					occurredAt: Date.now(),
@@ -272,8 +272,8 @@ export class StateProjectionService {
 		this.internalEventBus.subscribe(
 			'session.errorClear',
 			(data) => {
-				const { sessionId } = data as unknown as { sessionId: string };
-				this.errorCache.set(sessionId, null);
+				const { namespaceId } = data as unknown as { namespaceId: string };
+				this.errorCache.set(namespaceId, null);
 			},
 			{ subscriberName: 'StateProjectionService.sessionErrorClear' }
 		);

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -20,10 +20,10 @@ import {
 } from '../../../../src/lib/internal-event-bus';
 
 interface TestEventMap {
-	'session.created': { sessionId: string; title: string };
-	'session.updated': { sessionId: string; title?: string };
-	'session.deleted': { sessionId: string };
-	'app.ping': { sessionId: string; ts: number };
+	'session.created': { namespaceId: string; title: string };
+	'session.updated': { namespaceId: string; title?: string };
+	'session.deleted': { namespaceId: string };
+	'app.ping': { namespaceId: string; ts: number };
 }
 
 /**
@@ -31,8 +31,8 @@ interface TestEventMap {
  * is loose enough to accept normal keyed interfaces (P2).
  */
 interface KeyedInterfaceEventMap {
-	'order.placed': { sessionId: string; orderId: string };
-	'order.shipped': { sessionId: string; orderId: string; tracking: string };
+	'order.placed': { namespaceId: string; orderId: string };
+	'order.shipped': { namespaceId: string; orderId: string; tracking: string };
 }
 
 describe('InternalEventBus', () => {
@@ -53,11 +53,11 @@ describe('InternalEventBus', () => {
 			);
 		});
 
-		it('should reject the reserved global session key as an explicit sessionId', () => {
+		it('should reject the reserved global namespace key as an explicit namespaceId', () => {
 			expect(() =>
 				bus.subscribe('session.created', () => {}, {
 					subscriberName: 'bad',
-					sessionId: '__global__',
+					namespaceId: '__global__',
 				})
 			).toThrow('reserved');
 		});
@@ -74,16 +74,16 @@ describe('InternalEventBus', () => {
 			const unsub = bus.subscribe(
 				'session.created',
 				(data) => {
-					received.push(data.sessionId);
+					received.push(data.namespaceId);
 				},
 				{ subscriberName: 'a' }
 			);
 
-			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+			await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
 			expect(received).toEqual(['s1']);
 
 			unsub();
-			await bus.publish('session.created', { sessionId: 's2', title: 'T2' });
+			await bus.publish('session.created', { namespaceId: 's2', title: 'T2' });
 			expect(received).toEqual(['s1']);
 		});
 	});
@@ -101,7 +101,7 @@ describe('InternalEventBus', () => {
 			);
 
 			const result = await bus.publish('session.created', {
-				sessionId: 's1',
+				namespaceId: 's1',
 				title: 'T1',
 			});
 			expect(received).toBe(true);
@@ -131,7 +131,7 @@ describe('InternalEventBus', () => {
 			);
 
 			const result = await bus.publish('session.created', {
-				sessionId: 's1',
+				namespaceId: 's1',
 				title: 'T1',
 			});
 
@@ -140,7 +140,7 @@ describe('InternalEventBus', () => {
 		});
 
 		it('should return empty result when no handlers are registered', async () => {
-			const result = await bus.publish('session.deleted', { sessionId: 'orphan' });
+			const result = await bus.publish('session.deleted', { namespaceId: 'orphan' });
 			expect(result.delivered).toBe(0);
 			expect(result.failures).toHaveLength(0);
 		});
@@ -151,15 +151,15 @@ describe('InternalEventBus', () => {
 			bus.subscribe('session.created', () => hits.push('global'), { subscriberName: 'global' });
 			bus.subscribe('session.created', () => hits.push('scoped'), {
 				subscriberName: 'scoped',
-				sessionId: 's1',
+				namespaceId: 's1',
 			});
 			bus.subscribe('session.created', () => hits.push('other-scope'), {
 				subscriberName: 'other',
-				sessionId: 's2',
+				namespaceId: 's2',
 			});
 
 			const result = await bus.publish('session.created', {
-				sessionId: 's1',
+				namespaceId: 's1',
 				title: 'T1',
 			});
 
@@ -167,13 +167,13 @@ describe('InternalEventBus', () => {
 			expect(result.delivered).toBe(2);
 		});
 
-		it('should not double-deliver when sessionId equals the global sentinel', async () => {
+		it('should not double-deliver when namespaceId equals the global sentinel', async () => {
 			const hits: string[] = [];
 
 			bus.subscribe('session.created', () => hits.push('global'), { subscriberName: 'global' });
 
 			const result = await bus.publish('session.created', {
-				sessionId: '__global__',
+				namespaceId: '__global__',
 				title: 'T1',
 			});
 
@@ -194,7 +194,7 @@ describe('InternalEventBus', () => {
 			);
 
 			try {
-				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
 				expect.unreachable('should have thrown');
 			} catch (e) {
 				expect(e).toBeInstanceOf(InternalEventBusPublishError);
@@ -219,7 +219,7 @@ describe('InternalEventBus', () => {
 			);
 
 			await expect(
-				bus.publish('session.created', { sessionId: 's1', title: 'T1' })
+				bus.publish('session.created', { namespaceId: 's1', title: 'T1' })
 			).rejects.toBeInstanceOf(InternalEventBusPublishError);
 		});
 
@@ -252,7 +252,7 @@ describe('InternalEventBus', () => {
 			);
 
 			try {
-				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
 				expect.unreachable('should have thrown');
 			} catch (e) {
 				const pe = e as InternalEventBusPublishError;
@@ -279,7 +279,7 @@ describe('InternalEventBus', () => {
 			);
 
 			try {
-				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
 				expect.unreachable('should have thrown');
 			} catch (e) {
 				const pe = e as InternalEventBusPublishError;
@@ -299,7 +299,7 @@ describe('InternalEventBus', () => {
 			);
 
 			try {
-				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
 				expect.unreachable('should have thrown');
 			} catch (e) {
 				const pe = e as InternalEventBusPublishError;
@@ -322,7 +322,7 @@ describe('InternalEventBus', () => {
 			);
 
 			const start = performance.now();
-			bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' });
+			bus.publishAsync('session.created', { namespaceId: 's1', title: 'T1' });
 			const elapsed = performance.now() - start;
 
 			expect(elapsed).toBeLessThan(10);
@@ -344,7 +344,7 @@ describe('InternalEventBus', () => {
 
 			// Must not throw synchronously or as an unhandled rejection
 			expect(() =>
-				bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' })
+				bus.publishAsync('session.created', { namespaceId: 's1', title: 'T1' })
 			).not.toThrow();
 
 			// Give microtasks a chance to run
@@ -361,7 +361,7 @@ describe('InternalEventBus', () => {
 				{ subscriberName: 'sync' }
 			);
 
-			bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' });
+			bus.publishAsync('session.created', { namespaceId: 's1', title: 'T1' });
 			// Handler should NOT have run yet — it is deferred to the next microtask.
 			expect(handlerRan).toBe(false);
 
@@ -379,13 +379,13 @@ describe('InternalEventBus', () => {
 			factoryBus.subscribe(
 				'session.created',
 				(data) => {
-					hits.push(data.sessionId);
+					hits.push(data.namespaceId);
 				},
 				{ subscriberName: 'factory-sub' }
 			);
 
 			const result = await factoryBus.publish('session.created', {
-				sessionId: 'factory-test',
+				namespaceId: 'factory-test',
 				title: 'Factory Test',
 			});
 
@@ -400,11 +400,11 @@ describe('InternalEventBus', () => {
 
 			bus.subscribe('session.created', () => {}, { subscriberName: 'a' });
 			bus.subscribe('session.created', () => {}, { subscriberName: 'b' });
-			bus.subscribe('session.created', () => {}, { subscriberName: 'c', sessionId: 's1' });
+			bus.subscribe('session.created', () => {}, { subscriberName: 'c', namespaceId: 's1' });
 
 			expect(bus.getHandlerCount('session.created')).toBe(3);
-			expect(bus.getHandlerCountForSession('session.created', 's1')).toBe(1);
-			expect(bus.getHandlerCountForSession('session.created', 's2')).toBe(0);
+			expect(bus.getHandlerCountForNamespace('session.created', 's1')).toBe(1);
+			expect(bus.getHandlerCountForNamespace('session.created', 's2')).toBe(0);
 		});
 
 		it('should clear all handlers', async () => {
@@ -414,8 +414,8 @@ describe('InternalEventBus', () => {
 
 			bus.clear();
 
-			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
-			await bus.publish('session.updated', { sessionId: 's1' });
+			await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
+			await bus.publish('session.updated', { namespaceId: 's1' });
 
 			expect(hits).toHaveLength(0);
 		});
@@ -427,8 +427,8 @@ describe('InternalEventBus', () => {
 
 			bus.off('session.created');
 
-			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
-			await bus.publish('session.deleted', { sessionId: 's1' });
+			await bus.publish('session.created', { namespaceId: 's1', title: 'T1' });
+			await bus.publish('session.deleted', { namespaceId: 's1' });
 
 			expect(hits).toEqual(['deleted']);
 		});
@@ -449,7 +449,7 @@ describe('InternalEventBus keyed interface compatibility', () => {
 		);
 
 		const result = await keyedBus.publish('order.placed', {
-			sessionId: 's1',
+			namespaceId: 's1',
 			orderId: 'ord-123',
 		});
 
@@ -472,14 +472,14 @@ describe('DaemonInternalEventMap — settings.updated end-to-end', () => {
 		);
 
 		const result = await bus.publish('settings.updated', {
-			sessionId: 'global',
+			namespaceId: 'global',
 			settings: { model: 'claude-sonnet-4' } as unknown as import('@neokai/shared').GlobalSettings,
 		});
 
 		expect(result.delivered).toBe(1);
 		expect(result.failures).toHaveLength(0);
 		expect(received).toHaveLength(1);
-		expect(received[0].sessionId).toBe('global');
+		expect(received[0].namespaceId).toBe('global');
 		expect(received[0].settings).toEqual({ model: 'claude-sonnet-4' });
 	});
 
@@ -498,7 +498,7 @@ describe('DaemonInternalEventMap — settings.updated end-to-end', () => {
 
 		const start = performance.now();
 		bus.publishAsync('settings.updated', {
-			sessionId: 'global',
+			namespaceId: 'global',
 			settings: {} as unknown as import('@neokai/shared').GlobalSettings,
 		});
 		const elapsed = performance.now() - start;

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -461,7 +461,7 @@ describe('InternalEventBus keyed interface compatibility', () => {
 describe('DaemonInternalEventMap — settings.updated end-to-end', () => {
 	it('should flow through createDaemonInternalEventBus with typed payload', async () => {
 		const bus = createDaemonInternalEventBus();
-		const received: Array<{ sessionId: string; settings: Record<string, unknown> }> = [];
+		const received: Array<{ namespaceId: string; settings: Record<string, unknown> }> = [];
 
 		bus.subscribe(
 			'settings.updated',

--- a/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
@@ -309,7 +309,7 @@ describe('StateProjectionService', () => {
 			// Simulate session.updated event populating the cache
 			const updateHandler = eventSubscribers.get('session.updated')?.[0];
 			await updateHandler!({
-				sessionId: 'leader-session-id',
+				namespaceId: 'leader-session-id',
 				processingState: { status: 'waiting_for_input', pendingQuestion },
 			});
 
@@ -374,14 +374,14 @@ describe('StateProjectionService', () => {
 				// First create a session to cache
 				const createHandler = eventSubscribers.get('session.created')?.[0];
 				await createHandler!({
-					sessionId: 'test-id',
+					namespaceId: 'test-id',
 					session: { id: 'test-id', title: 'Original', status: 'active', metadata: {} },
 				});
 
 				// Now update it
 				const updateHandler = eventSubscribers.get('session.updated')?.[0];
 				await updateHandler!({
-					sessionId: 'test-id',
+					namespaceId: 'test-id',
 					session: { title: 'Updated' },
 					processingState: { status: 'processing' },
 				});
@@ -414,13 +414,13 @@ describe('StateProjectionService', () => {
 				// First create a session to cache
 				const createHandler = eventSubscribers.get('session.created')?.[0];
 				await createHandler!({
-					sessionId: 'test-id',
+					namespaceId: 'test-id',
 					session: { id: 'test-id', title: 'Test', status: 'active', metadata: {} },
 				});
 
 				// Now delete it
 				const deleteHandler = eventSubscribers.get('session.deleted')?.[0];
-				await deleteHandler!({ sessionId: 'test-id' });
+				await deleteHandler!({ namespaceId: 'test-id' });
 
 				// Forwarding extracted to ClientEventBridge; StateProjectionService only clears caches
 				expect(mockMessageHub.event).not.toHaveBeenCalledWith(
@@ -458,7 +458,7 @@ describe('StateProjectionService', () => {
 
 				// Delete the session
 				const deleteHandler = eventSubscribers.get('session.deleted')?.[0];
-				await deleteHandler!({ sessionId: 'test-id' });
+				await deleteHandler!({ namespaceId: 'test-id' });
 
 				// After deletion, versions for that session should be gone.
 				// Verify by broadcasting again for the same sessionId — if cleanup
@@ -477,7 +477,7 @@ describe('StateProjectionService', () => {
 		describe('settings.updated', () => {
 			it('should broadcast settings change via InternalEventBus', async () => {
 				const handler = eventSubscribers.get('settings.updated')?.[0];
-				await handler!({ sessionId: 'global', settings: {} as GlobalSettings });
+				await handler!({ namespaceId: 'global', settings: {} as GlobalSettings });
 
 				expect(mockMessageHub.event).toHaveBeenCalledWith(
 					STATE_CHANNELS.GLOBAL_SETTINGS,
@@ -494,7 +494,7 @@ describe('StateProjectionService', () => {
 				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
 				const handler = eventSubscribers.get('commands.updated')?.[0];
-				await handler!({ sessionId: 'test-id', commands: ['cmd1', 'cmd2'] });
+				await handler!({ namespaceId: 'test-id', commands: ['cmd1', 'cmd2'] });
 
 				// Forwarding extracted to ClientEventBridge; StateProjectionService only caches
 				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
@@ -509,7 +509,7 @@ describe('StateProjectionService', () => {
 
 				const handler = eventSubscribers.get('session.error')?.[0];
 				await handler!({
-					sessionId: 'test-id',
+					namespaceId: 'test-id',
 					error: 'Something went wrong',
 					details: { code: 'ERR_001' },
 				});
@@ -526,7 +526,7 @@ describe('StateProjectionService', () => {
 				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
 				const clearHandler = eventSubscribers.get('session.errorClear')?.[0];
-				await clearHandler!({ sessionId: 'test-id' });
+				await clearHandler!({ namespaceId: 'test-id' });
 
 				// Forwarding extracted to ClientEventBridge; StateProjectionService only clears cache
 				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
@@ -541,7 +541,7 @@ describe('StateProjectionService', () => {
 
 				const handler = eventSubscribers.get('api.connection')?.[0];
 				const connectionData = {
-					sessionId: 'global',
+					namespaceId: 'global',
 					status: 'disconnected' as const,
 					timestamp: Date.now(),
 				};

--- a/packages/daemon/tests/unit/2-handlers/rpc/settings-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/settings-handlers.test.ts
@@ -98,7 +98,7 @@ function createMockInternalEventBus(): {
 		publish: mock(async () => ({ delivered: 0, failures: [] })),
 		subscribe: mock(() => () => {}),
 		getHandlerCount: mock(() => 0),
-		getHandlerCountForSession: mock(() => 0),
+		getHandlerCountForNamespace: mock(() => 0),
 		clear: mock(() => {}),
 		off: mock(() => {}),
 	} as unknown as InternalEventBus<DaemonInternalEventMap>;
@@ -293,7 +293,7 @@ describe('Settings RPC Handlers', () => {
 			expect(internalEventBusData.publishAsyncMock).toHaveBeenCalledWith(
 				'settings.updated',
 				expect.objectContaining({
-					sessionId: 'global',
+					namespaceId: 'global',
 				})
 			);
 		});
@@ -308,7 +308,7 @@ describe('Settings RPC Handlers', () => {
 			expect(internalEventBusData.publishAsyncMock).toHaveBeenCalledWith(
 				'settings.updated',
 				expect.objectContaining({
-					sessionId: 'global',
+					namespaceId: 'global',
 				})
 			);
 		});
@@ -354,7 +354,7 @@ describe('Settings RPC Handlers', () => {
 			expect(internalEventBusData.publishAsyncMock).toHaveBeenCalledWith(
 				'settings.updated',
 				expect.objectContaining({
-					sessionId: 'global',
+					namespaceId: 'global',
 				})
 			);
 		});
@@ -438,7 +438,7 @@ describe('Settings RPC Handlers', () => {
 			expect(internalEventBusData.publishAsyncMock).toHaveBeenCalledWith(
 				'settings.updated',
 				expect.objectContaining({
-					sessionId: 'global',
+					namespaceId: 'global',
 				})
 			);
 			expect(result.results).toEqual([]);

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-service.test.ts
@@ -90,7 +90,7 @@ describe('publish — new event', () => {
 		// Bus fired with full event payload
 		expect(busReceived).toHaveLength(1);
 		expect(busReceived[0]!.spaceId).toBe(SPACE_ID);
-		expect(busReceived[0]!.sessionId).toBe(SPACE_ID);
+		expect(busReceived[0]!.namespaceId).toBe(SPACE_ID);
 		expect(busReceived[0]!.eventId).toBe(event.id);
 		expect(busReceived[0]!.source).toBe('github');
 		expect(busReceived[0]!.topic).toBe(event.topic);
@@ -191,21 +191,21 @@ describe('publish — duplicates', () => {
 // ---------------------------------------------------------------------------
 
 describe('publish — bus semantics', () => {
-	test('bus event is space-scoped (sessionId === spaceId)', async () => {
+	test('bus event is space-scoped (namespaceId === spaceId)', async () => {
 		const received: ExternalEventPublishedPayload[] = [];
 		bus.subscribe(
 			'externalEvent.published',
 			(data) => {
 				received.push(data);
 			},
-			{ subscriberName: 'scoped-sub', sessionId: SPACE_ID }
+			{ subscriberName: 'scoped-sub', namespaceId: SPACE_ID }
 		);
 
 		const event = makeEvent();
 		await service.publish(event);
 
 		expect(received).toHaveLength(1);
-		expect(received[0]!.sessionId).toBe(SPACE_ID);
+		expect(received[0]!.namespaceId).toBe(SPACE_ID);
 	});
 
 	test('global subscriber also receives space-scoped event', async () => {

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -79,7 +79,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('injects a message with [TASK_EVENT] prefix when space.task.blocked is published', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Agent reported an error',
@@ -94,7 +94,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('injects into the correct session ID', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -107,7 +107,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('uses defer delivery mode', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -120,7 +120,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('message includes human-readable text with taskId, spaceId, and reason', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-99',
 				reason: 'Unrecoverable build failure',
@@ -136,7 +136,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('message includes JSON payload with all event fields', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-42',
 				reason: 'Timed out',
@@ -155,7 +155,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('message includes autonomy level (default supervised)', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -171,7 +171,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('message includes semi_autonomous level when configured', async () => {
 			const { factory, bus } = makeService(undefined, { autonomyLevel: 3 });
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -189,7 +189,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats message correctly', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-55',
 				reason: 'Transition condition failed: tests did not pass',
@@ -212,7 +212,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats elapsed time in minutes', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.timeout', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-slow',
 				elapsedMs: 3600000, // 60 minutes
@@ -235,7 +235,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats a completed run', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.completed', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-1',
 				status: 'done',
@@ -257,7 +257,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats a cancelled run', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.completed', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-2',
 				status: 'cancelled',
@@ -275,7 +275,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats a blocked run', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.completed', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-3',
 				status: 'blocked',
@@ -294,7 +294,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats a reopen from done with attribution', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.reopened', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-rx',
 				fromStatus: 'done',
@@ -323,7 +323,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats agent crash with [TASK_EVENT] prefix', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.agent.crashed', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-crashed',
 				timestamp: TIMESTAMP,
@@ -348,7 +348,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats auto-completed message', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.agent.autoCompleted', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-auto',
 				elapsedMs: 300000,
@@ -370,7 +370,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats idle non-terminal message', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.agent.idleNonTerminal', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-idle',
 				runId: 'run-idle',
@@ -398,7 +398,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats retry message', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.retry', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-retry',
 				runId: 'run-retry',
@@ -424,7 +424,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats needs attention message', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.workflowRun.needsAttention', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-na',
 				taskId: 'task-na',
@@ -448,7 +448,7 @@ describe('SpaceAgentNotificationService', () => {
 		it('formats awaiting approval message', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.task.awaitingApproval', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				actionId: 'merge-pr',
@@ -490,7 +490,7 @@ describe('SpaceAgentNotificationService', () => {
 			// Should not throw despite injectMessage failing
 			await expect(
 				bus.publish('space.task.blocked', {
-					sessionId: 'global',
+					namespaceId: 'global',
 					spaceId: SPACE_ID,
 					taskId: 'task-1',
 					reason: 'Error',
@@ -506,7 +506,7 @@ describe('SpaceAgentNotificationService', () => {
 
 			// First event should be received
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -519,7 +519,7 @@ describe('SpaceAgentNotificationService', () => {
 
 			// Second event should NOT be received
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-2',
 				reason: 'Error 2',
@@ -535,7 +535,7 @@ describe('SpaceAgentNotificationService', () => {
 
 			// Event for the correct space
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Error',
@@ -544,7 +544,7 @@ describe('SpaceAgentNotificationService', () => {
 
 			// Event for a different space
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: 'other-space',
 				taskId: 'task-2',
 				reason: 'Other error',
@@ -564,7 +564,7 @@ describe('SpaceAgentNotificationService', () => {
 			const { factory, bus } = makeService();
 
 			await bus.publish('space.task.blocked', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				taskId: 'task-1',
 				reason: 'Agent error',
@@ -592,7 +592,7 @@ describe('SpaceAgentNotificationService', () => {
 			const { factory, bus } = makeService();
 
 			await bus.publish('space.workflowRun.completed', {
-				sessionId: 'global',
+				namespaceId: 'global',
 				spaceId: SPACE_ID,
 				runId: 'run-1',
 				status: 'done',


### PR DESCRIPTION
## Summary

- Rename `InternalEventPayload.sessionId` → `namespaceId`, `SubscribeOptions.sessionId` → `namespaceId`, and all routing logic variables (`sessionKey` → `namespaceKey`, `sessionMap` → `namespaceMap`, `GLOBAL_SESSION_KEY` → `GLOBAL_NAMESPACE_KEY`)
- Rename `getHandlerCountForSession()` → `getHandlerCountForNamespace()`
- Update all event type definitions (`SettingsEvents`, `SessionEvents`, `ApiConnectionEvents`, `SpaceEvents`) and `ExternalEventPublishedPayload`
- Update all publishers (app.ts bridge, settings-handlers, space-runtime, channel-router, external-event-service) and subscribers (state-projection-service, space-agent-notification-service)
- Update all affected tests; all 9947 daemon tests pass, `bun run check` clean

DaemonHub usage is untouched — its `sessionId` genuinely means session.

## Test plan

- [x] All daemon unit/integration tests pass (9947 tests, 0 failures)
- [x] `bun run check` passes (lint, typecheck, knip, session guards)