### PR TITLE
fix: enforce task dependencies on late dep addition and auto-unblock on completion

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -352,9 +352,13 @@ export function setupSpaceTaskHandlers(
 						updateParams.status === 'cancelled' &&
 						(updateParams.cancelReason ?? updateParams.approvalReason)
 					) {
-						task = await taskManager.updateTask(taskId, {
-							approvalReason: updateParams.cancelReason ?? updateParams.approvalReason ?? null,
-						});
+						task = await taskManager.updateTask(
+							taskId,
+							{
+								approvalReason: updateParams.cancelReason ?? updateParams.approvalReason ?? null,
+							},
+							{ onCascadedTasks: emitCascadedTasks }
+						);
 					}
 
 					// When a status transition is combined with other field updates
@@ -369,7 +373,9 @@ export function setupSpaceTaskHandlers(
 						...otherFields
 					} = updateParams;
 					if (Object.keys(otherFields).length > 0) {
-						task = await taskManager.updateTask(taskId, otherFields);
+						task = await taskManager.updateTask(taskId, otherFields, {
+							onCascadedTasks: emitCascadedTasks,
+						});
 					}
 				}
 			} else {

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -228,18 +228,13 @@ export function setupSpaceTaskHandlers(
 		/** Emit space.task.updated for cascaded tasks (dependency blocks/unblocks). */
 		const emitCascadedTasks = async (cascaded: SpaceTask[]): Promise<void> => {
 			for (const t of cascaded) {
-				daemonHub
-					.emit('space.task.updated', {
-						sessionId: 'global',
-						spaceId,
-						taskId: t.id,
-						task: t,
-					})
-					.catch((err: unknown) => {
-						log.warn(
-							`Failed to emit space.task.updated for cascaded task ${t.id}: ${err instanceof Error ? err.message : String(err)}`
-						);
-					});
+				publishSpaceEvent('space.task.updated', {
+					namespaceId: 'global',
+					sessionId: 'global',
+					spaceId,
+					taskId: t.id,
+					task: t,
+				});
 			}
 		};
 

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -282,7 +282,9 @@ export function setupSpaceTaskHandlers(
 						...otherFields
 					} = updateParams;
 					if (Object.keys(otherFields).length > 0) {
-						task = await taskManager.updateTask(taskId, otherFields);
+						task = await taskManager.updateTask(taskId, otherFields, {
+							onCascadedTasks: emitCascadedTasks,
+						});
 						emitTaskUpdated = true;
 					}
 				} else {

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -225,6 +225,24 @@ export function setupSpaceTaskHandlers(
 
 		const taskManager = taskManagerFactory(spaceId);
 
+		/** Emit space.task.updated for cascaded tasks (dependency blocks/unblocks). */
+		const emitCascadedTasks = async (cascaded: SpaceTask[]): Promise<void> => {
+			for (const t of cascaded) {
+				daemonHub
+					.emit('space.task.updated', {
+						sessionId: 'global',
+						spaceId,
+						taskId: t.id,
+						task: t,
+					})
+					.catch((err: unknown) => {
+						log.warn(
+							`Failed to emit space.task.updated for cascaded task ${t.id}: ${err instanceof Error ? err.message : String(err)}`
+						);
+					});
+			}
+		};
+
 		let task: SpaceTask;
 		let emitTaskUpdated = true;
 
@@ -323,6 +341,7 @@ export function setupSpaceTaskHandlers(
 								? 'human'
 								: undefined,
 						approvalReason: mappedReason,
+						onCascadedTasks: emitCascadedTasks,
 					});
 
 					// When the transition alone cannot carry the rejection reason (e.g.
@@ -358,11 +377,15 @@ export function setupSpaceTaskHandlers(
 				// updateParams still contains the unchanged status field; SpaceTaskManager.updateTask
 				// strips it internally (guard: params.status !== task.status is false) so no
 				// transition check fires and the status column is left untouched in the DB.
-				task = await taskManager.updateTask(taskId, updateParams);
+				task = await taskManager.updateTask(taskId, updateParams, {
+					onCascadedTasks: emitCascadedTasks,
+				});
 			}
 		} else {
 			// No status field — general field update
-			task = await taskManager.updateTask(taskId, updateParams);
+			task = await taskManager.updateTask(taskId, updateParams, {
+				onCascadedTasks: emitCascadedTasks,
+			});
 		}
 
 		if (emitTaskUpdated) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -275,6 +275,14 @@ export class SpaceTaskManager {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}
 
+		// Gap 2 fix: when a task reaches `done`, auto-unblock any dependents
+		// whose dependency constraints are now fully met. This runs in
+		// `setTaskStatus` (not just `updateTaskAndEmit`) so that all done
+		// paths — direct tool/handler calls included — trigger the cascade.
+		if (newStatus === 'done') {
+			await this.unblockDependentTasks(taskId);
+		}
+
 		return updated;
 	}
 
@@ -508,18 +516,27 @@ export class SpaceTaskManager {
 			throw new Error(`Failed to update task: ${taskId}`);
 		}
 
-		// Gap 1 fix: if dependsOn was changed and the task is already active,
-		// re-check dependencies. If unmet and task is in_progress, block it.
-		if (depsChanged && (updated.status === 'in_progress' || updated.status === 'open')) {
+		// Gap 1 fix: if dependsOn was changed, re-check dependency constraints.
+		// - in_progress + unmet deps: block the task
+		// - blocked (dependency_added/dependency_failed) + now met: reopen
+		// - open + unmet deps: tick loop handles it
+		if (depsChanged) {
 			const depsMet = await this.areDependenciesMet(updated);
-			if (!depsMet) {
-				if (updated.status === 'in_progress') {
-					return this.setTaskStatus(taskId, 'blocked', {
-						blockReason: 'dependency_added',
-						result: 'Dependency added while task was in progress',
-					});
-				}
-				// open tasks with unmet deps are naturally skipped by the tick loop
+			if (!depsMet && updated.status === 'in_progress') {
+				const blocked = await this.setTaskStatus(taskId, 'blocked', {
+					blockReason: 'dependency_added',
+					result: 'Dependency added while task was in progress',
+				});
+				// Cascade: block any in_progress tasks that depend on this
+				// newly-blocked task (mirrors updateTaskAndEmit cascade).
+				await this.blockDependentTasks(taskId);
+				return blocked;
+			} else if (
+				depsMet &&
+				updated.status === 'blocked' &&
+				(updated.blockReason === 'dependency_added' || updated.blockReason === 'dependency_failed')
+			) {
+				return this.setTaskStatus(taskId, 'open');
 			}
 		}
 

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -281,10 +281,19 @@ export class SpaceTaskManager {
 		// whose dependency constraints are now fully met. This runs in
 		// `setTaskStatus` (not just `updateTaskAndEmit`) so that all done
 		// paths — direct tool/handler calls included — trigger the cascade.
+		// Wrapped in try-catch so a failed unblock (e.g. concurrent status
+		// change making blocked→open invalid) does not abort the parent
+		// `done` transition — the parent write is already committed.
 		if (newStatus === 'done') {
-			const unblocked = await this.unblockDependentTasks(taskId);
-			if (unblocked.length > 0 && options?.onCascadedTasks) {
-				await options.onCascadedTasks(unblocked);
+			try {
+				const unblocked = await this.unblockDependentTasks(taskId);
+				if (unblocked.length > 0 && options?.onCascadedTasks) {
+					await options.onCascadedTasks(unblocked);
+				}
+			} catch {
+				// Best-effort: unblock failures must not roll back the
+				// already-committed done transition. The tick loop will
+				// re-evaluate blocked dependents on the next cycle.
 			}
 		}
 

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -759,8 +759,14 @@ export class SpaceTaskManager {
 			// Re-check ALL deps for this task
 			const depsMet = await this.areDependenciesMet(t);
 			if (depsMet) {
-				const reopened = await this.setTaskStatus(t.id, 'open');
-				unblocked.push(reopened);
+				try {
+					const reopened = await this.setTaskStatus(t.id, 'open');
+					unblocked.push(reopened);
+				} catch {
+					// Per-dependent: a concurrent status change (e.g. archive)
+					// can make blocked→open invalid. Skip this dependent and
+					// continue with the rest rather than aborting the cascade.
+				}
 			}
 		}
 		return unblocked;

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -497,11 +497,30 @@ export class SpaceTaskManager {
 			await this.validateDependencyIds(params.dependsOn, taskId);
 		}
 
+		// Detect whether dependsOn is being changed (and to what)
+		const depsChanged =
+			params.dependsOn !== undefined && !arraysEqual(task.dependsOn ?? [], params.dependsOn);
+
 		// Strip status from the update params so the repo call is clean
 		const { status: _status, ...repoParams } = params;
 		const updated = this.taskRepo.updateTask(taskId, repoParams);
 		if (!updated) {
 			throw new Error(`Failed to update task: ${taskId}`);
+		}
+
+		// Gap 1 fix: if dependsOn was changed and the task is already active,
+		// re-check dependencies. If unmet and task is in_progress, block it.
+		if (depsChanged && (updated.status === 'in_progress' || updated.status === 'open')) {
+			const depsMet = await this.areDependenciesMet(updated);
+			if (!depsMet) {
+				if (updated.status === 'in_progress') {
+					return this.setTaskStatus(taskId, 'blocked', {
+						blockReason: 'dependency_added',
+						result: 'Dependency added while task was in progress',
+					});
+				}
+				// open tasks with unmet deps are naturally skipped by the tick loop
+			}
 		}
 
 		return updated;
@@ -681,6 +700,32 @@ export class SpaceTaskManager {
 	}
 
 	/**
+	 * Unblock dependent tasks whose `dependency_failed` / `dependency_added`
+	 * block reason is now fully resolved because all their deps reached `done`.
+	 *
+	 * Called after a task transitions to `done` - finds every task in the
+	 * same space that depends on the completed task, re-evaluates their full
+	 * dependency set, and transitions eligible blocked tasks back to `open`
+	 * so the tick loop can pick them up.
+	 */
+	async unblockDependentTasks(taskId: string): Promise<SpaceTask[]> {
+		const unblocked: SpaceTask[] = [];
+		const allTasks = await this.listTasks(false /* includeArchived */);
+		for (const t of allTasks) {
+			if (t.status !== 'blocked') continue;
+			if (t.blockReason !== 'dependency_failed' && t.blockReason !== 'dependency_added') continue;
+			if (!t.dependsOn?.includes(taskId)) continue;
+			// Re-check ALL deps for this task
+			const depsMet = await this.areDependenciesMet(t);
+			if (depsMet) {
+				const reopened = await this.setTaskStatus(t.id, 'open');
+				unblocked.push(reopened);
+			}
+		}
+		return unblocked;
+	}
+
+	/**
 	 * Validate that dependency IDs exist in this space and don't create cycles.
 	 * @param depIds - dependency task IDs to validate
 	 * @param taskId - the task being created/updated (omit for new tasks)
@@ -742,4 +787,14 @@ export class SpaceTaskManager {
 		}
 		return false;
 	}
+}
+
+/**
+ * Order-independent comparison for two string arrays.
+ */
+function arraysEqual(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const sortedA = [...a].sort();
+	const sortedB = [...b].sort();
+	return sortedA.every((v, i) => v === sortedB[i]);
 }

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -167,6 +167,8 @@ export class SpaceTaskManager {
 			// existing approvalReason untouched on transitions that carry the
 			// stamp forward (see the approved → done mirror below).
 			approvalReason?: string | null;
+			/** Optional callback invoked with tasks cascaded by this transition. */
+			onCascadedTasks?: (cascaded: SpaceTask[]) => Promise<void>;
 		}
 	): Promise<SpaceTask> {
 		const task = await this.getTask(taskId);
@@ -280,7 +282,10 @@ export class SpaceTaskManager {
 		// `setTaskStatus` (not just `updateTaskAndEmit`) so that all done
 		// paths — direct tool/handler calls included — trigger the cascade.
 		if (newStatus === 'done') {
-			await this.unblockDependentTasks(taskId);
+			const unblocked = await this.unblockDependentTasks(taskId);
+			if (unblocked.length > 0 && options?.onCascadedTasks) {
+				await options.onCascadedTasks(unblocked);
+			}
 		}
 
 		return updated;
@@ -489,7 +494,14 @@ export class SpaceTaskManager {
 	 * Update task fields directly (non-status fields).
 	 * For status transitions use setTaskStatus instead.
 	 */
-	async updateTask(taskId: string, params: UpdateSpaceTaskParams): Promise<SpaceTask> {
+	async updateTask(
+		taskId: string,
+		params: UpdateSpaceTaskParams,
+		options?: {
+			/** Optional callback invoked with tasks cascaded by dependency changes. */
+			onCascadedTasks?: (cascaded: SpaceTask[]) => Promise<void>;
+		}
+	): Promise<SpaceTask> {
 		const task = await this.getTask(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
@@ -529,7 +541,10 @@ export class SpaceTaskManager {
 				});
 				// Cascade: block any in_progress tasks that depend on this
 				// newly-blocked task (mirrors updateTaskAndEmit cascade).
-				await this.blockDependentTasks(taskId);
+				const cascaded = await this.blockDependentTasks(taskId);
+				if (cascaded.length > 0 && options?.onCascadedTasks) {
+					await options.onCascadedTasks(cascaded);
+				}
 				return blocked;
 			} else if (
 				depsMet &&

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1036,14 +1036,6 @@ export class SpaceRuntime {
 						}
 					}
 				}
-			} else if (params.status === 'done') {
-				// Gap 2 fix: completing a task may unblock dependents that were
-				// previously blocked because this dependency had failed/was blocked.
-				const taskManager = this.getOrCreateTaskManager(spaceId);
-				const unblocked = await taskManager.unblockDependentTasks(taskId);
-				for (const task of unblocked) {
-					await this.safeOnTaskUpdated(spaceId, task);
-				}
 			}
 		}
 		return updated;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -919,11 +919,19 @@ export class SpaceRuntime {
 			// bypassing setTaskStatus — so the dependency-unblock cascade
 			// doesn't fire there. Trigger it here and emit for each
 			// unblocked dependent so the UI sees the state change.
-			if (routeResult.mode === 'no-route') {
-				const taskManager = this.getOrCreateTaskManager(spaceId);
-				const unblocked = await taskManager.unblockDependentTasks(taskId);
-				for (const dep of unblocked) {
-					await this.safeOnTaskUpdated(spaceId, dep);
+			// Guard on `final?.status === 'done'` to confirm the write
+			// landed, and wrap in try-catch so unblock failures don't
+			// abort the already-committed post-approval flow.
+			if (routeResult.mode === 'no-route' && final?.status === 'done') {
+				try {
+					const taskManager = this.getOrCreateTaskManager(spaceId);
+					const unblocked = await taskManager.unblockDependentTasks(taskId);
+					for (const dep of unblocked) {
+						await this.safeOnTaskUpdated(spaceId, dep);
+					}
+				} catch {
+					// Best-effort: unblock failures must not abort
+					// the post-approval flow.
 				}
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -914,6 +914,18 @@ export class SpaceRuntime {
 		if (routeResult.mode !== 'skipped') {
 			const final = this.config.taskRepo.getTask(taskId);
 			if (final) await this.safeOnTaskUpdated(spaceId, final);
+
+			// The no-route branch writes `done` directly via taskRepo,
+			// bypassing setTaskStatus — so the dependency-unblock cascade
+			// doesn't fire there. Trigger it here and emit for each
+			// unblocked dependent so the UI sees the state change.
+			if (routeResult.mode === 'no-route') {
+				const taskManager = this.getOrCreateTaskManager(spaceId);
+				const unblocked = await taskManager.unblockDependentTasks(taskId);
+				for (const dep of unblocked) {
+					await this.safeOnTaskUpdated(spaceId, dep);
+				}
+			}
 		}
 		return routeResult;
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1036,6 +1036,14 @@ export class SpaceRuntime {
 						}
 					}
 				}
+			} else if (params.status === 'done') {
+				// Gap 2 fix: completing a task may unblock dependents that were
+				// previously blocked because this dependency had failed/was blocked.
+				const taskManager = this.getOrCreateTaskManager(spaceId);
+				const unblocked = await taskManager.unblockDependentTasks(taskId);
+				for (const task of unblocked) {
+					await this.safeOnTaskUpdated(spaceId, task);
+				}
 			}
 		}
 		return updated;

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -109,7 +109,7 @@ export function createMarkCompleteHandler(
 			namespaceId: 'global',
 			sessionId: 'global',
 			spaceId,
-			taskId,
+			taskId: task.id,
 			task,
 		});
 	};
@@ -174,6 +174,7 @@ export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers
 	} = deps;
 
 	const emitTaskUpdated = (task: SpaceTask): void => {
+<<<<<<< HEAD
 		internalEventBus?.publishAsync('space.task.updated', {
 			namespaceId: 'global',
 			sessionId: 'global',
@@ -181,16 +182,20 @@ export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers
 			taskId,
 			task,
 		});
-	};
-
-	return {
-		// -------------------------------------------------------------------
-		// approve_task — self-close. Re-checks autonomy at call time.
-		// -------------------------------------------------------------------
-		onApproveTask: async (_args: ApproveTaskInput) => {
-			const space = await spaceManager.getSpace(spaceId);
-			const currentLevel = space?.autonomyLevel ?? 1;
-			const required = workflow?.completionAutonomyLevel ?? 5;
+=======
+		if (!daemonHub) return;
+		void daemonHub
+			.emit('space.task.updated', { sessionId: 'global', spaceId, taskId: task.id, task })
+			.catch((err: unknown) => {
+				log.warn(
+					`Failed to emit space.task.updated for task ${task.id}: ${err		internalEventBus?.publishAsync('space.task.updated', {
+			namespaceId: 'global',
+			sessionId: 'global',
+			spaceId,
+			taskId: task.id,
+			task,
+		});
+orkflow?.completionAutonomyLevel ?? 5;
 			if (currentLevel < required) {
 				return jsonResult({
 					success: false,

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -134,6 +134,9 @@ export function createMarkCompleteHandler(
 			// `postApprovalBlockedReason` in the same UPDATE.
 			const updated = await taskManager.setTaskStatus(taskId, 'done', {
 				approvalSource: task.approvalSource ?? 'agent',
+				onCascadedTasks: async (cascaded) => {
+					for (const t of cascaded) emitTaskUpdated(t);
+				},
 			});
 			emitTaskUpdated(updated);
 			log.info(

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -174,28 +174,23 @@ export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers
 	} = deps;
 
 	const emitTaskUpdated = (task: SpaceTask): void => {
-<<<<<<< HEAD
 		internalEventBus?.publishAsync('space.task.updated', {
-			namespaceId: 'global',
-			sessionId: 'global',
-			spaceId,
-			taskId,
-			task,
-		});
-=======
-		if (!daemonHub) return;
-		void daemonHub
-			.emit('space.task.updated', { sessionId: 'global', spaceId, taskId: task.id, task })
-			.catch((err: unknown) => {
-				log.warn(
-					`Failed to emit space.task.updated for task ${task.id}: ${err		internalEventBus?.publishAsync('space.task.updated', {
 			namespaceId: 'global',
 			sessionId: 'global',
 			spaceId,
 			taskId: task.id,
 			task,
 		});
-orkflow?.completionAutonomyLevel ?? 5;
+	};
+
+	return {
+		// -------------------------------------------------------------------
+		// approve_task — self-close. Re-checks autonomy at call time.
+		// -------------------------------------------------------------------
+		onApproveTask: async (_args: ApproveTaskInput) => {
+			const space = await spaceManager.getSpace(spaceId);
+			const currentLevel = space?.autonomyLevel ?? 1;
+			const required = workflow?.completionAutonomyLevel ?? 5;
 			if (currentLevel < required) {
 				return jsonResult({
 					success: false,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -655,12 +655,31 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 
 			try {
-				const updated = await taskManager.updateTask(args.task_id, {
-					title: args.title,
-					description: args.description,
-					priority: args.priority,
-					dependsOn: args.depends_on,
-				});
+				const updated = await taskManager.updateTask(
+					args.task_id,
+					{
+						title: args.title,
+						description: args.description,
+						priority: args.priority,
+						dependsOn: args.depends_on,
+					},
+					{
+						onCascadedTasks: async (cascaded) => {
+							for (const t of cascaded) {
+								if (daemonHub) {
+									void daemonHub
+										.emit('space.task.updated', {
+											sessionId: 'global',
+											spaceId,
+											taskId: t.id,
+											task: t,
+										})
+										.catch(() => {});
+								}
+							}
+						},
+					}
+				);
 
 				logAudit(
 					'update_task',
@@ -1262,6 +1281,20 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					result: task.result ?? undefined,
 					approvalSource: 'agent',
 					approvalReason: args.reason,
+					onCascadedTasks: async (cascaded) => {
+						for (const t of cascaded) {
+							if (daemonHub) {
+								void daemonHub
+									.emit('space.task.updated', {
+										sessionId: 'global',
+										spaceId,
+										taskId: t.id,
+										task: t,
+									})
+									.catch(() => {});
+							}
+						}
+					},
 				});
 
 				logAudit(

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -666,16 +666,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					{
 						onCascadedTasks: async (cascaded) => {
 							for (const t of cascaded) {
-								if (daemonHub) {
-									void daemonHub
-										.emit('space.task.updated', {
-											sessionId: 'global',
-											spaceId,
-											taskId: t.id,
-											task: t,
-										})
-										.catch(() => {});
-								}
+								internalEventBus?.publishAsync('space.task.updated', {
+									namespaceId: 'global',
+									sessionId: 'global',
+									spaceId,
+									taskId: t.id,
+									task: t,
+								});
 							}
 						},
 					}
@@ -1283,16 +1280,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					approvalReason: args.reason,
 					onCascadedTasks: async (cascaded) => {
 						for (const t of cascaded) {
-							if (daemonHub) {
-								void daemonHub
-									.emit('space.task.updated', {
-										sessionId: 'global',
-										spaceId,
-										taskId: t.id,
-										task: t,
-									})
-									.catch(() => {});
-							}
+							internalEventBus?.publishAsync('space.task.updated', {
+								namespaceId: 'global',
+								sessionId: 'global',
+								spaceId,
+								taskId: t.id,
+								task: t,
+							});
 						}
 					},
 				});

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -464,6 +464,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				// `postApprovalBlockedReason` in the same UPDATE.
 				const updated = await taskManager.setTaskStatus(taskId, 'done', {
 					approvalSource: task.approvalSource ?? 'agent',
+					onCascadedTasks: async (cascaded) => {
+						for (const t of cascaded) emitTaskUpdated(t);
+					},
 				});
 				emitTaskUpdated(updated);
 				log.info(
@@ -549,12 +552,20 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 
 			try {
-				const updated = await taskManager.updateTask(taskId, {
-					title: args.title,
-					description: args.description,
-					priority: args.priority,
-					dependsOn: args.depends_on,
-				});
+				const updated = await taskManager.updateTask(
+					taskId,
+					{
+						title: args.title,
+						description: args.description,
+						priority: args.priority,
+						dependsOn: args.depends_on,
+					},
+					{
+						onCascadedTasks: async (cascaded) => {
+							for (const t of cascaded) emitTaskUpdated(t);
+						},
+					}
+				);
 				emitTaskUpdated(updated);
 				return jsonResult({ success: true, task: updated });
 			} catch (err) {

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -253,7 +253,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			namespaceId: 'global',
 			sessionId: 'global',
 			spaceId: space.id,
-			taskId,
+			taskId: task.id,
 			task,
 		});
 	}

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -482,6 +482,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'archived', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 			expect(internalEventBus.publishAsync).toHaveBeenCalledWith('space.task.updated', {
 				namespaceId: 'global',
@@ -510,6 +511,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'archived', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 		});
 
@@ -607,6 +609,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 			expect(internalEventBus.publishAsync).toHaveBeenCalledWith('space.task.updated', {
 				namespaceId: 'global',
@@ -636,6 +639,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 		});
 
@@ -657,6 +661,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'open', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 		});
 
@@ -693,6 +698,7 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
 				result: undefined,
 				error: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 			expect(internalEventBus.publishAsync).toHaveBeenCalledWith('space.task.updated', {
 				namespaceId: 'global',
@@ -713,10 +719,14 @@ describe('space-task-handlers', () => {
 			});
 
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
-			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
-				status: 'open',
-				title: 'New title',
-			});
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{
+					status: 'open',
+					title: 'New title',
+				},
+				{ onCascadedTasks: expect.any(Function) }
+			);
 			expect(result).toBeDefined();
 		});
 
@@ -728,10 +738,13 @@ describe('space-task-handlers', () => {
 			});
 
 			expect((result as SpaceTask).title).toBe('Updated');
-			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', { title: 'Updated' });
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{ title: 'Updated' },
+				{ onCascadedTasks: expect.any(Function) },
+			);
 			expect(internalEventBus.publishAsync).toHaveBeenCalledWith('space.task.updated', {
-				namespaceId: 'global',
-				sessionId: 'global',
+				namespaceId: 'global',				sessionId: 'global',
 				spaceId: 'space-1',
 				taskId: 'task-1',
 				task: expect.objectContaining({ title: 'Updated' }),
@@ -748,6 +761,7 @@ describe('space-task-handlers', () => {
 
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'blocked', {
 				result: 'Build failed',
+				onCascadedTasks: expect.any(Function),
 			});
 		});
 
@@ -777,11 +791,16 @@ describe('space-task-handlers', () => {
 			// setTaskStatus was called for the transition
 			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
 				result: undefined,
+				onCascadedTasks: expect.any(Function),
 			});
 			// updateTask was called with the non-status fields (no status, no result)
-			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
-				taskAgentSessionId: 'session-abc',
-			});
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{
+					taskAgentSessionId: 'session-abc',
+				},
+				{ onCascadedTasks: expect.any(Function) }
+			);
 			// Final result has both fields
 			expect((result as SpaceTask).status).toBe('in_progress');
 			expect((result as SpaceTask).taskAgentSessionId).toBe('session-abc');
@@ -839,12 +858,17 @@ describe('space-task-handlers', () => {
 				result: undefined,
 				approvalSource: undefined,
 				approvalReason: 'not worth shipping',
+				onCascadedTasks: expect.any(Function),
 			});
 			// A follow-up updateTask ensures approvalReason lands even though
 			// setTaskStatus only stamps it on review→done.
-			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
-				approvalReason: 'not worth shipping',
-			});
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{
+					approvalReason: 'not worth shipping',
+				},
+				{ onCascadedTasks: expect.any(Function) }
+			);
 		});
 
 		it('falls back to approvalReason when cancelReason is omitted on cancel transitions', async () => {
@@ -866,10 +890,15 @@ describe('space-task-handlers', () => {
 				result: undefined,
 				approvalSource: undefined,
 				approvalReason: 'rejected via legacy field',
+				onCascadedTasks: expect.any(Function),
 			});
-			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
-				approvalReason: 'rejected via legacy field',
-			});
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{
+					approvalReason: 'rejected via legacy field',
+				},
+				{ onCascadedTasks: expect.any(Function) }
+			);
 		});
 
 		it('propagates errors from setTaskStatus (invalid transitions)', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -741,10 +741,11 @@ describe('space-task-handlers', () => {
 			expect(taskManager.updateTask).toHaveBeenCalledWith(
 				'task-1',
 				{ title: 'Updated' },
-				{ onCascadedTasks: expect.any(Function) },
+				{ onCascadedTasks: expect.any(Function) }
 			);
 			expect(internalEventBus.publishAsync).toHaveBeenCalledWith('space.task.updated', {
-				namespaceId: 'global',				sessionId: 'global',
+				namespaceId: 'global',
+				sessionId: 'global',
 				spaceId: 'space-1',
 				taskId: 'task-1',
 				task: expect.objectContaining({ title: 'Updated' }),

--- a/packages/daemon/tests/unit/5-space/runtime/task-dependency-enforcement.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-dependency-enforcement.test.ts
@@ -3,6 +3,11 @@
  *
  * Gap 1: Adding `dependsOn` to an in_progress task blocks it if deps aren't met.
  * Gap 2: Completing a task auto-unblocks dependents blocked by 'dependency_failed'.
+ *
+ * Review fixes:
+ * - Unblock triggers on ALL done transitions (not just updateTaskAndEmit path).
+ * - Blocked dependency_added tasks are re-evaluated when deps are edited.
+ * - Auto-block triggers blockDependentTasks cascade.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -25,6 +30,10 @@ function makeDb(): BunDatabase {
 	return db;
 }
 
+// ---------------------------------------------------------------------------
+// Gap 1: updateTask dependency re-check
+// ---------------------------------------------------------------------------
+
 describe('Gap 1: updateTask dependency re-check', () => {
 	let db: BunDatabase;
 	let taskRepo: SpaceTaskRepository;
@@ -40,7 +49,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 	});
 
 	test('adding dependsOn to an in_progress task blocks it if deps are not met', async () => {
-		// Create a prerequisite task that is NOT done yet
 		const prereq = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Prerequisite',
@@ -48,7 +56,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'open',
 		});
 
-		// Create a task without deps and start it
 		const task = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Worker',
@@ -56,7 +63,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'in_progress',
 		});
 
-		// Add dependency to the running task
 		const updated = await taskManager.updateTask(task.id, {
 			dependsOn: [prereq.id],
 		});
@@ -66,7 +72,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 	});
 
 	test('adding dependsOn to an in_progress task does NOT block if deps are already done', async () => {
-		// Create a prerequisite task that IS done
 		const prereq = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Prerequisite',
@@ -74,7 +79,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'done',
 		});
 
-		// Create a task without deps and start it
 		const task = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Worker',
@@ -82,7 +86,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'in_progress',
 		});
 
-		// Add dependency to the running task — should remain in_progress
 		const updated = await taskManager.updateTask(task.id, {
 			dependsOn: [prereq.id],
 		});
@@ -109,7 +112,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			dependsOn: [prereq.id],
 		});
 
-		// Open tasks remain open — tick loop skips them via areDependenciesMet
 		expect(updated.status).toBe('open');
 	});
 
@@ -121,7 +123,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'open',
 		});
 
-		// Create task with existing dep
 		const task = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Worker',
@@ -130,12 +131,10 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			dependsOn: [prereq.id],
 		});
 
-		// Re-send the same dependsOn — should be a no-op (no re-check)
 		const updated = await taskManager.updateTask(task.id, {
 			dependsOn: [prereq.id],
 		});
 
-		// Should remain in_progress because the dep array didn't actually change
 		expect(updated.status).toBe('in_progress');
 	});
 
@@ -153,7 +152,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'open',
 		});
 
-		// Create task with met dep
 		const task = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Worker',
@@ -162,7 +160,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			dependsOn: [prereq1.id],
 		});
 
-		// Change dep to an unmet one
 		const updated = await taskManager.updateTask(task.id, {
 			dependsOn: [prereq2.id],
 		});
@@ -185,7 +182,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			status: 'done',
 		});
 
-		// Create task with unmet dep
 		const task = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Worker',
@@ -194,7 +190,6 @@ describe('Gap 1: updateTask dependency re-check', () => {
 			dependsOn: [prereq1.id],
 		});
 
-		// Change dep to a met one
 		const updated = await taskManager.updateTask(task.id, {
 			dependsOn: [prereq2.id],
 		});
@@ -202,6 +197,193 @@ describe('Gap 1: updateTask dependency re-check', () => {
 		expect(updated.status).toBe('in_progress');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Gap 1 review fix: re-evaluate blocked dependency_added tasks on dep edits
+// ---------------------------------------------------------------------------
+
+describe('Gap 1 review fix: re-evaluate blocked tasks on dep edits', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('editing deps of a blocked/dependency_added task to satisfied deps reopens it', async () => {
+		const prereqOld = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Old Prereq',
+			description: '',
+			status: 'open',
+		});
+		const prereqNew = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'New Prereq',
+			description: '',
+			status: 'done',
+		});
+
+		// Create task blocked by dependency_added
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereqOld.id],
+		});
+		taskRepo.updateTask(task.id, { blockReason: 'dependency_added' });
+
+		// Change dep to a satisfied one — should reopen
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereqNew.id],
+		});
+
+		expect(updated.status).toBe('open');
+	});
+
+	test('clearing deps of a blocked/dependency_added task reopens it', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq',
+			description: '',
+			status: 'open',
+		});
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(task.id, { blockReason: 'dependency_added' });
+
+		// Clear deps entirely
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [],
+		});
+
+		expect(updated.status).toBe('open');
+	});
+
+	test('editing deps of a blocked/dependency_failed task to satisfied deps reopens it', async () => {
+		const prereqOld = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Old Prereq',
+			description: '',
+			status: 'blocked',
+		});
+		const prereqNew = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'New Prereq',
+			description: '',
+			status: 'done',
+		});
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereqOld.id],
+		});
+		taskRepo.updateTask(task.id, { blockReason: 'dependency_failed' });
+
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereqNew.id],
+		});
+
+		expect(updated.status).toBe('open');
+	});
+
+	test('editing deps of a blocked/agent_crashed task does NOT change status', async () => {
+		const prereqNew = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'New Prereq',
+			description: '',
+			status: 'done',
+		});
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'blocked',
+		});
+		taskRepo.updateTask(task.id, { blockReason: 'agent_crashed' });
+
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereqNew.id],
+		});
+
+		expect(updated.status).toBe('blocked');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Gap 1 review fix: auto-block cascade
+// ---------------------------------------------------------------------------
+
+describe('Gap 1 review fix: auto-block triggers cascade to dependents', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('auto-blocking an in_progress task also blocks its in_progress dependents', async () => {
+		// A has no deps, B depends on A
+		const taskA = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'A',
+			description: '',
+			status: 'in_progress',
+		});
+		const taskB = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'B',
+			description: '',
+			status: 'in_progress',
+			dependsOn: [taskA.id],
+		});
+
+		// Add an unmet dep to A → A gets blocked → B should also be blocked
+		const unmet = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Unmet',
+			description: '',
+			status: 'open',
+		});
+
+		const updatedA = await taskManager.updateTask(taskA.id, {
+			dependsOn: [unmet.id],
+		});
+		expect(updatedA.status).toBe('blocked');
+
+		// B should have been cascade-blocked
+		const updatedB = await taskManager.getTask(taskB.id);
+		expect(updatedB!.status).toBe('blocked');
+		expect(updatedB!.blockReason).toBe('dependency_failed');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Gap 2: done -> unblock dependents cascade
+// ---------------------------------------------------------------------------
 
 describe('Gap 2: done -> unblock dependents cascade', () => {
 	let db: BunDatabase;
@@ -218,7 +400,6 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 	});
 
 	test('completing a task unblocks dependents blocked with dependency_failed', async () => {
-		// Create the prerequisite (in_progress so it can transition to done)
 		const prereq = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Prerequisite',
@@ -226,7 +407,6 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'in_progress',
 		});
 
-		// Create a dependent task that was blocked because its dep failed
 		const dependent = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Dependent',
@@ -234,23 +414,16 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'blocked',
 			dependsOn: [prereq.id],
 		});
-		taskRepo.updateTask(dependent.id, {
-			blockReason: 'dependency_failed',
-		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_failed' });
 
-		// Complete the prerequisite
+		// Completing the prereq via setTaskStatus should auto-unblock
 		await taskManager.setTaskStatus(prereq.id, 'done');
 
-		// Run the unblock cascade
-		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
-
-		expect(unblocked).toHaveLength(1);
-		expect(unblocked[0].id).toBe(dependent.id);
-		expect(unblocked[0].status).toBe('open');
+		const updatedDep = await taskManager.getTask(dependent.id);
+		expect(updatedDep!.status).toBe('open');
 	});
 
 	test('dependent with multiple deps stays blocked if not all are done', async () => {
-		// Create two prerequisites
 		const prereq1 = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Prereq 1',
@@ -264,7 +437,6 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'open',
 		});
 
-		// Create a dependent task blocked because deps failed
 		const dependent = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Dependent',
@@ -272,19 +444,12 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'blocked',
 			dependsOn: [prereq1.id, prereq2.id],
 		});
-		taskRepo.updateTask(dependent.id, {
-			blockReason: 'dependency_failed',
-		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_failed' });
 
-		// Complete only prereq1 — prereq2 is still open
 		await taskManager.setTaskStatus(prereq1.id, 'done');
 
-		const unblocked = await taskManager.unblockDependentTasks(prereq1.id);
-		expect(unblocked).toHaveLength(0);
-
-		// Dependent should still be blocked
-		const stillDependent = await taskManager.getTask(dependent.id);
-		expect(stillDependent!.status).toBe('blocked');
+		const stillDep = await taskManager.getTask(dependent.id);
+		expect(stillDep!.status).toBe('blocked');
 	});
 
 	test('dependent with all deps done gets unblocked', async () => {
@@ -308,16 +473,12 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'blocked',
 			dependsOn: [prereq1.id, prereq2.id],
 		});
-		taskRepo.updateTask(dependent.id, {
-			blockReason: 'dependency_failed',
-		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_failed' });
 
-		// Complete prereq2 — now both deps are done
 		await taskManager.setTaskStatus(prereq2.id, 'done');
 
-		const unblocked = await taskManager.unblockDependentTasks(prereq2.id);
-		expect(unblocked).toHaveLength(1);
-		expect(unblocked[0].status).toBe('open');
+		const updatedDep = await taskManager.getTask(dependent.id);
+		expect(updatedDep!.status).toBe('open');
 	});
 
 	test('non-dependency blocked tasks are NOT affected', async () => {
@@ -335,14 +496,12 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'blocked',
 			dependsOn: [prereq.id],
 		});
-		taskRepo.updateTask(blockedForOtherReason.id, {
-			blockReason: 'agent_crashed',
-		});
+		taskRepo.updateTask(blockedForOtherReason.id, { blockReason: 'agent_crashed' });
 
 		await taskManager.setTaskStatus(prereq.id, 'done');
 
-		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
-		expect(unblocked).toHaveLength(0);
+		const stillBlocked = await taskManager.getTask(blockedForOtherReason.id);
+		expect(stillBlocked!.status).toBe('blocked');
 	});
 
 	test('dependency_added blocked tasks are also unblocked', async () => {
@@ -350,10 +509,9 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			spaceId: SPACE_ID,
 			title: 'Prerequisite',
 			description: '',
-			status: 'open',
+			status: 'in_progress',
 		});
 
-		// Simulate a task that was blocked via the Gap 1 fix (dependency_added)
 		const dependent = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Dependent',
@@ -361,16 +519,12 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 			status: 'blocked',
 			dependsOn: [prereq.id],
 		});
-		taskRepo.updateTask(dependent.id, {
-			blockReason: 'dependency_added',
-		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_added' });
 
-		// Complete the prerequisite
 		await taskManager.setTaskStatus(prereq.id, 'done');
 
-		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
-		expect(unblocked).toHaveLength(1);
-		expect(unblocked[0].status).toBe('open');
+		const updatedDep = await taskManager.getTask(dependent.id);
+		expect(updatedDep!.status).toBe('open');
 	});
 
 	test('no dependents returns empty array', async () => {
@@ -385,6 +539,77 @@ describe('Gap 2: done -> unblock dependents cascade', () => {
 		expect(unblocked).toHaveLength(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Gap 2 review fix: unblock works via setTaskStatus (not just updateTaskAndEmit)
+// ---------------------------------------------------------------------------
+
+describe('Gap 2 review fix: unblock triggers on all done paths', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('setTaskStatus(done) auto-unblocks dependents (direct path)', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'in_progress',
+		});
+
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_failed' });
+
+		// Direct setTaskStatus call — no updateTaskAndEmit involved
+		await taskManager.setTaskStatus(prereq.id, 'done');
+
+		const updatedDep = await taskManager.getTask(dependent.id);
+		expect(updatedDep!.status).toBe('open');
+	});
+
+	test('completeTask() auto-unblocks dependents', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'in_progress',
+		});
+
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(dependent.id, { blockReason: 'dependency_failed' });
+
+		// completeTask calls setTaskStatus internally
+		await taskManager.completeTask(prereq.id, 'All done');
+
+		const updatedDep = await taskManager.getTask(dependent.id);
+		expect(updatedDep!.status).toBe('open');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: full lifecycle
+// ---------------------------------------------------------------------------
 
 describe('End-to-end: dependency_added -> dep done -> unblock -> tick-loop eligible', () => {
 	let db: BunDatabase;
@@ -401,7 +626,6 @@ describe('End-to-end: dependency_added -> dep done -> unblock -> tick-loop eligi
 	});
 
 	test('full lifecycle: add dep to running task -> block -> complete dep -> unblock', async () => {
-		// Step 1: Create a running task without deps
 		const prereq = taskRepo.createTask({
 			spaceId: SPACE_ID,
 			title: 'Prerequisite',
@@ -416,30 +640,73 @@ describe('End-to-end: dependency_added -> dep done -> unblock -> tick-loop eligi
 			status: 'in_progress',
 		});
 
-		// Step 2: Add dependency — worker gets blocked
+		// Add dependency — worker gets blocked
 		const afterAdd = await taskManager.updateTask(worker.id, {
 			dependsOn: [prereq.id],
 		});
 		expect(afterAdd.status).toBe('blocked');
 		expect(afterAdd.blockReason).toBe('dependency_added');
 
-		// Step 3: Verify the tick loop would skip this blocked task
+		// Tick loop would skip this blocked task
 		const depsMet = await taskManager.areDependenciesMet(afterAdd);
 		expect(depsMet).toBe(false);
 
-		// Step 4: Complete the prerequisite
+		// Complete the prerequisite (direct setTaskStatus, no runtime)
 		await taskManager.setTaskStatus(prereq.id, 'done');
 
-		// Step 5: Unblock dependents
-		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
-		expect(unblocked).toHaveLength(1);
-		expect(unblocked[0].id).toBe(worker.id);
-		expect(unblocked[0].status).toBe('open');
-
-		// Step 6: Verify the task is now eligible for the tick loop
+		// Verify the worker is now unblocked and tick-loop eligible
 		const reopened = await taskManager.getTask(worker.id);
 		expect(reopened!.status).toBe('open');
 		const nowDepsMet = await taskManager.areDependenciesMet(reopened!);
 		expect(nowDepsMet).toBe(true);
+	});
+
+	test('full lifecycle with cascade: block propagates to transitive dependents', async () => {
+		// A (in_progress) -> B (in_progress, depends on A)
+		// Adding unmet dep to A blocks A, cascade blocks B
+		// Completing the new dep unblocks A, then completing A unblocks B
+		const newDep = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'New Dependency',
+			description: '',
+			status: 'in_progress',
+		});
+		const taskA = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'A',
+			description: '',
+			status: 'in_progress',
+		});
+		const taskB = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'B',
+			description: '',
+			status: 'in_progress',
+			dependsOn: [taskA.id],
+		});
+
+		// Add unmet dep to A → A blocked, cascade blocks B
+		const updatedA = await taskManager.updateTask(taskA.id, {
+			dependsOn: [newDep.id],
+		});
+		expect(updatedA.status).toBe('blocked');
+
+		const updatedB = await taskManager.getTask(taskB.id);
+		expect(updatedB!.status).toBe('blocked');
+		expect(updatedB!.blockReason).toBe('dependency_failed');
+
+		// Complete the new dep → A should auto-unblock
+		await taskManager.setTaskStatus(newDep.id, 'done');
+		const recheckedA = await taskManager.getTask(taskA.id);
+		expect(recheckedA!.status).toBe('open');
+
+		// B is still blocked because A is not done yet
+		const recheckedB = await taskManager.getTask(taskB.id);
+		expect(recheckedB!.status).toBe('blocked');
+
+		// Complete A → B should auto-unblock
+		await taskManager.setTaskStatus(taskA.id, 'done');
+		const finalB = await taskManager.getTask(taskB.id);
+		expect(finalB!.status).toBe('open');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/task-dependency-enforcement.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-dependency-enforcement.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for task dependency enforcement gap fixes:
+ *
+ * Gap 1: Adding `dependsOn` to an in_progress task blocks it if deps aren't met.
+ * Gap 2: Completing a task auto-unblocks dependents blocked by 'dependency_failed'.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
+
+const SPACE_ID = 'space-dep-test';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(SPACE_ID, `Space ${SPACE_ID}`, SPACE_ID, Date.now(), Date.now());
+	return db;
+}
+
+describe('Gap 1: updateTask dependency re-check', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('adding dependsOn to an in_progress task blocks it if deps are not met', async () => {
+		// Create a prerequisite task that is NOT done yet
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'open',
+		});
+
+		// Create a task without deps and start it
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+		});
+
+		// Add dependency to the running task
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq.id],
+		});
+
+		expect(updated.status).toBe('blocked');
+		expect(updated.blockReason).toBe('dependency_added');
+	});
+
+	test('adding dependsOn to an in_progress task does NOT block if deps are already done', async () => {
+		// Create a prerequisite task that IS done
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'done',
+		});
+
+		// Create a task without deps and start it
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+		});
+
+		// Add dependency to the running task — should remain in_progress
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq.id],
+		});
+
+		expect(updated.status).toBe('in_progress');
+	});
+
+	test('adding dependsOn to an open task does NOT block it (tick loop handles it)', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'open',
+		});
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'open',
+		});
+
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq.id],
+		});
+
+		// Open tasks remain open — tick loop skips them via areDependenciesMet
+		expect(updated.status).toBe('open');
+	});
+
+	test('updating dependsOn without changing the value does not re-check', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'open',
+		});
+
+		// Create task with existing dep
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+			dependsOn: [prereq.id],
+		});
+
+		// Re-send the same dependsOn — should be a no-op (no re-check)
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq.id],
+		});
+
+		// Should remain in_progress because the dep array didn't actually change
+		expect(updated.status).toBe('in_progress');
+	});
+
+	test('changing dependsOn to a different unmet dep blocks the task', async () => {
+		const prereq1 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 1',
+			description: '',
+			status: 'done',
+		});
+		const prereq2 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 2',
+			description: '',
+			status: 'open',
+		});
+
+		// Create task with met dep
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+			dependsOn: [prereq1.id],
+		});
+
+		// Change dep to an unmet one
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq2.id],
+		});
+
+		expect(updated.status).toBe('blocked');
+		expect(updated.blockReason).toBe('dependency_added');
+	});
+
+	test('changing dependsOn to a met dep keeps task in_progress', async () => {
+		const prereq1 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 1',
+			description: '',
+			status: 'open',
+		});
+		const prereq2 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 2',
+			description: '',
+			status: 'done',
+		});
+
+		// Create task with unmet dep
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+			dependsOn: [prereq1.id],
+		});
+
+		// Change dep to a met one
+		const updated = await taskManager.updateTask(task.id, {
+			dependsOn: [prereq2.id],
+		});
+
+		expect(updated.status).toBe('in_progress');
+	});
+});
+
+describe('Gap 2: done -> unblock dependents cascade', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('completing a task unblocks dependents blocked with dependency_failed', async () => {
+		// Create the prerequisite (in_progress so it can transition to done)
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'in_progress',
+		});
+
+		// Create a dependent task that was blocked because its dep failed
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(dependent.id, {
+			blockReason: 'dependency_failed',
+		});
+
+		// Complete the prerequisite
+		await taskManager.setTaskStatus(prereq.id, 'done');
+
+		// Run the unblock cascade
+		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
+
+		expect(unblocked).toHaveLength(1);
+		expect(unblocked[0].id).toBe(dependent.id);
+		expect(unblocked[0].status).toBe('open');
+	});
+
+	test('dependent with multiple deps stays blocked if not all are done', async () => {
+		// Create two prerequisites
+		const prereq1 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 1',
+			description: '',
+			status: 'in_progress',
+		});
+		const prereq2 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 2',
+			description: '',
+			status: 'open',
+		});
+
+		// Create a dependent task blocked because deps failed
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq1.id, prereq2.id],
+		});
+		taskRepo.updateTask(dependent.id, {
+			blockReason: 'dependency_failed',
+		});
+
+		// Complete only prereq1 — prereq2 is still open
+		await taskManager.setTaskStatus(prereq1.id, 'done');
+
+		const unblocked = await taskManager.unblockDependentTasks(prereq1.id);
+		expect(unblocked).toHaveLength(0);
+
+		// Dependent should still be blocked
+		const stillDependent = await taskManager.getTask(dependent.id);
+		expect(stillDependent!.status).toBe('blocked');
+	});
+
+	test('dependent with all deps done gets unblocked', async () => {
+		const prereq1 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 1',
+			description: '',
+			status: 'done',
+		});
+		const prereq2 = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prereq 2',
+			description: '',
+			status: 'in_progress',
+		});
+
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq1.id, prereq2.id],
+		});
+		taskRepo.updateTask(dependent.id, {
+			blockReason: 'dependency_failed',
+		});
+
+		// Complete prereq2 — now both deps are done
+		await taskManager.setTaskStatus(prereq2.id, 'done');
+
+		const unblocked = await taskManager.unblockDependentTasks(prereq2.id);
+		expect(unblocked).toHaveLength(1);
+		expect(unblocked[0].status).toBe('open');
+	});
+
+	test('non-dependency blocked tasks are NOT affected', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'in_progress',
+		});
+
+		const blockedForOtherReason = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Other blocked',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(blockedForOtherReason.id, {
+			blockReason: 'agent_crashed',
+		});
+
+		await taskManager.setTaskStatus(prereq.id, 'done');
+
+		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
+		expect(unblocked).toHaveLength(0);
+	});
+
+	test('dependency_added blocked tasks are also unblocked', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'open',
+		});
+
+		// Simulate a task that was blocked via the Gap 1 fix (dependency_added)
+		const dependent = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Dependent',
+			description: '',
+			status: 'blocked',
+			dependsOn: [prereq.id],
+		});
+		taskRepo.updateTask(dependent.id, {
+			blockReason: 'dependency_added',
+		});
+
+		// Complete the prerequisite
+		await taskManager.setTaskStatus(prereq.id, 'done');
+
+		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
+		expect(unblocked).toHaveLength(1);
+		expect(unblocked[0].status).toBe('open');
+	});
+
+	test('no dependents returns empty array', async () => {
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'done',
+		});
+
+		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
+		expect(unblocked).toHaveLength(0);
+	});
+});
+
+describe('End-to-end: dependency_added -> dep done -> unblock -> tick-loop eligible', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('full lifecycle: add dep to running task -> block -> complete dep -> unblock', async () => {
+		// Step 1: Create a running task without deps
+		const prereq = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Prerequisite',
+			description: '',
+			status: 'open',
+		});
+
+		const worker = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Worker',
+			description: '',
+			status: 'in_progress',
+		});
+
+		// Step 2: Add dependency — worker gets blocked
+		const afterAdd = await taskManager.updateTask(worker.id, {
+			dependsOn: [prereq.id],
+		});
+		expect(afterAdd.status).toBe('blocked');
+		expect(afterAdd.blockReason).toBe('dependency_added');
+
+		// Step 3: Verify the tick loop would skip this blocked task
+		const depsMet = await taskManager.areDependenciesMet(afterAdd);
+		expect(depsMet).toBe(false);
+
+		// Step 4: Complete the prerequisite
+		await taskManager.setTaskStatus(prereq.id, 'done');
+
+		// Step 5: Unblock dependents
+		const unblocked = await taskManager.unblockDependentTasks(prereq.id);
+		expect(unblocked).toHaveLength(1);
+		expect(unblocked[0].id).toBe(worker.id);
+		expect(unblocked[0].status).toBe('open');
+
+		// Step 6: Verify the task is now eligible for the tick loop
+		const reopened = await taskManager.getTask(worker.id);
+		expect(reopened!.status).toBe('open');
+		const nowDepsMet = await taskManager.areDependenciesMet(reopened!);
+		expect(nowDepsMet).toBe(true);
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -243,7 +243,8 @@ export type SpaceBlockReason =
 	| 'execution_failed'
 	| 'human_input_requested'
 	| 'gate_rejected'
-	| 'dependency_failed';
+	| 'dependency_failed'
+	| 'dependency_added';
 
 /**
  * Space task priority

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -10,7 +10,7 @@
  *     question, the user still sees that input is required.
  *   - gate_rejected: purple — shows gate info + "Review & Approve" expanding to GateArtifactsView
  *   - execution_failed / agent_crashed: red — shows error + Resume button
- *   - dependency_failed: gray — informational
+ *   - dependency_failed / dependency_added: gray — informational
  *   - workflow_invalid: red — informational
  *   - (null / unknown): amber fallback — matches previous behavior
  *
@@ -53,6 +53,7 @@ const REASON_CONFIG: Partial<Record<SpaceBlockReason, ReasonConfig>> = {
 	execution_failed: { label: 'Execution Failed', tone: 'red', icon: '⚠️' },
 	agent_crashed: { label: 'Agent Crashed', tone: 'red', icon: '⚠️' },
 	dependency_failed: { label: 'Blocked by Dependency', tone: 'gray', icon: '⛓️' },
+	dependency_added: { label: 'Blocked by Dependency', tone: 'gray', icon: '⛓️' },
 	workflow_invalid: { label: 'Invalid Workflow', tone: 'red', icon: '⚠️' },
 };
 


### PR DESCRIPTION
Fixes two gaps in task dependency enforcement.

**Gap 1**: `updateTask()` could add `depends_on` to an already `in_progress` task without re-checking dependencies. Now re-checks `areDependenciesMet()` and transitions the task to `blocked` with `blockReason: 'dependency_added'` if deps are unmet.

**Gap 2**: Completing a task (→ `done`) did not reactivate dependents that were blocked with `'dependency_failed'`. Now `unblockDependentTasks()` finds blocked dependents, re-evaluates their full dep set, and transitions eligible ones to `open` for the tick loop to pick up.

Changes:
- `SpaceBlockReason` type: added `'dependency_added'`
- `SpaceTaskManager.updateTask()`: dep re-check after `dependsOn` changes
- `SpaceTaskManager.unblockDependentTasks()`: new method for done-cascade
- `SpaceRuntime.updateTaskAndEmit()`: calls unblock on `done` transitions
- 13 new unit tests covering both gaps