### PR TITLE
fix: show task composer context usage

### DIFF
--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -73,6 +73,7 @@ export function TaskSessionChatComposer({
 		modelSwitching,
 		modelLoading,
 		thinkingLevel,
+		contextInfo,
 		isProcessing: targetIsProcessing,
 		isStarted,
 		switchModel,
@@ -204,6 +205,7 @@ export function TaskSessionChatComposer({
 				availableModels={availableModels}
 				modelSwitching={modelSwitching}
 				modelLoading={modelLoading}
+				contextUsage={contextInfo ?? undefined}
 				autoScroll={autoScroll}
 				coordinatorMode={false}
 				coordinatorSwitching={false}

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -4,6 +4,9 @@ import type { SpaceTaskActivityMember, ModelInfo } from '@neokai/shared';
 
 const mockRequest = vi.fn();
 const mockGetHubIfConnected = vi.fn();
+const mockOnEvent = vi.fn();
+const mockJoinChannel = vi.fn();
+const mockLeaveChannel = vi.fn();
 
 vi.mock('../../lib/connection-manager', () => ({
 	connectionManager: {
@@ -206,8 +209,23 @@ describe('useTargetSessionContext', () => {
 		vi.resetAllMocks();
 		mockGetHubIfConnected.mockReturnValue({
 			request: mockRequest,
+			onEvent: mockOnEvent,
+			joinChannel: mockJoinChannel,
+			leaveChannel: mockLeaveChannel,
 		});
+		mockOnEvent.mockReturnValue(vi.fn());
+		mockJoinChannel.mockResolvedValue(undefined);
+		mockLeaveChannel.mockResolvedValue(undefined);
 		mockRequest.mockImplementation((method: string) => {
+			if (method === 'state.session') {
+				return Promise.resolve({
+					sessionInfo: null,
+					agentState: { isProcessing: false },
+					commandsData: { availableCommands: [] },
+					error: null,
+					timestamp: Date.now(),
+				});
+			}
 			if (method === 'models.list') {
 				return Promise.resolve({
 					models: [
@@ -369,6 +387,148 @@ describe('useTargetSessionContext', () => {
 
 		await waitFor(() => {
 			expect(result.current.isProcessing).toBe(true);
+		});
+	});
+
+	it('loads contextInfo from initial session metadata', async () => {
+		const initialContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 12_000,
+			totalCapacity: 200_000,
+			percentUsed: 6,
+			breakdown: {},
+			lastUpdated: 123,
+			source: 'sdk-get-context-usage' as const,
+		};
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'state.session') {
+				return Promise.resolve({
+					sessionInfo: {
+						id: 'coder-session',
+						metadata: { lastContextInfo: initialContextInfo },
+					},
+					agentState: { isProcessing: false },
+					commandsData: { availableCommands: [] },
+					error: null,
+					timestamp: Date.now(),
+				});
+			}
+			if (method === 'models.list') {
+				return Promise.resolve({ models: [] });
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'off' });
+			}
+			return Promise.resolve({});
+		});
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				taskId: 'task-1',
+				targets: [coderTarget],
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.contextInfo).toEqual(initialContextInfo);
+		});
+		expect(mockJoinChannel).toHaveBeenCalledWith('session:coder-session');
+		expect(mockRequest).toHaveBeenCalledWith('state.session', { sessionId: 'coder-session' });
+	});
+
+	it('updates contextInfo from context.updated events for the target session', async () => {
+		const handlers = new Map<string, Function>();
+		mockOnEvent.mockImplementation((method: string, handler: Function) => {
+			handlers.set(method, handler);
+			return vi.fn();
+		});
+		const updatedContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 50_000,
+			totalCapacity: 200_000,
+			percentUsed: 25,
+			breakdown: {},
+			lastUpdated: 456,
+			source: 'stream' as const,
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				taskId: 'task-1',
+				targets: [coderTarget],
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(handlers.has('context.updated')).toBe(true);
+		});
+
+		act(() => {
+			handlers.get('context.updated')?.(updatedContextInfo, { channel: 'session:other-session' });
+		});
+		expect(result.current.contextInfo).toBeNull();
+
+		act(() => {
+			handlers.get('context.updated')?.(updatedContextInfo, { channel: 'session:coder-session' });
+		});
+
+		expect(result.current.contextInfo).toEqual(updatedContextInfo);
+	});
+
+	it('cleans up context subscriptions when the target session changes', async () => {
+		const unsubscribeState = vi.fn();
+		const unsubscribeContext = vi.fn();
+		mockOnEvent.mockImplementation((method: string) => {
+			if (method === 'state.session') return unsubscribeState;
+			if (method === 'context.updated') return unsubscribeContext;
+			return vi.fn();
+		});
+		const reviewerTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+		const reviewerMember: SpaceTaskActivityMember = {
+			id: 'm2',
+			sessionId: 'reviewer-session',
+			kind: 'node_agent',
+			label: 'Reviewer',
+			role: 'reviewer',
+			state: 'active',
+			processingStatus: 'idle',
+			messageCount: 0,
+		};
+
+		const { rerender } = renderHook(
+			(props: { selectedTarget: typeof coderTarget | typeof reviewerTarget }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [coderTarget, reviewerTarget],
+					selectedTarget: props.selectedTarget,
+					activityMembers: [...members, reviewerMember],
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { selectedTarget: coderTarget } }
+		);
+
+		await waitFor(() => {
+			expect(mockJoinChannel).toHaveBeenCalledWith('session:coder-session');
+		});
+
+		rerender({ selectedTarget: reviewerTarget });
+
+		await waitFor(() => {
+			expect(unsubscribeState).toHaveBeenCalled();
+			expect(unsubscribeContext).toHaveBeenCalled();
+			expect(mockLeaveChannel).toHaveBeenCalledWith('session:coder-session');
+			expect(mockJoinChannel).toHaveBeenCalledWith('session:reviewer-session');
 		});
 	});
 
@@ -918,7 +1078,12 @@ describe('useTargetSessionContext', () => {
 		expect(mockRequest).not.toHaveBeenCalledWith('session.thinking.set', expect.anything());
 
 		// Phase 4: reconnect the hub and re-render
-		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockGetHubIfConnected.mockReturnValue({
+			request: mockRequest,
+			onEvent: mockOnEvent,
+			joinChannel: mockJoinChannel,
+			leaveChannel: mockLeaveChannel,
+		});
 		rerender({ members: [...spawnedMembers] });
 
 		// The effect should retry now that the hub is available

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -7,6 +7,7 @@ const mockGetHubIfConnected = vi.fn();
 const mockOnEvent = vi.fn();
 const mockJoinChannel = vi.fn();
 const mockLeaveChannel = vi.fn();
+const mockConnectionState = vi.hoisted(() => ({ value: 'connected' }));
 
 vi.mock('../../lib/connection-manager', () => ({
 	connectionManager: {
@@ -23,7 +24,7 @@ vi.mock('../../lib/toast', () => ({
 }));
 
 vi.mock('../../lib/state', () => ({
-	connectionState: { value: 'connected' },
+	connectionState: mockConnectionState,
 }));
 
 import { useTargetSessionContext, resolveTargetSessionId } from '../useTargetSessionContext';
@@ -207,6 +208,7 @@ describe('resolveTargetSessionId', () => {
 describe('useTargetSessionContext', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mockConnectionState.value = 'connected';
 		mockGetHubIfConnected.mockReturnValue({
 			request: mockRequest,
 			onEvent: mockOnEvent,
@@ -479,6 +481,224 @@ describe('useTargetSessionContext', () => {
 		});
 
 		expect(result.current.contextInfo).toEqual(updatedContextInfo);
+	});
+
+	it('does not let initial state overwrite newer context.updated data', async () => {
+		const handlers = new Map<string, Function>();
+		let resolveInitialState: (value: unknown) => void = () => {};
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'state.session') {
+				return new Promise((resolve) => {
+					resolveInitialState = resolve;
+				});
+			}
+			if (method === 'models.list') return Promise.resolve({ models: [] });
+			if (method === 'session.thinking.get') return Promise.resolve({ thinkingLevel: 'off' });
+			return Promise.resolve({});
+		});
+		mockOnEvent.mockImplementation((method: string, handler: Function) => {
+			handlers.set(method, handler);
+			return vi.fn();
+		});
+		const staleContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 12_000,
+			totalCapacity: 200_000,
+			percentUsed: 6,
+			breakdown: {},
+			lastUpdated: 123,
+			source: 'sdk-get-context-usage' as const,
+		};
+		const liveContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 50_000,
+			totalCapacity: 200_000,
+			percentUsed: 25,
+			breakdown: {},
+			lastUpdated: 456,
+			source: 'stream' as const,
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				taskId: 'task-1',
+				targets: [coderTarget],
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(handlers.has('context.updated')).toBe(true);
+		});
+
+		act(() => {
+			handlers.get('context.updated')?.(liveContextInfo, { channel: 'session:coder-session' });
+		});
+		expect(result.current.contextInfo).toEqual(liveContextInfo);
+
+		await act(async () => {
+			resolveInitialState({
+				sessionInfo: { id: 'coder-session', metadata: { lastContextInfo: staleContextInfo } },
+				agentState: { isProcessing: false },
+				commandsData: { availableCommands: [] },
+				error: null,
+				timestamp: Date.now(),
+			});
+		});
+
+		expect(result.current.contextInfo).toEqual(liveContextInfo);
+	});
+
+	it('clears contextInfo when session metadata clears it', async () => {
+		const initialContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 12_000,
+			totalCapacity: 200_000,
+			percentUsed: 6,
+			breakdown: {},
+			lastUpdated: 123,
+			source: 'sdk-get-context-usage' as const,
+		};
+		const handlers = new Map<string, Function>();
+		mockOnEvent.mockImplementation((method: string, handler: Function) => {
+			handlers.set(method, handler);
+			return vi.fn();
+		});
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				taskId: 'task-1',
+				targets: [coderTarget],
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(handlers.has('context.updated')).toBe(true);
+		});
+		act(() => {
+			handlers.get('context.updated')?.(initialContextInfo, { channel: 'session:coder-session' });
+		});
+		expect(result.current.contextInfo).toEqual(initialContextInfo);
+
+		act(() => {
+			handlers.get('state.session')?.(
+				{
+					sessionInfo: { id: 'coder-session', metadata: { lastContextInfo: null } },
+					agentState: { isProcessing: false },
+					commandsData: { availableCommands: [] },
+					error: null,
+					timestamp: Date.now(),
+				},
+				{ channel: 'session:coder-session' }
+			);
+		});
+
+		expect(result.current.contextInfo).toBeNull();
+	});
+
+	it('keeps existing contextInfo when reconnect state fetch fails for the same session', async () => {
+		const handlers = new Map<string, Function>();
+		mockOnEvent.mockImplementation((method: string, handler: Function) => {
+			handlers.set(method, handler);
+			return vi.fn();
+		});
+		const existingContextInfo = {
+			model: 'claude-sonnet-4-6',
+			totalUsed: 50_000,
+			totalCapacity: 200_000,
+			percentUsed: 25,
+			breakdown: {},
+			lastUpdated: 456,
+			source: 'stream' as const,
+		};
+
+		const { result, rerender } = renderHook(
+			(props: { renderMarker: number }) => {
+				void props.renderMarker;
+				return useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [coderTarget],
+					selectedTarget: coderTarget,
+					activityMembers: members,
+					taskAgentSessionId: 'task-sess-123',
+				});
+			},
+			{ initialProps: { renderMarker: 1 } }
+		);
+
+		await waitFor(() => {
+			expect(handlers.has('context.updated')).toBe(true);
+		});
+		act(() => {
+			handlers.get('context.updated')?.(existingContextInfo, { channel: 'session:coder-session' });
+		});
+		expect(result.current.contextInfo).toEqual(existingContextInfo);
+
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'state.session') return Promise.reject(new Error('offline'));
+			if (method === 'models.list') return Promise.resolve({ models: [] });
+			if (method === 'session.thinking.get') return Promise.resolve({ thinkingLevel: 'off' });
+			return Promise.resolve({});
+		});
+		mockConnectionState.value = 'reconnecting';
+		rerender({ renderMarker: 2 });
+
+		expect(result.current.contextInfo).toEqual(existingContextInfo);
+	});
+
+	it('leaves a stale channel if join resolves after cleanup', async () => {
+		const joinResolvers: Array<() => void> = [];
+		mockJoinChannel.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					joinResolvers.push(resolve);
+				})
+		);
+		const reviewerTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+		const reviewerMember: SpaceTaskActivityMember = {
+			id: 'm2',
+			sessionId: 'reviewer-session',
+			kind: 'node_agent',
+			label: 'Reviewer',
+			role: 'reviewer',
+			state: 'active',
+			processingStatus: 'idle',
+			messageCount: 0,
+		};
+
+		const { rerender } = renderHook(
+			(props: { selectedTarget: typeof coderTarget | typeof reviewerTarget }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [coderTarget, reviewerTarget],
+					selectedTarget: props.selectedTarget,
+					activityMembers: [...members, reviewerMember],
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { selectedTarget: coderTarget } }
+		);
+
+		rerender({ selectedTarget: reviewerTarget });
+		expect(mockLeaveChannel).not.toHaveBeenCalledWith('session:coder-session');
+
+		await act(async () => {
+			joinResolvers[0]?.();
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(mockLeaveChannel).toHaveBeenCalledWith('session:coder-session');
+		});
 	});
 
 	it('cleans up context subscriptions when the target session changes', async () => {

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -177,57 +177,68 @@ export function useTargetSessionContext({
 	const [thinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>('off');
 
 	useEffect(() => {
-		setContextInfo(null);
-		if (!targetSessionId) return;
+		if (!targetSessionId) {
+			setContextInfo(null);
+			return;
+		}
 
 		let cancelled = false;
+		let liveContextReceived = false;
+		let joined = false;
+		let unsubscribeSessionState: (() => void) | null = null;
+		let unsubscribeContextUpdated: (() => void) | null = null;
 		const channel = `session:${targetSessionId}`;
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) return;
 
-		hub.joinChannel(channel);
-
 		const applySessionState = (state: SessionState) => {
-			const lastContextInfo = state.sessionInfo?.metadata?.lastContextInfo;
-			if (lastContextInfo) {
-				setContextInfo(lastContextInfo);
-			}
+			setContextInfo(state.sessionInfo?.metadata?.lastContextInfo ?? null);
 		};
 
-		const unsubSessionState = hub.onEvent<SessionState>('state.session', (state, context) => {
-			if (cancelled) return;
-			if (context.channel !== channel) return;
-			applySessionState(state);
-		});
-
-		const unsubContextUpdated = hub.onEvent<ContextInfo>(
-			'context.updated',
-			(nextContextInfo, context) => {
-				if (cancelled) return;
-				if (context.channel !== channel) return;
-				setContextInfo(nextContextInfo);
-			}
-		);
-
-		const loadInitialContext = async () => {
+		const setupContextSubscriptions = async () => {
 			try {
+				await hub.joinChannel(channel);
+				joined = true;
+				if (cancelled) {
+					void hub.leaveChannel(channel);
+					return;
+				}
+
+				unsubscribeSessionState = hub.onEvent<SessionState>('state.session', (state, context) => {
+					if (cancelled) return;
+					if (context.channel !== channel) return;
+					applySessionState(state);
+				});
+
+				unsubscribeContextUpdated = hub.onEvent<ContextInfo>(
+					'context.updated',
+					(nextContextInfo, context) => {
+						if (cancelled) return;
+						if (context.channel !== channel) return;
+						liveContextReceived = true;
+						setContextInfo(nextContextInfo);
+					}
+				);
+
 				const state = await hub.request<SessionState>('state.session', {
 					sessionId: targetSessionId,
 				});
-				if (!cancelled) {
+				if (!cancelled && !liveContextReceived) {
 					applySessionState(state);
 				}
 			} catch {
-				// Ignore errors — context will update on the next context.updated/state.session event.
+				// Ignore errors — keep the existing snapshot until the next successful state/event update.
 			}
 		};
-		void loadInitialContext();
+		void setupContextSubscriptions();
 
 		return () => {
 			cancelled = true;
-			unsubSessionState();
-			unsubContextUpdated();
-			hub.leaveChannel(channel);
+			unsubscribeSessionState?.();
+			unsubscribeContextUpdated?.();
+			if (joined) {
+				void hub.leaveChannel(channel);
+			}
 		};
 	}, [targetSessionId, connectionState.value]);
 

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -1,4 +1,10 @@
-import type { ModelInfo, SpaceTaskActivityMember, ThinkingLevel } from '@neokai/shared';
+import type {
+	ContextInfo,
+	ModelInfo,
+	SessionState,
+	SpaceTaskActivityMember,
+	ThinkingLevel,
+} from '@neokai/shared';
 import { useState, useEffect, useMemo, useCallback, useRef } from 'preact/hooks';
 import { connectionManager } from '../lib/connection-manager.ts';
 import { connectionState } from '../lib/state.ts';
@@ -30,6 +36,8 @@ export interface UseTargetSessionContextResult {
 	modelLoading: boolean;
 	/** Current thinking level (live or pre-configured) */
 	thinkingLevel: ThinkingLevel;
+	/** Current context usage for the targeted session */
+	contextInfo: ContextInfo | null;
 	/** Whether the targeted agent is actively processing */
 	isProcessing: boolean;
 	/** Whether the targeted agent has a live session */
@@ -114,6 +122,7 @@ export function useTargetSessionContext({
 	const [preConfiguredThinking, setPreConfiguredThinking] = useState<
 		Map<string, { level: ThinkingLevel; taskId: string }>
 	>(new Map());
+	const [contextInfo, setContextInfo] = useState<ContextInfo | null>(null);
 
 	// Track which targets have had each specific config type successfully
 	// auto-applied, so we don't loop and so a missing model lookup doesn't
@@ -166,6 +175,61 @@ export function useTargetSessionContext({
 
 	// Thinking level — default to off.
 	const [thinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>('off');
+
+	useEffect(() => {
+		setContextInfo(null);
+		if (!targetSessionId) return;
+
+		let cancelled = false;
+		const channel = `session:${targetSessionId}`;
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		hub.joinChannel(channel);
+
+		const applySessionState = (state: SessionState) => {
+			const lastContextInfo = state.sessionInfo?.metadata?.lastContextInfo;
+			if (lastContextInfo) {
+				setContextInfo(lastContextInfo);
+			}
+		};
+
+		const unsubSessionState = hub.onEvent<SessionState>('state.session', (state, context) => {
+			if (cancelled) return;
+			if (context.channel !== channel) return;
+			applySessionState(state);
+		});
+
+		const unsubContextUpdated = hub.onEvent<ContextInfo>(
+			'context.updated',
+			(nextContextInfo, context) => {
+				if (cancelled) return;
+				if (context.channel !== channel) return;
+				setContextInfo(nextContextInfo);
+			}
+		);
+
+		const loadInitialContext = async () => {
+			try {
+				const state = await hub.request<SessionState>('state.session', {
+					sessionId: targetSessionId,
+				});
+				if (!cancelled) {
+					applySessionState(state);
+				}
+			} catch {
+				// Ignore errors — context will update on the next context.updated/state.session event.
+			}
+		};
+		void loadInitialContext();
+
+		return () => {
+			cancelled = true;
+			unsubSessionState();
+			unsubContextUpdated();
+			hub.leaveChannel(channel);
+		};
+	}, [targetSessionId, connectionState.value]);
 
 	// Load the live thinking level from the session whenever the target
 	// session changes (e.g. switching to a different started agent).
@@ -373,6 +437,7 @@ export function useTargetSessionContext({
 		modelSwitching: modelSwitcher.switching,
 		modelLoading: modelSwitcher.loading,
 		thinkingLevel,
+		contextInfo,
 		isProcessing,
 		isStarted,
 		switchModel,


### PR DESCRIPTION
Fixes the task thread composer context bar by subscribing target sessions to context state and forwarding that data into ChatComposer.

Tests:
- cd packages/web && bunx vitest run src/hooks/__tests__/useTargetSessionContext.test.ts
- bun run check