### PR TITLE
Fix mobile overflow in space task tabs

### DIFF
--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -359,7 +359,9 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	// Task counts
 	const activeTasks = tasks.filter((t) => t.status === 'open' || t.status === 'in_progress');
 	const reviewTasks = tasks.filter((t) => t.status === 'blocked' || t.status === 'review');
-	const doneTasks = tasks.filter((t) => t.status === 'done' || t.status === 'cancelled');
+	const doneTasks = tasks.filter(
+		(t) => t.status === 'done' || t.status === 'cancelled' || t.status === 'archived'
+	);
 
 	// Recent tasks — sorted by updatedAt, top 5
 	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5);

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -4,7 +4,7 @@
  * Tabs: Action (review + blocked, grouped by reason),
  *       Active (open + in_progress + approved — see `task-filters.ts` for why
  *       `approved` belongs here),
- *       Completed (done + cancelled), Archived.
+ *       Completed (done + cancelled + archived), Scheduled.
  *
  * Within each tab, tasks are grouped by status/reason in TaskGroup cards,
  * matching the RoomTasks component style.
@@ -16,9 +16,10 @@ import { navigateToSpaceTasks } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTasksFilterTabSignal } from '../../lib/signals';
 import { spaceStore } from '../../lib/space-store';
 import { isActionRequired, isActiveTask, isDraftTask } from '../../lib/task-filters';
-import { getRelativeTime, formatRelativeFuture } from '../../lib/utils';
+import { formatRelativeFuture, getRelativeTime } from '../../lib/utils';
+import { Dropdown } from '../ui/Dropdown';
 
-type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled';
+type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'scheduled';
 
 /** Block reasons that indicate a task needs human attention */
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
@@ -44,8 +45,7 @@ export const TAB_PREDICATES: Record<
 	action: isActionRequired,
 	active: isActiveTask,
 	draft: isDraftTask,
-	completed: (t) => t.status === 'done' || t.status === 'cancelled',
-	archived: (t) => t.status === 'archived',
+	completed: (t) => ['done', 'cancelled', 'archived'].includes(t.status),
 };
 
 const STATUS_BORDER: Record<string, string> = {
@@ -148,9 +148,6 @@ const ACTIVE_GROUPS: StatusGroupDef[] = [
 const COMPLETED_GROUPS: StatusGroupDef[] = [
 	{ status: 'done', title: 'Done', variant: 'green' },
 	{ status: 'cancelled', title: 'Cancelled', variant: 'gray' },
-];
-
-const ARCHIVED_GROUPS: StatusGroupDef[] = [
 	{ status: 'archived', title: 'Archived', variant: 'gray' },
 ];
 
@@ -161,8 +158,16 @@ const TAB_GROUPS_DEF: Record<Exclude<TaskFilterTab, 'scheduled'>, StatusGroupDef
 	active: ACTIVE_GROUPS,
 	draft: DRAFT_GROUPS,
 	completed: COMPLETED_GROUPS,
-	archived: ARCHIVED_GROUPS,
 };
+
+type TabVariant = 'default' | 'amber' | 'purple' | 'green' | 'red' | 'gray';
+
+interface TabConfig {
+	key: TaskFilterTab;
+	label: string;
+	count: number;
+	variant?: TabVariant;
+}
 
 function TabButton({
 	label,
@@ -175,7 +180,7 @@ function TabButton({
 	count: number;
 	isActive: boolean;
 	onClick: () => void;
-	variant?: 'default' | 'amber' | 'purple' | 'green' | 'red' | 'gray';
+	variant?: TabVariant;
 }) {
 	const baseClasses =
 		'px-4 py-2 text-sm font-medium transition-colors relative flex items-center gap-1.5';
@@ -227,6 +232,65 @@ function TabButton({
 	);
 }
 
+function MoreTabsDropdown({
+	tabs,
+	activeTab,
+	spaceId,
+}: {
+	tabs: TabConfig[];
+	activeTab: TaskFilterTab;
+	spaceId: string;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const moreIsActive = tabs.some((tab) => tab.key === activeTab);
+
+	return (
+		<Dropdown
+			position="left"
+			items={[]}
+			isOpen={isOpen}
+			onOpenChange={setIsOpen}
+			class="sm:hidden"
+			customContent={
+				<div class="py-1 bg-dark-850 border border-dark-700 rounded-lg min-w-[180px]">
+					{tabs.map((tab) => (
+						<button
+							key={tab.key}
+							type="button"
+							role="menuitem"
+							class="w-full px-4 py-2 text-left text-sm flex items-center justify-between gap-3 text-gray-300 hover:bg-dark-800 hover:text-gray-100 transition-colors"
+							onClick={() => {
+								navigateToSpaceTasks(spaceId, tab.key);
+								setIsOpen(false);
+							}}
+						>
+							<span>{tab.label}</span>
+							{tab.count > 0 && (
+								<span class="text-xs px-1.5 py-0.5 rounded bg-dark-700 text-gray-300">
+									{tab.count}
+								</span>
+							)}
+						</button>
+					))}
+				</div>
+			}
+			trigger={
+				<button
+					type="button"
+					class={`px-4 py-2 text-sm font-medium transition-colors relative flex items-center gap-1.5 ${
+						moreIsActive
+							? 'text-blue-400 border-b-2 border-blue-400'
+							: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent'
+					}`}
+					aria-label="More task tabs"
+				>
+					⋯
+				</button>
+			}
+		/>
+	);
+}
+
 function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 	const messages: Record<TaskFilterTab, { title: string; description: string }> = {
 		action: {
@@ -235,8 +299,10 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 		},
 		active: { title: 'No active tasks', description: 'Active tasks will appear here' },
 		draft: { title: 'No draft tasks', description: 'Tasks created as drafts will appear here' },
-		completed: { title: 'No completed tasks', description: 'Completed tasks will appear here' },
-		archived: { title: 'No archived tasks', description: 'Archived tasks will appear here' },
+		completed: {
+			title: 'No completed tasks',
+			description: 'Completed, cancelled, and archived tasks will appear here',
+		},
 		scheduled: {
 			title: 'No scheduled tasks',
 			description: 'Recurring and one-shot scheduled tasks will appear here',
@@ -612,7 +678,6 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 			active: 0,
 			draft: 0,
 			completed: 0,
-			archived: 0,
 			scheduled: schedules.filter((s) => s.status !== 'completed').length,
 		};
 		for (const task of tasks) {
@@ -653,53 +718,48 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	// We always render the tab strip so users can navigate to the Scheduled tab
 	// even when no tasks have been spawned yet.
 	const showGlobalEmpty = tasks.length === 0 && activeTab !== 'scheduled';
+	const primaryTabs: TabConfig[] = [
+		{ key: 'action', label: 'Action', count: counts.action, variant: 'amber' },
+		{ key: 'active', label: 'Active', count: counts.active },
+	];
+	const secondaryTabs: TabConfig[] = [
+		...(counts.draft > 0 ? [{ key: 'draft' as const, label: 'Drafts', count: counts.draft }] : []),
+		{ key: 'completed', label: 'Completed', count: counts.completed, variant: 'green' },
+	];
+	const overflowTabs: TabConfig[] = [
+		{ key: 'scheduled', label: 'Scheduled', count: counts.scheduled },
+	];
+	const desktopTabs = [...primaryTabs, ...secondaryTabs, ...overflowTabs];
 
 	return (
 		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
 			<div class="min-h-[calc(100%+1px)] space-y-6">
 				<div class="flex border-b border-dark-700">
-					<TabButton
-						label="Action"
-						count={counts.action}
-						isActive={activeTab === 'action'}
-						onClick={() => navigateToSpaceTasks(spaceId, 'action')}
-						variant="amber"
-					/>
-					<TabButton
-						label="Active"
-						count={counts.active}
-						isActive={activeTab === 'active'}
-						onClick={() => navigateToSpaceTasks(spaceId, 'active')}
-					/>
-					{counts.draft > 0 && (
-						<TabButton
-							label="Drafts"
-							count={counts.draft}
-							isActive={activeTab === 'draft'}
-							onClick={() => navigateToSpaceTasks(spaceId, 'draft')}
-						/>
-					)}
-					<TabButton
-						label="Completed"
-						count={counts.completed}
-						isActive={activeTab === 'completed'}
-						onClick={() => navigateToSpaceTasks(spaceId, 'completed')}
-						variant="green"
-					/>
-					<TabButton
-						label="Archived"
-						count={counts.archived}
-						isActive={activeTab === 'archived'}
-						onClick={() => navigateToSpaceTasks(spaceId, 'archived')}
-						variant="gray"
-					/>
-					<TabButton
-						label="Scheduled"
-						count={counts.scheduled}
-						isActive={activeTab === 'scheduled'}
-						onClick={() => navigateToSpaceTasks(spaceId, 'scheduled')}
-						variant="default"
-					/>
+					<div class="flex sm:hidden">
+						{primaryTabs.map((tab) => (
+							<TabButton
+								key={tab.key}
+								label={tab.label}
+								count={tab.count}
+								isActive={activeTab === tab.key}
+								onClick={() => navigateToSpaceTasks(spaceId, tab.key)}
+								variant={tab.variant}
+							/>
+						))}
+						<MoreTabsDropdown tabs={overflowTabs} activeTab={activeTab} spaceId={spaceId} />
+					</div>
+					<div class="hidden sm:flex">
+						{desktopTabs.map((tab) => (
+							<TabButton
+								key={tab.key}
+								label={tab.label}
+								count={tab.count}
+								isActive={activeTab === tab.key}
+								onClick={() => navigateToSpaceTasks(spaceId, tab.key)}
+								variant={tab.variant}
+							/>
+						))}
+					</div>
 				</div>
 
 				{showGlobalEmpty ? (

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -20,6 +20,7 @@ import { formatRelativeFuture, getRelativeTime } from '../../lib/utils';
 import { Dropdown } from '../ui/Dropdown';
 
 type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'scheduled';
+type LegacyTaskFilterTab = TaskFilterTab | 'archived';
 
 /** Block reasons that indicate a task needs human attention */
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
@@ -660,7 +661,8 @@ interface SpaceTasksProps {
 export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps) {
 	const tasks = spaceStore.tasks.value;
 	const schedules = spaceStore.schedules.value;
-	const activeTab: TaskFilterTab = currentSpaceTasksFilterTabSignal.value as TaskFilterTab;
+	const rawActiveTab = currentSpaceTasksFilterTabSignal.value as LegacyTaskFilterTab;
+	const activeTab: TaskFilterTab = rawActiveTab === 'archived' ? 'completed' : rawActiveTab;
 	const spaceId = currentSpaceIdSignal.value ?? '';
 
 	// Load schedules when the tab is switched to 'scheduled' or the active space changes.
@@ -727,9 +729,14 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 		{ key: 'completed', label: 'Completed', count: counts.completed, variant: 'green' },
 	];
 	const overflowTabs: TabConfig[] = [
+		...secondaryTabs,
 		{ key: 'scheduled', label: 'Scheduled', count: counts.scheduled },
 	];
-	const desktopTabs = [...primaryTabs, ...secondaryTabs, ...overflowTabs];
+	const desktopTabs = [
+		...primaryTabs,
+		...secondaryTabs,
+		{ key: 'scheduled' as const, label: 'Scheduled', count: counts.scheduled },
+	];
 
 	return (
 		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -449,13 +449,14 @@ describe('SpaceOverview', () => {
 			expect(navigateToSpaceTasksMock).toHaveBeenCalledWith('space-1', 'completed');
 		});
 
-		it('Done count excludes archived tasks to match the completed tab', () => {
-			// t4 (done) counts; t5 (archived) does NOT count
+		it('Done count includes archived tasks to match the completed tab', () => {
+			// t4 (done) and t5 (archived) both count because the Completed tab now
+			// includes archived terminal tasks.
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const doneBtn = Array.from(container.querySelectorAll('button')).find((b) =>
 				b.textContent?.includes('Done')
 			)!;
-			expect(doneBtn.textContent).toContain('1');
+			expect(doneBtn.textContent).toContain('2');
 		});
 
 		it('stat cards have cursor-pointer class', () => {

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import type { SpaceTask } from '@neokai/shared';
+import type { SpaceTask, TaskSchedule } from '@neokai/shared';
 
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 const mockSchedules = signal<unknown[]>([]);
@@ -113,6 +113,7 @@ function defaultFetchTaskGroupImpl(
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: string[]) => args.filter(Boolean).join(' '),
+	formatRelativeFuture: () => 'in 1m',
 	getRelativeTime: (ts: number) => `${Math.floor((Date.now() - ts) / 60_000)}m ago`,
 }));
 
@@ -146,10 +147,37 @@ function makeTask(
 	};
 }
 
+function makeSchedule(id: string, overrides: Partial<TaskSchedule> = {}): TaskSchedule {
+	return {
+		id,
+		spaceId: 'space-1',
+		title: `Schedule ${id}`,
+		description: '',
+		priority: 'normal',
+		preferredWorkflowId: null,
+		labels: [],
+		triggerType: 'cron',
+		cronExpression: '0 9 * * 1',
+		runAt: null,
+		timezone: 'UTC',
+		nextRunAt: Date.now() + 60_000,
+		lastRunAt: null,
+		lastCreatedTaskId: null,
+		pendingJobId: null,
+		status: 'active',
+		createdByAgent: null,
+		createdBySession: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
 describe('SpaceTasks', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
+		mockSchedules.value = [];
 		mockCurrentSpaceTasksFilterTabSignal.value = 'active';
 		mockCurrentSpaceIdSignal.value = null;
 		mockNavigateToSpaceTasks.mockClear();
@@ -161,13 +189,15 @@ describe('SpaceTasks', () => {
 		cleanup();
 	});
 
-	it('renders all four tabs', () => {
+	it('renders desktop tabs inline and removes the standalone Archived tab', () => {
 		mockTasks.value = [makeTask('t1', 'open')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		expect(getByText('Action')).toBeTruthy();
-		expect(getByText('Active')).toBeTruthy();
-		expect(getByText('Completed')).toBeTruthy();
-		expect(getByText('Archived')).toBeTruthy();
+		const { getAllByText, queryByText, getByLabelText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(getAllByText('Action').length).toBeGreaterThan(0);
+		expect(getAllByText('Active').length).toBeGreaterThan(0);
+		expect(getAllByText('Completed').length).toBeGreaterThan(0);
+		expect(getAllByText('Scheduled').length).toBeGreaterThan(0);
+		expect(queryByText('Archived')).toBeNull();
+		expect(getByLabelText('More task tabs')).toBeTruthy();
 	});
 
 	it('shows global empty state when there are no tasks at all', () => {
@@ -178,8 +208,8 @@ describe('SpaceTasks', () => {
 
 	it('shows empty state for action tab', () => {
 		mockTasks.value = [makeTask('t1', 'open')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Action'));
+		const { getAllByText, getByText } = render(<SpaceTasks spaceId="space-1" />);
+		fireEvent.click(getAllByText('Action')[0]);
 		expect(getByText('No tasks needing action')).toBeTruthy();
 	});
 
@@ -188,13 +218,6 @@ describe('SpaceTasks', () => {
 		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
 		fireEvent.click(getByText('Completed'));
 		expect(getByText('No completed tasks')).toBeTruthy();
-	});
-
-	it('shows empty state for archived tab', () => {
-		mockTasks.value = [makeTask('t1', 'open')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Archived'));
-		expect(getByText('No archived tasks')).toBeTruthy();
 	});
 
 	it('displays tasks in active tab (open + in_progress)', async () => {
@@ -219,25 +242,24 @@ describe('SpaceTasks', () => {
 
 	it('displays tasks in action tab (blocked + review)', async () => {
 		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'review')];
-		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Action'));
+		const { getAllByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
+		fireEvent.click(getAllByText('Action')[0]);
 		expect(await findByText('Task t1')).toBeTruthy();
 		expect(await findByText('Task t2')).toBeTruthy();
 	});
 
-	it('displays tasks in completed tab (done + cancelled)', async () => {
-		mockTasks.value = [makeTask('t1', 'done'), makeTask('t2', 'cancelled')];
+	it('displays archived tasks in the completed tab as an Archived group', async () => {
+		mockTasks.value = [
+			makeTask('t1', 'done'),
+			makeTask('t2', 'cancelled'),
+			makeTask('t3', 'archived'),
+		];
 		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
 		fireEvent.click(getByText('Completed'));
 		expect(await findByText('Task t1')).toBeTruthy();
 		expect(await findByText('Task t2')).toBeTruthy();
-	});
-
-	it('displays tasks in archived tab', async () => {
-		mockTasks.value = [makeTask('t1', 'archived')];
-		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Archived'));
-		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t3')).toBeTruthy();
+		expect(getByText(/Archived \(1\)/)).toBeTruthy();
 	});
 
 	it('shows correct tab counts', () => {
@@ -256,8 +278,21 @@ describe('SpaceTasks', () => {
 
 		expect(text.some((t) => t?.includes('Active') && t?.includes('2'))).toBe(true);
 		expect(text.some((t) => t?.includes('Action') && t?.includes('2'))).toBe(true);
-		expect(text.some((t) => t?.includes('Completed') && t?.includes('2'))).toBe(true);
-		expect(text.some((t) => t?.includes('Archived') && t?.includes('1'))).toBe(true);
+		expect(text.some((t) => t?.includes('Completed') && t?.includes('3'))).toBe(true);
+		expect(text.some((t) => t?.includes('Archived'))).toBe(false);
+	});
+
+	it('shows Scheduled in the mobile More dropdown and navigates when selected', async () => {
+		mockTasks.value = [makeTask('t1', 'open')];
+		mockSchedules.value = [makeSchedule('s1')];
+		const { getByLabelText, findByRole } = render(<SpaceTasks spaceId="space-1" />);
+
+		fireEvent.click(getByLabelText('More task tabs'));
+		const scheduledItem = await findByRole('menuitem', { name: /Scheduled/ });
+		expect(scheduledItem.textContent).toContain('1');
+		fireEvent.click(scheduledItem);
+
+		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('', 'scheduled');
 	});
 
 	it('sorts tasks by updatedAt descending', async () => {

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -215,9 +215,18 @@ describe('SpaceTasks', () => {
 
 	it('shows empty state for completed tab', () => {
 		mockTasks.value = [makeTask('t1', 'open')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Completed'));
+		const { getAllByText, getByText } = render(<SpaceTasks spaceId="space-1" />);
+		fireEvent.click(getAllByText('Completed')[0]);
 		expect(getByText('No completed tasks')).toBeTruthy();
+	});
+
+	it('treats legacy archived routes as completed', async () => {
+		mockCurrentSpaceTasksFilterTabSignal.value = 'archived';
+		mockTasks.value = [makeTask('t1', 'archived')];
+		const { findByText, getAllByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(getAllByText('Completed')[0].className).toContain('text-green-400');
+		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText(/Archived \(1\)/)).toBeTruthy();
 	});
 
 	it('displays tasks in active tab (open + in_progress)', async () => {
@@ -254,8 +263,8 @@ describe('SpaceTasks', () => {
 			makeTask('t2', 'cancelled'),
 			makeTask('t3', 'archived'),
 		];
-		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Completed'));
+		const { getAllByText, getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
+		fireEvent.click(getAllByText('Completed')[0]);
 		expect(await findByText('Task t1')).toBeTruthy();
 		expect(await findByText('Task t2')).toBeTruthy();
 		expect(await findByText('Task t3')).toBeTruthy();
@@ -282,17 +291,27 @@ describe('SpaceTasks', () => {
 		expect(text.some((t) => t?.includes('Archived'))).toBe(false);
 	});
 
-	it('shows Scheduled in the mobile More dropdown and navigates when selected', async () => {
-		mockTasks.value = [makeTask('t1', 'open')];
+	it('shows secondary tabs and Scheduled in the mobile More dropdown', async () => {
+		mockTasks.value = [
+			makeTask('t1', 'open'),
+			makeTask('t2', 'draft'),
+			makeTask('t3', 'done'),
+			makeTask('t4', 'archived'),
+		];
 		mockSchedules.value = [makeSchedule('s1')];
 		const { getByLabelText, findByRole } = render(<SpaceTasks spaceId="space-1" />);
 
 		fireEvent.click(getByLabelText('More task tabs'));
+		const draftsItem = await findByRole('menuitem', { name: /Drafts/ });
+		const completedItem = await findByRole('menuitem', { name: /Completed/ });
 		const scheduledItem = await findByRole('menuitem', { name: /Scheduled/ });
+		expect(draftsItem.textContent).toContain('1');
+		expect(completedItem.textContent).toContain('2');
 		expect(scheduledItem.textContent).toContain('1');
-		fireEvent.click(scheduledItem);
 
-		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('', 'scheduled');
+		fireEvent.click(completedItem);
+
+		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('', 'completed');
 	});
 
 	it('sorts tasks by updatedAt descending', async () => {
@@ -349,14 +368,14 @@ describe('SpaceTasks', () => {
 
 	it('switches tabs and shows filtered tasks', async () => {
 		mockTasks.value = [makeTask('t1', 'open'), makeTask('t2', 'done')];
-		const { getByText, findByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
+		const { getAllByText, findByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
 
 		// Active tab shows t1
 		expect(await findByText('Task t1')).toBeTruthy();
 		expect(queryByText('Task t2')).toBeNull();
 
 		// Switch to completed
-		fireEvent.click(getByText('Completed'));
+		fireEvent.click(getAllByText('Completed')[0]);
 		expect(await findByText('Task t2')).toBeTruthy();
 		expect(queryByText('Task t1')).toBeNull();
 	});

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -156,6 +156,20 @@ describe('router', () => {
 		expect(currentSpaceTasksFilterTabSignal.value).toBe('completed');
 	});
 
+	it('redirects legacy archived task tabs to completed', () => {
+		setPath(`/space/${SPACE_ID}/tasks/archived`);
+		initializeRouter();
+
+		expect(currentSpaceIdSignal.value).toBe(SPACE_ID);
+		expect(currentSpaceViewModeSignal.value).toBe('tasks');
+		expect(currentSpaceTasksFilterTabSignal.value).toBe('completed');
+		expect(window.history.replaceState).toHaveBeenLastCalledWith(
+			{ spaceId: SPACE_ID, path: `/space/${SPACE_ID}/tasks/completed` },
+			'',
+			`/space/${SPACE_ID}/tasks/completed`
+		);
+	});
+
 	it('navigates session, settings, inbox, and home routes', () => {
 		navigateToSession(SESSION_ID);
 		expect(window.history.pushState).toHaveBeenLastCalledWith(

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -36,8 +36,9 @@ const SPACE_CONFIGURE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/configure$/;
 const SPACE_CONFIGURE_TAB_ROUTE_PATTERN =
 	/^\/space\/([a-z0-9-]+)\/configure\/(agents|workflows|settings)$/;
 const SPACE_TASKS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks$/;
+const SPACE_TASKS_ARCHIVED_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks\/archived$/;
 const SPACE_TASKS_TAB_ROUTE_PATTERN =
-	/^\/space\/([a-z0-9-]+)\/tasks\/(action|active|draft|completed|archived|scheduled)$/;
+	/^\/space\/([a-z0-9-]+)\/tasks\/(action|active|draft|completed|scheduled)$/;
 const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-fA-F0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)$/;
@@ -66,6 +67,9 @@ export function getSpaceIdFromPath(path: string): string | null {
 
 	const configureMatch = path.match(SPACE_CONFIGURE_ROUTE_PATTERN);
 	if (configureMatch) return configureMatch[1];
+
+	const archivedTasksMatch = path.match(SPACE_TASKS_ARCHIVED_ROUTE_PATTERN);
+	if (archivedTasksMatch) return archivedTasksMatch[1];
 
 	const tasksTabMatch = path.match(SPACE_TASKS_TAB_ROUTE_PATTERN);
 	if (tasksTabMatch) return tasksTabMatch[1];
@@ -117,13 +121,16 @@ export function getSpaceTasksFromPath(path: string): string | null {
 
 export function getSpaceTasksTabFromPath(path: string): {
 	spaceId: string;
-	tab: 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled';
+	tab: 'action' | 'active' | 'draft' | 'completed' | 'scheduled';
 } | null {
+	const archivedMatch = path.match(SPACE_TASKS_ARCHIVED_ROUTE_PATTERN);
+	if (archivedMatch) return { spaceId: archivedMatch[1], tab: 'completed' };
+
 	const match = path.match(SPACE_TASKS_TAB_ROUTE_PATTERN);
 	if (!match) return null;
 	return {
 		spaceId: match[1],
-		tab: match[2] as 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled',
+		tab: match[2] as 'action' | 'active' | 'draft' | 'completed' | 'scheduled',
 	};
 }
 
@@ -394,7 +401,7 @@ export function navigateToSpaceConfigure(
 
 export function navigateToSpaceTasks(
 	spaceId: string,
-	tab?: 'action' | 'active' | 'completed' | 'archived' | 'draft' | 'scheduled',
+	tab?: 'action' | 'active' | 'completed' | 'draft' | 'scheduled',
 	replace = false
 ): void {
 	if (routerState.isNavigating) return;
@@ -513,6 +520,17 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 }
 
 function applyPathToSignals(path: string): string | null {
+	const legacyArchivedTasksMatch = path.match(SPACE_TASKS_ARCHIVED_ROUTE_PATTERN);
+	if (legacyArchivedTasksMatch) {
+		pushPath(
+			createSpaceTasksPath(legacyArchivedTasksMatch[1], 'completed'),
+			{
+				spaceId: legacyArchivedTasksMatch[1],
+			},
+			true
+		);
+	}
+
 	const sessionId = getSessionIdFromPath(path);
 	const spaceConfigureTab = getSpaceConfigureTabFromPath(path);
 	const spaceConfigure = spaceConfigureTab

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -34,14 +34,8 @@ export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 export type SpaceConfigureTab = 'agents' | 'workflows' | 'settings';
 export const currentSpaceConfigureTabSignal = signal<SpaceConfigureTab>('agents');
 
-// Tasks filter tab (action | active | draft | completed | archived | scheduled) — driven by URL
-export type SpaceTasksFilterTab =
-	| 'action'
-	| 'active'
-	| 'completed'
-	| 'archived'
-	| 'draft'
-	| 'scheduled';
+// Tasks filter tab (action | active | draft | completed | scheduled) — driven by URL
+export type SpaceTasksFilterTab = 'action' | 'active' | 'completed' | 'draft' | 'scheduled';
 export const currentSpaceTasksFilterTabSignal = signal<SpaceTasksFilterTab>('active');
 
 // Task detail sub-view (thread | canvas | artifacts) — driven by URL


### PR DESCRIPTION
Merges Archived into the Completed task tab and adds an Archived subgroup there.

Moves Scheduled into a mobile More dropdown while keeping desktop task tabs inline.

Tests: `cd packages/web && bunx vitest run src/components/space/__tests__/SpaceTasks.test.tsx`; `bun run check`