### PR TITLE
Enable Space Agent subagents

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -471,10 +471,10 @@ export class QueryOptionsBuilder {
 		};
 
 		// ============ Space Chat Session Restrictions ============
-		// Space chat sessions are read-only coordinators — they can read files and run
-		// diagnostics but must not create or modify files.  File editing tools
-		// (Write/Edit/NotebookEdit) are excluded; the agent uses its space-agent-tools
-		// MCP server for all coordination operations.
+		// Space chat sessions are read-only coordinators — they can read files, run
+		// diagnostics, and spawn read-only SDK subagents for lightweight investigation.
+		// File editing tools (Write/Edit/NotebookEdit) are excluded; the agent uses its
+		// space-agent-tools MCP server for all coordination operations.
 		if (this.ctx.session.type === 'space_chat') {
 			const spaceAllowedBuiltinTools = [
 				'Read',
@@ -485,15 +485,11 @@ export class QueryOptionsBuilder {
 				'WebSearch',
 				'ToolSearch',
 				'AskUserQuestion',
-			];
-			const spaceRestrictedBuiltinTools = [
 				'Task',
 				'TaskOutput',
 				'TaskStop',
-				'Edit',
-				'Write',
-				'NotebookEdit',
 			];
+			const spaceRestrictedBuiltinTools = ['Edit', 'Write', 'NotebookEdit'];
 
 			// Space chat must not use Claude Code preset prompt.
 			const systemPrompt = queryOptions.systemPrompt;

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -145,6 +145,34 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 	);
 	sections.push('');
 
+	sections.push(`\n## Subagents\n`);
+	sections.push(
+		`You may use SDK-native subagents with the \`Task\`, \`TaskOutput\`, and \`TaskStop\` tools ` +
+			`for lightweight parallel investigation before deciding whether real task delegation is needed.`
+	);
+	sections.push('');
+	sections.push(
+		`**Use subagents for quick, read-only investigation:** codebase research, reading files, ` +
+			`gathering context, and answering questions like "what does X do?" or "is Y implemented?" ` +
+			`Subagents run inside your Space Agent session, create no task entity, have no side effects, ` +
+			`and their results are ephemeral conversation context rather than persisted task artifacts.`
+	);
+	sections.push('');
+	sections.push(
+		`**Use standalone tasks for actual work:** implementation, code changes, PRs, and multi-step ` +
+			`workflows must use \`create_standalone_task\`. Standalone tasks create visible task entities, ` +
+			`spawn workflow execution, and produce artifacts in the Tasks view.`
+	);
+	sections.push('');
+	sections.push(
+		`**Subagent guidelines:**\n` +
+			`  - Use subagents for anything that can be answered by reading code or files without side effects.\n` +
+			`  - Subagents inherit your read-only restriction: they can investigate, but cannot edit files.\n` +
+			`  - If code changes are needed, create a standalone task instead.\n` +
+			`  - Do not use subagents as a replacement for proper task delegation. If the user asks you to "fix X" or "implement Y", create a standalone task rather than a subagent investigation.`
+	);
+	sections.push('');
+
 	// Workflow shape guidance — what each built-in workflow is good at and when
 	// to pick it. Kept short so the LLM can skim it before calling the discovery
 	// tools above. Descriptions mirror the tags declared in built-in-workflows.ts.

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -626,7 +626,7 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 		});
 
-		it('should enforce space built-in tool allowlist including Bash', async () => {
+		it('should enforce space built-in tool allowlist including Bash and subagents', async () => {
 			mockSession.type = 'space_chat';
 			const options = await builder.build();
 			expect(options.tools).toEqual([
@@ -638,6 +638,9 @@ describe('QueryOptionsBuilder', () => {
 				'WebSearch',
 				'ToolSearch',
 				'AskUserQuestion',
+				'Task',
+				'TaskOutput',
+				'TaskStop',
 			]);
 			expect(options.allowedTools).toEqual(
 				expect.arrayContaining([
@@ -649,8 +652,23 @@ describe('QueryOptionsBuilder', () => {
 					'WebSearch',
 					'ToolSearch',
 					'AskUserQuestion',
+					'Task',
+					'TaskOutput',
+					'TaskStop',
 				])
 			);
+		});
+
+		it('should keep file editing tools disallowed while allowing subagents', async () => {
+			mockSession.type = 'space_chat';
+			const options = await builder.build();
+
+			expect(options.disallowedTools).toEqual(
+				expect.arrayContaining(['Edit', 'Write', 'NotebookEdit'])
+			);
+			expect(options.disallowedTools).not.toContain('Task');
+			expect(options.disallowedTools).not.toContain('TaskOutput');
+			expect(options.disallowedTools).not.toContain('TaskStop');
 		});
 
 		it('should not include Write/Edit/NotebookEdit in space chat tool allowlist', async () => {


### PR DESCRIPTION
Enables SDK-native Task subagents for space_chat sessions so the Space Agent can perform lightweight read-only investigation without creating standalone tasks.

Keeps Edit/Write/NotebookEdit denied and updates the Space Agent prompt plus query-options tests to document and verify the distinction between subagents and standalone task delegation.

Tests:
- cd packages/daemon && bun test tests/unit/1-core/agent/query-options-builder.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/enable-space-agent-subagents-for-lightweight-parallel check