### PR TITLE
Make settings tabs addressable by URL

### DIFF
--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -68,7 +68,6 @@ import {
 	replaceOverlayHistory,
 } from '../lib/router.ts';
 import { sessionStore } from '../lib/session-store.ts';
-import { settingsSectionSignal } from '../lib/signals.ts';
 import { spaceStore } from '../lib/space-store.ts';
 import { connectionState } from '../lib/state.ts';
 import { toast } from '../lib/toast.ts';
@@ -946,8 +945,7 @@ export default function ChatContainer({
 				{
 					label: `Re-authenticate ${providerLabel}`,
 					onClick: () => {
-						navigateToSettings();
-						settingsSectionSignal.value = 'providers';
+						navigateToSettings('providers');
 					},
 				},
 			];

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -599,7 +599,7 @@ export function ContextPanel() {
 										return (
 											<button
 												key={section.id}
-												onClick={() => (settingsSectionSignal.value = section.id)}
+												onClick={() => navigateToSettings(section.id)}
 												class={cn(
 													'w-full px-4 py-3 flex items-center gap-3 text-left',
 													'transition-colors duration-150',

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -39,6 +39,7 @@ import {
 	currentSpaceTaskViewTabSignal,
 	currentSpaceViewModeSignal,
 	navSectionSignal,
+	settingsSectionSignal,
 } from '../signals';
 
 const SESSION_ID = '550e8400-e29b-41d4-a716-446655440000';
@@ -55,6 +56,7 @@ function resetSignals() {
 	currentSpaceTasksFilterTabSignal.value = 'active';
 	currentSpaceTaskViewTabSignal.value = 'thread';
 	navSectionSignal.value = 'spaces';
+	settingsSectionSignal.value = 'general';
 }
 
 function finishNavigation() {
@@ -62,8 +64,9 @@ function finishNavigation() {
 }
 
 function setPath(path: string) {
+	const url = new URL(path, 'https://neokai.test');
 	Object.defineProperty(window, 'location', {
-		value: { pathname: path },
+		value: { pathname: url.pathname, search: url.search },
 		configurable: true,
 	});
 }
@@ -167,6 +170,45 @@ describe('router', () => {
 			{ spaceId: SPACE_ID, path: `/space/${SPACE_ID}/tasks/completed` },
 			'',
 			`/space/${SPACE_ID}/tasks/completed`
+		);
+	});
+
+	it('initializes settings routes from tab query parameters', () => {
+		setPath('/settings?tab=providers');
+		initializeRouter();
+
+		expect(navSectionSignal.value).toBe('settings');
+		expect(settingsSectionSignal.value).toBe('providers');
+		expect(currentSessionIdSignal.value).toBeNull();
+
+		cleanupRouter();
+		settingsSectionSignal.value = 'providers';
+		setPath('/settings?tab=unknown');
+		initializeRouter();
+
+		expect(navSectionSignal.value).toBe('settings');
+		expect(settingsSectionSignal.value).toBe('general');
+	});
+
+	it('navigates to settings tabs and updates URL query parameters', () => {
+		navigateToSettings('skills');
+
+		expect(navSectionSignal.value).toBe('settings');
+		expect(settingsSectionSignal.value).toBe('skills');
+		expect(window.history.pushState).toHaveBeenLastCalledWith(
+			{ section: 'skills', path: '/settings?tab=skills' },
+			'',
+			'/settings?tab=skills'
+		);
+		finishNavigation();
+
+		navigateToSettings('providers');
+
+		expect(settingsSectionSignal.value).toBe('providers');
+		expect(window.history.pushState).toHaveBeenLastCalledWith(
+			{ section: 'providers', path: '/settings?tab=providers' },
+			'',
+			'/settings?tab=providers'
 		);
 	});
 

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -17,6 +17,8 @@ import {
 	currentSpaceTasksFilterTabSignal,
 	currentSpaceTaskViewTabSignal,
 	navSectionSignal,
+	settingsSectionSignal,
+	type SettingsSection,
 	spaceOverlaySessionIdSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
@@ -45,6 +47,16 @@ const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[
 const SPACE_TASK_VIEW_ROUTE_PATTERN =
 	/^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)\/(thread|canvas|artifacts)$/;
 const SPACE_SESSIONS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/sessions$/;
+const SETTINGS_SECTIONS = new Set<SettingsSection>([
+	'general',
+	'providers',
+	'app-mcp-servers',
+	'skills',
+	'models',
+	'neo',
+	'usage',
+	'about',
+]);
 
 interface RouterState {
 	isInitialized: boolean;
@@ -169,6 +181,17 @@ function getCurrentPath(): string {
 	return window.location.pathname;
 }
 
+function getCurrentPathWithSearch(): string {
+	return `${window.location.pathname}${window.location.search}`;
+}
+
+export function getSettingsSectionFromSearch(search: string): SettingsSection {
+	const section = new URLSearchParams(search).get('tab');
+	return section && SETTINGS_SECTIONS.has(section as SettingsSection)
+		? (section as SettingsSection)
+		: 'general';
+}
+
 export function createSessionPath(sessionId: string): string {
 	return `/session/${sessionId}`;
 }
@@ -201,8 +224,8 @@ export function createSpaceAgentPath(spaceId: string): string {
 	return `/space/${spaceId}/agent`;
 }
 
-export function createSettingsPath(): string {
-	return '/settings';
+export function createSettingsPath(section?: SettingsSection): string {
+	return section ? `/settings?tab=${section}` : '/settings';
 }
 
 function pushPath(path: string, state: Record<string, unknown>, replace: boolean): void {
@@ -297,20 +320,27 @@ export function navigateToInbox(replace = false): void {
 	}
 }
 
-export function navigateToSettings(replace = false): void {
+export function navigateToSettings(
+	sectionOrReplace?: SettingsSection | boolean,
+	replace = false
+): void {
 	if (routerState.isNavigating) return;
 
-	const targetPath = createSettingsPath();
-	if (getCurrentPath() === targetPath) {
+	const section = typeof sectionOrReplace === 'boolean' ? undefined : sectionOrReplace;
+	const shouldReplace = typeof sectionOrReplace === 'boolean' ? sectionOrReplace : replace;
+	const targetPath = createSettingsPath(section);
+	if (getCurrentPathWithSearch() === targetPath) {
 		setSessionRoute(null);
+		settingsSectionSignal.value = section ?? 'general';
 		navSectionSignal.value = 'settings';
 		return;
 	}
 
 	routerState.isNavigating = true;
 	try {
-		pushPath(targetPath, {}, replace);
+		pushPath(targetPath, { section: section ?? 'general' }, shouldReplace);
 		setSessionRoute(null);
+		settingsSectionSignal.value = section ?? 'general';
 		navSectionSignal.value = 'settings';
 	} finally {
 		finishNavigation();
@@ -519,7 +549,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 	navSectionSignal.value = 'spaces';
 }
 
-function applyPathToSignals(path: string): string | null {
+function applyPathToSignals(path: string, search = window.location.search): string | null {
 	const legacyArchivedTasksMatch = path.match(SPACE_TASKS_ARCHIVED_ROUTE_PATTERN);
 	if (legacyArchivedTasksMatch) {
 		pushPath(
@@ -616,6 +646,7 @@ function applyPathToSignals(path: string): string | null {
 			setSpacesListRoute();
 		} else if (SETTINGS_ROUTE_PATTERN.test(path)) {
 			setSessionRoute(null);
+			settingsSectionSignal.value = getSettingsSectionFromSearch(search);
 			navSectionSignal.value = 'settings';
 		} else {
 			setSessionRoute(sessionId);
@@ -640,7 +671,7 @@ function handlePopState(_event: PopStateEvent): void {
 		return;
 	}
 
-	applyPathToSignals(getCurrentPath());
+	applyPathToSignals(getCurrentPath(), window.location.search);
 }
 
 export function initializeRouter(): string | null {
@@ -648,7 +679,7 @@ export function initializeRouter(): string | null {
 		return getSessionIdFromPath(getCurrentPath());
 	}
 
-	const initialSessionId = applyPathToSignals(getCurrentPath());
+	const initialSessionId = applyPathToSignals(getCurrentPath(), window.location.search);
 	window.addEventListener('popstate', handlePopState);
 	routerState.isInitialized = true;
 	return initialSessionId;


### PR DESCRIPTION
Adds settings tab query routing so `/settings?tab=providers` opens the providers section directly and tab clicks update browser history.

Also updates settings-related navigation actions to use the router and adds unit coverage for direct links and invalid tab fallback.

Tests:
- bunx vitest run src/lib/__tests__/router.test.ts
- bun run check