### PR TITLE
Preserve branches after post-approval merge

### DIFF
--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -61,7 +61,7 @@ export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'   coder follow-up for those thread URLs and wait for them to be resolved.',
 	'   Auto-merging or auto-resolving review conversations is NOT allowed.',
 	'3. Merge:',
-	'     gh pr merge {{pr_url}} --squash --delete-branch',
+	'     gh pr merge {{pr_url}} --squash',
 	'   On a merge conflict, do NOT force — exit, call request_human_input with',
 	'   a clear summary of the conflict, and let the human resolve.',
 	'4. Sync your worktree with main/dev:',

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -335,9 +335,8 @@ describe('Shared merge template canonical content', () => {
 	test('template contains the squash-merge command and conflict guard', () => {
 		// Specific command shapes: protects against well-intentioned edits
 		// that swap `--squash` for `--merge` or drop the conflict guard.
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain(
-			'gh pr merge {{pr_url}} --squash --delete-branch'
-		);
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('gh pr merge {{pr_url}} --squash');
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('--delete-branch');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('merge conflict');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('do NOT force');
 	});


### PR DESCRIPTION
Updates the post-approval merge template to squash merge without deleting the source branch.

Tests:
- bun test tests/unit/5-space/workflow/end-node-handoff.test.ts
- bun run check