### PR TITLE
Fix Codex auto-compaction context windows

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -61,8 +61,6 @@ import { getCoordinatorAgents } from './coordinator-agents';
 import { createLoopDetectorHooks } from './loop-detector-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
-export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
-
 /**
  * Compile a single declarative tool guard into a PreToolUse hook callback.
  * The guard specifies a tool matcher, a regex pattern against the tool input,
@@ -193,7 +191,8 @@ const NATIVE_CONTEXT_WINDOW_PROVIDERS = ['anthropic', 'anthropic-copilot'];
 /**
  * Provider-specific SDK settings overrides.
  *
- * For the Codex bridge, returns a hardcoded 1M autoCompactWindow.
+ * For the Codex bridge, looks up the model's actual context window so the
+ * SDK auto-compacts at the right threshold.
  * For other non-native providers, the caller should supply the model's
  * actual contextWindow so the SDK auto-compacts at the right threshold.
  */
@@ -207,16 +206,13 @@ export function buildProviderSettings(
 			throw new Error(`Unknown Codex model auto-compact window: ${modelId ?? 'missing model'}`);
 		}
 		try {
-			requireModelContextWindow(modelId);
+			const actualContextWindow = requireModelContextWindow(modelId);
+			return {
+				autoCompactWindow: actualContextWindow,
+			};
 		} catch {
 			throw new Error(`Unknown Codex model auto-compact window: ${modelId}`);
 		}
-
-		return {
-			// Keep SDK-driven compaction disabled for the Codex bridge. The bridge uses
-			// a single persistent Codex turn per session and rejects overlapping turns.
-			autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
-		};
 	}
 
 	// For non-native providers where the SDK can't discover the actual context

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -12,7 +12,6 @@ import type { Provider } from '@neokai/shared/provider';
 import { homedir } from 'os';
 import {
 	buildProviderSettings,
-	CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
 	ensureAgentTools,
 	QueryOptionsBuilder,
 	type QueryOptionsBuilderContext,
@@ -169,15 +168,30 @@ describe('QueryOptionsBuilder', () => {
 	});
 
 	describe('provider settings', () => {
-		it('should keep SDK auto-compaction disabled after validating Codex model metadata', () => {
+		it('should use the actual context window for full-size Codex models', () => {
 			expect(buildProviderSettings('anthropic-codex', 'gpt-5.5')).toEqual({
-				autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+				autoCompactWindow: 272_000,
+			});
+			expect(buildProviderSettings('anthropic-codex', 'gpt-5.4')).toEqual({
+				autoCompactWindow: 272_000,
+			});
+		});
+
+		it('should use the actual context window for mini Codex models', () => {
+			expect(buildProviderSettings('anthropic-codex', 'gpt-5.4-mini')).toEqual({
+				autoCompactWindow: 128_000,
+			});
+			expect(buildProviderSettings('anthropic-codex', 'gpt-5.1-codex-mini')).toEqual({
+				autoCompactWindow: 128_000,
 			});
 		});
 
 		it('should resolve Codex aliases before applying SDK auto-compaction settings', () => {
 			expect(buildProviderSettings('anthropic-codex', 'codex-latest')).toEqual({
-				autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+				autoCompactWindow: 272_000,
+			});
+			expect(buildProviderSettings('anthropic-codex', 'codex-mini')).toEqual({
+				autoCompactWindow: 128_000,
 			});
 		});
 


### PR DESCRIPTION
Fix Codex bridge auto-compaction by passing each model's actual context window to the SDK instead of a fixed 1M window.

Updated unit coverage verifies full-size, mini, and alias Codex models use the expected 272k/128k windows.