### PR TITLE
Add external event extension management

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -401,7 +401,9 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	// (space/room/session), not useful for ad-hoc agent queries. Agents should
 	// read MCP state through the resolver rather than hitting the table directly.
 	'mcp_enablement',
-	// External Event Bus — internal event routing/delivery state, not useful for ad-hoc agent queries.
+	// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
+	'external_event_source_configs',
+	'space_external_event_source_configs',
 	'space_external_events',
 	'space_external_event_deliveries',
 	// Dropped tables (no longer exist in schema)

--- a/packages/daemon/src/lib/external-events/extension-config-store.ts
+++ b/packages/daemon/src/lib/external-events/extension-config-store.ts
@@ -1,0 +1,231 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type {
+	ExternalEventExtensionConfig,
+	ExternalEventExtensionConfigStore as ExternalEventExtensionConfigStoreContract,
+	SpaceExternalEventSourceConfig,
+} from './types';
+
+interface GlobalConfigRow {
+	source: string;
+	globally_enabled: number;
+	capabilities_json: string;
+	secrets_ref: string | null;
+	settings_json: string | null;
+}
+
+interface SpaceConfigRow {
+	space_id: string;
+	source: string;
+	enabled: number;
+	settings_json: string;
+}
+
+export type { ExternalEventExtensionConfig, SpaceExternalEventSourceConfig } from './types';
+
+export class ExternalEventExtensionConfigStore
+	implements ExternalEventExtensionConfigStoreContract
+{
+	constructor(private readonly db: BunDatabase) {
+		ensureExternalEventExtensionConfigTables(this.db);
+	}
+
+	async getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig> {
+		validateSourceId(source);
+		const row = this.db
+			.prepare(`SELECT * FROM external_event_source_configs WHERE source = ?`)
+			.get(source) as GlobalConfigRow | undefined;
+
+		if (!row) {
+			return {
+				source,
+				globallyEnabled: false,
+				capabilities: {},
+			};
+		}
+
+		return globalRowToConfig(row);
+	}
+
+	async getSpaceConfig(
+		spaceId: string,
+		source: string
+	): Promise<SpaceExternalEventSourceConfig | null> {
+		validateSpaceId(spaceId);
+		validateSourceId(source);
+		const row = this.db
+			.prepare(
+				`SELECT * FROM space_external_event_source_configs WHERE space_id = ? AND source = ?`
+			)
+			.get(spaceId, source) as SpaceConfigRow | undefined;
+		return row ? spaceRowToConfig(row) : null;
+	}
+
+	async listEnabledSpaces(source: string): Promise<SpaceExternalEventSourceConfig[]> {
+		validateSourceId(source);
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_external_event_source_configs
+				 WHERE source = ? AND enabled = 1
+				 ORDER BY space_id`
+			)
+			.all(source) as SpaceConfigRow[];
+		return rows.map(spaceRowToConfig);
+	}
+
+	async setGlobalConfig(source: string, config: ExternalEventExtensionConfig): Promise<void> {
+		validateSourceId(source);
+		validateGlobalConfig(source, config);
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO external_event_source_configs (
+					source, globally_enabled, capabilities_json, secrets_ref,
+					settings_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(source) DO UPDATE SET
+					globally_enabled = excluded.globally_enabled,
+					capabilities_json = excluded.capabilities_json,
+					secrets_ref = excluded.secrets_ref,
+					settings_json = excluded.settings_json,
+					updated_at = excluded.updated_at`
+			)
+			.run(
+				source,
+				config.globallyEnabled ? 1 : 0,
+				JSON.stringify(config.capabilities),
+				config.secretsRef ?? null,
+				config.settings === undefined ? null : JSON.stringify(config.settings),
+				now,
+				now
+			);
+	}
+
+	async setSpaceConfig(
+		spaceId: string,
+		source: string,
+		config: SpaceExternalEventSourceConfig
+	): Promise<void> {
+		validateSpaceId(spaceId);
+		validateSourceId(source);
+		validateSpaceConfig(spaceId, source, config);
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_external_event_source_configs (
+					space_id, source, enabled, settings_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?)
+				ON CONFLICT(space_id, source) DO UPDATE SET
+					enabled = excluded.enabled,
+					settings_json = excluded.settings_json,
+					updated_at = excluded.updated_at`
+			)
+			.run(spaceId, source, config.enabled ? 1 : 0, JSON.stringify(config.settings), now, now);
+	}
+}
+
+export function ensureExternalEventExtensionConfigTables(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+			source TEXT PRIMARY KEY,
+			globally_enabled INTEGER NOT NULL DEFAULT 0,
+			capabilities_json TEXT NOT NULL,
+			secrets_ref TEXT,
+			settings_json TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
+			space_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 0,
+			settings_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY(space_id, source)
+		)
+	`);
+}
+
+function globalRowToConfig(row: GlobalConfigRow): ExternalEventExtensionConfig {
+	const config: ExternalEventExtensionConfig = {
+		source: row.source,
+		globallyEnabled: row.globally_enabled === 1,
+		capabilities: parseJsonRecord(row.capabilities_json),
+	};
+	if (row.secrets_ref !== null) config.secretsRef = row.secrets_ref;
+	if (row.settings_json !== null) config.settings = parseJsonRecord(row.settings_json);
+	return config;
+}
+
+function spaceRowToConfig(row: SpaceConfigRow): SpaceExternalEventSourceConfig {
+	return {
+		spaceId: row.space_id,
+		source: row.source,
+		enabled: row.enabled === 1,
+		settings: parseJsonRecord(row.settings_json),
+	};
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		// Treat corrupted JSON as empty configuration so callers can still recover
+		// by writing a valid replacement config.
+	}
+	return {};
+}
+
+function validateGlobalConfig(source: string, config: ExternalEventExtensionConfig): void {
+	if (config.source !== source) {
+		throw new Error(
+			`Global external-event config source "${config.source}" must match "${source}"`
+		);
+	}
+	if (!config.capabilities || typeof config.capabilities !== 'object') {
+		throw new Error('Global external-event config capabilities must be an object');
+	}
+	if (config.settings !== undefined && !isRecord(config.settings)) {
+		throw new Error('Global external-event config settings must be an object when present');
+	}
+}
+
+function validateSpaceConfig(
+	spaceId: string,
+	source: string,
+	config: SpaceExternalEventSourceConfig
+): void {
+	if (config.spaceId !== spaceId) {
+		throw new Error(
+			`Space external-event config spaceId "${config.spaceId}" must match "${spaceId}"`
+		);
+	}
+	if (config.source !== source) {
+		throw new Error(`Space external-event config source "${config.source}" must match "${source}"`);
+	}
+	if (!isRecord(config.settings)) {
+		throw new Error('Space external-event config settings must be an object');
+	}
+}
+
+function validateSourceId(source: string): void {
+	if (!source || source.trim().length === 0 || source !== source.trim()) {
+		throw new Error('External event source must be non-empty and must not include edge whitespace');
+	}
+}
+
+function validateSpaceId(spaceId: string): void {
+	if (!spaceId || spaceId.trim().length === 0 || spaceId !== spaceId.trim()) {
+		throw new Error('Space id must be non-empty and must not include edge whitespace');
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/daemon/src/lib/external-events/extension-config-store.ts
+++ b/packages/daemon/src/lib/external-events/extension-config-store.ts
@@ -144,7 +144,8 @@ export function ensureExternalEventExtensionConfigTables(db: BunDatabase): void 
 			settings_json TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
-			PRIMARY KEY(space_id, source)
+			PRIMARY KEY(space_id, source),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
 }
@@ -188,7 +189,7 @@ function validateGlobalConfig(source: string, config: ExternalEventExtensionConf
 			`Global external-event config source "${config.source}" must match "${source}"`
 		);
 	}
-	if (!config.capabilities || typeof config.capabilities !== 'object') {
+	if (!isRecord(config.capabilities)) {
 		throw new Error('Global external-event config capabilities must be an object');
 	}
 	if (config.settings !== undefined && !isRecord(config.settings)) {

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -139,12 +139,26 @@ export class ExternalEventExtensionManager {
 
 	private findSourceIdForRoutes(routes: readonly Route[]): string | undefined {
 		for (const extension of this.extensions.values()) {
-			if (!isHttpExtension(extension)) continue;
-			if (extension.routes === routes || routesMatch(extension.routes, routes)) {
+			if (isHttpExtension(extension) && extension.routes === routes) {
 				return extension.sourceId;
 			}
 		}
-		return undefined;
+
+		const matchingSourceIds: string[] = [];
+		for (const extension of this.extensions.values()) {
+			if (!isHttpExtension(extension)) continue;
+			if (routesMatch(extension.routes, routes)) {
+				matchingSourceIds.push(extension.sourceId);
+			}
+		}
+
+		if (matchingSourceIds.length > 1) {
+			throw new Error(
+				`Cannot infer external event route owner: route signatures match multiple sources ` +
+					`(${matchingSourceIds.join(', ')}). Pass the registered extension.routes array directly.`
+			);
+		}
+		return matchingSourceIds[0];
 	}
 }
 

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -14,8 +14,14 @@ export class ExternalEventExtensionManager {
 	private rpcUnsubscribers = new Map<string, (() => void)[]>();
 
 	register(extension: ExternalEventExtension): void {
-		if (!extension.sourceId || extension.sourceId.trim().length === 0) {
-			throw new Error('External event extension sourceId must be non-empty');
+		if (
+			!extension.sourceId ||
+			extension.sourceId.trim().length === 0 ||
+			extension.sourceId !== extension.sourceId.trim()
+		) {
+			throw new Error(
+				'External event extension sourceId must be non-empty and must not include edge whitespace'
+			);
 		}
 		if (this.extensions.has(extension.sourceId)) {
 			throw new Error(`External event extension "${extension.sourceId}" is already registered`);
@@ -49,6 +55,7 @@ export class ExternalEventExtensionManager {
 		} finally {
 			this.started.delete(sourceId);
 			this.unregisterRpcHandlers(sourceId);
+			this.unregisterRoutes(sourceId);
 		}
 	}
 
@@ -57,10 +64,13 @@ export class ExternalEventExtensionManager {
 	}
 
 	registerRoutes(routes: readonly Route[], context: ExternalEventExtensionContext): void {
+		const sourceId = this.findSourceIdForRoutes(routes);
+		if (sourceId) {
+			this.unregisterRoutes(sourceId);
+		}
 		for (const route of routes) {
-			const extension = this.findExtensionForRoute(route);
 			this.routeHandlers.push({
-				sourceId: extension?.sourceId,
+				sourceId,
 				method: route.method,
 				path: route.path,
 				handle: (req) => route.handle(req, context),
@@ -92,7 +102,14 @@ export class ExternalEventExtensionManager {
 				};
 			},
 		});
-		extension.registerRpcHandlers(trackingHub, context);
+		try {
+			extension.registerRpcHandlers(trackingHub, context);
+		} catch (error) {
+			for (const unsubscribe of unsubscribers) {
+				unsubscribe();
+			}
+			throw error;
+		}
 		this.rpcUnsubscribers.set(sourceId, unsubscribers);
 	}
 
@@ -116,10 +133,16 @@ export class ExternalEventExtensionManager {
 		this.rpcUnsubscribers.delete(sourceId);
 	}
 
-	private findExtensionForRoute(route: Route): HttpExternalEventExtension | undefined {
+	private unregisterRoutes(sourceId: string): void {
+		this.routeHandlers = this.routeHandlers.filter((route) => route.sourceId !== sourceId);
+	}
+
+	private findSourceIdForRoutes(routes: readonly Route[]): string | undefined {
 		for (const extension of this.extensions.values()) {
 			if (!isHttpExtension(extension)) continue;
-			if (extension.routes.includes(route)) return extension;
+			if (extension.routes === routes || routesMatch(extension.routes, routes)) {
+				return extension.sourceId;
+			}
 		}
 		return undefined;
 	}
@@ -130,6 +153,14 @@ export interface RegisteredRoute {
 	readonly method: Route['method'];
 	readonly path: string;
 	handle(req: Request): Promise<Response>;
+}
+
+function routesMatch(left: readonly Route[], right: readonly Route[]): boolean {
+	if (left.length !== right.length) return false;
+	return left.every((route, index) => {
+		const other = right[index];
+		return Boolean(other) && route.method === other.method && route.path === other.path;
+	});
 }
 
 function isHttpExtension(

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -1,0 +1,143 @@
+import type { MessageHub } from '@neokai/shared/message-hub/message-hub.ts';
+import type {
+	ExternalEventExtension,
+	ExternalEventExtensionContext,
+	HttpExternalEventExtension,
+	Route,
+	RpcExternalEventExtension,
+} from './types';
+
+export class ExternalEventExtensionManager {
+	private extensions = new Map<string, ExternalEventExtension>();
+	private started = new Map<string, ExternalEventExtensionContext>();
+	private routeHandlers: RegisteredRoute[] = [];
+	private rpcUnsubscribers = new Map<string, (() => void)[]>();
+
+	register(extension: ExternalEventExtension): void {
+		if (!extension.sourceId || extension.sourceId.trim().length === 0) {
+			throw new Error('External event extension sourceId must be non-empty');
+		}
+		if (this.extensions.has(extension.sourceId)) {
+			throw new Error(`External event extension "${extension.sourceId}" is already registered`);
+		}
+		this.extensions.set(extension.sourceId, extension);
+	}
+
+	unregister(sourceId: string): void {
+		if (this.started.has(sourceId)) {
+			throw new Error(`Cannot unregister started external event extension "${sourceId}"`);
+		}
+		this.unregisterRpcHandlers(sourceId);
+		this.routeHandlers = this.routeHandlers.filter((route) => route.sourceId !== sourceId);
+		this.extensions.delete(sourceId);
+	}
+
+	async startExtension(sourceId: string, context: ExternalEventExtensionContext): Promise<void> {
+		if (this.started.has(sourceId)) return;
+		const extension = this.getRequiredExtension(sourceId);
+		const globalConfig = await context.config.getGlobalConfig(sourceId);
+		if (!globalConfig.globallyEnabled) return;
+		await extension.start(context);
+		this.started.set(sourceId, context);
+	}
+
+	async stopExtension(sourceId: string): Promise<void> {
+		const extension = this.extensions.get(sourceId);
+		if (!extension || !this.started.has(sourceId)) return;
+		try {
+			await extension.stop();
+		} finally {
+			this.started.delete(sourceId);
+			this.unregisterRpcHandlers(sourceId);
+		}
+	}
+
+	getExtension(sourceId: string): ExternalEventExtension | undefined {
+		return this.extensions.get(sourceId);
+	}
+
+	registerRoutes(routes: readonly Route[], context: ExternalEventExtensionContext): void {
+		for (const route of routes) {
+			const extension = this.findExtensionForRoute(route);
+			this.routeHandlers.push({
+				sourceId: extension?.sourceId,
+				method: route.method,
+				path: route.path,
+				handle: (req) => route.handle(req, context),
+			});
+		}
+	}
+
+	registerRpcHandlers(
+		sourceId: string,
+		hub: MessageHub,
+		context: ExternalEventExtensionContext
+	): void {
+		this.unregisterRpcHandlers(sourceId);
+		const extension = this.getRequiredExtension(sourceId);
+		if (!isRpcExtension(extension)) {
+			throw new Error(`External event extension "${sourceId}" does not expose RPC handlers`);
+		}
+
+		const unsubscribers: (() => void)[] = [];
+		const trackingHub = new Proxy(hub, {
+			get(target, prop, receiver) {
+				if (prop !== 'onRequest') {
+					return Reflect.get(target, prop, receiver);
+				}
+				return (method: string, handler: Parameters<MessageHub['onRequest']>[1]) => {
+					const unsubscribe = target.onRequest(method, handler);
+					unsubscribers.push(unsubscribe);
+					return unsubscribe;
+				};
+			},
+		});
+		extension.registerRpcHandlers(trackingHub, context);
+		this.rpcUnsubscribers.set(sourceId, unsubscribers);
+	}
+
+	getRegisteredRoutes(): readonly RegisteredRoute[] {
+		return this.routeHandlers;
+	}
+
+	private getRequiredExtension(sourceId: string): ExternalEventExtension {
+		const extension = this.extensions.get(sourceId);
+		if (!extension) {
+			throw new Error(`External event extension "${sourceId}" is not registered`);
+		}
+		return extension;
+	}
+
+	private unregisterRpcHandlers(sourceId: string): void {
+		const unsubscribers = this.rpcUnsubscribers.get(sourceId) ?? [];
+		for (const unsubscribe of unsubscribers) {
+			unsubscribe();
+		}
+		this.rpcUnsubscribers.delete(sourceId);
+	}
+
+	private findExtensionForRoute(route: Route): HttpExternalEventExtension | undefined {
+		for (const extension of this.extensions.values()) {
+			if (!isHttpExtension(extension)) continue;
+			if (extension.routes.includes(route)) return extension;
+		}
+		return undefined;
+	}
+}
+
+export interface RegisteredRoute {
+	readonly sourceId?: string;
+	readonly method: Route['method'];
+	readonly path: string;
+	handle(req: Request): Promise<Response>;
+}
+
+function isHttpExtension(
+	extension: ExternalEventExtension
+): extension is HttpExternalEventExtension {
+	return 'routes' in extension && Array.isArray((extension as { routes?: unknown }).routes);
+}
+
+function isRpcExtension(extension: ExternalEventExtension): extension is RpcExternalEventExtension {
+	return typeof (extension as { registerRpcHandlers?: unknown }).registerRpcHandlers === 'function';
+}

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -10,6 +10,7 @@ import type {
 export class ExternalEventExtensionManager {
 	private extensions = new Map<string, ExternalEventExtension>();
 	private started = new Map<string, ExternalEventExtensionContext>();
+	private starting = new Map<string, Promise<void>>();
 	private routeHandlers: RegisteredRoute[] = [];
 	private rpcUnsubscribers = new Map<string, (() => void)[]>();
 
@@ -40,11 +41,19 @@ export class ExternalEventExtensionManager {
 
 	async startExtension(sourceId: string, context: ExternalEventExtensionContext): Promise<void> {
 		if (this.started.has(sourceId)) return;
-		const extension = this.getRequiredExtension(sourceId);
-		const globalConfig = await context.config.getGlobalConfig(sourceId);
-		if (!globalConfig.globallyEnabled) return;
-		await extension.start(context);
-		this.started.set(sourceId, context);
+		const existingStart = this.starting.get(sourceId);
+		if (existingStart) {
+			await existingStart;
+			return;
+		}
+
+		const startPromise = this.runStartExtension(sourceId, context);
+		this.starting.set(sourceId, startPromise);
+		try {
+			await startPromise;
+		} finally {
+			this.starting.delete(sourceId);
+		}
 	}
 
 	async stopExtension(sourceId: string): Promise<void> {
@@ -118,6 +127,18 @@ export class ExternalEventExtensionManager {
 
 	getRegisteredRoutes(): readonly RegisteredRoute[] {
 		return this.routeHandlers;
+	}
+
+	private async runStartExtension(
+		sourceId: string,
+		context: ExternalEventExtensionContext
+	): Promise<void> {
+		if (this.started.has(sourceId)) return;
+		const extension = this.getRequiredExtension(sourceId);
+		const globalConfig = await context.config.getGlobalConfig(sourceId);
+		if (!globalConfig.globallyEnabled) return;
+		await extension.start(context);
+		this.started.set(sourceId, context);
 	}
 
 	private getRequiredExtension(sourceId: string): ExternalEventExtension {

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -65,9 +65,12 @@ export class ExternalEventExtensionManager {
 
 	registerRoutes(routes: readonly Route[], context: ExternalEventExtensionContext): void {
 		const sourceId = this.findSourceIdForRoutes(routes);
-		if (sourceId) {
-			this.unregisterRoutes(sourceId);
+		if (!sourceId) {
+			throw new Error(
+				'Cannot infer external event route owner: route signatures do not match a registered source'
+			);
 		}
+		this.unregisterRoutes(sourceId);
 		for (const route of routes) {
 			this.routeHandlers.push({
 				sourceId,
@@ -163,7 +166,7 @@ export class ExternalEventExtensionManager {
 }
 
 export interface RegisteredRoute {
-	readonly sourceId?: string;
+	readonly sourceId: string;
 	readonly method: Route['method'];
 	readonly path: string;
 	handle(req: Request): Promise<Response>;
@@ -171,10 +174,17 @@ export interface RegisteredRoute {
 
 function routesMatch(left: readonly Route[], right: readonly Route[]): boolean {
 	if (left.length !== right.length) return false;
-	return left.every((route, index) => {
-		const other = right[index];
-		return Boolean(other) && route.method === other.method && route.path === other.path;
-	});
+	const unmatched = right.map(routeSignature);
+	for (const route of left) {
+		const matchIndex = unmatched.indexOf(routeSignature(route));
+		if (matchIndex === -1) return false;
+		unmatched.splice(matchIndex, 1);
+	}
+	return unmatched.length === 0;
+}
+
+function routeSignature(route: Route): string {
+	return `${route.method} ${route.path}`;
 }
 
 function isHttpExtension(

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -13,6 +13,7 @@ export class ExternalEventExtensionManager {
 	private starting = new Map<string, Promise<void>>();
 	private routeHandlers: RegisteredRoute[] = [];
 	private rpcUnsubscribers = new Map<string, (() => void)[]>();
+	private rpcMethodOwners = new Map<string, string>();
 
 	register(extension: ExternalEventExtension): void {
 		if (
@@ -44,7 +45,7 @@ export class ExternalEventExtensionManager {
 		const existingStart = this.starting.get(sourceId);
 		if (existingStart) {
 			await existingStart;
-			return;
+			if (this.started.has(sourceId)) return;
 		}
 
 		const startPromise = this.runStartExtension(sourceId, context);
@@ -59,7 +60,11 @@ export class ExternalEventExtensionManager {
 	async stopExtension(sourceId: string): Promise<void> {
 		const inFlightStart = this.starting.get(sourceId);
 		if (inFlightStart) {
-			await inFlightStart;
+			try {
+				await inFlightStart;
+			} catch {
+				// Best-effort stop should not fail just because an overlapping start failed.
+			}
 		}
 
 		const extension = this.extensions.get(sourceId);
@@ -107,13 +112,23 @@ export class ExternalEventExtensionManager {
 		}
 
 		const unsubscribers: (() => void)[] = [];
+		const registeredMethods: string[] = [];
 		const trackingHub = new Proxy(hub, {
-			get(target, prop, receiver) {
+			get: (target, prop, receiver) => {
 				if (prop !== 'onRequest') {
 					return Reflect.get(target, prop, receiver);
 				}
 				return (method: string, handler: Parameters<MessageHub['onRequest']>[1]) => {
+					const owner = this.rpcMethodOwners.get(method);
+					if (owner && owner !== sourceId) {
+						throw new Error(
+							`Cannot register external event RPC handler "${method}" for "${sourceId}": ` +
+								`already registered by "${owner}"`
+						);
+					}
 					const unsubscribe = target.onRequest(method, handler);
+					this.rpcMethodOwners.set(method, sourceId);
+					registeredMethods.push(method);
 					unsubscribers.push(unsubscribe);
 					return unsubscribe;
 				};
@@ -124,6 +139,9 @@ export class ExternalEventExtensionManager {
 		} catch (error) {
 			for (const unsubscribe of unsubscribers) {
 				unsubscribe();
+			}
+			for (const method of registeredMethods) {
+				this.rpcMethodOwners.delete(method);
 			}
 			throw error;
 		}
@@ -160,6 +178,11 @@ export class ExternalEventExtensionManager {
 			unsubscribe();
 		}
 		this.rpcUnsubscribers.delete(sourceId);
+		for (const [method, owner] of this.rpcMethodOwners) {
+			if (owner === sourceId) {
+				this.rpcMethodOwners.delete(method);
+			}
+		}
 	}
 
 	private unregisterRoutes(sourceId: string): void {

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -31,7 +31,7 @@ export class ExternalEventExtensionManager {
 	}
 
 	unregister(sourceId: string): void {
-		if (this.started.has(sourceId)) {
+		if (this.started.has(sourceId) || this.starting.has(sourceId)) {
 			throw new Error(`Cannot unregister started external event extension "${sourceId}"`);
 		}
 		this.unregisterRpcHandlers(sourceId);
@@ -57,6 +57,11 @@ export class ExternalEventExtensionManager {
 	}
 
 	async stopExtension(sourceId: string): Promise<void> {
+		const inFlightStart = this.starting.get(sourceId);
+		if (inFlightStart) {
+			await inFlightStart;
+		}
+
 		const extension = this.extensions.get(sourceId);
 		if (!extension || !this.started.has(sourceId)) return;
 		try {

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -11,6 +11,7 @@ export class ExternalEventExtensionManager {
 	private extensions = new Map<string, ExternalEventExtension>();
 	private started = new Map<string, ExternalEventExtensionContext>();
 	private starting = new Map<string, Promise<void>>();
+	private stopping = new Map<string, Promise<void>>();
 	private routeHandlers: RegisteredRoute[] = [];
 	private rpcUnsubscribers = new Map<string, (() => void)[]>();
 	private rpcMethodOwners = new Map<string, string>();
@@ -41,6 +42,10 @@ export class ExternalEventExtensionManager {
 	}
 
 	async startExtension(sourceId: string, context: ExternalEventExtensionContext): Promise<void> {
+		const existingStop = this.stopping.get(sourceId);
+		if (existingStop) {
+			await existingStop;
+		}
 		if (this.started.has(sourceId)) return;
 		const existingStart = this.starting.get(sourceId);
 		if (existingStart) {
@@ -58,23 +63,18 @@ export class ExternalEventExtensionManager {
 	}
 
 	async stopExtension(sourceId: string): Promise<void> {
-		const inFlightStart = this.starting.get(sourceId);
-		if (inFlightStart) {
-			try {
-				await inFlightStart;
-			} catch {
-				// Best-effort stop should not fail just because an overlapping start failed.
-			}
+		const existingStop = this.stopping.get(sourceId);
+		if (existingStop) {
+			await existingStop;
+			return;
 		}
 
-		const extension = this.extensions.get(sourceId);
-		if (!extension || !this.started.has(sourceId)) return;
+		const stopPromise = this.runStopExtension(sourceId);
+		this.stopping.set(sourceId, stopPromise);
 		try {
-			await extension.stop();
+			await stopPromise;
 		} finally {
-			this.started.delete(sourceId);
-			this.unregisterRpcHandlers(sourceId);
-			this.unregisterRoutes(sourceId);
+			this.stopping.delete(sourceId);
 		}
 	}
 
@@ -164,6 +164,27 @@ export class ExternalEventExtensionManager {
 		this.started.set(sourceId, context);
 	}
 
+	private async runStopExtension(sourceId: string): Promise<void> {
+		const inFlightStart = this.starting.get(sourceId);
+		if (inFlightStart) {
+			try {
+				await inFlightStart;
+			} catch {
+				// Best-effort stop should not fail just because an overlapping start failed.
+			}
+		}
+
+		const extension = this.extensions.get(sourceId);
+		if (!extension || !this.started.has(sourceId)) return;
+		try {
+			await extension.stop();
+		} finally {
+			this.started.delete(sourceId);
+			this.unregisterRpcHandlers(sourceId);
+			this.unregisterRoutes(sourceId);
+		}
+	}
+
 	private getRequiredExtension(sourceId: string): ExternalEventExtension {
 		const extension = this.extensions.get(sourceId);
 		if (!extension) {
@@ -190,10 +211,20 @@ export class ExternalEventExtensionManager {
 	}
 
 	private findSourceIdForRoutes(routes: readonly Route[]): string | undefined {
+		const identityMatchingSourceIds: string[] = [];
 		for (const extension of this.extensions.values()) {
 			if (isHttpExtension(extension) && extension.routes === routes) {
-				return extension.sourceId;
+				identityMatchingSourceIds.push(extension.sourceId);
 			}
+		}
+		if (identityMatchingSourceIds.length > 1) {
+			throw new Error(
+				`Cannot infer external event route owner: route array is shared by multiple sources ` +
+					`(${identityMatchingSourceIds.join(', ')}). Each extension must expose a distinct routes array.`
+			);
+		}
+		if (identityMatchingSourceIds.length === 1) {
+			return identityMatchingSourceIds[0];
 		}
 
 		const matchingSourceIds: string[] = [];

--- a/packages/daemon/src/lib/external-events/index.ts
+++ b/packages/daemon/src/lib/external-events/index.ts
@@ -15,6 +15,14 @@ export {
 	type DeliveryFailure,
 	type DeliveryTarget,
 	type StoreResult,
+	type ExternalEventExtensionConfig,
+	type SpaceExternalEventSourceConfig,
+	type ExternalEventExtensionContext,
+	type ExternalEventExtensionConfigStore as ExternalEventExtensionConfigStoreContract,
+	type ExternalEventExtension,
+	type Route,
+	type HttpExternalEventExtension,
+	type RpcExternalEventExtension,
 	TERMINAL_EVENT_STATES,
 	TERMINAL_DELIVERY_STATES,
 } from './types';
@@ -36,3 +44,11 @@ export {
 	type ExternalEventPublishedPayload,
 } from './external-event-service';
 export { TopicTrie, isReceivingStatus } from './topic-trie';
+export {
+	ExternalEventExtensionConfigStore,
+	ensureExternalEventExtensionConfigTables,
+} from './extension-config-store';
+export {
+	ExternalEventExtensionManager,
+	type RegisteredRoute,
+} from './extension-manager';

--- a/packages/daemon/src/lib/external-events/types.ts
+++ b/packages/daemon/src/lib/external-events/types.ts
@@ -10,6 +10,9 @@
  * See docs/plans/design-external-event-bus-for-space-workflow-nodes.md.
  */
 
+import type { MessageHub } from '@neokai/shared/message-hub/message-hub.ts';
+import type { ExternalEventPublisher } from './external-event-service';
+
 /**
  * A normalized external event on the bus.
  *
@@ -137,4 +140,70 @@ export interface DeliveryFailure {
 	terminal: boolean;
 	/** Free-form failure reason for diagnostics (logged + persisted). */
 	reason: string;
+}
+
+export interface ExternalEventExtensionConfig {
+	source: string;
+	globallyEnabled: boolean;
+	capabilities: {
+		webhooks?: boolean;
+		polling?: boolean;
+		rpcConfig?: boolean;
+	};
+	secretsRef?: string;
+	settings?: Record<string, unknown>;
+}
+
+export interface SpaceExternalEventSourceConfig {
+	spaceId: string;
+	source: string;
+	enabled: boolean;
+	settings: Record<string, unknown>;
+}
+
+export interface ExternalEventExtensionContext {
+	/** Publish a normalized event into the shared external-event subsystem. */
+	publisher: ExternalEventPublisher;
+	/** Read global extension config, secrets references, and per-space config. */
+	config: ExternalEventExtensionConfigStore;
+	/** Notify core services that source configuration changed for a space. */
+	onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }): void;
+}
+
+export interface ExternalEventExtensionConfigStore {
+	getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig>;
+	getSpaceConfig(spaceId: string, source: string): Promise<SpaceExternalEventSourceConfig | null>;
+	listEnabledSpaces(source: string): Promise<SpaceExternalEventSourceConfig[]>;
+	setGlobalConfig(source: string, config: ExternalEventExtensionConfig): Promise<void>;
+	setSpaceConfig(
+		spaceId: string,
+		source: string,
+		config: SpaceExternalEventSourceConfig
+	): Promise<void>;
+}
+
+/** Interface that event source extensions must implement. */
+export interface ExternalEventExtension {
+	/** Source identifier used in topic namespace: '{source}/...'. */
+	readonly sourceId: string;
+
+	/** Start the extension. Called once when the source is globally enabled. */
+	start(context: ExternalEventExtensionContext): Promise<void>;
+
+	/** Stop the extension. Called at daemon shutdown or when globally disabled. */
+	stop(): Promise<void>;
+}
+
+export interface Route {
+	readonly method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	readonly path: string;
+	handle(req: Request, context: ExternalEventExtensionContext): Promise<Response>;
+}
+
+export interface HttpExternalEventExtension extends ExternalEventExtension {
+	readonly routes: readonly Route[];
+}
+
+export interface RpcExternalEventExtension extends ExternalEventExtension {
+	registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void;
 }

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -93,6 +93,8 @@ export { runMigration125 } from './migrations';
 export { runMigration126 } from './migrations';
 // knip-ignore-next-line
 export { runMigration127 } from './migrations';
+// knip-ignore-next-line
+export { runMigration128 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8736,32 +8736,6 @@ export function runMigration126(db: BunDatabase): void {
  * repeatedly: rows with a non-null handle are untouched (the SELECT filters
  * them out), so existing handles are always preserved across restarts.
  */
-export function runMigration128(db: BunDatabase): void {
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS external_event_source_configs (
-			source TEXT PRIMARY KEY,
-			globally_enabled INTEGER NOT NULL DEFAULT 0,
-			capabilities_json TEXT NOT NULL,
-			secrets_ref TEXT,
-			settings_json TEXT,
-			created_at INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL
-		)
-	`);
-
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
-			space_id TEXT NOT NULL,
-			source TEXT NOT NULL,
-			enabled INTEGER NOT NULL DEFAULT 0,
-			settings_json TEXT NOT NULL,
-			created_at INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL,
-			PRIMARY KEY(space_id, source)
-		)
-	`);
-}
-
 export function runMigration127(db: BunDatabase): void {
 	if (!tableExists(db, 'space_workflows')) return;
 
@@ -8818,6 +8792,43 @@ export function runMigration127(db: BunDatabase): void {
 		handles.push(handle);
 		spaceHandles.set(row.space_id, handles);
 	}
+}
+
+/**
+ * Migration 128: Add external-event extension configuration tables.
+ *
+ * external_event_source_configs stores global source enablement, capabilities,
+ * secrets references, and source-level settings.
+ *
+ * space_external_event_source_configs stores per-space source enablement and
+ * settings, with a cascading FK to spaces so deleting a space removes its
+ * extension configuration.
+ */
+export function runMigration128(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+			source TEXT PRIMARY KEY,
+			globally_enabled INTEGER NOT NULL DEFAULT 0,
+			capabilities_json TEXT NOT NULL,
+			secrets_ref TEXT,
+			settings_json TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
+			space_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 0,
+			settings_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY(space_id, source),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
 }
 
 /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -614,6 +614,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 127: Add `handle` column to `space_workflows` for human-readable
 	// workflow identifiers (alternative to UUID). Unique per space.
 	runMigration127(db);
+
+	// Migration 128: Add external-event extension configuration tables.
+	runMigration128(db);
 }
 
 /**
@@ -8733,6 +8736,32 @@ export function runMigration126(db: BunDatabase): void {
  * repeatedly: rows with a non-null handle are untouched (the SELECT filters
  * them out), so existing handles are always preserved across restarts.
  */
+export function runMigration128(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+			source TEXT PRIMARY KEY,
+			globally_enabled INTEGER NOT NULL DEFAULT 0,
+			capabilities_json TEXT NOT NULL,
+			secrets_ref TEXT,
+			settings_json TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
+			space_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 0,
+			settings_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY(space_id, source)
+		)
+	`);
+}
+
 export function runMigration127(db: BunDatabase): void {
 	if (!tableExists(db, 'space_workflows')) return;
 

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -298,6 +298,14 @@ describe('scope-config', () => {
 			expect(excluded).toContain('github_filter_configs');
 		});
 
+		it('includes external event bus tables', () => {
+			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('external_event_source_configs');
+			expect(excluded).toContain('space_external_event_source_configs');
+			expect(excluded).toContain('space_external_events');
+			expect(excluded).toContain('space_external_event_deliveries');
+		});
+
 		it('returns a non-empty array', () => {
 			expect(getExcludedTableNames().length).toBeGreaterThan(0);
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
@@ -1,6 +1,7 @@
 import { Database } from 'bun:sqlite';
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { ExternalEventExtensionConfigStore } from '../../../../src/lib/external-events/extension-config-store';
+import { createSpaceTables } from '../../helpers/space-test-db';
 
 let db: Database;
 let store: ExternalEventExtensionConfigStore;
@@ -148,5 +149,38 @@ describe('ExternalEventExtensionConfigStore', () => {
 				settings: {},
 			})
 		).rejects.toThrow('must match');
+	});
+
+	test('rejects array capabilities to keep writes consistent with reads', async () => {
+		await expect(
+			store.setGlobalConfig('github', {
+				source: 'github',
+				globallyEnabled: true,
+				capabilities: [] as unknown as { webhooks?: boolean },
+			})
+		).rejects.toThrow('capabilities must be an object');
+	});
+
+	test('cascades per-space config rows when spaces are deleted', async () => {
+		db.close();
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		store = new ExternalEventExtensionConfigStore(db);
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('space-1', 'space-1', '/tmp/space-1', 'Space 1', now, now);
+
+		await store.setSpaceConfig('space-1', 'github', {
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: { repo: 'one' },
+		});
+
+		db.prepare(`DELETE FROM spaces WHERE id = ?`).run('space-1');
+
+		await expect(store.listEnabledSpaces('github')).resolves.toEqual([]);
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
@@ -1,0 +1,152 @@
+import { Database } from 'bun:sqlite';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { ExternalEventExtensionConfigStore } from '../../../../src/lib/external-events/extension-config-store';
+
+let db: Database;
+let store: ExternalEventExtensionConfigStore;
+
+beforeEach(() => {
+	db = new Database(':memory:');
+	store = new ExternalEventExtensionConfigStore(db);
+});
+
+describe('ExternalEventExtensionConfigStore', () => {
+	test('creates configuration tables on construction', () => {
+		const rows = db
+			.prepare(
+				`SELECT name FROM sqlite_master
+				 WHERE type = 'table' AND name IN (
+					'external_event_source_configs',
+					'space_external_event_source_configs'
+				 )
+				 ORDER BY name`
+			)
+			.all() as { name: string }[];
+
+		expect(rows.map((row) => row.name)).toEqual([
+			'external_event_source_configs',
+			'space_external_event_source_configs',
+		]);
+	});
+
+	test('returns disabled default global config when no row exists', async () => {
+		await expect(store.getGlobalConfig('github')).resolves.toEqual({
+			source: 'github',
+			globallyEnabled: false,
+			capabilities: {},
+		});
+	});
+
+	test('persists and updates global config', async () => {
+		await store.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true, polling: true, rpcConfig: true },
+			secretsRef: 'secret/github',
+			settings: { webhookPath: '/webhooks/github', pollIntervalMs: 60_000 },
+		});
+
+		await expect(store.getGlobalConfig('github')).resolves.toEqual({
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true, polling: true, rpcConfig: true },
+			secretsRef: 'secret/github',
+			settings: { webhookPath: '/webhooks/github', pollIntervalMs: 60_000 },
+		});
+
+		await store.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: false,
+			capabilities: { polling: true },
+			settings: { pollIntervalMs: 120_000 },
+		});
+
+		await expect(store.getGlobalConfig('github')).resolves.toEqual({
+			source: 'github',
+			globallyEnabled: false,
+			capabilities: { polling: true },
+			settings: { pollIntervalMs: 120_000 },
+		});
+	});
+
+	test('persists and updates per-space config', async () => {
+		await expect(store.getSpaceConfig('space-1', 'github')).resolves.toBeNull();
+
+		await store.setSpaceConfig('space-1', 'github', {
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: { owner: 'neokai', repo: 'app' },
+		});
+
+		await expect(store.getSpaceConfig('space-1', 'github')).resolves.toEqual({
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: { owner: 'neokai', repo: 'app' },
+		});
+
+		await store.setSpaceConfig('space-1', 'github', {
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: false,
+			settings: { owner: 'neokai', repo: 'app', branch: 'dev' },
+		});
+
+		await expect(store.getSpaceConfig('space-1', 'github')).resolves.toEqual({
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: false,
+			settings: { owner: 'neokai', repo: 'app', branch: 'dev' },
+		});
+	});
+
+	test('lists only enabled spaces for a source', async () => {
+		await store.setSpaceConfig('space-1', 'github', {
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: { repo: 'one' },
+		});
+		await store.setSpaceConfig('space-2', 'github', {
+			spaceId: 'space-2',
+			source: 'github',
+			enabled: false,
+			settings: { repo: 'two' },
+		});
+		await store.setSpaceConfig('space-3', 'slack', {
+			spaceId: 'space-3',
+			source: 'slack',
+			enabled: true,
+			settings: { channel: 'alerts' },
+		});
+
+		await expect(store.listEnabledSpaces('github')).resolves.toEqual([
+			{
+				spaceId: 'space-1',
+				source: 'github',
+				enabled: true,
+				settings: { repo: 'one' },
+			},
+		]);
+	});
+
+	test('rejects mismatched source and space identifiers', async () => {
+		await expect(
+			store.setGlobalConfig('github', {
+				source: 'slack',
+				globallyEnabled: true,
+				capabilities: {},
+			})
+		).rejects.toThrow('must match');
+
+		await expect(
+			store.setSpaceConfig('space-1', 'github', {
+				spaceId: 'space-2',
+				source: 'github',
+				enabled: true,
+				settings: {},
+			})
+		).rejects.toThrow('must match');
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -156,6 +156,52 @@ describe('ExternalEventExtensionManager', () => {
 		expect(manager.getRegisteredRoutes()).toHaveLength(1);
 	});
 
+	test('throws when cloned route signatures match multiple extensions', () => {
+		const githubRoutes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/events',
+				handle: async () => new Response('github'),
+			},
+		];
+		const slackRoutes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/events',
+				handle: async () => new Response('slack'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes: githubRoutes,
+			async start() {},
+			async stop() {},
+		});
+		manager.register({
+			sourceId: 'slack',
+			routes: slackRoutes,
+			async start() {},
+			async stop() {},
+		});
+
+		expect(() =>
+			manager.registerRoutes(
+				[
+					{
+						method: 'POST' as const,
+						path: '/webhooks/events',
+						handle: async () => new Response('clone'),
+					},
+				],
+				context
+			)
+		).toThrow('multiple sources');
+
+		manager.registerRoutes(slackRoutes, context);
+		expect(manager.getRegisteredRoutes()).toHaveLength(1);
+		expect(manager.getRegisteredRoutes()[0]!.sourceId).toBe('slack');
+	});
+
 	test('removes source route handlers on stop', async () => {
 		const routes = [
 			{

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -1,0 +1,150 @@
+import { Database } from 'bun:sqlite';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { ExternalEventExtensionConfigStore } from '../../../../src/lib/external-events/extension-config-store';
+import { MessageHub } from '@neokai/shared/message-hub/message-hub.ts';
+import { ExternalEventExtensionManager } from '../../../../src/lib/external-events/extension-manager';
+import type {
+	ExternalEventExtension,
+	ExternalEventExtensionContext,
+	RpcExternalEventExtension,
+} from '../../../../src/lib/external-events/types';
+
+let db: Database;
+let config: ExternalEventExtensionConfigStore;
+let context: ExternalEventExtensionContext;
+let manager: ExternalEventExtensionManager;
+
+beforeEach(() => {
+	db = new Database(':memory:');
+	config = new ExternalEventExtensionConfigStore(db);
+	context = {
+		publisher: { publish: async () => ({ outcome: 'published', eventId: 'evt-1' }) },
+		config,
+		onSourceConfigChanged() {},
+	};
+	manager = new ExternalEventExtensionManager();
+});
+
+describe('ExternalEventExtensionManager', () => {
+	test('registers and unregisters extensions', () => {
+		const extension = createExtension('github');
+
+		manager.register(extension);
+		expect(manager.getExtension('github')).toBe(extension);
+
+		manager.unregister('github');
+		expect(manager.getExtension('github')).toBeUndefined();
+	});
+
+	test('rejects duplicate registrations', () => {
+		manager.register(createExtension('github'));
+		expect(() => manager.register(createExtension('github'))).toThrow('already registered');
+	});
+
+	test('does not start globally disabled extensions', async () => {
+		const extension = createExtension('github');
+		manager.register(extension);
+
+		await manager.startExtension('github', context);
+
+		expect(extension.starts).toBe(0);
+		expect(extension.stops).toBe(0);
+	});
+
+	test('starts and stops globally enabled extensions once', async () => {
+		const extension = createExtension('github');
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		await manager.startExtension('github', context);
+		await manager.startExtension('github', context);
+		expect(extension.starts).toBe(1);
+
+		await manager.stopExtension('github');
+		await manager.stopExtension('github');
+		expect(extension.stops).toBe(1);
+	});
+
+	test('allows restart after stop when still globally enabled', async () => {
+		const extension = createExtension('github');
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: {},
+		});
+
+		await manager.startExtension('github', context);
+		await manager.stopExtension('github');
+		await manager.startExtension('github', context);
+
+		expect(extension.starts).toBe(2);
+		expect(extension.stops).toBe(1);
+	});
+
+	test('registers and unregisters RPC handlers through tracked unsubscribe callbacks', () => {
+		const calls: string[] = [];
+		const hub = new MessageHub();
+		const originalOnRequest = hub.onRequest.bind(hub);
+		hub.onRequest = ((method, handler) => {
+			calls.push(`register:${method}`);
+			const unsubscribe = originalOnRequest(method, handler);
+			return () => {
+				calls.push(`unregister:${method}`);
+				unsubscribe();
+			};
+		}) as MessageHub['onRequest'];
+		const extension: RpcExternalEventExtension = {
+			sourceId: 'github',
+			async start() {},
+			async stop() {},
+			registerRpcHandlers(hubLike) {
+				hubLike.onRequest('space.github.watchRepo', () => ({ ok: true }));
+				hubLike.onRequest('space.github.pollOnce', () => ({ ok: true }));
+			},
+		};
+		manager.register(extension);
+
+		manager.registerRpcHandlers('github', hub, context);
+		expect(calls).toEqual(['register:space.github.watchRepo', 'register:space.github.pollOnce']);
+
+		manager.registerRpcHandlers('github', hub, context);
+		expect(calls).toEqual([
+			'register:space.github.watchRepo',
+			'register:space.github.pollOnce',
+			'unregister:space.github.watchRepo',
+			'unregister:space.github.pollOnce',
+			'register:space.github.watchRepo',
+			'register:space.github.pollOnce',
+		]);
+
+		manager.unregister('github');
+		expect(calls.slice(-2)).toEqual([
+			'unregister:space.github.watchRepo',
+			'unregister:space.github.pollOnce',
+		]);
+	});
+});
+
+interface TestExtension extends ExternalEventExtension {
+	starts: number;
+	stops: number;
+}
+
+function createExtension(sourceId: string): TestExtension {
+	return {
+		sourceId,
+		starts: 0,
+		stops: 0,
+		async start() {
+			this.starts += 1;
+		},
+		async stop() {
+			this.stops += 1;
+		},
+	};
+}

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -41,6 +41,10 @@ describe('ExternalEventExtensionManager', () => {
 		expect(() => manager.register(createExtension('github'))).toThrow('already registered');
 	});
 
+	test('rejects source IDs with edge whitespace', () => {
+		expect(() => manager.register(createExtension(' github '))).toThrow('edge whitespace');
+	});
+
 	test('does not start globally disabled extensions', async () => {
 		const extension = createExtension('github');
 		manager.register(extension);
@@ -86,6 +90,99 @@ describe('ExternalEventExtensionManager', () => {
 		expect(extension.stops).toBe(1);
 	});
 
+	test('removes registered routes for source-owned route arrays on unregister', () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github',
+				handle: async () => new Response('ok'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+
+		manager.registerRoutes(routes, context);
+		expect(manager.getRegisteredRoutes()).toHaveLength(1);
+		expect(manager.getRegisteredRoutes()[0]!.sourceId).toBe('github');
+
+		manager.unregister('github');
+		expect(manager.getRegisteredRoutes()).toHaveLength(0);
+	});
+
+	test('assigns source ownership for cloned route arrays by method and path', () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github',
+				handle: async () => new Response('ok'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+
+		manager.registerRoutes(
+			routes.map((route) => ({ ...route })),
+			context
+		);
+		expect(manager.getRegisteredRoutes()).toHaveLength(1);
+		expect(manager.getRegisteredRoutes()[0]!.sourceId).toBe('github');
+	});
+
+	test('deduplicates route handlers when routes are registered repeatedly', () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github',
+				handle: async () => new Response('ok'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+
+		manager.registerRoutes(routes, context);
+		manager.registerRoutes(routes, context);
+		expect(manager.getRegisteredRoutes()).toHaveLength(1);
+	});
+
+	test('removes source route handlers on stop', async () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github',
+				handle: async () => new Response('ok'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		await manager.startExtension('github', context);
+		manager.registerRoutes(routes, context);
+		await manager.stopExtension('github');
+
+		expect(manager.getRegisteredRoutes()).toHaveLength(0);
+	});
+
 	test('registers and unregisters RPC handlers through tracked unsubscribe callbacks', () => {
 		const calls: string[] = [];
 		const hub = new MessageHub();
@@ -127,6 +224,35 @@ describe('ExternalEventExtensionManager', () => {
 			'unregister:space.github.watchRepo',
 			'unregister:space.github.pollOnce',
 		]);
+	});
+
+	test('cleans up partially registered RPC handlers when extension registration throws', () => {
+		const calls: string[] = [];
+		const hub = new MessageHub();
+		const originalOnRequest = hub.onRequest.bind(hub);
+		hub.onRequest = ((method, handler) => {
+			calls.push(`register:${method}`);
+			const unsubscribe = originalOnRequest(method, handler);
+			return () => {
+				calls.push(`unregister:${method}`);
+				unsubscribe();
+			};
+		}) as MessageHub['onRequest'];
+		const extension: RpcExternalEventExtension = {
+			sourceId: 'github',
+			async start() {},
+			async stop() {},
+			registerRpcHandlers(hubLike) {
+				hubLike.onRequest('space.github.watchRepo', () => ({ ok: true }));
+				throw new Error('registration failed');
+			},
+		};
+		manager.register(extension);
+
+		expect(() => manager.registerRpcHandlers('github', hub, context)).toThrow(
+			'registration failed'
+		);
+		expect(calls).toEqual(['register:space.github.watchRepo', 'unregister:space.github.watchRepo']);
 	});
 });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -136,6 +136,67 @@ describe('ExternalEventExtensionManager', () => {
 		expect(manager.getRegisteredRoutes()[0]!.sourceId).toBe('github');
 	});
 
+	test('assigns source ownership for cloned route arrays regardless of order', () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github/issues',
+				handle: async () => new Response('issues'),
+			},
+			{
+				method: 'POST' as const,
+				path: '/webhooks/github/pulls',
+				handle: async () => new Response('pulls'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+
+		manager.registerRoutes(
+			routes.toReversed().map((route) => ({ ...route })),
+			context
+		);
+
+		expect(manager.getRegisteredRoutes()).toHaveLength(2);
+		expect(manager.getRegisteredRoutes().map((route) => route.sourceId)).toEqual([
+			'github',
+			'github',
+		]);
+	});
+
+	test('rejects route arrays that do not belong to a registered extension', () => {
+		manager.register({
+			sourceId: 'github',
+			routes: [
+				{
+					method: 'POST' as const,
+					path: '/webhooks/github',
+					handle: async () => new Response('ok'),
+				},
+			],
+			async start() {},
+			async stop() {},
+		});
+
+		expect(() =>
+			manager.registerRoutes(
+				[
+					{
+						method: 'POST' as const,
+						path: '/webhooks/slack',
+						handle: async () => new Response('ok'),
+					},
+				],
+				context
+			)
+		).toThrow('do not match a registered source');
+		expect(manager.getRegisteredRoutes()).toHaveLength(0);
+	});
+
 	test('deduplicates route handlers when routes are registered repeatedly', () => {
 		const routes = [
 			{

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -73,6 +73,39 @@ describe('ExternalEventExtensionManager', () => {
 		expect(extension.stops).toBe(1);
 	});
 
+	test('serializes concurrent starts for the same extension', async () => {
+		let releaseStart: (() => void) | undefined;
+		const extension: TestExtension = {
+			sourceId: 'github',
+			starts: 0,
+			stops: 0,
+			async start() {
+				this.starts += 1;
+				await new Promise<void>((resolve) => {
+					releaseStart = resolve;
+				});
+			},
+			async stop() {
+				this.stops += 1;
+			},
+		};
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		const firstStart = manager.startExtension('github', context);
+		const secondStart = manager.startExtension('github', context);
+		await waitFor(() => releaseStart !== undefined);
+
+		releaseStart!();
+		await Promise.all([firstStart, secondStart]);
+
+		expect(extension.starts).toBe(1);
+	});
+
 	test('allows restart after stop when still globally enabled', async () => {
 		const extension = createExtension('github');
 		manager.register(extension);
@@ -380,4 +413,12 @@ function createExtension(sourceId: string): TestExtension {
 			this.stops += 1;
 		},
 	};
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempts = 0; attempts < 10; attempts += 1) {
+		if (predicate()) return;
+		await Promise.resolve();
+	}
+	throw new Error('Timed out waiting for condition');
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -74,21 +74,7 @@ describe('ExternalEventExtensionManager', () => {
 	});
 
 	test('serializes concurrent starts for the same extension', async () => {
-		let releaseStart: (() => void) | undefined;
-		const extension: TestExtension = {
-			sourceId: 'github',
-			starts: 0,
-			stops: 0,
-			async start() {
-				this.starts += 1;
-				await new Promise<void>((resolve) => {
-					releaseStart = resolve;
-				});
-			},
-			async stop() {
-				this.stops += 1;
-			},
-		};
+		const { extension, releaseStart } = createBlockedStartExtension('github');
 		manager.register(extension);
 		await config.setGlobalConfig('github', {
 			source: 'github',
@@ -98,12 +84,53 @@ describe('ExternalEventExtensionManager', () => {
 
 		const firstStart = manager.startExtension('github', context);
 		const secondStart = manager.startExtension('github', context);
-		await waitFor(() => releaseStart !== undefined);
+		await releaseStart.waitUntilBlocked();
 
-		releaseStart!();
+		releaseStart.resolve();
 		await Promise.all([firstStart, secondStart]);
 
 		expect(extension.starts).toBe(1);
+	});
+
+	test('rejects unregister while start is in flight', async () => {
+		const { extension, releaseStart } = createBlockedStartExtension('github');
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		const start = manager.startExtension('github', context);
+		await releaseStart.waitUntilBlocked();
+
+		expect(() => manager.unregister('github')).toThrow('started external event extension');
+
+		releaseStart.resolve();
+		await start;
+		await manager.stopExtension('github');
+		expect(extension.starts).toBe(1);
+		expect(extension.stops).toBe(1);
+	});
+
+	test('waits for in-flight start before stopping extension', async () => {
+		const { extension, releaseStart } = createBlockedStartExtension('github');
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		const start = manager.startExtension('github', context);
+		await releaseStart.waitUntilBlocked();
+		const stop = manager.stopExtension('github');
+
+		releaseStart.resolve();
+		await Promise.all([start, stop]);
+
+		expect(extension.starts).toBe(1);
+		expect(extension.stops).toBe(1);
 	});
 
 	test('allows restart after stop when still globally enabled', async () => {
@@ -413,6 +440,44 @@ function createExtension(sourceId: string): TestExtension {
 			this.stops += 1;
 		},
 	};
+}
+
+function createBlockedStartExtension(sourceId: string): {
+	extension: TestExtension;
+	releaseStart: BlockedStartHandle;
+} {
+	let resolveStart: (() => void) | undefined;
+	const releaseStart: BlockedStartHandle = {
+		resolve() {
+			if (!resolveStart) throw new Error('Start is not blocked yet');
+			resolveStart();
+		},
+		async waitUntilBlocked() {
+			await waitFor(() => resolveStart !== undefined);
+		},
+	};
+	return {
+		extension: {
+			sourceId,
+			starts: 0,
+			stops: 0,
+			async start() {
+				this.starts += 1;
+				await new Promise<void>((resolve) => {
+					resolveStart = resolve;
+				});
+			},
+			async stop() {
+				this.stops += 1;
+			},
+		},
+		releaseStart,
+	};
+}
+
+interface BlockedStartHandle {
+	resolve(): void;
+	waitUntilBlocked(): Promise<void>;
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -92,6 +92,39 @@ describe('ExternalEventExtensionManager', () => {
 		expect(extension.starts).toBe(1);
 	});
 
+	test('retries start after awaiting an in-flight start that did not start', async () => {
+		const extension = createExtension('github');
+		let configReads = 0;
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: false,
+			capabilities: { webhooks: true },
+		});
+		const originalGetGlobalConfig = config.getGlobalConfig.bind(config);
+		config.getGlobalConfig = async (source) => {
+			configReads += 1;
+			await Promise.resolve();
+			return originalGetGlobalConfig(source);
+		};
+
+		const firstStart = manager.startExtension('github', context);
+		const secondStart = (async () => {
+			await waitFor(() => configReads > 0);
+			await config.setGlobalConfig('github', {
+				source: 'github',
+				globallyEnabled: true,
+				capabilities: { webhooks: true },
+			});
+			await manager.startExtension('github', context);
+		})();
+
+		await Promise.all([firstStart, secondStart]);
+
+		expect(extension.starts).toBe(1);
+		expect(configReads).toBe(2);
+	});
+
 	test('rejects unregister while start is in flight', async () => {
 		const { extension, releaseStart } = createBlockedStartExtension('github');
 		manager.register(extension);
@@ -131,6 +164,36 @@ describe('ExternalEventExtensionManager', () => {
 
 		expect(extension.starts).toBe(1);
 		expect(extension.stops).toBe(1);
+	});
+
+	test('swallows in-flight start failures while stopping extension', async () => {
+		const extension: TestExtension = {
+			sourceId: 'github',
+			starts: 0,
+			stops: 0,
+			async start() {
+				this.starts += 1;
+				await Promise.resolve();
+				throw new Error('start failed');
+			},
+			async stop() {
+				this.stops += 1;
+			},
+		};
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		const start = manager.startExtension('github', context);
+		const stop = manager.stopExtension('github');
+
+		await expect(start).rejects.toThrow('start failed');
+		await expect(stop).resolves.toBeUndefined();
+		expect(extension.starts).toBe(1);
+		expect(extension.stops).toBe(0);
 	});
 
 	test('allows restart after stop when still globally enabled', async () => {
@@ -421,11 +484,52 @@ describe('ExternalEventExtensionManager', () => {
 		);
 		expect(calls).toEqual(['register:space.github.watchRepo', 'unregister:space.github.watchRepo']);
 	});
+
+	test('rejects RPC handler methods already owned by another extension', () => {
+		const calls: string[] = [];
+		const hub = new MessageHub();
+		const originalOnRequest = hub.onRequest.bind(hub);
+		hub.onRequest = ((method, handler) => {
+			calls.push(`register:${method}`);
+			const unsubscribe = originalOnRequest(method, handler);
+			return () => {
+				calls.push(`unregister:${method}`);
+				unsubscribe();
+			};
+		}) as MessageHub['onRequest'];
+		manager.register(createRpcExtension('github', 'space.external.sync'));
+		manager.register(createRpcExtension('slack', 'space.external.sync'));
+
+		manager.registerRpcHandlers('github', hub, context);
+		expect(() => manager.registerRpcHandlers('slack', hub, context)).toThrow(
+			'already registered by "github"'
+		);
+		expect(calls).toEqual(['register:space.external.sync']);
+
+		manager.unregister('github');
+		manager.registerRpcHandlers('slack', hub, context);
+		expect(calls).toEqual([
+			'register:space.external.sync',
+			'unregister:space.external.sync',
+			'register:space.external.sync',
+		]);
+	});
 });
 
 interface TestExtension extends ExternalEventExtension {
 	starts: number;
 	stops: number;
+}
+
+function createRpcExtension(sourceId: string, method: string): RpcExternalEventExtension {
+	return {
+		sourceId,
+		async start() {},
+		async stop() {},
+		registerRpcHandlers(hubLike) {
+			hubLike.onRequest(method, () => ({ ok: true }));
+		},
+	};
 }
 
 function createExtension(sourceId: string): TestExtension {

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-manager.test.ts
@@ -213,6 +213,27 @@ describe('ExternalEventExtensionManager', () => {
 		expect(extension.stops).toBe(1);
 	});
 
+	test('waits for an in-flight stop before starting again', async () => {
+		const { extension, releaseStop } = createBlockedStopExtension('github');
+		manager.register(extension);
+		await config.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		await manager.startExtension('github', context);
+		const stop = manager.stopExtension('github');
+		await releaseStop.waitUntilBlocked();
+		const start = manager.startExtension('github', context);
+
+		releaseStop.resolve();
+		await Promise.all([stop, start]);
+
+		expect(extension.starts).toBe(2);
+		expect(extension.stops).toBe(1);
+	});
+
 	test('removes registered routes for source-owned route arrays on unregister', () => {
 		const routes = [
 			{
@@ -338,6 +359,31 @@ describe('ExternalEventExtensionManager', () => {
 		manager.registerRoutes(routes, context);
 		manager.registerRoutes(routes, context);
 		expect(manager.getRegisteredRoutes()).toHaveLength(1);
+	});
+
+	test('throws when route array identity matches multiple extensions', () => {
+		const routes = [
+			{
+				method: 'POST' as const,
+				path: '/webhooks/events',
+				handle: async () => new Response('ok'),
+			},
+		];
+		manager.register({
+			sourceId: 'github',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+		manager.register({
+			sourceId: 'slack',
+			routes,
+			async start() {},
+			async stop() {},
+		});
+
+		expect(() => manager.registerRoutes(routes, context)).toThrow('shared by multiple sources');
+		expect(manager.getRegisteredRoutes()).toHaveLength(0);
 	});
 
 	test('throws when cloned route signatures match multiple extensions', () => {
@@ -548,18 +594,10 @@ function createExtension(sourceId: string): TestExtension {
 
 function createBlockedStartExtension(sourceId: string): {
 	extension: TestExtension;
-	releaseStart: BlockedStartHandle;
+	releaseStart: BlockedLifecycleHandle;
 } {
 	let resolveStart: (() => void) | undefined;
-	const releaseStart: BlockedStartHandle = {
-		resolve() {
-			if (!resolveStart) throw new Error('Start is not blocked yet');
-			resolveStart();
-		},
-		async waitUntilBlocked() {
-			await waitFor(() => resolveStart !== undefined);
-		},
-	};
+	const releaseStart = createBlockedLifecycleHandle(() => resolveStart);
 	return {
 		extension: {
 			sourceId,
@@ -579,7 +617,47 @@ function createBlockedStartExtension(sourceId: string): {
 	};
 }
 
-interface BlockedStartHandle {
+function createBlockedStopExtension(sourceId: string): {
+	extension: TestExtension;
+	releaseStop: BlockedLifecycleHandle;
+} {
+	let resolveStop: (() => void) | undefined;
+	const releaseStop = createBlockedLifecycleHandle(() => resolveStop);
+	return {
+		extension: {
+			sourceId,
+			starts: 0,
+			stops: 0,
+			async start() {
+				this.starts += 1;
+			},
+			async stop() {
+				this.stops += 1;
+				await new Promise<void>((resolve) => {
+					resolveStop = resolve;
+				});
+			},
+		},
+		releaseStop,
+	};
+}
+
+function createBlockedLifecycleHandle(
+	getResolver: () => (() => void) | undefined
+): BlockedLifecycleHandle {
+	return {
+		resolve() {
+			const resolver = getResolver();
+			if (!resolver) throw new Error('Lifecycle operation is not blocked yet');
+			resolver();
+		},
+		async waitUntilBlocked() {
+			await waitFor(() => getResolver() !== undefined);
+		},
+	};
+}
+
+interface BlockedLifecycleHandle {
 	resolve(): void;
 	waitUntilBlocked(): Promise<void>;
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -1,0 +1,78 @@
+import { Database } from 'bun:sqlite';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { runMigration128 } from '../../../../../src/storage/schema/index.ts';
+
+let db: Database;
+
+beforeEach(() => {
+	db = new Database(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL,
+			workspace_path TEXT NOT NULL,
+			name TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+});
+
+describe('Migration 128: external event extension config tables', () => {
+	test('creates global source config table with expected columns', () => {
+		runMigration128(db);
+
+		const columns = columnNames('external_event_source_configs');
+		expect(columns).toEqual([
+			'source',
+			'globally_enabled',
+			'capabilities_json',
+			'secrets_ref',
+			'settings_json',
+			'created_at',
+			'updated_at',
+		]);
+	});
+
+	test('creates per-space source config table with cascading space foreign key', () => {
+		runMigration128(db);
+
+		const columns = columnNames('space_external_event_source_configs');
+		expect(columns).toEqual([
+			'space_id',
+			'source',
+			'enabled',
+			'settings_json',
+			'created_at',
+			'updated_at',
+		]);
+
+		const fks = db
+			.prepare(`PRAGMA foreign_key_list('space_external_event_source_configs')`)
+			.all() as Array<{
+			from: string;
+			table: string;
+			to: string;
+			on_delete: string;
+		}>;
+		expect(fks).toContainEqual(
+			expect.objectContaining({
+				from: 'space_id',
+				table: 'spaces',
+				to: 'id',
+				on_delete: 'CASCADE',
+			})
+		);
+	});
+
+	test('is idempotent', () => {
+		runMigration128(db);
+		expect(() => runMigration128(db)).not.toThrow();
+	});
+});
+
+function columnNames(table: string): string[] {
+	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
+	return rows.map((row) => row.name);
+}

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -372,6 +372,30 @@ export function createSpaceTables(db: BunDatabase): void {
 			`WHERE idempotency_key IS NOT NULL`
 	);
 
+	// External Event Bus extension configuration tables.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+			source TEXT PRIMARY KEY,
+			globally_enabled INTEGER NOT NULL DEFAULT 0,
+			capabilities_json TEXT NOT NULL,
+			secrets_ref TEXT,
+			settings_json TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
+			space_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			enabled INTEGER NOT NULL DEFAULT 0,
+			settings_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY(space_id, source)
+		)
+	`);
+
 	// External Event Bus tables (migration 124 — simplified schema)
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_external_events (

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -392,7 +392,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			settings_json TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
-			PRIMARY KEY(space_id, source)
+			PRIMARY KEY(space_id, source),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
 


### PR DESCRIPTION
Adds the external event extension config store and manager framework for source lifecycle, route registration, and RPC handler registration.

Tests: bun run check; ./scripts/test-daemon.sh 4-space-storage