### PR TITLE
Extract GitHub event extension

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -410,7 +410,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		},
 	};
 	githubEventExtension.registerRpcHandlers(messageHub, externalEventExtensionContext);
-	await githubEventExtension.start(externalEventExtensionContext);
 
 	// Setup RPC handlers (returns cleanup function + exposed services)
 	const {
@@ -440,6 +439,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		mcpImportService,
 	});
 	taskAgentManagerForGithub = taskAgentManager;
+	await githubEventExtension.start(externalEventExtensionContext);
 
 	// Wait for SpaceRuntimeService startup provisioning to complete before we
 	// bind the WebSocket/HTTP server. `start()` inside `setupRPCHandlers` kicks

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -390,13 +390,17 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	);
 	const externalEventStore = new ExternalEventStore(db.getDatabase());
 	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
+	const githubEventPollingEnabled = !!(
+		config.githubPollingInterval && config.githubPollingInterval > 0
+	);
 	const githubEventConfig = new StaticExternalEventExtensionConfigStore({
 		globallyEnabled: true,
 		webhooks: true,
-		polling: true,
+		polling: githubEventPollingEnabled,
 	});
 	const githubEventExtension = new GitHubEventExtension(spaceGitHubService.eventExtensionRepo, {
 		githubToken: process.env.GITHUB_TOKEN,
+		pollIntervalMs: githubEventPollingEnabled ? config.githubPollingInterval! * 1000 : undefined,
 		onWatchedReposChanged: () => reactiveDb.notifyChange('space_github_watched_repos'),
 		legacyIngest: async (spaceId, event) => {
 			await spaceGitHubService.ingest(spaceId, event);

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -398,6 +398,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const githubEventExtension = new GitHubEventExtension(spaceGitHubService.eventExtensionRepo, {
 		githubToken: process.env.GITHUB_TOKEN,
 		onWatchedReposChanged: () => reactiveDb.notifyChange('space_github_watched_repos'),
+		legacyIngest: async (spaceId, event) => {
+			await spaceGitHubService.ingest(spaceId, event);
+		},
 	});
 	const externalEventExtensionContext = {
 		publisher: externalEventService,

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -21,6 +21,11 @@ import { WebSocketServerTransport } from './lib/websocket-server-transport';
 import { createWebSocketHandlers } from './routes/setup-websocket';
 import { createGitHubService, type GitHubService } from './lib/github/github-service';
 import { SpaceGitHubService } from './lib/github/space-github';
+import { ExternalEventService, ExternalEventStore } from './lib/external-events';
+import {
+	GitHubEventExtension,
+	StaticExternalEventExtensionConfigStore,
+} from './lib/external-events/github';
 import { getProviderRegistry } from './lib/providers/registry.js';
 import { createReactiveDatabase } from './storage/reactive-database';
 import { LiveQueryEngine } from './storage/live-query';
@@ -80,8 +85,10 @@ export interface DaemonAppContext {
 	 * GitHub service instance (null if not configured)
 	 */
 	gitHubService: GitHubService | null;
-	/** Space-level GitHub PR activity ingestion service */
+	/** Legacy Space-level GitHub PR activity ingestion service */
 	spaceGitHubService: SpaceGitHubService;
+	/** GitHub external-event source extension */
+	githubEventExtension: GitHubEventExtension;
 	/** Phase 2: Reactive database wrapper for change event emission */
 	reactiveDb: ReturnType<typeof createReactiveDatabase>;
 	/** Phase 2: Live query engine for reactive SQL queries */
@@ -381,6 +388,26 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		process.env.GITHUB_TOKEN,
 		() => reactiveDb.notifyChange('space_github_events')
 	);
+	const externalEventStore = new ExternalEventStore(db.getDatabase());
+	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
+	const githubEventConfig = new StaticExternalEventExtensionConfigStore({
+		globallyEnabled: true,
+		webhooks: true,
+		polling: true,
+	});
+	const githubEventExtension = new GitHubEventExtension(spaceGitHubService.eventExtensionRepo, {
+		githubToken: process.env.GITHUB_TOKEN,
+		onWatchedReposChanged: () => reactiveDb.notifyChange('space_github_watched_repos'),
+	});
+	const externalEventExtensionContext = {
+		publisher: externalEventService,
+		config: githubEventConfig,
+		onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
+			if (change.source === 'github') reactiveDb.notifyChange('space_github_watched_repos');
+		},
+	};
+	githubEventExtension.registerRpcHandlers(messageHub, externalEventExtensionContext);
+	await githubEventExtension.start(externalEventExtensionContext);
 
 	// Setup RPC handlers (returns cleanup function + exposed services)
 	const {
@@ -479,8 +506,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			}
 
 			// Space-level public-safe GitHub webhook endpoint.
-			if (url.pathname === '/webhook/github/space' && req.method === 'POST') {
-				return spaceGitHubService.handleWebhook(req);
+			const githubExtensionRoute = githubEventExtension.routes.find(
+				(route) => route.path === url.pathname && route.method === req.method
+			);
+			if (githubExtensionRoute) {
+				return githubExtensionRoute.handle(req);
 			}
 
 			// Legacy room GitHub webhook endpoint (kept as a compatibility alias only).
@@ -785,6 +815,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				gitHubService.stop();
 				logInfo('[Daemon] GitHub service stopped');
 			}
+			await githubEventExtension.stop();
+			logInfo('[Daemon] GitHub event extension stopped');
 
 			// Stop all Task Agent sessions before sessionManager.cleanup() so that
 			// Task Agent sessions are interrupted cleanly before the session pool drains.
@@ -834,6 +866,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		queryBus,
 		gitHubService,
 		spaceGitHubService,
+		githubEventExtension,
 		reactiveDb,
 		liveQueries,
 		spaceAgentManager,

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -517,7 +517,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				(route) => route.path === url.pathname && route.method === req.method
 			);
 			if (githubExtensionRoute) {
-				return githubExtensionRoute.handle(req);
+				return githubExtensionRoute.handle(req, externalEventExtensionContext);
 			}
 
 			// Legacy room GitHub webhook endpoint (kept as a compatibility alias only).

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -42,6 +42,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 	readonly repo: GitHubEventExtensionRepository;
 	private context?: ExternalEventExtensionContext;
 	private pollTimer?: ReturnType<typeof setTimeout>;
+	private activePollCycle?: Promise<void>;
 	private stopped = true;
 
 	constructor(
@@ -65,6 +66,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		this.stopped = true;
 		if (this.pollTimer) clearTimeout(this.pollTimer);
 		this.pollTimer = undefined;
+		await this.activePollCycle;
 	}
 
 	registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void {
@@ -150,7 +152,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		if (!this.context)
 			return Response.json({ error: 'GitHub extension not started' }, { status: 503 });
 		const global = await this.context.config.getGlobalConfig(this.sourceId);
-		if (!global.globallyEnabled || !global.capabilities.webhooks) {
+		if (!global.globallyEnabled || global.capabilities.webhooks === false) {
 			return Response.json(
 				{ message: 'Event ignored', reason: 'github_extension_disabled' },
 				{ status: 202 }
@@ -241,7 +243,9 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		if (this.stopped) return;
 		if (this.pollTimer) clearTimeout(this.pollTimer);
 		this.pollTimer = setTimeout(() => {
-			void this.runPollCycle();
+			this.activePollCycle = this.runPollCycle().finally(() => {
+				this.activePollCycle = undefined;
+			});
 		}, this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
 		this.pollTimer.unref?.();
 	}
@@ -254,7 +258,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 				error: error instanceof Error ? error.message : String(error),
 			});
 		} finally {
-			this.scheduleNextPoll();
+			if (!this.stopped) this.scheduleNextPoll();
 		}
 	}
 

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -36,7 +36,11 @@ interface GitHubEventExtensionOptions {
 export class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEventExtension {
 	readonly sourceId = 'github';
 	readonly routes = [
-		{ method: 'POST', path: '/webhook/github/space', handle: this.handleWebhook.bind(this) },
+		{
+			method: 'POST',
+			path: '/webhook/github/space',
+			handle: (req: Request, _context: ExternalEventExtensionContext) => this.handleWebhook(req),
+		},
 	] as const;
 
 	readonly repo: GitHubEventExtensionRepository;
@@ -371,4 +375,15 @@ export class StaticExternalEventExtensionConfigStore implements ExternalEventExt
 		// rows as the source of enabled spaces for the migration period.
 		return [];
 	}
+
+	async setGlobalConfig(
+		_source: string,
+		_config: Awaited<ReturnType<ExternalEventExtensionConfigStore['getGlobalConfig']>>
+	): Promise<void> {}
+
+	async setSpaceConfig(
+		_spaceId: string,
+		_source: string,
+		_config: SpaceExternalEventSourceConfig
+	): Promise<void> {}
 }

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -27,6 +27,10 @@ interface GitHubEventExtensionOptions {
 	githubToken?: string;
 	pollIntervalMs?: number;
 	onWatchedReposChanged?: () => void;
+	legacyIngest?: (
+		spaceId: string,
+		event: import('./github-normalizer').NormalizedGitHubEvent
+	) => Promise<void>;
 }
 
 export class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEventExtension {
@@ -53,8 +57,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 	async start(context: ExternalEventExtensionContext): Promise<void> {
 		this.context = context;
 		this.stopped = false;
-		const global = await context.config.getGlobalConfig(this.sourceId);
-		if (!global.globallyEnabled || !global.capabilities.polling) return;
+		if (!(await this.isPollingGloballyEnabled())) return;
 		this.scheduleNextPoll();
 	}
 
@@ -195,7 +198,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		for (const repo of validForRepo) {
 			const spaceConfig = await this.context.config.getSpaceConfig(repo.spaceId, this.sourceId);
 			if (spaceConfig && !spaceConfig.enabled) continue;
-			await this.context.publisher.publish(toExternalEvent(repo.spaceId, normalized));
+			await this.publishAndLegacyIngest(repo.spaceId, normalized);
 			this.repo.markWebhookReceived(repo.id);
 			published++;
 		}
@@ -205,8 +208,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 
 	private async pollEnabledSpaces(): Promise<number> {
 		if (!this.context) return 0;
-		const global = await this.context.config.getGlobalConfig(this.sourceId);
-		if (!global.globallyEnabled || !global.capabilities.polling) return 0;
+		if (!(await this.isPollingGloballyEnabled())) return 0;
 		const enabledSpaces = await this.context.config.listEnabledSpaces(this.sourceId);
 		if (enabledSpaces.length > 0) {
 			let count = 0;
@@ -220,12 +222,19 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 
 	private async pollSpace(spaceId: string): Promise<number> {
 		if (!this.context) return 0;
+		if (!(await this.isPollingGloballyEnabled())) return 0;
 		const spaceConfig = await this.context.config.getSpaceConfig(spaceId, this.sourceId);
 		if (spaceConfig && !spaceConfig.enabled) return 0;
 		let count = 0;
 		for (const repo of this.repo.listPollingRepos(spaceId))
 			count += await this.pollWatchedRepo(repo);
 		return count;
+	}
+
+	private async isPollingGloballyEnabled(): Promise<boolean> {
+		if (!this.context) return false;
+		const global = await this.context.config.getGlobalConfig(this.sourceId);
+		return global.globallyEnabled && global.capabilities.polling !== false;
 	}
 
 	private scheduleNextPoll(): void {
@@ -249,7 +258,16 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		}
 	}
 
-	private async pollWatchedRepo(
+	private async publishAndLegacyIngest(
+		spaceId: string,
+		event: import('./github-normalizer').NormalizedGitHubEvent
+	): Promise<void> {
+		if (!this.context) return;
+		await this.context.publisher.publish(toExternalEvent(spaceId, event));
+		await this.options.legacyIngest?.(spaceId, event);
+	}
+
+	async pollWatchedRepo(
 		watched: GitHubWatchedRepo,
 		fetchImpl: typeof fetch = fetch
 	): Promise<number> {
@@ -299,7 +317,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			for (const row of rows) {
 				const event = normalizeGitHubPollingRow(watched, row, endpoint.key);
 				if (event) {
-					await this.context.publisher.publish(toExternalEvent(watched.spaceId, event));
+					await this.publishAndLegacyIngest(watched.spaceId, event);
 					watermarks.pending = Math.max(watermarks.pending, event.occurredAt);
 					count++;
 				}
@@ -344,6 +362,9 @@ export class StaticExternalEventExtensionConfigStore implements ExternalEventExt
 	}
 
 	async listEnabledSpaces(_source: string): Promise<SpaceExternalEventSourceConfig[]> {
+		// The static store has no DB-backed per-space source table yet. Returning an
+		// empty list intentionally lets GitHubEventExtension fall back to watched-repo
+		// rows as the source of enabled spaces for the migration period.
 		return [];
 	}
 }

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -1,0 +1,349 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { MessageHub } from '@neokai/shared';
+import { Logger } from '../../logger';
+import { verifySignature } from '../../github/webhook-handler';
+import type {
+	ExternalEventExtensionConfigStore,
+	ExternalEventExtensionContext,
+	HttpExternalEventExtension,
+	RpcExternalEventExtension,
+	SpaceExternalEventSourceConfig,
+} from '../types';
+import {
+	normalizeGitHubPollingRow,
+	normalizeGitHubWebhook,
+	toExternalEvent,
+} from './github-normalizer';
+import {
+	GitHubEventExtensionRepository,
+	type GitHubWatchedRepo,
+	type PollCursor,
+} from './github-repository';
+
+const log = new Logger('github-event-extension');
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+interface GitHubEventExtensionOptions {
+	githubToken?: string;
+	pollIntervalMs?: number;
+	onWatchedReposChanged?: () => void;
+}
+
+export class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEventExtension {
+	readonly sourceId = 'github';
+	readonly routes = [
+		{ method: 'POST', path: '/webhook/github/space', handle: this.handleWebhook.bind(this) },
+	] as const;
+
+	readonly repo: GitHubEventExtensionRepository;
+	private context?: ExternalEventExtensionContext;
+	private pollTimer?: ReturnType<typeof setTimeout>;
+	private stopped = true;
+
+	constructor(
+		dbOrRepo: BunDatabase | GitHubEventExtensionRepository,
+		private readonly options: GitHubEventExtensionOptions = {}
+	) {
+		this.repo =
+			dbOrRepo instanceof GitHubEventExtensionRepository
+				? dbOrRepo
+				: new GitHubEventExtensionRepository(dbOrRepo);
+	}
+
+	async start(context: ExternalEventExtensionContext): Promise<void> {
+		this.context = context;
+		this.stopped = false;
+		const global = await context.config.getGlobalConfig(this.sourceId);
+		if (!global.globallyEnabled || !global.capabilities.polling) return;
+		this.scheduleNextPoll();
+	}
+
+	async stop(): Promise<void> {
+		this.stopped = true;
+		if (this.pollTimer) clearTimeout(this.pollTimer);
+		this.pollTimer = undefined;
+	}
+
+	registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void {
+		hub.onRequest('space.github.enable', async (data) => {
+			const params = data as { spaceId: string };
+			if (!params.spaceId) throw new Error('spaceId is required');
+			this.repo.setRepoEnabled(params.spaceId, true);
+			this.options.onWatchedReposChanged?.();
+			context.onSourceConfigChanged({
+				source: this.sourceId,
+				spaceId: params.spaceId,
+				kind: 'space_enabled',
+			});
+			return { spaceId: params.spaceId, source: this.sourceId, enabled: true };
+		});
+
+		hub.onRequest('space.github.disable', async (data) => {
+			const params = data as { spaceId: string };
+			if (!params.spaceId) throw new Error('spaceId is required');
+			this.repo.setRepoEnabled(params.spaceId, false);
+			this.options.onWatchedReposChanged?.();
+			context.onSourceConfigChanged({
+				source: this.sourceId,
+				spaceId: params.spaceId,
+				kind: 'space_disabled',
+			});
+			return { spaceId: params.spaceId, source: this.sourceId, enabled: false };
+		});
+
+		hub.onRequest('space.github.watchRepo', async (data) => {
+			const params = data as {
+				spaceId: string;
+				owner: string;
+				repo: string;
+				webhookSecret?: string;
+				webhookEnabled?: boolean;
+				pollingEnabled?: boolean;
+				enabled?: boolean;
+			};
+			if (!params.spaceId || !params.owner || !params.repo) {
+				throw new Error('spaceId, owner and repo are required');
+			}
+			const watchedRepo = this.repo.upsertWatchedRepo({
+				spaceId: params.spaceId,
+				owner: params.owner,
+				repo: params.repo,
+				webhookSecret: params.webhookSecret,
+				webhookEnabled: params.webhookEnabled,
+				pollingEnabled: params.pollingEnabled,
+				enabled: params.enabled,
+			});
+			this.options.onWatchedReposChanged?.();
+			context.onSourceConfigChanged({
+				source: this.sourceId,
+				spaceId: watchedRepo.spaceId,
+				kind: 'watched_repo_changed',
+			});
+			return { watchedRepo, webhookUrl: '/webhook/github/space' };
+		});
+
+		hub.onRequest('space.github.listWatchedRepos', async (data) => {
+			const params = data as { spaceId?: string };
+			if (!params.spaceId) throw new Error('spaceId is required');
+			return {
+				repositories: this.repo.listWatchedRepos(params.spaceId).map((repo) => ({
+					...repo,
+					webhookSecret: repo.webhookSecret ? 'configured' : null,
+				})),
+			};
+		});
+
+		hub.onRequest('space.github.pollOnce', async (data) => {
+			const params = (data ?? {}) as { spaceId?: string };
+			return {
+				count: params.spaceId
+					? await this.pollSpace(params.spaceId)
+					: await this.pollEnabledSpaces(),
+			};
+		});
+	}
+
+	private async handleWebhook(req: Request): Promise<Response> {
+		if (!this.context)
+			return Response.json({ error: 'GitHub extension not started' }, { status: 503 });
+		const global = await this.context.config.getGlobalConfig(this.sourceId);
+		if (!global.globallyEnabled || !global.capabilities.webhooks) {
+			return Response.json(
+				{ message: 'Event ignored', reason: 'github_extension_disabled' },
+				{ status: 202 }
+			);
+		}
+
+		const signature = req.headers.get('X-Hub-Signature-256');
+		const eventType = req.headers.get('X-GitHub-Event');
+		const deliveryId = req.headers.get('X-GitHub-Delivery');
+		if (!signature) return Response.json({ error: 'Missing signature header' }, { status: 401 });
+		if (!eventType || !deliveryId)
+			return Response.json({ error: 'Missing GitHub event headers' }, { status: 400 });
+
+		const raw = await req.text();
+		const signatureMatchedRepos: GitHubWatchedRepo[] = [];
+		for (const repo of this.repo.listEnabledWebhookRepos()) {
+			if (repo.webhookSecret && (await verifySignature(raw, signature, repo.webhookSecret))) {
+				signatureMatchedRepos.push(repo);
+			}
+		}
+		if (signatureMatchedRepos.length === 0) {
+			return Response.json({ error: 'Invalid signature' }, { status: 401 });
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(raw);
+		} catch {
+			return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+		}
+
+		const normalized = normalizeGitHubWebhook(eventType, deliveryId, payload);
+		if (!normalized)
+			return Response.json({ message: 'Event ignored', deliveryId }, { status: 202 });
+
+		const validForRepo = signatureMatchedRepos.filter(
+			(r) =>
+				r.owner.toLowerCase() === normalized.repoOwner.toLowerCase() &&
+				r.repo.toLowerCase() === normalized.repoName.toLowerCase()
+		);
+		if (validForRepo.length === 0)
+			return Response.json({ error: 'Repository is not watched' }, { status: 404 });
+
+		let published = 0;
+		for (const repo of validForRepo) {
+			const spaceConfig = await this.context.config.getSpaceConfig(repo.spaceId, this.sourceId);
+			if (spaceConfig && !spaceConfig.enabled) continue;
+			await this.context.publisher.publish(toExternalEvent(repo.spaceId, normalized));
+			this.repo.markWebhookReceived(repo.id);
+			published++;
+		}
+
+		return Response.json({ message: 'Webhook received', deliveryId, spaces: published });
+	}
+
+	private async pollEnabledSpaces(): Promise<number> {
+		if (!this.context) return 0;
+		const global = await this.context.config.getGlobalConfig(this.sourceId);
+		if (!global.globallyEnabled || !global.capabilities.polling) return 0;
+		const enabledSpaces = await this.context.config.listEnabledSpaces(this.sourceId);
+		if (enabledSpaces.length > 0) {
+			let count = 0;
+			for (const space of enabledSpaces) count += await this.pollSpace(space.spaceId);
+			return count;
+		}
+		let count = 0;
+		for (const repo of this.repo.listPollingRepos()) count += await this.pollWatchedRepo(repo);
+		return count;
+	}
+
+	private async pollSpace(spaceId: string): Promise<number> {
+		if (!this.context) return 0;
+		const spaceConfig = await this.context.config.getSpaceConfig(spaceId, this.sourceId);
+		if (spaceConfig && !spaceConfig.enabled) return 0;
+		let count = 0;
+		for (const repo of this.repo.listPollingRepos(spaceId))
+			count += await this.pollWatchedRepo(repo);
+		return count;
+	}
+
+	private scheduleNextPoll(): void {
+		if (this.stopped) return;
+		if (this.pollTimer) clearTimeout(this.pollTimer);
+		this.pollTimer = setTimeout(() => {
+			void this.runPollCycle();
+		}, this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+		this.pollTimer.unref?.();
+	}
+
+	private async runPollCycle(): Promise<void> {
+		try {
+			await this.pollEnabledSpaces();
+		} catch (error) {
+			log.warn('GitHub polling cycle failed', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		} finally {
+			this.scheduleNextPoll();
+		}
+	}
+
+	private async pollWatchedRepo(
+		watched: GitHubWatchedRepo,
+		fetchImpl: typeof fetch = fetch
+	): Promise<number> {
+		if (!this.context) return 0;
+		let count = 0;
+		const cursor = watched.pollCursor ?? {};
+		const etags = cursor.etags ?? {};
+		const processedPages = cursor.processedPages ?? {};
+		const watermarks = {
+			committed: cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
+			pending: cursor.pendingLastSeenAt ?? cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
+		};
+		const since = watermarks.committed ? new Date(watermarks.committed).toISOString() : undefined;
+		const base = `https://api.github.com/repos/${watched.owner}/${watched.repo}`;
+		const endpoints = [
+			{ key: 'issue_comments', path: '/issues/comments' },
+			{ key: 'review_comments', path: '/pulls/comments' },
+			{ key: 'pulls', path: '/pulls', extra: 'state=all&sort=updated&direction=desc' },
+		];
+
+		for (const endpoint of endpoints) {
+			const page = processedPages[endpoint.key] ?? 1;
+			const query = new URLSearchParams();
+			if (endpoint.extra) {
+				for (const part of endpoint.extra.split('&')) {
+					const [key, value = ''] = part.split('=');
+					query.set(key, value);
+				}
+			}
+			if (since) query.set('since', since);
+			query.set('per_page', '100');
+			query.set('page', String(page));
+			const url = `${base}${endpoint.path}?${query.toString()}`;
+			const headers: Record<string, string> = {
+				Accept: 'application/vnd.github+json',
+				'User-Agent': 'NeoKai-Space-GitHub/1.0',
+				'X-GitHub-Api-Version': '2022-11-28',
+			};
+			if (this.options.githubToken) headers.Authorization = `Bearer ${this.options.githubToken}`;
+			if (page === 1 && etags[endpoint.key]) headers['If-None-Match'] = etags[endpoint.key];
+			const response = await fetchImpl(url, { headers });
+			if (response.status === 304) continue;
+			if (!response.ok) continue;
+			const etag = response.headers.get('ETag');
+			if (etag && page === 1) etags[endpoint.key] = etag;
+			const rows = (await response.json()) as unknown[];
+			for (const row of rows) {
+				const event = normalizeGitHubPollingRow(watched, row, endpoint.key);
+				if (event) {
+					await this.context.publisher.publish(toExternalEvent(watched.spaceId, event));
+					watermarks.pending = Math.max(watermarks.pending, event.occurredAt);
+					count++;
+				}
+			}
+			processedPages[endpoint.key] = rows.length >= 100 ? page + 1 : 1;
+		}
+		const hasBacklog = Object.values(processedPages).some((page) => page > 1);
+		const cursorPayload: PollCursor = {
+			lastSeenAt: hasBacklog ? watermarks.committed : watermarks.pending,
+			pendingLastSeenAt: hasBacklog ? watermarks.pending : undefined,
+			etags,
+			processedPages,
+		};
+		this.repo.updatePollCursor(watched.id, cursorPayload);
+		return count;
+	}
+}
+
+export class StaticExternalEventExtensionConfigStore implements ExternalEventExtensionConfigStore {
+	constructor(
+		private readonly options: { globallyEnabled?: boolean; webhooks?: boolean; polling?: boolean }
+	) {}
+
+	async getGlobalConfig(source: string) {
+		return {
+			source,
+			globallyEnabled: this.options.globallyEnabled ?? true,
+			capabilities: {
+				webhooks: this.options.webhooks ?? true,
+				polling: this.options.polling ?? true,
+				rpcConfig: true,
+			},
+			settings: {},
+		};
+	}
+
+	async getSpaceConfig(
+		spaceId: string,
+		source: string
+	): Promise<SpaceExternalEventSourceConfig | null> {
+		return { spaceId, source, enabled: true, settings: {} };
+	}
+
+	async listEnabledSpaces(_source: string): Promise<SpaceExternalEventSourceConfig[]> {
+		return [];
+	}
+}

--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -1,0 +1,271 @@
+import type { ExternalEvent } from '../types';
+
+export type GitHubEventKind =
+	| 'issue_comment'
+	| 'pull_request_review'
+	| 'pull_request_review_comment'
+	| 'pull_request';
+
+export interface NormalizedGitHubEvent {
+	deliveryId: string;
+	dedupeKey: string;
+	source: 'webhook' | 'polling';
+	eventType: GitHubEventKind;
+	action: string;
+	repoOwner: string;
+	repoName: string;
+	prNumber: number;
+	prUrl: string;
+	actor: string;
+	actorType: string;
+	body: string;
+	summary: string;
+	externalUrl: string;
+	externalId: string;
+	occurredAt: number;
+	rawPayload: unknown;
+}
+
+export interface GitHubPollingRepo {
+	owner: string;
+	repo: string;
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function getString(value: unknown, fallback = ''): string {
+	return typeof value === 'string' ? value : fallback;
+}
+
+function getNumber(value: unknown, fallback = 0): number {
+	return typeof value === 'number' ? value : fallback;
+}
+
+function parseTs(value: unknown): number {
+	const raw = getString(value);
+	const parsed = raw ? Date.parse(raw) : Number.NaN;
+	return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function repoFromPayload(payload: Record<string, unknown>): { owner: string; repo: string } {
+	const repository = asObject(payload.repository);
+	const owner = asObject(repository.owner);
+	const fullName = getString(repository.full_name);
+	const [fullOwner, fullRepo] = fullName.split('/');
+	return {
+		owner: getString(owner.login, fullOwner ?? ''),
+		repo: getString(repository.name, fullRepo ?? ''),
+	};
+}
+
+function userFrom(value: unknown): { login: string; type: string } {
+	const user = asObject(value);
+	return { login: getString(user.login, 'unknown'), type: getString(user.type, 'User') };
+}
+
+function truncateBody(body: string): string {
+	const singleLine = body.replace(/\s+/g, ' ').trim();
+	return singleLine.length > 240 ? `${singleLine.slice(0, 237)}...` : singleLine;
+}
+
+function prUrl(owner: string, repo: string, number: number): string {
+	return `https://github.com/${owner}/${repo}/pull/${number}`;
+}
+
+export function normalizeGitHubWebhook(
+	eventType: string,
+	deliveryId: string,
+	payload: unknown
+): NormalizedGitHubEvent | null {
+	if (
+		eventType !== 'issue_comment' &&
+		eventType !== 'pull_request_review' &&
+		eventType !== 'pull_request_review_comment' &&
+		eventType !== 'pull_request'
+	) {
+		return null;
+	}
+	const root = asObject(payload);
+	const action = getString(root.action, 'unknown');
+	const repo = repoFromPayload(root);
+	const sender = userFrom(root.sender);
+	let prNumber = 0;
+	let actor = sender;
+	let body = '';
+	let externalUrl = '';
+	let externalId = `${eventType}:${deliveryId}`;
+	let occurredAt = Date.now();
+	let title = '';
+
+	if (eventType === 'issue_comment') {
+		const issue = asObject(root.issue);
+		if (!asObject(issue.pull_request).url) return null;
+		const comment = asObject(root.comment);
+		actor = userFrom(comment.user ?? root.sender);
+		prNumber = getNumber(issue.number);
+		body = getString(comment.body);
+		externalId = `issue_comment:${getNumber(comment.id) || deliveryId}:${action}`;
+		externalUrl = getString(comment.html_url, prUrl(repo.owner, repo.repo, prNumber));
+		occurredAt = parseTs(comment.updated_at ?? comment.created_at);
+		title = `PR #${prNumber} comment`;
+	} else if (eventType === 'pull_request_review') {
+		const pr = asObject(root.pull_request);
+		const review = asObject(root.review);
+		actor = userFrom(review.user ?? root.sender);
+		prNumber = getNumber(pr.number);
+		body = getString(review.body);
+		externalId = `review:${getNumber(review.id) || deliveryId}:${action}`;
+		externalUrl = getString(
+			review.html_url,
+			getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
+		);
+		occurredAt = parseTs(review.submitted_at ?? review.updated_at);
+		title = `PR #${prNumber} review ${getString(review.state, action)}`;
+	} else if (eventType === 'pull_request_review_comment') {
+		const pr = asObject(root.pull_request);
+		const comment = asObject(root.comment);
+		actor = userFrom(comment.user ?? root.sender);
+		prNumber = getNumber(pr.number);
+		body = getString(comment.body);
+		externalId = `review_comment:${getNumber(comment.id) || deliveryId}:${action}`;
+		externalUrl = getString(
+			comment.html_url,
+			getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
+		);
+		occurredAt = parseTs(comment.updated_at ?? comment.created_at);
+		title = `PR #${prNumber} inline review comment`;
+	} else {
+		const pr = asObject(root.pull_request);
+		actor = userFrom(pr.user ?? root.sender);
+		prNumber = getNumber(pr.number);
+		body = getString(pr.body);
+		externalId = `pull_request:${getNumber(pr.id) || prNumber}:${action}:${deliveryId}`;
+		externalUrl = getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber));
+		occurredAt = parseTs(pr.updated_at ?? pr.created_at);
+		title = `PR #${prNumber} ${action}`;
+	}
+	if (!repo.owner || !repo.repo || !prNumber) return null;
+	const canonicalOwner = repo.owner.toLowerCase();
+	const canonicalRepo = repo.repo.toLowerCase();
+	return {
+		deliveryId,
+		dedupeKey: `${canonicalOwner}/${canonicalRepo}:${externalId}`,
+		source: 'webhook',
+		eventType,
+		action,
+		repoOwner: repo.owner,
+		repoName: repo.repo,
+		prNumber,
+		prUrl: prUrl(repo.owner, repo.repo, prNumber),
+		actor: actor.login,
+		actorType: actor.type,
+		body,
+		summary: `${title} by ${actor.login}${body ? `: ${truncateBody(body)}` : ''}`,
+		externalUrl,
+		externalId,
+		occurredAt,
+		rawPayload: payload,
+	};
+}
+
+export function normalizeGitHubPollingRow(
+	watched: GitHubPollingRepo,
+	row: unknown,
+	endpointKey: string
+): NormalizedGitHubEvent | null {
+	const obj = asObject(row);
+	const apiUrl = getString(obj.url);
+	const htmlUrl = getString(obj.html_url);
+	let prNumber = 0;
+	if (endpointKey === 'issue_comments') {
+		const issue = asObject(obj.issue);
+		const issuePullRequest = asObject(issue.pull_request);
+		const issueUrl = getString(obj.issue_url);
+		if (!issuePullRequest.url && !htmlUrl.includes('/pull/')) return null;
+		const issueMatch = issueUrl.match(/\/issues\/(\d+)/);
+		prNumber = getNumber(issue.number, issueMatch ? Number(issueMatch[1]) : 0);
+	} else {
+		const prMatch = htmlUrl.match(/\/pull\/(\d+)/) ?? apiUrl.match(/\/pulls\/(\d+)/);
+		prNumber = prMatch ? Number(prMatch[1]) : getNumber(obj.number);
+	}
+	if (!prNumber) return null;
+	const user = userFrom(obj.user);
+	let eventType: GitHubEventKind = 'pull_request';
+	if (endpointKey === 'issue_comments') eventType = 'issue_comment';
+	if (endpointKey === 'review_comments') eventType = 'pull_request_review_comment';
+	const id = getNumber(obj.id) || prNumber;
+	const updatedAt = parseTs(obj.updated_at ?? obj.created_at);
+	const dedupeVersion =
+		endpointKey === 'pulls' ? String(updatedAt) : getString(obj.updated_at ?? obj.created_at);
+	const dedupeSuffix = dedupeVersion ? `:${dedupeVersion}` : '';
+	const canonicalOwner = watched.owner.toLowerCase();
+	const canonicalRepo = watched.repo.toLowerCase();
+	return {
+		deliveryId: `poll:${eventType}:${id}${dedupeSuffix}`,
+		dedupeKey: `${canonicalOwner}/${canonicalRepo}:${eventType}:${id}${dedupeSuffix}`,
+		source: 'polling',
+		eventType,
+		action: 'polled',
+		repoOwner: watched.owner,
+		repoName: watched.repo,
+		prNumber,
+		prUrl: prUrl(watched.owner, watched.repo, prNumber),
+		actor: user.login,
+		actorType: user.type,
+		body: getString(obj.body),
+		summary: `PR #${prNumber} ${eventType} by ${user.login}: ${truncateBody(getString(obj.body, getString(obj.title)))}`,
+		externalUrl: htmlUrl || prUrl(watched.owner, watched.repo, prNumber),
+		externalId: `${eventType}:${id}${dedupeSuffix}`,
+		occurredAt: updatedAt,
+		rawPayload: row,
+	};
+}
+
+export function mapEventType(kind: GitHubEventKind, action: string): string {
+	switch (kind) {
+		case 'issue_comment':
+			return `pull_request.comment_${action}`;
+		case 'pull_request_review':
+			return `pull_request.review_${action}`;
+		case 'pull_request_review_comment':
+			return `pull_request.review_comment_${action}`;
+		case 'pull_request':
+			return `pull_request.${action}`;
+	}
+}
+
+export function toExternalEvent(spaceId: string, event: NormalizedGitHubEvent): ExternalEvent {
+	const repoOwner = event.repoOwner.toLowerCase();
+	const repoName = event.repoName.toLowerCase();
+	const resourceAction = mapEventType(event.eventType, event.action);
+
+	return {
+		id: crypto.randomUUID(),
+		spaceId,
+		topic: `github/${repoOwner}/${repoName}/${resourceAction}`,
+		occurredAt: event.occurredAt,
+		ingestedAt: Date.now(),
+		source: 'github',
+		sourceEventId: event.deliveryId,
+		summary: event.summary,
+		externalUrl: event.externalUrl || event.prUrl,
+		payload: {
+			eventType: event.eventType,
+			action: event.action,
+			source: event.source,
+			prUrl: event.prUrl,
+			prNumber: event.prNumber,
+			repoOwner,
+			repoName,
+			deliveryId: event.deliveryId,
+			externalId: event.externalId,
+			actor: event.actor,
+			actorType: event.actorType,
+			body: event.body,
+			rawPayload: event.rawPayload,
+		},
+		dedupeKey: event.dedupeKey,
+	};
+}

--- a/packages/daemon/src/lib/external-events/github/github-repository.ts
+++ b/packages/daemon/src/lib/external-events/github/github-repository.ts
@@ -25,7 +25,16 @@ export interface GitHubWatchedRepo {
 }
 
 export class GitHubEventExtensionRepository {
-	constructor(private readonly db: BunDatabase) {}
+	constructor(private readonly db: BunDatabase) {
+		this.db.exec(`
+			CREATE TABLE IF NOT EXISTS space_github_source_settings (
+				space_id TEXT PRIMARY KEY,
+				enabled INTEGER NOT NULL DEFAULT 1,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+	}
 
 	upsertWatchedRepo(params: {
 		spaceId: string;
@@ -68,6 +77,7 @@ export class GitHubEventExtensionRepository {
 			return this.getWatchedRepoById(existing.id)!;
 		}
 		const id = generateUUID();
+		const spaceEnabled = params.enabled ?? this.isSpaceEnabled(params.spaceId);
 		this.db
 			.prepare(
 				`INSERT INTO space_github_watched_repos
@@ -79,7 +89,7 @@ export class GitHubEventExtensionRepository {
 				params.spaceId,
 				params.owner,
 				params.repo,
-				params.enabled === false ? 0 : 1,
+				spaceEnabled ? 1 : 0,
 				params.webhookEnabled === false ? 0 : 1,
 				params.pollingEnabled ? 1 : 0,
 				params.webhookSecret ?? null,
@@ -90,11 +100,26 @@ export class GitHubEventExtensionRepository {
 	}
 
 	setRepoEnabled(spaceId: string, enabled: boolean): number {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_github_source_settings (space_id, enabled, created_at, updated_at)
+				 VALUES (?, ?, ?, ?)
+				 ON CONFLICT(space_id) DO UPDATE SET enabled = excluded.enabled, updated_at = excluded.updated_at`
+			)
+			.run(spaceId, enabled ? 1 : 0, now, now);
 		return this.db
 			.prepare(
 				`UPDATE space_github_watched_repos SET enabled = ?, updated_at = ? WHERE space_id = ?`
 			)
-			.run(enabled ? 1 : 0, Date.now(), spaceId).changes;
+			.run(enabled ? 1 : 0, now, spaceId).changes;
+	}
+
+	isSpaceEnabled(spaceId: string): boolean {
+		const row = this.db
+			.prepare(`SELECT enabled FROM space_github_source_settings WHERE space_id = ?`)
+			.get(spaceId) as { enabled: number } | undefined;
+		return row ? row.enabled === 1 : true;
 	}
 
 	listWatchedRepos(spaceId?: string): GitHubWatchedRepo[] {

--- a/packages/daemon/src/lib/external-events/github/github-repository.ts
+++ b/packages/daemon/src/lib/external-events/github/github-repository.ts
@@ -1,0 +1,187 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+
+export interface PollCursor {
+	lastSeenAt?: number;
+	pendingLastSeenAt?: number;
+	etags?: Record<string, string>;
+	processedPages?: Record<string, number>;
+}
+
+export interface GitHubWatchedRepo {
+	id: string;
+	spaceId: string;
+	owner: string;
+	repo: string;
+	enabled: boolean;
+	webhookEnabled: boolean;
+	pollingEnabled: boolean;
+	webhookSecret: string | null;
+	lastWebhookAt: number | null;
+	lastPollAt: number | null;
+	pollCursor: PollCursor | null;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export class GitHubEventExtensionRepository {
+	constructor(private readonly db: BunDatabase) {}
+
+	upsertWatchedRepo(params: {
+		spaceId: string;
+		owner: string;
+		repo: string;
+		enabled?: boolean;
+		webhookEnabled?: boolean;
+		pollingEnabled?: boolean;
+		webhookSecret?: string | null;
+	}): GitHubWatchedRepo {
+		const now = Date.now();
+		const existing = this.getWatchedRepo(params.spaceId, params.owner, params.repo);
+		if (existing) {
+			this.db
+				.prepare(
+					`UPDATE space_github_watched_repos
+					 SET enabled = ?, webhook_enabled = ?, polling_enabled = ?, webhook_secret = COALESCE(?, webhook_secret), updated_at = ?
+					 WHERE id = ?`
+				)
+				.run(
+					params.enabled === undefined ? (existing.enabled ? 1 : 0) : params.enabled ? 1 : 0,
+					params.webhookEnabled === undefined
+						? existing.webhookEnabled
+							? 1
+							: 0
+						: params.webhookEnabled
+							? 1
+							: 0,
+					params.pollingEnabled === undefined
+						? existing.pollingEnabled
+							? 1
+							: 0
+						: params.pollingEnabled
+							? 1
+							: 0,
+					params.webhookSecret ?? null,
+					now,
+					existing.id
+				);
+			return this.getWatchedRepoById(existing.id)!;
+		}
+		const id = generateUUID();
+		this.db
+			.prepare(
+				`INSERT INTO space_github_watched_repos
+				 (id, space_id, owner, repo, enabled, webhook_enabled, polling_enabled, webhook_secret, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.owner,
+				params.repo,
+				params.enabled === false ? 0 : 1,
+				params.webhookEnabled === false ? 0 : 1,
+				params.pollingEnabled ? 1 : 0,
+				params.webhookSecret ?? null,
+				now,
+				now
+			);
+		return this.getWatchedRepoById(id)!;
+	}
+
+	setRepoEnabled(spaceId: string, enabled: boolean): number {
+		return this.db
+			.prepare(
+				`UPDATE space_github_watched_repos SET enabled = ?, updated_at = ? WHERE space_id = ?`
+			)
+			.run(enabled ? 1 : 0, Date.now(), spaceId).changes;
+	}
+
+	listWatchedRepos(spaceId?: string): GitHubWatchedRepo[] {
+		const rows = spaceId
+			? (this.db
+					.prepare(
+						`SELECT * FROM space_github_watched_repos WHERE space_id = ? ORDER BY owner, repo`
+					)
+					.all(spaceId) as Record<string, unknown>[])
+			: (this.db
+					.prepare(`SELECT * FROM space_github_watched_repos ORDER BY space_id, owner, repo`)
+					.all() as Record<string, unknown>[]);
+		return rows.map((r) => this.rowToRepo(r));
+	}
+
+	listEnabledWebhookRepos(): GitHubWatchedRepo[] {
+		return (
+			this.db
+				.prepare(
+					`SELECT * FROM space_github_watched_repos WHERE enabled = 1 AND webhook_enabled = 1 AND webhook_secret IS NOT NULL`
+				)
+				.all() as Record<string, unknown>[]
+		).map((r) => this.rowToRepo(r));
+	}
+
+	listPollingRepos(spaceId?: string): GitHubWatchedRepo[] {
+		const rows = spaceId
+			? (this.db
+					.prepare(
+						`SELECT * FROM space_github_watched_repos WHERE space_id = ? AND enabled = 1 AND polling_enabled = 1 ORDER BY owner, repo`
+					)
+					.all(spaceId) as Record<string, unknown>[])
+			: (this.db
+					.prepare(
+						`SELECT * FROM space_github_watched_repos WHERE enabled = 1 AND polling_enabled = 1 ORDER BY space_id, owner, repo`
+					)
+					.all() as Record<string, unknown>[]);
+		return rows.map((r) => this.rowToRepo(r));
+	}
+
+	getWatchedRepo(spaceId: string, owner: string, repo: string): GitHubWatchedRepo | null {
+		const row = this.db
+			.prepare(
+				`SELECT * FROM space_github_watched_repos WHERE space_id = ? AND lower(owner)=lower(?) AND lower(repo)=lower(?)`
+			)
+			.get(spaceId, owner, repo) as Record<string, unknown> | undefined;
+		return row ? this.rowToRepo(row) : null;
+	}
+
+	getWatchedRepoById(id: string): GitHubWatchedRepo | null {
+		const row = this.db.prepare(`SELECT * FROM space_github_watched_repos WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? this.rowToRepo(row) : null;
+	}
+
+	markWebhookReceived(id: string): void {
+		this.db
+			.prepare(
+				`UPDATE space_github_watched_repos SET last_webhook_at = ?, updated_at = ? WHERE id = ?`
+			)
+			.run(Date.now(), Date.now(), id);
+	}
+
+	updatePollCursor(id: string, cursor: PollCursor): void {
+		this.db
+			.prepare(
+				`UPDATE space_github_watched_repos SET last_poll_at = ?, poll_cursor = ?, updated_at = ? WHERE id = ?`
+			)
+			.run(Date.now(), JSON.stringify(cursor), Date.now(), id);
+	}
+
+	private rowToRepo(row: Record<string, unknown>): GitHubWatchedRepo {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			owner: row.owner as string,
+			repo: row.repo as string,
+			enabled: row.enabled === 1,
+			webhookEnabled: row.webhook_enabled === 1,
+			pollingEnabled: row.polling_enabled === 1,
+			webhookSecret: (row.webhook_secret as string | null) ?? null,
+			lastWebhookAt: (row.last_webhook_at as number | null) ?? null,
+			lastPollAt: (row.last_poll_at as number | null) ?? null,
+			pollCursor: row.poll_cursor ? (JSON.parse(row.poll_cursor as string) as PollCursor) : null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/lib/external-events/github/index.ts
+++ b/packages/daemon/src/lib/external-events/github/index.ts
@@ -1,0 +1,17 @@
+export {
+	GitHubEventExtension,
+	StaticExternalEventExtensionConfigStore,
+} from './github-event-extension';
+export {
+	normalizeGitHubWebhook,
+	normalizeGitHubPollingRow,
+	mapEventType,
+	toExternalEvent,
+	type GitHubEventKind,
+	type NormalizedGitHubEvent,
+} from './github-normalizer';
+export {
+	GitHubEventExtensionRepository,
+	type GitHubWatchedRepo,
+	type PollCursor,
+} from './github-repository';

--- a/packages/daemon/src/lib/external-events/types.ts
+++ b/packages/daemon/src/lib/external-events/types.ts
@@ -82,57 +82,6 @@ export type ExternalEventDeliveryState = 'pending' | 'delivered' | 'failed';
 export const TERMINAL_DELIVERY_STATES: ReadonlySet<ExternalEventDeliveryState> =
 	new Set<ExternalEventDeliveryState>(['delivered', 'failed']);
 
-export interface ExternalEventExtensionConfig {
-	source: string;
-	globallyEnabled: boolean;
-	capabilities: {
-		webhooks?: boolean;
-		polling?: boolean;
-		rpcConfig?: boolean;
-	};
-	settings?: Record<string, unknown>;
-}
-
-export interface SpaceExternalEventSourceConfig {
-	spaceId: string;
-	source: string;
-	enabled: boolean;
-	settings: Record<string, unknown>;
-}
-
-export interface ExternalEventExtensionConfigStore {
-	getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig>;
-	getSpaceConfig(spaceId: string, source: string): Promise<SpaceExternalEventSourceConfig | null>;
-	listEnabledSpaces(source: string): Promise<SpaceExternalEventSourceConfig[]>;
-}
-
-export interface ExternalEventExtensionContext {
-	publisher: { publish(event: ExternalEvent): Promise<unknown> };
-	config: ExternalEventExtensionConfigStore;
-	onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }): void;
-}
-
-export interface ExternalEventExtension {
-	readonly sourceId: string;
-	start(context: ExternalEventExtensionContext): Promise<void>;
-	stop(): Promise<void>;
-}
-
-export interface HttpExternalEventExtension extends ExternalEventExtension {
-	readonly routes: readonly {
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-		path: string;
-		handle(req: Request): Promise<Response>;
-	}[];
-}
-
-export interface RpcExternalEventExtension extends ExternalEventExtension {
-	registerRpcHandlers(
-		hub: import('@neokai/shared').MessageHub,
-		context: ExternalEventExtensionContext
-	): void;
-}
-
 /**
  * Stored event row, including current state. Useful for diagnostics and tests.
  */

--- a/packages/daemon/src/lib/external-events/types.ts
+++ b/packages/daemon/src/lib/external-events/types.ts
@@ -82,6 +82,57 @@ export type ExternalEventDeliveryState = 'pending' | 'delivered' | 'failed';
 export const TERMINAL_DELIVERY_STATES: ReadonlySet<ExternalEventDeliveryState> =
 	new Set<ExternalEventDeliveryState>(['delivered', 'failed']);
 
+export interface ExternalEventExtensionConfig {
+	source: string;
+	globallyEnabled: boolean;
+	capabilities: {
+		webhooks?: boolean;
+		polling?: boolean;
+		rpcConfig?: boolean;
+	};
+	settings?: Record<string, unknown>;
+}
+
+export interface SpaceExternalEventSourceConfig {
+	spaceId: string;
+	source: string;
+	enabled: boolean;
+	settings: Record<string, unknown>;
+}
+
+export interface ExternalEventExtensionConfigStore {
+	getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig>;
+	getSpaceConfig(spaceId: string, source: string): Promise<SpaceExternalEventSourceConfig | null>;
+	listEnabledSpaces(source: string): Promise<SpaceExternalEventSourceConfig[]>;
+}
+
+export interface ExternalEventExtensionContext {
+	publisher: { publish(event: ExternalEvent): Promise<unknown> };
+	config: ExternalEventExtensionConfigStore;
+	onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }): void;
+}
+
+export interface ExternalEventExtension {
+	readonly sourceId: string;
+	start(context: ExternalEventExtensionContext): Promise<void>;
+	stop(): Promise<void>;
+}
+
+export interface HttpExternalEventExtension extends ExternalEventExtension {
+	readonly routes: readonly {
+		method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+		path: string;
+		handle(req: Request): Promise<Response>;
+	}[];
+}
+
+export interface RpcExternalEventExtension extends ExternalEventExtension {
+	registerRpcHandlers(
+		hub: import('@neokai/shared').MessageHub,
+		context: ExternalEventExtensionContext
+	): void;
+}
+
 /**
  * Stored event row, including current state. Useful for diagnostics and tests.
  */

--- a/packages/daemon/src/lib/github/space-github.ts
+++ b/packages/daemon/src/lib/github/space-github.ts
@@ -85,38 +85,6 @@ export interface ResolveResult {
 	note?: string;
 }
 
-function asObject(value: unknown): Record<string, unknown> {
-	return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
-}
-
-function getString(value: unknown, fallback = ''): string {
-	return typeof value === 'string' ? value : fallback;
-}
-
-function getNumber(value: unknown, fallback = 0): number {
-	return typeof value === 'number' ? value : fallback;
-}
-
-function parseTs(value: unknown): number {
-	const raw = getString(value);
-	const parsed = raw ? Date.parse(raw) : Number.NaN;
-	return Number.isFinite(parsed) ? parsed : Date.now();
-}
-
-function userFrom(value: unknown): { login: string; type: string } {
-	const user = asObject(value);
-	return { login: getString(user.login, 'unknown'), type: getString(user.type, 'User') };
-}
-
-function truncateBody(body: string): string {
-	const singleLine = body.replace(/\s+/g, ' ').trim();
-	return singleLine.length > 240 ? `${singleLine.slice(0, 237)}...` : singleLine;
-}
-
-function prUrl(owner: string, repo: string, number: number): string {
-	return `https://github.com/${owner}/${repo}/pull/${number}`;
-}
-
 export const normalizeSpaceGitHubWebhook = normalizeGitHubWebhook;
 
 export class SpaceGitHubRepository {
@@ -439,19 +407,12 @@ export class SpaceGitHubService {
 		private readonly db: BunDatabase,
 		private readonly internalEventBus?: InternalEventBus<DaemonInternalEventMap>,
 		private readonly injectTaskAgent?: (taskId: string, message: string) => Promise<void>,
-		private readonly githubToken?: string,
+		_githubToken?: string,
 		private readonly onEventsChanged?: () => void
 	) {
 		this.repo = new SpaceGitHubRepository(db);
 		this.eventExtensionRepo = new GitHubEventExtensionRepository(db);
 		this.resolver = new SpacePrTaskResolver(db);
-	}
-
-	async handleWebhook(_req: Request): Promise<Response> {
-		return Response.json(
-			{ error: 'SpaceGitHubService webhook ingestion moved to GitHubEventExtension' },
-			{ status: 410 }
-		);
 	}
 
 	async ingest(
@@ -478,132 +439,6 @@ export class SpaceGitHubService {
 		this.appendTaskActivity(resolved.taskId, event);
 		this.scheduleTaskNotification(resolved.taskId, stored.event.id);
 		return this.repo.getEvent(stored.event.id)!;
-	}
-
-	async pollOnce(fetchImpl: typeof fetch = fetch): Promise<number> {
-		let count = 0;
-		for (const watched of this.repo
-			.listWatchedRepos()
-			.filter((r) => r.enabled && r.pollingEnabled)) {
-			const cursor = watched.pollCursor ?? {};
-			const etags = cursor.etags ?? {};
-			const processedPages = cursor.processedPages ?? {};
-			const watermarks = {
-				committed: cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
-				pending: cursor.pendingLastSeenAt ?? cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
-			};
-			const since = watermarks.committed ? new Date(watermarks.committed).toISOString() : undefined;
-			// Poll issue comments, review comments, and PR metadata; all feed the same ingest path.
-			const base = `https://api.github.com/repos/${watched.owner}/${watched.repo}`;
-			const endpoints = [
-				{ key: 'issue_comments', path: '/issues/comments' },
-				{ key: 'review_comments', path: '/pulls/comments' },
-				{ key: 'pulls', path: '/pulls', extra: 'state=all&sort=updated&direction=desc' },
-			];
-			for (const endpoint of endpoints) {
-				const page = processedPages[endpoint.key] ?? 1;
-				const query = new URLSearchParams();
-				if (endpoint.extra) {
-					for (const part of endpoint.extra.split('&')) {
-						const [key, value = ''] = part.split('=');
-						query.set(key, value);
-					}
-				}
-				if (since) query.set('since', since);
-				query.set('per_page', '100');
-				query.set('page', String(page));
-				const url = `${base}${endpoint.path}?${query.toString()}`;
-				const headers: Record<string, string> = {
-					Accept: 'application/vnd.github+json',
-					'User-Agent': 'NeoKai-Space-GitHub/1.0',
-					'X-GitHub-Api-Version': '2022-11-28',
-				};
-				if (this.githubToken) headers.Authorization = `Bearer ${this.githubToken}`;
-				if (page === 1 && etags[endpoint.key]) headers['If-None-Match'] = etags[endpoint.key];
-				const response = await fetchImpl(url, { headers });
-				if (response.status === 304) continue;
-				if (!response.ok) continue;
-				const etag = response.headers.get('ETag');
-				if (etag && page === 1) etags[endpoint.key] = etag;
-				const rows = (await response.json()) as unknown[];
-				for (const row of rows) {
-					const event = this.normalizePollingRow(watched, row, endpoint.key);
-					if (event) {
-						event.source = 'polling';
-						await this.ingest(watched.spaceId, event);
-						watermarks.pending = Math.max(watermarks.pending, event.occurredAt);
-						count++;
-					}
-				}
-				processedPages[endpoint.key] = rows.length >= 100 ? page + 1 : 1;
-			}
-			const hasBacklog = Object.values(processedPages).some((page) => page > 1);
-			const cursorPayload: PollCursor = {
-				lastSeenAt: hasBacklog ? watermarks.committed : watermarks.pending,
-				pendingLastSeenAt: hasBacklog ? watermarks.pending : undefined,
-				etags,
-				processedPages,
-			};
-			this.db
-				.prepare(
-					`UPDATE space_github_watched_repos SET last_poll_at = ?, poll_cursor = ?, updated_at = ? WHERE id = ?`
-				)
-				.run(Date.now(), JSON.stringify(cursorPayload), Date.now(), watched.id);
-		}
-		return count;
-	}
-
-	private normalizePollingRow(
-		watched: WatchedRepo,
-		row: unknown,
-		endpointKey: string
-	): NormalizedSpaceGitHubEvent | null {
-		const obj = asObject(row);
-		const apiUrl = getString(obj.url);
-		const htmlUrl = getString(obj.html_url);
-		let prNumber = 0;
-		if (endpointKey === 'issue_comments') {
-			const issue = asObject(obj.issue);
-			const issuePullRequest = asObject(issue.pull_request);
-			const issueUrl = getString(obj.issue_url);
-			if (!issuePullRequest.url && !htmlUrl.includes('/pull/')) return null;
-			const issueMatch = issueUrl.match(/\/issues\/(\d+)/);
-			prNumber = getNumber(issue.number, issueMatch ? Number(issueMatch[1]) : 0);
-		} else {
-			const prMatch = htmlUrl.match(/\/pull\/(\d+)/) ?? apiUrl.match(/\/pulls\/(\d+)/);
-			prNumber = prMatch ? Number(prMatch[1]) : getNumber(obj.number);
-		}
-		if (!prNumber) return null;
-		const user = userFrom(obj.user);
-		let eventType: SpaceGitHubEventKind = 'pull_request';
-		if (endpointKey === 'issue_comments') eventType = 'issue_comment';
-		if (endpointKey === 'review_comments') eventType = 'pull_request_review_comment';
-		const id = getNumber(obj.id) || prNumber;
-		const updatedAt = parseTs(obj.updated_at ?? obj.created_at);
-		const dedupeVersion =
-			endpointKey === 'pulls' ? String(updatedAt) : getString(obj.updated_at ?? obj.created_at);
-		const dedupeSuffix = dedupeVersion ? `:${dedupeVersion}` : '';
-		const canonicalOwner = watched.owner.toLowerCase();
-		const canonicalRepo = watched.repo.toLowerCase();
-		return {
-			deliveryId: `poll:${eventType}:${id}${dedupeSuffix}`,
-			dedupeKey: `${canonicalOwner}/${canonicalRepo}:${eventType}:${id}${dedupeSuffix}`,
-			source: 'polling',
-			eventType,
-			action: 'polled',
-			repoOwner: watched.owner,
-			repoName: watched.repo,
-			prNumber,
-			prUrl: prUrl(watched.owner, watched.repo, prNumber),
-			actor: user.login,
-			actorType: user.type,
-			body: getString(obj.body),
-			summary: `PR #${prNumber} ${eventType} by ${user.login}: ${truncateBody(getString(obj.body, getString(obj.title)))}`,
-			externalUrl: htmlUrl || prUrl(watched.owner, watched.repo, prNumber),
-			externalId: `${eventType}:${id}${dedupeSuffix}`,
-			occurredAt: updatedAt,
-			rawPayload: row,
-		};
 	}
 
 	private appendTaskActivity(taskId: string, event: NormalizedSpaceGitHubEvent): void {

--- a/packages/daemon/src/lib/github/space-github.ts
+++ b/packages/daemon/src/lib/github/space-github.ts
@@ -2,7 +2,8 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
-import { verifySignature } from './webhook-handler';
+import { normalizeGitHubWebhook } from '../external-events/github/github-normalizer';
+import { GitHubEventExtensionRepository } from '../external-events/github/github-repository';
 
 const log = new Logger('space-github');
 
@@ -102,17 +103,6 @@ function parseTs(value: unknown): number {
 	return Number.isFinite(parsed) ? parsed : Date.now();
 }
 
-function repoFromPayload(payload: Record<string, unknown>): { owner: string; repo: string } {
-	const repository = asObject(payload.repository);
-	const owner = asObject(repository.owner);
-	const fullName = getString(repository.full_name);
-	const [fullOwner, fullRepo] = fullName.split('/');
-	return {
-		owner: getString(owner.login, fullOwner ?? ''),
-		repo: getString(repository.name, fullRepo ?? ''),
-	};
-}
-
 function userFrom(value: unknown): { login: string; type: string } {
 	const user = asObject(value);
 	return { login: getString(user.login, 'unknown'), type: getString(user.type, 'User') };
@@ -127,101 +117,7 @@ function prUrl(owner: string, repo: string, number: number): string {
 	return `https://github.com/${owner}/${repo}/pull/${number}`;
 }
 
-export function normalizeSpaceGitHubWebhook(
-	eventType: string,
-	deliveryId: string,
-	payload: unknown
-): NormalizedSpaceGitHubEvent | null {
-	if (
-		eventType !== 'issue_comment' &&
-		eventType !== 'pull_request_review' &&
-		eventType !== 'pull_request_review_comment' &&
-		eventType !== 'pull_request'
-	) {
-		return null;
-	}
-	const root = asObject(payload);
-	const action = getString(root.action, 'unknown');
-	const repo = repoFromPayload(root);
-	const sender = userFrom(root.sender);
-	let prNumber = 0;
-	let actor = sender;
-	let body = '';
-	let externalUrl = '';
-	let externalId = `${eventType}:${deliveryId}`;
-	let occurredAt = Date.now();
-	let title = '';
-
-	if (eventType === 'issue_comment') {
-		const issue = asObject(root.issue);
-		if (!asObject(issue.pull_request).url) return null;
-		const comment = asObject(root.comment);
-		actor = userFrom(comment.user ?? root.sender);
-		prNumber = getNumber(issue.number);
-		body = getString(comment.body);
-		externalId = `issue_comment:${getNumber(comment.id) || deliveryId}:${action}`;
-		externalUrl = getString(comment.html_url, prUrl(repo.owner, repo.repo, prNumber));
-		occurredAt = parseTs(comment.updated_at ?? comment.created_at);
-		title = `PR #${prNumber} comment`;
-	} else if (eventType === 'pull_request_review') {
-		const pr = asObject(root.pull_request);
-		const review = asObject(root.review);
-		actor = userFrom(review.user ?? root.sender);
-		prNumber = getNumber(pr.number);
-		body = getString(review.body);
-		externalId = `review:${getNumber(review.id) || deliveryId}:${action}`;
-		externalUrl = getString(
-			review.html_url,
-			getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
-		);
-		occurredAt = parseTs(review.submitted_at ?? review.updated_at);
-		title = `PR #${prNumber} review ${getString(review.state, action)}`;
-	} else if (eventType === 'pull_request_review_comment') {
-		const pr = asObject(root.pull_request);
-		const comment = asObject(root.comment);
-		actor = userFrom(comment.user ?? root.sender);
-		prNumber = getNumber(pr.number);
-		body = getString(comment.body);
-		externalId = `review_comment:${getNumber(comment.id) || deliveryId}:${action}`;
-		externalUrl = getString(
-			comment.html_url,
-			getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
-		);
-		occurredAt = parseTs(comment.updated_at ?? comment.created_at);
-		title = `PR #${prNumber} inline review comment`;
-	} else {
-		const pr = asObject(root.pull_request);
-		actor = userFrom(pr.user ?? root.sender);
-		prNumber = getNumber(pr.number);
-		body = getString(pr.body);
-		externalId = `pull_request:${getNumber(pr.id) || prNumber}:${action}:${deliveryId}`;
-		externalUrl = getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber));
-		occurredAt = parseTs(pr.updated_at ?? pr.created_at);
-		title = `PR #${prNumber} ${action}`;
-	}
-	if (!repo.owner || !repo.repo || !prNumber) return null;
-	const canonicalOwner = repo.owner.toLowerCase();
-	const canonicalRepo = repo.repo.toLowerCase();
-	return {
-		deliveryId,
-		dedupeKey: `${canonicalOwner}/${canonicalRepo}:${externalId}`,
-		source: 'webhook',
-		eventType,
-		action,
-		repoOwner: repo.owner,
-		repoName: repo.repo,
-		prNumber,
-		prUrl: prUrl(repo.owner, repo.repo, prNumber),
-		actor: actor.login,
-		actorType: actor.type,
-		body,
-		summary: `${title} by ${actor.login}${body ? `: ${truncateBody(body)}` : ''}`,
-		externalUrl,
-		externalId,
-		occurredAt,
-		rawPayload: payload,
-	};
-}
+export const normalizeSpaceGitHubWebhook = normalizeGitHubWebhook;
 
 export class SpaceGitHubRepository {
 	constructor(private readonly db: BunDatabase) {}
@@ -532,6 +428,7 @@ export class SpacePrTaskResolver {
 
 export class SpaceGitHubService {
 	readonly repo: SpaceGitHubRepository;
+	readonly eventExtensionRepo: GitHubEventExtensionRepository;
 	private readonly resolver: SpacePrTaskResolver;
 	private readonly debounce = new Map<
 		string,
@@ -546,52 +443,15 @@ export class SpaceGitHubService {
 		private readonly onEventsChanged?: () => void
 	) {
 		this.repo = new SpaceGitHubRepository(db);
+		this.eventExtensionRepo = new GitHubEventExtensionRepository(db);
 		this.resolver = new SpacePrTaskResolver(db);
 	}
 
-	async handleWebhook(req: Request): Promise<Response> {
-		const signature = req.headers.get('X-Hub-Signature-256');
-		const eventType = req.headers.get('X-GitHub-Event');
-		const deliveryId = req.headers.get('X-GitHub-Delivery');
-		if (!signature) return Response.json({ error: 'Missing signature header' }, { status: 401 });
-		if (!eventType || !deliveryId)
-			return Response.json({ error: 'Missing GitHub event headers' }, { status: 400 });
-		const raw = await req.text();
-		const signatureMatchedRepos = this.repo
-			.listWatchedRepos()
-			.filter((r) => r.enabled && r.webhookEnabled && r.webhookSecret);
-		const valid = [] as WatchedRepo[];
-		for (const repo of signatureMatchedRepos) {
-			if (repo.webhookSecret && (await verifySignature(raw, signature, repo.webhookSecret))) {
-				valid.push(repo);
-			}
-		}
-		if (valid.length === 0) return Response.json({ error: 'Invalid signature' }, { status: 401 });
-		let payload: unknown;
-		try {
-			payload = JSON.parse(raw);
-		} catch {
-			return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
-		}
-		const normalized = normalizeSpaceGitHubWebhook(eventType, deliveryId, payload);
-		if (!normalized)
-			return Response.json({ message: 'Event ignored', deliveryId }, { status: 202 });
-		const validForRepo = valid.filter(
-			(r) =>
-				r.owner.toLowerCase() === normalized.repoOwner.toLowerCase() &&
-				r.repo.toLowerCase() === normalized.repoName.toLowerCase()
+	async handleWebhook(_req: Request): Promise<Response> {
+		return Response.json(
+			{ error: 'SpaceGitHubService webhook ingestion moved to GitHubEventExtension' },
+			{ status: 410 }
 		);
-		if (validForRepo.length === 0)
-			return Response.json({ error: 'Repository is not watched' }, { status: 404 });
-		for (const repo of validForRepo) {
-			await this.ingest(repo.spaceId, normalized);
-			this.db
-				.prepare(
-					`UPDATE space_github_watched_repos SET last_webhook_at = ?, updated_at = ? WHERE id = ?`
-				)
-				.run(Date.now(), Date.now(), repo.id);
-		}
-		return Response.json({ message: 'Webhook received', deliveryId, spaces: validForRepo.length });
 	}
 
 	async ingest(

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -186,48 +186,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
 
-	const spaceGithubRpc = deps.spaceGitHubService;
-	deps.messageHub.onRequest('space.github.watchRepo', async (data) => {
-		const params = data as {
-			spaceId: string;
-			owner: string;
-			repo: string;
-			webhookSecret?: string;
-			webhookEnabled?: boolean;
-			pollingEnabled?: boolean;
-			enabled?: boolean;
-		};
-		if (!params.spaceId || !params.owner || !params.repo) {
-			throw new Error('spaceId, owner and repo are required');
-		}
-		const watchedRepo = spaceGithubRpc.repo.upsertWatchedRepo({
-			spaceId: params.spaceId,
-			owner: params.owner,
-			repo: params.repo,
-			webhookSecret: params.webhookSecret,
-			webhookEnabled: params.webhookEnabled,
-			pollingEnabled: params.pollingEnabled,
-			enabled: params.enabled,
-		});
-		deps.reactiveDb.notifyChange('space_github_watched_repos');
-		return { watchedRepo, webhookUrl: '/webhook/github/space' };
-	});
-	deps.messageHub.onRequest('space.github.listWatchedRepos', async (data) => {
-		const params = data as { spaceId?: string };
-		if (!params.spaceId) {
-			throw new Error('spaceId is required');
-		}
-		return {
-			repositories: spaceGithubRpc.repo.listWatchedRepos(params.spaceId).map((repo) => ({
-				...repo,
-				webhookSecret: repo.webhookSecret ? 'configured' : null,
-			})),
-		};
-	});
-	deps.messageHub.onRequest('space.github.pollOnce', async () => ({
-		count: await spaceGithubRpc.pollOnce(),
-	}));
-
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
 

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -1,4 +1,5 @@
 import { Database as BunDatabase } from 'bun:sqlite';
+import { InProcessTransport, MessageHub } from '@neokai/shared';
 import { describe, expect, test } from 'bun:test';
 import { createTables, runMigrations } from '../../../../src/storage/schema';
 import {
@@ -76,14 +77,15 @@ function payloadFor(event: string): unknown {
 	};
 }
 
-function webhookRequest(payload: unknown, event: string, signature: string): Request {
+function webhookRequest(payload: unknown, event: string, signature?: string): Request {
+	const headers: Record<string, string> = {
+		'X-GitHub-Event': event,
+		'X-GitHub-Delivery': 'delivery-1',
+	};
+	if (signature) headers['X-Hub-Signature-256'] = signature;
 	return new Request('http://localhost/webhook/github/space', {
 		method: 'POST',
-		headers: {
-			'X-Hub-Signature-256': signature,
-			'X-GitHub-Event': event,
-			'X-GitHub-Delivery': 'delivery-1',
-		},
+		headers,
 		body: JSON.stringify(payload),
 	});
 }
@@ -170,6 +172,26 @@ describe('GitHubEventExtension', () => {
 		);
 		expect(bad.status).toBe(401);
 
+		const missingSignature = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment')
+		);
+		expect(missingSignature.status).toBe(401);
+
+		const otherRepoPayload = {
+			...(payload as Record<string, unknown>),
+			repository: {
+				id: 2,
+				name: 'other',
+				full_name: 'acme/other',
+				owner: { login: 'acme' },
+			},
+		};
+		const otherRaw = JSON.stringify(otherRepoPayload);
+		const repoNotWatched = await extension.routes[0].handle(
+			webhookRequest(otherRepoPayload, 'issue_comment', await createSignature(otherRaw, 'secret'))
+		);
+		expect(repoNotWatched.status).toBe(404);
+
 		await extension.stop();
 	});
 
@@ -209,6 +231,75 @@ describe('GitHubEventExtension', () => {
 		expect(response.status).toBe(200);
 		expect(await response.json()).toMatchObject({ spaces: 0 });
 		expect(published).toHaveLength(0);
+		await extension.stop();
+	});
+
+	test('RPC disable persists for newly watched repositories', async () => {
+		const db = setupDb();
+		const extension = new GitHubEventExtension(db);
+		const clientHub = new MessageHub();
+		const hub = new MessageHub();
+		const [clientTransport, serverTransport] = InProcessTransport.createPair();
+		clientHub.registerTransport(clientTransport);
+		hub.registerTransport(serverTransport);
+		await Promise.all([clientTransport.initialize(), serverTransport.initialize()]);
+		const context = {
+			publisher: { publish: async () => {} },
+			config: new StaticExternalEventExtensionConfigStore({ globallyEnabled: true }),
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.registerRpcHandlers(hub, context);
+
+		await clientHub.request('space.github.disable', { spaceId: 'space-1' });
+		await clientHub.request('space.github.watchRepo', {
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+
+		expect(extension.repo.listWatchedRepos('space-1')[0].enabled).toBe(false);
+		await extension.stop();
+	});
+
+	test('space-scoped pollOnce respects global polling disable', async () => {
+		const db = setupDb();
+		const extension = new GitHubEventExtension(db);
+		const clientHub = new MessageHub();
+		const hub = new MessageHub();
+		const [clientTransport, serverTransport] = InProcessTransport.createPair();
+		clientHub.registerTransport(clientTransport);
+		hub.registerTransport(serverTransport);
+		await Promise.all([clientTransport.initialize(), serverTransport.initialize()]);
+		let publishCount = 0;
+		const context = {
+			publisher: {
+				publish: async () => {
+					publishCount++;
+				},
+			},
+			config: new StaticExternalEventExtensionConfigStore({
+				globallyEnabled: true,
+				polling: false,
+			}),
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.registerRpcHandlers(hub, context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+
+		const result = (await clientHub.request('space.github.pollOnce', { spaceId: 'space-1' })) as {
+			count: number;
+		};
+
+		expect(result.count).toBe(0);
+		expect(publishCount).toBe(0);
 		await extension.stop();
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -1,0 +1,214 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { createTables, runMigrations } from '../../../../src/storage/schema';
+import {
+	ExternalEventService,
+	ExternalEventStore,
+	type ExternalEvent,
+} from '../../../../src/lib/external-events';
+import {
+	GitHubEventExtension,
+	StaticExternalEventExtensionConfigStore,
+	mapEventType,
+	normalizeGitHubWebhook,
+	toExternalEvent,
+} from '../../../../src/lib/external-events/github';
+import { createDaemonInternalEventBus } from '../../../../src/lib/internal-event-bus';
+
+async function createSignature(payload: string, secret: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const cryptoKey = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	const buffer = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(payload));
+	return `sha256=${Array.from(new Uint8Array(buffer))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')}`;
+}
+
+function setupDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	createTables(db);
+	runMigrations(db, () => {});
+	return db;
+}
+
+const baseRepo = {
+	id: 1,
+	name: 'widgets',
+	full_name: 'Acme/Widgets',
+	owner: { login: 'Acme' },
+};
+
+function payloadFor(event: string): unknown {
+	if (event === 'issue_comment') {
+		return {
+			action: 'created',
+			repository: baseRepo,
+			sender: { login: 'bot', type: 'Bot' },
+			issue: { number: 7, title: 'PR', pull_request: { url: 'api' } },
+			comment: {
+				id: 101,
+				body: 'looks good',
+				html_url: 'https://github.com/acme/widgets/pull/7#issuecomment-101',
+				user: { login: 'bot', type: 'Bot' },
+				created_at: '2026-01-01T00:00:00Z',
+			},
+		};
+	}
+	return {
+		action: 'synchronize',
+		repository: baseRepo,
+		sender: { login: 'dev', type: 'User' },
+		pull_request: {
+			id: 77,
+			number: 7,
+			body: 'pr body',
+			html_url: 'https://github.com/acme/widgets/pull/7',
+			user: { login: 'dev', type: 'User' },
+			updated_at: '2026-01-01T00:00:00Z',
+		},
+	};
+}
+
+function webhookRequest(payload: unknown, event: string, signature: string): Request {
+	return new Request('http://localhost/webhook/github/space', {
+		method: 'POST',
+		headers: {
+			'X-Hub-Signature-256': signature,
+			'X-GitHub-Event': event,
+			'X-GitHub-Delivery': 'delivery-1',
+		},
+		body: JSON.stringify(payload),
+	});
+}
+
+describe('GitHubEventExtension', () => {
+	test('normalizes webhooks and constructs canonical topics', () => {
+		const normalized = normalizeGitHubWebhook(
+			'issue_comment',
+			'delivery-1',
+			payloadFor('issue_comment')
+		)!;
+		expect(normalized.repoOwner).toBe('Acme');
+		expect(normalized.repoName).toBe('widgets');
+		expect(mapEventType(normalized.eventType, normalized.action)).toBe(
+			'pull_request.comment_created'
+		);
+
+		const event = toExternalEvent('space-1', normalized);
+		expect(event.topic).toBe('github/acme/widgets/pull_request.comment_created');
+		expect(event.source).toBe('github');
+		expect(event.payload.prNumber).toBe(7);
+		expect(event.payload.repoOwner).toBe('acme');
+		expect(event.dedupeKey).toBe('acme/widgets:issue_comment:101:created');
+	});
+
+	test('webhook verifies signatures, checks enablement, and publishes ExternalEventService event', async () => {
+		const db = setupDb();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, name, workspace_path, status, created_at, updated_at) VALUES ('space-1', 'space-1', 'Space', '/tmp', 'active', 1, 1)`
+		).run();
+		const bus = createDaemonInternalEventBus();
+		const service = new ExternalEventService(new ExternalEventStore(db), bus);
+		const received: ExternalEvent[] = [];
+		bus.subscribe(
+			'externalEvent.published',
+			(payload) => {
+				received.push({
+					id: payload.eventId,
+					spaceId: payload.spaceId,
+					topic: payload.topic,
+					occurredAt: payload.occurredAt,
+					ingestedAt: payload.ingestedAt,
+					source: payload.source,
+					summary: payload.summary,
+					externalUrl: payload.externalUrl,
+					payload: payload.payload,
+					dedupeKey: payload.dedupeKey,
+				});
+			},
+			{ subscriberName: 'github-event-extension-test' }
+		);
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: service,
+			config: new StaticExternalEventExtensionConfigStore({ globallyEnabled: true }),
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			webhookSecret: 'secret',
+		});
+
+		const payload = payloadFor('issue_comment');
+		const raw = JSON.stringify(payload);
+		const ok = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
+		);
+		expect(ok.status).toBe(200);
+		expect(received).toHaveLength(1);
+		expect(received[0].topic).toBe('github/acme/widgets/pull_request.comment_created');
+		expect(db.prepare('SELECT COUNT(*) AS c FROM space_external_events').get()).toEqual({ c: 1 });
+
+		const duplicate = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
+		);
+		expect(duplicate.status).toBe(200);
+		expect(db.prepare('SELECT COUNT(*) AS c FROM space_external_events').get()).toEqual({ c: 1 });
+
+		const bad = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'wrong'))
+		);
+		expect(bad.status).toBe(401);
+
+		await extension.stop();
+	});
+
+	test('does not publish when a matched space is disabled', async () => {
+		const db = setupDb();
+		const published: ExternalEvent[] = [];
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: { publish: async (event: ExternalEvent) => published.push(event) },
+			config: {
+				async getGlobalConfig(source: string) {
+					return { source, globallyEnabled: true, capabilities: { webhooks: true, polling: true } };
+				},
+				async getSpaceConfig(spaceId: string, source: string) {
+					return { spaceId, source, enabled: false, settings: {} };
+				},
+				async listEnabledSpaces() {
+					return [];
+				},
+			},
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			webhookSecret: 'secret',
+		});
+
+		const payload = payloadFor('issue_comment');
+		const raw = JSON.stringify(payload);
+		const response = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ spaces: 0 });
+		expect(published).toHaveLength(0);
+		await extension.stop();
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -195,6 +195,44 @@ describe('GitHubEventExtension', () => {
 		await extension.stop();
 	});
 
+	test('treats omitted webhook capability as enabled', async () => {
+		const db = setupDb();
+		const published: ExternalEvent[] = [];
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: { publish: async (event: ExternalEvent) => published.push(event) },
+			config: {
+				async getGlobalConfig(source: string) {
+					return { source, globallyEnabled: true, capabilities: {} };
+				},
+				async getSpaceConfig(spaceId: string, source: string) {
+					return { spaceId, source, enabled: true, settings: {} };
+				},
+				async listEnabledSpaces() {
+					return [];
+				},
+			},
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			webhookSecret: 'secret',
+		});
+
+		const payload = payloadFor('issue_comment');
+		const raw = JSON.stringify(payload);
+		const response = await extension.routes[0].handle(
+			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
+		);
+
+		expect(response.status).toBe(200);
+		expect(published).toHaveLength(1);
+		await extension.stop();
+	});
+
 	test('does not publish when a matched space is disabled', async () => {
 		const db = setupDb();
 		const published: ExternalEvent[] = [];
@@ -301,5 +339,57 @@ describe('GitHubEventExtension', () => {
 		expect(result.count).toBe(0);
 		expect(publishCount).toBe(0);
 		await extension.stop();
+	});
+
+	test('stop waits for an active polling cycle before returning', async () => {
+		const db = setupDb();
+		const extension = new GitHubEventExtension(db, { pollIntervalMs: 1 });
+		let releaseFetch!: () => void;
+		let fetchStarted!: Promise<void>;
+		let resolveFetchStarted!: () => void;
+		fetchStarted = new Promise((resolve) => {
+			resolveFetchStarted = resolve;
+		});
+		await extension.start({
+			publisher: { publish: async () => {} },
+			config: new StaticExternalEventExtensionConfigStore({ globallyEnabled: true }),
+			onSourceConfigChanged() {},
+		});
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+
+		let blocked = false;
+		const pollPromise = extension.pollWatchedRepo(
+			extension.repo.listPollingRepos()[0],
+			(async () => {
+				if (!blocked) {
+					blocked = true;
+					resolveFetchStarted();
+					await new Promise<void>((resolve) => {
+						releaseFetch = resolve;
+					});
+				}
+				return new Response(JSON.stringify([]), { status: 200 });
+			}) as typeof fetch
+		);
+		(extension as unknown as { activePollCycle: Promise<void> }).activePollCycle = pollPromise.then(
+			() => {}
+		);
+		await fetchStarted;
+
+		let stopped = false;
+		const stopPromise = extension.stop().then(() => {
+			stopped = true;
+		});
+		await Promise.resolve();
+		expect(stopped).toBe(false);
+
+		releaseFetch();
+		await stopPromise;
+		expect(stopped).toBe(true);
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
@@ -142,59 +142,6 @@ describe('Space GitHub integration', () => {
 		}
 	});
 
-	test('verifies signatures, allowlist and dedupes deliveries', async () => {
-		const db = setupDb();
-		seedTask(db);
-		const service = new SpaceGitHubService(db);
-		service.repo.upsertWatchedRepo({
-			spaceId: 'space-1',
-			owner: 'acme',
-			repo: 'widgets',
-			webhookSecret: 'secret',
-		});
-		const payload = payloadFor('issue_comment');
-		const raw = JSON.stringify(payload);
-		const ok = await service.handleWebhook(
-			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
-		);
-		expect(ok.status).toBe(200);
-		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 1 });
-		const duplicate = await service.handleWebhook(
-			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'secret'))
-		);
-		expect(duplicate.status).toBe(200);
-		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 1 });
-		const bad = await service.handleWebhook(
-			webhookRequest(payload, 'issue_comment', await createSignature(raw, 'wrong'))
-		);
-		expect(bad.status).toBe(401);
-		const missing = await service.handleWebhook(
-			new Request('http://localhost/webhook/github/space', {
-				method: 'POST',
-				headers: { 'X-GitHub-Event': 'issue_comment', 'X-GitHub-Delivery': 'd' },
-				body: raw,
-			})
-		);
-		expect(missing.status).toBe(401);
-		const unknownRepo = await service.handleWebhook(
-			webhookRequest(
-				{
-					...(payload as object),
-					repository: { ...baseRepo, name: 'other', full_name: 'acme/other' },
-				},
-				'issue_comment',
-				await createSignature(
-					JSON.stringify({
-						...(payload as object),
-						repository: { ...baseRepo, name: 'other', full_name: 'acme/other' },
-					}),
-					'secret'
-				)
-			)
-		);
-		expect(unknownRepo.status).toBe(404);
-	});
-
 	test('resolves by task text, artifacts, gate data, ambiguous and unknown', async () => {
 		let db = setupDb();
 		seedTask(db);

--- a/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
@@ -1,25 +1,11 @@
 import { Database as BunDatabase } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
+import { GitHubEventExtension } from '../../../../src/lib/external-events/github';
 import { createTables, runMigrations } from '../../../../src/storage/schema';
 import {
 	SpaceGitHubService,
 	normalizeSpaceGitHubWebhook,
 } from '../../../../src/lib/github/space-github';
-
-async function createSignature(payload: string, secret: string): Promise<string> {
-	const encoder = new TextEncoder();
-	const cryptoKey = await crypto.subtle.importKey(
-		'raw',
-		encoder.encode(secret),
-		{ name: 'HMAC', hash: 'SHA-256' },
-		false,
-		['sign']
-	);
-	const buffer = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(payload));
-	return `sha256=${Array.from(new Uint8Array(buffer))
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('')}`;
-}
 
 function setupDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
@@ -112,18 +98,6 @@ function payloadFor(event: string): unknown {
 			updated_at: '2026-01-01T00:00:00Z',
 		},
 	};
-}
-
-function webhookRequest(payload: unknown, event: string, signature: string): Request {
-	return new Request('http://localhost/webhook/github/space', {
-		method: 'POST',
-		headers: {
-			'X-Hub-Signature-256': signature,
-			'X-GitHub-Event': event,
-			'X-GitHub-Delivery': 'delivery-1',
-		},
-		body: JSON.stringify(payload),
-	});
 }
 
 describe('Space GitHub integration', () => {
@@ -236,11 +210,30 @@ describe('Space GitHub integration', () => {
 		});
 	});
 
-	test('polling uses auth/cursors and shares dedupe with webhooks', async () => {
+	test('extension polling uses auth/cursors and preserves legacy ingestion dedupe', async () => {
 		const db = setupDb();
 		seedTask(db);
-		const service = new SpaceGitHubService(db, undefined, undefined, 'token');
-		service.repo.upsertWatchedRepo({
+		const service = new SpaceGitHubService(db);
+		const extension = new GitHubEventExtension(service.eventExtensionRepo, {
+			githubToken: 'token',
+			legacyIngest: (spaceId, event) => service.ingest(spaceId, event),
+		});
+		await extension.start({
+			publisher: { publish: async () => {} },
+			config: {
+				async getGlobalConfig(source: string) {
+					return { source, globallyEnabled: true, capabilities: { webhooks: true, polling: true } };
+				},
+				async getSpaceConfig(spaceId: string, source: string) {
+					return { spaceId, source, enabled: true, settings: {} };
+				},
+				async listEnabledSpaces() {
+					return [];
+				},
+			},
+			onSourceConfigChanged() {},
+		});
+		extension.repo.upsertWatchedRepo({
 			spaceId: 'space-1',
 			owner: 'acme',
 			repo: 'widgets',
@@ -264,12 +257,19 @@ describe('Space GitHub integration', () => {
 				: [];
 			return new Response(JSON.stringify(rows), { status: 200, headers: { ETag: 'etag-1' } });
 		};
-		await service.pollOnce(fakeFetch as typeof fetch);
+		await extension.pollWatchedRepo(
+			extension.repo.listPollingRepos()[0],
+			fakeFetch as typeof fetch
+		);
 		expect((calls[0].headers as Record<string, string>).Authorization).toBe('Bearer token');
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 1 });
-		await service.pollOnce(fakeFetch as typeof fetch);
+		await extension.pollWatchedRepo(
+			extension.repo.listPollingRepos()[0],
+			fakeFetch as typeof fetch
+		);
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 1 });
 		expect((calls[3].headers as Record<string, string>)['If-None-Match']).toBe('etag-1');
+		await extension.stop();
 	});
 
 	test('dedupe keys preserve repeated webhook actions and polling PR updates', async () => {
@@ -309,11 +309,30 @@ describe('Space GitHub integration', () => {
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 2 });
 	});
 
-	test('polling ignores issue comments and keeps watermark stable while draining pages', async () => {
+	test('extension polling ignores issue comments and keeps watermark stable while draining pages', async () => {
 		const db = setupDb();
 		seedTask(db);
-		const service = new SpaceGitHubService(db, undefined, undefined, 'token');
-		service.repo.upsertWatchedRepo({
+		const service = new SpaceGitHubService(db);
+		const extension = new GitHubEventExtension(service.eventExtensionRepo, {
+			githubToken: 'token',
+			legacyIngest: (spaceId, event) => service.ingest(spaceId, event),
+		});
+		await extension.start({
+			publisher: { publish: async () => {} },
+			config: {
+				async getGlobalConfig(source: string) {
+					return { source, globallyEnabled: true, capabilities: { webhooks: true, polling: true } };
+				},
+				async getSpaceConfig(spaceId: string, source: string) {
+					return { spaceId, source, enabled: true, settings: {} };
+				},
+				async listEnabledSpaces() {
+					return [];
+				},
+			},
+			onSourceConfigChanged() {},
+		});
+		extension.repo.upsertWatchedRepo({
 			spaceId: 'space-1',
 			owner: 'Acme',
 			repo: 'Widgets',
@@ -360,7 +379,10 @@ describe('Space GitHub integration', () => {
 			return new Response(JSON.stringify([]), { status: 200 });
 		};
 
-		await service.pollOnce(fakeFetch as typeof fetch);
+		await extension.pollWatchedRepo(
+			extension.repo.listPollingRepos()[0],
+			fakeFetch as typeof fetch
+		);
 
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 100 });
 		expect(calls.some((url) => url.includes('per_page=100'))).toBe(true);
@@ -375,7 +397,10 @@ describe('Space GitHub integration', () => {
 		expect(cursor.lastSeenAt).toBe(0);
 		expect(cursor.pendingLastSeenAt).toBeGreaterThan(0);
 
-		await service.pollOnce(fakeFetch as typeof fetch);
+		await extension.pollWatchedRepo(
+			extension.repo.listPollingRepos()[0],
+			fakeFetch as typeof fetch
+		);
 
 		expect(calls.some((url) => url.includes('page=2') && !url.includes('since='))).toBe(true);
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 101 });
@@ -396,5 +421,6 @@ describe('Space GitHub integration', () => {
 				}
 			).dedupe_key.startsWith('acme/widgets:')
 		).toBe(true);
+		await extension.stop();
 	});
 });


### PR DESCRIPTION
Extracts GitHub webhook and polling ingestion into a standalone external-event extension that publishes normalized GitHub events through the shared external event bus.

Also moves watched-repo configuration/RPC handling behind the extension and adds focused tests for normalization, topic construction, enablement, and webhook publication.

Tests:
- bun run check
- cd packages/daemon && bun test tests/unit/2-handlers/github/github-event-extension.test.ts tests/unit/2-handlers/github/space-github.test.ts