### PR TITLE
Wire GitHub external event extension

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -8,30 +8,25 @@ import { AuthManager } from './lib/auth-manager';
 import { SettingsManager } from './lib/settings-manager';
 import { StateProjectionService } from './lib/state-projection-service';
 import { createClientEventBridge } from './lib/client-event-bridge';
-import { MessageHub, MessageHubRouter } from '@neokai/shared';
+import { ClientEventGateway, MessageHub, MessageHubRouter } from '@neokai/shared';
+import { createDaemonHub } from './lib/daemon-hub';
 import {
 	createDaemonInternalEventBus,
 	type DaemonInternalEventMap,
 	type InternalEventBus,
 } from './lib/internal-event-bus';
-import {
-	createInternalCommandBus,
-	type DaemonCommandMap,
-	type InternalCommandBus,
-} from './lib/internal-command-bus';
 import { createInternalQueryBus, type DaemonQueryMap } from './lib/internal-query-bus';
 import { setupRPCHandlers } from './lib/rpc-handlers';
 import { applyProviderModelAllowlistsToEnv } from './lib/rpc-handlers/settings-handlers';
 import { WebSocketServerTransport } from './lib/websocket-server-transport';
 import { createWebSocketHandlers } from './routes/setup-websocket';
 import { createGitHubService, type GitHubService } from './lib/github/github-service';
-import { SpaceGitHubService } from './lib/github/space-github';
-import { ExternalEventService, ExternalEventStore } from './lib/external-events';
-import {
-	GitHubEventExtension,
-	StaticExternalEventExtensionConfigStore,
-} from './lib/external-events/github';
 import { getProviderRegistry } from './lib/providers/registry.js';
+import { ExternalEventStore } from './lib/external-events/external-event-store';
+import { ExternalEventService } from './lib/external-events/external-event-service';
+import { ExternalEventExtensionConfigStore } from './lib/external-events/extension-config-store';
+import { ExternalEventExtensionManager } from './lib/external-events/extension-manager';
+import { GitHubEventExtension } from './lib/external-events/github';
 import { createReactiveDatabase } from './storage/reactive-database';
 import { LiveQueryEngine } from './storage/live-query';
 import { SpaceAgentRepository } from './storage/repositories/space-agent-repository';
@@ -53,11 +48,6 @@ import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from 
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
 import { NeoAgentManager } from './lib/neo/neo-agent-manager';
-import {
-	cleanupSuspiciousProcesses,
-	ProcessWatchdog,
-	type ProcessSnapshot,
-} from './lib/process-watchdog';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -84,23 +74,25 @@ export interface DaemonAppContext {
 	settingsManager: SettingsManager;
 	stateManager: StateProjectionService;
 	transport: WebSocketServerTransport;
+	daemonHub: Awaited<ReturnType<typeof createDaemonHub>>;
 	/**
-	 * Semantic internal event bus for daemon domain events.
+	 * Semantic internal event bus for migrated daemon domain events.
+	 * New publishers/subscribers should use this instead of DaemonHub.
 	 * See docs/plans/internal-event-command-query-architecture.md.
 	 */
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>;
-	/** Semantic internal command bus for action dispatch */
-	commandBus: InternalCommandBus<DaemonCommandMap>;
 	/** Semantic internal query bus for point-in-time reads */
 	queryBus: ReturnType<typeof createInternalQueryBus<DaemonQueryMap>>;
 	/**
 	 * GitHub service instance (null if not configured)
 	 */
 	gitHubService: GitHubService | null;
-	/** Legacy Space-level GitHub PR activity ingestion service */
-	spaceGitHubService: SpaceGitHubService;
-	/** GitHub external-event source extension */
-	githubEventExtension: GitHubEventExtension;
+	/** Source-agnostic external event persistence and delivery lifecycle store */
+	externalEventStore: ExternalEventStore;
+	/** External event publisher used by source extensions */
+	externalEventService: ExternalEventService;
+	/** External event extension manager */
+	extensionManager: ExternalEventExtensionManager;
 	/** Phase 2: Reactive database wrapper for change event emission */
 	reactiveDb: ReturnType<typeof createReactiveDatabase>;
 	/** Phase 2: Live query engine for reactive SQL queries */
@@ -191,38 +183,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	//       Ephemeral, within a single async call; cleaned up before the call returns.
 	//   • app.ts graceful-shutdown readiness check (this file, waitForPendingCalls)
 	//       One-shot shutdown polling with hard timeout; not a recurring task.
-	//   • ProcessWatchdog timer (process-watchdog.ts)
-	//       Last-resort OS process leak safety net; intentionally independent from the job queue.
 	jobProcessor.setChangeNotifier((table) => {
 		reactiveDb.notifyChange(table);
 	});
-	let sessionManager: SessionManager | null = null;
-	let neoAgentManager: NeoAgentManager | null = null;
-	let taskAgentManager: TaskAgentManager | null = null;
-	const processWatchdog = new ProcessWatchdog(undefined, () =>
-		cleanupSuspiciousProcesses({
-			getRootPids: (snapshot?: ProcessSnapshot[]) => {
-				const live: number[] = [];
-				const exited: number[] = [];
-				if (sessionManager) {
-					const split = sessionManager.getTrackedAgentRootPidsSplit(snapshot);
-					live.push(...split.live);
-					exited.push(...split.exited);
-				}
-				if (neoAgentManager) {
-					const split = neoAgentManager.getTrackedAgentRootPidsSplit();
-					live.push(...split.live);
-					exited.push(...split.exited);
-				}
-				if (taskAgentManager) {
-					const split = taskAgentManager.getTrackedAgentRootPidsSplit();
-					live.push(...split.live);
-					exited.push(...split.exited);
-				}
-				return { live, exited };
-			},
-		})
-	);
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
@@ -282,15 +245,37 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// 5. Register Transport with MessageHub
 	messageHub.registerTransport(transport);
 
-	// Initialize InternalEventBus for daemon domain events.
-	const internalEventBus = createDaemonInternalEventBus();
+	// Initialize DaemonHub (TypedHub-based event coordination)
+	const daemonHub = createDaemonHub('daemon');
+	await daemonHub.initialize();
 
-	// Initialize InternalCommandBus for daemon action dispatch.
-	const commandBus = createInternalCommandBus<DaemonCommandMap>();
+	// Initialize InternalEventBus for migrated daemon domain events.
+	// Subscribers/publishers register here as they migrate off DaemonHub.
+	const internalEventBus = createDaemonInternalEventBus();
 
 	// Initialize InternalQueryBus for point-in-time reads.
 	// Handlers will be registered by domain services as they migrate.
 	const queryBus = createInternalQueryBus<DaemonQueryMap>();
+
+	// Initialize external event services after the internal bus so extensions can
+	// publish source-normalized events into the workflow runtime.
+	const externalEventStore = new ExternalEventStore(db.getDatabase());
+	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
+	const extensionConfigStore = new ExternalEventExtensionConfigStore(db.getDatabase());
+	const sourceConfigTables: Record<string, string[]> = {
+		github: ['space_github_watched_repos'],
+	};
+	const extensionContext = {
+		publisher: externalEventService,
+		config: extensionConfigStore,
+		onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
+			logInfo('[Daemon] Extension config changed', change);
+			for (const table of sourceConfigTables[change.source] ?? []) {
+				reactiveDb.notifyChange(table);
+			}
+		},
+	};
+	const extensionManager = new ExternalEventExtensionManager();
 
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
@@ -333,15 +318,15 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		logError('[Daemon] Failed to ensure builtin skill plugin wrappers (non-fatal):', err);
 	}
 
-	// Initialize session manager (with InternalEventBus<DaemonInternalEventMap>, SettingsManager, no StateManager dependency!)
+	// Initialize session manager (with DaemonHub, SettingsManager, no StateManager dependency!)
 	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
 	// trigger LiveQuery invalidation immediately.
-	sessionManager = new SessionManager(
+	const sessionManager = new SessionManager(
 		reactiveDb.db,
 		messageHub,
 		authManager,
 		settingsManager,
-		internalEventBus,
+		daemonHub,
 		{
 			defaultModel: config.defaultModel,
 			maxTokens: config.maxTokens,
@@ -350,7 +335,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobQueue,
 		jobProcessor,
 		skillsManager,
-		db.appMcpServers
+		db.appMcpServers,
+		internalEventBus
 	);
 
 	// Register session title generation handler before jobProcessor starts
@@ -358,11 +344,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize Neo agent manager (singleton global AI assistant).
 	// Instantiated after sessionManager so it can be passed as the NeoSessionManager.
-	neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
+	const neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
 
-	// Initialize StateProjectionService (read-model caches from InternalEventBus)
+	// Initialize StateProjectionService (pure read-model caches from InternalEventBus)
 	const stateManager = new StateProjectionService(
-		messageHub,
 		sessionManager,
 		authManager,
 		settingsManager,
@@ -371,14 +356,74 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		internalEventBus
 	);
 
-	// Initialize ClientEventBridge — forwards selected InternalEventBus events to
-	// WebSocket clients via ClientEventGateway. This extracts the repetitive
-	// room/space forwarding out of StateProjectionService.
-	const clientEventGateway = stateManager.getClientEventGateway();
+	// Bridge migrated DaemonHub events to InternalEventBus so
+	// StateProjectionService (and future subscribers) receive them without
+	// touching every publisher call site. This is the M5 compatibility path;
+	// publishers will migrate to InternalEventBus directly in later milestones.
+	//
+	// We use publish() (awaited) instead of publishAsync() so cache updates
+	// settle before ClientEventBridge triggers broadcastSystemChange() from
+	// the same DaemonHub event — preserving the ordering between cache write
+	// and broadcast read.
+	const unsubSessionCreated = daemonHub.on('session.created', (data) => {
+		void internalEventBus.publish('session.created', {
+			namespaceId: data.sessionId,
+			session: data.session,
+		});
+	});
+	const unsubSessionUpdated = daemonHub.on('session.updated', (data) => {
+		void internalEventBus.publish('session.updated', {
+			namespaceId: data.sessionId,
+			source: data.source,
+			session: data.session,
+			processingState: data.processingState,
+		});
+	});
+	const unsubSessionDeleted = daemonHub.on('session.deleted', (data) => {
+		void internalEventBus.publish('session.deleted', {
+			namespaceId: data.sessionId,
+		});
+	});
+	const unsubCommandsUpdated = daemonHub.on('commands.updated', (data) => {
+		void internalEventBus.publish('commands.updated', {
+			namespaceId: data.sessionId,
+			commands: data.commands,
+		});
+	});
+	const unsubSessionError = daemonHub.on('session.error', (data) => {
+		void internalEventBus.publish('session.error', {
+			namespaceId: data.sessionId,
+			error: data.error,
+			details: data.details,
+		});
+	});
+	const unsubSessionErrorClear = daemonHub.on('session.errorClear', (data) => {
+		void internalEventBus.publish('session.errorClear', {
+			namespaceId: data.sessionId,
+		});
+	});
+	const unsubApiConnection = daemonHub.on('api.connection', (data) => {
+		// Forward the complete payload so diagnostic fields (errorCount,
+		// lastError, lastSuccessfulCall) are preserved in projections.
+		void internalEventBus.publish('api.connection', {
+			namespaceId: data.sessionId,
+			...data,
+		});
+	});
+
+	// Initialize ClientEventBridge — owns ALL client-facing delivery:
+	// - Event forwarding (space, session, connection, config, error events)
+	// - Versioned state broadcasts (system, settings, session state, SDK messages)
+	// - RPC handler registration (state snapshot queries)
+	// Migrated space events route through InternalEventBus; unmigrated spaceAgent/spaceWorkflow
+	// events remain on DaemonHub.
+	const clientEventGateway = new ClientEventGateway({ hub: messageHub });
 	const clientEventBridge = createClientEventBridge(
-		internalEventBus,
+		daemonHub,
+		messageHub,
 		clientEventGateway,
-		stateManager
+		stateManager,
+		internalEventBus
 	);
 	clientEventBridge.start();
 
@@ -396,7 +441,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		if (apiKey) {
 			gitHubService = createGitHubService({
 				db,
-				internalEventBus,
+				daemonHub,
 				config,
 				apiKey,
 				githubToken: process.env.GITHUB_TOKEN, // Optional GitHub token for polling
@@ -419,49 +464,24 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const fileIndex = new FileIndex(config.workspaceRoot);
 	void fileIndex.init();
 
-	const spaceGitHubService = new SpaceGitHubService(
-		db.getDatabase(),
-		internalEventBus,
-		process.env.GITHUB_TOKEN,
-		() => reactiveDb.notifyChange('space_github_events')
-	);
-	const externalEventStore = new ExternalEventStore(db.getDatabase());
-	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
-	const githubEventPollingEnabled = !!(
-		config.githubPollingInterval && config.githubPollingInterval > 0
-	);
-	const githubEventConfig = new StaticExternalEventExtensionConfigStore({
-		globallyEnabled: true,
-		webhooks: true,
-		polling: githubEventPollingEnabled,
-	});
-	const githubEventExtension = new GitHubEventExtension(spaceGitHubService.eventExtensionRepo, {
-		githubToken: process.env.GITHUB_TOKEN,
-		pollIntervalMs: githubEventPollingEnabled ? config.githubPollingInterval! * 1000 : undefined,
-		onWatchedReposChanged: () => reactiveDb.notifyChange('space_github_watched_repos'),
-	});
-	const externalEventExtensionContext = {
-		publisher: externalEventService,
-		config: githubEventConfig,
-		onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
-			if (change.source === 'github') reactiveDb.notifyChange('space_github_watched_repos');
-		},
-	};
-	githubEventExtension.registerRpcHandlers(messageHub, externalEventExtensionContext);
-
 	// Setup RPC handlers (returns cleanup function + exposed services)
-	const rpcHandlers = setupRPCHandlers({
+	const {
+		cleanup: rpcHandlerCleanup,
+		spaceRuntimeService,
+		taskAgentManager,
+		spaceWorktreeManager,
+	} = setupRPCHandlers({
 		messageHub,
 		sessionManager,
 		authManager,
 		settingsManager,
 		config,
+		daemonHub,
 		internalEventBus,
-		commandBus,
-		externalEventStore,
 		db,
 		gitHubService: gitHubService ?? undefined,
-		spaceGitHubService,
+		externalEventStore,
+		externalEventService,
 		spaceManager,
 		spaceAgentManager,
 		jobQueue,
@@ -473,9 +493,25 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		neoAgentManager,
 		mcpImportService,
 	});
-	const { cleanup: rpcHandlerCleanup, spaceRuntimeService, spaceWorktreeManager } = rpcHandlers;
-	taskAgentManager = rpcHandlers.taskAgentManager;
-	await githubEventExtension.start(externalEventExtensionContext);
+
+	extensionManager.register(new GitHubEventExtension(db.getDatabase()));
+
+	for (const sourceId of ['github']) {
+		const extension = extensionManager.getExtension(sourceId);
+		if (!extension) continue;
+		const globalConfig = await extensionContext.config.getGlobalConfig(extension.sourceId);
+		if (!globalConfig.globallyEnabled) continue;
+
+		if ('routes' in extension) {
+			extensionManager.registerRoutes(extension.routes, extensionContext);
+		}
+		if ('registerRpcHandlers' in extension && globalConfig.capabilities.rpcConfig) {
+			extensionManager.registerRpcHandlers(extension.sourceId, messageHub, extensionContext);
+		}
+
+		await extensionManager.startExtension(extension.sourceId, extensionContext);
+		logInfo(`[Daemon] Started external event extension: ${extension.sourceId}`);
+	}
 
 	// Wait for SpaceRuntimeService startup provisioning to complete before we
 	// bind the WebSocket/HTTP server. `start()` inside `setupRPCHandlers` kicks
@@ -544,13 +580,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				);
 			}
 
-			// Space-level public-safe GitHub webhook endpoint.
-			const githubExtensionRoute = githubEventExtension.routes.find(
-				(route) => route.path === url.pathname && route.method === req.method
-			);
-			if (githubExtensionRoute) {
-				return githubExtensionRoute.handle(req, externalEventExtensionContext);
-			}
+			const extensionRoute = extensionManager
+				.getRegisteredRoutes()
+				.find((route) => route.method === req.method && route.path === url.pathname);
+			if (extensionRoute) return extensionRoute.handle(req);
 
 			// Legacy room GitHub webhook endpoint (kept as a compatibility alias only).
 			if (url.pathname === '/webhook/github' && req.method === 'POST') {
@@ -628,7 +661,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			jobQueue,
 			spaceRepo: taskScheduleSpaceRepo,
 			taskRepo: taskScheduleTaskRepo,
-			eventHub: internalEventBus,
+			internalEventBus,
 		});
 	});
 
@@ -724,10 +757,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Start job queue processor last (after all handler registrations)
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
-	if (process.env.NODE_ENV !== 'test') {
-		processWatchdog.start();
-		logInfo('[Daemon] Process watchdog started');
-	}
 
 	// Provision the Neo agent session (skip in test mode unless explicitly enabled).
 	// Mirrors the spaces agent guard: test runs are clean by default; online/e2e
@@ -799,6 +828,15 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			// while we're tearing down sessions and transport.
 			clientEventBridge.stop();
 
+			// Unsubscribe DaemonHub → InternalEventBus bridge listeners
+			unsubSessionCreated();
+			unsubSessionUpdated();
+			unsubSessionDeleted();
+			unsubCommandsUpdated();
+			unsubSessionError();
+			unsubSessionErrorClear();
+			unsubApiConnection();
+
 			try {
 				server.stop();
 			} catch {
@@ -839,9 +877,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				}
 			}
 
-			// Stop background processors before MessageHub cleanup
-			processWatchdog.stop();
-			logInfo('[Daemon] Process watchdog stopped');
+			// Stop external event extensions before MessageHub cleanup so polling and
+			// webhook handlers stop publishing into a shutting-down bus.
+			for (const sourceId of ['github']) {
+				await extensionManager.stopExtension(sourceId);
+			}
+			logInfo('[Daemon] External event extensions stopped');
+
+			// Stop job queue processor before MessageHub cleanup
 			await jobProcessor.stop();
 			logInfo('[Daemon] Job queue processor stopped');
 
@@ -860,8 +903,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				gitHubService.stop();
 				logInfo('[Daemon] GitHub service stopped');
 			}
-			await githubEventExtension.stop();
-			logInfo('[Daemon] GitHub event extension stopped');
 
 			// Stop all Task Agent sessions before sessionManager.cleanup() so that
 			// Task Agent sessions are interrupted cleanly before the session pool drains.
@@ -907,12 +948,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		settingsManager,
 		stateManager,
 		transport,
+		daemonHub,
 		internalEventBus,
-		commandBus,
 		queryBus,
 		gitHubService,
-		spaceGitHubService,
-		githubEventExtension,
+		externalEventStore,
+		externalEventService,
+		extensionManager,
 		reactiveDb,
 		liveQueries,
 		spaceAgentManager,

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -440,7 +440,22 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		},
 	};
 	const extensionManager = new ExternalEventExtensionManager();
-	extensionManager.register(new GitHubEventExtension(db.getDatabase()));
+	const githubPollingEnabled = !!(config.githubPollingInterval && config.githubPollingInterval > 0);
+	if (!githubPollingEnabled) {
+		await extensionConfigStore.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true, polling: false, rpcConfig: true },
+			settings: { pollingDisabledByEnv: true },
+		});
+	}
+	extensionManager.register(
+		new GitHubEventExtension(
+			db.getDatabase(),
+			process.env.GITHUB_TOKEN,
+			githubPollingEnabled ? { pollIntervalMs: config.githubPollingInterval! * 1000 } : undefined
+		)
+	);
 
 	function isHttpExternalEventExtension(
 		extension: unknown

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -441,12 +441,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	};
 	const extensionManager = new ExternalEventExtensionManager();
 	const githubPollingEnabled = !!(config.githubPollingInterval && config.githubPollingInterval > 0);
-	if (!githubPollingEnabled) {
+	if (githubPollingEnabled) {
+		const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
 		await extensionConfigStore.setGlobalConfig('github', {
-			source: 'github',
-			globallyEnabled: true,
-			capabilities: { webhooks: true, polling: false, rpcConfig: true },
-			settings: { pollingDisabledByEnv: true },
+			...githubGlobalConfig,
+			capabilities: {
+				...githubGlobalConfig.capabilities,
+				polling: true,
+			},
 		});
 	}
 	extensionManager.register(

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -8,25 +8,32 @@ import { AuthManager } from './lib/auth-manager';
 import { SettingsManager } from './lib/settings-manager';
 import { StateProjectionService } from './lib/state-projection-service';
 import { createClientEventBridge } from './lib/client-event-bridge';
-import { ClientEventGateway, MessageHub, MessageHubRouter } from '@neokai/shared';
-import { createDaemonHub } from './lib/daemon-hub';
+import { MessageHub, MessageHubRouter } from '@neokai/shared';
 import {
 	createDaemonInternalEventBus,
 	type DaemonInternalEventMap,
 	type InternalEventBus,
 } from './lib/internal-event-bus';
+import {
+	createInternalCommandBus,
+	type DaemonCommandMap,
+	type InternalCommandBus,
+} from './lib/internal-command-bus';
 import { createInternalQueryBus, type DaemonQueryMap } from './lib/internal-query-bus';
 import { setupRPCHandlers } from './lib/rpc-handlers';
 import { applyProviderModelAllowlistsToEnv } from './lib/rpc-handlers/settings-handlers';
 import { WebSocketServerTransport } from './lib/websocket-server-transport';
 import { createWebSocketHandlers } from './routes/setup-websocket';
 import { createGitHubService, type GitHubService } from './lib/github/github-service';
-import { getProviderRegistry } from './lib/providers/registry.js';
-import { ExternalEventStore } from './lib/external-events/external-event-store';
-import { ExternalEventService } from './lib/external-events/external-event-service';
+import { ExternalEventService, ExternalEventStore } from './lib/external-events';
 import { ExternalEventExtensionConfigStore } from './lib/external-events/extension-config-store';
 import { ExternalEventExtensionManager } from './lib/external-events/extension-manager';
+import type {
+	HttpExternalEventExtension,
+	RpcExternalEventExtension,
+} from './lib/external-events/types';
 import { GitHubEventExtension } from './lib/external-events/github';
+import { getProviderRegistry } from './lib/providers/registry.js';
 import { createReactiveDatabase } from './storage/reactive-database';
 import { LiveQueryEngine } from './storage/live-query';
 import { SpaceAgentRepository } from './storage/repositories/space-agent-repository';
@@ -48,6 +55,11 @@ import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from 
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
 import { NeoAgentManager } from './lib/neo/neo-agent-manager';
+import {
+	cleanupSuspiciousProcesses,
+	ProcessWatchdog,
+	type ProcessSnapshot,
+} from './lib/process-watchdog';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -74,13 +86,13 @@ export interface DaemonAppContext {
 	settingsManager: SettingsManager;
 	stateManager: StateProjectionService;
 	transport: WebSocketServerTransport;
-	daemonHub: Awaited<ReturnType<typeof createDaemonHub>>;
 	/**
-	 * Semantic internal event bus for migrated daemon domain events.
-	 * New publishers/subscribers should use this instead of DaemonHub.
+	 * Semantic internal event bus for daemon domain events.
 	 * See docs/plans/internal-event-command-query-architecture.md.
 	 */
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>;
+	/** Semantic internal command bus for action dispatch */
+	commandBus: InternalCommandBus<DaemonCommandMap>;
 	/** Semantic internal query bus for point-in-time reads */
 	queryBus: ReturnType<typeof createInternalQueryBus<DaemonQueryMap>>;
 	/**
@@ -183,9 +195,38 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	//       Ephemeral, within a single async call; cleaned up before the call returns.
 	//   • app.ts graceful-shutdown readiness check (this file, waitForPendingCalls)
 	//       One-shot shutdown polling with hard timeout; not a recurring task.
+	//   • ProcessWatchdog timer (process-watchdog.ts)
+	//       Last-resort OS process leak safety net; intentionally independent from the job queue.
 	jobProcessor.setChangeNotifier((table) => {
 		reactiveDb.notifyChange(table);
 	});
+	let sessionManager: SessionManager | null = null;
+	let neoAgentManager: NeoAgentManager | null = null;
+	let taskAgentManager: TaskAgentManager | null = null;
+	const processWatchdog = new ProcessWatchdog(undefined, () =>
+		cleanupSuspiciousProcesses({
+			getRootPids: (snapshot?: ProcessSnapshot[]) => {
+				const live: number[] = [];
+				const exited: number[] = [];
+				if (sessionManager) {
+					const split = sessionManager.getTrackedAgentRootPidsSplit(snapshot);
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				if (neoAgentManager) {
+					const split = neoAgentManager.getTrackedAgentRootPidsSplit();
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				if (taskAgentManager) {
+					const split = taskAgentManager.getTrackedAgentRootPidsSplit();
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				return { live, exited };
+			},
+		})
+	);
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
@@ -245,37 +286,15 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// 5. Register Transport with MessageHub
 	messageHub.registerTransport(transport);
 
-	// Initialize DaemonHub (TypedHub-based event coordination)
-	const daemonHub = createDaemonHub('daemon');
-	await daemonHub.initialize();
-
-	// Initialize InternalEventBus for migrated daemon domain events.
-	// Subscribers/publishers register here as they migrate off DaemonHub.
+	// Initialize InternalEventBus for daemon domain events.
 	const internalEventBus = createDaemonInternalEventBus();
+
+	// Initialize InternalCommandBus for daemon action dispatch.
+	const commandBus = createInternalCommandBus<DaemonCommandMap>();
 
 	// Initialize InternalQueryBus for point-in-time reads.
 	// Handlers will be registered by domain services as they migrate.
 	const queryBus = createInternalQueryBus<DaemonQueryMap>();
-
-	// Initialize external event services after the internal bus so extensions can
-	// publish source-normalized events into the workflow runtime.
-	const externalEventStore = new ExternalEventStore(db.getDatabase());
-	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
-	const extensionConfigStore = new ExternalEventExtensionConfigStore(db.getDatabase());
-	const sourceConfigTables: Record<string, string[]> = {
-		github: ['space_github_watched_repos'],
-	};
-	const extensionContext = {
-		publisher: externalEventService,
-		config: extensionConfigStore,
-		onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
-			logInfo('[Daemon] Extension config changed', change);
-			for (const table of sourceConfigTables[change.source] ?? []) {
-				reactiveDb.notifyChange(table);
-			}
-		},
-	};
-	const extensionManager = new ExternalEventExtensionManager();
 
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
@@ -318,15 +337,15 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		logError('[Daemon] Failed to ensure builtin skill plugin wrappers (non-fatal):', err);
 	}
 
-	// Initialize session manager (with DaemonHub, SettingsManager, no StateManager dependency!)
+	// Initialize session manager (with InternalEventBus<DaemonInternalEventMap>, SettingsManager, no StateManager dependency!)
 	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
 	// trigger LiveQuery invalidation immediately.
-	const sessionManager = new SessionManager(
+	sessionManager = new SessionManager(
 		reactiveDb.db,
 		messageHub,
 		authManager,
 		settingsManager,
-		daemonHub,
+		internalEventBus,
 		{
 			defaultModel: config.defaultModel,
 			maxTokens: config.maxTokens,
@@ -335,8 +354,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		jobQueue,
 		jobProcessor,
 		skillsManager,
-		db.appMcpServers,
-		internalEventBus
+		db.appMcpServers
 	);
 
 	// Register session title generation handler before jobProcessor starts
@@ -344,10 +362,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize Neo agent manager (singleton global AI assistant).
 	// Instantiated after sessionManager so it can be passed as the NeoSessionManager.
-	const neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
+	neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
 
-	// Initialize StateProjectionService (pure read-model caches from InternalEventBus)
+	// Initialize StateProjectionService (read-model caches from InternalEventBus)
 	const stateManager = new StateProjectionService(
+		messageHub,
 		sessionManager,
 		authManager,
 		settingsManager,
@@ -356,74 +375,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		internalEventBus
 	);
 
-	// Bridge migrated DaemonHub events to InternalEventBus so
-	// StateProjectionService (and future subscribers) receive them without
-	// touching every publisher call site. This is the M5 compatibility path;
-	// publishers will migrate to InternalEventBus directly in later milestones.
-	//
-	// We use publish() (awaited) instead of publishAsync() so cache updates
-	// settle before ClientEventBridge triggers broadcastSystemChange() from
-	// the same DaemonHub event — preserving the ordering between cache write
-	// and broadcast read.
-	const unsubSessionCreated = daemonHub.on('session.created', (data) => {
-		void internalEventBus.publish('session.created', {
-			namespaceId: data.sessionId,
-			session: data.session,
-		});
-	});
-	const unsubSessionUpdated = daemonHub.on('session.updated', (data) => {
-		void internalEventBus.publish('session.updated', {
-			namespaceId: data.sessionId,
-			source: data.source,
-			session: data.session,
-			processingState: data.processingState,
-		});
-	});
-	const unsubSessionDeleted = daemonHub.on('session.deleted', (data) => {
-		void internalEventBus.publish('session.deleted', {
-			namespaceId: data.sessionId,
-		});
-	});
-	const unsubCommandsUpdated = daemonHub.on('commands.updated', (data) => {
-		void internalEventBus.publish('commands.updated', {
-			namespaceId: data.sessionId,
-			commands: data.commands,
-		});
-	});
-	const unsubSessionError = daemonHub.on('session.error', (data) => {
-		void internalEventBus.publish('session.error', {
-			namespaceId: data.sessionId,
-			error: data.error,
-			details: data.details,
-		});
-	});
-	const unsubSessionErrorClear = daemonHub.on('session.errorClear', (data) => {
-		void internalEventBus.publish('session.errorClear', {
-			namespaceId: data.sessionId,
-		});
-	});
-	const unsubApiConnection = daemonHub.on('api.connection', (data) => {
-		// Forward the complete payload so diagnostic fields (errorCount,
-		// lastError, lastSuccessfulCall) are preserved in projections.
-		void internalEventBus.publish('api.connection', {
-			namespaceId: data.sessionId,
-			...data,
-		});
-	});
-
-	// Initialize ClientEventBridge — owns ALL client-facing delivery:
-	// - Event forwarding (space, session, connection, config, error events)
-	// - Versioned state broadcasts (system, settings, session state, SDK messages)
-	// - RPC handler registration (state snapshot queries)
-	// Migrated space events route through InternalEventBus; unmigrated spaceAgent/spaceWorkflow
-	// events remain on DaemonHub.
-	const clientEventGateway = new ClientEventGateway({ hub: messageHub });
+	// Initialize ClientEventBridge — forwards selected InternalEventBus events to
+	// WebSocket clients via ClientEventGateway. This extracts the repetitive
+	// room/space forwarding out of StateProjectionService.
+	const clientEventGateway = stateManager.getClientEventGateway();
 	const clientEventBridge = createClientEventBridge(
-		daemonHub,
-		messageHub,
+		internalEventBus,
 		clientEventGateway,
-		stateManager,
-		internalEventBus
+		stateManager
 	);
 	clientEventBridge.start();
 
@@ -441,7 +400,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		if (apiKey) {
 			gitHubService = createGitHubService({
 				db,
-				daemonHub,
+				internalEventBus,
 				config,
 				apiKey,
 				githubToken: process.env.GITHUB_TOKEN, // Optional GitHub token for polling
@@ -464,23 +423,62 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const fileIndex = new FileIndex(config.workspaceRoot);
 	void fileIndex.init();
 
+	const externalEventStore = new ExternalEventStore(db.getDatabase());
+	const externalEventService = new ExternalEventService(externalEventStore, internalEventBus);
+	const extensionConfigStore = new ExternalEventExtensionConfigStore(db.getDatabase());
+	const sourceConfigTables: Record<string, string[]> = {
+		github: ['space_github_watched_repos'],
+	};
+	const extensionContext = {
+		publisher: externalEventService,
+		config: extensionConfigStore,
+		onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
+			logInfo('[Daemon] Extension config changed', change);
+			for (const table of sourceConfigTables[change.source] ?? []) {
+				reactiveDb.notifyChange(table);
+			}
+		},
+	};
+	const extensionManager = new ExternalEventExtensionManager();
+	extensionManager.register(new GitHubEventExtension(db.getDatabase()));
+
+	function isHttpExternalEventExtension(
+		extension: unknown
+	): extension is HttpExternalEventExtension {
+		return 'routes' in (extension as Record<string, unknown>);
+	}
+
+	function isRpcExternalEventExtension(extension: unknown): extension is RpcExternalEventExtension {
+		return 'registerRpcHandlers' in (extension as Record<string, unknown>);
+	}
+
+	for (const extension of extensionManager.getAll()) {
+		const globalConfig = await extensionContext.config.getGlobalConfig(extension.sourceId);
+		if (!globalConfig.globallyEnabled) continue;
+
+		if (isHttpExternalEventExtension(extension)) {
+			extensionManager.registerRoutes(extension.routes, extensionContext);
+		}
+		if (isRpcExternalEventExtension(extension) && globalConfig.capabilities.rpcConfig) {
+			extensionManager.registerRpcHandlers(extension.sourceId, messageHub, extensionContext);
+		}
+
+		await extensionManager.startExtension(extension.sourceId, extensionContext);
+		logInfo(`[Daemon] Started external event extension: ${extension.sourceId}`);
+	}
+
 	// Setup RPC handlers (returns cleanup function + exposed services)
-	const {
-		cleanup: rpcHandlerCleanup,
-		spaceRuntimeService,
-		taskAgentManager,
-		spaceWorktreeManager,
-	} = setupRPCHandlers({
+	const rpcHandlers = setupRPCHandlers({
 		messageHub,
 		sessionManager,
 		authManager,
 		settingsManager,
 		config,
-		daemonHub,
 		internalEventBus,
+		commandBus,
+		externalEventStore,
 		db,
 		gitHubService: gitHubService ?? undefined,
-		externalEventStore,
 		externalEventService,
 		spaceManager,
 		spaceAgentManager,
@@ -493,25 +491,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		neoAgentManager,
 		mcpImportService,
 	});
-
-	extensionManager.register(new GitHubEventExtension(db.getDatabase()));
-
-	for (const sourceId of ['github']) {
-		const extension = extensionManager.getExtension(sourceId);
-		if (!extension) continue;
-		const globalConfig = await extensionContext.config.getGlobalConfig(extension.sourceId);
-		if (!globalConfig.globallyEnabled) continue;
-
-		if ('routes' in extension) {
-			extensionManager.registerRoutes(extension.routes, extensionContext);
-		}
-		if ('registerRpcHandlers' in extension && globalConfig.capabilities.rpcConfig) {
-			extensionManager.registerRpcHandlers(extension.sourceId, messageHub, extensionContext);
-		}
-
-		await extensionManager.startExtension(extension.sourceId, extensionContext);
-		logInfo(`[Daemon] Started external event extension: ${extension.sourceId}`);
-	}
+	const { cleanup: rpcHandlerCleanup, spaceRuntimeService, spaceWorktreeManager } = rpcHandlers;
+	taskAgentManager = rpcHandlers.taskAgentManager;
 
 	// Wait for SpaceRuntimeService startup provisioning to complete before we
 	// bind the WebSocket/HTTP server. `start()` inside `setupRPCHandlers` kicks
@@ -580,10 +561,13 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				);
 			}
 
+			// Space-level public-safe GitHub webhook endpoint.
 			const extensionRoute = extensionManager
 				.getRegisteredRoutes()
-				.find((route) => route.method === req.method && route.path === url.pathname);
-			if (extensionRoute) return extensionRoute.handle(req);
+				.find((route) => route.path === url.pathname && route.method === req.method);
+			if (extensionRoute) {
+				return extensionRoute.handle(req);
+			}
 
 			// Legacy room GitHub webhook endpoint (kept as a compatibility alias only).
 			if (url.pathname === '/webhook/github' && req.method === 'POST') {
@@ -661,7 +645,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			jobQueue,
 			spaceRepo: taskScheduleSpaceRepo,
 			taskRepo: taskScheduleTaskRepo,
-			internalEventBus,
+			eventHub: internalEventBus,
 		});
 	});
 
@@ -757,6 +741,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Start job queue processor last (after all handler registrations)
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
+	if (process.env.NODE_ENV !== 'test') {
+		processWatchdog.start();
+		logInfo('[Daemon] Process watchdog started');
+	}
 
 	// Provision the Neo agent session (skip in test mode unless explicitly enabled).
 	// Mirrors the spaces agent guard: test runs are clean by default; online/e2e
@@ -828,15 +816,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			// while we're tearing down sessions and transport.
 			clientEventBridge.stop();
 
-			// Unsubscribe DaemonHub → InternalEventBus bridge listeners
-			unsubSessionCreated();
-			unsubSessionUpdated();
-			unsubSessionDeleted();
-			unsubCommandsUpdated();
-			unsubSessionError();
-			unsubSessionErrorClear();
-			unsubApiConnection();
-
 			try {
 				server.stop();
 			} catch {
@@ -877,14 +856,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				}
 			}
 
-			// Stop external event extensions before MessageHub cleanup so polling and
-			// webhook handlers stop publishing into a shutting-down bus.
-			for (const sourceId of ['github']) {
-				await extensionManager.stopExtension(sourceId);
-			}
-			logInfo('[Daemon] External event extensions stopped');
-
-			// Stop job queue processor before MessageHub cleanup
+			// Stop background processors before MessageHub cleanup
+			processWatchdog.stop();
+			logInfo('[Daemon] Process watchdog stopped');
 			await jobProcessor.stop();
 			logInfo('[Daemon] Job queue processor stopped');
 
@@ -903,6 +877,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				gitHubService.stop();
 				logInfo('[Daemon] GitHub service stopped');
 			}
+			for (const extension of extensionManager.getAll()) {
+				await extensionManager.stopExtension(extension.sourceId);
+			}
+			logInfo('[Daemon] External event extensions stopped');
 
 			// Stop all Task Agent sessions before sessionManager.cleanup() so that
 			// Task Agent sessions are interrupted cleanly before the session pool drains.
@@ -948,8 +926,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		settingsManager,
 		stateManager,
 		transport,
-		daemonHub,
 		internalEventBus,
+		commandBus,
 		queryBus,
 		gitHubService,
 		externalEventStore,

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -403,9 +403,9 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	// (space/room/session), not useful for ad-hoc agent queries. Agents should
 	// read MCP state through the resolver rather than hitting the table directly.
 	'mcp_enablement',
-	// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
-	'external_event_source_configs',
-	'space_external_event_source_configs',
+		// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
+		'external_event_extension_configs',
+		'space_external_event_source_configs',
 	'space_external_events',
 	'space_external_event_deliveries',
 	// Dropped tables (no longer exist in schema)

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -404,6 +404,7 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	// read MCP state through the resolver rather than hitting the table directly.
 	'mcp_enablement',
 	// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
+	'external_event_source_configs',
 	'external_event_extension_configs',
 	'space_external_event_source_configs',
 	'space_external_events',

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -403,9 +403,9 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	// (space/room/session), not useful for ad-hoc agent queries. Agents should
 	// read MCP state through the resolver rather than hitting the table directly.
 	'mcp_enablement',
-		// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
-		'external_event_extension_configs',
-		'space_external_event_source_configs',
+	// External Event Bus — internal event routing/delivery/config state, not useful for ad-hoc agent queries.
+	'external_event_extension_configs',
+	'space_external_event_source_configs',
 	'space_external_events',
 	'space_external_event_deliveries',
 	// Dropped tables (no longer exist in schema)

--- a/packages/daemon/src/lib/external-events/extension-config-store.ts
+++ b/packages/daemon/src/lib/external-events/extension-config-store.ts
@@ -94,7 +94,7 @@ export class ExternalEventExtensionConfigStore
 				config.globallyEnabled ? 1 : 0,
 				JSON.stringify(config.capabilities),
 				config.secretsRef ?? null,
-				config.settings === undefined ? null : JSON.stringify(config.settings),
+				JSON.stringify(config.settings ?? {}),
 				now,
 				now
 			);

--- a/packages/daemon/src/lib/external-events/extension-config-store.ts
+++ b/packages/daemon/src/lib/external-events/extension-config-store.ts
@@ -32,7 +32,7 @@ export class ExternalEventExtensionConfigStore
 	async getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig> {
 		validateSourceId(source);
 		const row = this.db
-			.prepare(`SELECT * FROM external_event_source_configs WHERE source = ?`)
+			.prepare(`SELECT * FROM external_event_extension_configs WHERE source = ?`)
 			.get(source) as GlobalConfigRow | undefined;
 
 		if (!row) {
@@ -78,7 +78,7 @@ export class ExternalEventExtensionConfigStore
 		const now = Date.now();
 		this.db
 			.prepare(
-				`INSERT INTO external_event_source_configs (
+				`INSERT INTO external_event_extension_configs (
 					source, globally_enabled, capabilities_json, secrets_ref,
 					settings_json, created_at, updated_at
 				) VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -125,7 +125,7 @@ export class ExternalEventExtensionConfigStore
 
 export function ensureExternalEventExtensionConfigTables(db: BunDatabase): void {
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+		CREATE TABLE IF NOT EXISTS external_event_extension_configs (
 			source TEXT PRIMARY KEY,
 			globally_enabled INTEGER NOT NULL DEFAULT 0,
 			capabilities_json TEXT NOT NULL,

--- a/packages/daemon/src/lib/external-events/extension-manager.ts
+++ b/packages/daemon/src/lib/external-events/extension-manager.ts
@@ -82,6 +82,10 @@ export class ExternalEventExtensionManager {
 		return this.extensions.get(sourceId);
 	}
 
+	getAll(): ExternalEventExtension[] {
+		return Array.from(this.extensions.values());
+	}
+
 	registerRoutes(routes: readonly Route[], context: ExternalEventExtensionContext): void {
 		const sourceId = this.findSourceIdForRoutes(routes);
 		if (!sourceId) {

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -24,7 +24,6 @@ const log = new Logger('github-event-extension');
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 interface GitHubEventExtensionOptions {
-	githubToken?: string;
 	pollIntervalMs?: number;
 	onWatchedReposChanged?: () => void;
 }
@@ -46,13 +45,11 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 	private stopped = true;
 
 	constructor(
-		dbOrRepo: BunDatabase | GitHubEventExtensionRepository,
+		db: BunDatabase,
+		private readonly githubToken = process.env.GITHUB_TOKEN,
 		private readonly options: GitHubEventExtensionOptions = {}
 	) {
-		this.repo =
-			dbOrRepo instanceof GitHubEventExtensionRepository
-				? dbOrRepo
-				: new GitHubEventExtensionRepository(dbOrRepo);
+		this.repo = new GitHubEventExtensionRepository(db);
 	}
 
 	async start(context: ExternalEventExtensionContext): Promise<void> {
@@ -71,6 +68,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 
 	registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void {
 		hub.onRequest('space.github.enable', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
 			const params = data as { spaceId: string };
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, true);
@@ -84,6 +82,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		});
 
 		hub.onRequest('space.github.disable', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
 			const params = data as { spaceId: string };
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, false);
@@ -97,6 +96,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		});
 
 		hub.onRequest('space.github.watchRepo', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
 			const params = data as {
 				spaceId: string;
 				owner: string;
@@ -128,6 +128,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		});
 
 		hub.onRequest('space.github.listWatchedRepos', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
 			const params = data as { spaceId?: string };
 			if (!params.spaceId) throw new Error('spaceId is required');
 			return {
@@ -138,7 +139,19 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			};
 		});
 
+		hub.onRequest('space.github.listConfig', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
+			const params = data as { spaceId?: string };
+			if (!params.spaceId) throw new Error('spaceId is required');
+			return await context.config.getSpaceConfig(params.spaceId, this.sourceId);
+		});
+
 		hub.onRequest('space.github.pollOnce', async (data) => {
+			await assertRpcConfigEnabled(context, this.sourceId);
+			const global = await context.config.getGlobalConfig(this.sourceId);
+			if (!global.capabilities.polling) {
+				throw new Error('GitHub polling capability is disabled');
+			}
 			const params = (data ?? {}) as { spaceId?: string };
 			return {
 				count: params.spaceId
@@ -200,7 +213,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		for (const repo of validForRepo) {
 			const spaceConfig = await this.context.config.getSpaceConfig(repo.spaceId, this.sourceId);
 			if (spaceConfig && !spaceConfig.enabled) continue;
-			await this.publishNormalizedEvent(repo.spaceId, normalized);
+			await this.publishEvent(repo.spaceId, normalized, this.context);
 			this.repo.markWebhookReceived(repo.id);
 			published++;
 		}
@@ -262,12 +275,12 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		}
 	}
 
-	private async publishNormalizedEvent(
+	private async publishEvent(
 		spaceId: string,
-		event: import('./github-normalizer').NormalizedGitHubEvent
+		event: import('./github-normalizer').NormalizedGitHubEvent,
+		context: ExternalEventExtensionContext
 	): Promise<void> {
-		if (!this.context) return;
-		await this.context.publisher.publish(toExternalEvent(spaceId, event));
+		await context.publisher.publish(toExternalEvent(spaceId, event));
 	}
 
 	async pollWatchedRepo(
@@ -309,7 +322,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 				'User-Agent': 'NeoKai-Space-GitHub/1.0',
 				'X-GitHub-Api-Version': '2022-11-28',
 			};
-			if (this.options.githubToken) headers.Authorization = `Bearer ${this.options.githubToken}`;
+			if (this.githubToken) headers.Authorization = `Bearer ${this.githubToken}`;
 			if (page === 1 && etags[endpoint.key]) headers['If-None-Match'] = etags[endpoint.key];
 			const response = await fetchImpl(url, { headers });
 			if (response.status === 304) continue;
@@ -320,7 +333,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			for (const row of rows) {
 				const event = normalizeGitHubPollingRow(watched, row, endpoint.key);
 				if (event) {
-					await this.publishNormalizedEvent(watched.spaceId, event);
+					await this.publishEvent(watched.spaceId, event, this.context);
 					watermarks.pending = Math.max(watermarks.pending, event.occurredAt);
 					count++;
 				}
@@ -336,6 +349,16 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		};
 		this.repo.updatePollCursor(watched.id, cursorPayload);
 		return count;
+	}
+}
+
+async function assertRpcConfigEnabled(
+	context: ExternalEventExtensionContext,
+	sourceId: string
+): Promise<void> {
+	const global = await context.config.getGlobalConfig(sourceId);
+	if (!global.globallyEnabled || !global.capabilities.rpcConfig) {
+		throw new Error('GitHub RPC configuration capability is disabled');
 	}
 }
 

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -40,7 +40,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 
 	readonly repo: GitHubEventExtensionRepository;
 	private context?: ExternalEventExtensionContext;
-	private pollTimer?: ReturnType<typeof setTimeout>;
+	private pollTimer: ReturnType<typeof setTimeout> | null = null;
 	private activePollCycle?: Promise<void>;
 	private stopped = true;
 
@@ -62,7 +62,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 	async stop(): Promise<void> {
 		this.stopped = true;
 		if (this.pollTimer) clearTimeout(this.pollTimer);
-		this.pollTimer = undefined;
+		this.pollTimer = null;
 		await this.activePollCycle;
 	}
 
@@ -221,28 +221,33 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		return Response.json({ message: 'Webhook received', deliveryId, spaces: published });
 	}
 
-	private async pollEnabledSpaces(): Promise<number> {
+	async pollOnce(fetchImpl: typeof fetch = fetch): Promise<number> {
+		return await this.pollEnabledSpaces(fetchImpl);
+	}
+
+	private async pollEnabledSpaces(fetchImpl: typeof fetch = fetch): Promise<number> {
 		if (!this.context) return 0;
 		if (!(await this.isPollingGloballyEnabled())) return 0;
 		const enabledSpaces = await this.context.config.listEnabledSpaces(this.sourceId);
 		if (enabledSpaces.length > 0) {
 			let count = 0;
-			for (const space of enabledSpaces) count += await this.pollSpace(space.spaceId);
+			for (const space of enabledSpaces) count += await this.pollSpace(space.spaceId, fetchImpl);
 			return count;
 		}
 		let count = 0;
-		for (const repo of this.repo.listPollingRepos()) count += await this.pollWatchedRepo(repo);
+		for (const repo of this.repo.listPollingRepos())
+			count += await this.pollWatchedRepo(repo, fetchImpl);
 		return count;
 	}
 
-	private async pollSpace(spaceId: string): Promise<number> {
+	private async pollSpace(spaceId: string, fetchImpl: typeof fetch = fetch): Promise<number> {
 		if (!this.context) return 0;
 		if (!(await this.isPollingGloballyEnabled())) return 0;
 		const spaceConfig = await this.context.config.getSpaceConfig(spaceId, this.sourceId);
 		if (spaceConfig && !spaceConfig.enabled) return 0;
 		let count = 0;
 		for (const repo of this.repo.listPollingRepos(spaceId))
-			count += await this.pollWatchedRepo(repo);
+			count += await this.pollWatchedRepo(repo, fetchImpl);
 		return count;
 	}
 

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -72,6 +72,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			const params = data as { spaceId: string };
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, true);
+			await this.persistSpaceConfig(context, params.spaceId);
 			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
@@ -86,6 +87,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			const params = data as { spaceId: string };
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, false);
+			await this.persistSpaceConfig(context, params.spaceId);
 			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
@@ -118,6 +120,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 				pollingEnabled: params.pollingEnabled,
 				enabled: params.enabled,
 			});
+			await this.persistSpaceConfig(context, watchedRepo.spaceId);
 			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
@@ -286,6 +289,33 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		context: ExternalEventExtensionContext
 	): Promise<void> {
 		await context.publisher.publish(toExternalEvent(spaceId, event));
+	}
+
+	private async persistSpaceConfig(
+		context: ExternalEventExtensionContext,
+		spaceId: string
+	): Promise<void> {
+		const repos = this.repo.listWatchedRepos(spaceId);
+		await context.config.setSpaceConfig(spaceId, this.sourceId, {
+			spaceId,
+			source: this.sourceId,
+			enabled: repos.some((repo) => repo.enabled),
+			settings: {
+				watchedRepos: repos.map((repo) => ({
+					id: repo.id,
+					owner: repo.owner,
+					repo: repo.repo,
+					enabled: repo.enabled,
+					webhookEnabled: repo.webhookEnabled,
+					pollingEnabled: repo.pollingEnabled,
+					webhookSecret: repo.webhookSecret ? 'configured' : null,
+					lastWebhookAt: repo.lastWebhookAt,
+					lastPollAt: repo.lastPollAt,
+					createdAt: repo.createdAt,
+					updatedAt: repo.updatedAt,
+				})),
+			},
+		});
 	}
 
 	async pollWatchedRepo(

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -146,7 +146,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 		hub.onRequest('space.github.pollOnce', async (data) => {
 			await assertRpcConfigEnabled(context, this.sourceId);
 			const global = await context.config.getGlobalConfig(this.sourceId);
-			if (!global.capabilities.polling) {
+			if (global.capabilities.polling === false) {
 				throw new Error('GitHub polling capability is disabled');
 			}
 			const params = (data ?? {}) as { spaceId?: string };
@@ -225,15 +225,12 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 	private async pollEnabledSpaces(fetchImpl: typeof fetch = fetch): Promise<number> {
 		if (!this.context) return 0;
 		if (!(await this.isPollingGloballyEnabled())) return 0;
-		const enabledSpaces = await this.context.config.listEnabledSpaces(this.sourceId);
-		if (enabledSpaces.length > 0) {
-			let count = 0;
-			for (const space of enabledSpaces) count += await this.pollSpace(space.spaceId, fetchImpl);
-			return count;
-		}
 		let count = 0;
-		for (const repo of this.repo.listPollingRepos())
+		for (const repo of this.repo.listPollingRepos()) {
+			const spaceConfig = await this.context.config.getSpaceConfig(repo.spaceId, this.sourceId);
+			if (spaceConfig && !spaceConfig.enabled) continue;
 			count += await this.pollWatchedRepo(repo, fetchImpl);
+		}
 		return count;
 	}
 

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -3,11 +3,9 @@ import type { MessageHub } from '@neokai/shared';
 import { Logger } from '../../logger';
 import { verifySignature } from '../../github/webhook-handler';
 import type {
-	ExternalEventExtensionConfigStore,
 	ExternalEventExtensionContext,
 	HttpExternalEventExtension,
 	RpcExternalEventExtension,
-	SpaceExternalEventSourceConfig,
 } from '../types';
 import {
 	normalizeGitHubPollingRow,
@@ -25,7 +23,6 @@ const DEFAULT_POLL_INTERVAL_MS = 60_000;
 
 interface GitHubEventExtensionOptions {
 	pollIntervalMs?: number;
-	onWatchedReposChanged?: () => void;
 }
 
 export class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEventExtension {
@@ -73,7 +70,6 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, true);
 			await this.persistSpaceConfig(context, params.spaceId);
-			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
 				spaceId: params.spaceId,
@@ -88,7 +84,6 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 			if (!params.spaceId) throw new Error('spaceId is required');
 			this.repo.setRepoEnabled(params.spaceId, false);
 			await this.persistSpaceConfig(context, params.spaceId);
-			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
 				spaceId: params.spaceId,
@@ -121,7 +116,6 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 				enabled: params.enabled,
 			});
 			await this.persistSpaceConfig(context, watchedRepo.spaceId);
-			this.options.onWatchedReposChanged?.();
 			context.onSourceConfigChanged({
 				source: this.sourceId,
 				spaceId: watchedRepo.spaceId,
@@ -395,48 +389,4 @@ async function assertRpcConfigEnabled(
 	if (!global.globallyEnabled || !global.capabilities.rpcConfig) {
 		throw new Error('GitHub RPC configuration capability is disabled');
 	}
-}
-
-export class StaticExternalEventExtensionConfigStore implements ExternalEventExtensionConfigStore {
-	constructor(
-		private readonly options: { globallyEnabled?: boolean; webhooks?: boolean; polling?: boolean }
-	) {}
-
-	async getGlobalConfig(source: string) {
-		return {
-			source,
-			globallyEnabled: this.options.globallyEnabled ?? true,
-			capabilities: {
-				webhooks: this.options.webhooks ?? true,
-				polling: this.options.polling ?? true,
-				rpcConfig: true,
-			},
-			settings: {},
-		};
-	}
-
-	async getSpaceConfig(
-		spaceId: string,
-		source: string
-	): Promise<SpaceExternalEventSourceConfig | null> {
-		return { spaceId, source, enabled: true, settings: {} };
-	}
-
-	async listEnabledSpaces(_source: string): Promise<SpaceExternalEventSourceConfig[]> {
-		// The static store has no DB-backed per-space source table yet. Returning an
-		// empty list intentionally lets GitHubEventExtension fall back to watched-repo
-		// rows as the source of enabled spaces for the migration period.
-		return [];
-	}
-
-	async setGlobalConfig(
-		_source: string,
-		_config: Awaited<ReturnType<ExternalEventExtensionConfigStore['getGlobalConfig']>>
-	): Promise<void> {}
-
-	async setSpaceConfig(
-		_spaceId: string,
-		_source: string,
-		_config: SpaceExternalEventSourceConfig
-	): Promise<void> {}
 }

--- a/packages/daemon/src/lib/external-events/github/index.ts
+++ b/packages/daemon/src/lib/external-events/github/index.ts
@@ -1,7 +1,4 @@
-export {
-	GitHubEventExtension,
-	StaticExternalEventExtensionConfigStore,
-} from './github-event-extension';
+export { GitHubEventExtension } from './github-event-extension';
 export {
 	normalizeGitHubWebhook,
 	normalizeGitHubPollingRow,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -9,9 +9,8 @@ import type { MessageHub } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
+import type { DaemonHub } from '../daemon-hub';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
-import type { DaemonCommandMap, InternalCommandBus } from '../internal-command-bus';
-import type { ExternalEventStore } from '../external-events/external-event-store';
 import type { SessionManager } from '../session-manager';
 import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
@@ -42,7 +41,6 @@ import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-ta
 import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
-import { ReplyRoutingRegistry } from '../space/runtime/reply-routing-registry';
 import { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
 import {
 	setupSpaceWorkflowHandlers,
@@ -54,10 +52,8 @@ import { SpaceTaskManager } from '../space/managers/space-task-manager';
 import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceAgentLookup } from '../space/managers/space-workflow-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
-import { SpaceGitHubService } from '../github/space-github';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
-import { GateOpenStateRepository } from '../../storage/repositories/gate-open-state-repository';
 import { WorkflowRunArtifactRepository } from '../../storage/repositories/workflow-run-artifact-repository';
 import { WorkflowRunArtifactCacheRepository } from '../../storage/repositories/workflow-run-artifact-cache-repository';
 import { createSyncArtifactHandlers } from '../job-handlers/space-workflow-run-artifact.handler';
@@ -100,6 +96,8 @@ import { TaskScheduleRepository } from '../../storage/repositories/task-schedule
 import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
+import type { ExternalEventStore } from '../external-events/external-event-store';
+import type { ExternalEventService } from '../external-events/external-event-service';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -107,13 +105,18 @@ export interface RPCHandlerDependencies {
 	authManager: AuthManager;
 	settingsManager: SettingsManager;
 	config: Config;
-	/** Semantic internal event bus for daemon domain events. */
+	daemonHub: DaemonHub;
+	/**
+	 * Semantic internal event bus for daemon domain events that have been
+	 * migrated off DaemonHub. New publishers/subscribers should use this.
+	 */
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>;
-	commandBus: InternalCommandBus<DaemonCommandMap>;
-	externalEventStore: ExternalEventStore;
 	db: Database;
 	gitHubService?: GitHubService;
-	spaceGitHubService: SpaceGitHubService;
+	/** Source-agnostic external event store for workflow runtime delivery tracking. */
+	externalEventStore: ExternalEventStore;
+	/** External event service available to runtime subscribers when direct publishing is needed. */
+	externalEventService: ExternalEventService;
 	/** Space manager instance — shared with DaemonAppContext (single source of truth) */
 	spaceManager: SpaceManager;
 	spaceAgentManager: SpaceAgentManager;
@@ -183,20 +186,21 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	registerSettingsHandlers(
 		deps.messageHub,
 		deps.settingsManager,
+		deps.daemonHub,
 		deps.internalEventBus,
 		deps.db,
 		deps.mcpImportService
 	);
-	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
+	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 	// Use reactiveDb.db so test-injected sdk_messages rows also invalidate LiveQuery.
 	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
-	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
+	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
 
 	// Question handlers (AskUserQuestion respond / saveDraft / cancel)
-	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
+	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
 	// Reference handlers (@ mention system — search + resolve tasks, goals, files, folders)
 	const fileIndex = new FileIndex(deps.config.workspaceRoot);
@@ -224,17 +228,30 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// App-level MCP registry handlers
 	registerAppMcpHandlers(deps.messageHub, {
 		db: deps.db,
+		daemonHub: deps.daemonHub,
 		internalEventBus: deps.internalEventBus,
 	});
 
 	// MCP enablement RPC handlers
-	setupAppMcpHandlers(deps.messageHub, deps.internalEventBus, deps.db);
+	setupAppMcpHandlers(deps.messageHub, deps.daemonHub, deps.internalEventBus, deps.db);
 
 	// Per-space MCP enablement RPC handlers + `.mcp.json` import refresh.
-	setupSpaceMcpHandlers(deps.messageHub, deps.internalEventBus, deps.db, deps.spaceManager);
+	setupSpaceMcpHandlers(
+		deps.messageHub,
+		deps.daemonHub,
+		deps.internalEventBus,
+		deps.db,
+		deps.spaceManager
+	);
 
 	// Skills registry RPC handlers
-	registerSkillHandlers(deps.messageHub, deps.skillsManager, deps.internalEventBus, undefined);
+	registerSkillHandlers(
+		deps.messageHub,
+		deps.skillsManager,
+		deps.daemonHub,
+		deps.internalEventBus,
+		undefined
+	);
 
 	// Workspace history RPC handlers.
 	// The import service is passed in so `workspace.add` can trigger a
@@ -261,12 +278,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase(), deps.reactiveDb);
+	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
-	const gateOpenStateRepo = new GateOpenStateRepository(deps.db.getDatabase());
-	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(
-		deps.db.getDatabase(),
-		gateOpenStateRepo
-	);
 	const artifactRepo = new WorkflowRunArtifactRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const artifactCacheRepo = new WorkflowRunArtifactCacheRepository(deps.db.getDatabase());
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
@@ -341,7 +354,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Space agent handlers
 	setupSpaceAgentHandlers(
 		deps.messageHub,
-		deps.internalEventBus,
+		deps.daemonHub,
 		deps.spaceAgentManager,
 		deps.spaceManager
 	);
@@ -350,7 +363,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.messageHub,
 		deps.spaceManager,
 		spaceWorkflowManager,
-		deps.internalEventBus,
+		deps.daemonHub,
 		deps.spaceAgentManager,
 		spaceWorkflowRunRepo
 	);
@@ -391,13 +404,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Not started yet: TaskAgentManager is created next and injected before start().
 	// gateDataRepo is injected so notifyGateDataChanged() can trigger lazy node activation
 	// after gate data is written externally (e.g. approveGate RPC, writeGateData RPC).
-	// sessionManager and internalEventBus are injected so space:chat:${spaceId} sessions are
+	// sessionManager and daemonHub are injected so space:chat:${spaceId} sessions are
 	// provisioned with MCP tools and system prompts on startup and on space.created.
 	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
-	// Reply Routing Registry — shared between space-agent-tools (register)
-	// and task-agent-tools / node-agent-tools (lookup).
-	const replyRoutingRegistry = new ReplyRoutingRegistry();
-
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		dbPath: deps.db.getDatabasePath(),
@@ -409,26 +418,26 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		nodeExecutionRepo,
 		reactiveDb: deps.reactiveDb,
 		gateDataRepo,
-		gateOpenStateRepo,
 		channelCycleRepo,
 		sessionManager: deps.sessionManager,
-		internalEventBus: deps.internalEventBus,
+		daemonHub: deps.daemonHub,
 		artifactRepo,
 		pendingMessageRepo,
 		scheduleService,
-		commandBus: deps.commandBus,
+		internalEventBus: deps.internalEventBus,
 		externalEventStore: deps.externalEventStore,
-		replyRoutingRegistry,
+		externalEventService: deps.externalEventService,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
 	// session.create can synchronously call attachSpaceToolsToMemberSession for
-	// ad-hoc Space sessions. Doing this via the internalEventBus 'session.created' event
+	// ad-hoc Space sessions. Doing this via the daemonHub 'session.created' event
 	// would be racy: the query can start (and freeze its MCP config) before the
 	// event handler completes.
 	setupSessionHandlers(
 		deps.messageHub,
 		deps.sessionManager,
+		deps.daemonHub,
 		deps.internalEventBus,
 		deps.spaceManager,
 		spaceRuntimeService
@@ -452,15 +461,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()
-	// directly after session creation, avoiding reliance on the internalEventBus event.
+	// directly after session creation, avoiding reliance on the daemonHub event.
 	setupSpaceHandlers(
 		deps.messageHub,
 		deps.spaceManager,
 		spaceTaskRepo,
 		spaceWorkflowRunRepo,
-		deps.internalEventBus,
 		deps.spaceAgentManager,
 		spaceWorkflowManager,
+		deps.internalEventBus,
 		deps.sessionManager,
 		spaceRuntimeService
 	);
@@ -472,22 +481,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// `space:chat:${spaceId}` session via SessionManager. Shared between
 	// TaskAgentManager (for queue flush) and task-agent tool wiring.
 	const sessionManagerRef = deps.sessionManager;
-	const spaceAgentInjector = async (
-		spaceId: string,
-		message: string,
-		replyToSessionId?: string | null
-	): Promise<void> => {
-		let sessionId = replyToSessionId || `space:chat:${spaceId}`;
-		let session = await sessionManagerRef.getSessionAsync(sessionId);
-		// Fallback: if the routed-to session no longer exists (e.g. ad-hoc member
-		// session ended), fall back to the canonical space chat session so the
-		// reply is not silently dropped.
-		if (!session && replyToSessionId) {
-			sessionId = `space:chat:${spaceId}`;
-			session = await sessionManagerRef.getSessionAsync(sessionId);
-		}
+	const spaceAgentInjector = async (spaceId: string, message: string): Promise<void> => {
+		const sessionId = `space:chat:${spaceId}`;
+		const session = await sessionManagerRef.getSessionAsync(sessionId);
 		if (!session) {
-			throw new Error(`Session not found for Space Agent reply routing: ${sessionId}`);
+			throw new Error(`Space Agent chat session not found: ${sessionId}`);
 		}
 		const messageId = generateUUID();
 		const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
@@ -521,8 +519,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		gateDataRepo,
-		gateOpenStateRepo,
 		channelCycleRepo,
+		daemonHub: deps.daemonHub,
 		messageHub: deps.messageHub,
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
@@ -537,25 +535,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceAgentInjector,
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
-		replyRoutingRegistry,
-	});
-
-	deps.commandBus.register('agent.message.inject', async (command) => {
-		if (!taskAgentManager) {
-			return { ok: false, error: 'TaskAgentManager unavailable' };
-		}
-		try {
-			await taskAgentManager.injectSubSessionMessage(
-				command.sessionId,
-				command.message,
-				true,
-				undefined,
-				command.deliveryMode ?? 'immediate'
-			);
-			return { ok: true };
-		} catch (err) {
-			return { ok: false, error: err };
-		}
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn
@@ -580,17 +559,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			await spaceRuntimeService.notifyGateDataChanged(runId, gateId);
 		},
 		onWorkflowRunUpdated: (spaceId: string, runId: string, run: NeoWorkflowRun) => {
-			deps.internalEventBus
-				.publish('space.workflowRun.updated', {
-					sessionId: 'global',
-					spaceId,
-					runId,
-					// NeoWorkflowRun is a subset of SpaceWorkflowRun — cast for hub emission
-					run: run as unknown as Record<string, unknown>,
-				})
-				.catch((err) => {
-					log.warn('Neo: failed to emit space.workflowRun.updated:', err);
-				});
+			deps.internalEventBus.publishAsync('space.workflowRun.updated', {
+				namespaceId: 'global',
+				sessionId: 'global',
+				spaceId,
+				runId,
+				// NeoWorkflowRun is a subset of SpaceWorkflowRun — cast for event emission
+				run: run as unknown as DaemonInternalEventMap['space.workflowRun.updated']['run'],
+			});
 		},
 		onGateDataUpdated: (
 			spaceId: string,
@@ -598,17 +574,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			gateId: string,
 			data: Record<string, unknown>
 		) => {
-			deps.internalEventBus
-				.publish('space.gateData.updated', {
-					sessionId: 'global',
-					spaceId,
-					runId,
-					gateId,
-					data,
-				})
-				.catch((err) => {
-					log.warn('Neo: failed to emit space.gateData.updated:', err);
-				});
+			deps.internalEventBus.publishAsync('space.gateData.updated', {
+				namespaceId: 'global',
+				sessionId: 'global',
+				spaceId,
+				runId,
+				gateId,
+				data,
+			});
 		},
 		mcpManager: {
 			createMcpServer: (params) => deps.db.appMcpServers.create(params),
@@ -661,7 +634,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowRepo,
 		spaceWorkflowManager,
 		deps.db.getDatabase(),
-		deps.internalEventBus
+		deps.daemonHub
 	);
 
 	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -9,8 +9,10 @@ import type { MessageHub } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { UUID } from 'crypto';
-import type { DaemonHub } from '../daemon-hub';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
+import type { DaemonCommandMap, InternalCommandBus } from '../internal-command-bus';
+import type { ExternalEventStore } from '../external-events/external-event-store';
+import type { ExternalEventService } from '../external-events/external-event-service';
 import type { SessionManager } from '../session-manager';
 import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
@@ -41,6 +43,7 @@ import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-ta
 import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import { ReplyRoutingRegistry } from '../space/runtime/reply-routing-registry';
 import { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
 import {
 	setupSpaceWorkflowHandlers,
@@ -54,6 +57,7 @@ import type { SpaceAgentLookup } from '../space/managers/space-workflow-manager'
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
+import { GateOpenStateRepository } from '../../storage/repositories/gate-open-state-repository';
 import { WorkflowRunArtifactRepository } from '../../storage/repositories/workflow-run-artifact-repository';
 import { WorkflowRunArtifactCacheRepository } from '../../storage/repositories/workflow-run-artifact-cache-repository';
 import { createSyncArtifactHandlers } from '../job-handlers/space-workflow-run-artifact.handler';
@@ -96,8 +100,6 @@ import { TaskScheduleRepository } from '../../storage/repositories/task-schedule
 import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
-import type { ExternalEventStore } from '../external-events/external-event-store';
-import type { ExternalEventService } from '../external-events/external-event-service';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -105,18 +107,14 @@ export interface RPCHandlerDependencies {
 	authManager: AuthManager;
 	settingsManager: SettingsManager;
 	config: Config;
-	daemonHub: DaemonHub;
-	/**
-	 * Semantic internal event bus for daemon domain events that have been
-	 * migrated off DaemonHub. New publishers/subscribers should use this.
-	 */
+	/** Semantic internal event bus for daemon domain events. */
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>;
-	db: Database;
-	gitHubService?: GitHubService;
-	/** Source-agnostic external event store for workflow runtime delivery tracking. */
+	commandBus: InternalCommandBus<DaemonCommandMap>;
 	externalEventStore: ExternalEventStore;
 	/** External event service available to runtime subscribers when direct publishing is needed. */
 	externalEventService: ExternalEventService;
+	db: Database;
+	gitHubService?: GitHubService;
 	/** Space manager instance — shared with DaemonAppContext (single source of truth) */
 	spaceManager: SpaceManager;
 	spaceAgentManager: SpaceAgentManager;
@@ -186,21 +184,20 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	registerSettingsHandlers(
 		deps.messageHub,
 		deps.settingsManager,
-		deps.daemonHub,
 		deps.internalEventBus,
 		deps.db,
 		deps.mcpImportService
 	);
-	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
+	setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
 	// Use reactiveDb.db so test-injected sdk_messages rows also invalidate LiveQuery.
 	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
-	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
+	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
 
 	// Dialog handlers (native OS dialogs)
 	setupDialogHandlers(deps.messageHub);
 
 	// Question handlers (AskUserQuestion respond / saveDraft / cancel)
-	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
+	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
 
 	// Reference handlers (@ mention system — search + resolve tasks, goals, files, folders)
 	const fileIndex = new FileIndex(deps.config.workspaceRoot);
@@ -228,30 +225,17 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// App-level MCP registry handlers
 	registerAppMcpHandlers(deps.messageHub, {
 		db: deps.db,
-		daemonHub: deps.daemonHub,
 		internalEventBus: deps.internalEventBus,
 	});
 
 	// MCP enablement RPC handlers
-	setupAppMcpHandlers(deps.messageHub, deps.daemonHub, deps.internalEventBus, deps.db);
+	setupAppMcpHandlers(deps.messageHub, deps.internalEventBus, deps.db);
 
 	// Per-space MCP enablement RPC handlers + `.mcp.json` import refresh.
-	setupSpaceMcpHandlers(
-		deps.messageHub,
-		deps.daemonHub,
-		deps.internalEventBus,
-		deps.db,
-		deps.spaceManager
-	);
+	setupSpaceMcpHandlers(deps.messageHub, deps.internalEventBus, deps.db, deps.spaceManager);
 
 	// Skills registry RPC handlers
-	registerSkillHandlers(
-		deps.messageHub,
-		deps.skillsManager,
-		deps.daemonHub,
-		deps.internalEventBus,
-		undefined
-	);
+	registerSkillHandlers(deps.messageHub, deps.skillsManager, deps.internalEventBus, undefined);
 
 	// Workspace history RPC handlers.
 	// The import service is passed in so `workspace.add` can trigger a
@@ -278,8 +262,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase(), deps.reactiveDb);
-	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
+	const gateOpenStateRepo = new GateOpenStateRepository(deps.db.getDatabase());
+	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(
+		deps.db.getDatabase(),
+		gateOpenStateRepo
+	);
 	const artifactRepo = new WorkflowRunArtifactRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const artifactCacheRepo = new WorkflowRunArtifactCacheRepository(deps.db.getDatabase());
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
@@ -354,7 +342,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Space agent handlers
 	setupSpaceAgentHandlers(
 		deps.messageHub,
-		deps.daemonHub,
+		deps.internalEventBus,
 		deps.spaceAgentManager,
 		deps.spaceManager
 	);
@@ -363,7 +351,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.messageHub,
 		deps.spaceManager,
 		spaceWorkflowManager,
-		deps.daemonHub,
+		deps.internalEventBus,
 		deps.spaceAgentManager,
 		spaceWorkflowRunRepo
 	);
@@ -404,9 +392,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Not started yet: TaskAgentManager is created next and injected before start().
 	// gateDataRepo is injected so notifyGateDataChanged() can trigger lazy node activation
 	// after gate data is written externally (e.g. approveGate RPC, writeGateData RPC).
-	// sessionManager and daemonHub are injected so space:chat:${spaceId} sessions are
+	// sessionManager and internalEventBus are injected so space:chat:${spaceId} sessions are
 	// provisioned with MCP tools and system prompts on startup and on space.created.
 	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
+	// Reply Routing Registry — shared between space-agent-tools (register)
+	// and task-agent-tools / node-agent-tools (lookup).
+	const replyRoutingRegistry = new ReplyRoutingRegistry();
+
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		dbPath: deps.db.getDatabasePath(),
@@ -418,26 +410,27 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		nodeExecutionRepo,
 		reactiveDb: deps.reactiveDb,
 		gateDataRepo,
+		gateOpenStateRepo,
 		channelCycleRepo,
 		sessionManager: deps.sessionManager,
-		daemonHub: deps.daemonHub,
+		internalEventBus: deps.internalEventBus,
 		artifactRepo,
 		pendingMessageRepo,
 		scheduleService,
-		internalEventBus: deps.internalEventBus,
+		commandBus: deps.commandBus,
 		externalEventStore: deps.externalEventStore,
 		externalEventService: deps.externalEventService,
+		replyRoutingRegistry,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
 	// session.create can synchronously call attachSpaceToolsToMemberSession for
-	// ad-hoc Space sessions. Doing this via the daemonHub 'session.created' event
+	// ad-hoc Space sessions. Doing this via the internalEventBus 'session.created' event
 	// would be racy: the query can start (and freeze its MCP config) before the
 	// event handler completes.
 	setupSessionHandlers(
 		deps.messageHub,
 		deps.sessionManager,
-		deps.daemonHub,
 		deps.internalEventBus,
 		deps.spaceManager,
 		spaceRuntimeService
@@ -461,15 +454,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()
-	// directly after session creation, avoiding reliance on the daemonHub event.
+	// directly after session creation, avoiding reliance on the internalEventBus event.
 	setupSpaceHandlers(
 		deps.messageHub,
 		deps.spaceManager,
 		spaceTaskRepo,
 		spaceWorkflowRunRepo,
+		deps.internalEventBus,
 		deps.spaceAgentManager,
 		spaceWorkflowManager,
-		deps.internalEventBus,
 		deps.sessionManager,
 		spaceRuntimeService
 	);
@@ -481,11 +474,22 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// `space:chat:${spaceId}` session via SessionManager. Shared between
 	// TaskAgentManager (for queue flush) and task-agent tool wiring.
 	const sessionManagerRef = deps.sessionManager;
-	const spaceAgentInjector = async (spaceId: string, message: string): Promise<void> => {
-		const sessionId = `space:chat:${spaceId}`;
-		const session = await sessionManagerRef.getSessionAsync(sessionId);
+	const spaceAgentInjector = async (
+		spaceId: string,
+		message: string,
+		replyToSessionId?: string | null
+	): Promise<void> => {
+		let sessionId = replyToSessionId || `space:chat:${spaceId}`;
+		let session = await sessionManagerRef.getSessionAsync(sessionId);
+		// Fallback: if the routed-to session no longer exists (e.g. ad-hoc member
+		// session ended), fall back to the canonical space chat session so the
+		// reply is not silently dropped.
+		if (!session && replyToSessionId) {
+			sessionId = `space:chat:${spaceId}`;
+			session = await sessionManagerRef.getSessionAsync(sessionId);
+		}
 		if (!session) {
-			throw new Error(`Space Agent chat session not found: ${sessionId}`);
+			throw new Error(`Session not found for Space Agent reply routing: ${sessionId}`);
 		}
 		const messageId = generateUUID();
 		const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
@@ -519,8 +523,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		gateDataRepo,
+		gateOpenStateRepo,
 		channelCycleRepo,
-		daemonHub: deps.daemonHub,
 		messageHub: deps.messageHub,
 		getApiKey: () => deps.authManager.getCurrentApiKey(),
 		defaultModel: deps.config.defaultModel,
@@ -535,6 +539,25 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceAgentInjector,
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
+		replyRoutingRegistry,
+	});
+
+	deps.commandBus.register('agent.message.inject', async (command) => {
+		if (!taskAgentManager) {
+			return { ok: false, error: 'TaskAgentManager unavailable' };
+		}
+		try {
+			await taskAgentManager.injectSubSessionMessage(
+				command.sessionId,
+				command.message,
+				true,
+				undefined,
+				command.deliveryMode ?? 'immediate'
+			);
+			return { ok: true };
+		} catch (err) {
+			return { ok: false, error: err };
+		}
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn
@@ -559,14 +582,17 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			await spaceRuntimeService.notifyGateDataChanged(runId, gateId);
 		},
 		onWorkflowRunUpdated: (spaceId: string, runId: string, run: NeoWorkflowRun) => {
-			deps.internalEventBus.publishAsync('space.workflowRun.updated', {
-				namespaceId: 'global',
-				sessionId: 'global',
-				spaceId,
-				runId,
-				// NeoWorkflowRun is a subset of SpaceWorkflowRun — cast for event emission
-				run: run as unknown as DaemonInternalEventMap['space.workflowRun.updated']['run'],
-			});
+			deps.internalEventBus
+				.publish('space.workflowRun.updated', {
+					sessionId: 'global',
+					spaceId,
+					runId,
+					// NeoWorkflowRun is a subset of SpaceWorkflowRun — cast for hub emission
+					run: run as unknown as Record<string, unknown>,
+				})
+				.catch((err) => {
+					log.warn('Neo: failed to emit space.workflowRun.updated:', err);
+				});
 		},
 		onGateDataUpdated: (
 			spaceId: string,
@@ -574,14 +600,17 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 			gateId: string,
 			data: Record<string, unknown>
 		) => {
-			deps.internalEventBus.publishAsync('space.gateData.updated', {
-				namespaceId: 'global',
-				sessionId: 'global',
-				spaceId,
-				runId,
-				gateId,
-				data,
-			});
+			deps.internalEventBus
+				.publish('space.gateData.updated', {
+					sessionId: 'global',
+					spaceId,
+					runId,
+					gateId,
+					data,
+				})
+				.catch((err) => {
+					log.warn('Neo: failed to emit space.gateData.updated:', err);
+				});
 		},
 		mcpManager: {
 			createMcpServer: (params) => deps.db.appMcpServers.create(params),
@@ -634,7 +663,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowRepo,
 		spaceWorkflowManager,
 		deps.db.getDatabase(),
-		deps.daemonHub
+		deps.internalEventBus
 	);
 
 	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -25,14 +25,13 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
-import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
+import type { DaemonHub } from '../../daemon-hub';
 import { SpaceRuntime } from './space-runtime';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import { selectWorkflowWithLlmDefault } from './llm-workflow-selector';
 import { ChannelRouter } from './channel-router';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
-import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
@@ -40,8 +39,9 @@ import {
 	SpaceAgentNotificationService,
 	type SpaceAgentNotificationServiceConfig,
 } from './space-agent-notification-service';
-import type { DaemonCommandMap, InternalCommandBus } from '../../internal-command-bus';
+import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
+import type { ExternalEventService } from '../../external-events/external-event-service';
 
 const log = new Logger('space-runtime-service');
 
@@ -75,10 +75,6 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	gateDataRepo?: GateDataRepository;
 	/**
-	 * Optional gate open state repository for persisting gate-open cache across daemon restarts.
-	 */
-	gateOpenStateRepo?: import('../../../storage/repositories/gate-open-state-repository').GateOpenStateRepository;
-	/**
 	 * Optional pending message repository for queueing messages to not-yet-spawned
 	 * workflow node agents.
 	 */
@@ -90,6 +86,12 @@ export interface SpaceRuntimeServiceConfig {
 	 * to space chat sessions on startup and on space.created events.
 	 */
 	sessionManager?: SessionManager;
+	/**
+	 * Optional DaemonHub for subscribing to space.created events.
+	 * When provided together with sessionManager, new spaces get their chat sessions
+	 * provisioned automatically.
+	 */
+	daemonHub?: DaemonHub;
 	/**
 	 * Optional artifact repository for resolving completion action context.
 	 * Passed through to SpaceRuntime so completion actions with `artifactType`
@@ -110,27 +112,22 @@ export interface SpaceRuntimeServiceConfig {
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 	/**
 	 * Optional InternalEventBus for publishing Space runtime domain events.
-	 * When provided, SpaceRuntime publishes typed events alongside the legacy
-	 * NotificationSink path, and SpaceAgentNotificationService is wired per-space
-	 * to inject agent-facing messages into space:chat:${spaceId} sessions.
-	 *
-	 * This is the preferred integration point for M6+.
+	 * When provided, SpaceRuntime publishes typed events such as
+	 * `space.task.blocked` / `space.workflowRun.completed`, and a
+	 * `SpaceAgentNotificationService` is wired per-space to inject agent-facing
+	 * messages into `space:chat:${spaceId}` sessions.
 	 */
 	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
-	commandBus?: InternalCommandBus<DaemonCommandMap>;
+	/** External event lifecycle store for workflow-node event delivery tracking. */
 	externalEventStore?: ExternalEventStore;
-	/**
-	 * Reply routing registry for symmetric message routing.
-	 * Passed to space-agent-tools so member sessions can register their
-	 * session ID as the reply target when sending messages to task/node agents.
-	 */
-	replyRoutingRegistry?: ReplyRoutingRegistry;
+	/** External event publisher, available for runtime-owned direct publications if needed. */
+	externalEventService?: ExternalEventService;
 }
 
 export class SpaceRuntimeService {
 	private readonly runtime: SpaceRuntime;
 	private started = false;
-	/** Unsubscribe handles for InternalEventBus<DaemonInternalEventMap> event subscriptions (daemon-lifetime). */
+	/** Unsubscribe handles for DaemonHub event subscriptions (daemon-lifetime). */
 	private readonly unsubscribers: Array<() => void> = [];
 	/** Reference to TaskAgentManager, stored when injected via setTaskAgentManager(). */
 	private taskAgentManager: TaskAgentManager | null = null;
@@ -183,8 +180,8 @@ export class SpaceRuntimeService {
 			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
 			internalEventBus: config.internalEventBus,
 			onTaskUpdated: async ({ spaceId, task, archiveSource }) => {
-				if (!this.config.internalEventBus) return;
-				await this.config.internalEventBus.publish('space.task.updated', {
+				this.config.internalEventBus?.publishAsync('space.task.updated', {
+					namespaceId: 'global',
 					sessionId: 'global',
 					spaceId,
 					taskId: task.id,
@@ -193,8 +190,8 @@ export class SpaceRuntimeService {
 				});
 			},
 			onWorkflowRunCreated: async ({ spaceId, run }) => {
-				if (!this.config.internalEventBus) return;
-				await this.config.internalEventBus.publish('space.workflowRun.created', {
+				this.config.internalEventBus?.publishAsync('space.workflowRun.created', {
+					namespaceId: 'global',
 					sessionId: 'global',
 					spaceId,
 					runId: run.id,
@@ -202,8 +199,8 @@ export class SpaceRuntimeService {
 				});
 			},
 			onWorkflowRunUpdated: async ({ spaceId, run }) => {
-				if (!this.config.internalEventBus) return;
-				await this.config.internalEventBus.publish('space.workflowRun.updated', {
+				this.config.internalEventBus?.publishAsync('space.workflowRun.updated', {
+					namespaceId: 'global',
 					sessionId: 'global',
 					spaceId,
 					runId: run.id,
@@ -219,8 +216,6 @@ export class SpaceRuntimeService {
 	 * Resolves the circular dependency: SpaceRuntimeService must exist before
 	 * TaskAgentManager (which takes it as a constructor argument), so the manager
 	 * is injected back here once both are created.
-	 *
-	 * Mirrors the setNotificationSink() pattern.
 	 */
 	setTaskAgentManager(manager: TaskAgentManager): void {
 		this.taskAgentManager = manager;
@@ -422,117 +417,146 @@ export class SpaceRuntimeService {
 	 * `space-agent-tools` (and `db-query`) attached so it can coordinate with
 	 * the rest of the Space.
 	 *
-	 * Called once during start(). No-op when sessionManager or internalEventBus are absent.
+	 * Called once during start(). No-op when sessionManager is absent.
+	 * DaemonHub is still used for unmigrated session/workflow events, but migrated
+	 * space lifecycle subscriptions can run with InternalEventBus alone.
 	 */
 	private subscribeToSpaceEvents(): void {
-		const { sessionManager, internalEventBus } = this.config;
-		if (!sessionManager || !internalEventBus) return;
+		const { sessionManager, daemonHub, internalEventBus } = this.config;
+		if (!sessionManager || (!daemonHub && !internalEventBus)) return;
 
-		const unsubCreated = internalEventBus.subscribe(
-			'space.created',
-			(event) => {
-				void this.setupSpaceAgentSession(event.space).catch((err) => {
-					log.error(`Failed to provision space chat session for space ${event.spaceId}:`, err);
-				});
-			},
-			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
-		);
+		const handleSpaceCreated = (event: DaemonInternalEventMap['space.created']): void => {
+			void this.setupSpaceAgentSession(event.space).catch((err) => {
+				log.error(`Failed to provision space chat session for space ${event.spaceId}:`, err);
+			});
+		};
+		const unsubCreated = internalEventBus
+			? internalEventBus.subscribe('space.created', handleSpaceCreated, {
+					subscriberName: 'SpaceRuntimeService.spaceCreated',
+				})
+			: daemonHub!.on(
+					'space.created',
+					handleSpaceCreated as (event: {
+						sessionId: string;
+						spaceId: string;
+						space: Space;
+					}) => void
+				);
 		this.unsubscribers.push(unsubCreated);
 
-		// When a workflow definition is updated, refresh gate poll timers for
-		// all active runs using that workflow so mid-run config changes are
-		// picked up without requiring a task restart.
-		const unsubWorkflowUpdated = internalEventBus.subscribe(
-			'spaceWorkflow.updated',
-			(event) => {
-				try {
-					this.runtime.onWorkflowDefChanged(event.workflow.id);
-				} catch (err) {
-					log.error(`Failed to refresh gate polls for workflow ${event.workflow.id}:`, err);
-				}
-			},
-			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
-		);
-		this.unsubscribers.push(unsubWorkflowUpdated);
+		if (daemonHub) {
+			// When a workflow definition is updated, refresh gate poll timers for
+			// all active runs using that workflow so mid-run config changes are
+			// picked up without requiring a task restart.
+			const unsubWorkflowUpdated = daemonHub.on(
+				'spaceWorkflow.updated',
+				(event) => {
+					try {
+						this.runtime.onWorkflowDefChanged(event.workflow.id);
+					} catch (err) {
+						log.error(`Failed to refresh gate polls for workflow ${event.workflow.id}:`, err);
+					}
+				},
+				{ sessionId: 'global' }
+			);
+			this.unsubscribers.push(unsubWorkflowUpdated);
 
-		// When any new session is created with `context.spaceId`, attach the
-		// shared Space coordination tools. The space-chat session itself is
-		// handled by `setupSpaceAgentSession` (it also sets the system prompt);
-		// the space_task_agent sessions are handled by `TaskAgentManager`
-		// (which merges `space-agent-tools` into its MCP set). This subscription
-		// covers the remaining cases: worker sessions
-		// that live inside a Space and need to send/receive messages via
-		// `send_message_to_agent`, inspect tasks, etc.
-		//
-		// NOTE: no `{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }` filter here — `session.created` is
-		// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
-		// filter would never match. We want every session.created event, so we
-		// subscribe globally (TypedHub's default).
-		const unsubSessionCreated = internalEventBus.subscribe(
-			'session.created',
-			(event) => {
+			// When any new session is created with `context.spaceId`, attach the
+			// shared Space coordination tools. The space-chat session itself is
+			// handled by `setupSpaceAgentSession` (it also sets the system prompt);
+			// the space_task_agent sessions are handled by `TaskAgentManager`
+			// (which merges `space-agent-tools` into its MCP set). This subscription
+			// covers the remaining cases: worker sessions
+			// that live inside a Space and need to send/receive messages via
+			// `send_message_to_agent`, inspect tasks, etc.
+			//
+			// NOTE: no `{ namespaceId: 'global', sessionId: 'global' }` filter here — `session.created` is
+			// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
+			// filter would never match. We want every session.created event, so we
+			// subscribe globally (TypedHub's default).
+			const unsubSessionCreated = daemonHub.on('session.created', (event) => {
 				void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
 					log.error(
 						`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
 						err
 					);
 				});
-			},
-			{ subscriberName: 'SpaceRuntimeService.sessionCreated' }
-		);
-		this.unsubscribers.push(unsubSessionCreated);
+			});
+			this.unsubscribers.push(unsubSessionCreated);
 
-		// When a session is deleted, release any per-session db-query server we
-		// spun up for it so read-only SQLite handles don't accumulate on a
-		// long-lived daemon serving many short-lived worker sessions.
-		// (Same reasoning as above: `session.deleted` is emitted with the
-		// deleted session's UUID as `sessionId`, not `'global'`.)
-		const unsubSessionDeleted = internalEventBus.subscribe(
-			'session.deleted',
-			(event) => {
+			// When a session is deleted, release any per-session db-query server we
+			// spun up for it so read-only SQLite handles don't accumulate on a
+			// long-lived daemon serving many short-lived worker sessions.
+			// (Same reasoning as above: `session.deleted` is emitted with the
+			// deleted session's UUID as `sessionId`, not `'global'`.)
+			const unsubSessionDeleted = daemonHub.on('session.deleted', (event) => {
 				this.releaseMemberSessionDbQuery(event.sessionId);
-			},
-			{ subscriberName: 'SpaceRuntimeService.sessionDeleted' }
-		);
-		this.unsubscribers.push(unsubSessionDeleted);
+			});
+			this.unsubscribers.push(unsubSessionDeleted);
+		}
 
 		// When a space is archived or deleted, tear down its notification service
 		// so stale subscribers don't accumulate and fan-out to non-existent sessions.
-		const unsubSpaceArchived = internalEventBus.subscribe(
-			'space.archived',
-			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'archived'),
-			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
-		);
+		const handleSpaceArchived = (event: DaemonInternalEventMap['space.archived']): void =>
+			this.tearDownSpaceNotificationService(event.spaceId, 'archived');
+		const unsubSpaceArchived = internalEventBus
+			? internalEventBus.subscribe('space.archived', handleSpaceArchived, {
+					subscriberName: 'SpaceRuntimeService.spaceArchived',
+				})
+			: daemonHub!.on(
+					'space.archived',
+					handleSpaceArchived as (event: {
+						sessionId: string;
+						spaceId: string;
+						space: Space;
+					}) => void,
+					{ sessionId: 'global' }
+				);
 		this.unsubscribers.push(unsubSpaceArchived);
 
-		const unsubSpaceDeleted = internalEventBus.subscribe(
-			'space.deleted',
-			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'deleted'),
-			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
-		);
+		const handleSpaceDeleted = (event: DaemonInternalEventMap['space.deleted']): void =>
+			this.tearDownSpaceNotificationService(event.spaceId, 'deleted');
+		const unsubSpaceDeleted = internalEventBus
+			? internalEventBus.subscribe('space.deleted', handleSpaceDeleted, {
+					subscriberName: 'SpaceRuntimeService.spaceDeleted',
+				})
+			: daemonHub!.on(
+					'space.deleted',
+					handleSpaceDeleted as (event: { sessionId: string; spaceId: string }) => void,
+					{ sessionId: 'global' }
+				);
 		this.unsubscribers.push(unsubSpaceDeleted);
 
 		// When a space is updated, refresh the autonomy level in its notification
 		// service so [TASK_EVENT] messages report the current level.
-		const unsubSpaceUpdated = internalEventBus.subscribe(
-			'space.updated',
-			(event) => {
-				const existingUnsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
-				if (!existingUnsub) return;
+		const handleSpaceUpdated = (event: DaemonInternalEventMap['space.updated']): void => {
+			const existingUnsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
+			if (!existingUnsub) return;
 
-				// Re-provision the space chat session, which re-creates the
-				// SpaceAgentNotificationService with the updated autonomy level.
-				if (event.space) {
-					void this.setupSpaceAgentSession(event.space as Space).catch((err) => {
-						log.error(
-							`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`,
-							err
-						);
-					});
-				}
-			},
-			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
-		);
+			// Re-provision the space chat session, which re-creates the
+			// SpaceAgentNotificationService with the updated autonomy level.
+			if (event.space) {
+				void this.setupSpaceAgentSession(event.space as Space).catch((err) => {
+					log.error(
+						`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`,
+						err
+					);
+				});
+			}
+		};
+		const unsubSpaceUpdated = internalEventBus
+			? internalEventBus.subscribe('space.updated', handleSpaceUpdated, {
+					subscriberName: 'SpaceRuntimeService.spaceUpdated',
+				})
+			: daemonHub!.on(
+					'space.updated',
+					handleSpaceUpdated as (event: {
+						sessionId: string;
+						spaceId: string;
+						space?: Partial<Space>;
+					}) => void,
+					{ sessionId: 'global' }
+				);
 		this.unsubscribers.push(unsubSpaceUpdated);
 
 		// Hard resets replace the cached AgentSession with a fresh instance built
@@ -782,7 +806,6 @@ export class SpaceRuntimeService {
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
-			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		const additional: Record<string, McpServerConfig> = {
@@ -877,7 +900,6 @@ export class SpaceRuntimeService {
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
-			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.
@@ -955,7 +977,8 @@ export class SpaceRuntimeService {
 		}
 
 		// Wire SpaceAgentNotificationService for this space when InternalEventBus is available.
-		// This replaces the legacy SessionNotificationSink / setNotificationSink path.
+		// This delivers agent-facing notifications for runtime events (`space.task.blocked`,
+		// `space.workflowRun.completed`, etc.) into the space chat session.
 		if (this.config.internalEventBus && sessionManager) {
 			// Tear down any existing notification service for this space (re-provision safety).
 			const existingUnsub = this.spaceAgentNotificationUnsubs.get(space.id);
@@ -1045,14 +1068,13 @@ export class SpaceRuntimeService {
 		});
 		if (!updated) return;
 
-		if (this.config.internalEventBus) {
-			await this.config.internalEventBus.publish('space.task.updated', {
-				sessionId: 'global',
-				spaceId: run.spaceId,
-				taskId: updated.id,
-				task: updated,
-			});
-		}
+		this.config.internalEventBus?.publishAsync('space.task.updated', {
+			namespaceId: 'global',
+			sessionId: 'global',
+			spaceId: run.spaceId,
+			taskId: updated.id,
+			task: updated,
+		});
 	}
 
 	/**
@@ -1085,7 +1107,6 @@ export class SpaceRuntimeService {
 			agentManager: this.config.spaceAgentManager,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			gateDataRepo: this.config.gateDataRepo,
-			gateOpenStateRepo: this.config.gateOpenStateRepo,
 			channelCycleRepo: this.config.channelCycleRepo,
 			db: this.config.db,
 			workspacePath,
@@ -1097,9 +1118,7 @@ export class SpaceRuntimeService {
 			cancelSessionById: taskAgentManager
 				? (sid) => taskAgentManager.cancelBySessionId(sid)
 				: undefined,
-			// Forward the runtime's current sink so a gate-driven reopen still
-			// surfaces `workflow_run_reopened` to the Space Agent session.
-			// Forward the InternalEventBus so gate-driven reopens also publish
+			// Forward the InternalEventBus so gate-driven reopens publish
 			// typed `space.workflowRun.reopened` events for bus subscribers.
 			internalEventBus: this.config.internalEventBus,
 			onGatePendingApproval: (runId, gateId) => this.handleGatePendingApproval(runId, gateId),
@@ -1147,7 +1166,6 @@ export class SpaceRuntimeService {
 			agentManager: this.config.spaceAgentManager,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			gateDataRepo: this.config.gateDataRepo,
-			gateOpenStateRepo: this.config.gateOpenStateRepo,
 			channelCycleRepo: this.config.channelCycleRepo,
 			db: this.config.db,
 			workspacePath,
@@ -1159,10 +1177,7 @@ export class SpaceRuntimeService {
 			cancelSessionById: taskAgentManager
 				? (sid) => taskAgentManager.cancelBySessionId(sid)
 				: undefined,
-			// Forward the runtime's current sink so activation-driven reopens of
-			// terminal runs still surface `workflow_run_reopened` to the Space
-			// Agent session (mirrors `notifyGateDataChanged` above).
-			// Forward the InternalEventBus so activation-driven reopens also publish
+			// Forward the InternalEventBus so activation-driven reopens publish
 			// typed `space.workflowRun.reopened` events for bus subscribers.
 			internalEventBus: this.config.internalEventBus,
 		});

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -25,13 +25,14 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
-import type { DaemonHub } from '../../daemon-hub';
+import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import { selectWorkflowWithLlmDefault } from './llm-workflow-selector';
 import { ChannelRouter } from './channel-router';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
+import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
@@ -39,7 +40,7 @@ import {
 	SpaceAgentNotificationService,
 	type SpaceAgentNotificationServiceConfig,
 } from './space-agent-notification-service';
-import type { InternalEventBus, DaemonInternalEventMap } from '../../internal-event-bus';
+import type { DaemonCommandMap, InternalCommandBus } from '../../internal-command-bus';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
 import type { ExternalEventService } from '../../external-events/external-event-service';
 
@@ -75,6 +76,10 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	gateDataRepo?: GateDataRepository;
 	/**
+	 * Optional gate open state repository for persisting gate-open cache across daemon restarts.
+	 */
+	gateOpenStateRepo?: import('../../../storage/repositories/gate-open-state-repository').GateOpenStateRepository;
+	/**
 	 * Optional pending message repository for queueing messages to not-yet-spawned
 	 * workflow node agents.
 	 */
@@ -86,12 +91,6 @@ export interface SpaceRuntimeServiceConfig {
 	 * to space chat sessions on startup and on space.created events.
 	 */
 	sessionManager?: SessionManager;
-	/**
-	 * Optional DaemonHub for subscribing to space.created events.
-	 * When provided together with sessionManager, new spaces get their chat sessions
-	 * provisioned automatically.
-	 */
-	daemonHub?: DaemonHub;
 	/**
 	 * Optional artifact repository for resolving completion action context.
 	 * Passed through to SpaceRuntime so completion actions with `artifactType`
@@ -112,22 +111,29 @@ export interface SpaceRuntimeServiceConfig {
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 	/**
 	 * Optional InternalEventBus for publishing Space runtime domain events.
-	 * When provided, SpaceRuntime publishes typed events such as
-	 * `space.task.blocked` / `space.workflowRun.completed`, and a
-	 * `SpaceAgentNotificationService` is wired per-space to inject agent-facing
-	 * messages into `space:chat:${spaceId}` sessions.
+	 * When provided, SpaceRuntime publishes typed events alongside the legacy
+	 * NotificationSink path, and SpaceAgentNotificationService is wired per-space
+	 * to inject agent-facing messages into space:chat:${spaceId} sessions.
+	 *
+	 * This is the preferred integration point for M6+.
 	 */
 	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
-	/** External event lifecycle store for workflow-node event delivery tracking. */
+	commandBus?: InternalCommandBus<DaemonCommandMap>;
 	externalEventStore?: ExternalEventStore;
 	/** External event publisher, available for runtime-owned direct publications if needed. */
 	externalEventService?: ExternalEventService;
+	/**
+	 * Reply routing registry for symmetric message routing.
+	 * Passed to space-agent-tools so member sessions can register their
+	 * session ID as the reply target when sending messages to task/node agents.
+	 */
+	replyRoutingRegistry?: ReplyRoutingRegistry;
 }
 
 export class SpaceRuntimeService {
 	private readonly runtime: SpaceRuntime;
 	private started = false;
-	/** Unsubscribe handles for DaemonHub event subscriptions (daemon-lifetime). */
+	/** Unsubscribe handles for InternalEventBus<DaemonInternalEventMap> event subscriptions (daemon-lifetime). */
 	private readonly unsubscribers: Array<() => void> = [];
 	/** Reference to TaskAgentManager, stored when injected via setTaskAgentManager(). */
 	private taskAgentManager: TaskAgentManager | null = null;
@@ -180,8 +186,8 @@ export class SpaceRuntimeService {
 			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
 			internalEventBus: config.internalEventBus,
 			onTaskUpdated: async ({ spaceId, task, archiveSource }) => {
-				this.config.internalEventBus?.publishAsync('space.task.updated', {
-					namespaceId: 'global',
+				if (!this.config.internalEventBus) return;
+				await this.config.internalEventBus.publish('space.task.updated', {
 					sessionId: 'global',
 					spaceId,
 					taskId: task.id,
@@ -190,8 +196,8 @@ export class SpaceRuntimeService {
 				});
 			},
 			onWorkflowRunCreated: async ({ spaceId, run }) => {
-				this.config.internalEventBus?.publishAsync('space.workflowRun.created', {
-					namespaceId: 'global',
+				if (!this.config.internalEventBus) return;
+				await this.config.internalEventBus.publish('space.workflowRun.created', {
 					sessionId: 'global',
 					spaceId,
 					runId: run.id,
@@ -199,8 +205,8 @@ export class SpaceRuntimeService {
 				});
 			},
 			onWorkflowRunUpdated: async ({ spaceId, run }) => {
-				this.config.internalEventBus?.publishAsync('space.workflowRun.updated', {
-					namespaceId: 'global',
+				if (!this.config.internalEventBus) return;
+				await this.config.internalEventBus.publish('space.workflowRun.updated', {
 					sessionId: 'global',
 					spaceId,
 					runId: run.id,
@@ -216,6 +222,8 @@ export class SpaceRuntimeService {
 	 * Resolves the circular dependency: SpaceRuntimeService must exist before
 	 * TaskAgentManager (which takes it as a constructor argument), so the manager
 	 * is injected back here once both are created.
+	 *
+	 * Mirrors the setNotificationSink() pattern.
 	 */
 	setTaskAgentManager(manager: TaskAgentManager): void {
 		this.taskAgentManager = manager;
@@ -417,146 +425,117 @@ export class SpaceRuntimeService {
 	 * `space-agent-tools` (and `db-query`) attached so it can coordinate with
 	 * the rest of the Space.
 	 *
-	 * Called once during start(). No-op when sessionManager is absent.
-	 * DaemonHub is still used for unmigrated session/workflow events, but migrated
-	 * space lifecycle subscriptions can run with InternalEventBus alone.
+	 * Called once during start(). No-op when sessionManager or internalEventBus are absent.
 	 */
 	private subscribeToSpaceEvents(): void {
-		const { sessionManager, daemonHub, internalEventBus } = this.config;
-		if (!sessionManager || (!daemonHub && !internalEventBus)) return;
+		const { sessionManager, internalEventBus } = this.config;
+		if (!sessionManager || !internalEventBus) return;
 
-		const handleSpaceCreated = (event: DaemonInternalEventMap['space.created']): void => {
-			void this.setupSpaceAgentSession(event.space).catch((err) => {
-				log.error(`Failed to provision space chat session for space ${event.spaceId}:`, err);
-			});
-		};
-		const unsubCreated = internalEventBus
-			? internalEventBus.subscribe('space.created', handleSpaceCreated, {
-					subscriberName: 'SpaceRuntimeService.spaceCreated',
-				})
-			: daemonHub!.on(
-					'space.created',
-					handleSpaceCreated as (event: {
-						sessionId: string;
-						spaceId: string;
-						space: Space;
-					}) => void
-				);
+		const unsubCreated = internalEventBus.subscribe(
+			'space.created',
+			(event) => {
+				void this.setupSpaceAgentSession(event.space).catch((err) => {
+					log.error(`Failed to provision space chat session for space ${event.spaceId}:`, err);
+				});
+			},
+			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
+		);
 		this.unsubscribers.push(unsubCreated);
 
-		if (daemonHub) {
-			// When a workflow definition is updated, refresh gate poll timers for
-			// all active runs using that workflow so mid-run config changes are
-			// picked up without requiring a task restart.
-			const unsubWorkflowUpdated = daemonHub.on(
-				'spaceWorkflow.updated',
-				(event) => {
-					try {
-						this.runtime.onWorkflowDefChanged(event.workflow.id);
-					} catch (err) {
-						log.error(`Failed to refresh gate polls for workflow ${event.workflow.id}:`, err);
-					}
-				},
-				{ sessionId: 'global' }
-			);
-			this.unsubscribers.push(unsubWorkflowUpdated);
+		// When a workflow definition is updated, refresh gate poll timers for
+		// all active runs using that workflow so mid-run config changes are
+		// picked up without requiring a task restart.
+		const unsubWorkflowUpdated = internalEventBus.subscribe(
+			'spaceWorkflow.updated',
+			(event) => {
+				try {
+					this.runtime.onWorkflowDefChanged(event.workflow.id);
+				} catch (err) {
+					log.error(`Failed to refresh gate polls for workflow ${event.workflow.id}:`, err);
+				}
+			},
+			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
+		);
+		this.unsubscribers.push(unsubWorkflowUpdated);
 
-			// When any new session is created with `context.spaceId`, attach the
-			// shared Space coordination tools. The space-chat session itself is
-			// handled by `setupSpaceAgentSession` (it also sets the system prompt);
-			// the space_task_agent sessions are handled by `TaskAgentManager`
-			// (which merges `space-agent-tools` into its MCP set). This subscription
-			// covers the remaining cases: worker sessions
-			// that live inside a Space and need to send/receive messages via
-			// `send_message_to_agent`, inspect tasks, etc.
-			//
-			// NOTE: no `{ namespaceId: 'global', sessionId: 'global' }` filter here — `session.created` is
-			// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
-			// filter would never match. We want every session.created event, so we
-			// subscribe globally (TypedHub's default).
-			const unsubSessionCreated = daemonHub.on('session.created', (event) => {
+		// When any new session is created with `context.spaceId`, attach the
+		// shared Space coordination tools. The space-chat session itself is
+		// handled by `setupSpaceAgentSession` (it also sets the system prompt);
+		// the space_task_agent sessions are handled by `TaskAgentManager`
+		// (which merges `space-agent-tools` into its MCP set). This subscription
+		// covers the remaining cases: worker sessions
+		// that live inside a Space and need to send/receive messages via
+		// `send_message_to_agent`, inspect tasks, etc.
+		//
+		// NOTE: no `{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }` filter here — `session.created` is
+		// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
+		// filter would never match. We want every session.created event, so we
+		// subscribe globally (TypedHub's default).
+		const unsubSessionCreated = internalEventBus.subscribe(
+			'session.created',
+			(event) => {
 				void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
 					log.error(
 						`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
 						err
 					);
 				});
-			});
-			this.unsubscribers.push(unsubSessionCreated);
+			},
+			{ subscriberName: 'SpaceRuntimeService.sessionCreated' }
+		);
+		this.unsubscribers.push(unsubSessionCreated);
 
-			// When a session is deleted, release any per-session db-query server we
-			// spun up for it so read-only SQLite handles don't accumulate on a
-			// long-lived daemon serving many short-lived worker sessions.
-			// (Same reasoning as above: `session.deleted` is emitted with the
-			// deleted session's UUID as `sessionId`, not `'global'`.)
-			const unsubSessionDeleted = daemonHub.on('session.deleted', (event) => {
+		// When a session is deleted, release any per-session db-query server we
+		// spun up for it so read-only SQLite handles don't accumulate on a
+		// long-lived daemon serving many short-lived worker sessions.
+		// (Same reasoning as above: `session.deleted` is emitted with the
+		// deleted session's UUID as `sessionId`, not `'global'`.)
+		const unsubSessionDeleted = internalEventBus.subscribe(
+			'session.deleted',
+			(event) => {
 				this.releaseMemberSessionDbQuery(event.sessionId);
-			});
-			this.unsubscribers.push(unsubSessionDeleted);
-		}
+			},
+			{ subscriberName: 'SpaceRuntimeService.sessionDeleted' }
+		);
+		this.unsubscribers.push(unsubSessionDeleted);
 
 		// When a space is archived or deleted, tear down its notification service
 		// so stale subscribers don't accumulate and fan-out to non-existent sessions.
-		const handleSpaceArchived = (event: DaemonInternalEventMap['space.archived']): void =>
-			this.tearDownSpaceNotificationService(event.spaceId, 'archived');
-		const unsubSpaceArchived = internalEventBus
-			? internalEventBus.subscribe('space.archived', handleSpaceArchived, {
-					subscriberName: 'SpaceRuntimeService.spaceArchived',
-				})
-			: daemonHub!.on(
-					'space.archived',
-					handleSpaceArchived as (event: {
-						sessionId: string;
-						spaceId: string;
-						space: Space;
-					}) => void,
-					{ sessionId: 'global' }
-				);
+		const unsubSpaceArchived = internalEventBus.subscribe(
+			'space.archived',
+			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'archived'),
+			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
+		);
 		this.unsubscribers.push(unsubSpaceArchived);
 
-		const handleSpaceDeleted = (event: DaemonInternalEventMap['space.deleted']): void =>
-			this.tearDownSpaceNotificationService(event.spaceId, 'deleted');
-		const unsubSpaceDeleted = internalEventBus
-			? internalEventBus.subscribe('space.deleted', handleSpaceDeleted, {
-					subscriberName: 'SpaceRuntimeService.spaceDeleted',
-				})
-			: daemonHub!.on(
-					'space.deleted',
-					handleSpaceDeleted as (event: { sessionId: string; spaceId: string }) => void,
-					{ sessionId: 'global' }
-				);
+		const unsubSpaceDeleted = internalEventBus.subscribe(
+			'space.deleted',
+			(event) => this.tearDownSpaceNotificationService(event.spaceId, 'deleted'),
+			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
+		);
 		this.unsubscribers.push(unsubSpaceDeleted);
 
 		// When a space is updated, refresh the autonomy level in its notification
 		// service so [TASK_EVENT] messages report the current level.
-		const handleSpaceUpdated = (event: DaemonInternalEventMap['space.updated']): void => {
-			const existingUnsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
-			if (!existingUnsub) return;
+		const unsubSpaceUpdated = internalEventBus.subscribe(
+			'space.updated',
+			(event) => {
+				const existingUnsub = this.spaceAgentNotificationUnsubs.get(event.spaceId);
+				if (!existingUnsub) return;
 
-			// Re-provision the space chat session, which re-creates the
-			// SpaceAgentNotificationService with the updated autonomy level.
-			if (event.space) {
-				void this.setupSpaceAgentSession(event.space as Space).catch((err) => {
-					log.error(
-						`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`,
-						err
-					);
-				});
-			}
-		};
-		const unsubSpaceUpdated = internalEventBus
-			? internalEventBus.subscribe('space.updated', handleSpaceUpdated, {
-					subscriberName: 'SpaceRuntimeService.spaceUpdated',
-				})
-			: daemonHub!.on(
-					'space.updated',
-					handleSpaceUpdated as (event: {
-						sessionId: string;
-						spaceId: string;
-						space?: Partial<Space>;
-					}) => void,
-					{ sessionId: 'global' }
-				);
+				// Re-provision the space chat session, which re-creates the
+				// SpaceAgentNotificationService with the updated autonomy level.
+				if (event.space) {
+					void this.setupSpaceAgentSession(event.space as Space).catch((err) => {
+						log.error(
+							`Failed to re-provision space chat session after autonomy update for space ${event.spaceId}:`,
+							err
+						);
+					});
+				}
+			},
+			{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }
+		);
 		this.unsubscribers.push(unsubSpaceUpdated);
 
 		// Hard resets replace the cached AgentSession with a fresh instance built
@@ -806,6 +785,7 @@ export class SpaceRuntimeService {
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		const additional: Record<string, McpServerConfig> = {
@@ -900,6 +880,7 @@ export class SpaceRuntimeService {
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.
@@ -977,8 +958,7 @@ export class SpaceRuntimeService {
 		}
 
 		// Wire SpaceAgentNotificationService for this space when InternalEventBus is available.
-		// This delivers agent-facing notifications for runtime events (`space.task.blocked`,
-		// `space.workflowRun.completed`, etc.) into the space chat session.
+		// This replaces the legacy SessionNotificationSink / setNotificationSink path.
 		if (this.config.internalEventBus && sessionManager) {
 			// Tear down any existing notification service for this space (re-provision safety).
 			const existingUnsub = this.spaceAgentNotificationUnsubs.get(space.id);
@@ -1068,13 +1048,14 @@ export class SpaceRuntimeService {
 		});
 		if (!updated) return;
 
-		this.config.internalEventBus?.publishAsync('space.task.updated', {
-			namespaceId: 'global',
-			sessionId: 'global',
-			spaceId: run.spaceId,
-			taskId: updated.id,
-			task: updated,
-		});
+		if (this.config.internalEventBus) {
+			await this.config.internalEventBus.publish('space.task.updated', {
+				sessionId: 'global',
+				spaceId: run.spaceId,
+				taskId: updated.id,
+				task: updated,
+			});
+		}
 	}
 
 	/**
@@ -1107,6 +1088,7 @@ export class SpaceRuntimeService {
 			agentManager: this.config.spaceAgentManager,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			gateDataRepo: this.config.gateDataRepo,
+			gateOpenStateRepo: this.config.gateOpenStateRepo,
 			channelCycleRepo: this.config.channelCycleRepo,
 			db: this.config.db,
 			workspacePath,
@@ -1118,7 +1100,9 @@ export class SpaceRuntimeService {
 			cancelSessionById: taskAgentManager
 				? (sid) => taskAgentManager.cancelBySessionId(sid)
 				: undefined,
-			// Forward the InternalEventBus so gate-driven reopens publish
+			// Forward the runtime's current sink so a gate-driven reopen still
+			// surfaces `workflow_run_reopened` to the Space Agent session.
+			// Forward the InternalEventBus so gate-driven reopens also publish
 			// typed `space.workflowRun.reopened` events for bus subscribers.
 			internalEventBus: this.config.internalEventBus,
 			onGatePendingApproval: (runId, gateId) => this.handleGatePendingApproval(runId, gateId),
@@ -1166,6 +1150,7 @@ export class SpaceRuntimeService {
 			agentManager: this.config.spaceAgentManager,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			gateDataRepo: this.config.gateDataRepo,
+			gateOpenStateRepo: this.config.gateOpenStateRepo,
 			channelCycleRepo: this.config.channelCycleRepo,
 			db: this.config.db,
 			workspacePath,
@@ -1177,7 +1162,10 @@ export class SpaceRuntimeService {
 			cancelSessionById: taskAgentManager
 				? (sid) => taskAgentManager.cancelBySessionId(sid)
 				: undefined,
-			// Forward the InternalEventBus so activation-driven reopens publish
+			// Forward the runtime's current sink so activation-driven reopens of
+			// terminal runs still surface `workflow_run_reopened` to the Space
+			// Agent session (mirrors `notifyGateDataChanged` above).
+			// Forward the InternalEventBus so activation-driven reopens also publish
 			// typed `space.workflowRun.reopened` events for bus subscribers.
 			internalEventBus: this.config.internalEventBus,
 		});

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8834,7 +8834,11 @@ export function runMigration128(db: BunDatabase): void {
 			SELECT
 				source,
 				globally_enabled,
-				json_set(COALESCE(capabilities_json, '{}'), '$.rpcConfig', json('true')),
+				json_set(
+						CASE WHEN json_valid(capabilities_json) THEN capabilities_json ELSE '{}' END,
+						'$.rpcConfig',
+						json('true')
+					),
 				secrets_ref,
 				COALESCE(settings_json, '{}'),
 				created_at,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8834,7 +8834,7 @@ export function runMigration128(db: BunDatabase): void {
 			SELECT
 				source,
 				globally_enabled,
-				COALESCE(capabilities_json, '{}'),
+				json_set(COALESCE(capabilities_json, '{}'), '$.rpcConfig', json('true')),
 				secrets_ref,
 				COALESCE(settings_json, '{}'),
 				created_at,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8803,7 +8803,7 @@ export function runMigration127(db: BunDatabase): void {
 /**
  * Migration 128: Add external-event extension configuration tables.
  *
- * external_event_source_configs stores global source enablement, capabilities,
+ * external_event_extension_configs stores global source enablement, capabilities,
  * secrets references, and source-level settings.
  *
  * space_external_event_source_configs stores per-space source enablement and
@@ -8812,12 +8812,12 @@ export function runMigration127(db: BunDatabase): void {
  */
 export function runMigration128(db: BunDatabase): void {
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+		CREATE TABLE IF NOT EXISTS external_event_extension_configs (
 			source TEXT PRIMARY KEY,
-			globally_enabled INTEGER NOT NULL DEFAULT 0,
-			capabilities_json TEXT NOT NULL,
-			secrets_ref TEXT,
-			settings_json TEXT,
+			globally_enabled INTEGER NOT NULL DEFAULT 0 CHECK(globally_enabled IN (0, 1)),
+			capabilities_json TEXT NOT NULL DEFAULT '{}',
+			secrets_ref TEXT DEFAULT NULL,
+			settings_json TEXT NOT NULL DEFAULT '{}',
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
@@ -8835,6 +8835,13 @@ export function runMigration128(db: BunDatabase): void {
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
+
+	const now = Date.now();
+	db.prepare(
+		`INSERT OR IGNORE INTO external_event_extension_configs
+		 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
+		 VALUES ('github', 1, ?, NULL, '{}', ?, ?)`
+	).run(JSON.stringify({ webhooks: true, polling: true, rpcConfig: true }), now, now);
 }
 
 /**
@@ -8843,6 +8850,21 @@ export function runMigration128(db: BunDatabase): void {
  * Backfills from legacy config.maxConcurrentTasks when present and valid, otherwise
  * defaults to 1. This preserves legacy SpaceConfig-based limits during upgrade.
  */
+export function runMigration129(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+	if (tableHasColumn(db, 'spaces', 'max_concurrent_tasks')) return;
+
+	db.exec(`ALTER TABLE spaces ADD COLUMN max_concurrent_tasks INTEGER NOT NULL DEFAULT 1`);
+	db.exec(`
+		UPDATE spaces
+		SET max_concurrent_tasks = CAST(json_extract(config, '$.maxConcurrentTasks') AS INTEGER)
+		WHERE config IS NOT NULL
+		  AND json_valid(config)
+		  AND json_type(config, '$.maxConcurrentTasks') = 'integer'
+		  AND CAST(json_extract(config, '$.maxConcurrentTasks') AS INTEGER) BETWEEN 1 AND 10
+	`);
+}
+
 /**
  * Migration 130: Add `gate_open_state` table.
  *
@@ -8868,21 +8890,6 @@ export function runMigration130(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`CREATE INDEX idx_gate_open_state_run ON gate_open_state(run_id)`);
-}
-
-export function runMigration129(db: BunDatabase): void {
-	if (!tableExists(db, 'spaces')) return;
-	if (tableHasColumn(db, 'spaces', 'max_concurrent_tasks')) return;
-
-	db.exec(`ALTER TABLE spaces ADD COLUMN max_concurrent_tasks INTEGER NOT NULL DEFAULT 1`);
-	db.exec(`
-		UPDATE spaces
-		SET max_concurrent_tasks = CAST(json_extract(config, '$.maxConcurrentTasks') AS INTEGER)
-		WHERE config IS NOT NULL
-		  AND json_valid(config)
-		  AND json_type(config, '$.maxConcurrentTasks') = 'integer'
-		  AND CAST(json_extract(config, '$.maxConcurrentTasks') AS INTEGER) BETWEEN 1 AND 10
-	`);
 }
 
 /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8835,7 +8835,11 @@ export function runMigration128(db: BunDatabase): void {
 				source,
 				globally_enabled,
 				json_set(
-						CASE WHEN json_valid(capabilities_json) THEN capabilities_json ELSE '{}' END,
+						CASE
+							WHEN json_valid(capabilities_json) AND json_type(capabilities_json) = 'object'
+								THEN capabilities_json
+							ELSE '{}'
+						END,
 						'$.rpcConfig',
 						json('true')
 					),

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8811,6 +8811,8 @@ export function runMigration127(db: BunDatabase): void {
  * extension configuration.
  */
 export function runMigration128(db: BunDatabase): void {
+	const hadLegacyGlobalConfigTable = tableExists(db, 'external_event_source_configs');
+
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS external_event_extension_configs (
 			source TEXT PRIMARY KEY,
@@ -8822,6 +8824,24 @@ export function runMigration128(db: BunDatabase): void {
 			updated_at INTEGER NOT NULL
 		)
 	`);
+
+	if (hadLegacyGlobalConfigTable) {
+		db.exec(`
+			INSERT OR IGNORE INTO external_event_extension_configs (
+				source, globally_enabled, capabilities_json, secrets_ref,
+				settings_json, created_at, updated_at
+			)
+			SELECT
+				source,
+				globally_enabled,
+				COALESCE(capabilities_json, '{}'),
+				secrets_ref,
+				COALESCE(settings_json, '{}'),
+				created_at,
+				updated_at
+			FROM external_event_source_configs
+		`);
+	}
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
@@ -8841,7 +8861,7 @@ export function runMigration128(db: BunDatabase): void {
 		`INSERT OR IGNORE INTO external_event_extension_configs
 		 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
 		 VALUES ('github', 1, ?, NULL, '{}', ?, ?)`
-	).run(JSON.stringify({ webhooks: true, polling: true, rpcConfig: true }), now, now);
+	).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }), now, now);
 }
 
 /**

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -300,6 +300,7 @@ describe('scope-config', () => {
 
 		it('includes external event bus tables', () => {
 			const excluded = getExcludedTableNames();
+			expect(excluded).toContain('external_event_source_configs');
 			expect(excluded).toContain('external_event_extension_configs');
 			expect(excluded).toContain('space_external_event_source_configs');
 			expect(excluded).toContain('space_external_events');

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -300,7 +300,7 @@ describe('scope-config', () => {
 
 		it('includes external event bus tables', () => {
 			const excluded = getExcludedTableNames();
-			expect(excluded).toContain('external_event_source_configs');
+			expect(excluded).toContain('external_event_extension_configs');
 			expect(excluded).toContain('space_external_event_source_configs');
 			expect(excluded).toContain('space_external_events');
 			expect(excluded).toContain('space_external_event_deliveries');

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -332,18 +332,16 @@ describe('GitHubEventExtension', () => {
 			pollingEnabled: true,
 		});
 
-		const result = (await clientHub.request('space.github.pollOnce', { spaceId: 'space-1' })) as {
-			count: number;
-		};
-
-		expect(result.count).toBe(0);
+		await expect(
+			clientHub.request('space.github.pollOnce', { spaceId: 'space-1' })
+		).rejects.toThrow('GitHub polling capability is disabled');
 		expect(publishCount).toBe(0);
 		await extension.stop();
 	});
 
 	test('stop waits for an active polling cycle before returning', async () => {
 		const db = setupDb();
-		const extension = new GitHubEventExtension(db, { pollIntervalMs: 1 });
+		const extension = new GitHubEventExtension(db, undefined, { pollIntervalMs: 1 });
 		let releaseFetch!: () => void;
 		let fetchStarted!: Promise<void>;
 		let resolveFetchStarted!: () => void;

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -7,13 +7,16 @@ import {
 	ExternalEventStore,
 	type ExternalEvent,
 } from '../../../../src/lib/external-events';
+import { GitHubEventExtension } from '../../../../src/lib/external-events/github';
 import {
-	GitHubEventExtension,
-	StaticExternalEventExtensionConfigStore,
 	mapEventType,
 	normalizeGitHubWebhook,
 	toExternalEvent,
-} from '../../../../src/lib/external-events/github';
+} from '../../../../src/lib/external-events/github/github-normalizer';
+import type {
+	ExternalEventExtensionConfigStore,
+	SpaceExternalEventSourceConfig,
+} from '../../../../src/lib/external-events/types';
 import { createDaemonInternalEventBus } from '../../../../src/lib/internal-event-bus';
 
 async function createSignature(payload: string, secret: string): Promise<string> {
@@ -37,6 +40,47 @@ function setupDb(): BunDatabase {
 	createTables(db);
 	runMigrations(db, () => {});
 	return db;
+}
+
+class StaticExternalEventExtensionConfigStore implements ExternalEventExtensionConfigStore {
+	constructor(
+		private readonly options: { globallyEnabled?: boolean; webhooks?: boolean; polling?: boolean }
+	) {}
+
+	async getGlobalConfig(source: string) {
+		return {
+			source,
+			globallyEnabled: this.options.globallyEnabled ?? true,
+			capabilities: {
+				webhooks: this.options.webhooks ?? true,
+				polling: this.options.polling ?? true,
+				rpcConfig: true,
+			},
+			settings: {},
+		};
+	}
+
+	async getSpaceConfig(
+		spaceId: string,
+		source: string
+	): Promise<SpaceExternalEventSourceConfig | null> {
+		return { spaceId, source, enabled: true, settings: {} };
+	}
+
+	async listEnabledSpaces(_source: string): Promise<SpaceExternalEventSourceConfig[]> {
+		return [];
+	}
+
+	async setGlobalConfig(
+		_source: string,
+		_config: Awaited<ReturnType<ExternalEventExtensionConfigStore['getGlobalConfig']>>
+	): Promise<void> {}
+
+	async setSpaceConfig(
+		_spaceId: string,
+		_source: string,
+		_config: SpaceExternalEventSourceConfig
+	): Promise<void> {}
 }
 
 const baseRepo = {

--- a/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
@@ -188,11 +188,8 @@ describe('Space GitHub integration', () => {
 	test('extension polling uses auth/cursors and publishes to ExternalEventService', async () => {
 		const db = setupDb();
 		seedTask(db);
-		const service = new SpaceGitHubService(db);
 		const published: { spaceId: string; topic: string }[] = [];
-		const extension = new GitHubEventExtension(service.eventExtensionRepo, {
-			githubToken: 'token',
-		});
+		const extension = new GitHubEventExtension(db, 'token');
 		await extension.start({
 			publisher: {
 				publish: async (event: any) => {
@@ -293,11 +290,8 @@ describe('Space GitHub integration', () => {
 	test('extension polling ignores issue comments and keeps watermark stable while draining pages', async () => {
 		const db = setupDb();
 		seedTask(db);
-		const service = new SpaceGitHubService(db);
 		let publishCount = 0;
-		const extension = new GitHubEventExtension(service.eventExtensionRepo, {
-			githubToken: 'token',
-		});
+		const extension = new GitHubEventExtension(db, 'token');
 		await extension.start({
 			publisher: {
 				publish: async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
@@ -70,6 +70,21 @@ describe('ExternalEventExtensionConfigStore', () => {
 		});
 	});
 
+	test('persists global config when optional settings are omitted', async () => {
+		await store.setGlobalConfig('github', {
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+		});
+
+		await expect(store.getGlobalConfig('github')).resolves.toEqual({
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true },
+			settings: {},
+		});
+	});
+
 	test('persists and updates per-space config', async () => {
 		await expect(store.getSpaceConfig('space-1', 'github')).resolves.toBeNull();
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension-config-store.test.ts
@@ -17,7 +17,7 @@ describe('ExternalEventExtensionConfigStore', () => {
 			.prepare(
 				`SELECT name FROM sqlite_master
 				 WHERE type = 'table' AND name IN (
-					'external_event_source_configs',
+					'external_event_extension_configs',
 					'space_external_event_source_configs'
 				 )
 				 ORDER BY name`
@@ -25,7 +25,7 @@ describe('ExternalEventExtensionConfigStore', () => {
 			.all() as { name: string }[];
 
 		expect(rows.map((row) => row.name)).toEqual([
-			'external_event_source_configs',
+			'external_event_extension_configs',
 			'space_external_event_source_configs',
 		]);
 	});

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
@@ -55,6 +55,21 @@ function getRequestHandler(hub: MessageHub, method: string): RequestHandler | un
 	);
 }
 
+function seedTask(db: BunDatabase): void {
+	db.prepare(
+		`INSERT INTO space_workflows (id, space_id, name, description, channels, gates, created_at, updated_at)
+		 VALUES ('wf-1', 'space-1', 'wf', '', '[]', '[]', 1, 1)`
+	).run();
+	db.prepare(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, description, status, created_at, updated_at)
+		 VALUES ('run-1', 'space-1', 'wf-1', 'run', '', 'in_progress', 1, 1)`
+	).run();
+	db.prepare(
+		`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, depends_on, created_at, updated_at)
+		 VALUES ('task-1', 'space-1', 1, 'task', 'https://github.com/acme/widgets/pull/7', 'in_progress', 'normal', '[]', 'run-1', '[]', 1, 1)`
+	).run();
+}
+
 function githubPayload(): unknown {
 	return {
 		action: 'created',
@@ -73,6 +88,19 @@ function githubPayload(): unknown {
 			user: { login: 'bot', type: 'Bot' },
 			created_at: '2026-01-01T00:00:00Z',
 		},
+	};
+}
+
+function pollingRow(): unknown {
+	return {
+		id: 202,
+		body: 'poll comment',
+		html_url: 'https://github.com/acme/widgets/pull/7#issuecomment-202',
+		issue_url: 'https://api.github.com/repos/acme/widgets/issues/7',
+		issue: { number: 7, pull_request: { url: 'api' } },
+		user: { login: 'bot', type: 'Bot' },
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
 	};
 }
 
@@ -117,6 +145,7 @@ describe('external event extension startup primitives', () => {
 			await registered.start(context);
 		}
 
+		seedTask(db);
 		const watchRepo = getRequestHandler(hub, 'space.github.watchRepo');
 		expect(watchRepo).toBeDefined();
 		const watchResult = (await watchRepo!({
@@ -155,7 +184,200 @@ describe('external event extension startup primitives', () => {
 			topic: 'github/acme/widgets/pull_request.comment_created',
 			state: 'published',
 		});
+		expect(db.prepare(`SELECT COUNT(*) AS count FROM space_github_events`).get()).toEqual({
+			count: 0,
+		});
 		await extension.stop();
+	});
+
+	test('pollOnce publishes bus events without legacy task activity records', async () => {
+		seedTask(db);
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+		const rowsByUrl = new Map<string, unknown[]>([
+			['/issues/comments', [pollingRow()]],
+			['/pulls/comments', []],
+			['/pulls', []],
+		]);
+		const fetchImpl = async (url: string | URL | Request) => {
+			const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+			const path = new URL(href).pathname;
+			const rows = rowsByUrl.get(path.replace('/repos/acme/widgets', '')) ?? [];
+			return new Response(JSON.stringify(rows), { status: 200 });
+		};
+
+		expect(await extension.pollOnce(fetchImpl as typeof fetch)).toBe(1);
+		expect(db.prepare(`SELECT COUNT(*) AS count FROM space_external_events`).get()).toEqual({
+			count: 1,
+		});
+		expect(db.prepare(`SELECT COUNT(*) AS count FROM space_github_events`).get()).toEqual({
+			count: 0,
+		});
+		await extension.stop();
+	});
+
+	test('seeds GitHub globally enabled independent of one-time env state', async () => {
+		expect(await config.getGlobalConfig('github')).toMatchObject({
+			source: 'github',
+			globallyEnabled: true,
+			capabilities: { webhooks: true, polling: true, rpcConfig: true },
+		});
+	});
+
+	test('listConfig returns space GitHub configuration via RPC handler', async () => {
+		const extension = new GitHubEventExtension(db);
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		extension.registerRpcHandlers(hub, context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+
+		const listConfig = getRequestHandler(hub, 'space.github.listConfig');
+		expect(listConfig).toBeDefined();
+		expect(await listConfig!({ spaceId: 'space-1' })).toMatchObject({
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: {
+				watchedRepos: [
+					{
+						owner: 'acme',
+						repo: 'widgets',
+						polling_enabled: 1,
+					},
+				],
+			},
+		});
+	});
+
+	test('stop clears the GitHub extension poll timer', async () => {
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		expect((extension as unknown as { pollTimer: unknown }).pollTimer).not.toBeNull();
+
+		await extension.stop();
+
+		expect((extension as unknown as { pollTimer: unknown }).pollTimer).toBeNull();
+	});
+
+	test('scheduled poll cycle skips polling when capability is disabled after start', async () => {
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+		db.prepare(
+			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
+		).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }));
+
+		await (
+			extension as unknown as {
+				runPollCycle(): Promise<void>;
+			}
+		).runPollCycle();
+
+		expect(db.prepare(`SELECT COUNT(*) AS count FROM space_external_events`).get()).toEqual({
+			count: 0,
+		});
+		expect(
+			db.prepare(`SELECT last_poll_at FROM space_github_watched_repos WHERE owner = 'acme'`).get()
+		).toEqual({ last_poll_at: null });
+		await extension.stop();
+	});
+
+	test('pollOnce RPC rejects when polling capability is disabled', async () => {
+		db.prepare(
+			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
+		).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }));
+		const extension = new GitHubEventExtension(db);
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		extension.registerRpcHandlers(hub, context);
+
+		const pollOnce = getRequestHandler(hub, 'space.github.pollOnce');
+		expect(pollOnce).toBeDefined();
+		await expect(pollOnce!({})).rejects.toThrow('GitHub polling capability is disabled');
+	});
+
+	test('does not register RPC handlers when rpcConfig capability is disabled', async () => {
+		db.prepare(
+			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
+		).run(JSON.stringify({ webhooks: true, polling: true, rpcConfig: false }));
+		const manager = new ExternalEventExtensionManager();
+		manager.register(new GitHubEventExtension(db));
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+
+		for (const registered of manager.getAll()) {
+			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
+			if (!globalConfig.globallyEnabled) continue;
+			if (isRpcExternalEventExtension(registered) && globalConfig.capabilities.rpcConfig) {
+				registered.registerRpcHandlers(hub, context);
+			}
+		}
+
+		expect(getRequestHandler(hub, 'space.github.watchRepo')).toBeUndefined();
+		expect(getRequestHandler(hub, 'space.github.pollOnce')).toBeUndefined();
+	});
+
+	test('registered RPC handlers reject when rpcConfig capability is disabled later', async () => {
+		const extension = new GitHubEventExtension(db);
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		extension.registerRpcHandlers(hub, context);
+		db.prepare(
+			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
+		).run(JSON.stringify({ webhooks: true, polling: true, rpcConfig: false }));
+
+		const listConfig = getRequestHandler(hub, 'space.github.listConfig');
+		expect(listConfig).toBeDefined();
+		await expect(listConfig!({ spaceId: 'space-1' })).rejects.toThrow(
+			'GitHub RPC configuration capability is disabled'
+		);
 	});
 
 	test('does not register disabled extension routes or RPC handlers', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
@@ -241,6 +241,56 @@ describe('external event extension startup primitives', () => {
 		await extension.stop();
 	});
 
+	test('pollOnce includes watched repos without per-space config rows', async () => {
+		seedTask(db);
+		db.prepare(
+			`INSERT INTO spaces (id, slug, name, workspace_path, status, created_at, updated_at)
+			 VALUES ('space-2', 'space-2', 'Space 2', '/tmp/space-2', 'active', 1, 1)`
+		).run();
+		const extension = new GitHubEventExtension(db);
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		await extension.start(context);
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+		extension.repo.upsertWatchedRepo({
+			spaceId: 'space-2',
+			owner: 'acme',
+			repo: 'widgets',
+			pollingEnabled: true,
+		});
+		await config.setSpaceConfig('space-1', 'github', {
+			spaceId: 'space-1',
+			source: 'github',
+			enabled: true,
+			settings: {},
+		});
+		const rowsByUrl = new Map<string, unknown[]>([
+			['/issues/comments', [pollingRow()]],
+			['/pulls/comments', []],
+			['/pulls', []],
+		]);
+		const fetchImpl = async (url: string | URL | Request) => {
+			const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+			const path = new URL(href).pathname;
+			const rows = rowsByUrl.get(path.replace('/repos/acme/widgets', '')) ?? [];
+			return new Response(JSON.stringify(rows), { status: 200 });
+		};
+
+		expect(await extension.pollOnce(fetchImpl as typeof fetch)).toBe(2);
+		expect(db.prepare(`SELECT COUNT(*) AS count FROM space_external_events`).get()).toEqual({
+			count: 2,
+		});
+		await extension.stop();
+	});
+
 	test('seeds GitHub globally enabled independent of one-time env state', async () => {
 		expect(await config.getGlobalConfig('github')).toMatchObject({
 			source: 'github',
@@ -336,7 +386,7 @@ describe('external event extension startup primitives', () => {
 		await extension.stop();
 	});
 
-	test('pollOnce RPC rejects when polling capability is disabled', async () => {
+	test('pollOnce RPC rejects when polling capability is explicitly disabled', async () => {
 		db.prepare(
 			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
 		).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }));
@@ -352,6 +402,24 @@ describe('external event extension startup primitives', () => {
 		const pollOnce = getRequestHandler(hub, 'space.github.pollOnce');
 		expect(pollOnce).toBeDefined();
 		await expect(pollOnce!({})).rejects.toThrow('GitHub polling capability is disabled');
+	});
+
+	test('pollOnce RPC allows missing polling capability', async () => {
+		db.prepare(
+			`UPDATE external_event_extension_configs SET capabilities_json = ? WHERE source = 'github'`
+		).run(JSON.stringify({ webhooks: true, rpcConfig: true }));
+		const extension = new GitHubEventExtension(db);
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			onSourceConfigChanged() {},
+		};
+		extension.registerRpcHandlers(hub, context);
+
+		const pollOnce = getRequestHandler(hub, 'space.github.pollOnce');
+		expect(pollOnce).toBeDefined();
+		expect(await pollOnce!({})).toEqual({ count: 0 });
 	});
 
 	test('does not register RPC handlers when rpcConfig capability is disabled', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
@@ -4,12 +4,12 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 import { ExternalEventService } from '../../../../src/lib/external-events/external-event-service';
 import { ExternalEventStore } from '../../../../src/lib/external-events/external-event-store';
 import { ExternalEventExtensionConfigStore } from '../../../../src/lib/external-events/extension-config-store';
-import {
-	ExternalEventExtensionManager,
-	InMemoryExternalEventRouteRegistry,
-	isHttpExternalEventExtension,
-	isRpcExternalEventExtension,
-} from '../../../../src/lib/external-events/extension-manager';
+import { ExternalEventExtensionManager } from '../../../../src/lib/external-events/extension-manager';
+import type {
+	ExternalEventExtension,
+	HttpExternalEventExtension,
+	RpcExternalEventExtension,
+} from '../../../../src/lib/external-events/types';
 import { GitHubEventExtension } from '../../../../src/lib/external-events/github';
 import {
 	createInternalEventBus,
@@ -53,6 +53,18 @@ function getRequestHandler(hub: MessageHub, method: string): RequestHandler | un
 	return (hub as unknown as { requestHandlers: Map<string, RequestHandler> }).requestHandlers.get(
 		method
 	);
+}
+
+function isHttpExternalEventExtension(
+	extension: ExternalEventExtension
+): extension is HttpExternalEventExtension {
+	return 'routes' in extension;
+}
+
+function isRpcExternalEventExtension(
+	extension: ExternalEventExtension
+): extension is RpcExternalEventExtension {
+	return 'registerRpcHandlers' in extension;
 }
 
 function seedTask(db: BunDatabase): void {
@@ -121,13 +133,11 @@ describe('external event extension startup primitives', () => {
 		const manager = new ExternalEventExtensionManager();
 		const extension = new GitHubEventExtension(db);
 		manager.register(extension);
-		const routeRegistry = new InMemoryExternalEventRouteRegistry();
 		const hub = new MessageHub({ defaultSessionId: 'global' });
 		const changes: Array<{ source: string; spaceId?: string; kind: string }> = [];
 		const context = {
 			publisher: service,
 			config,
-			routeRegistry,
 			onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
 				changes.push(change);
 			},
@@ -137,12 +147,12 @@ describe('external event extension startup primitives', () => {
 			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
 			if (!globalConfig.globallyEnabled) continue;
 			if (isHttpExternalEventExtension(registered)) {
-				context.routeRegistry.register(registered.routes, context);
+				manager.registerRoutes(registered.routes, context);
 			}
 			if (isRpcExternalEventExtension(registered)) {
-				registered.registerRpcHandlers(hub, context);
+				manager.registerRpcHandlers(registered.sourceId, hub, context);
 			}
-			await registered.start(context);
+			await manager.startExtension(registered.sourceId, context);
 		}
 
 		seedTask(db);
@@ -161,7 +171,11 @@ describe('external event extension startup primitives', () => {
 
 		const payload = githubPayload();
 		const raw = JSON.stringify(payload);
-		const response = await routeRegistry.handle(
+		const route = manager
+			.getRegisteredRoutes()
+			.find((route) => route.path === '/webhook/github/space');
+		expect(route).toBeDefined();
+		const response = await route!.handle(
 			new Request('http://localhost/webhook/github/space', {
 				method: 'POST',
 				headers: {
@@ -240,7 +254,17 @@ describe('external event extension startup primitives', () => {
 		const hub = new MessageHub({ defaultSessionId: 'global' });
 		const context = {
 			publisher: service,
-			config,
+			config: new (class extends ExternalEventExtensionConfigStore {
+				override async getSpaceConfig(spaceId: string, source: string) {
+					const repos = extension.repo.listWatchedRepos(spaceId);
+					return {
+						spaceId,
+						source,
+						enabled: repos.some((repo) => repo.enabled),
+						settings: { watchedRepos: repos },
+					};
+				}
+			})(db),
 			onSourceConfigChanged() {},
 		};
 		extension.registerRpcHandlers(hub, context);
@@ -262,7 +286,7 @@ describe('external event extension startup primitives', () => {
 					{
 						owner: 'acme',
 						repo: 'widgets',
-						polling_enabled: 1,
+						pollingEnabled: true,
 					},
 				],
 			},
@@ -352,7 +376,7 @@ describe('external event extension startup primitives', () => {
 			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
 			if (!globalConfig.globallyEnabled) continue;
 			if (isRpcExternalEventExtension(registered) && globalConfig.capabilities.rpcConfig) {
-				registered.registerRpcHandlers(hub, context);
+				manager.registerRpcHandlers(registered.sourceId, hub, context);
 			}
 		}
 
@@ -386,12 +410,10 @@ describe('external event extension startup primitives', () => {
 		).run();
 		const manager = new ExternalEventExtensionManager();
 		manager.register(new GitHubEventExtension(db));
-		const routeRegistry = new InMemoryExternalEventRouteRegistry();
 		const hub = new MessageHub({ defaultSessionId: 'global' });
 		const context = {
 			publisher: service,
 			config,
-			routeRegistry,
 			onSourceConfigChanged() {},
 		};
 
@@ -399,19 +421,15 @@ describe('external event extension startup primitives', () => {
 			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
 			if (!globalConfig.globallyEnabled) continue;
 			if (isHttpExternalEventExtension(registered)) {
-				context.routeRegistry.register(registered.routes, context);
+				manager.registerRoutes(registered.routes, context);
 			}
 			if (isRpcExternalEventExtension(registered)) {
-				registered.registerRpcHandlers(hub, context);
+				manager.registerRpcHandlers(registered.sourceId, hub, context);
 			}
-			await registered.start(context);
+			await manager.startExtension(registered.sourceId, context);
 		}
 
-		expect(
-			await routeRegistry.handle(
-				new Request('http://localhost/webhook/github/space', { method: 'POST' })
-			)
-		).toBeNull();
+		expect(manager.getRegisteredRoutes()).toEqual([]);
 		expect(getRequestHandler(hub, 'space.github.pollOnce')).toBeUndefined();
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
@@ -1,0 +1,195 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { MessageHub, type RequestHandler, generateUUID } from '@neokai/shared';
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { ExternalEventService } from '../../../../src/lib/external-events/external-event-service';
+import { ExternalEventStore } from '../../../../src/lib/external-events/external-event-store';
+import { ExternalEventExtensionConfigStore } from '../../../../src/lib/external-events/extension-config-store';
+import {
+	ExternalEventExtensionManager,
+	InMemoryExternalEventRouteRegistry,
+	isHttpExternalEventExtension,
+	isRpcExternalEventExtension,
+} from '../../../../src/lib/external-events/extension-manager';
+import { GitHubEventExtension } from '../../../../src/lib/external-events/github';
+import {
+	createInternalEventBus,
+	type InternalEventBus,
+} from '../../../../src/lib/internal-event-bus';
+import { createTables, runMigrations } from '../../../../src/storage/schema';
+
+async function createSignature(payload: string, secret: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const cryptoKey = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	const buffer = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(payload));
+	return `sha256=${Array.from(new Uint8Array(buffer))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')}`;
+}
+
+function setupDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	createTables(db);
+	runMigrations(db, () => {});
+	db.prepare(
+		`UPDATE external_event_extension_configs
+		 SET globally_enabled = 1, capabilities_json = ?
+		 WHERE source = 'github'`
+	).run(JSON.stringify({ webhooks: true, polling: true, rpcConfig: true }));
+	db.prepare(
+		`INSERT INTO spaces (id, slug, name, workspace_path, status, created_at, updated_at)
+		 VALUES ('space-1', 'space-1', 'Space', '/tmp', 'active', 1, 1)`
+	).run();
+	return db;
+}
+
+function getRequestHandler(hub: MessageHub, method: string): RequestHandler | undefined {
+	return (hub as unknown as { requestHandlers: Map<string, RequestHandler> }).requestHandlers.get(
+		method
+	);
+}
+
+function githubPayload(): unknown {
+	return {
+		action: 'created',
+		repository: {
+			id: 1,
+			name: 'widgets',
+			full_name: 'acme/widgets',
+			owner: { login: 'acme' },
+		},
+		sender: { login: 'bot', type: 'Bot' },
+		issue: { number: 7, title: 'PR', pull_request: { url: 'api' } },
+		comment: {
+			id: 101,
+			body: 'looks good',
+			html_url: 'https://github.com/acme/widgets/pull/7#issuecomment-101',
+			user: { login: 'bot', type: 'Bot' },
+			created_at: '2026-01-01T00:00:00Z',
+		},
+	};
+}
+
+describe('external event extension startup primitives', () => {
+	let db: BunDatabase;
+	let bus: InternalEventBus<Record<string, unknown>>;
+	let service: ExternalEventService;
+	let config: ExternalEventExtensionConfigStore;
+
+	beforeEach(() => {
+		db = setupDb();
+		bus = createInternalEventBus<Record<string, unknown>>();
+		service = new ExternalEventService(new ExternalEventStore(db), bus);
+		config = new ExternalEventExtensionConfigStore(db);
+	});
+
+	test('registers GitHub routes and RPC handlers when globally enabled', async () => {
+		const manager = new ExternalEventExtensionManager();
+		const extension = new GitHubEventExtension(db);
+		manager.register(extension);
+		const routeRegistry = new InMemoryExternalEventRouteRegistry();
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const changes: Array<{ source: string; spaceId?: string; kind: string }> = [];
+		const context = {
+			publisher: service,
+			config,
+			routeRegistry,
+			onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }) {
+				changes.push(change);
+			},
+		};
+
+		for (const registered of manager.getAll()) {
+			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
+			if (!globalConfig.globallyEnabled) continue;
+			if (isHttpExternalEventExtension(registered)) {
+				context.routeRegistry.register(registered.routes, context);
+			}
+			if (isRpcExternalEventExtension(registered)) {
+				registered.registerRpcHandlers(hub, context);
+			}
+			await registered.start(context);
+		}
+
+		const watchRepo = getRequestHandler(hub, 'space.github.watchRepo');
+		expect(watchRepo).toBeDefined();
+		const watchResult = (await watchRepo!({
+			spaceId: 'space-1',
+			owner: 'acme',
+			repo: 'widgets',
+			webhookSecret: 'secret',
+		})) as { webhookUrl: string };
+		expect(watchResult.webhookUrl).toBe('/webhook/github/space');
+		expect(changes).toEqual([
+			{ source: 'github', spaceId: 'space-1', kind: 'watched_repo_changed' },
+		]);
+
+		const payload = githubPayload();
+		const raw = JSON.stringify(payload);
+		const response = await routeRegistry.handle(
+			new Request('http://localhost/webhook/github/space', {
+				method: 'POST',
+				headers: {
+					'X-Hub-Signature-256': await createSignature(raw, 'secret'),
+					'X-GitHub-Event': 'issue_comment',
+					'X-GitHub-Delivery': generateUUID(),
+				},
+				body: raw,
+			})
+		);
+		expect(response?.status).toBe(200);
+
+		const stored = db.prepare(`SELECT source, topic, state FROM space_external_events`).get() as {
+			source: string;
+			topic: string;
+			state: string;
+		};
+		expect(stored).toEqual({
+			source: 'github',
+			topic: 'github/acme/widgets/pull_request.comment_created',
+			state: 'published',
+		});
+		await extension.stop();
+	});
+
+	test('does not register disabled extension routes or RPC handlers', async () => {
+		db.prepare(
+			`UPDATE external_event_extension_configs SET globally_enabled = 0 WHERE source = 'github'`
+		).run();
+		const manager = new ExternalEventExtensionManager();
+		manager.register(new GitHubEventExtension(db));
+		const routeRegistry = new InMemoryExternalEventRouteRegistry();
+		const hub = new MessageHub({ defaultSessionId: 'global' });
+		const context = {
+			publisher: service,
+			config,
+			routeRegistry,
+			onSourceConfigChanged() {},
+		};
+
+		for (const registered of manager.getAll()) {
+			const globalConfig = await context.config.getGlobalConfig(registered.sourceId);
+			if (!globalConfig.globallyEnabled) continue;
+			if (isHttpExternalEventExtension(registered)) {
+				context.routeRegistry.register(registered.routes, context);
+			}
+			if (isRpcExternalEventExtension(registered)) {
+				registered.registerRpcHandlers(hub, context);
+			}
+			await registered.start(context);
+		}
+
+		expect(
+			await routeRegistry.handle(
+				new Request('http://localhost/webhook/github/space', { method: 'POST' })
+			)
+		).toBeNull();
+		expect(getRequestHandler(hub, 'space.github.pollOnce')).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/external-event-extension.test.ts
@@ -249,30 +249,24 @@ describe('external event extension startup primitives', () => {
 		});
 	});
 
-	test('listConfig returns space GitHub configuration via RPC handler', async () => {
+	test('listConfig returns persisted space GitHub configuration after watchRepo RPC', async () => {
 		const extension = new GitHubEventExtension(db);
 		const hub = new MessageHub({ defaultSessionId: 'global' });
 		const context = {
 			publisher: service,
-			config: new (class extends ExternalEventExtensionConfigStore {
-				override async getSpaceConfig(spaceId: string, source: string) {
-					const repos = extension.repo.listWatchedRepos(spaceId);
-					return {
-						spaceId,
-						source,
-						enabled: repos.some((repo) => repo.enabled),
-						settings: { watchedRepos: repos },
-					};
-				}
-			})(db),
+			config,
 			onSourceConfigChanged() {},
 		};
 		extension.registerRpcHandlers(hub, context);
-		extension.repo.upsertWatchedRepo({
+
+		const watchRepo = getRequestHandler(hub, 'space.github.watchRepo');
+		expect(watchRepo).toBeDefined();
+		await watchRepo!({
 			spaceId: 'space-1',
 			owner: 'acme',
 			repo: 'widgets',
 			pollingEnabled: true,
+			webhookSecret: 'secret',
 		});
 
 		const listConfig = getRequestHandler(hub, 'space.github.listConfig');
@@ -287,6 +281,7 @@ describe('external event extension startup primitives', () => {
 						owner: 'acme',
 						repo: 'widgets',
 						pollingEnabled: true,
+						webhookSecret: 'configured',
 					},
 				],
 			},

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -108,6 +108,33 @@ describe('Migration 128: external event extension config tables', () => {
 		expect(JSON.parse(row.capabilities_json)).toEqual({ polling: true, rpcConfig: true });
 	});
 
+	test('falls back to empty capabilities when legacy capabilities JSON is malformed', () => {
+		db.exec(`
+			CREATE TABLE external_event_source_configs (
+				source TEXT PRIMARY KEY,
+				globally_enabled INTEGER NOT NULL,
+				capabilities_json TEXT,
+				secrets_ref TEXT,
+				settings_json TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.prepare(
+			`INSERT INTO external_event_source_configs
+			 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('github', 1, '{not valid json', null, null, 1, 2);
+
+		expect(() => runMigration128(db)).not.toThrow();
+		const row = db
+			.prepare(
+				`SELECT capabilities_json FROM external_event_extension_configs WHERE source = 'github'`
+			)
+			.get() as { capabilities_json: string };
+		expect(JSON.parse(row.capabilities_json)).toEqual({ rpcConfig: true });
+	});
+
 	test('seeds GitHub polling disabled by default', () => {
 		runMigration128(db);
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -108,7 +108,12 @@ describe('Migration 128: external event extension config tables', () => {
 		expect(JSON.parse(row.capabilities_json)).toEqual({ polling: true, rpcConfig: true });
 	});
 
-	test('falls back to empty capabilities when legacy capabilities JSON is malformed', () => {
+	test.each([
+		['malformed JSON', '{not valid json'],
+		['array JSON', '[]'],
+		['string JSON', '"x"'],
+		['number JSON', '123'],
+	])('falls back to empty capabilities when legacy capabilities JSON is %s', (_label, rawJson) => {
 		db.exec(`
 			CREATE TABLE external_event_source_configs (
 				source TEXT PRIMARY KEY,
@@ -124,7 +129,7 @@ describe('Migration 128: external event extension config tables', () => {
 			`INSERT INTO external_event_source_configs
 			 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?)`
-		).run('github', 1, '{not valid json', null, null, 1, 2);
+		).run('github', 1, rawJson, null, null, 1, 2);
 
 		expect(() => runMigration128(db)).not.toThrow();
 		const row = db

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -66,6 +66,54 @@ describe('Migration 128: external event extension config tables', () => {
 		);
 	});
 
+	test('copies existing legacy global config rows into renamed table', () => {
+		db.exec(`
+			CREATE TABLE external_event_source_configs (
+				source TEXT PRIMARY KEY,
+				globally_enabled INTEGER NOT NULL,
+				capabilities_json TEXT,
+				secrets_ref TEXT,
+				settings_json TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.prepare(
+			`INSERT INTO external_event_source_configs
+			 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		).run('github', 1, JSON.stringify({ polling: true }), 'secret/github', null, 1, 2);
+
+		runMigration128(db);
+
+		expect(
+			db.prepare(`SELECT * FROM external_event_extension_configs WHERE source = 'github'`).get()
+		).toMatchObject({
+			source: 'github',
+			globally_enabled: 1,
+			capabilities_json: JSON.stringify({ polling: true }),
+			secrets_ref: 'secret/github',
+			settings_json: '{}',
+			created_at: 1,
+			updated_at: 2,
+		});
+	});
+
+	test('seeds GitHub polling disabled by default', () => {
+		runMigration128(db);
+
+		const row = db
+			.prepare(
+				`SELECT capabilities_json FROM external_event_extension_configs WHERE source = 'github'`
+			)
+			.get() as { capabilities_json: string };
+		expect(JSON.parse(row.capabilities_json)).toEqual({
+			webhooks: true,
+			polling: false,
+			rpcConfig: true,
+		});
+	});
+
 	test('is idempotent', () => {
 		runMigration128(db);
 		expect(() => runMigration128(db)).not.toThrow();

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -23,7 +23,7 @@ describe('Migration 128: external event extension config tables', () => {
 	test('creates global source config table with expected columns', () => {
 		runMigration128(db);
 
-		const columns = columnNames('external_event_source_configs');
+		const columns = columnNames('external_event_extension_configs');
 		expect(columns).toEqual([
 			'source',
 			'globally_enabled',

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-128_test.ts
@@ -86,17 +86,26 @@ describe('Migration 128: external event extension config tables', () => {
 
 		runMigration128(db);
 
-		expect(
-			db.prepare(`SELECT * FROM external_event_extension_configs WHERE source = 'github'`).get()
-		).toMatchObject({
+		const row = db
+			.prepare(`SELECT * FROM external_event_extension_configs WHERE source = 'github'`)
+			.get() as {
+			source: string;
+			globally_enabled: number;
+			capabilities_json: string;
+			secrets_ref: string;
+			settings_json: string;
+			created_at: number;
+			updated_at: number;
+		};
+		expect(row).toMatchObject({
 			source: 'github',
 			globally_enabled: 1,
-			capabilities_json: JSON.stringify({ polling: true }),
 			secrets_ref: 'secret/github',
 			settings_json: '{}',
 			created_at: 1,
 			updated_at: 2,
 		});
+		expect(JSON.parse(row.capabilities_json)).toEqual({ polling: true, rpcConfig: true });
 	});
 
 	test('seeds GitHub polling disabled by default', () => {


### PR DESCRIPTION
Wires the external event extension manager into daemon startup and registers the GitHub extension for `/webhook/github/space` plus `space.github.*` RPC handlers when enabled.

Adds DB-backed extension config storage, lifecycle startup/shutdown, workflow-runtime external-event plumbing, GitHub polling capability handling, and migration compatibility for legacy extension config rows.

Tests:
- `bun run check`
- `cd packages/daemon && bun test tests/unit/4-space-storage/storage/external-event-extension.test.ts tests/unit/4-space-storage/storage/migrations/migration-128_test.ts tests/unit/2-handlers/github/github-event-extension.test.ts`
- CI: all green