### PR TITLE
fix: clean up agent subprocess groups

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -48,6 +48,7 @@ import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from 
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
 import { NeoAgentManager } from './lib/neo/neo-agent-manager';
+import { ProcessWatchdog } from './lib/process-watchdog';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -179,9 +180,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	//       Ephemeral, within a single async call; cleaned up before the call returns.
 	//   • app.ts graceful-shutdown readiness check (this file, waitForPendingCalls)
 	//       One-shot shutdown polling with hard timeout; not a recurring task.
+	//   • ProcessWatchdog timer (process-watchdog.ts)
+	//       Last-resort OS process leak safety net; intentionally independent from the job queue.
 	jobProcessor.setChangeNotifier((table) => {
 		reactiveDb.notifyChange(table);
 	});
+	const processWatchdog = new ProcessWatchdog();
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
@@ -681,6 +685,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Start job queue processor last (after all handler registrations)
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
+	processWatchdog.start();
+	logInfo('[Daemon] Process watchdog started');
 
 	// Provision the Neo agent session (skip in test mode unless explicitly enabled).
 	// Mirrors the spaces agent guard: test runs are clean by default; online/e2e
@@ -792,7 +798,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 				}
 			}
 
-			// Stop job queue processor before MessageHub cleanup
+			// Stop background processors before MessageHub cleanup
+			processWatchdog.stop();
+			logInfo('[Daemon] Process watchdog stopped');
 			await jobProcessor.stop();
 			logInfo('[Daemon] Job queue processor stopped');
 

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -48,7 +48,7 @@ import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from 
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
 import { NeoAgentManager } from './lib/neo/neo-agent-manager';
-import { ProcessWatchdog } from './lib/process-watchdog';
+import { cleanupSuspiciousProcesses, ProcessWatchdog } from './lib/process-watchdog';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -185,7 +185,18 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	jobProcessor.setChangeNotifier((table) => {
 		reactiveDb.notifyChange(table);
 	});
-	const processWatchdog = new ProcessWatchdog();
+	let sessionManager: SessionManager | null = null;
+	let neoAgentManager: NeoAgentManager | null = null;
+	let taskAgentManager: TaskAgentManager | null = null;
+	const processWatchdog = new ProcessWatchdog(undefined, () =>
+		cleanupSuspiciousProcesses({
+			getRootPids: function* () {
+				if (sessionManager) yield* sessionManager.getTrackedAgentRootPids();
+				if (neoAgentManager) yield* neoAgentManager.getTrackedAgentRootPids();
+				if (taskAgentManager) yield* taskAgentManager.getTrackedAgentRootPids();
+			},
+		})
+	);
 
 	// Initialize Space agent manager
 	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
@@ -296,7 +307,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Initialize session manager (with InternalEventBus<DaemonInternalEventMap>, SettingsManager, no StateManager dependency!)
 	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
 	// trigger LiveQuery invalidation immediately.
-	const sessionManager = new SessionManager(
+	sessionManager = new SessionManager(
 		reactiveDb.db,
 		messageHub,
 		authManager,
@@ -318,7 +329,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize Neo agent manager (singleton global AI assistant).
 	// Instantiated after sessionManager so it can be passed as the NeoSessionManager.
-	const neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
+	neoAgentManager = new NeoAgentManager(sessionManager, settingsManager);
 
 	// Initialize StateProjectionService (read-model caches from InternalEventBus)
 	const stateManager = new StateProjectionService(
@@ -410,12 +421,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	githubEventExtension.registerRpcHandlers(messageHub, externalEventExtensionContext);
 
 	// Setup RPC handlers (returns cleanup function + exposed services)
-	const {
-		cleanup: rpcHandlerCleanup,
-		spaceRuntimeService,
-		taskAgentManager,
-		spaceWorktreeManager,
-	} = setupRPCHandlers({
+	const rpcHandlers = setupRPCHandlers({
 		messageHub,
 		sessionManager,
 		authManager,
@@ -436,6 +442,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		neoAgentManager,
 		mcpImportService,
 	});
+	const { cleanup: rpcHandlerCleanup, spaceRuntimeService, spaceWorktreeManager } = rpcHandlers;
+	taskAgentManager = rpcHandlers.taskAgentManager;
 	await githubEventExtension.start(externalEventExtensionContext);
 
 	// Wait for SpaceRuntimeService startup provisioning to complete before we
@@ -685,8 +693,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Start job queue processor last (after all handler registrations)
 	jobProcessor.start();
 	logInfo('[Daemon] Job queue processor started');
-	processWatchdog.start();
-	logInfo('[Daemon] Process watchdog started');
+	if (process.env.NODE_ENV !== 'test') {
+		processWatchdog.start();
+		logInfo('[Daemon] Process watchdog started');
+	}
 
 	// Provision the Neo agent session (skip in test mode unless explicitly enabled).
 	// Mirrors the spaces agent guard: test runs are clean by default; online/e2e

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -190,10 +190,25 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	let taskAgentManager: TaskAgentManager | null = null;
 	const processWatchdog = new ProcessWatchdog(undefined, () =>
 		cleanupSuspiciousProcesses({
-			getRootPids: function* () {
-				if (sessionManager) yield* sessionManager.getTrackedAgentRootPids();
-				if (neoAgentManager) yield* neoAgentManager.getTrackedAgentRootPids();
-				if (taskAgentManager) yield* taskAgentManager.getTrackedAgentRootPids();
+			getRootPids: () => {
+				const live: number[] = [];
+				const exited: number[] = [];
+				if (sessionManager) {
+					const split = sessionManager.getTrackedAgentRootPidsSplit();
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				if (neoAgentManager) {
+					const split = neoAgentManager.getTrackedAgentRootPidsSplit();
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				if (taskAgentManager) {
+					const split = taskAgentManager.getTrackedAgentRootPidsSplit();
+					live.push(...split.live);
+					exited.push(...split.exited);
+				}
+				return { live, exited };
 			},
 		})
 	);

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -223,7 +223,12 @@ import {
 	AskUserQuestionHandler,
 	type AskUserQuestionHandlerContext,
 } from './ask-user-question-handler';
-import { QueryRunner, type QueryRunnerContext, type OriginalEnvVars } from './query-runner';
+import {
+	QueryRunner,
+	type QueryRunnerContext,
+	type OriginalEnvVars,
+	type TrackedAgentProcess,
+} from './query-runner';
 import { InterruptHandler, type InterruptHandlerContext } from './interrupt-handler';
 import { SDKRuntimeConfig, type SDKRuntimeConfigContext } from './sdk-runtime-config';
 import {
@@ -291,6 +296,9 @@ export class AgentSession
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
 	originalEnvVars: OriginalEnvVars = {};
 	processExitedPromise: Promise<void> | null = null;
+	private trackedAgentProcesses = new Map<number, TrackedAgentProcess>();
+	private rootProcessPid: number | null = null;
+	private forceKillTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Session state
 	private _isCleaningUp = false;
@@ -1227,6 +1235,70 @@ export class AgentSession
 
 	setCleaningUp(value: boolean): void {
 		this._isCleaningUp = value;
+	}
+
+	trackAgentProcess(proc: TrackedAgentProcess): void {
+		const pid = proc.pid;
+		if (typeof pid === 'number' && pid > 0) {
+			this.trackedAgentProcesses.set(pid, proc);
+			this.rootProcessPid = pid;
+		}
+
+		this.processExitedPromise = new Promise<void>((resolve) => {
+			proc.once('exit', () => {
+				if (typeof pid === 'number') {
+					this.trackedAgentProcesses.delete(pid);
+					if (this.rootProcessPid === pid) {
+						this.rootProcessPid = null;
+					}
+				}
+				resolve();
+			});
+		});
+	}
+
+	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void {
+		const forceDelayMs = options?.forceDelayMs ?? 2000;
+		if (this.forceKillTimer) {
+			clearTimeout(this.forceKillTimer);
+			this.forceKillTimer = null;
+		}
+
+		this.signalTrackedAgentProcesses('SIGTERM');
+		this.forceKillTimer = setTimeout(() => {
+			this.forceKillTimer = null;
+			this.signalTrackedAgentProcesses('SIGKILL');
+		}, forceDelayMs);
+		this.forceKillTimer.unref?.();
+	}
+
+	private signalTrackedAgentProcesses(signal: NodeJS.Signals): void {
+		const rootPid = this.rootProcessPid;
+		if (process.platform !== 'win32' && typeof rootPid === 'number' && rootPid > 0) {
+			try {
+				process.kill(-rootPid, signal);
+			} catch {
+				// Process group may have already exited.
+			}
+		}
+
+		for (const [pid, proc] of this.trackedAgentProcesses) {
+			try {
+				if (typeof proc.kill === 'function') {
+					proc.kill(signal);
+				} else {
+					process.kill(pid, signal);
+				}
+			} catch {
+				// Child may have already exited.
+			}
+			if (signal === 'SIGKILL') {
+				this.trackedAgentProcesses.delete(pid);
+				if (this.rootProcessPid === pid) {
+					this.rootProcessPid = null;
+				}
+			}
+		}
 	}
 
 	cleanupEventSubscriptions(): void {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1274,6 +1274,14 @@ export class AgentSession
 		yield* this.recentlyExitedAgentRootPids.keys();
 	}
 
+	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
+		this.expireRecentlyExitedAgentRootPids();
+		return {
+			live: [...this.trackedAgentProcesses.keys()],
+			exited: [...this.recentlyExitedAgentRootPids.keys()],
+		};
+	}
+
 	snapshotTrackedAgentProcesses(): Array<[number, TrackedAgentProcess]> {
 		return [...this.trackedAgentProcesses];
 	}
@@ -1314,7 +1322,12 @@ export class AgentSession
 		processes: Array<[number, TrackedAgentProcess]>,
 		signal: NodeJS.Signals
 	): void {
-		for (const [pid] of processes) {
+		for (const [pid, proc] of processes) {
+			// Ownership guard: skip stale snapshot entries where the PID no longer
+			// maps to the same process object (e.g. child exited + PID reused).
+			if (this.trackedAgentProcesses.get(pid) !== proc) continue;
+
+			// Signal the entire process group (reaches tool grandchildren).
 			if (process.platform !== 'win32' && pid > 0) {
 				try {
 					process.kill(-pid, signal);
@@ -1322,11 +1335,10 @@ export class AgentSession
 					// Process group may have already exited.
 				}
 			}
-		}
 
-		for (const [pid, proc] of processes) {
+			// Direct signal to the tracked child.
 			const signaled = this.signalTrackedAgentProcess(pid, proc, signal);
-			if (signal === 'SIGKILL' && signaled && this.trackedAgentProcesses.get(pid) === proc) {
+			if (signal === 'SIGKILL' && signaled) {
 				this.trackedAgentProcesses.delete(pid);
 				this.trackedAgentProcessExitPromises.delete(pid);
 				this.recentlyExitedAgentRootPids.set(pid, Date.now());

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -297,7 +297,7 @@ export class AgentSession
 	originalEnvVars: OriginalEnvVars = {};
 	processExitedPromise: Promise<void> | null = null;
 	private trackedAgentProcesses = new Map<number, TrackedAgentProcess>();
-	private rootProcessPid: number | null = null;
+	private recentlyExitedAgentRootPids = new Set<number>();
 	private forceKillTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 	// Session state
@@ -1241,17 +1241,17 @@ export class AgentSession
 		const pid = proc.pid;
 		if (typeof pid === 'number' && pid > 0) {
 			this.clearForceKillTimer(pid);
+			this.recentlyExitedAgentRootPids.delete(pid);
 			this.trackedAgentProcesses.set(pid, proc);
-			this.rootProcessPid = pid;
 		}
 
 		this.processExitedPromise = new Promise<void>((resolve) => {
 			proc.once('exit', () => {
 				if (typeof pid === 'number') {
 					this.clearForceKillTimer(pid);
-					this.trackedAgentProcesses.delete(pid);
-					if (this.rootProcessPid === pid) {
-						this.rootProcessPid = null;
+					if (this.trackedAgentProcesses.get(pid) === proc) {
+						this.trackedAgentProcesses.delete(pid);
+						this.recentlyExitedAgentRootPids.add(pid);
 					}
 				}
 				resolve();
@@ -1259,74 +1259,76 @@ export class AgentSession
 		});
 	}
 
-	getTrackedAgentRootPids(): Iterable<number> {
-		return this.trackedAgentProcesses.keys();
+	*getTrackedAgentRootPids(): Iterable<number> {
+		yield* this.trackedAgentProcesses.keys();
+		yield* this.recentlyExitedAgentRootPids;
 	}
 
 	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void {
 		const forceDelayMs = options?.forceDelayMs ?? 2000;
 		const processSnapshot = [...this.trackedAgentProcesses];
-		const rootPidSnapshot = this.rootProcessPid;
-		if (processSnapshot.length === 0 && !rootPidSnapshot) return;
+		if (processSnapshot.length === 0) return;
 
-		this.signalTrackedAgentProcesses(processSnapshot, rootPidSnapshot, 'SIGTERM');
-		for (const [pid] of processSnapshot) {
+		this.signalTrackedAgentProcesses(processSnapshot, 'SIGTERM');
+		for (const [pid, proc] of processSnapshot) {
 			this.clearForceKillTimer(pid);
+			this.scheduleForceKill(pid, proc, forceDelayMs);
 		}
+	}
 
+	private scheduleForceKill(pid: number, proc: TrackedAgentProcess, forceDelayMs: number): void {
 		const timer = setTimeout(() => {
-			for (const [pid] of processSnapshot) {
-				this.forceKillTimers.delete(pid);
-			}
-			this.signalTrackedAgentProcesses(processSnapshot, rootPidSnapshot, 'SIGKILL');
+			this.forceKillTimers.delete(pid);
+			this.signalTrackedAgentProcesses([[pid, proc]], 'SIGKILL');
 		}, forceDelayMs);
 		timer.unref?.();
-
-		for (const [pid] of processSnapshot) {
-			this.forceKillTimers.set(pid, timer);
-		}
+		this.forceKillTimers.set(pid, timer);
 	}
 
 	private clearForceKillTimer(pid: number): void {
 		const timer = this.forceKillTimers.get(pid);
 		if (!timer) return;
 		clearTimeout(timer);
-		for (const [trackedPid, trackedTimer] of this.forceKillTimers) {
-			if (trackedTimer === timer) {
-				this.forceKillTimers.delete(trackedPid);
-			}
-		}
+		this.forceKillTimers.delete(pid);
 	}
 
 	private signalTrackedAgentProcesses(
 		processes: Array<[number, TrackedAgentProcess]>,
-		rootPid: number | null,
 		signal: NodeJS.Signals
 	): void {
-		if (process.platform !== 'win32' && typeof rootPid === 'number' && rootPid > 0) {
-			try {
-				process.kill(-rootPid, signal);
-			} catch {
-				// Process group may have already exited.
+		for (const [pid] of processes) {
+			if (process.platform !== 'win32' && pid > 0) {
+				try {
+					process.kill(-pid, signal);
+				} catch {
+					// Process group may have already exited.
+				}
 			}
 		}
 
 		for (const [pid, proc] of processes) {
-			try {
-				if (typeof proc.kill === 'function') {
-					proc.kill(signal);
-				} else {
-					process.kill(pid, signal);
-				}
-			} catch {
-				// Child may have already exited.
-			}
-			if (signal === 'SIGKILL' && this.trackedAgentProcesses.get(pid) === proc) {
+			const signaled = this.signalTrackedAgentProcess(pid, proc, signal);
+			if (signal === 'SIGKILL' && signaled && this.trackedAgentProcesses.get(pid) === proc) {
 				this.trackedAgentProcesses.delete(pid);
-				if (this.rootProcessPid === pid) {
-					this.rootProcessPid = null;
-				}
+				this.recentlyExitedAgentRootPids.add(pid);
 			}
+		}
+	}
+
+	private signalTrackedAgentProcess(
+		pid: number,
+		proc: TrackedAgentProcess,
+		signal: NodeJS.Signals
+	): boolean {
+		try {
+			if (typeof proc.kill === 'function') {
+				return proc.kill(signal) !== false;
+			}
+			process.kill(pid, signal);
+			return true;
+		} catch {
+			// Child may have already exited.
+			return false;
 		}
 	}
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -98,6 +98,8 @@ import { Logger } from '../logger';
 import { SettingsManager } from '../settings-manager';
 import { DEFAULT_WORKER_FEATURES as WORKER_FEATURES } from '@neokai/shared';
 
+const RECENTLY_EXITED_ROOT_PID_RETENTION_MS = 15 * 60 * 1000;
+
 /**
  * AgentSessionInit - Configuration for creating a new AgentSession
  *
@@ -297,7 +299,8 @@ export class AgentSession
 	originalEnvVars: OriginalEnvVars = {};
 	processExitedPromise: Promise<void> | null = null;
 	private trackedAgentProcesses = new Map<number, TrackedAgentProcess>();
-	private recentlyExitedAgentRootPids = new Set<number>();
+	private trackedAgentProcessExitPromises = new Map<number, Promise<void>>();
+	private recentlyExitedAgentRootPids = new Map<number, number>();
 	private forceKillTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 	// Session state
@@ -1239,38 +1242,53 @@ export class AgentSession
 
 	trackAgentProcess(proc: TrackedAgentProcess): void {
 		const pid = proc.pid;
-		if (typeof pid === 'number' && pid > 0) {
-			this.clearForceKillTimer(pid);
-			this.recentlyExitedAgentRootPids.delete(pid);
-			this.trackedAgentProcesses.set(pid, proc);
+		if (typeof pid !== 'number' || pid <= 0) {
+			this.processExitedPromise = new Promise<void>((resolve) => {
+				proc.once('exit', () => resolve());
+			});
+			return;
 		}
 
-		this.processExitedPromise = new Promise<void>((resolve) => {
+		this.clearForceKillTimer(pid);
+		this.recentlyExitedAgentRootPids.delete(pid);
+		this.trackedAgentProcesses.set(pid, proc);
+
+		const exitPromise = new Promise<void>((resolve) => {
 			proc.once('exit', () => {
-				if (typeof pid === 'number') {
-					this.clearForceKillTimer(pid);
-					if (this.trackedAgentProcesses.get(pid) === proc) {
-						this.trackedAgentProcesses.delete(pid);
-						this.recentlyExitedAgentRootPids.add(pid);
-					}
+				this.clearForceKillTimer(pid);
+				if (this.trackedAgentProcesses.get(pid) === proc) {
+					this.trackedAgentProcesses.delete(pid);
+					this.trackedAgentProcessExitPromises.delete(pid);
+					this.recentlyExitedAgentRootPids.set(pid, Date.now());
 				}
 				resolve();
 			});
 		});
+		this.trackedAgentProcessExitPromises.set(pid, exitPromise);
+		this.updateProcessExitedPromise();
 	}
 
 	*getTrackedAgentRootPids(): Iterable<number> {
+		this.expireRecentlyExitedAgentRootPids();
 		yield* this.trackedAgentProcesses.keys();
-		yield* this.recentlyExitedAgentRootPids;
+		yield* this.recentlyExitedAgentRootPids.keys();
 	}
 
-	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void {
+	snapshotTrackedAgentProcesses(): Array<[number, TrackedAgentProcess]> {
+		return [...this.trackedAgentProcesses];
+	}
+
+	terminateTrackedAgentProcesses(options?: {
+		forceDelayMs?: number;
+		processes?: Array<[number, TrackedAgentProcess]>;
+	}): void {
 		const forceDelayMs = options?.forceDelayMs ?? 2000;
-		const processSnapshot = [...this.trackedAgentProcesses];
+		const processSnapshot = options?.processes ?? [...this.trackedAgentProcesses];
 		if (processSnapshot.length === 0) return;
 
 		this.signalTrackedAgentProcesses(processSnapshot, 'SIGTERM');
 		for (const [pid, proc] of processSnapshot) {
+			if (this.trackedAgentProcesses.get(pid) !== proc) continue;
 			this.clearForceKillTimer(pid);
 			this.scheduleForceKill(pid, proc, forceDelayMs);
 		}
@@ -1310,7 +1328,9 @@ export class AgentSession
 			const signaled = this.signalTrackedAgentProcess(pid, proc, signal);
 			if (signal === 'SIGKILL' && signaled && this.trackedAgentProcesses.get(pid) === proc) {
 				this.trackedAgentProcesses.delete(pid);
-				this.recentlyExitedAgentRootPids.add(pid);
+				this.trackedAgentProcessExitPromises.delete(pid);
+				this.recentlyExitedAgentRootPids.set(pid, Date.now());
+				this.updateProcessExitedPromise();
 			}
 		}
 	}
@@ -1329,6 +1349,20 @@ export class AgentSession
 		} catch {
 			// Child may have already exited.
 			return false;
+		}
+	}
+
+	private updateProcessExitedPromise(): void {
+		const exitPromises = [...this.trackedAgentProcessExitPromises.values()];
+		this.processExitedPromise =
+			exitPromises.length > 0 ? Promise.all(exitPromises).then(() => {}) : null;
+	}
+
+	private expireRecentlyExitedAgentRootPids(now = Date.now()): void {
+		for (const [pid, exitedAt] of this.recentlyExitedAgentRootPids) {
+			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
+				this.recentlyExitedAgentRootPids.delete(pid);
+			}
 		}
 	}
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -298,7 +298,7 @@ export class AgentSession
 	processExitedPromise: Promise<void> | null = null;
 	private trackedAgentProcesses = new Map<number, TrackedAgentProcess>();
 	private rootProcessPid: number | null = null;
-	private forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+	private forceKillTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 	// Session state
 	private _isCleaningUp = false;
@@ -1240,6 +1240,7 @@ export class AgentSession
 	trackAgentProcess(proc: TrackedAgentProcess): void {
 		const pid = proc.pid;
 		if (typeof pid === 'number' && pid > 0) {
+			this.clearForceKillTimer(pid);
 			this.trackedAgentProcesses.set(pid, proc);
 			this.rootProcessPid = pid;
 		}
@@ -1247,6 +1248,7 @@ export class AgentSession
 		this.processExitedPromise = new Promise<void>((resolve) => {
 			proc.once('exit', () => {
 				if (typeof pid === 'number') {
+					this.clearForceKillTimer(pid);
 					this.trackedAgentProcesses.delete(pid);
 					if (this.rootProcessPid === pid) {
 						this.rootProcessPid = null;
@@ -1257,23 +1259,50 @@ export class AgentSession
 		});
 	}
 
-	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void {
-		const forceDelayMs = options?.forceDelayMs ?? 2000;
-		if (this.forceKillTimer) {
-			clearTimeout(this.forceKillTimer);
-			this.forceKillTimer = null;
-		}
-
-		this.signalTrackedAgentProcesses('SIGTERM');
-		this.forceKillTimer = setTimeout(() => {
-			this.forceKillTimer = null;
-			this.signalTrackedAgentProcesses('SIGKILL');
-		}, forceDelayMs);
-		this.forceKillTimer.unref?.();
+	getTrackedAgentRootPids(): Iterable<number> {
+		return this.trackedAgentProcesses.keys();
 	}
 
-	private signalTrackedAgentProcesses(signal: NodeJS.Signals): void {
-		const rootPid = this.rootProcessPid;
+	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void {
+		const forceDelayMs = options?.forceDelayMs ?? 2000;
+		const processSnapshot = [...this.trackedAgentProcesses];
+		const rootPidSnapshot = this.rootProcessPid;
+		if (processSnapshot.length === 0 && !rootPidSnapshot) return;
+
+		this.signalTrackedAgentProcesses(processSnapshot, rootPidSnapshot, 'SIGTERM');
+		for (const [pid] of processSnapshot) {
+			this.clearForceKillTimer(pid);
+		}
+
+		const timer = setTimeout(() => {
+			for (const [pid] of processSnapshot) {
+				this.forceKillTimers.delete(pid);
+			}
+			this.signalTrackedAgentProcesses(processSnapshot, rootPidSnapshot, 'SIGKILL');
+		}, forceDelayMs);
+		timer.unref?.();
+
+		for (const [pid] of processSnapshot) {
+			this.forceKillTimers.set(pid, timer);
+		}
+	}
+
+	private clearForceKillTimer(pid: number): void {
+		const timer = this.forceKillTimers.get(pid);
+		if (!timer) return;
+		clearTimeout(timer);
+		for (const [trackedPid, trackedTimer] of this.forceKillTimers) {
+			if (trackedTimer === timer) {
+				this.forceKillTimers.delete(trackedPid);
+			}
+		}
+	}
+
+	private signalTrackedAgentProcesses(
+		processes: Array<[number, TrackedAgentProcess]>,
+		rootPid: number | null,
+		signal: NodeJS.Signals
+	): void {
 		if (process.platform !== 'win32' && typeof rootPid === 'number' && rootPid > 0) {
 			try {
 				process.kill(-rootPid, signal);
@@ -1282,7 +1311,7 @@ export class AgentSession
 			}
 		}
 
-		for (const [pid, proc] of this.trackedAgentProcesses) {
+		for (const [pid, proc] of processes) {
 			try {
 				if (typeof proc.kill === 'function') {
 					proc.kill(signal);
@@ -1292,7 +1321,7 @@ export class AgentSession
 			} catch {
 				// Child may have already exited.
 			}
-			if (signal === 'SIGKILL') {
+			if (signal === 'SIGKILL' && this.trackedAgentProcesses.get(pid) === proc) {
 				this.trackedAgentProcesses.delete(pid);
 				if (this.rootProcessPid === pid) {
 					this.rootProcessPid = null;

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -66,7 +66,11 @@ export interface QueryLifecycleManagerContext {
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
 	/** Abort controller for the current query — must be cleared during stop(). */
 	queryAbortController: AbortController | null;
-	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void;
+	terminateTrackedAgentProcesses(options?: {
+		forceDelayMs?: number;
+		processes?: Array<[number, import('./query-runner').TrackedAgentProcess]>;
+	}): void;
+	snapshotTrackedAgentProcesses(): Array<[number, import('./query-runner').TrackedAgentProcess]>;
 
 	// Mutable session state
 	pendingRestartReason: 'settings.local.json' | null;
@@ -229,6 +233,9 @@ export class QueryLifecycleManager {
 		// Snapshot BEFORE awaiting — runQuery()'s finally block clears ctx.processExitedPromise
 		// during queryPromise settlement, so capture it here while it's still set.
 		const processExitedPromise = this.ctx.processExitedPromise;
+		// Snapshot tracked processes before awaiting so that terminateTrackedAgentProcesses
+		// only signals processes belonging to THIS query, not a concurrently started new one.
+		const trackedProcessSnapshot = this.ctx.snapshotTrackedAgentProcesses();
 
 		// 1. Stop the message queue (no new messages processed)
 		messageQueue.stop();
@@ -270,7 +277,10 @@ export class QueryLifecycleManager {
 		// 4. Ask the tracked SDK process group to terminate. queryObject.close()
 		// kills the direct SDK child, but detached process-group cleanup also reaches
 		// tool grandchildren (bun test, make dev, etc.) that would otherwise survive.
-		this.ctx.terminateTrackedAgentProcesses({ forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS });
+		this.ctx.terminateTrackedAgentProcesses({
+			forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS,
+			processes: trackedProcessSnapshot,
+		});
 
 		// 5. Close query only if runQuery()'s finally block has not already done so.
 		// When queryPromise resolves normally, the finally block ran during the await

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -36,6 +36,7 @@ import {
 
 const DEFAULT_TERMINATION_TIMEOUT_MS = 5000;
 const RESET_TERMINATION_TIMEOUT_MS = 3000;
+const FORCE_PROCESS_KILL_DELAY_MS = 2000;
 const MAX_TIMEOUT_DELIVERY_RETRIES = 1;
 
 export type EnsureQueryStartedResult = 'started' | 'already-running' | 'blocked';
@@ -65,6 +66,7 @@ export interface QueryLifecycleManagerContext {
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
 	/** Abort controller for the current query — must be cleared during stop(). */
 	queryAbortController: AbortController | null;
+	terminateTrackedAgentProcesses(options?: { forceDelayMs?: number }): void;
 
 	// Mutable session state
 	pendingRestartReason: 'settings.local.json' | null;
@@ -265,7 +267,12 @@ export class QueryLifecycleManager {
 			}
 		}
 
-		// 4. Close query only if runQuery()'s finally block has not already done so.
+		// 4. Ask the tracked SDK process group to terminate. queryObject.close()
+		// kills the direct SDK child, but detached process-group cleanup also reaches
+		// tool grandchildren (bun test, make dev, etc.) that would otherwise survive.
+		this.ctx.terminateTrackedAgentProcesses({ forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS });
+
+		// 5. Close query only if runQuery()'s finally block has not already done so.
 		// When queryPromise resolves normally, the finally block ran during the await
 		// above: it called close() and nulled ctx.queryObject. Check the live reference
 		// against our local snapshot — if they differ (null or new query), skip close()
@@ -279,7 +286,7 @@ export class QueryLifecycleManager {
 			}
 		}
 
-		// 5. Wait for the SDK subprocess to fully exit after close().
+		// 6. Wait for the SDK subprocess to fully exit after close().
 		// close() sends SIGTERM but the process may take time to clean up.
 		// Without this, starting a new subprocess immediately can fail because
 		// the old process still holds workspace locks (.claude/ files).
@@ -294,7 +301,7 @@ export class QueryLifecycleManager {
 			this.ctx.processExitedPromise = null;
 		}
 
-		// 6. Clear stale startup timer and abort controller.
+		// 7. Clear stale startup timer and abort controller.
 		// The old runQuery()'s finally block normally clears these, but if stop()
 		// timed out waiting for queryPromise, finally hasn't run yet. Leaving them
 		// alive is dangerous: the old timer's closure reads this.ctx.firstMessageReceived
@@ -312,7 +319,7 @@ export class QueryLifecycleManager {
 			this.ctx.queryAbortController = null;
 		}
 
-		// 7. Clear references
+		// 8. Clear references
 		this.ctx.queryObject = null;
 		this.ctx.queryPromise = null;
 	}

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -121,9 +121,10 @@ export interface QueryRunnerContext {
 	firstMessageReceived: boolean;
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
 	originalEnvVars: OriginalEnvVars;
-	/** Resolves when the SDK subprocess exits. Set by QueryRunner via spawnClaudeCodeProcess wrapper. */
+	/** Resolves when tracked SDK subprocesses exit. Set by QueryRunner via spawnClaudeCodeProcess wrapper. */
 	processExitedPromise: Promise<void> | null;
 	trackAgentProcess(proc: TrackedAgentProcess): void;
+	snapshotTrackedAgentProcesses(): Array<[number, TrackedAgentProcess]>;
 	// Methods for state coordination
 	incrementQueryGeneration(): number;
 	getQueryGeneration(): number;

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -48,6 +48,11 @@ export type { OriginalEnvVars } from '../provider-service';
  * Re-verify this implementation matches the SDK's spawn behavior on SDK upgrades —
  * mismatches in stdio/env/signal can cause subtle subprocess communication failures.
  */
+export type TrackedAgentProcess = SpawnedProcess & {
+	pid?: number;
+	kill?: (signal?: NodeJS.Signals | number) => boolean;
+};
+
 function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
 	const debugSdk = opts.env?.DEBUG_CLAUDE_AGENT_SDK;
 	const stderr = debugSdk && debugSdk !== '0' && debugSdk !== 'false' ? 'pipe' : 'ignore';
@@ -57,6 +62,10 @@ function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
 		stdio: ['pipe', 'pipe', stderr],
 		signal: opts.signal,
 		windowsHide: true,
+		// Run the SDK subprocess as a process-group leader so session cleanup can
+		// terminate descendant commands spawned by tool use (bun test, make dev, etc.).
+		// On Windows this starts an independent process; group signalling is POSIX-only.
+		detached: process.platform !== 'win32',
 	});
 	return proc as unknown as SpawnedProcess;
 }
@@ -114,6 +123,7 @@ export interface QueryRunnerContext {
 	originalEnvVars: OriginalEnvVars;
 	/** Resolves when the SDK subprocess exits. Set by QueryRunner via spawnClaudeCodeProcess wrapper. */
 	processExitedPromise: Promise<void> | null;
+	trackAgentProcess(proc: TrackedAgentProcess): void;
 	// Methods for state coordination
 	incrementQueryGeneration(): number;
 	getQueryGeneration(): number;
@@ -450,10 +460,10 @@ export class QueryRunner {
 			// This lets stop() await the actual process exit instead of using arbitrary delays.
 			const originalSpawn = queryOptions.spawnClaudeCodeProcess;
 			queryOptions.spawnClaudeCodeProcess = (opts: SpawnOptions): SpawnedProcess => {
-				const proc = originalSpawn ? originalSpawn(opts) : defaultSpawn(opts);
-				this.ctx.processExitedPromise = new Promise<void>((resolve) => {
-					proc.once('exit', () => resolve());
-				});
+				const proc = (
+					originalSpawn ? originalSpawn(opts) : defaultSpawn(opts)
+				) as TrackedAgentProcess;
+				this.ctx.trackAgentProcess(proc);
 				return proc;
 			};
 

--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -151,6 +151,12 @@ export class NeoAgentManager {
 		return this.session;
 	}
 
+	*getTrackedAgentRootPids(): Iterable<number> {
+		if (this.session) {
+			yield* this.session.getTrackedAgentRootPids();
+		}
+	}
+
 	/**
 	 * Wire in the query tools dependencies and optional MCP registry manager.
 	 *

--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -157,6 +157,11 @@ export class NeoAgentManager {
 		}
 	}
 
+	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
+		if (!this.session) return { live: [], exited: [] };
+		return this.session.getTrackedAgentRootPidsSplit();
+	}
+
 	/**
 	 * Wire in the query tools dependencies and optional MCP registry manager.
 	 *

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -14,6 +14,7 @@ export interface ProcessSnapshot {
 
 export type ProcessLister = () => Promise<ProcessSnapshot[]>;
 export type ProcessKiller = (pid: number, signal: NodeJS.Signals) => void;
+export type RootPidProvider = () => Iterable<number>;
 
 const SUSPICIOUS_THRESHOLDS = [
 	{ pattern: /\bbun\s+test\b/, thresholdMs: 15 * 60 * 1000 },
@@ -25,39 +26,87 @@ export const PROCESS_WATCHDOG_INTERVAL_MS = 5 * 60 * 1000;
 export async function listProcesses(): Promise<ProcessSnapshot[]> {
 	if (process.platform === 'win32') return [];
 
+	if (usesBsdPsElapsedFormat()) {
+		const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,etime=,command='], {
+			maxBuffer: 1024 * 1024,
+		});
+		return parseProcessList(stdout, 'duration');
+	}
+
 	const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,etimes=,command='], {
 		maxBuffer: 1024 * 1024,
 	});
+	return parseProcessList(stdout, 'seconds');
+}
 
+function usesBsdPsElapsedFormat(): boolean {
+	return (
+		process.platform === 'darwin' ||
+		process.platform === 'freebsd' ||
+		process.platform === 'openbsd'
+	);
+}
+
+export function parseProcessList(
+	stdout: string,
+	elapsedFormat: 'seconds' | 'duration'
+): ProcessSnapshot[] {
 	return stdout
 		.split('\n')
 		.map((line) => line.trim())
 		.filter(Boolean)
 		.flatMap((line): ProcessSnapshot[] => {
-			const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+			const match = line.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
 			if (!match) return [];
 			const [, pidRaw, ppidRaw, elapsedRaw, command] = match;
+			const elapsedSeconds =
+				elapsedFormat === 'seconds' ? Number(elapsedRaw) : parsePsElapsedDuration(elapsedRaw);
+			if (!Number.isFinite(elapsedSeconds)) return [];
 			return [
 				{
 					pid: Number(pidRaw),
 					ppid: Number(ppidRaw),
-					elapsedSeconds: Number(elapsedRaw),
+					elapsedSeconds,
 					command,
 				},
 			];
 		});
 }
 
+export function parsePsElapsedDuration(raw: string): number {
+	const [dayPart, timePart] = raw.includes('-') ? raw.split('-', 2) : ['0', raw];
+	const parts = timePart.split(':').map((part) => Number(part));
+	if (parts.some((part) => !Number.isFinite(part))) return Number.NaN;
+	const days = Number(dayPart);
+	if (!Number.isFinite(days)) return Number.NaN;
+
+	if (parts.length === 2) {
+		const [minutes, seconds] = parts;
+		return days * 86400 + minutes * 60 + seconds;
+	}
+	if (parts.length === 3) {
+		const [hours, minutes, seconds] = parts;
+		return days * 86400 + hours * 3600 + minutes * 60 + seconds;
+	}
+	return Number.NaN;
+}
+
 export async function cleanupSuspiciousProcesses(options?: {
 	listProcesses?: ProcessLister;
 	killProcess?: ProcessKiller;
+	getRootPids?: RootPidProvider;
 }): Promise<number> {
 	const lister = options?.listProcesses ?? listProcesses;
 	const killer = options?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+	const rootPids = new Set(options?.getRootPids ? [...options.getRootPids()] : []);
+	if (rootPids.size === 0) return 0;
+
 	const snapshots = await lister();
+	const ownedPids = collectDescendantPids(snapshots, rootPids);
 	let killed = 0;
 
 	for (const snapshot of snapshots) {
+		if (!ownedPids.has(snapshot.pid)) continue;
 		const runtimeMs = snapshot.elapsedSeconds * 1000;
 		const threshold = SUSPICIOUS_THRESHOLDS.find(
 			({ pattern, thresholdMs }) => pattern.test(snapshot.command) && runtimeMs > thresholdMs
@@ -68,12 +117,12 @@ export async function cleanupSuspiciousProcesses(options?: {
 			killer(snapshot.pid, 'SIGTERM');
 			killed++;
 			logger.warn(
-				`Killing suspicious long-running process pid=${snapshot.pid} ppid=${snapshot.ppid} ` +
+				`Killing suspicious daemon-owned long-running process pid=${snapshot.pid} ppid=${snapshot.ppid} ` +
 					`runtimeMs=${runtimeMs} thresholdMs=${threshold.thresholdMs} command=${snapshot.command}`
 			);
 		} catch (error) {
 			logger.warn(
-				`Failed to kill suspicious process pid=${snapshot.pid}: ${error instanceof Error ? error.message : String(error)}`
+				`Failed to kill suspicious daemon-owned process pid=${snapshot.pid}: ${error instanceof Error ? error.message : String(error)}`
 			);
 		}
 	}
@@ -81,12 +130,34 @@ export async function cleanupSuspiciousProcesses(options?: {
 	return killed;
 }
 
+export function collectDescendantPids(
+	snapshots: ProcessSnapshot[],
+	rootPids: ReadonlySet<number>
+): Set<number> {
+	const childrenByParent = new Map<number, number[]>();
+	for (const snapshot of snapshots) {
+		const children = childrenByParent.get(snapshot.ppid) ?? [];
+		children.push(snapshot.pid);
+		childrenByParent.set(snapshot.ppid, children);
+	}
+
+	const owned = new Set<number>();
+	const queue = [...rootPids];
+	while (queue.length > 0) {
+		const pid = queue.shift()!;
+		if (owned.has(pid)) continue;
+		owned.add(pid);
+		queue.push(...(childrenByParent.get(pid) ?? []));
+	}
+	return owned;
+}
+
 export class ProcessWatchdog {
 	private timer: ReturnType<typeof setInterval> | null = null;
 
 	constructor(
 		private readonly intervalMs = PROCESS_WATCHDOG_INTERVAL_MS,
-		private readonly cleanup = cleanupSuspiciousProcesses
+		private readonly cleanup: () => Promise<number> = cleanupSuspiciousProcesses
 	) {}
 
 	start(): void {

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -8,6 +8,7 @@ const logger = new Logger('ProcessWatchdog');
 export interface ProcessSnapshot {
 	pid: number;
 	ppid: number;
+	pgid?: number;
 	elapsedSeconds: number;
 	command: string;
 }
@@ -27,13 +28,13 @@ export async function listProcesses(): Promise<ProcessSnapshot[]> {
 	if (process.platform === 'win32') return [];
 
 	if (usesBsdPsElapsedFormat()) {
-		const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,etime=,command='], {
+		const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,pgid=,etime=,command='], {
 			maxBuffer: 1024 * 1024,
 		});
 		return parseProcessList(stdout, 'duration');
 	}
 
-	const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,etimes=,command='], {
+	const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,pgid=,etimes=,command='], {
 		maxBuffer: 1024 * 1024,
 	});
 	return parseProcessList(stdout, 'seconds');
@@ -56,9 +57,9 @@ export function parseProcessList(
 		.map((line) => line.trim())
 		.filter(Boolean)
 		.flatMap((line): ProcessSnapshot[] => {
-			const match = line.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+			const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
 			if (!match) return [];
-			const [, pidRaw, ppidRaw, elapsedRaw, command] = match;
+			const [, pidRaw, ppidRaw, pgidRaw, elapsedRaw, command] = match;
 			const elapsedSeconds =
 				elapsedFormat === 'seconds' ? Number(elapsedRaw) : parsePsElapsedDuration(elapsedRaw);
 			if (!Number.isFinite(elapsedSeconds)) return [];
@@ -66,6 +67,7 @@ export function parseProcessList(
 				{
 					pid: Number(pidRaw),
 					ppid: Number(ppidRaw),
+					pgid: Number(pgidRaw),
 					elapsedSeconds,
 					command,
 				},
@@ -135,10 +137,17 @@ export function collectDescendantPids(
 	rootPids: ReadonlySet<number>
 ): Set<number> {
 	const childrenByParent = new Map<number, number[]>();
+	const processesByGroup = new Map<number, number[]>();
 	for (const snapshot of snapshots) {
 		const children = childrenByParent.get(snapshot.ppid) ?? [];
 		children.push(snapshot.pid);
 		childrenByParent.set(snapshot.ppid, children);
+
+		if (typeof snapshot.pgid === 'number' && Number.isFinite(snapshot.pgid)) {
+			const groupProcesses = processesByGroup.get(snapshot.pgid) ?? [];
+			groupProcesses.push(snapshot.pid);
+			processesByGroup.set(snapshot.pgid, groupProcesses);
+		}
 	}
 
 	const owned = new Set<number>();
@@ -148,6 +157,7 @@ export function collectDescendantPids(
 		if (owned.has(pid)) continue;
 		owned.add(pid);
 		queue.push(...(childrenByParent.get(pid) ?? []));
+		queue.push(...(processesByGroup.get(pid) ?? []));
 	}
 	return owned;
 }

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -1,0 +1,109 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Logger } from './logger';
+
+const execFileAsync = promisify(execFile);
+const logger = new Logger('ProcessWatchdog');
+
+export interface ProcessSnapshot {
+	pid: number;
+	ppid: number;
+	elapsedSeconds: number;
+	command: string;
+}
+
+export type ProcessLister = () => Promise<ProcessSnapshot[]>;
+export type ProcessKiller = (pid: number, signal: NodeJS.Signals) => void;
+
+const SUSPICIOUS_THRESHOLDS = [
+	{ pattern: /\bbun\s+test\b/, thresholdMs: 15 * 60 * 1000 },
+	{ pattern: /\bmake\s+dev\b/, thresholdMs: 24 * 60 * 60 * 1000 },
+] as const;
+
+export const PROCESS_WATCHDOG_INTERVAL_MS = 5 * 60 * 1000;
+
+export async function listProcesses(): Promise<ProcessSnapshot[]> {
+	if (process.platform === 'win32') return [];
+
+	const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,etimes=,command='], {
+		maxBuffer: 1024 * 1024,
+	});
+
+	return stdout
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.flatMap((line): ProcessSnapshot[] => {
+			const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+			if (!match) return [];
+			const [, pidRaw, ppidRaw, elapsedRaw, command] = match;
+			return [
+				{
+					pid: Number(pidRaw),
+					ppid: Number(ppidRaw),
+					elapsedSeconds: Number(elapsedRaw),
+					command,
+				},
+			];
+		});
+}
+
+export async function cleanupSuspiciousProcesses(options?: {
+	listProcesses?: ProcessLister;
+	killProcess?: ProcessKiller;
+}): Promise<number> {
+	const lister = options?.listProcesses ?? listProcesses;
+	const killer = options?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+	const snapshots = await lister();
+	let killed = 0;
+
+	for (const snapshot of snapshots) {
+		const runtimeMs = snapshot.elapsedSeconds * 1000;
+		const threshold = SUSPICIOUS_THRESHOLDS.find(
+			({ pattern, thresholdMs }) => pattern.test(snapshot.command) && runtimeMs > thresholdMs
+		);
+		if (!threshold) continue;
+
+		try {
+			killer(snapshot.pid, 'SIGTERM');
+			killed++;
+			logger.warn(
+				`Killing suspicious long-running process pid=${snapshot.pid} ppid=${snapshot.ppid} ` +
+					`runtimeMs=${runtimeMs} thresholdMs=${threshold.thresholdMs} command=${snapshot.command}`
+			);
+		} catch (error) {
+			logger.warn(
+				`Failed to kill suspicious process pid=${snapshot.pid}: ${error instanceof Error ? error.message : String(error)}`
+			);
+		}
+	}
+
+	return killed;
+}
+
+export class ProcessWatchdog {
+	private timer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(
+		private readonly intervalMs = PROCESS_WATCHDOG_INTERVAL_MS,
+		private readonly cleanup = cleanupSuspiciousProcesses
+	) {}
+
+	start(): void {
+		if (this.timer) return;
+		this.timer = setInterval(() => {
+			this.cleanup().catch((error) => {
+				logger.warn(
+					`Process watchdog cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+				);
+			});
+		}, this.intervalMs);
+		this.timer.unref?.();
+	}
+
+	stop(): void {
+		if (!this.timer) return;
+		clearInterval(this.timer);
+		this.timer = null;
+	}
+}

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -15,7 +15,7 @@ export interface ProcessSnapshot {
 
 export type ProcessLister = () => Promise<ProcessSnapshot[]>;
 export type ProcessKiller = (pid: number, signal: NodeJS.Signals) => void;
-export type RootPidProvider = () => Iterable<number>;
+export type RootPidProvider = () => { live: Iterable<number>; exited: Iterable<number> };
 
 const SUSPICIOUS_THRESHOLDS = [
 	{ pattern: /\bbun\s+test\b/, thresholdMs: 15 * 60 * 1000 },
@@ -100,11 +100,15 @@ export async function cleanupSuspiciousProcesses(options?: {
 }): Promise<number> {
 	const lister = options?.listProcesses ?? listProcesses;
 	const killer = options?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
-	const rootPids = new Set(options?.getRootPids ? [...options.getRootPids()] : []);
-	if (rootPids.size === 0) return 0;
+	const rootResult = options?.getRootPids
+		? options.getRootPids()
+		: { live: [] as number[], exited: [] as number[] };
+	const liveRoots = new Set(rootResult.live);
+	const exitedRoots = new Set(rootResult.exited);
+	if (liveRoots.size === 0 && exitedRoots.size === 0) return 0;
 
 	const snapshots = await lister();
-	const ownedPids = collectDescendantPids(snapshots, rootPids);
+	const ownedPids = collectDescendantPids(snapshots, liveRoots, exitedRoots);
 	let killed = 0;
 
 	for (const snapshot of snapshots) {
@@ -134,11 +138,14 @@ export async function cleanupSuspiciousProcesses(options?: {
 
 export function collectDescendantPids(
 	snapshots: ProcessSnapshot[],
-	rootPids: ReadonlySet<number>
+	liveRootPids: ReadonlySet<number>,
+	exitedRootPids?: ReadonlySet<number>
 ): Set<number> {
 	const childrenByParent = new Map<number, number[]>();
 	const processesByGroup = new Map<number, number[]>();
+	const snapshotPids = new Set<number>();
 	for (const snapshot of snapshots) {
+		snapshotPids.add(snapshot.pid);
 		const children = childrenByParent.get(snapshot.ppid) ?? [];
 		children.push(snapshot.pid);
 		childrenByParent.set(snapshot.ppid, children);
@@ -151,7 +158,25 @@ export function collectDescendantPids(
 	}
 
 	const owned = new Set<number>();
-	const queue = [...rootPids];
+	const queue: number[] = [];
+
+	// Live roots that exist in the snapshot — traverse normally (parent-child + PGID).
+	for (const pid of liveRootPids) {
+		if (snapshotPids.has(pid)) {
+			queue.push(pid);
+		}
+	}
+
+	// Exited roots: discover orphaned children via PGID only.
+	// If an exited root PID appears in the snapshot it was reused by an unrelated
+	// process — skip it to avoid cross-process kills.
+	const effectiveExited = exitedRootPids ?? new Set<number>();
+	for (const pid of effectiveExited) {
+		if (snapshotPids.has(pid)) continue;
+		const groupMembers = processesByGroup.get(pid);
+		if (groupMembers) queue.push(...groupMembers);
+	}
+
 	while (queue.length > 0) {
 		const pid = queue.shift()!;
 		if (owned.has(pid)) continue;

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -415,6 +415,17 @@ export class SessionManager {
 		}
 	}
 
+	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
+		const live: number[] = [];
+		const exited: number[] = [];
+		for (const [, agentSession] of this.sessionCache.entries()) {
+			const split = agentSession.getTrackedAgentRootPidsSplit();
+			live.push(...split.live);
+			exited.push(...split.exited);
+		}
+		return { live, exited };
+	}
+
 	/**
 	 * Remove an AgentSession from the session cache.
 	 *

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -409,6 +409,12 @@ export class SessionManager {
 		this.sessionCache.set(agentSession.getSessionData().id, agentSession);
 	}
 
+	*getTrackedAgentRootPids(): Iterable<number> {
+		for (const [, agentSession] of this.sessionCache.entries()) {
+			yield* agentSession.getTrackedAgentRootPids();
+		}
+	}
+
 	/**
 	 * Remove an AgentSession from the session cache.
 	 *

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -362,6 +362,24 @@ export class TaskAgentManager {
 		}
 	}
 
+	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
+		const live: number[] = [];
+		const exited: number[] = [];
+		for (const [, session] of this.taskAgentSessions) {
+			const split = session.getTrackedAgentRootPidsSplit();
+			live.push(...split.live);
+			exited.push(...split.exited);
+		}
+		for (const [, nodeSessions] of this.subSessions) {
+			for (const [, session] of nodeSessions) {
+				const split = session.getTrackedAgentRootPidsSplit();
+				live.push(...split.live);
+				exited.push(...split.exited);
+			}
+		}
+		return { live, exited };
+	}
+
 	/**
 	 * Subscribe to `space.task.updated` and run the archive pipeline for tasks
 	 * that reach the `archived` state.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -351,6 +351,17 @@ export class TaskAgentManager {
 		this.subscribeToTaskArchiveEvents();
 	}
 
+	*getTrackedAgentRootPids(): Iterable<number> {
+		for (const [, session] of this.taskAgentSessions) {
+			yield* session.getTrackedAgentRootPids();
+		}
+		for (const [, nodeSessions] of this.subSessions) {
+			for (const [, session] of nodeSessions) {
+				yield* session.getTrackedAgentRootPids();
+			}
+		}
+	}
+
 	/**
 	 * Subscribe to `space.task.updated` and run the archive pipeline for tasks
 	 * that reach the `archived` state.

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -318,7 +318,75 @@ describe('AgentSession', () => {
 
 			expect(firstProc.kill).toHaveBeenCalledWith('SIGKILL');
 			expect(secondProc.kill).not.toHaveBeenCalledWith('SIGKILL');
-			expect([...agentSession.getTrackedAgentRootPids()]).toEqual([222]);
+			expect([...agentSession.getTrackedAgentRootPids()]).toEqual([222, 111]);
+		});
+
+		it('keeps SIGKILL escalation for remaining processes when one exits', async () => {
+			const agentSession = createAgentSession();
+			processKillSpy = spyOn(process, 'kill').mockImplementation(() => true);
+			let firstExitHandler: (() => void) | null = null;
+			const firstProc = {
+				pid: 111,
+				once: mock((_event: string, handler: () => void) => {
+					firstExitHandler = handler;
+					return firstProc;
+				}),
+				kill: mock(() => true),
+			};
+			const secondProc = {
+				pid: 222,
+				once: mock((_event: string, _handler: () => void) => secondProc),
+				kill: mock(() => true),
+			};
+
+			agentSession.trackAgentProcess(firstProc as never);
+			agentSession.trackAgentProcess(secondProc as never);
+			agentSession.terminateTrackedAgentProcesses({ forceDelayMs: 15 });
+			firstExitHandler?.();
+
+			await new Promise((resolve) => setTimeout(resolve, 30));
+
+			expect(secondProc.kill).toHaveBeenCalledWith('SIGKILL');
+		});
+
+		it('signals each tracked process group in the stop snapshot', () => {
+			const agentSession = createAgentSession();
+			processKillSpy = spyOn(process, 'kill').mockImplementation(() => true);
+			const firstProc = {
+				pid: 111,
+				once: mock((_event: string, _handler: () => void) => firstProc),
+				kill: mock(() => true),
+			};
+			const secondProc = {
+				pid: 222,
+				once: mock((_event: string, _handler: () => void) => secondProc),
+				kill: mock(() => true),
+			};
+
+			agentSession.trackAgentProcess(firstProc as never);
+			agentSession.trackAgentProcess(secondProc as never);
+			agentSession.terminateTrackedAgentProcesses({ forceDelayMs: 50 });
+
+			expect(processKillSpy).toHaveBeenCalledWith(-111, 'SIGTERM');
+			expect(processKillSpy).toHaveBeenCalledWith(-222, 'SIGTERM');
+		});
+
+		it('keeps failed SIGKILL deliveries tracked for later cleanup', async () => {
+			const agentSession = createAgentSession();
+			processKillSpy = spyOn(process, 'kill').mockImplementation(() => true);
+			const proc = {
+				pid: 333,
+				once: mock((_event: string, _handler: () => void) => proc),
+				kill: mock((signal: NodeJS.Signals) => signal !== 'SIGKILL'),
+			};
+
+			agentSession.trackAgentProcess(proc as never);
+			agentSession.terminateTrackedAgentProcesses({ forceDelayMs: 10 });
+
+			await new Promise((resolve) => setTimeout(resolve, 25));
+
+			expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+			expect([...agentSession.getTrackedAgentRootPids()]).toEqual([333]);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -6,7 +6,7 @@
  * using mock.module() which affects other test files globally.
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { describe, expect, it, mock, beforeEach, afterEach, spyOn } from 'bun:test';
 import type {
 	Session,
 	ContextInfo,
@@ -229,6 +229,96 @@ describe('AgentSession', () => {
 			expect(response.questionIndex).toBe(0);
 			expect(response.selectedOptionIndices).toEqual([0, 2]);
 			expect(response.customText).toBe('custom input');
+		});
+	});
+
+	describe('process tracking cleanup', () => {
+		let processKillSpy: ReturnType<typeof spyOn> | null = null;
+
+		afterEach(() => {
+			processKillSpy?.mockRestore();
+			processKillSpy = null;
+		});
+
+		function createAgentSession(): AgentSession {
+			const mockSession: Session = {
+				id: `test-session-${Math.random()}`,
+				title: 'Test Session',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 8192,
+					temperature: 1.0,
+				},
+				metadata: {},
+			} as Session;
+
+			const mockDb = {
+				getSession: mock(() => mockSession),
+				updateSession: mock(() => {}),
+				getUserMessages: mock(() => []),
+				getSDKMessages: mock(() => ({ messages: [], hasMore: false })),
+				deleteMessagesAfter: mock(() => 0),
+				deleteMessagesAtAndAfter: mock(() => 0),
+				getUserMessageByUuid: mock(() => undefined),
+				countMessagesAfter: mock(() => 0),
+				getMessagesByStatus: mock(() => []),
+				updateMessage: mock(() => {}),
+				getSDKMessageCount: mock(() => 0),
+			} as unknown as Database;
+
+			return new AgentSession(
+				mockSession,
+				mockDb,
+				{} as MessageHub,
+				{
+					publish: mock(async () => {}),
+					publishAsync: mock(() => {}),
+					subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
+				} as unknown as InternalEventBus<any>,
+				mock(async () => 'test-api-key')
+			);
+		}
+
+		it('exposes tracked root pids for daemon-owned watchdog scoping', () => {
+			const agentSession = createAgentSession();
+			const proc = {
+				pid: 12345,
+				once: mock((_event: string, _handler: () => void) => proc),
+				kill: mock(() => true),
+			};
+
+			agentSession.trackAgentProcess(proc as never);
+
+			expect([...agentSession.getTrackedAgentRootPids()]).toEqual([12345]);
+		});
+
+		it('binds deferred SIGKILL to the process snapshot being terminated', async () => {
+			const agentSession = createAgentSession();
+			processKillSpy = spyOn(process, 'kill').mockImplementation(() => true);
+			const firstProc = {
+				pid: 111,
+				once: mock((_event: string, _handler: () => void) => firstProc),
+				kill: mock(() => true),
+			};
+			const secondProc = {
+				pid: 222,
+				once: mock((_event: string, _handler: () => void) => secondProc),
+				kill: mock(() => true),
+			};
+
+			agentSession.trackAgentProcess(firstProc as never);
+			agentSession.terminateTrackedAgentProcesses({ forceDelayMs: 10 });
+			agentSession.trackAgentProcess(secondProc as never);
+
+			await new Promise((resolve) => setTimeout(resolve, 25));
+
+			expect(firstProc.kill).toHaveBeenCalledWith('SIGKILL');
+			expect(secondProc.kill).not.toHaveBeenCalledWith('SIGKILL');
+			expect([...agentSession.getTrackedAgentRootPids()]).toEqual([222]);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
@@ -401,6 +401,7 @@ describe('QueryLifecycleManager restart() — session continuity (sdkSessionId)'
 			processExitedPromise: null,
 			startupTimeoutTimer: null,
 			queryAbortController: null,
+			terminateTrackedAgentProcesses: mock(() => {}),
 			pendingRestartReason: null,
 			startStreamingQuery: async () => {
 				startStreamingCalled = true;

--- a/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
@@ -402,6 +402,7 @@ describe('QueryLifecycleManager restart() — session continuity (sdkSessionId)'
 			startupTimeoutTimer: null,
 			queryAbortController: null,
 			terminateTrackedAgentProcesses: mock(() => {}),
+			snapshotTrackedAgentProcesses: mock(() => []),
 			pendingRestartReason: null,
 			startStreamingQuery: async () => {
 				startStreamingCalled = true;

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -45,6 +45,7 @@ describe('QueryLifecycleManager', () => {
 	let getInterruptPromiseSpy: ReturnType<typeof mock>;
 	let handleErrorSpy: ReturnType<typeof mock>;
 	let clearModelsCacheSpy: ReturnType<typeof mock>;
+	let terminateTrackedAgentProcessesSpy: ReturnType<typeof mock>;
 	let internalPublishAsyncSpy: ReturnType<typeof mock>;
 	let internalPublishSpy: ReturnType<typeof mock>;
 
@@ -89,6 +90,7 @@ describe('QueryLifecycleManager', () => {
 		getInterruptPromiseSpy = mock(() => null);
 		handleErrorSpy = mock(async () => {});
 		clearModelsCacheSpy = mock(async () => {});
+		terminateTrackedAgentProcessesSpy = mock(() => {});
 		internalPublishAsyncSpy = mock(async () => {});
 		internalPublishSpy = mock(async () => {});
 
@@ -139,6 +141,7 @@ describe('QueryLifecycleManager', () => {
 			processExitedPromise: null,
 			startupTimeoutTimer: null,
 			queryAbortController: null,
+			terminateTrackedAgentProcesses: terminateTrackedAgentProcessesSpy,
 			// Cleanup support methods
 			setCleaningUp: mock(() => {}),
 			cleanupEventSubscriptions: mock(() => {}),
@@ -270,6 +273,24 @@ describe('QueryLifecycleManager', () => {
 
 			// Should not throw
 			await manager.stop();
+		});
+
+		test('terminates tracked process group before closing query object', async () => {
+			const closeMock = mock(() => {});
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: closeMock,
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.queryPromise = Promise.resolve();
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			expect(terminateTrackedAgentProcessesSpy).toHaveBeenCalledWith({ forceDelayMs: 2000 });
+			expect(closeMock).toHaveBeenCalled();
+			expect(terminateTrackedAgentProcessesSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				closeMock.mock.invocationCallOrder[0]
+			);
 		});
 
 		test('calls close() on query object to terminate subprocess', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -46,6 +46,7 @@ describe('QueryLifecycleManager', () => {
 	let handleErrorSpy: ReturnType<typeof mock>;
 	let clearModelsCacheSpy: ReturnType<typeof mock>;
 	let terminateTrackedAgentProcessesSpy: ReturnType<typeof mock>;
+	let snapshotTrackedAgentProcessesSpy: ReturnType<typeof mock>;
 	let internalPublishAsyncSpy: ReturnType<typeof mock>;
 	let internalPublishSpy: ReturnType<typeof mock>;
 
@@ -91,6 +92,7 @@ describe('QueryLifecycleManager', () => {
 		handleErrorSpy = mock(async () => {});
 		clearModelsCacheSpy = mock(async () => {});
 		terminateTrackedAgentProcessesSpy = mock(() => {});
+		snapshotTrackedAgentProcessesSpy = mock(() => []);
 		internalPublishAsyncSpy = mock(async () => {});
 		internalPublishSpy = mock(async () => {});
 
@@ -142,6 +144,7 @@ describe('QueryLifecycleManager', () => {
 			startupTimeoutTimer: null,
 			queryAbortController: null,
 			terminateTrackedAgentProcesses: terminateTrackedAgentProcessesSpy,
+			snapshotTrackedAgentProcesses: snapshotTrackedAgentProcessesSpy,
 			// Cleanup support methods
 			setCleaningUp: mock(() => {}),
 			cleanupEventSubscriptions: mock(() => {}),
@@ -286,7 +289,10 @@ describe('QueryLifecycleManager', () => {
 
 			await manager.stop();
 
-			expect(terminateTrackedAgentProcessesSpy).toHaveBeenCalledWith({ forceDelayMs: 2000 });
+			expect(terminateTrackedAgentProcessesSpy).toHaveBeenCalledWith({
+				forceDelayMs: 2000,
+				processes: [],
+			});
 			expect(closeMock).toHaveBeenCalled();
 			expect(terminateTrackedAgentProcessesSpy.mock.invocationCallOrder[0]).toBeLessThan(
 				closeMock.mock.invocationCallOrder[0]

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -58,6 +58,7 @@ describe('QueryRunner', () => {
 	let onSlashCommandsFetchedSpy: ReturnType<typeof mock>;
 	let onModelsFetchedSpy: ReturnType<typeof mock>;
 	let onMarkApiSuccessSpy: ReturnType<typeof mock>;
+	let trackAgentProcessSpy: ReturnType<typeof mock>;
 
 	beforeEach(() => {
 		mockSession = {
@@ -86,6 +87,7 @@ describe('QueryRunner', () => {
 		queryGeneration = 0;
 
 		// Create callback spies
+		trackAgentProcessSpy = mock(() => {});
 		onSDKMessageSpy = mock(async () => {});
 		onSlashCommandsFetchedSpy = mock(async () => {});
 		onModelsFetchedSpy = mock(async () => {});
@@ -198,6 +200,7 @@ describe('QueryRunner', () => {
 			originalEnvVars: {},
 
 			processExitedPromise: null,
+			trackAgentProcess: trackAgentProcessSpy,
 
 			// Methods for state coordination
 			incrementQueryGeneration: () => ++queryGeneration,

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -129,15 +129,43 @@ describe('process-watchdog', () => {
 	test('collects descendants recursively from daemon root pids', () => {
 		const descendants = collectDescendantPids(
 			[
-				{ pid: 100, ppid: 1, elapsedSeconds: 1, command: 'root' },
-				{ pid: 101, ppid: 100, elapsedSeconds: 1, command: 'child' },
-				{ pid: 102, ppid: 101, elapsedSeconds: 1, command: 'grandchild' },
-				{ pid: 200, ppid: 1, elapsedSeconds: 1, command: 'other' },
+				{ pid: 100, ppid: 1, pgid: 100, elapsedSeconds: 1, command: 'root' },
+				{ pid: 101, ppid: 100, pgid: 100, elapsedSeconds: 1, command: 'child' },
+				{ pid: 102, ppid: 101, pgid: 100, elapsedSeconds: 1, command: 'grandchild' },
+				{ pid: 200, ppid: 1, pgid: 200, elapsedSeconds: 1, command: 'other' },
 			],
 			new Set([100])
 		);
 
 		expect(descendants).toEqual(new Set([100, 101, 102]));
+	});
+
+	test('retains ownership for orphaned processes in a recently exited root process group', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 321,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/orphaned.test.ts',
+				},
+				{
+					pid: 999,
+					ppid: 1,
+					pgid: 999,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test unrelated.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => [100],
+		});
+
+		expect(killed).toBe(1);
+		expect(killProcess).toHaveBeenCalledWith(321, 'SIGTERM');
 	});
 
 	test('parses BSD ps elapsed durations', () => {
@@ -148,13 +176,13 @@ describe('process-watchdog', () => {
 
 	test('parses process list output with BSD duration elapsed field', () => {
 		const processes = parseProcessList(
-			'  123     1 01:02:03 bun test foo.test.ts\n  456   123 2-03:04:05 make dev\n',
+			'  123     1   123 01:02:03 bun test foo.test.ts\n  456   123   123 2-03:04:05 make dev\n',
 			'duration'
 		);
 
 		expect(processes).toEqual([
-			{ pid: 123, ppid: 1, elapsedSeconds: 3723, command: 'bun test foo.test.ts' },
-			{ pid: 456, ppid: 123, elapsedSeconds: 183845, command: 'make dev' },
+			{ pid: 123, ppid: 1, pgid: 123, elapsedSeconds: 3723, command: 'bun test foo.test.ts' },
+			{ pid: 456, ppid: 123, pgid: 123, elapsedSeconds: 183845, command: 'make dev' },
 		]);
 	});
 

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -33,7 +33,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [100],
+			getRootPids: () => ({ live: [100], exited: [] }),
 		});
 
 		expect(killed).toBe(1);
@@ -53,7 +53,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [100],
+			getRootPids: () => ({ live: [100], exited: [] }),
 		});
 
 		expect(killed).toBe(0);
@@ -73,7 +73,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [100],
+			getRootPids: () => ({ live: [100], exited: [] }),
 		});
 
 		expect(killed).toBe(0);
@@ -99,7 +99,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [100],
+			getRootPids: () => ({ live: [100], exited: [] }),
 		});
 
 		expect(killed).toBe(0);
@@ -119,7 +119,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [],
+			getRootPids: () => ({ live: [], exited: [] }),
 		});
 
 		expect(killed).toBe(0);
@@ -134,7 +134,8 @@ describe('process-watchdog', () => {
 				{ pid: 102, ppid: 101, pgid: 100, elapsedSeconds: 1, command: 'grandchild' },
 				{ pid: 200, ppid: 1, pgid: 200, elapsedSeconds: 1, command: 'other' },
 			],
-			new Set([100])
+			new Set([100]),
+			new Set()
 		);
 
 		expect(descendants).toEqual(new Set([100, 101, 102]));
@@ -161,7 +162,7 @@ describe('process-watchdog', () => {
 				},
 			],
 			killProcess,
-			getRootPids: () => [100],
+			getRootPids: () => ({ live: [], exited: [100] }),
 		});
 
 		expect(killed).toBe(1);
@@ -184,6 +185,33 @@ describe('process-watchdog', () => {
 			{ pid: 123, ppid: 1, pgid: 123, elapsedSeconds: 3723, command: 'bun test foo.test.ts' },
 			{ pid: 456, ppid: 123, pgid: 123, elapsedSeconds: 183845, command: 'make dev' },
 		]);
+	});
+
+	test('skips reused exited root PIDs in descendant collection', () => {
+		// PID 100 was a daemon root that exited. PID 100 is now reused by an unrelated process.
+		const descendants = collectDescendantPids(
+			[
+				{ pid: 100, ppid: 1, pgid: 999, elapsedSeconds: 1, command: 'other' },
+				{ pid: 200, ppid: 1, pgid: 999, elapsedSeconds: 1, command: 'child' },
+			],
+			new Set(), // no live roots
+			new Set([100]) // exited root
+		);
+
+		// PID 100 appears in snapshot (reused) — should NOT be treated as owned.
+		// PID 200 shares PGID 999 (unrelated group) — should NOT be found via the exited root.
+		expect(descendants).toEqual(new Set());
+	});
+
+	test('finds orphaned children via exited root PGID when root is not reused', () => {
+		// PID 100 exited and is NOT in the snapshot. Orphaned child PID 200 shares PGID 100.
+		const descendants = collectDescendantPids(
+			[{ pid: 200, ppid: 1, pgid: 100, elapsedSeconds: 1, command: 'orphaned-child' }],
+			new Set(), // no live roots
+			new Set([100]) // exited root
+		);
+
+		expect(descendants).toEqual(new Set([200]));
 	});
 
 	test('starts only one interval and stops it', async () => {

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { cleanupSuspiciousProcesses } from '../../../src/lib/process-watchdog';
+
+describe('process-watchdog', () => {
+	test('kills suspicious bun test processes older than threshold', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 123,
+					ppid: 1,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+		});
+
+		expect(killed).toBe(1);
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
+	test('does not kill short-lived bun test processes', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 456,
+					ppid: 1,
+					elapsedSeconds: 5 * 60,
+					command: 'bun test tests/unit/normal.test.ts',
+				},
+			],
+			killProcess,
+		});
+
+		expect(killed).toBe(0);
+		expect(killProcess).not.toHaveBeenCalled();
+	});
+
+	test('allows long-running make dev processes below the dev-server threshold', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 789,
+					ppid: 1,
+					elapsedSeconds: 2 * 60 * 60,
+					command: 'make dev PORT=8484',
+				},
+			],
+			killProcess,
+		});
+
+		expect(killed).toBe(0);
+		expect(killProcess).not.toHaveBeenCalled();
+	});
+});

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -1,20 +1,39 @@
-import { describe, expect, test, mock } from 'bun:test';
-import { cleanupSuspiciousProcesses } from '../../../src/lib/process-watchdog';
+import { describe, expect, test, mock, afterEach } from 'bun:test';
+import {
+	cleanupSuspiciousProcesses,
+	collectDescendantPids,
+	parseProcessList,
+	parsePsElapsedDuration,
+	ProcessWatchdog,
+} from '../../../src/lib/process-watchdog';
 
 describe('process-watchdog', () => {
+	let watchdog: ProcessWatchdog | null = null;
+
+	afterEach(() => {
+		watchdog?.stop();
+		watchdog = null;
+	});
 	test('kills suspicious bun test processes older than threshold', async () => {
 		const killProcess = mock(() => {});
 
 		const killed = await cleanupSuspiciousProcesses({
 			listProcesses: async () => [
 				{
-					pid: 123,
+					pid: 100,
 					ppid: 1,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
 					elapsedSeconds: 16 * 60,
 					command: 'bun test tests/unit/leaky.test.ts',
 				},
 			],
 			killProcess,
+			getRootPids: () => [100],
 		});
 
 		expect(killed).toBe(1);
@@ -28,12 +47,13 @@ describe('process-watchdog', () => {
 			listProcesses: async () => [
 				{
 					pid: 456,
-					ppid: 1,
+					ppid: 100,
 					elapsedSeconds: 5 * 60,
 					command: 'bun test tests/unit/normal.test.ts',
 				},
 			],
 			killProcess,
+			getRootPids: () => [100],
 		});
 
 		expect(killed).toBe(0);
@@ -47,15 +67,112 @@ describe('process-watchdog', () => {
 			listProcesses: async () => [
 				{
 					pid: 789,
-					ppid: 1,
+					ppid: 100,
 					elapsedSeconds: 2 * 60 * 60,
 					command: 'make dev PORT=8484',
 				},
 			],
 			killProcess,
+			getRootPids: () => [100],
 		});
 
 		expect(killed).toBe(0);
 		expect(killProcess).not.toHaveBeenCalled();
+	});
+
+	test('does not kill matching processes outside daemon-owned descendant tree', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 999,
+					ppid: 1,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test other-project.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => [100],
+		});
+
+		expect(killed).toBe(0);
+		expect(killProcess).not.toHaveBeenCalled();
+	});
+
+	test('does not kill anything when no daemon roots are registered', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 999,
+					ppid: 1,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test other-project.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => [],
+		});
+
+		expect(killed).toBe(0);
+		expect(killProcess).not.toHaveBeenCalled();
+	});
+
+	test('collects descendants recursively from daemon root pids', () => {
+		const descendants = collectDescendantPids(
+			[
+				{ pid: 100, ppid: 1, elapsedSeconds: 1, command: 'root' },
+				{ pid: 101, ppid: 100, elapsedSeconds: 1, command: 'child' },
+				{ pid: 102, ppid: 101, elapsedSeconds: 1, command: 'grandchild' },
+				{ pid: 200, ppid: 1, elapsedSeconds: 1, command: 'other' },
+			],
+			new Set([100])
+		);
+
+		expect(descendants).toEqual(new Set([100, 101, 102]));
+	});
+
+	test('parses BSD ps elapsed durations', () => {
+		expect(parsePsElapsedDuration('03:04')).toBe(184);
+		expect(parsePsElapsedDuration('02:03:04')).toBe(7384);
+		expect(parsePsElapsedDuration('1-02:03:04')).toBe(93784);
+	});
+
+	test('parses process list output with BSD duration elapsed field', () => {
+		const processes = parseProcessList(
+			'  123     1 01:02:03 bun test foo.test.ts\n  456   123 2-03:04:05 make dev\n',
+			'duration'
+		);
+
+		expect(processes).toEqual([
+			{ pid: 123, ppid: 1, elapsedSeconds: 3723, command: 'bun test foo.test.ts' },
+			{ pid: 456, ppid: 123, elapsedSeconds: 183845, command: 'make dev' },
+		]);
+	});
+
+	test('starts only one interval and stops it', async () => {
+		let cleanupCalls = 0;
+		watchdog = new ProcessWatchdog(5, async () => {
+			cleanupCalls++;
+			return 0;
+		});
+
+		watchdog.start();
+		watchdog.start();
+		await new Promise((resolve) => setTimeout(resolve, 18));
+		watchdog.stop();
+		const callsAfterStop = cleanupCalls;
+		await new Promise((resolve) => setTimeout(resolve, 12));
+
+		expect(cleanupCalls).toBeGreaterThan(0);
+		expect(cleanupCalls).toBe(callsAfterStop);
 	});
 });


### PR DESCRIPTION
Fixes agent session process leaks by starting SDK subprocesses in a process group, tracking the spawned process, and terminating the group during session stop/reset/cleanup.

Adds a daemon process watchdog as a safety net for suspicious long-running `bun test` and `make dev` commands, with unit coverage for both the lifecycle cleanup hook and watchdog thresholds.

Tests:
- `cd packages/daemon && bun test tests/unit/1-core/agent/query-lifecycle-manager.test.ts tests/unit/1-core/process-watchdog.test.ts tests/unit/1-core/agent/query-runner.test.ts`
- `cd packages/daemon && bun test tests/unit/1-core/agent/model-switch-session-continuity.test.ts`
- `./scripts/test-daemon.sh`
- `bun run check`