### PR TITLE
feat: add publish_task and archive_task MCP tools

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -467,24 +467,11 @@ export class SpaceTaskManager {
 	 * Validates that the current status allows transitioning to 'archived'.
 	 */
 	async archiveTask(taskId: string): Promise<SpaceTask> {
-		const task = await this.getTask(taskId);
-		if (!task) {
-			throw new Error(`Task not found: ${taskId}`);
-		}
-
-		if (!isValidSpaceTaskTransition(task.status, 'archived')) {
-			throw new Error(
-				`Cannot archive task in '${task.status}' status. ` +
-					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
-			);
-		}
-
-		const updated = this.taskRepo.archiveTask(taskId);
-		if (!updated) {
-			throw new Error(`Failed to archive task: ${taskId}`);
-		}
-
-		return updated;
+		// Delegate to setTaskStatus so that workflow cleanup logic runs:
+		// - Clear pendingCheckpointType/pendingCompletion* when leaving 'review'
+		// - Clear postApproval* fields when leaving 'approved'
+		// updateTask also stamps archived_at when status is 'archived'.
+		return this.setTaskStatus(taskId, 'archived');
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4550,6 +4550,15 @@ export class TaskAgentManager {
 		const onPublishTask = async (args: { task_id: string }) => {
 			try {
 				const updated = await boundTaskManager.publishTask(args.task_id);
+				// Emit event so subscribers (e.g. task list UI) see the status change.
+				this.config.internalEventBus
+					?.publish('space.task.updated', {
+						sessionId: 'global',
+						spaceId,
+						taskId: updated.id,
+						task: updated,
+					})
+					.catch(() => {});
 				return jsonResult({ success: true, task: updated });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -4560,6 +4569,16 @@ export class TaskAgentManager {
 		const onArchiveTask = async (args: { task_id: string }) => {
 			try {
 				const updated = await boundTaskManager.archiveTask(args.task_id);
+				// Emit event so subscribeToTaskArchiveEvents() triggers cleanup
+				// (session teardown, SDK JSONL archival, worktree removal).
+				this.config.internalEventBus
+					?.publish('space.task.updated', {
+						sessionId: 'global',
+						spaceId,
+						taskId: updated.id,
+						task: updated,
+					})
+					.catch(() => {});
 				return jsonResult({ success: true, task: updated });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4547,6 +4547,26 @@ export class TaskAgentManager {
 			}
 		};
 
+		const onPublishTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await boundTaskManager.publishTask(args.task_id);
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
+		const onArchiveTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await boundTaskManager.archiveTask(args.task_id);
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
 		return createNodeAgentMcpServer({
 			mySessionId: subSessionId,
 			myAgentName: agentName,
@@ -4576,6 +4596,8 @@ export class TaskAgentManager {
 			onSubmitForApproval,
 			onMarkComplete,
 			onCreateStandaloneTask,
+			onPublishTask,
+			onArchiveTask,
 			artifactRepo: this.config.artifactRepo,
 			taskRepo: this.config.taskRepo,
 			auditLogRepo: this.auditLogRepo,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4558,7 +4558,11 @@ export class TaskAgentManager {
 						taskId: updated.id,
 						task: updated,
 					})
-					.catch(() => {});
+					.catch((err: unknown) => {
+						log.warn(
+							`Failed to emit space.task.updated (publish) for task ${updated.id}: ${err instanceof Error ? err.message : String(err)}`
+						);
+					});
 				return jsonResult({ success: true, task: updated });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -4578,7 +4582,11 @@ export class TaskAgentManager {
 						taskId: updated.id,
 						task: updated,
 					})
-					.catch(() => {});
+					.catch((err: unknown) => {
+						log.warn(
+							`Failed to emit space.task.updated (archive) for task ${updated.id}: ${err instanceof Error ? err.message : String(err)}`
+						);
+					});
 				return jsonResult({ success: true, task: updated });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -402,6 +402,42 @@ export const RestoreNodeAgentSchema = z.object({
 export type RestoreNodeAgentInput = z.infer<typeof RestoreNodeAgentSchema>;
 
 // ---------------------------------------------------------------------------
+// publish_task
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `publish_task` input.
+ *
+ * Transitions a draft task to open status so the runtime's tick loop can
+ * pick it up for orchestration. Only valid when the task is in `draft` status.
+ */
+export const PublishTaskSchema = z.object({
+	/** UUID of the task to publish. */
+	task_id: z.string().describe('UUID of the draft task to publish (draft → open)'),
+});
+
+export type PublishTaskInput = z.infer<typeof PublishTaskSchema>;
+
+// ---------------------------------------------------------------------------
+// archive_task
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `archive_task` input.
+ *
+ * Transitions a task to archived status — the true terminal state.
+ * Valid from any status that allows the `archived` transition (see
+ * VALID_SPACE_TASK_TRANSITIONS). Archived tasks are excluded from most
+ * queries and cannot be reactivated.
+ */
+export const ArchiveTaskSchema = z.object({
+	/** UUID of the task to archive. */
+	task_id: z.string().describe('UUID of the task to archive'),
+});
+
+export type ArchiveTaskInput = z.infer<typeof ArchiveTaskSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -422,6 +458,8 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
 	list_tasks: ListTasksSchema,
 	get_task: GetTaskSchema,
 	list_audit_entries: ListAuditEntriesSchema,
+	publish_task: PublishTaskSchema,
+	archive_task: ArchiveTaskSchema,
 } as const;
 
 export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -68,6 +68,8 @@ import {
 	ListTasksSchema,
 	GetTaskSchema,
 	ListAuditEntriesSchema,
+	PublishTaskSchema,
+	ArchiveTaskSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
@@ -83,6 +85,8 @@ import type {
 	ListTasksInput,
 	GetTaskInput,
 	ListAuditEntriesInput,
+	PublishTaskInput,
+	ArchiveTaskInput,
 } from './node-agent-tool-schemas';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
@@ -225,6 +229,17 @@ export interface NodeAgentToolsConfig {
 	 * namespace.
 	 */
 	onCreateStandaloneTask?: (args: CreateStandaloneTaskInput) => Promise<ToolResult>;
+	/**
+	 * Optional callback for \`publish_task\`. When provided, node agents can
+	 * publish draft tasks (transition draft → open) without the broader
+	 * space-agent-tools namespace.
+	 */
+	onPublishTask?: (args: PublishTaskInput) => Promise<ToolResult>;
+	/**
+	 * Optional callback for \`archive_task\`. When provided, node agents can
+	 * archive tasks without the broader space-agent-tools namespace.
+	 */
+	onArchiveTask?: (args: ArchiveTaskInput) => Promise<ToolResult>;
 	/**
 	 * Resolves the space's current autonomy level.
 	 * When provided, agent gate writes via send_message are blocked when
@@ -1219,6 +1234,38 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			return result;
 		},
 
+		async publish_task(args: PublishTaskInput): Promise<ToolResult> {
+			if (!config.onPublishTask) {
+				return jsonResult({
+					success: false,
+					error: 'publish_task is not available in this node-agent session.',
+				});
+			}
+			const result = await config.onPublishTask(args);
+			const payload = decodeToolResultPayload(result);
+			if (payload?.success) {
+				const publishedTask = payload?.task as { id: string } | undefined;
+				logAudit('publish_task', { task_id: args.task_id }, publishedTask?.id);
+			}
+			return result;
+		},
+
+		async archive_task(args: ArchiveTaskInput): Promise<ToolResult> {
+			if (!config.onArchiveTask) {
+				return jsonResult({
+					success: false,
+					error: 'archive_task is not available in this node-agent session.',
+				});
+			}
+			const result = await config.onArchiveTask(args);
+			const payload = decodeToolResultPayload(result);
+			if (payload?.success) {
+				const archivedTask = payload?.task as { id: string } | undefined;
+				logAudit('archive_task', { task_id: args.task_id }, archivedTask?.id);
+			}
+			return result;
+		},
+
 		async approve_task(args: ApproveTaskInput): Promise<ToolResult> {
 			if (!config.onApproveTask) {
 				return jsonResult({
@@ -1510,6 +1557,26 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 						'Create a task request in this Space. Runtime may attach and execute a workflow for this task during orchestration. Supports structured task dependencies via depends_on — the task will be blocked until every listed dependency reaches status=done, and cascade-cancelled if a dependency is cancelled.',
 						CreateStandaloneTaskSchema.shape,
 						(args) => handlers.create_standalone_task(args)
+					),
+				]
+			: []),
+		...(config.onPublishTask
+			? [
+					tool(
+						'publish_task',
+						'Publish a draft task, transitioning it from draft to open status. Published tasks become eligible for orchestration by the runtime tick loop. Only valid for tasks currently in draft status.',
+						PublishTaskSchema.shape,
+						(args) => handlers.publish_task(args)
+					),
+				]
+			: []),
+		...(config.onArchiveTask
+			? [
+					tool(
+						'archive_task',
+						"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated. Valid from any status that allows the 'archived' transition (e.g. draft, open, done, cancelled).",
+						ArchiveTaskSchema.shape,
+						(args) => handlers.archive_task(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1574,7 +1574,7 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			? [
 					tool(
 						'archive_task',
-						"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated. Valid from any status that allows the 'archived' transition (e.g. draft, open, done, cancelled).",
+						"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated. Valid from any status that allows the 'archived' transition (e.g. draft, done, cancelled, blocked, review, approved).",
 						ArchiveTaskSchema.shape,
 						(args) => handlers.archive_task(args)
 					),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1778,7 +1778,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'archive_task',
-			"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated — this is the true terminal state. Valid from any status that allows the 'archived' transition (e.g. draft, open, done, cancelled).",
+			"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated — this is the true terminal state. Valid from any status that allows the 'archived' transition (e.g. draft, done, cancelled, blocked, review, approved).",
 			{
 				task_id: z.string().describe('UUID of the task to archive'),
 			},

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -781,6 +781,72 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		},
 
 		/**
+		 * Publish a draft task, transitioning it from `draft` to `open`.
+		 * Published tasks become eligible for the runtime's orchestration tick loop.
+		 * Only valid for tasks currently in `draft` status.
+		 */
+		async publish_task(args: { task_id: string }): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			if (task.spaceId !== spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to this space.`,
+				});
+			}
+			if (task.status !== 'draft') {
+				return jsonResult({
+					success: false,
+					error: `Task is in '${task.status}' status, not 'draft'. Only draft tasks can be published.`,
+				});
+			}
+			try {
+				const updated = await taskManager.publishTask(args.task_id);
+
+				logAudit('publish_task', { previousStatus: task.status }, args.task_id);
+
+				emitTaskUpdated(updated);
+
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Archive a task, transitioning it to `archived` status.
+		 * Archived tasks are excluded from most queries and cannot be reactivated.
+		 * Valid from any status that allows the `archived` transition.
+		 */
+		async archive_task(args: { task_id: string }): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			if (task.spaceId !== spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to this space.`,
+				});
+			}
+			try {
+				const updated = await taskManager.archiveTask(args.task_id);
+
+				logAudit('archive_task', { previousStatus: task.status }, args.task_id);
+
+				emitTaskUpdated(updated);
+
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
 		 * Reassign a task to a different agent.
 		 */
 		async reassign_task(args: {
@@ -1701,6 +1767,22 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.describe('Agent type to assign (coder or general)'),
 			},
 			(args) => handlers.reassign_task(args)
+		),
+		tool(
+			'publish_task',
+			'Publish a draft task, transitioning it from draft to open status. Published tasks become eligible for orchestration by the runtime tick loop. Only valid for tasks in draft status.',
+			{
+				task_id: z.string().describe('UUID of the draft task to publish'),
+			},
+			(args) => handlers.publish_task(args)
+		),
+		tool(
+			'archive_task',
+			"Archive a task. Archived tasks are excluded from most queries and cannot be reactivated — this is the true terminal state. Valid from any status that allows the 'archived' transition (e.g. draft, open, done, cancelled).",
+			{
+				task_id: z.string().describe('UUID of the task to archive'),
+			},
+			(args) => handlers.archive_task(args)
 		),
 
 		// Task agent communication tools

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -333,14 +333,16 @@ describe('SpaceTaskManager', () => {
 
 		it('throws when archiving a task in open status', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
-			await expect(manager.archiveTask(task.id)).rejects.toThrow("Cannot archive task in 'open'");
+			await expect(manager.archiveTask(task.id)).rejects.toThrow(
+				"Invalid status transition from 'open' to 'archived'"
+			);
 		});
 
 		it('throws when archiving a task in in_progress status', async () => {
 			const task = await manager.createTask({ title: 'T', description: '' });
 			await manager.setTaskStatus(task.id, 'in_progress');
 			await expect(manager.archiveTask(task.id)).rejects.toThrow(
-				"Cannot archive task in 'in_progress'"
+				"Invalid status transition from 'in_progress' to 'archived'"
 			);
 		});
 	});

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -30,6 +30,7 @@ import { AgentMessageRouter } from '../../../../src/lib/space/runtime/agent-mess
 import { ChannelResolver } from '../../../../src/lib/space/runtime/channel-resolver.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { McpAuditLogRepository } from '../../../../src/storage/repositories/mcp-audit-log-repository.ts';
+import { jsonResult } from '../../../../src/lib/space/tools/tool-result.ts';
 import type { SpaceWorkflow, Gate, WorkflowChannel } from '@neokai/shared';
 import type {
 	DaemonInternalEventMap,
@@ -3902,5 +3903,175 @@ describe('node-agent-tools: list_audit_entries', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('Audit log repository not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// publish_task
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools \u2014 publish_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('publishes a draft task via callback', async () => {
+		const draftTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Draft task',
+			description: 'Will publish',
+			status: 'draft',
+		});
+
+		const onPublishTask = async (args: { task_id: string }) => {
+			const updated = await ctx.taskManager.publishTask(args.task_id);
+			return jsonResult({ success: true, task: updated });
+		};
+
+		const config = makeConfig(ctx, { onPublishTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.publish_task({ task_id: draftTask.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('open');
+	});
+
+	test('returns error when callback is not available', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.publish_task({ task_id: 'any-id' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not available');
+	});
+
+	test('returns error when callback fails', async () => {
+		const openTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Open task',
+			description: 'Not draft',
+			status: 'open',
+		});
+
+		const onPublishTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await ctx.taskManager.publishTask(args.task_id);
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
+		const config = makeConfig(ctx, { onPublishTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.publish_task({ task_id: openTask.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain("'open'");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// archive_task
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools \u2014 archive_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('archives a draft task via callback', async () => {
+		const draftTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Draft task',
+			description: 'Will archive',
+			status: 'draft',
+		});
+
+		const onArchiveTask = async (args: { task_id: string }) => {
+			const updated = await ctx.taskManager.archiveTask(args.task_id);
+			return jsonResult({ success: true, task: updated });
+		};
+
+		const config = makeConfig(ctx, { onArchiveTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: draftTask.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('archived');
+	});
+
+	test('archives a cancelled task via callback', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Task',
+			description: 'Will cancel then archive',
+			status: 'open',
+		});
+		await ctx.taskManager.cancelTask(task.id);
+
+		const onArchiveTask = async (args: { task_id: string }) => {
+			const updated = await ctx.taskManager.archiveTask(args.task_id);
+			return jsonResult({ success: true, task: updated });
+		};
+
+		const config = makeConfig(ctx, { onArchiveTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: task.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('archived');
+	});
+
+	test('returns error when callback is not available', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: 'any-id' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('not available');
+	});
+
+	test('returns error when trying to archive an already-archived task', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Task',
+			description: 'Already archived',
+			status: 'draft',
+		});
+		await ctx.taskManager.archiveTask(task.id);
+
+		const onArchiveTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await ctx.taskManager.archiveTask(args.task_id);
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
+		const config = makeConfig(ctx, { onArchiveTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: task.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('archived');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -4182,4 +4182,35 @@ describe('node-agent-tools \u2014 archive_task', () => {
 		expect(publishedEvents[0].data.spaceId).toBe(ctx.spaceId);
 		expect(publishedEvents[0].data.sessionId).toBe('global');
 	});
+
+	test('clears pending-completion fields when archiving from review', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Review task',
+			description: 'Will archive from review',
+			status: 'open',
+		});
+		await ctx.taskManager.startTask(task.id);
+		await ctx.taskManager.submitTaskForReview(task.id, {
+			submittedByNodeId: null,
+			reason: 'Test submission',
+		});
+		const reviewTask = ctx.taskRepo.getTask(task.id);
+		expect(reviewTask?.pendingCheckpointType).toBe('task_completion');
+
+		const onArchiveTask = async (args: { task_id: string }) => {
+			const updated = await ctx.taskManager.archiveTask(args.task_id);
+			return jsonResult({ success: true, task: updated });
+		};
+
+		const config = makeConfig(ctx, { onArchiveTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: task.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('archived');
+		expect(data.task.pendingCheckpointType).toBeNull();
+		expect(data.task.pendingCompletionSubmittedByNodeId).toBeNull();
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -3977,6 +3977,60 @@ describe('node-agent-tools \u2014 publish_task', () => {
 		expect(data.success).toBe(false);
 		expect(data.error).toContain("'open'");
 	});
+	test('callback emits space.task.updated event after publishing', async () => {
+		const draftTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Draft task',
+			description: 'Event emission test',
+			status: 'draft',
+		});
+
+		const publishedEvents: Array<{
+			event: string;
+			data: { sessionId: string; spaceId: string; taskId: string };
+		}> = [];
+		const mockEventBus = {
+			publish: async (
+				event: string,
+				data: { sessionId: string; spaceId: string; taskId: string }
+			) => {
+				publishedEvents.push({ event, data });
+				return { delivered: 1, failures: [] };
+			},
+		} as unknown as InternalEventBus<DaemonInternalEventMap>;
+
+		// This callback mirrors the wiring in task-agent-manager.ts
+		const onPublishTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await ctx.taskManager.publishTask(args.task_id);
+				mockEventBus
+					?.publish('space.task.updated', {
+						sessionId: 'global',
+						spaceId: ctx.spaceId,
+						taskId: updated.id,
+						task: updated,
+					})
+					.catch(() => {});
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
+		const config = makeConfig(ctx, { onPublishTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.publish_task({ task_id: draftTask.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('open');
+		expect(publishedEvents).toHaveLength(1);
+		expect(publishedEvents[0].event).toBe('space.task.updated');
+		expect(publishedEvents[0].data.taskId).toBe(draftTask.id);
+		expect(publishedEvents[0].data.spaceId).toBe(ctx.spaceId);
+		expect(publishedEvents[0].data.sessionId).toBe('global');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -4073,5 +4127,59 @@ describe('node-agent-tools \u2014 archive_task', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('archived');
+	});
+	test('callback emits space.task.updated event after archiving', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Draft task',
+			description: 'Event emission test',
+			status: 'draft',
+		});
+
+		const publishedEvents: Array<{
+			event: string;
+			data: { sessionId: string; spaceId: string; taskId: string };
+		}> = [];
+		const mockEventBus = {
+			publish: async (
+				event: string,
+				data: { sessionId: string; spaceId: string; taskId: string }
+			) => {
+				publishedEvents.push({ event, data });
+				return { delivered: 1, failures: [] };
+			},
+		} as unknown as InternalEventBus<DaemonInternalEventMap>;
+
+		// This callback mirrors the wiring in task-agent-manager.ts
+		const onArchiveTask = async (args: { task_id: string }) => {
+			try {
+				const updated = await ctx.taskManager.archiveTask(args.task_id);
+				mockEventBus
+					?.publish('space.task.updated', {
+						sessionId: 'global',
+						spaceId: ctx.spaceId,
+						taskId: updated.id,
+						task: updated,
+					})
+					.catch(() => {});
+				return jsonResult({ success: true, task: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		};
+
+		const config = makeConfig(ctx, { onArchiveTask });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.archive_task({ task_id: task.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.status).toBe('archived');
+		expect(publishedEvents).toHaveLength(1);
+		expect(publishedEvents[0].event).toBe('space.task.updated');
+		expect(publishedEvents[0].data.taskId).toBe(task.id);
+		expect(publishedEvents[0].data.spaceId).toBe(ctx.spaceId);
+		expect(publishedEvents[0].data.sessionId).toBe('global');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3071,3 +3071,208 @@ describe('createSpaceAgentToolHandlers — update_task', () => {
 		expect(names).toContain('update_task');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// publish_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — publish_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('publishes a draft task to open', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Draft task',
+			description: 'Created as draft',
+			draft: true,
+		});
+		const parsed = JSON.parse(createResult.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('draft');
+		const taskId = parsed.task.id;
+
+		const result = await makeHandlers(ctx).publish_task({ task_id: taskId });
+		const publishParsed = JSON.parse(result.content[0].text);
+		expect(publishParsed.success).toBe(true);
+		expect(publishParsed.task.status).toBe('open');
+		expect(publishParsed.task.id).toBe(taskId);
+	});
+
+	test('returns error when task is not in draft status', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Open task',
+			description: 'Created as open',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).publish_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain("not 'draft'");
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).publish_task({ task_id: 'task-nonexistent' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not found');
+	});
+
+	test('returns error when task belongs to different space', async () => {
+		// Create task in current space
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Draft',
+			description: 'Test',
+			draft: true,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Create handlers for a different space
+		const otherSpaceId = 'space-other';
+		seedSpaceRow(ctx.db, otherSpaceId);
+		const otherTaskManager = new SpaceTaskManager(ctx.db, otherSpaceId);
+		const otherHandlers = createSpaceAgentToolHandlers({
+			spaceId: otherSpaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: otherTaskManager,
+			spaceAgentManager: ctx.agentManager,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+		});
+
+		const result = await otherHandlers.publish_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('does not belong');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// archive_task
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — archive_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('archives a draft task', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Draft task',
+			description: 'Will archive',
+			draft: true,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).archive_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('archived');
+		expect(parsed.task.archivedAt).toBeTruthy();
+	});
+
+	test('archives a done task', async () => {
+		const t = await ctx.taskManager.createTask({ title: 'T', description: 'Done' });
+		await ctx.taskManager.startTask(t.id);
+		await ctx.taskManager.completeTask(t.id, 'done');
+
+		const result = await makeHandlers(ctx).archive_task({ task_id: t.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('archived');
+	});
+
+	test('archives a cancelled task', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Cancel then archive',
+			description: 'Will cancel and archive',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Cancel first
+		await makeHandlers(ctx).cancel_task({ task_id: taskId });
+
+		const result = await makeHandlers(ctx).archive_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('archived');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).archive_task({ task_id: 'task-nonexistent' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not found');
+	});
+
+	test('returns error when task belongs to different space', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Draft',
+			description: 'Test',
+			draft: true,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const otherSpaceId = 'space-other-2';
+		seedSpaceRow(ctx.db, otherSpaceId);
+		const otherTaskManager = new SpaceTaskManager(ctx.db, otherSpaceId);
+		const otherHandlers = createSpaceAgentToolHandlers({
+			spaceId: otherSpaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: otherTaskManager,
+			spaceAgentManager: ctx.agentManager,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+		});
+
+		const result = await otherHandlers.archive_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('does not belong');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cancel_task on draft (verifies error message consistency)
+// ---------------------------------------------------------------------------
+
+describe('cancel_task on draft — error message consistency', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('cancel_task on draft returns error with allowed transitions', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Draft task',
+			description: 'Cannot cancel',
+			draft: true,
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).cancel_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain("'draft'");
+		expect(parsed.error).toContain("'cancelled'");
+		// Should mention what transitions ARE allowed from draft
+		expect(parsed.error).toContain('open');
+		expect(parsed.error).toContain('archived');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3243,6 +3243,51 @@ describe('createSpaceAgentToolHandlers — archive_task', () => {
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('does not belong');
 	});
+
+	test('clears pending-completion fields when archiving from review', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Review task',
+			description: 'Will archive from review',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Submit for review to set pendingCheckpointType
+		await ctx.taskManager.submitTaskForReview(taskId, {
+			submittedByNodeId: null,
+			reason: 'Test submission',
+		});
+		const reviewTask = ctx.taskRepo.getTask(taskId);
+		expect(reviewTask?.pendingCheckpointType).toBe('task_completion');
+
+		const result = await makeHandlers(ctx).archive_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('archived');
+		// setTaskStatus cleanup should have cleared pending-completion fields
+		expect(parsed.task.pendingCheckpointType).toBeNull();
+		expect(parsed.task.pendingCompletionSubmittedByNodeId).toBeNull();
+		expect(parsed.task.pendingCompletionReason).toBeNull();
+	});
+
+	test('clears post-approval fields when archiving from approved', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Approved task',
+			description: 'Will archive from approved',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Transition to in_progress then approved (via setTaskStatus)
+		await ctx.taskManager.startTask(taskId);
+		await ctx.taskManager.setTaskStatus(taskId, 'approved', {
+			approvalSource: 'human',
+			approvalReason: 'LGTM',
+		});
+
+		const result = await makeHandlers(ctx).archive_task({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('archived');
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `publish_task` MCP tool for draft → open transition, enabling tasks created with `create_standalone_task({ draft: true })` to be published for orchestration
- Add `archive_task` MCP tool for transitioning tasks to the terminal archived state from any valid source status
- Wire up both tools in space-agent-tools (always available), node-agent-tools (via optional callbacks), and TaskAgentManager

Closes #1892

## Test plan
- [x] Unit tests for `publish_task` in space-agent-tools: draft→open, non-draft rejection, not-found, cross-space guard
- [x] Unit tests for `archive_task` in space-agent-tools: draft→archived, done→archived, cancelled→archived, not-found, cross-space guard
- [x] Unit tests for `cancel_task` on draft: verifies error message lists correct allowed transitions (open, archived)
- [x] Unit tests for `publish_task` and `archive_task` in node-agent-tools: callback delegation, error propagation, missing callback
- [x] All existing tests pass, lint/typecheck/knip clean