### PR TITLE
fix: watchdog process group kills, exit promise aggregation, root PID retention

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1243,9 +1243,15 @@ export class AgentSession
 	trackAgentProcess(proc: TrackedAgentProcess): void {
 		const pid = proc.pid;
 		if (typeof pid !== 'number' || pid <= 0) {
-			this.processExitedPromise = new Promise<void>((resolve) => {
+			// Don't overwrite processExitedPromise — other tracked SDK roots may
+			// still be running and stop() relies on the aggregated promise.
+			const noPidExitPromise = new Promise<void>((resolve) => {
 				proc.once('exit', () => resolve());
 			});
+			const existing = this.processExitedPromise;
+			this.processExitedPromise = existing
+				? Promise.all([existing, noPidExitPromise]).then(() => {})
+				: noPidExitPromise;
 			return;
 		}
 

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -120,12 +120,15 @@ export async function cleanupSuspiciousProcesses(options?: {
 		if (!threshold) continue;
 
 		try {
-			// Signal the entire process group first (reaches tool-wrapper children).
+			// Signal the entire process group first (reaches tool-wrapper children),
+			// but only if the group leader is not a live root — otherwise we'd kill
+			// an active SDK session that happens to have a suspicious descendant.
 			if (
 				typeof snapshot.pgid === 'number' &&
 				Number.isFinite(snapshot.pgid) &&
 				snapshot.pgid > 0 &&
-				snapshot.pgid !== snapshot.pid
+				snapshot.pgid !== snapshot.pid &&
+				!liveRoots.has(snapshot.pgid)
 			) {
 				try {
 					killer(-snapshot.pgid, 'SIGTERM');

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -120,11 +120,24 @@ export async function cleanupSuspiciousProcesses(options?: {
 		if (!threshold) continue;
 
 		try {
+			// Signal the entire process group first (reaches tool-wrapper children).
+			if (
+				typeof snapshot.pgid === 'number' &&
+				Number.isFinite(snapshot.pgid) &&
+				snapshot.pgid > 0 &&
+				snapshot.pgid !== snapshot.pid
+			) {
+				try {
+					killer(-snapshot.pgid, 'SIGTERM');
+				} catch {
+					// Process group may have already exited — fall through to direct signal.
+				}
+			}
 			killer(snapshot.pid, 'SIGTERM');
 			killed++;
 			logger.warn(
 				`Killing suspicious daemon-owned long-running process pid=${snapshot.pid} ppid=${snapshot.ppid} ` +
-					`runtimeMs=${runtimeMs} thresholdMs=${threshold.thresholdMs} command=${snapshot.command}`
+					`pgid=${snapshot.pgid ?? 'n/a'} runtimeMs=${runtimeMs} thresholdMs=${threshold.thresholdMs} command=${snapshot.command}`
 			);
 		} catch (error) {
 			logger.warn(

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -27,6 +27,9 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
+
+/** Retain recently-exited PID roots for 15 minutes after session eviction. */
+const RECENTLY_EXITED_ROOT_PID_RETENTION_MS = 15 * 60 * 1000;
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
@@ -75,6 +78,17 @@ export class SessionManager {
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
 	private hardResetInFlight = new Map<string, Promise<{ success: boolean; error?: string }>>();
+
+	/**
+	 * Exited PID roots retained at the SessionManager level so the watchdog
+	 * keeps ownership attribution even after AgentSessions are evicted from
+	 * the sessionCache (e.g. via interruptInMemorySession).
+	 *
+	 * Keyed by PID → exit timestamp, same semantics as
+	 * AgentSession.recentlyExitedAgentRootPids. Expired by the
+	 * RECENTLY_EXITED_ROOT_PID_RETENTION_MS constant (15 min).
+	 */
+	private recentlyExitedRootPids = new Map<number, number>();
 
 	// Extracted modules
 	private sessionCache: SessionCache;
@@ -423,7 +437,20 @@ export class SessionManager {
 			live.push(...split.live);
 			exited.push(...split.exited);
 		}
+		// Merge manager-level retained exited PIDs (survive cache eviction).
+		this.expireRecentlyExitedRootPids();
+		for (const pid of this.recentlyExitedRootPids.keys()) {
+			exited.push(pid);
+		}
 		return { live, exited };
+	}
+
+	private expireRecentlyExitedRootPids(now = Date.now()): void {
+		for (const [pid, exitedAt] of this.recentlyExitedRootPids) {
+			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
+				this.recentlyExitedRootPids.delete(pid);
+			}
+		}
 	}
 
 	/**
@@ -440,6 +467,16 @@ export class SessionManager {
 	 * Space runtime callers will be added as that subsystem is wired up.
 	 */
 	unregisterSession(sessionId: string): void {
+		const agentSession = this.sessionCache.get(sessionId);
+		if (agentSession && typeof agentSession.getTrackedAgentRootPidsSplit === 'function') {
+			// Capture exited PIDs before eviction so the watchdog retains ownership.
+			const split = agentSession.getTrackedAgentRootPidsSplit();
+			for (const pid of split.exited) {
+				if (!this.recentlyExitedRootPids.has(pid)) {
+					this.recentlyExitedRootPids.set(pid, Date.now());
+				}
+			}
+		}
 		this.sessionCache.remove(sessionId);
 	}
 
@@ -549,6 +586,13 @@ export class SessionManager {
 					error
 				);
 			}
+			// Capture exited PIDs before eviction so the watchdog retains ownership.
+			const split = agentSession.getTrackedAgentRootPidsSplit();
+			for (const pid of split.exited) {
+				if (!this.recentlyExitedRootPids.has(pid)) {
+					this.recentlyExitedRootPids.set(pid, Date.now());
+				}
+			}
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -635,6 +679,7 @@ export class SessionManager {
 			// Clear session cache
 			this.sessionCache.clear();
 			this.hardResetInFlight.clear();
+			this.recentlyExitedRootPids.clear();
 
 			// Transition to CLEANED state
 			this.cleanupState = CleanupState.CLEANED;

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -467,13 +467,16 @@ export class SessionManager {
 	 * Space runtime callers will be added as that subsystem is wired up.
 	 */
 	unregisterSession(sessionId: string): void {
-		const agentSession = this.sessionCache.get(sessionId);
-		if (agentSession && typeof agentSession.getTrackedAgentRootPidsSplit === 'function') {
-			// Capture exited PIDs before eviction so the watchdog retains ownership.
-			const split = agentSession.getTrackedAgentRootPidsSplit();
-			for (const pid of split.exited) {
-				if (!this.recentlyExitedRootPids.has(pid)) {
-					this.recentlyExitedRootPids.set(pid, Date.now());
+		// Use has() to avoid triggering a DB lazy-load via get().
+		if (this.sessionCache.has(sessionId)) {
+			const agentSession = this.sessionCache.get(sessionId);
+			if (agentSession && typeof agentSession.getTrackedAgentRootPidsSplit === 'function') {
+				// Capture exited PIDs before eviction so the watchdog retains ownership.
+				const split = agentSession.getTrackedAgentRootPidsSplit();
+				for (const pid of split.exited) {
+					if (!this.recentlyExitedRootPids.has(pid)) {
+						this.recentlyExitedRootPids.set(pid, Date.now());
+					}
 				}
 			}
 		}

--- a/packages/daemon/tests/unit/1-core/agent/agent-session-process-tracking.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session-process-tracking.test.ts
@@ -1,0 +1,194 @@
+/**
+ * AgentSession — Process Tracking Tests
+ *
+ * Tests for trackAgentProcess PID tracking, exit promises, and
+ * processExitedPromise aggregation behavior.
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import type { Session, MessageHub } from '@neokai/shared';
+import type { Database } from '../../../../src/storage/database';
+import type { InternalEventBus } from '../../../../src/lib/internal-event-bus';
+import { AgentSession } from '../../../../src/lib/agent/agent-session';
+import type { TrackedAgentProcess } from '../../../../src/lib/agent/query-runner';
+import { EventEmitter } from 'node:events';
+
+function createMockProcess(pid: number | undefined): TrackedAgentProcess {
+	const ee = new EventEmitter() as TrackedAgentProcess;
+	ee.pid = pid;
+	ee.kill = mock(() => true);
+	ee.once = ee.once.bind(ee);
+	ee.emit = ee.emit.bind(ee);
+	return ee;
+}
+
+function createBaseSession(): Session {
+	return {
+		id: 'test-process-tracking',
+		title: 'Test',
+		workspacePath: '/test',
+		createdAt: new Date().toISOString(),
+		lastActiveAt: new Date().toISOString(),
+		status: 'active',
+		config: { model: 'default', maxTokens: 8192, temperature: 1.0 },
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+		},
+	};
+}
+
+function createAgentSession(): AgentSession {
+	const session = createBaseSession();
+	const db = {
+		updateSession: mock(() => {}),
+		getSession: mock(() => session),
+		getSDKMessages: mock(() => ({ messages: [], hasMore: false })),
+		getSDKMessageCount: mock(() => 0),
+		getMessagesByStatus: mock(() => []),
+		saveSDKMessage: mock(() => {}),
+		saveNeokaiActionMessage: mock(() => {}),
+		mcpEnablement: { getEnablementForScope: mock(() => ({})) } as any,
+	} as unknown as Database;
+
+	const messageHub = {
+		event: mock(async () => {}),
+		onRequest: mock(() => () => {}),
+		query: mock(async () => ({})),
+		command: mock(async () => {}),
+	} as unknown as MessageHub;
+
+	const internalEventBus = {
+		publish: mock(async () => {}),
+		publishAsync: mock(async () => {}),
+		subscribe: mock(() => () => {}),
+	} as unknown as InternalEventBus<any>;
+
+	const getApiKey = mock(async () => 'test-key');
+
+	return new AgentSession(session, db, messageHub, internalEventBus, getApiKey);
+}
+
+describe('AgentSession — process tracking', () => {
+	describe('trackAgentProcess', () => {
+		it('sets processExitedPromise for numeric PID', () => {
+			const sut = createAgentSession();
+			const proc = createMockProcess(1234);
+
+			sut.trackAgentProcess(proc);
+
+			expect(sut.processExitedPromise).not.toBeNull();
+		});
+
+		it('aggregates exit promises across multiple tracked processes', () => {
+			const sut = createAgentSession();
+			const proc1 = createMockProcess(100);
+			const proc2 = createMockProcess(200);
+
+			sut.trackAgentProcess(proc1);
+			sut.trackAgentProcess(proc2);
+
+			expect(sut.processExitedPromise).not.toBeNull();
+		});
+
+		it('preserves existing processExitedPromise when no-PID process is tracked', async () => {
+			const sut = createAgentSession();
+
+			// Track a real process first
+			const realProc = createMockProcess(100);
+			sut.trackAgentProcess(realProc);
+			const firstPromise = sut.processExitedPromise;
+			expect(firstPromise).not.toBeNull();
+
+			// Track a no-PID process (spawn failure path)
+			const noPidProc = createMockProcess(undefined);
+			sut.trackAgentProcess(noPidProc);
+
+			// processExitedPromise should be a NEW promise that aggregates both,
+			// not a replacement that drops the first.
+			expect(sut.processExitedPromise).not.toBe(firstPromise);
+			expect(sut.processExitedPromise).not.toBeNull();
+
+			// The new promise should resolve only when BOTH exit promises resolve.
+			// Emit exit for the no-PID process — the aggregated promise should NOT resolve yet
+			// because the real process hasn't exited.
+			let resolved = false;
+			sut.processExitedPromise!.then(() => {
+				resolved = true;
+			});
+
+			(noPidProc as unknown as EventEmitter).emit('exit');
+			// Give microtask queue a tick
+			await new Promise((r) => setTimeout(r, 5));
+			expect(resolved).toBe(false);
+
+			// Now emit exit for the real process
+			(realProc as unknown as EventEmitter).emit('exit');
+			await new Promise((r) => setTimeout(r, 5));
+			expect(resolved).toBe(true);
+		});
+
+		it('handles no-PID process when processExitedPromise is null', async () => {
+			const sut = createAgentSession();
+			expect(sut.processExitedPromise).toBeNull();
+
+			const noPidProc = createMockProcess(undefined);
+			sut.trackAgentProcess(noPidProc);
+
+			expect(sut.processExitedPromise).not.toBeNull();
+
+			let resolved = false;
+			sut.processExitedPromise!.then(() => {
+				resolved = true;
+			});
+
+			(noPidProc as unknown as EventEmitter).emit('exit');
+			await new Promise((r) => setTimeout(r, 5));
+			expect(resolved).toBe(true);
+		});
+	});
+
+	describe('getTrackedAgentRootPidsSplit', () => {
+		it('returns live and exited PIDs', async () => {
+			const sut = createAgentSession();
+			const proc1 = createMockProcess(100);
+			const proc2 = createMockProcess(200);
+
+			sut.trackAgentProcess(proc1);
+			sut.trackAgentProcess(proc2);
+
+			let split = sut.getTrackedAgentRootPidsSplit();
+			expect(split.live).toEqual([100, 200]);
+			expect(split.exited).toEqual([]);
+
+			// Simulate exit of proc1
+			(proc1 as unknown as EventEmitter).emit('exit');
+			await new Promise((r) => setTimeout(r, 5));
+
+			split = sut.getTrackedAgentRootPidsSplit();
+			expect(split.live).toEqual([200]);
+			expect(split.exited).toEqual([100]);
+		});
+	});
+
+	describe('terminateTrackedAgentProcesses', () => {
+		it('signals process groups on terminate', () => {
+			const sut = createAgentSession();
+			const proc = createMockProcess(100);
+			sut.trackAgentProcess(proc);
+
+			// Access the internal state via snapshot
+			const snapshot = sut.snapshotTrackedAgentProcesses();
+			expect(snapshot.length).toBe(1);
+
+			sut.terminateTrackedAgentProcesses({ processes: snapshot, forceDelayMs: 99999 });
+
+			// kill should have been called
+			expect((proc.kill as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThanOrEqual(1);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -28,6 +28,7 @@ describe('process-watchdog', () => {
 				{
 					pid: 123,
 					ppid: 100,
+					pgid: 123,
 					elapsedSeconds: 16 * 60,
 					command: 'bun test tests/unit/leaky.test.ts',
 				},
@@ -230,5 +231,65 @@ describe('process-watchdog', () => {
 
 		expect(cleanupCalls).toBeGreaterThan(0);
 		expect(cleanupCalls).toBe(callsAfterStop);
+	});
+
+	test('signals process group when pgid differs from pid', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 200,
+					ppid: 100,
+					pgid: 100, // same group as root — tool wrapper grandchildren
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Should signal the process group first, then the individual process.
+		expect(killProcess).toHaveBeenCalledWith(-100, 'SIGTERM');
+		expect(killProcess).toHaveBeenCalledWith(200, 'SIGTERM');
+	});
+
+	test('does not signal process group when pgid equals pid', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 200,
+					ppid: 100,
+					pgid: 200, // own group — no group signal needed
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Only direct signal, no group signal.
+		expect(killProcess).toHaveBeenCalledWith(200, 'SIGTERM');
+		expect(killProcess).not.toHaveBeenCalledWith(-200, 'SIGTERM');
 	});
 });

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -233,7 +233,7 @@ describe('process-watchdog', () => {
 		expect(cleanupCalls).toBe(callsAfterStop);
 	});
 
-	test('signals process group when pgid differs from pid', async () => {
+	test('signals process group when pgid is not a live root', async () => {
 		const killProcess = mock(() => {});
 
 		const killed = await cleanupSuspiciousProcesses({
@@ -248,7 +248,7 @@ describe('process-watchdog', () => {
 				{
 					pid: 200,
 					ppid: 100,
-					pgid: 100, // same group as root — tool wrapper grandchildren
+					pgid: 150, // group leader (150) is NOT a live root
 					elapsedSeconds: 16 * 60,
 					command: 'bun test tests/unit/leaky.test.ts',
 				},
@@ -259,8 +259,38 @@ describe('process-watchdog', () => {
 
 		expect(killed).toBe(1);
 		// Should signal the process group first, then the individual process.
-		expect(killProcess).toHaveBeenCalledWith(-100, 'SIGTERM');
+		expect(killProcess).toHaveBeenCalledWith(-150, 'SIGTERM');
 		expect(killProcess).toHaveBeenCalledWith(200, 'SIGTERM');
+	});
+
+	test('does not signal process group when pgid is a live root', async () => {
+		const killProcess = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 200,
+					ppid: 100,
+					pgid: 100, // same group as live root — must NOT signal group
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Only direct signal — group signal skipped because PGID is a live root.
+		expect(killProcess).toHaveBeenCalledWith(200, 'SIGTERM');
+		expect(killProcess).not.toHaveBeenCalledWith(-100, 'SIGTERM');
 	});
 
 	test('does not signal process group when pgid equals pid', async () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -331,6 +331,37 @@ describe('SessionManager', () => {
 			const result = await sessionManager.getSessionAsync('room:1:task:2:xyz');
 			expect(result).toBeNull();
 		});
+
+		it('unregisterSession preserves exited PIDs at manager level', () => {
+			const mockSession: Session = {
+				id: 'room:1:task:2:pids',
+				title: 'PID Session',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {}),
+				getTrackedAgentRootPidsSplit: mock(() => ({
+					live: [],
+					exited: [500, 600],
+				})),
+			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+
+			// Before unregister: exited PIDs come from the session
+			let split = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(split.exited).toEqual([500, 600]);
+
+			sessionManager.unregisterSession('room:1:task:2:pids');
+
+			// After unregister: exited PIDs survive at manager level
+			split = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(split.exited).toEqual([500, 600]);
+		});
 	});
 
 	describe('listSessions', () => {


### PR DESCRIPTION
Addresses 3 P2 review comments from PR #1890 (post-merge).

**1. Watchdog signals process groups** (`process-watchdog.ts`)
`cleanupSuspiciousProcesses` now sends `SIGTERM` to the process group (`-pgid`) before the individual PID, reaching tool-wrapper children that the parent may not forward signals to.

**2. No-PID early return preserves exit promise** (`agent-session.ts`)
`trackAgentProcess` no-PID path now aggregates with existing `processExitedPromise` instead of replacing it. Prevents `stop()` from waiting on the wrong promise when multiple SDK roots are tracked concurrently.

**3. SessionManager retains exited PIDs after cache eviction** (`session-manager.ts`)
Manager-level `recentlyExitedRootPids` map captures exited PIDs from sessions being removed via `unregisterSession`/`interruptInMemorySession`, ensuring the watchdog retains ownership for the full 15-min retention window.