### PR TITLE
fix: address P2 review comments on process cleanup (#1890)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -53,7 +53,11 @@ import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from 
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
 import { NeoAgentManager } from './lib/neo/neo-agent-manager';
-import { cleanupSuspiciousProcesses, ProcessWatchdog } from './lib/process-watchdog';
+import {
+	cleanupSuspiciousProcesses,
+	ProcessWatchdog,
+	type ProcessSnapshot,
+} from './lib/process-watchdog';
 
 export interface CreateDaemonAppOptions {
 	config: Config;
@@ -197,11 +201,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	let taskAgentManager: TaskAgentManager | null = null;
 	const processWatchdog = new ProcessWatchdog(undefined, () =>
 		cleanupSuspiciousProcesses({
-			getRootPids: () => {
+			getRootPids: (snapshot?: ProcessSnapshot[]) => {
 				const live: number[] = [];
 				const exited: number[] = [];
 				if (sessionManager) {
-					const split = sessionManager.getTrackedAgentRootPidsSplit();
+					const split = sessionManager.getTrackedAgentRootPidsSplit(snapshot);
 					live.push(...split.live);
 					exited.push(...split.exited);
 				}

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1395,6 +1395,17 @@ export class AgentSession
 			exitPromises.length > 0 ? Promise.all(exitPromises).then(() => {}) : null;
 	}
 
+	/**
+	 * Clear processExitedPromise and any stale no-PID exit promises.
+	 * Called when retry paths time out and abandon the current wait.
+	 * Without this, unresolved no-PID promises accumulate and block
+	 * future teardown waits for processes that were already abandoned.
+	 */
+	resetProcessExitedPromise(): void {
+		this.noPidExitPromises.length = 0;
+		this.processExitedPromise = null;
+	}
+
 	private expireRecentlyExitedAgentRootPids(now = Date.now()): void {
 		for (const [pid, exitedAt] of this.recentlyExitedAgentRootPids) {
 			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -98,7 +98,7 @@ import { Logger } from '../logger';
 import { SettingsManager } from '../settings-manager';
 import { DEFAULT_WORKER_FEATURES as WORKER_FEATURES } from '@neokai/shared';
 
-const RECENTLY_EXITED_ROOT_PID_RETENTION_MS = 15 * 60 * 1000;
+export const RECENTLY_EXITED_ROOT_PID_RETENTION_MS = 15 * 60 * 1000;
 
 /**
  * AgentSessionInit - Configuration for creating a new AgentSession
@@ -1243,9 +1243,15 @@ export class AgentSession
 	trackAgentProcess(proc: TrackedAgentProcess): void {
 		const pid = proc.pid;
 		if (typeof pid !== 'number' || pid <= 0) {
-			this.processExitedPromise = new Promise<void>((resolve) => {
+			// Aggregate the no-PID exit promise alongside existing tracked
+			// process exit promises instead of overwriting processExitedPromise.
+			// Overwriting would lose the aggregated state of numeric-PID
+			// processes still being tracked during restart/overlap.
+			const noPidExitPromise = new Promise<void>((resolve) => {
 				proc.once('exit', () => resolve());
 			});
+			const existingPromises = [...this.trackedAgentProcessExitPromises.values(), noPidExitPromise];
+			this.processExitedPromise = Promise.all(existingPromises).then(() => {});
 			return;
 		}
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -300,6 +300,8 @@ export class AgentSession
 	processExitedPromise: Promise<void> | null = null;
 	private trackedAgentProcesses = new Map<number, TrackedAgentProcess>();
 	private trackedAgentProcessExitPromises = new Map<number, Promise<void>>();
+	/** Durable no-PID exit promises — retained until resolved so updateProcessExitedPromise() never drops them. */
+	private noPidExitPromises: Promise<void>[] = [];
 	private recentlyExitedAgentRootPids = new Map<number, number>();
 	private forceKillTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
@@ -1243,15 +1245,19 @@ export class AgentSession
 	trackAgentProcess(proc: TrackedAgentProcess): void {
 		const pid = proc.pid;
 		if (typeof pid !== 'number' || pid <= 0) {
-			// Aggregate the no-PID exit promise alongside existing tracked
-			// process exit promises instead of overwriting processExitedPromise.
-			// Overwriting would lose the aggregated state of numeric-PID
-			// processes still being tracked during restart/overlap.
+			// Store no-PID promises in a durable collection so
+			// updateProcessExitedPromise() includes them on every rebuild
+			// (e.g. when a later numeric-PID process is tracked).
 			const noPidExitPromise = new Promise<void>((resolve) => {
-				proc.once('exit', () => resolve());
+				proc.once('exit', () => {
+					// Self-clean from the durable collection once resolved.
+					const idx = this.noPidExitPromises.indexOf(noPidExitPromise);
+					if (idx >= 0) this.noPidExitPromises.splice(idx, 1);
+					resolve();
+				});
 			});
-			const existingPromises = [...this.trackedAgentProcessExitPromises.values(), noPidExitPromise];
-			this.processExitedPromise = Promise.all(existingPromises).then(() => {});
+			this.noPidExitPromises.push(noPidExitPromise);
+			this.updateProcessExitedPromise();
 			return;
 		}
 
@@ -1371,7 +1377,10 @@ export class AgentSession
 	}
 
 	private updateProcessExitedPromise(): void {
-		const exitPromises = [...this.trackedAgentProcessExitPromises.values()];
+		const exitPromises = [
+			...this.trackedAgentProcessExitPromises.values(),
+			...this.noPidExitPromises,
+		];
 		this.processExitedPromise =
 			exitPromises.length > 0 ? Promise.all(exitPromises).then(() => {}) : null;
 	}

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1294,6 +1294,16 @@ export class AgentSession
 		};
 	}
 
+	/**
+	 * Returns exit timestamps for recently-exited agent root PIDs.
+	 * Used by SessionManager to preserve accurate retention windows
+	 * when snapshots are transferred to the evicted-root maps.
+	 */
+	getExitedRootPidTimestamps(): Map<number, number> {
+		this.expireRecentlyExitedAgentRootPids();
+		return new Map(this.recentlyExitedAgentRootPids);
+	}
+
 	snapshotTrackedAgentProcesses(): Array<[number, TrackedAgentProcess]> {
 		return [...this.trackedAgentProcesses];
 	}

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -62,6 +62,8 @@ export interface QueryLifecycleManagerContext {
 	firstMessageReceived: boolean;
 	/** Resolves when the SDK subprocess exits. Used by stop() to wait deterministically. */
 	processExitedPromise: Promise<void> | null;
+	/** Clear processExitedPromise and any stale no-PID exit promises. */
+	resetProcessExitedPromise(): void;
 	/** SDK startup timeout timer — must be cleared during stop() to prevent stale timers. */
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
 	/** Abort controller for the current query — must be cleared during stop(). */
@@ -308,7 +310,7 @@ export class QueryLifecycleManager {
 				processExitedPromise,
 				new Promise((resolve) => setTimeout(resolve, timeoutMs)),
 			]);
-			this.ctx.processExitedPromise = null;
+			this.ctx.resetProcessExitedPromise();
 		}
 
 		// 7. Clear stale startup timer and abort controller.

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -123,6 +123,8 @@ export interface QueryRunnerContext {
 	originalEnvVars: OriginalEnvVars;
 	/** Resolves when tracked SDK subprocesses exit. Set by QueryRunner via spawnClaudeCodeProcess wrapper. */
 	processExitedPromise: Promise<void> | null;
+	/** Clear processExitedPromise and any stale no-PID exit promises. */
+	resetProcessExitedPromise(): void;
 	trackAgentProcess(proc: TrackedAgentProcess): void;
 	snapshotTrackedAgentProcesses(): Array<[number, TrackedAgentProcess]>;
 	// Methods for state coordination
@@ -681,7 +683,7 @@ export class QueryRunner {
 						exitPromise,
 						new Promise((resolve) => setTimeout(resolve, RETRY_EXIT_TIMEOUT_MS)),
 					]);
-					this.ctx.processExitedPromise = null;
+					this.ctx.resetProcessExitedPromise();
 				}
 
 				// Use `return await` so this call's finally{} runs only after the retry
@@ -713,7 +715,7 @@ export class QueryRunner {
 						exitPromise,
 						new Promise((resolve) => setTimeout(resolve, RETRY_EXIT_TIMEOUT_MS)),
 					]);
-					this.ctx.processExitedPromise = null;
+					this.ctx.resetProcessExitedPromise();
 				}
 
 				return await this.runQuery(queryGeneration, true);
@@ -771,7 +773,7 @@ export class QueryRunner {
 						exitPromise,
 						new Promise((resolve) => setTimeout(resolve, RETRY_EXIT_TIMEOUT_MS)),
 					]);
-					this.ctx.processExitedPromise = null;
+					this.ctx.resetProcessExitedPromise();
 				}
 
 				return await this.runQuery(queryGeneration, true);
@@ -921,7 +923,7 @@ export class QueryRunner {
 				// previous generation being observed by stop() after a restart: without
 				// this clear, a future stop() call on a new query could snapshot a stale
 				// resolved promise and skip the real wait for the new subprocess's exit.
-				this.ctx.processExitedPromise = null;
+				this.ctx.resetProcessExitedPromise();
 
 				messageQueue.stop();
 

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -138,7 +138,8 @@ export async function cleanupSuspiciousProcesses(options?: {
 			if (
 				typeof snapshot.pgid === 'number' &&
 				Number.isFinite(snapshot.pgid) &&
-				snapshot.pgid > 0
+				snapshot.pgid > 1 &&
+				ownedPids.has(snapshot.pgid)
 			) {
 				try {
 					groupKiller(snapshot.pgid, 'SIGTERM');

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -140,7 +140,11 @@ export async function cleanupSuspiciousProcesses(options?: {
 				Number.isFinite(snapshot.pgid) &&
 				snapshot.pgid > 0
 			) {
-				groupKiller(snapshot.pgid, 'SIGTERM');
+				try {
+					groupKiller(snapshot.pgid, 'SIGTERM');
+				} catch {
+					// Group kill failed; fall through to direct PID signal.
+				}
 			}
 			killer(snapshot.pid, 'SIGTERM');
 			killed++;

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -16,7 +16,10 @@ export interface ProcessSnapshot {
 export type ProcessLister = () => Promise<ProcessSnapshot[]>;
 export type ProcessKiller = (pid: number, signal: NodeJS.Signals) => void;
 export type ProcessGroupKiller = (pgid: number, signal: NodeJS.Signals) => void;
-export type RootPidProvider = () => { live: Iterable<number>; exited: Iterable<number> };
+export type RootPidProvider = (snapshot?: ProcessSnapshot[]) => {
+	live: Iterable<number>;
+	exited: Iterable<number>;
+};
 
 const SUSPICIOUS_THRESHOLDS = [
 	{ pattern: /\bbun\s+test\b/, thresholdMs: 15 * 60 * 1000 },
@@ -113,14 +116,14 @@ export async function cleanupSuspiciousProcesses(options?: {
 						// Process group may have already exited.
 					}
 				});
+	const snapshots = await lister();
+
 	const rootResult = options?.getRootPids
-		? options.getRootPids()
+		? options.getRootPids(snapshots)
 		: { live: [] as number[], exited: [] as number[] };
 	const liveRoots = new Set(rootResult.live);
 	const exitedRoots = new Set(rootResult.exited);
 	if (liveRoots.size === 0 && exitedRoots.size === 0) return 0;
-
-	const snapshots = await lister();
 	const ownedPids = collectDescendantPids(snapshots, liveRoots, exitedRoots);
 	let killed = 0;
 
@@ -150,7 +153,22 @@ export async function cleanupSuspiciousProcesses(options?: {
 					// Group kill failed; fall through to direct PID signal.
 				}
 			}
-			killer(snapshot.pid, 'SIGTERM');
+			try {
+				killer(snapshot.pid, 'SIGTERM');
+			} catch (error: unknown) {
+				// ESRCH after group kill means the process was already terminated —
+				// count it as a successful cleanup rather than a failure.
+				if (
+					!(
+						error &&
+						typeof error === 'object' &&
+						'code' in error &&
+						(error as { code: string }).code === 'ESRCH'
+					)
+				) {
+					throw error;
+				}
+			}
 			killed++;
 			logger.warn(
 				`Killing suspicious daemon-owned long-running process pid=${snapshot.pid} ppid=${snapshot.ppid} ` +

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -125,6 +125,11 @@ export async function cleanupSuspiciousProcesses(options?: {
 	const exitedRoots = new Set(rootResult.exited);
 	if (liveRoots.size === 0 && exitedRoots.size === 0) return 0;
 	const ownedPids = collectDescendantPids(snapshots, liveRoots, exitedRoots);
+	// Set of PIDs present in the current snapshot â used to detect PID reuse.
+	// An exited root whose PGID appears in this set has been reused by an
+	// unrelated process; group-signaling it would kill non-daemon processes.
+	const snapshotPids = new Set<number>();
+	for (const snap of snapshots) snapshotPids.add(snap.pid);
 	let killed = 0;
 
 	for (const snapshot of snapshots) {
@@ -145,7 +150,8 @@ export async function cleanupSuspiciousProcesses(options?: {
 				Number.isFinite(snapshot.pgid) &&
 				snapshot.pgid > 1 &&
 				!liveRoots.has(snapshot.pgid) &&
-				(ownedPids.has(snapshot.pgid) || exitedRoots.has(snapshot.pgid))
+				(ownedPids.has(snapshot.pgid) ||
+					(exitedRoots.has(snapshot.pgid) && !snapshotPids.has(snapshot.pgid)))
 			) {
 				try {
 					groupKiller(snapshot.pgid, 'SIGTERM');

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -133,13 +133,16 @@ export async function cleanupSuspiciousProcesses(options?: {
 		if (!threshold) continue;
 
 		try {
-			// Signal the entire process group first (reaches tool grandchildren
+			// Signal the process group first (reaches tool grandchildren
 			// that the parent may not have forwarded signals to).
+			// The PGID must be attributable to the daemon tree (owned or a
+			// tracked root) but NOT a live root (would kill the active session).
 			if (
 				typeof snapshot.pgid === 'number' &&
 				Number.isFinite(snapshot.pgid) &&
 				snapshot.pgid > 1 &&
-				ownedPids.has(snapshot.pgid)
+				!liveRoots.has(snapshot.pgid) &&
+				(ownedPids.has(snapshot.pgid) || exitedRoots.has(snapshot.pgid))
 			) {
 				try {
 					groupKiller(snapshot.pgid, 'SIGTERM');

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -15,6 +15,7 @@ export interface ProcessSnapshot {
 
 export type ProcessLister = () => Promise<ProcessSnapshot[]>;
 export type ProcessKiller = (pid: number, signal: NodeJS.Signals) => void;
+export type ProcessGroupKiller = (pgid: number, signal: NodeJS.Signals) => void;
 export type RootPidProvider = () => { live: Iterable<number>; exited: Iterable<number> };
 
 const SUSPICIOUS_THRESHOLDS = [
@@ -96,10 +97,22 @@ export function parsePsElapsedDuration(raw: string): number {
 export async function cleanupSuspiciousProcesses(options?: {
 	listProcesses?: ProcessLister;
 	killProcess?: ProcessKiller;
+	killProcessGroup?: ProcessGroupKiller;
 	getRootPids?: RootPidProvider;
 }): Promise<number> {
 	const lister = options?.listProcesses ?? listProcesses;
 	const killer = options?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+	const groupKiller =
+		options?.killProcessGroup ??
+		(process.platform === 'win32'
+			? () => {}
+			: (pgid, signal) => {
+					try {
+						process.kill(-pgid, signal);
+					} catch {
+						// Process group may have already exited.
+					}
+				});
 	const rootResult = options?.getRootPids
 		? options.getRootPids()
 		: { live: [] as number[], exited: [] as number[] };
@@ -120,6 +133,15 @@ export async function cleanupSuspiciousProcesses(options?: {
 		if (!threshold) continue;
 
 		try {
+			// Signal the entire process group first (reaches tool grandchildren
+			// that the parent may not have forwarded signals to).
+			if (
+				typeof snapshot.pgid === 'number' &&
+				Number.isFinite(snapshot.pgid) &&
+				snapshot.pgid > 0
+			) {
+				groupKiller(snapshot.pgid, 'SIGTERM');
+			}
 			killer(snapshot.pid, 'SIGTERM');
 			killed++;
 			logger.warn(

--- a/packages/daemon/src/lib/process-watchdog.ts
+++ b/packages/daemon/src/lib/process-watchdog.ts
@@ -116,8 +116,19 @@ export async function cleanupSuspiciousProcesses(options?: {
 						// Process group may have already exited.
 					}
 				});
+	// Quick emptiness check without shelling out to ps â avoids
+	// unnecessary load on idle daemons with no tracked roots.
+	const quickResult = options?.getRootPids
+		? options.getRootPids()
+		: { live: [] as number[], exited: [] as number[] };
+	const quickLive = [...quickResult.live];
+	const quickExited = [...quickResult.exited];
+	if (quickLive.length === 0 && quickExited.length === 0) return 0;
+
+	// Only shell out to ps if there are tracked roots to process.
 	const snapshots = await lister();
 
+	// Re-fetch with snapshot for accurate identity verification.
 	const rootResult = options?.getRootPids
 		? options.getRootPids(snapshots)
 		: { live: [] as number[], exited: [] as number[] };

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -81,15 +81,19 @@ export class SessionManager {
 	private hardResetInFlight = new Map<string, Promise<{ success: boolean; error?: string }>>();
 
 	/**
-	 * Recently-exited agent root PIDs that survived session cache eviction.
+	 * Agent root PIDs that survived session cache eviction, split by liveness.
 	 *
 	 * When `interruptInMemorySession()` or `unregisterSession()` removes an
-	 * AgentSession from the cache, its own `recentlyExitedAgentRootPids` are
-	 * no longer visible to `getTrackedAgentRootPidsSplit()`. We snapshot those
-	 * PIDs here so the process watchdog retains ownership attribution for the
-	 * full 15-minute retention window.
+	 * AgentSession from the cache, its tracked PIDs are no longer visible to
+	 * `getTrackedAgentRootPidsSplit()`. We snapshot them here so the process
+	 * watchdog retains ownership attribution.
+	 *
+	 * Live PIDs are tracked separately so `collectDescendantPids()` treats them
+	 * as live roots (not exited), avoiding false PID-reuse skips while the
+	 * process is still running.
 	 */
-	private recentlyExitedAgentRootPids = new Map<number, number>();
+	private evictedLiveRootPids = new Set<number>();
+	private evictedExitedRootPids = new Map<number, number>();
 
 	// Extracted modules
 	private sessionCache: SessionCache;
@@ -431,7 +435,7 @@ export class SessionManager {
 	}
 
 	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
-		this.expireRecentlyExitedAgentRootPids();
+		this.expireEvictedRoots();
 		const live: number[] = [];
 		const exited: number[] = [];
 		// Collect from sessions still in the cache.
@@ -440,8 +444,14 @@ export class SessionManager {
 			live.push(...split.live);
 			exited.push(...split.exited);
 		}
-		// Merge session-manager-level PIDs that survived cache eviction.
-		for (const pid of this.recentlyExitedAgentRootPids.keys()) {
+		// Merge session-manager-level live PIDs that survived cache eviction.
+		for (const pid of this.evictedLiveRootPids) {
+			if (!live.includes(pid)) {
+				live.push(pid);
+			}
+		}
+		// Merge session-manager-level exited PIDs that survived cache eviction.
+		for (const pid of this.evictedExitedRootPids.keys()) {
 			if (!exited.includes(pid)) {
 				exited.push(pid);
 			}
@@ -465,7 +475,7 @@ export class SessionManager {
 	unregisterSession(sessionId: string): void {
 		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
 		if (agentSession) {
-			this.preserveExitedRootPids(agentSession);
+			this.preserveRootPids(agentSession);
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -576,11 +586,13 @@ export class SessionManager {
 					error
 				);
 			}
-			// Snapshot exited root PIDs AFTER cleanup so the retention window
-			// starts from the actual process exit time, not from eviction time.
-			// cleanup() awaits process exit, so live PIDs will have transitioned
-			// to the exited set with their real exit timestamps.
-			this.preserveExitedRootPids(agentSession);
+			// Snapshot root PIDs AFTER cleanup so the retention window for
+			// exited PIDs starts from the actual process exit time.
+			// cleanup() awaits process exit, so live PIDs will have
+			// transitioned to exited with real exit timestamps. Any
+			// stubborn live roots that survive cleanup are preserved as
+			// live so the watchdog tracks them correctly.
+			this.preserveRootPids(agentSession);
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -594,27 +606,34 @@ export class SessionManager {
 	}
 
 	/**
-	 * Snapshot exited root PIDs from an AgentSession after it is removed from
-	 * the session cache, so the process watchdog retains ownership attribution.
+	 * Snapshot live and exited root PIDs from an AgentSession before/after
+	 * it is removed from the session cache.
 	 *
-	 * Callers must invoke this AFTER cleanup so live PIDs have transitioned to
-	 * the exited set with their actual exit timestamps — this ensures the
-	 * 15-minute retention window starts from real exit time, not eviction time.
+	 * Live PIDs are preserved as live so the watchdog tracks them correctly
+	 * (exited roots are skipped if the PID appears in the process snapshot).
+	 * Exited PIDs are preserved with their actual exit timestamp for the
+	 * 15-minute retention window.
 	 */
-	private preserveExitedRootPids(agentSession: AgentSession): void {
+	private preserveRootPids(agentSession: AgentSession): void {
 		const split = agentSession.getTrackedAgentRootPidsSplit();
 		const now = Date.now();
+		// Preserve live PIDs as live so the watchdog can track them
+		// as live roots (not exited) while the process is still running.
+		for (const pid of split.live) {
+			this.evictedLiveRootPids.add(pid);
+		}
+		// Preserve exited PIDs with their actual exit timestamp.
 		for (const pid of split.exited) {
-			if (!this.recentlyExitedAgentRootPids.has(pid)) {
-				this.recentlyExitedAgentRootPids.set(pid, now);
+			if (!this.evictedExitedRootPids.has(pid)) {
+				this.evictedExitedRootPids.set(pid, now);
 			}
 		}
 	}
 
-	private expireRecentlyExitedAgentRootPids(now = Date.now()): void {
-		for (const [pid, exitedAt] of this.recentlyExitedAgentRootPids) {
+	private expireEvictedRoots(now = Date.now()): void {
+		for (const [pid, exitedAt] of this.evictedExitedRootPids) {
 			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
-				this.recentlyExitedAgentRootPids.delete(pid);
+				this.evictedExitedRootPids.delete(pid);
 			}
 		}
 	}

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -31,6 +31,7 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
+import type { ProcessSnapshot } from '../process-watchdog';
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
@@ -96,7 +97,7 @@ export class SessionManager {
 	 * 3. If a live root outlives the retention window it is removed,
 	 *    preventing PID-reuse misattribution for long-lived reused PIDs.
 	 */
-	private evictedLiveRootPids = new Map<number, number>();
+	private evictedLiveRootPids = new Map<number, { evictedAt: number; startTime: number }>();
 	private evictedExitedRootPids = new Map<number, number>();
 
 	// Extracted modules
@@ -438,8 +439,8 @@ export class SessionManager {
 		}
 	}
 
-	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
-		this.expireEvictedRoots();
+	getTrackedAgentRootPidsSplit(snapshot?: ProcessSnapshot[]): { live: number[]; exited: number[] } {
+		this.expireEvictedRoots(snapshot);
 		const live: number[] = [];
 		const exited: number[] = [];
 		// Collect from sessions still in the cache.
@@ -623,62 +624,59 @@ export class SessionManager {
 		const now = Date.now();
 		// Preserve live PIDs as live so the watchdog can track them
 		// as live roots (not exited) while the process is still running.
+		// Store startTime as 0 (unknown) — populated on first snapshot-based probe.
 		for (const pid of split.live) {
-			if (!this.evictedLiveRootPids.has(pid)) this.evictedLiveRootPids.set(pid, now);
+			if (!this.evictedLiveRootPids.has(pid))
+				this.evictedLiveRootPids.set(pid, { evictedAt: now, startTime: 0 });
 		}
 		// Preserve exited PIDs with their actual exit timestamp from the
 		// AgentSession, not Date.now(), so the retention window reflects
 		// real process exit time rather than eviction time.
 		const exitTimestamps = agentSession.getExitedRootPidTimestamps();
+		// Always update the exit timestamp so reused PIDs that exit
+		// again get the latest exit time (Fix P2: stale timestamp on re-preservation).
 		for (const [pid, exitedAt] of exitTimestamps) {
-			if (!this.evictedExitedRootPids.has(pid)) {
-				this.evictedExitedRootPids.set(pid, exitedAt);
-			}
+			this.evictedExitedRootPids.set(pid, exitedAt);
 		}
 	}
 
-	private expireEvictedRoots(now = Date.now()): void {
-		// Probe evicted live roots and transition their tracking state.
-		// kill(pid, 0) (signal 0) is a cheap existence probe that does not
-		// affect the process. Results:
-		//  - ESRCH: PID is gone → promote to exited for PGID orphan discovery.
-		//  - EPERM: PID exists but not signalable → keep as live.
-		//  - Success: PID exists but identity is ambiguous (could be reused)
-		//  - Success: PID exists → keep as live (retention window handles
-		//    the rare case of PID reuse within the retention window).
-		//    eventual expiry; suspicious pattern filters guard against
-		for (const [pid, evictedAt] of this.evictedLiveRootPids) {
-			// Expire live roots that outlived the retention window.
-			// This prevents PID-reuse misattribution: if the OS recycles
-			// an old daemon root PID, the watchdog would incorrectly
-			// traverse from the unrelated process and kill its children.
-			if (now - evictedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
+	private expireEvictedRoots(snapshot: ProcessSnapshot[] = [], now = Date.now()): void {
+		// Build PID → snapshot lookup for identity verification.
+		const snapshotByPid = new Map<number, ProcessSnapshot>();
+		for (const snap of snapshot) snapshotByPid.set(snap.pid, snap);
+
+		for (const [pid, meta] of this.evictedLiveRootPids) {
+			// Expire entries past the retention window regardless.
+			if (now - meta.evictedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
 				this.evictedLiveRootPids.delete(pid);
 				continue;
 			}
-			try {
-				process.kill(pid, 0);
-				// PID still exists — keep as live. PID reuse within the
-				// retention window is extremely rare on modern systems, and
-				// the suspicious pattern filters provide an additional safeguard.
-			} catch (error: unknown) {
-				if (
-					error &&
-					typeof error === 'object' &&
-					'code' in error &&
-					(error as { code: string }).code === 'ESRCH'
-				) {
-					// PID no longer exists — promote to exited for the PGID-based
-					// orphan discovery window.
-					this.evictedLiveRootPids.delete(pid);
-					if (!this.evictedExitedRootPids.has(pid)) {
-						this.evictedExitedRootPids.set(pid, now);
-					}
+
+			const snap = snapshotByPid.get(pid);
+			if (!snap) {
+				// PID absent from snapshot → process exited.
+				// Promote to exited for PGID-based orphan discovery.
+				this.evictedLiveRootPids.delete(pid);
+				if (!this.evictedExitedRootPids.has(pid)) {
+					this.evictedExitedRootPids.set(pid, now);
 				}
-				// EPERM or other errors: PID exists but is not signalable.
-				// Keep as live — the root is still alive, just restricted.
+				continue;
 			}
+
+			// PID exists in snapshot — verify identity via start time.
+			const currentStartTime = now - snap.elapsedSeconds * 1000;
+			if (meta.startTime === 0) {
+				// First snapshot-based probe: capture start time.
+				meta.startTime = currentStartTime;
+			} else if (Math.abs(currentStartTime - meta.startTime) > 1000) {
+				// Start time changed by >1s → PID was reused by a different process.
+				// Remove to prevent cross-process attribution.
+				this.evictedLiveRootPids.delete(pid);
+				continue;
+			}
+			// Identity verified — keep as live.
 		}
+
 		// Expire old exited roots past the retention window.
 		for (const [pid, exitedAt] of this.evictedExitedRootPids) {
 			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -646,11 +646,19 @@ export class SessionManager {
 		// startTime is captured from the process snapshot above, or 0 if
 		// unavailable (will be populated on first snapshot-based probe).
 		for (const pid of split.live) {
-			if (!this.evictedLiveRootPids.has(pid))
+			const newStartTime = startTimeByPid.get(pid) ?? 0;
+			const existing = this.evictedLiveRootPids.get(pid);
+			if (existing) {
+				// Refresh metadata on re-eviction so the retention window
+				// restarts from the latest eviction and startTime is current.
+				existing.evictedAt = now;
+				if (newStartTime !== 0) existing.startTime = newStartTime;
+			} else {
 				this.evictedLiveRootPids.set(pid, {
 					evictedAt: now,
-					startTime: startTimeByPid.get(pid) ?? 0,
+					startTime: newStartTime,
 				});
+			}
 		}
 		// Preserve exited PIDs with their actual exit timestamp from the
 		// AgentSession, not Date.now(), so the retention window reflects
@@ -685,9 +693,9 @@ export class SessionManager {
 				// PID absent from snapshot → process exited.
 				// Promote to exited for PGID-based orphan discovery.
 				this.evictedLiveRootPids.delete(pid);
-				if (!this.evictedExitedRootPids.has(pid)) {
-					this.evictedExitedRootPids.set(pid, now);
-				}
+				// Always overwrite with latest exit time so reused PIDs
+				// that exit again get the full retention window.
+				this.evictedExitedRootPids.set(pid, now);
 				continue;
 			}
 

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -635,9 +635,13 @@ export class SessionManager {
 	}
 
 	private expireEvictedRoots(now = Date.now()): void {
-		// Promote evicted live roots that have exited since last check.
-		// Uses kill(pid, 0) (signal 0) which is a cheap existence probe —
-		// it does not affect the process but throws ESRCH if the PID is gone.
+		// Probe evicted live roots and transition their tracking state.
+		// kill(pid, 0) (signal 0) is a cheap existence probe that does not
+		// affect the process. Results:
+		//  - ESRCH: PID is gone → promote to exited for PGID orphan discovery.
+		//  - EPERM: PID exists but not signalable → keep as live.
+		//  - Success: PID exists but identity is ambiguous (could be reused)
+		//    → remove from live to prevent cross-process attribution.
 		for (const [pid, evictedAt] of this.evictedLiveRootPids) {
 			// Expire live roots that outlived the retention window.
 			// This prevents PID-reuse misattribution: if the OS recycles
@@ -649,13 +653,27 @@ export class SessionManager {
 			}
 			try {
 				process.kill(pid, 0);
-			} catch {
-				// PID no longer exists — promote to exited for the PGID-based
-				// orphan discovery window.
+				// PID exists but we cannot verify it is the same process that was
+				// evicted (PID reuse is possible). Treat ambiguous probes as
+				// non-owned: remove from live tracking without promoting to exited,
+				// avoiding cross-process attribution.
 				this.evictedLiveRootPids.delete(pid);
-				if (!this.evictedExitedRootPids.has(pid)) {
-					this.evictedExitedRootPids.set(pid, now);
+			} catch (error: unknown) {
+				if (
+					error &&
+					typeof error === 'object' &&
+					'code' in error &&
+					(error as { code: string }).code === 'ESRCH'
+				) {
+					// PID no longer exists — promote to exited for the PGID-based
+					// orphan discovery window.
+					this.evictedLiveRootPids.delete(pid);
+					if (!this.evictedExitedRootPids.has(pid)) {
+						this.evictedExitedRootPids.set(pid, now);
+					}
 				}
+				// EPERM or other errors: PID exists but is not signalable.
+				// Keep as live — the root is still alive, just restricted.
 			}
 		}
 		// Expire old exited roots past the retention window.

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -568,9 +568,6 @@ export class SessionManager {
 	async interruptInMemorySession(sessionId: string): Promise<void> {
 		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
 		if (agentSession) {
-			// Snapshot exited root PIDs before cleanup so the watchdog retains
-			// ownership attribution for the full 15-minute retention window.
-			this.preserveExitedRootPids(agentSession);
 			try {
 				await agentSession.cleanup();
 			} catch (error) {
@@ -579,6 +576,11 @@ export class SessionManager {
 					error
 				);
 			}
+			// Snapshot exited root PIDs AFTER cleanup so the retention window
+			// starts from the actual process exit time, not from eviction time.
+			// cleanup() awaits process exit, so live PIDs will have transitioned
+			// to the exited set with their real exit timestamps.
+			this.preserveExitedRootPids(agentSession);
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -592,22 +594,17 @@ export class SessionManager {
 	}
 
 	/**
-	 * Snapshot exited root PIDs from an AgentSession before it is removed from
+	 * Snapshot exited root PIDs from an AgentSession after it is removed from
 	 * the session cache, so the process watchdog retains ownership attribution.
+	 *
+	 * Callers must invoke this AFTER cleanup so live PIDs have transitioned to
+	 * the exited set with their actual exit timestamps — this ensures the
+	 * 15-minute retention window starts from real exit time, not eviction time.
 	 */
 	private preserveExitedRootPids(agentSession: AgentSession): void {
 		const split = agentSession.getTrackedAgentRootPidsSplit();
 		const now = Date.now();
 		for (const pid of split.exited) {
-			if (!this.recentlyExitedAgentRootPids.has(pid)) {
-				this.recentlyExitedAgentRootPids.set(pid, now);
-			}
-		}
-		// Also preserve live PIDs — they will transition to exited when the
-		// process actually exits (the session is being interrupted/removed,
-		// so the SDK subprocess will terminate shortly). Without this, live
-		// roots would be lost entirely when the cache entry is removed.
-		for (const pid of split.live) {
 			if (!this.recentlyExitedAgentRootPids.has(pid)) {
 				this.recentlyExitedAgentRootPids.set(pid, now);
 			}

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -22,7 +22,11 @@ import type {
 import { generateUUID } from '@neokai/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { Database } from '../../storage/database';
-import { AgentSession, type AgentSessionRuntimeOptions } from '../agent/agent-session';
+import {
+	AgentSession,
+	type AgentSessionRuntimeOptions,
+	RECENTLY_EXITED_ROOT_PID_RETENTION_MS,
+} from '../agent/agent-session';
 import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
@@ -75,6 +79,17 @@ export class SessionManager {
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
 	private hardResetInFlight = new Map<string, Promise<{ success: boolean; error?: string }>>();
+
+	/**
+	 * Recently-exited agent root PIDs that survived session cache eviction.
+	 *
+	 * When `interruptInMemorySession()` or `unregisterSession()` removes an
+	 * AgentSession from the cache, its own `recentlyExitedAgentRootPids` are
+	 * no longer visible to `getTrackedAgentRootPidsSplit()`. We snapshot those
+	 * PIDs here so the process watchdog retains ownership attribution for the
+	 * full 15-minute retention window.
+	 */
+	private recentlyExitedAgentRootPids = new Map<number, number>();
 
 	// Extracted modules
 	private sessionCache: SessionCache;
@@ -416,12 +431,20 @@ export class SessionManager {
 	}
 
 	getTrackedAgentRootPidsSplit(): { live: number[]; exited: number[] } {
+		this.expireRecentlyExitedAgentRootPids();
 		const live: number[] = [];
 		const exited: number[] = [];
+		// Collect from sessions still in the cache.
 		for (const [, agentSession] of this.sessionCache.entries()) {
 			const split = agentSession.getTrackedAgentRootPidsSplit();
 			live.push(...split.live);
 			exited.push(...split.exited);
+		}
+		// Merge session-manager-level PIDs that survived cache eviction.
+		for (const pid of this.recentlyExitedAgentRootPids.keys()) {
+			if (!exited.includes(pid)) {
+				exited.push(pid);
+			}
 		}
 		return { live, exited };
 	}
@@ -440,6 +463,10 @@ export class SessionManager {
 	 * Space runtime callers will be added as that subsystem is wired up.
 	 */
 	unregisterSession(sessionId: string): void {
+		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
+		if (agentSession) {
+			this.preserveExitedRootPids(agentSession);
+		}
 		this.sessionCache.remove(sessionId);
 	}
 
@@ -541,6 +568,9 @@ export class SessionManager {
 	async interruptInMemorySession(sessionId: string): Promise<void> {
 		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
 		if (agentSession) {
+			// Snapshot exited root PIDs before cleanup so the watchdog retains
+			// ownership attribution for the full 15-minute retention window.
+			this.preserveExitedRootPids(agentSession);
 			try {
 				await agentSession.cleanup();
 			} catch (error) {
@@ -559,6 +589,37 @@ export class SessionManager {
 
 	getTotalSessions(): number {
 		return this.db.listSessions({ includeArchived: true }).length;
+	}
+
+	/**
+	 * Snapshot exited root PIDs from an AgentSession before it is removed from
+	 * the session cache, so the process watchdog retains ownership attribution.
+	 */
+	private preserveExitedRootPids(agentSession: AgentSession): void {
+		const split = agentSession.getTrackedAgentRootPidsSplit();
+		const now = Date.now();
+		for (const pid of split.exited) {
+			if (!this.recentlyExitedAgentRootPids.has(pid)) {
+				this.recentlyExitedAgentRootPids.set(pid, now);
+			}
+		}
+		// Also preserve live PIDs — they will transition to exited when the
+		// process actually exits (the session is being interrupted/removed,
+		// so the SDK subprocess will terminate shortly). Without this, live
+		// roots would be lost entirely when the cache entry is removed.
+		for (const pid of split.live) {
+			if (!this.recentlyExitedAgentRootPids.has(pid)) {
+				this.recentlyExitedAgentRootPids.set(pid, now);
+			}
+		}
+	}
+
+	private expireRecentlyExitedAgentRootPids(now = Date.now()): void {
+		for (const [pid, exitedAt] of this.recentlyExitedAgentRootPids) {
+			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
+				this.recentlyExitedAgentRootPids.delete(pid);
+			}
+		}
 	}
 
 	// ==================== Tools Configuration ====================

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -626,10 +626,13 @@ export class SessionManager {
 		for (const pid of split.live) {
 			if (!this.evictedLiveRootPids.has(pid)) this.evictedLiveRootPids.set(pid, now);
 		}
-		// Preserve exited PIDs with their actual exit timestamp.
-		for (const pid of split.exited) {
+		// Preserve exited PIDs with their actual exit timestamp from the
+		// AgentSession, not Date.now(), so the retention window reflects
+		// real process exit time rather than eviction time.
+		const exitTimestamps = agentSession.getExitedRootPidTimestamps();
+		for (const [pid, exitedAt] of exitTimestamps) {
 			if (!this.evictedExitedRootPids.has(pid)) {
-				this.evictedExitedRootPids.set(pid, now);
+				this.evictedExitedRootPids.set(pid, exitedAt);
 			}
 		}
 	}
@@ -641,7 +644,9 @@ export class SessionManager {
 		//  - ESRCH: PID is gone → promote to exited for PGID orphan discovery.
 		//  - EPERM: PID exists but not signalable → keep as live.
 		//  - Success: PID exists but identity is ambiguous (could be reused)
-		//    → remove from live to prevent cross-process attribution.
+		//  - Success: PID exists → keep as live (retention window handles
+		//    the rare case of PID reuse within the retention window).
+		//    eventual expiry; suspicious pattern filters guard against
 		for (const [pid, evictedAt] of this.evictedLiveRootPids) {
 			// Expire live roots that outlived the retention window.
 			// This prevents PID-reuse misattribution: if the OS recycles
@@ -653,11 +658,9 @@ export class SessionManager {
 			}
 			try {
 				process.kill(pid, 0);
-				// PID exists but we cannot verify it is the same process that was
-				// evicted (PID reuse is possible). Treat ambiguous probes as
-				// non-owned: remove from live tracking without promoting to exited,
-				// avoiding cross-process attribution.
-				this.evictedLiveRootPids.delete(pid);
+				// PID still exists — keep as live. PID reuse within the
+				// retention window is extremely rare on modern systems, and
+				// the suspicious pattern filters provide an additional safeguard.
 			} catch (error: unknown) {
 				if (
 					error &&

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -88,11 +88,15 @@ export class SessionManager {
 	 * `getTrackedAgentRootPidsSplit()`. We snapshot them here so the process
 	 * watchdog retains ownership attribution.
 	 *
-	 * Live PIDs are tracked separately so `collectDescendantPids()` treats them
-	 * as live roots (not exited), avoiding false PID-reuse skips while the
-	 * process is still running.
+	 * Live PIDs are tracked separately with their eviction timestamp so:
+	 * 1. `collectDescendantPids()` treats them as live roots while the
+	 *    process is still running (avoids false PID-reuse skips).
+	 * 2. When the process exits, they are promoted to exited for the
+	 *    PGID-based orphan discovery window.
+	 * 3. If a live root outlives the retention window it is removed,
+	 *    preventing PID-reuse misattribution for long-lived reused PIDs.
 	 */
-	private evictedLiveRootPids = new Set<number>();
+	private evictedLiveRootPids = new Map<number, number>();
 	private evictedExitedRootPids = new Map<number, number>();
 
 	// Extracted modules
@@ -445,7 +449,7 @@ export class SessionManager {
 			exited.push(...split.exited);
 		}
 		// Merge session-manager-level live PIDs that survived cache eviction.
-		for (const pid of this.evictedLiveRootPids) {
+		for (const pid of this.evictedLiveRootPids.keys()) {
 			if (!live.includes(pid)) {
 				live.push(pid);
 			}
@@ -620,7 +624,7 @@ export class SessionManager {
 		// Preserve live PIDs as live so the watchdog can track them
 		// as live roots (not exited) while the process is still running.
 		for (const pid of split.live) {
-			this.evictedLiveRootPids.add(pid);
+			if (!this.evictedLiveRootPids.has(pid)) this.evictedLiveRootPids.set(pid, now);
 		}
 		// Preserve exited PIDs with their actual exit timestamp.
 		for (const pid of split.exited) {
@@ -631,6 +635,30 @@ export class SessionManager {
 	}
 
 	private expireEvictedRoots(now = Date.now()): void {
+		// Promote evicted live roots that have exited since last check.
+		// Uses kill(pid, 0) (signal 0) which is a cheap existence probe —
+		// it does not affect the process but throws ESRCH if the PID is gone.
+		for (const [pid, evictedAt] of this.evictedLiveRootPids) {
+			// Expire live roots that outlived the retention window.
+			// This prevents PID-reuse misattribution: if the OS recycles
+			// an old daemon root PID, the watchdog would incorrectly
+			// traverse from the unrelated process and kill its children.
+			if (now - evictedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
+				this.evictedLiveRootPids.delete(pid);
+				continue;
+			}
+			try {
+				process.kill(pid, 0);
+			} catch {
+				// PID no longer exists — promote to exited for the PGID-based
+				// orphan discovery window.
+				this.evictedLiveRootPids.delete(pid);
+				if (!this.evictedExitedRootPids.has(pid)) {
+					this.evictedExitedRootPids.set(pid, now);
+				}
+			}
+		}
+		// Expire old exited roots past the retention window.
 		for (const [pid, exitedAt] of this.evictedExitedRootPids) {
 			if (now - exitedAt > RECENTLY_EXITED_ROOT_PID_RETENTION_MS) {
 				this.evictedExitedRootPids.delete(pid);

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -621,16 +621,19 @@ export class SessionManager {
 	 */
 	private async preserveRootPids(agentSession: AgentSession): Promise<void> {
 		const split = agentSession.getTrackedAgentRootPidsSplit();
-		const now = Date.now();
 
 		// Capture process start times from a contemporaneous snapshot so
 		// the PID+startTime identity guard is effective from eviction time.
 		// Without this, a PID reused before the first watchdog poll would
 		// establish the wrong baseline identity.
+		// Note: `now` is captured AFTER listProcesses() returns to avoid
+		// skewing the startTime calculation when ps collection is slow.
 		let startTimeByPid = new Map<number, number>();
+		let now = Date.now();
 		if (split.live.length > 0) {
 			try {
 				const snapshot = await listProcesses();
+				now = Date.now(); // Re-capture after ps to avoid skew
 				for (const snap of snapshot) {
 					if (split.live.includes(snap.pid)) {
 						startTimeByPid.set(snap.pid, now - snap.elapsedSeconds * 1000);

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -31,7 +31,7 @@ import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
 import { Logger } from '../logger';
-import type { ProcessSnapshot } from '../process-watchdog';
+import { listProcesses, type ProcessSnapshot } from '../process-watchdog';
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
@@ -477,10 +477,10 @@ export class SessionManager {
 	 * Currently called by TaskAgentManager when a task agent session is torn down.
 	 * Space runtime callers will be added as that subsystem is wired up.
 	 */
-	unregisterSession(sessionId: string): void {
+	async unregisterSession(sessionId: string): Promise<void> {
 		const agentSession = this.sessionCache.has(sessionId) ? this.sessionCache.get(sessionId) : null;
 		if (agentSession) {
-			this.preserveRootPids(agentSession);
+			await this.preserveRootPids(agentSession);
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -597,7 +597,7 @@ export class SessionManager {
 			// transitioned to exited with real exit timestamps. Any
 			// stubborn live roots that survive cleanup are preserved as
 			// live so the watchdog tracks them correctly.
-			this.preserveRootPids(agentSession);
+			await this.preserveRootPids(agentSession);
 		}
 		this.sessionCache.remove(sessionId);
 	}
@@ -619,15 +619,38 @@ export class SessionManager {
 	 * Exited PIDs are preserved with their actual exit timestamp for the
 	 * 15-minute retention window.
 	 */
-	private preserveRootPids(agentSession: AgentSession): void {
+	private async preserveRootPids(agentSession: AgentSession): Promise<void> {
 		const split = agentSession.getTrackedAgentRootPidsSplit();
 		const now = Date.now();
+
+		// Capture process start times from a contemporaneous snapshot so
+		// the PID+startTime identity guard is effective from eviction time.
+		// Without this, a PID reused before the first watchdog poll would
+		// establish the wrong baseline identity.
+		let startTimeByPid = new Map<number, number>();
+		if (split.live.length > 0) {
+			try {
+				const snapshot = await listProcesses();
+				for (const snap of snapshot) {
+					if (split.live.includes(snap.pid)) {
+						startTimeByPid.set(snap.pid, now - snap.elapsedSeconds * 1000);
+					}
+				}
+			} catch {
+				// Process listing failed â start times remain unknown.
+			}
+		}
+
 		// Preserve live PIDs as live so the watchdog can track them
 		// as live roots (not exited) while the process is still running.
-		// Store startTime as 0 (unknown) — populated on first snapshot-based probe.
+		// startTime is captured from the process snapshot above, or 0 if
+		// unavailable (will be populated on first snapshot-based probe).
 		for (const pid of split.live) {
 			if (!this.evictedLiveRootPids.has(pid))
-				this.evictedLiveRootPids.set(pid, { evictedAt: now, startTime: 0 });
+				this.evictedLiveRootPids.set(pid, {
+					evictedAt: now,
+					startTime: startTimeByPid.get(pid) ?? 0,
+				});
 		}
 		// Preserve exited PIDs with their actual exit timestamp from the
 		// AgentSession, not Date.now(), so the retention window reflects
@@ -651,6 +674,11 @@ export class SessionManager {
 				this.evictedLiveRootPids.delete(pid);
 				continue;
 			}
+
+			// Without a real snapshot we cannot reliably determine whether
+			// the process is still running or the PID was reused, so we skip
+			// live-root promotion to avoid false attribution.
+			if (snapshot.length === 0) continue;
 
 			const snap = snapshotByPid.get(pid);
 			if (!snap) {

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -646,20 +646,23 @@ export class SessionManager {
 
 		// Preserve live PIDs as live so the watchdog can track them
 		// as live roots (not exited) while the process is still running.
-		// startTime is captured from the process snapshot above, or 0 if
-		// unavailable (will be populated on first snapshot-based probe).
+		// Only preserve when we have a valid identity baseline (startTime
+		// from the process snapshot). Without it, expireEvictedRoots cannot
+		// distinguish the real root from a reused PID, risking cross-process
+		// attribution and kills.
 		for (const pid of split.live) {
 			const newStartTime = startTimeByPid.get(pid) ?? 0;
 			const existing = this.evictedLiveRootPids.get(pid);
 			if (existing) {
-				// Refresh metadata on re-eviction so the retention window
-				// restarts from the latest eviction. Always reset startTime
-				// since this PID comes from a live AgentSession and is
-				// authoritative — stale prior-generation startTime would
-				// cause false reuse detection on the next watchdog poll.
+				// Refresh retention window on re-eviction. Only update startTime
+				// when we have a valid baseline — a stale prior-generation
+				// startTime is better than 0 (unknown), which would disable
+				// identity verification until the next watchdog poll.
 				existing.evictedAt = now;
-				existing.startTime = newStartTime;
-			} else {
+				if (newStartTime !== 0) {
+					existing.startTime = newStartTime;
+				}
+			} else if (newStartTime !== 0) {
 				this.evictedLiveRootPids.set(pid, {
 					evictedAt: now,
 					startTime: newStartTime,
@@ -706,11 +709,10 @@ export class SessionManager {
 			}
 
 			// PID exists in snapshot — verify identity via start time.
+			// (startTime is always > 0 because preserveRootPids skips
+			// entries without a valid identity baseline.)
 			const currentStartTime = now - snap.elapsedSeconds * 1000;
-			if (meta.startTime === 0) {
-				// First snapshot-based probe: capture start time.
-				meta.startTime = currentStartTime;
-			} else if (Math.abs(currentStartTime - meta.startTime) > 1000) {
+			if (Math.abs(currentStartTime - meta.startTime) > 1000) {
 				// Start time changed by >1s → PID was reused by a different process.
 				// Remove to prevent cross-process attribution.
 				this.evictedLiveRootPids.delete(pid);

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -650,9 +650,12 @@ export class SessionManager {
 			const existing = this.evictedLiveRootPids.get(pid);
 			if (existing) {
 				// Refresh metadata on re-eviction so the retention window
-				// restarts from the latest eviction and startTime is current.
+				// restarts from the latest eviction. Always reset startTime
+				// since this PID comes from a live AgentSession and is
+				// authoritative — stale prior-generation startTime would
+				// cause false reuse detection on the next watchdog poll.
 				existing.evictedAt = now;
-				if (newStartTime !== 0) existing.startTime = newStartTime;
+				existing.startTime = newStartTime;
 			} else {
 				this.evictedLiveRootPids.set(pid, {
 					evictedAt: now,

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -499,6 +499,77 @@ describe('AgentSession', () => {
 			exitHandlerNoPid?.();
 			await expect(promise).resolves.toBeUndefined();
 		});
+
+		it('no-PID-first then numeric-PID keeps no-PID promise in aggregation', async () => {
+			const agentSession = createAgentSession();
+
+			// Track a no-PID process first
+			let noPidExitHandler: (() => void) | null = null;
+			const noPidProc = {
+				once: mock((_event: string, handler: () => void) => {
+					noPidExitHandler = handler;
+					return noPidProc;
+				}),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(noPidProc as never);
+
+			// Now track a numeric-PID process — updateProcessExitedPromise must
+			// still include the pending no-PID promise.
+			let numericExitHandler: (() => void) | null = null;
+			const numericProc = {
+				pid: 700,
+				once: mock((_event: string, handler: () => void) => {
+					numericExitHandler = handler;
+					return numericProc;
+				}),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(numericProc as never);
+
+			const promise = agentSession.processExitedPromise;
+			expect(promise).not.toBeNull();
+
+			// Resolve the numeric process — promise should NOT resolve yet
+			numericExitHandler?.();
+			await new Promise((resolve) => setTimeout(resolve, 5));
+
+			// Now resolve the no-PID process
+			noPidExitHandler?.();
+			await expect(promise).resolves.toBeUndefined();
+		});
+
+		it('multiple no-PID processes are all aggregated', async () => {
+			const agentSession = createAgentSession();
+
+			const exitHandlers: (() => void)[] = [];
+			const createNoPidProc = () => {
+				const proc = {
+					once: mock((_event: string, handler: () => void) => {
+						exitHandlers.push(handler);
+						return proc;
+					}),
+					kill: mock(() => true),
+				};
+				return proc;
+			};
+
+			agentSession.trackAgentProcess(createNoPidProc() as never);
+			agentSession.trackAgentProcess(createNoPidProc() as never);
+			agentSession.trackAgentProcess(createNoPidProc() as never);
+
+			const promise = agentSession.processExitedPromise;
+			expect(promise).not.toBeNull();
+
+			// Resolve first two — promise should still be pending
+			exitHandlers[0]();
+			exitHandlers[1]();
+			await new Promise((resolve) => setTimeout(resolve, 5));
+
+			// Resolve the last one
+			exitHandlers[2]();
+			await expect(promise).resolves.toBeUndefined();
+		});
 	});
 
 	describe('component initialization', () => {

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -390,6 +390,117 @@ describe('AgentSession', () => {
 		});
 	});
 
+	describe('no-PID process tracking', () => {
+		function createAgentSession(): AgentSession {
+			const mockSession: Session = {
+				id: `test-session-nopid-${Math.random()}`,
+				title: 'Test Session',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 8192,
+					temperature: 1.0,
+				},
+				metadata: {},
+			} as Session;
+
+			const mockDb = {
+				getSession: mock(() => mockSession),
+				updateSession: mock(() => {}),
+				getUserMessages: mock(() => []),
+				getSDKMessages: mock(() => ({ messages: [], hasMore: false })),
+				deleteMessagesAfter: mock(() => 0),
+				deleteMessagesAtAndAfter: mock(() => 0),
+				getUserMessageByUuid: mock(() => undefined),
+				countMessagesAfter: mock(() => 0),
+				getMessagesByStatus: mock(() => []),
+				updateMessage: mock(() => {}),
+				getSDKMessageCount: mock(() => 0),
+			} as unknown as Database;
+
+			return new AgentSession(
+				mockSession,
+				mockDb,
+				{} as MessageHub,
+				{
+					publish: mock(async () => {}),
+					publishAsync: mock(() => {}),
+					subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
+				} as unknown as InternalEventBus<any>,
+				mock(async () => 'test-api-key')
+			);
+		}
+
+		it('preserves existing processExitedPromise when tracking a no-PID process', async () => {
+			const agentSession = createAgentSession();
+
+			// Track a numeric-PID process first
+			const numericProc = {
+				pid: 500,
+				once: mock((_event: string, _handler: () => void) => numericProc),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(numericProc as never);
+			const existingPromise = agentSession.processExitedPromise;
+			expect(existingPromise).not.toBeNull();
+
+			// Track a no-PID process — should NOT overwrite processExitedPromise
+			const noPidProc = {
+				once: mock((_event: string, _handler: () => void) => noPidProc),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(noPidProc as never);
+			const updatedPromise = agentSession.processExitedPromise;
+
+			// processExitedPromise should still be set (not null) and should
+			// aggregate both the numeric-PID and no-PID exit promises
+			expect(updatedPromise).not.toBeNull();
+			// It should be a new promise (aggregated), not the same reference
+			expect(updatedPromise).not.toBe(existingPromise);
+		});
+
+		it('aggregates no-PID exit promise with existing numeric-PID promises', async () => {
+			const agentSession = createAgentSession();
+
+			// Track a numeric-PID process
+			let exitHandler1: (() => void) | null = null;
+			const proc1 = {
+				pid: 600,
+				once: mock((_event: string, handler: () => void) => {
+					exitHandler1 = handler;
+					return proc1;
+				}),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(proc1 as never);
+
+			// Track a no-PID process
+			let exitHandlerNoPid: (() => void) | null = null;
+			const noPidProc = {
+				once: mock((_event: string, handler: () => void) => {
+					exitHandlerNoPid = handler;
+					return noPidProc;
+				}),
+				kill: mock(() => true),
+			};
+			agentSession.trackAgentProcess(noPidProc as never);
+
+			const promise = agentSession.processExitedPromise;
+			expect(promise).not.toBeNull();
+
+			// Resolve the numeric-PID process — promise should NOT resolve yet
+			// because the no-PID promise is still pending
+			exitHandler1?.();
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			// Resolve the no-PID process
+			exitHandlerNoPid?.();
+			await expect(promise).resolves.toBeUndefined();
+		});
+	});
+
 	describe('component initialization', () => {
 		let mockSession: Session;
 		let mockDb: Database;

--- a/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/model-switch-session-continuity.test.ts
@@ -399,6 +399,7 @@ describe('QueryLifecycleManager restart() — session continuity (sdkSessionId)'
 			queryPromise: null,
 			firstMessageReceived: true,
 			processExitedPromise: null,
+			resetProcessExitedPromise: mock(() => {}),
 			startupTimeoutTimer: null,
 			queryAbortController: null,
 			terminateTrackedAgentProcesses: mock(() => {}),

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -141,6 +141,9 @@ describe('QueryLifecycleManager', () => {
 				mockContext.queryPromise = Promise.resolve();
 			},
 			processExitedPromise: null,
+			resetProcessExitedPromise: mock(() => {
+				mockContext.processExitedPromise = null;
+			}),
 			startupTimeoutTimer: null,
 			queryAbortController: null,
 			terminateTrackedAgentProcesses: terminateTrackedAgentProcessesSpy,

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -200,6 +200,11 @@ describe('QueryRunner', () => {
 			originalEnvVars: {},
 
 			processExitedPromise: null,
+			resetProcessExitedPromise: mock(function (this: {
+				processExitedPromise: Promise<void> | null;
+			}) {
+				this.processExitedPromise = null;
+			}),
 			trackAgentProcess: trackAgentProcessSpy,
 
 			// Methods for state coordination

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -139,6 +139,73 @@ describe('process-watchdog', () => {
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
+	test('rejects PGID 1 before issuing group SIGTERM', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 1, // PGID 1 = init — kill(-1, SIGTERM) targets everything
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill must NOT be called for PGID 1
+		expect(killProcessGroup).not.toHaveBeenCalled();
+		// Individual PID kill still fires
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
+	test('skips group kill when PGID leader is not daemon-owned', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		// PID 500 is an external process group leader — not in the daemon tree.
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 500, // PGID 500 is NOT an owned PID
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill must NOT be called — PGID leader (500) is not daemon-owned
+		expect(killProcessGroup).not.toHaveBeenCalled();
+		// Individual PID kill still fires
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
 	test('does not kill short-lived bun test processes', async () => {
 		const killProcess = mock(() => {});
 

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -228,6 +228,49 @@ describe('process-watchdog', () => {
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
+	test('skips group kill when exited root PGID is reused by an unrelated process', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		// PID 300 was an exited root but has been reused by an unrelated process.
+		// The suspicious child (PID 123) has PGID 300, but signaling that group
+		// would kill the unrelated process that now leads PGID 300.
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 300, // PGID 300 is in exitedRoots but also in snapshot (reused)
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+				{
+					pid: 300,
+					ppid: 1,
+					pgid: 300, // Reused PID â now leads an unrelated process group
+					elapsedSeconds: 30,
+					command: 'unrelated-browser',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [300] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill must NOT be called â PGID 300 is reused by an unrelated process.
+		expect(killProcessGroup).not.toHaveBeenCalled();
+		// Individual PID kill still fires for the suspicious child
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
 	test('skips group kill when PGID is a live daemon root (protects active session)', async () => {
 		const killProcess = mock(() => {});
 		const killProcessGroup = mock(() => {});

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -129,6 +129,38 @@ describe('process-watchdog', () => {
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
+	test('counts kill as success when group kill terminates the PID (ESRCH)', async () => {
+		const killProcess = mock(() => {
+			const err = new Error('ESRCH') as Error & { code: string };
+			err.code = 'ESRCH';
+			throw err;
+		});
+		const killProcessGroup = mock(() => {});
+
+		// PID 200 was an exited root (group leader). PID 123 is orphaned.
+		// The group kill terminates PID 123, so the individual kill gets ESRCH.
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 123,
+					ppid: 1,
+					pgid: 200,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [], exited: [200] }),
+		});
+
+		// ESRCH after group kill means the process was already terminated —
+		// counted as a successful cleanup.
+		expect(killed).toBe(1);
+		expect(killProcessGroup).toHaveBeenCalledWith(200, 'SIGTERM');
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
 	test('rejects PGID 1 before issuing group SIGTERM', async () => {
 		const killProcess = mock(() => {});
 		const killProcessGroup = mock(() => {});

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -104,6 +104,41 @@ describe('process-watchdog', () => {
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
+	test('still kills individual PID when killProcessGroup throws', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {
+			throw new Error('group kill failed');
+		});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 100,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill was attempted but threw
+		expect(killProcessGroup).toHaveBeenCalledWith(100, 'SIGTERM');
+		// Direct PID signal still ran despite group kill failure
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
 	test('does not kill short-lived bun test processes', async () => {
 		const killProcess = mock(() => {});
 

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -40,6 +40,70 @@ describe('process-watchdog', () => {
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
+	test('sends SIGTERM to the process group before killing the suspicious process', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 100,
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill called with pgid before individual kill
+		expect(killProcessGroup).toHaveBeenCalledWith(100, 'SIGTERM');
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
+	test('skips group kill when pgid is undefined or zero', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 0,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					// No pgid (undefined)
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill should NOT be called (pgid is 0 or undefined)
+		expect(killProcessGroup).not.toHaveBeenCalled();
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
 	test('does not kill short-lived bun test processes', async () => {
 		const killProcess = mock(() => {});
 

--- a/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/process-watchdog.test.ts
@@ -44,31 +44,27 @@ describe('process-watchdog', () => {
 		const killProcess = mock(() => {});
 		const killProcessGroup = mock(() => {});
 
+		// PID 200 was an exited root (group leader). PID 123 is a suspicious
+		// orphaned descendant still in PGID 200. Group kill is safe because
+		// PGID 200 is NOT a live root.
 		const killed = await cleanupSuspiciousProcesses({
 			listProcesses: async () => [
 				{
-					pid: 100,
-					ppid: 1,
-					pgid: 100,
-					elapsedSeconds: 20 * 60,
-					command: 'claude-code-sdk',
-				},
-				{
 					pid: 123,
-					ppid: 100,
-					pgid: 100,
+					ppid: 1,
+					pgid: 200,
 					elapsedSeconds: 16 * 60,
 					command: 'bun test tests/unit/leaky.test.ts',
 				},
 			],
 			killProcess,
 			killProcessGroup,
-			getRootPids: () => ({ live: [100], exited: [] }),
+			getRootPids: () => ({ live: [], exited: [200] }),
 		});
 
 		expect(killed).toBe(1);
 		// Group kill called with pgid before individual kill
-		expect(killProcessGroup).toHaveBeenCalledWith(100, 'SIGTERM');
+		expect(killProcessGroup).toHaveBeenCalledWith(200, 'SIGTERM');
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 
@@ -110,31 +106,25 @@ describe('process-watchdog', () => {
 			throw new Error('group kill failed');
 		});
 
+		// PID 200 was an exited root (group leader). PID 123 is orphaned.
 		const killed = await cleanupSuspiciousProcesses({
 			listProcesses: async () => [
 				{
-					pid: 100,
-					ppid: 1,
-					pgid: 100,
-					elapsedSeconds: 20 * 60,
-					command: 'claude-code-sdk',
-				},
-				{
 					pid: 123,
-					ppid: 100,
-					pgid: 100,
+					ppid: 1,
+					pgid: 200,
 					elapsedSeconds: 16 * 60,
 					command: 'bun test tests/unit/leaky.test.ts',
 				},
 			],
 			killProcess,
 			killProcessGroup,
-			getRootPids: () => ({ live: [100], exited: [] }),
+			getRootPids: () => ({ live: [], exited: [200] }),
 		});
 
 		expect(killed).toBe(1);
 		// Group kill was attempted but threw
-		expect(killProcessGroup).toHaveBeenCalledWith(100, 'SIGTERM');
+		expect(killProcessGroup).toHaveBeenCalledWith(200, 'SIGTERM');
 		// Direct PID signal still ran despite group kill failure
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
@@ -203,6 +193,41 @@ describe('process-watchdog', () => {
 		// Group kill must NOT be called — PGID leader (500) is not daemon-owned
 		expect(killProcessGroup).not.toHaveBeenCalled();
 		// Individual PID kill still fires
+		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
+	});
+
+	test('skips group kill when PGID is a live daemon root (protects active session)', async () => {
+		const killProcess = mock(() => {});
+		const killProcessGroup = mock(() => {});
+
+		// PID 100 is the SDK root (live). PID 123 is a suspicious child with
+		// PGID 100 — same group as the root. Group kill would kill the agent.
+		const killed = await cleanupSuspiciousProcesses({
+			listProcesses: async () => [
+				{
+					pid: 100,
+					ppid: 1,
+					pgid: 100,
+					elapsedSeconds: 20 * 60,
+					command: 'claude-code-sdk',
+				},
+				{
+					pid: 123,
+					ppid: 100,
+					pgid: 100, // Same PGID as the live SDK root
+					elapsedSeconds: 16 * 60,
+					command: 'bun test tests/unit/leaky.test.ts',
+				},
+			],
+			killProcess,
+			killProcessGroup,
+			getRootPids: () => ({ live: [100], exited: [] }),
+		});
+
+		expect(killed).toBe(1);
+		// Group kill must NOT be called — PGID 100 is the live SDK root
+		expect(killProcessGroup).not.toHaveBeenCalled();
+		// Individual PID kill still fires for the suspicious child
 		expect(killProcess).toHaveBeenCalledWith(123, 'SIGTERM');
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -8,6 +8,8 @@
 import { describe, expect, it, beforeEach, mock, afterEach, spyOn } from 'bun:test';
 import { SessionManager, CleanupState } from '../../../../src/lib/session/session-manager';
 import { AgentSession } from '../../../../src/lib/agent/agent-session';
+import * as processWatchdog from '../../../../src/lib/process-watchdog';
+import type { ProcessSnapshot } from '../../../../src/lib/process-watchdog';
 import type { Database } from '../../../../src/storage/database';
 import type { InternalEventBus } from '../../../../src/lib/internal-event-bus';
 import type { AuthManager } from '../../../../src/lib/auth-manager';
@@ -28,6 +30,7 @@ describe('SessionManager', () => {
 	let mockJobProcessor: JobQueueProcessor;
 	let config: Record<string, unknown>;
 	let eventHandlers: Map<string, (...args: unknown[]) => unknown>;
+	let listProcessesSpy: ReturnType<typeof spyOn>;
 
 	beforeEach(() => {
 		eventHandlers = new Map();
@@ -141,9 +144,13 @@ describe('SessionManager', () => {
 			undefined, // skillsManager
 			undefined // appMcpServerRepo
 		);
+		// Default: listProcesses returns empty array (no test PIDs in process table).
+		// Tests with live PIDs override this to include their fake PIDs.
+		listProcessesSpy = spyOn(processWatchdog, 'listProcesses').mockResolvedValue([]);
 	});
 
 	afterEach(async () => {
+		listProcessesSpy?.mockRestore();
 		// Ensure cleanup after each test
 		try {
 			await sessionManager.cleanup();
@@ -358,6 +365,9 @@ describe('SessionManager', () => {
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
+			listProcessesSpy.mockResolvedValue([
+				{ pid: 7000, ppid: 1, pgid: 7000, elapsedSeconds: 60, command: 'live-root' },
+			]);
 			await sessionManager.unregisterSession('room:1:task:2:abc');
 
 			// Pass snapshot with PID 7000 so snapshot-based identity
@@ -551,6 +561,9 @@ describe('SessionManager', () => {
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
+			listProcessesSpy.mockResolvedValue([
+				{ pid: 8000, ppid: 1, pgid: 8000, elapsedSeconds: 60, command: 'live-root' },
+			]);
 			await sessionManager.interruptInMemorySession('session-evicted-live');
 
 			// Pass snapshot with PID 8000 so snapshot-based identity
@@ -592,6 +605,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 9001, ppid: 1, pgid: 9001, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.interruptInMemorySession('session-promote-live');
 
 		// Pass snapshot with PID 9001 so identity is verified as live.
@@ -636,6 +652,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 9002, ppid: 1, pgid: 9002, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.interruptInMemorySession('session-no-snapshot');
 
 		// Without a snapshot, the evicted live root stays live â no false
@@ -672,6 +691,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 9999, ppid: 1, pgid: 9999, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.interruptInMemorySession('session-reuse-safety');
 
 		const RETENTION_MS = 15 * 60 * 1000;
@@ -720,6 +742,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 7777, ppid: 1, pgid: 7777, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.interruptInMemorySession('session-identity-verified');
 
 		// Pass snapshot with PID 7777 â first probe captures startTime,
@@ -759,6 +784,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 6666, ppid: 1, pgid: 6666, elapsedSeconds: 60, command: 'original-process' },
+		]);
 		await sessionManager.interruptInMemorySession('session-pid-reuse');
 
 		// First snapshot: PID 6666 with 60s elapsed â captures startTime.
@@ -801,6 +829,9 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession1);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 5555, ppid: 1, pgid: 5555, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.unregisterSession('session-reevict');
 
 		// First eviction establishes evictedAt and startTime for PID 5555
@@ -821,12 +852,48 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession2);
+		listProcessesSpy.mockResolvedValue([
+			{ pid: 5555, ppid: 1, pgid: 5555, elapsedSeconds: 60, command: 'live-root' },
+		]);
 		await sessionManager.unregisterSession('session-reevict-2');
 
 		// After re-eviction, PID 5555 should still be tracked as live with
 		// refreshed evictedAt (retention window restarts from now).
 		const second = sessionManager.getTrackedAgentRootPidsSplit([]);
 		expect(second.live).toContain(5555);
+	});
+
+	it('skips live-root preservation when identity baseline is unknown (listProcesses fails)', async () => {
+		const mockSession: Session = {
+			id: 'session-no-identity',
+			title: 'No Identity',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit = mock(() => ({
+			live: [4321],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {}),
+			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		// listProcesses returns empty — PID 4321 not found, no identity baseline.
+		// The default beforeEach mock already returns [].
+		await sessionManager.interruptInMemorySession('session-no-identity');
+
+		// PID 4321 should NOT be tracked as live because no startTime
+		// baseline was captured (cannot verify identity against reuse).
+		const split = sessionManager.getTrackedAgentRootPidsSplit([]);
+		expect(split.live).not.toContain(4321);
+		expect(split.exited).not.toContain(4321);
 	});
 
 	describe('getActiveSessions', () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -354,10 +354,21 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			sessionManager.unregisterSession('room:1:task:2:abc');
 
-			// PIDs should survive eviction — live as live, exited as exited.
-			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(split.live).toContain(7000);
-			expect(split.exited).toContain(7001);
+			// Mock process.kill to report PID 7000 as alive (signal 0 probe succeeds).
+			const originalKill = process.kill;
+			// @ts-expect-error — overriding for test
+			process.kill = mock((pid: number, signal: number) => {
+				if (pid === 7000 && signal === 0) return;
+				return originalKill(pid, signal);
+			});
+			try {
+				// PIDs should survive eviction — live as live, exited as exited.
+				const split = sessionManager.getTrackedAgentRootPidsSplit();
+				expect(split.live).toContain(7000);
+				expect(split.exited).toContain(7001);
+			} finally {
+				process.kill = originalKill;
+			}
 		});
 	});
 
@@ -534,12 +545,133 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			await sessionManager.interruptInMemorySession('session-evicted-live');
 
-			// The live root PID must appear as live (not exited) so
-			// collectDescendantPids doesn't skip it as a reused PID.
-			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(split.live).toContain(8000);
-			expect(split.exited).not.toContain(8000);
+			// Mock process.kill to report PID 8000 as alive.
+			const originalKill = process.kill;
+			// @ts-expect-error — overriding for test
+			process.kill = mock((pid: number, signal: number) => {
+				if (pid === 8000 && signal === 0) return;
+				return originalKill(pid, signal);
+			});
+			try {
+				// The live root PID must appear as live (not exited) so
+				// collectDescendantPids doesn't skip it as a reused PID.
+				const split = sessionManager.getTrackedAgentRootPidsSplit();
+				expect(split.live).toContain(8000);
+				expect(split.exited).not.toContain(8000);
+			} finally {
+				process.kill = originalKill;
+			}
 		});
+	});
+
+	it('promotes evicted live root to exited when the process leaves the process table', async () => {
+		const mockSession: Session = {
+			id: 'session-promote-live',
+			title: 'Promote Live',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		// Simulate a live root that survives cleanup
+		const getSplit = mock(() => ({
+			live: [9001],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {
+				getSplit.mockImplementation(() => ({
+					live: [9001],
+					exited: [],
+				}));
+			}),
+			getTrackedAgentRootPidsSplit: getSplit,
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		await sessionManager.interruptInMemorySession('session-promote-live');
+
+		// Mock process.kill to report PID 9001 as alive initially.
+		const originalKill = process.kill;
+		// @ts-expect-error — overriding for test
+		process.kill = mock((pid: number, signal: number) => {
+			if (pid === 9001 && signal === 0) return;
+			return originalKill(pid, signal);
+		});
+
+		try {
+			// Initially the PID is tracked as live
+			const before = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(before.live).toContain(9001);
+			expect(before.exited).not.toContain(9001);
+
+			// Now simulate the process exiting: mock process.kill(pid, 0) to throw
+			// @ts-expect-error — overriding for test
+			process.kill = mock((_pid: number, _signal: number) => {
+				throw new Error('ESRCH');
+			});
+
+			const after = sessionManager.getTrackedAgentRootPidsSplit();
+			// PID should be promoted from live to exited
+			expect(after.live).not.toContain(9001);
+			expect(after.exited).toContain(9001);
+		} finally {
+			process.kill = originalKill;
+		}
+	});
+
+	it('removes evicted live root past retention window (PID reuse safety)', async () => {
+		const mockSession: Session = {
+			id: 'session-reuse-safety',
+			title: 'Reuse Safety',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit = mock(() => ({
+			live: [9999],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {
+				getSplit.mockImplementation(() => ({
+					live: [9999],
+					exited: [],
+				}));
+			}),
+			getTrackedAgentRootPidsSplit: getSplit,
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		await sessionManager.interruptInMemorySession('session-reuse-safety');
+
+		// Mock process.kill to report PID 9999 as alive (even though it's past retention).
+		const originalKill = process.kill;
+		// @ts-expect-error — overriding for test
+		process.kill = mock((_pid: number, _signal: number) => {});
+
+		const RETENTION_MS = 15 * 60 * 1000;
+		const futureNow = Date.now() + RETENTION_MS + 1000;
+
+		try {
+			// Call the internal method with a future timestamp.
+			// Access via type cast since expireEvictedRoots is private.
+			(sessionManager as any).expireEvictedRoots(futureNow);
+
+			const after = sessionManager.getTrackedAgentRootPidsSplit();
+			// PID should be completely removed — not live, not exited.
+			// Even though process.kill(9999, 0) succeeds (PID reused by
+			// an unrelated process), the eviction timestamp is too old.
+			expect(after.live).not.toContain(9999);
+			expect(after.exited).not.toContain(9999);
+		} finally {
+			process.kill = originalKill;
+		}
 	});
 
 	describe('getActiveSessions', () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -333,7 +333,7 @@ describe('SessionManager', () => {
 			expect(result).toBeNull();
 		});
 
-		it('unregisterSession preserves exited root PIDs for watchdog', () => {
+		it('unregisterSession preserves live and exited root PIDs for watchdog', () => {
 			const mockSession: Session = {
 				id: 'room:1:task:2:abc',
 				title: 'Room Session',
@@ -346,17 +346,17 @@ describe('SessionManager', () => {
 				getSessionData: mock(() => mockSession),
 				cleanup: mock(async () => {}),
 				getTrackedAgentRootPidsSplit: mock(() => ({
-					live: [],
-					exited: [7000, 7001],
+					live: [7000],
+					exited: [7001],
 				})),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
 			sessionManager.unregisterSession('room:1:task:2:abc');
 
-			// PIDs should survive eviction via the SessionManager-level map
+			// PIDs should survive eviction — live as live, exited as exited.
 			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(split.exited).toContain(7000);
+			expect(split.live).toContain(7000);
 			expect(split.exited).toContain(7001);
 		});
 	});
@@ -495,12 +495,50 @@ describe('SessionManager', () => {
 			// Interrupt removes the session from cache
 			await sessionManager.interruptInMemorySession('session-with-pids');
 
-			// After interrupt: PIDs should still be visible via the SessionManager-level map
+			// After interrupt: PIDs should still be visible via the SessionManager-level map.
+			// cleanup() transitions live PID 5000 to exited, so all three are preserved as exited.
 			const afterInterrupt = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(afterInterrupt.live).not.toContain(5000); // live becomes "exited" via preserveExitedRootPids
-			expect(afterInterrupt.exited).toContain(5000); // live PID was preserved as exited
+			expect(afterInterrupt.live).not.toContain(5000);
+			expect(afterInterrupt.exited).toContain(5000);
 			expect(afterInterrupt.exited).toContain(5001);
 			expect(afterInterrupt.exited).toContain(5002);
+		});
+
+		it('evicted live root still present in snapshot is tracked as live', async () => {
+			const mockSession: Session = {
+				id: 'session-evicted-live',
+				title: 'Evicted Live',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+
+			// Simulate cleanup that fails to kill the process
+			const getSplit = mock(() => ({
+				live: [8000],
+				exited: [],
+			}));
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {
+					// Process survives cleanup — still live
+					getSplit.mockImplementation(() => ({
+						live: [8000],
+						exited: [],
+					}));
+				}),
+				getTrackedAgentRootPidsSplit: getSplit,
+			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+			await sessionManager.interruptInMemorySession('session-evicted-live');
+
+			// The live root PID must appear as live (not exited) so
+			// collectDescendantPids doesn't skip it as a reused PID.
+			const split = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(split.live).toContain(8000);
+			expect(split.exited).not.toContain(8000);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -354,15 +354,18 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			sessionManager.unregisterSession('room:1:task:2:abc');
 
-			// Mock process.kill to report PID 7000 as alive (signal 0 probe succeeds).
+			// Mock process.kill to throw EPERM for PID 7000 (exists but not signalable).
+			// A successful probe would remove the PID due to ambiguous identity.
 			const originalKill = process.kill;
+			const epermError = new Error('EPERM') as Error & { code: string };
+			epermError.code = 'EPERM';
 			// @ts-expect-error — overriding for test
 			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 7000 && signal === 0) return;
+				if (pid === 7000 && signal === 0) throw epermError;
 				return originalKill(pid, signal);
 			});
 			try {
-				// PIDs should survive eviction — live as live, exited as exited.
+				// Exited PIDs preserved. Live PID kept as live on EPERM.
 				const split = sessionManager.getTrackedAgentRootPidsSplit();
 				expect(split.live).toContain(7000);
 				expect(split.exited).toContain(7001);
@@ -545,11 +548,15 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			await sessionManager.interruptInMemorySession('session-evicted-live');
 
-			// Mock process.kill to report PID 8000 as alive.
+			// Mock process.kill to throw EPERM for PID 8000 (exists but not signalable).
+			// A successful probe removes the PID due to ambiguous identity, but
+			// EPERM keeps it as live.
 			const originalKill = process.kill;
+			const epermError = new Error('EPERM') as Error & { code: string };
+			epermError.code = 'EPERM';
 			// @ts-expect-error — overriding for test
 			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 8000 && signal === 0) return;
+				if (pid === 8000 && signal === 0) throw epermError;
 				return originalKill(pid, signal);
 			});
 			try {
@@ -593,11 +600,13 @@ describe('SessionManager', () => {
 		sessionManager.registerSession(fakeAgentSession);
 		await sessionManager.interruptInMemorySession('session-promote-live');
 
-		// Mock process.kill to report PID 9001 as alive initially.
+		// Mock process.kill to throw EPERM for PID 9001 initially (keeps as live).
+		const epermError = new Error('EPERM') as Error & { code: string };
+		epermError.code = 'EPERM';
 		const originalKill = process.kill;
 		// @ts-expect-error — overriding for test
 		process.kill = mock((pid: number, signal: number) => {
-			if (pid === 9001 && signal === 0) return;
+			if (pid === 9001 && signal === 0) throw epermError;
 			return originalKill(pid, signal);
 		});
 
@@ -610,7 +619,9 @@ describe('SessionManager', () => {
 			// Now simulate the process exiting: mock process.kill(pid, 0) to throw
 			// @ts-expect-error — overriding for test
 			process.kill = mock((_pid: number, _signal: number) => {
-				throw new Error('ESRCH');
+				const esrchError = new Error('ESRCH') as Error & { code: string };
+				esrchError.code = 'ESRCH';
+				throw esrchError;
 			});
 
 			const after = sessionManager.getTrackedAgentRootPidsSplit();
@@ -669,6 +680,98 @@ describe('SessionManager', () => {
 			// an unrelated process), the eviction timestamp is too old.
 			expect(after.live).not.toContain(9999);
 			expect(after.exited).not.toContain(9999);
+		} finally {
+			process.kill = originalKill;
+		}
+	});
+
+	it('removes evicted live root on successful probe (PID identity ambiguous)', async () => {
+		const mockSession: Session = {
+			id: 'session-identity-ambiguous',
+			title: 'Identity Ambiguous',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit = mock(() => ({
+			live: [7777],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {
+				getSplit.mockImplementation(() => ({
+					live: [7777],
+					exited: [],
+				}));
+			}),
+			getTrackedAgentRootPidsSplit: getSplit,
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		await sessionManager.interruptInMemorySession('session-identity-ambiguous');
+
+		// Mock process.kill to succeed — PID exists but identity is ambiguous.
+		const originalKill = process.kill;
+		// @ts-expect-error — overriding for test
+		process.kill = mock((_pid: number, _signal: number) => {});
+
+		try {
+			const split = sessionManager.getTrackedAgentRootPidsSplit();
+			// PID should be removed from both live and exited — we cannot
+			// verify it is the same process that was evicted.
+			expect(split.live).not.toContain(7777);
+			expect(split.exited).not.toContain(7777);
+		} finally {
+			process.kill = originalKill;
+		}
+	});
+
+	it('keeps evicted live root on EPERM (process exists but not signalable)', async () => {
+		const mockSession: Session = {
+			id: 'session-eperm',
+			title: 'EPERM Test',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit = mock(() => ({
+			live: [6666],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {
+				getSplit.mockImplementation(() => ({
+					live: [6666],
+					exited: [],
+				}));
+			}),
+			getTrackedAgentRootPidsSplit: getSplit,
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		await sessionManager.interruptInMemorySession('session-eperm');
+
+		// Mock process.kill to throw EPERM — process exists but not signalable.
+		const originalKill = process.kill;
+		const epermError = new Error('EPERM') as Error & { code: string };
+		epermError.code = 'EPERM';
+		// @ts-expect-error — overriding for test
+		process.kill = mock((pid: number, signal: number) => {
+			if (pid === 6666 && signal === 0) throw epermError;
+			return originalKill(pid, signal);
+		});
+
+		try {
+			const split = sessionManager.getTrackedAgentRootPidsSplit();
+			// PID should remain as live — EPERM means the process exists.
+			expect(split.live).toContain(6666);
+			expect(split.exited).not.toContain(6666);
 		} finally {
 			process.kill = originalKill;
 		}

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -322,6 +322,7 @@ describe('SessionManager', () => {
 				getSessionData: mock(() => mockSession),
 				cleanup: mock(async () => {}),
 				getTrackedAgentRootPidsSplit: mock(() => ({ live: [], exited: [] })),
+				getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
@@ -349,23 +350,25 @@ describe('SessionManager', () => {
 					live: [7000],
 					exited: [7001],
 				})),
+				getExitedRootPidTimestamps: mock(() => {
+					const m = new Map<number, number>();
+					m.set(7001, Date.now() - 5 * 60 * 1000);
+					return m;
+				}),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
 			sessionManager.unregisterSession('room:1:task:2:abc');
 
-			// Mock process.kill to throw EPERM for PID 7000 (exists but not signalable).
-			// A successful probe would remove the PID due to ambiguous identity.
+			// Mock process.kill to succeed for PID 7000 (process is alive).
 			const originalKill = process.kill;
-			const epermError = new Error('EPERM') as Error & { code: string };
-			epermError.code = 'EPERM';
 			// @ts-expect-error — overriding for test
 			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 7000 && signal === 0) throw epermError;
+				if (pid === 7000 && signal === 0) return;
 				return originalKill(pid, signal);
 			});
 			try {
-				// Exited PIDs preserved. Live PID kept as live on EPERM.
+				// PIDs survive eviction — live as live, exited as exited.
 				const split = sessionManager.getTrackedAgentRootPidsSplit();
 				expect(split.live).toContain(7000);
 				expect(split.exited).toContain(7001);
@@ -497,6 +500,14 @@ describe('SessionManager', () => {
 					}));
 				}),
 				getTrackedAgentRootPidsSplit: getSplit,
+				getExitedRootPidTimestamps: mock(() => {
+					const m = new Map<number, number>();
+					// Before cleanup: 5001 and 5002 already exited
+					m.set(5001, Date.now() - 3 * 60 * 1000);
+					m.set(5002, Date.now() - 7 * 60 * 1000);
+					m.set(5000, Date.now() - 1 * 60 * 1000);
+					return m;
+				}),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
@@ -543,20 +554,17 @@ describe('SessionManager', () => {
 					}));
 				}),
 				getTrackedAgentRootPidsSplit: getSplit,
+				getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
 			await sessionManager.interruptInMemorySession('session-evicted-live');
 
-			// Mock process.kill to throw EPERM for PID 8000 (exists but not signalable).
-			// A successful probe removes the PID due to ambiguous identity, but
-			// EPERM keeps it as live.
+			// Mock process.kill to succeed for PID 8000 (process is alive).
 			const originalKill = process.kill;
-			const epermError = new Error('EPERM') as Error & { code: string };
-			epermError.code = 'EPERM';
 			// @ts-expect-error — overriding for test
 			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 8000 && signal === 0) throw epermError;
+				if (pid === 8000 && signal === 0) return;
 				return originalKill(pid, signal);
 			});
 			try {
@@ -595,18 +603,17 @@ describe('SessionManager', () => {
 				}));
 			}),
 			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
 		await sessionManager.interruptInMemorySession('session-promote-live');
 
-		// Mock process.kill to throw EPERM for PID 9001 initially (keeps as live).
-		const epermError = new Error('EPERM') as Error & { code: string };
-		epermError.code = 'EPERM';
+		// Mock process.kill to succeed for PID 9001 (process is alive).
 		const originalKill = process.kill;
 		// @ts-expect-error — overriding for test
 		process.kill = mock((pid: number, signal: number) => {
-			if (pid === 9001 && signal === 0) throw epermError;
+			if (pid === 9001 && signal === 0) return;
 			return originalKill(pid, signal);
 		});
 
@@ -656,6 +663,7 @@ describe('SessionManager', () => {
 				}));
 			}),
 			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
@@ -685,7 +693,7 @@ describe('SessionManager', () => {
 		}
 	});
 
-	it('removes evicted live root on successful probe (PID identity ambiguous)', async () => {
+	it('keeps evicted live root on successful liveness probe', async () => {
 		const mockSession: Session = {
 			id: 'session-identity-ambiguous',
 			title: 'Identity Ambiguous',
@@ -708,21 +716,22 @@ describe('SessionManager', () => {
 				}));
 			}),
 			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
 		await sessionManager.interruptInMemorySession('session-identity-ambiguous');
 
-		// Mock process.kill to succeed — PID exists but identity is ambiguous.
+		// Mock process.kill to succeed — process is alive.
 		const originalKill = process.kill;
 		// @ts-expect-error — overriding for test
 		process.kill = mock((_pid: number, _signal: number) => {});
 
 		try {
 			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			// PID should be removed from both live and exited — we cannot
-			// verify it is the same process that was evicted.
-			expect(split.live).not.toContain(7777);
+			// PID should remain as live — retention window handles eventual
+			// expiry; suspicious pattern filters guard against PID reuse.
+			expect(split.live).toContain(7777);
 			expect(split.exited).not.toContain(7777);
 		} finally {
 			process.kill = originalKill;
@@ -752,6 +761,7 @@ describe('SessionManager', () => {
 				}));
 			}),
 			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -326,7 +326,7 @@ describe('SessionManager', () => {
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
-			sessionManager.unregisterSession('room:1:task:2:xyz');
+			await sessionManager.unregisterSession('room:1:task:2:xyz');
 
 			// After unregister, getSession should return null (not in cache, not in DB)
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(null);
@@ -334,7 +334,7 @@ describe('SessionManager', () => {
 			expect(result).toBeNull();
 		});
 
-		it('unregisterSession preserves live and exited root PIDs for watchdog', () => {
+		it('unregisterSession preserves live and exited root PIDs for watchdog', async () => {
 			const mockSession: Session = {
 				id: 'room:1:task:2:abc',
 				title: 'Room Session',
@@ -358,7 +358,7 @@ describe('SessionManager', () => {
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
-			sessionManager.unregisterSession('room:1:task:2:abc');
+			await sessionManager.unregisterSession('room:1:task:2:abc');
 
 			// Pass snapshot with PID 7000 so snapshot-based identity
 			// verification confirms it as live (first probe captures startTime).
@@ -602,10 +602,47 @@ describe('SessionManager', () => {
 		expect(before.live).toContain(9001);
 		expect(before.exited).not.toContain(9001);
 
-		// Without snapshot, PID is not found in the process table â promoted to exited.
-		const after = sessionManager.getTrackedAgentRootPidsSplit();
+		// Pass snapshot without PID 9001 (process exited) â promoted to exited.
+		const otherSnapshot = [{ pid: 1, ppid: 0, pgid: 1, elapsedSeconds: 100, command: 'init' }];
+		const after = sessionManager.getTrackedAgentRootPidsSplit(otherSnapshot);
 		expect(after.live).not.toContain(9001);
 		expect(after.exited).toContain(9001);
+	});
+
+	it('skips live-root promotion when no snapshot is provided', async () => {
+		const mockSession: Session = {
+			id: 'session-no-snapshot',
+			title: 'No Snapshot',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit = mock(() => ({
+			live: [9002],
+			exited: [],
+		}));
+		const fakeAgentSession = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {
+				getSplit.mockImplementation(() => ({
+					live: [9002],
+					exited: [],
+				}));
+			}),
+			getTrackedAgentRootPidsSplit: getSplit,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession);
+		await sessionManager.interruptInMemorySession('session-no-snapshot');
+
+		// Without a snapshot, the evicted live root stays live â no false
+		// promotion to exited when the process table is unavailable.
+		const split = sessionManager.getTrackedAgentRootPidsSplit();
+		expect(split.live).toContain(9002);
+		expect(split.exited).not.toContain(9002);
 	});
 
 	it('removes evicted live root past retention window (PID reuse safety)', async () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -321,6 +321,7 @@ describe('SessionManager', () => {
 			const fakeAgentSession = {
 				getSessionData: mock(() => mockSession),
 				cleanup: mock(async () => {}),
+				getTrackedAgentRootPidsSplit: mock(() => ({ live: [], exited: [] })),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);
@@ -330,6 +331,33 @@ describe('SessionManager', () => {
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(null);
 			const result = await sessionManager.getSessionAsync('room:1:task:2:xyz');
 			expect(result).toBeNull();
+		});
+
+		it('unregisterSession preserves exited root PIDs for watchdog', () => {
+			const mockSession: Session = {
+				id: 'room:1:task:2:abc',
+				title: 'Room Session',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {}),
+				getTrackedAgentRootPidsSplit: mock(() => ({
+					live: [7000],
+					exited: [7001],
+				})),
+			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+			sessionManager.unregisterSession('room:1:task:2:abc');
+
+			// PIDs should survive eviction via the SessionManager-level map
+			const split = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(split.exited).toContain(7000); // was live, now preserved as exited
+			expect(split.exited).toContain(7001);
 		});
 	});
 
@@ -428,6 +456,44 @@ describe('SessionManager', () => {
 			await sessionManager.interruptInMemorySession('ephemeral-id');
 
 			expect(mockDb.deleteSession).not.toHaveBeenCalled();
+		});
+
+		it('preserves exited root PIDs after cache eviction for watchdog ownership', async () => {
+			const mockSession: Session = {
+				id: 'session-with-pids',
+				title: 'PID Session',
+				workspacePath: '/test',
+				status: 'active',
+				config: {},
+				metadata: {},
+			};
+
+			// Create a fake AgentSession with tracked exited root PIDs
+			const fakeAgentSession = {
+				getSessionData: mock(() => mockSession),
+				cleanup: mock(async () => {}),
+				getTrackedAgentRootPidsSplit: mock(() => ({
+					live: [5000],
+					exited: [5001, 5002],
+				})),
+			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+			sessionManager.registerSession(fakeAgentSession);
+
+			// Before interrupt: PIDs come from the session cache
+			const beforeInterrupt = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(beforeInterrupt.live).toContain(5000);
+			expect(beforeInterrupt.exited).toContain(5001);
+
+			// Interrupt removes the session from cache
+			await sessionManager.interruptInMemorySession('session-with-pids');
+
+			// After interrupt: PIDs should still be visible via the SessionManager-level map
+			const afterInterrupt = sessionManager.getTrackedAgentRootPidsSplit();
+			expect(afterInterrupt.live).not.toContain(5000); // live becomes "exited" via preserveExitedRootPids
+			expect(afterInterrupt.exited).toContain(5000); // live PID was preserved as exited
+			expect(afterInterrupt.exited).toContain(5001);
+			expect(afterInterrupt.exited).toContain(5002);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -360,21 +360,14 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			sessionManager.unregisterSession('room:1:task:2:abc');
 
-			// Mock process.kill to succeed for PID 7000 (process is alive).
-			const originalKill = process.kill;
-			// @ts-expect-error — overriding for test
-			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 7000 && signal === 0) return;
-				return originalKill(pid, signal);
-			});
-			try {
-				// PIDs survive eviction — live as live, exited as exited.
-				const split = sessionManager.getTrackedAgentRootPidsSplit();
-				expect(split.live).toContain(7000);
-				expect(split.exited).toContain(7001);
-			} finally {
-				process.kill = originalKill;
-			}
+			// Pass snapshot with PID 7000 so snapshot-based identity
+			// verification confirms it as live (first probe captures startTime).
+			const fakeSnapshot = [
+				{ pid: 7000, ppid: 1, pgid: 7000, elapsedSeconds: 60, command: 'live-root' },
+			];
+			const split = sessionManager.getTrackedAgentRootPidsSplit(fakeSnapshot);
+			expect(split.live).toContain(7000);
+			expect(split.exited).toContain(7001);
 		});
 	});
 
@@ -547,7 +540,7 @@ describe('SessionManager', () => {
 			const fakeAgentSession = {
 				getSessionData: mock(() => mockSession),
 				cleanup: mock(async () => {
-					// Process survives cleanup — still live
+					// Process survives cleanup â still live
 					getSplit.mockImplementation(() => ({
 						live: [8000],
 						exited: [],
@@ -560,22 +553,14 @@ describe('SessionManager', () => {
 			sessionManager.registerSession(fakeAgentSession);
 			await sessionManager.interruptInMemorySession('session-evicted-live');
 
-			// Mock process.kill to succeed for PID 8000 (process is alive).
-			const originalKill = process.kill;
-			// @ts-expect-error — overriding for test
-			process.kill = mock((pid: number, signal: number) => {
-				if (pid === 8000 && signal === 0) return;
-				return originalKill(pid, signal);
-			});
-			try {
-				// The live root PID must appear as live (not exited) so
-				// collectDescendantPids doesn't skip it as a reused PID.
-				const split = sessionManager.getTrackedAgentRootPidsSplit();
-				expect(split.live).toContain(8000);
-				expect(split.exited).not.toContain(8000);
-			} finally {
-				process.kill = originalKill;
-			}
+			// Pass snapshot with PID 8000 so snapshot-based identity
+			// verification confirms it as live (first probe captures startTime).
+			const fakeSnapshot = [
+				{ pid: 8000, ppid: 1, pgid: 8000, elapsedSeconds: 60, command: 'live-root' },
+			];
+			const split = sessionManager.getTrackedAgentRootPidsSplit(fakeSnapshot);
+			expect(split.live).toContain(8000);
+			expect(split.exited).not.toContain(8000);
 		});
 	});
 
@@ -609,35 +594,18 @@ describe('SessionManager', () => {
 		sessionManager.registerSession(fakeAgentSession);
 		await sessionManager.interruptInMemorySession('session-promote-live');
 
-		// Mock process.kill to succeed for PID 9001 (process is alive).
-		const originalKill = process.kill;
-		// @ts-expect-error — overriding for test
-		process.kill = mock((pid: number, signal: number) => {
-			if (pid === 9001 && signal === 0) return;
-			return originalKill(pid, signal);
-		});
+		// Pass snapshot with PID 9001 so identity is verified as live.
+		const fakeSnapshot = [
+			{ pid: 9001, ppid: 1, pgid: 9001, elapsedSeconds: 60, command: 'live-root' },
+		];
+		const before = sessionManager.getTrackedAgentRootPidsSplit(fakeSnapshot);
+		expect(before.live).toContain(9001);
+		expect(before.exited).not.toContain(9001);
 
-		try {
-			// Initially the PID is tracked as live
-			const before = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(before.live).toContain(9001);
-			expect(before.exited).not.toContain(9001);
-
-			// Now simulate the process exiting: mock process.kill(pid, 0) to throw
-			// @ts-expect-error — overriding for test
-			process.kill = mock((_pid: number, _signal: number) => {
-				const esrchError = new Error('ESRCH') as Error & { code: string };
-				esrchError.code = 'ESRCH';
-				throw esrchError;
-			});
-
-			const after = sessionManager.getTrackedAgentRootPidsSplit();
-			// PID should be promoted from live to exited
-			expect(after.live).not.toContain(9001);
-			expect(after.exited).toContain(9001);
-		} finally {
-			process.kill = originalKill;
-		}
+		// Without snapshot, PID is not found in the process table â promoted to exited.
+		const after = sessionManager.getTrackedAgentRootPidsSplit();
+		expect(after.live).not.toContain(9001);
+		expect(after.exited).toContain(9001);
 	});
 
 	it('removes evicted live root past retention window (PID reuse safety)', async () => {
@@ -669,34 +637,29 @@ describe('SessionManager', () => {
 		sessionManager.registerSession(fakeAgentSession);
 		await sessionManager.interruptInMemorySession('session-reuse-safety');
 
-		// Mock process.kill to report PID 9999 as alive (even though it's past retention).
-		const originalKill = process.kill;
-		// @ts-expect-error — overriding for test
-		process.kill = mock((_pid: number, _signal: number) => {});
-
 		const RETENTION_MS = 15 * 60 * 1000;
 		const futureNow = Date.now() + RETENTION_MS + 1000;
 
-		try {
-			// Call the internal method with a future timestamp.
-			// Access via type cast since expireEvictedRoots is private.
-			(sessionManager as any).expireEvictedRoots(futureNow);
+		// Call the internal method with a future timestamp and a snapshot
+		// containing PID 9999 (simulating PID reuse by an unrelated process).
+		// Access via type cast since expireEvictedRoots is private.
+		const fakeSnapshot = [
+			{ pid: 9999, ppid: 1, pgid: 9999, elapsedSeconds: 60, command: 'unrelated' },
+		];
+		(sessionManager as any).expireEvictedRoots(fakeSnapshot, futureNow);
 
-			const after = sessionManager.getTrackedAgentRootPidsSplit();
-			// PID should be completely removed — not live, not exited.
-			// Even though process.kill(9999, 0) succeeds (PID reused by
-			// an unrelated process), the eviction timestamp is too old.
-			expect(after.live).not.toContain(9999);
-			expect(after.exited).not.toContain(9999);
-		} finally {
-			process.kill = originalKill;
-		}
+		const after = sessionManager.getTrackedAgentRootPidsSplit();
+		// PID should be completely removed â not live, not exited.
+		// The retention window expired, so even though the PID exists in the
+		// snapshot (reused by an unrelated process), it is removed.
+		expect(after.live).not.toContain(9999);
+		expect(after.exited).not.toContain(9999);
 	});
 
-	it('keeps evicted live root on successful liveness probe', async () => {
+	it('keeps evicted live root on successful identity verification via snapshot', async () => {
 		const mockSession: Session = {
-			id: 'session-identity-ambiguous',
-			title: 'Identity Ambiguous',
+			id: 'session-identity-verified',
+			title: 'Identity Verified',
 			workspacePath: '/test',
 			status: 'active',
 			config: {},
@@ -720,28 +683,22 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
-		await sessionManager.interruptInMemorySession('session-identity-ambiguous');
+		await sessionManager.interruptInMemorySession('session-identity-verified');
 
-		// Mock process.kill to succeed — process is alive.
-		const originalKill = process.kill;
-		// @ts-expect-error — overriding for test
-		process.kill = mock((_pid: number, _signal: number) => {});
-
-		try {
-			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			// PID should remain as live — retention window handles eventual
-			// expiry; suspicious pattern filters guard against PID reuse.
-			expect(split.live).toContain(7777);
-			expect(split.exited).not.toContain(7777);
-		} finally {
-			process.kill = originalKill;
-		}
+		// Pass snapshot with PID 7777 â first probe captures startTime,
+		// subsequent calls with matching elapsed time confirm identity.
+		const fakeSnapshot = [
+			{ pid: 7777, ppid: 1, pgid: 7777, elapsedSeconds: 60, command: 'live-root' },
+		];
+		const split = sessionManager.getTrackedAgentRootPidsSplit(fakeSnapshot);
+		expect(split.live).toContain(7777);
+		expect(split.exited).not.toContain(7777);
 	});
 
-	it('keeps evicted live root on EPERM (process exists but not signalable)', async () => {
+	it('removes evicted live root on PID reuse detected via startTime mismatch', async () => {
 		const mockSession: Session = {
-			id: 'session-eperm',
-			title: 'EPERM Test',
+			id: 'session-pid-reuse',
+			title: 'PID Reuse',
 			workspacePath: '/test',
 			status: 'active',
 			config: {},
@@ -765,26 +722,24 @@ describe('SessionManager', () => {
 		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 		sessionManager.registerSession(fakeAgentSession);
-		await sessionManager.interruptInMemorySession('session-eperm');
+		await sessionManager.interruptInMemorySession('session-pid-reuse');
 
-		// Mock process.kill to throw EPERM — process exists but not signalable.
-		const originalKill = process.kill;
-		const epermError = new Error('EPERM') as Error & { code: string };
-		epermError.code = 'EPERM';
-		// @ts-expect-error — overriding for test
-		process.kill = mock((pid: number, signal: number) => {
-			if (pid === 6666 && signal === 0) throw epermError;
-			return originalKill(pid, signal);
-		});
+		// First snapshot: PID 6666 with 60s elapsed â captures startTime.
+		const snapshot1 = [
+			{ pid: 6666, ppid: 1, pgid: 6666, elapsedSeconds: 60, command: 'original-process' },
+		];
+		const first = sessionManager.getTrackedAgentRootPidsSplit(snapshot1);
+		expect(first.live).toContain(6666);
 
-		try {
-			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			// PID should remain as live — EPERM means the process exists.
-			expect(split.live).toContain(6666);
-			expect(split.exited).not.toContain(6666);
-		} finally {
-			process.kill = originalKill;
-		}
+		// Second snapshot: PID 6666 with 5s elapsed â startTime changed by ~55s,
+		// indicating PID reuse by a different process.
+		const snapshot2 = [
+			{ pid: 6666, ppid: 1, pgid: 6666, elapsedSeconds: 5, command: 'replaced-process' },
+		];
+		const second = sessionManager.getTrackedAgentRootPidsSplit(snapshot2);
+		// PID removed â startTime mismatch indicates PID reuse.
+		expect(second.live).not.toContain(6666);
+		expect(second.exited).not.toContain(6666);
 	});
 
 	describe('getActiveSessions', () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -779,6 +779,56 @@ describe('SessionManager', () => {
 		expect(second.exited).not.toContain(6666);
 	});
 
+	it('refreshes evictedAt and startTime on same-PID re-eviction before watchdog poll', async () => {
+		const mockSession: Session = {
+			id: 'session-reevict',
+			title: 'Re-Evict',
+			workspacePath: '/test',
+			status: 'active',
+			config: {},
+			metadata: {},
+		};
+
+		const getSplit1 = mock(() => ({
+			live: [5555],
+			exited: [],
+		}));
+		const fakeAgentSession1 = {
+			getSessionData: mock(() => mockSession),
+			cleanup: mock(async () => {}),
+			getTrackedAgentRootPidsSplit: getSplit1,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession1);
+		await sessionManager.unregisterSession('session-reevict');
+
+		// First eviction establishes evictedAt and startTime for PID 5555
+		const first = sessionManager.getTrackedAgentRootPidsSplit([]);
+		expect(first.live).toContain(5555);
+
+		// Re-register the same PID via a new session eviction (PID reused by
+		// a new daemon-owned session before the watchdog observed it).
+		const getSplit2 = mock(() => ({
+			live: [5555],
+			exited: [],
+		}));
+		const fakeAgentSession2 = {
+			getSessionData: mock(() => ({ ...mockSession, id: 'session-reevict-2' })),
+			cleanup: mock(async () => {}),
+			getTrackedAgentRootPidsSplit: getSplit2,
+			getExitedRootPidTimestamps: mock(() => new Map<number, number>()),
+		} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
+
+		sessionManager.registerSession(fakeAgentSession2);
+		await sessionManager.unregisterSession('session-reevict-2');
+
+		// After re-eviction, PID 5555 should still be tracked as live with
+		// refreshed evictedAt (retention window restarts from now).
+		const second = sessionManager.getTrackedAgentRootPidsSplit([]);
+		expect(second.live).toContain(5555);
+	});
+
 	describe('getActiveSessions', () => {
 		it('should return count from sessionCache', () => {
 			expect(sessionManager.getActiveSessions()).toBe(0);

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -346,8 +346,8 @@ describe('SessionManager', () => {
 				getSessionData: mock(() => mockSession),
 				cleanup: mock(async () => {}),
 				getTrackedAgentRootPidsSplit: mock(() => ({
-					live: [7000],
-					exited: [7001],
+					live: [],
+					exited: [7000, 7001],
 				})),
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
@@ -356,7 +356,7 @@ describe('SessionManager', () => {
 
 			// PIDs should survive eviction via the SessionManager-level map
 			const split = sessionManager.getTrackedAgentRootPidsSplit();
-			expect(split.exited).toContain(7000); // was live, now preserved as exited
+			expect(split.exited).toContain(7000);
 			expect(split.exited).toContain(7001);
 		});
 	});
@@ -468,14 +468,21 @@ describe('SessionManager', () => {
 				metadata: {},
 			};
 
-			// Create a fake AgentSession with tracked exited root PIDs
+			// Before cleanup: process is live. After cleanup: transitions to exited.
+			const getSplit = mock(() => ({
+				live: [5000],
+				exited: [5001, 5002],
+			}));
 			const fakeAgentSession = {
 				getSessionData: mock(() => mockSession),
-				cleanup: mock(async () => {}),
-				getTrackedAgentRootPidsSplit: mock(() => ({
-					live: [5000],
-					exited: [5001, 5002],
-				})),
+				cleanup: mock(async () => {
+					// Simulate cleanup transitioning live PID to exited
+					getSplit.mockImplementation(() => ({
+						live: [],
+						exited: [5000, 5001, 5002],
+					}));
+				}),
+				getTrackedAgentRootPidsSplit: getSplit,
 			} as unknown as import('../../../../src/lib/agent/agent-session').AgentSession;
 
 			sessionManager.registerSession(fakeAgentSession);


### PR DESCRIPTION
Addresses three post-merge P2 review comments from #1890.

1. **Watchdog process groups** (`process-watchdog.ts`): `cleanupSuspiciousProcesses` now sends `SIGTERM` to the owned process group (via `pgid`) before the individual PID, reaching tool grandchildren that the parent may not have forwarded signals to.

2. **No-PID exit promise aggregation** (`agent-session.ts`): `trackAgentProcess` now aggregates the no-PID exit promise alongside existing `trackedAgentProcessExitPromises` instead of overwriting `processExitedPromise`, which caused `stop()` to wait on the wrong promise during restart overlap.

3. **Watchdog roots after cache eviction** (`session-manager.ts`): A new `recentlyExitedAgentRootPids` map at the SessionManager level preserves exited root PIDs when sessions are evicted from cache via `interruptInMemorySession()` or `unregisterSession()`, preventing ownership attribution loss before the 15-minute retention window expires.

Closes comment threads: #r3237801589, #r3237801591, #r3237801594