### PR TITLE
fix(web): reset auto-scroll latch on navigation to ensure scroll-to-bottom

### DIFF
--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -185,7 +185,7 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('auto-scroll behavior', () => {
-		it('should observe the content wrapper for markdown height changes', () => {
+		it('should observe the container and content wrapper for resize-driven anchoring', () => {
 			const { containerRef, endRef } = createMockRefs();
 
 			renderHook(() =>
@@ -197,7 +197,10 @@ describe('useAutoScroll', () => {
 				})
 			);
 
-			expect(resizeObserverInstances[0]?.observedTargets).toEqual([endRef.current!.parentElement]);
+			expect(resizeObserverInstances[0]?.observedTargets).toEqual([
+				containerRef.current,
+				endRef.current!.parentElement,
+			]);
 		});
 
 		it('should scroll on initial load when messages arrive', () => {

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -14,15 +14,21 @@ import { useAutoScroll } from '../useAutoScroll.ts';
 
 // Helper to create mock refs
 function createMockRefs() {
-	const scrollIntoViewMock = vi.fn(() => {});
+	const scrollIntoViewMock = vi.fn(function (this: HTMLDivElement, options?: ScrollToOptions) {
+		if (typeof options?.top === 'number') {
+			this.scrollTop = options.top;
+		}
+	});
 	const addEventListenerMock = vi.fn(() => {});
 	const removeEventListenerMock = vi.fn(() => {});
+	const scrollToMock = scrollIntoViewMock;
 
 	const containerRef = {
 		current: {
 			scrollTop: 0,
 			scrollHeight: 1000,
 			clientHeight: 500,
+			scrollTo: scrollToMock,
 			addEventListener: addEventListenerMock,
 			removeEventListener: removeEventListenerMock,
 		} as unknown as HTMLDivElement,
@@ -38,6 +44,7 @@ function createMockRefs() {
 		containerRef,
 		endRef,
 		scrollIntoViewMock,
+		scrollToMock,
 		addEventListenerMock,
 		removeEventListenerMock,
 	};
@@ -111,8 +118,8 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('scrollToBottom', () => {
-		it('should call scrollIntoView with instant behavior and block: end by default', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+		it('should scroll the container to its scrollHeight with instant behavior by default', () => {
+			const { containerRef, endRef, scrollToMock, scrollIntoViewMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -127,13 +134,12 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom();
 			});
 
-			// block: 'end' combined with the container's scroll-padding-bottom keeps
-			// the last message above the floating composer rather than behind it.
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant', block: 'end' });
+			expect(scrollToMock).toHaveBeenCalledWith({ top: 1000, behavior: 'instant' });
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
-		it('should call scrollIntoView with smooth behavior and block: end when specified', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+		it('should scroll the container to its scrollHeight with smooth behavior when specified', () => {
+			const { containerRef, endRef, scrollToMock, scrollIntoViewMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -148,7 +154,8 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom(true);
 			});
 
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
+			expect(scrollToMock).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should handle null endRef gracefully', () => {
@@ -467,11 +474,12 @@ describe('useAutoScroll', () => {
 			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 		});
 
-		it('should reset mount-scroll latch when isInitialLoad flips back to true', () => {
-			// Preserves the existing reset semantic — a parent can signal
-			// "treat the next non-empty messageCount as a fresh load" by
-			// toggling the prop. Used for in-place session swaps that don't
-			// remount the hook.
+		it('should scroll to bottom on task switch without remount (messageCount N → 0 → M)', () => {
+			// Reproduces the SpaceTaskUnifiedThread task-switch scenario:
+			// Component re-renders in place (no key change), so hasScrolledOnMountRef
+			// stays true from the previous task. When rows are cleared (messageCount→0)
+			// and then repopulated from the new task (messageCount→M), the hook must
+			// still scroll to the bottom via the hasNewContent path.
 			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			const { rerender } = renderHook(
@@ -479,28 +487,138 @@ describe('useAutoScroll', () => {
 					useAutoScroll({
 						containerRef,
 						endRef,
-						enabled: false,
+						enabled: true,
 						messageCount,
 						isInitialLoad,
 					}),
 				{
-					initialProps: { messageCount: 5, isInitialLoad: false },
+					// Task A: loaded with 10 messages, isInitialLoad=false (loaded)
+					initialProps: { messageCount: 10, isInitialLoad: false },
 				}
 			);
 
-			// Initial mount-scroll fires (messageCount > 0).
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			// Initial mount-scroll fires (messageCount > 0 on first render)
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 			scrollIntoViewMock.mockClear();
 
-			// Parent signals "fresh session" by toggling isInitialLoad back to
-			// true with a fresh (empty) messageCount.
+			// Task B: rows cleared, loading starts (isInitialLoad=true)
 			rerender({ messageCount: 0, isInitialLoad: true });
-			rerender({ messageCount: 0, isInitialLoad: false });
 
-			// New session's messages arrive — should scroll again because the
-			// mount-scroll latch was reset by the isInitialLoad → true edge.
-			rerender({ messageCount: 7, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			// Task B: snapshot arrives, loading done (isInitialLoad=false)
+			rerender({ messageCount: 15, isInitialLoad: false });
+
+			// Should have scrolled for the new task's content
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should scroll to bottom on task switch when new task has fewer messages', () => {
+			// Edge case: switching from a task with many messages to one with fewer.
+			// The hasNewContent path checks messageCount > prevMessageCountRef,
+			// but the 0 → M transition ensures hasNewContent is always true.
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, isInitialLoad }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad,
+					}),
+				{
+					// Task A has 50 messages
+					initialProps: { messageCount: 50, isInitialLoad: false },
+				}
+			);
+
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			scrollIntoViewMock.mockClear();
+
+			// Task B: rows cleared, loading starts
+			rerender({ messageCount: 0, isInitialLoad: true });
+
+			// Task B: only 5 messages (fewer than task A's 50)
+			rerender({ messageCount: 5, isInitialLoad: false });
+
+			// Should still scroll even though new task has fewer messages
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should scroll on repeated task switches (N → 0 → M → 0 → K)', () => {
+			// Simulates switching between multiple tasks in sequence.
+			// Each switch goes through: loaded → loading (0) → loaded (new messages).
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, isInitialLoad }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad,
+					}),
+				{
+					initialProps: { messageCount: 10, isInitialLoad: false },
+				}
+			);
+
+			// Task A: initial load
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			scrollIntoViewMock.mockClear();
+
+			// Switch to task B: loading → loaded
+			rerender({ messageCount: 0, isInitialLoad: true });
+			rerender({ messageCount: 20, isInitialLoad: false });
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			scrollIntoViewMock.mockClear();
+
+			// Switch to task C: loading → loaded (fewer messages)
+			rerender({ messageCount: 0, isInitialLoad: true });
+			rerender({ messageCount: 3, isInitialLoad: false });
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should scroll on new content after messageCount drops to 0', () => {
+			// When the message list is cleared (task switch, session navigation),
+			// prevMessageCountRef resets so the next non-zero count is
+			// seen as new content. This is the fix for SpaceTaskUnifiedThread,
+			// which re-renders in place without a key change on task switch.
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, enabled }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled,
+						messageCount,
+						isInitialLoad: false,
+					}),
+				{
+					initialProps: { messageCount: 10, enabled: true },
+				}
+			);
+
+			// Initial mount-scroll fires.
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			scrollIntoViewMock.mockClear();
+
+			// Messages cleared (e.g., loading state during task switch).
+			rerender({ messageCount: 0, enabled: true });
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+			// New task's messages arrive — prevMessageCountRef was reset to 0,
+			// so the 0→7 transition is seen as new content and scrolls.
+			rerender({ messageCount: 7, enabled: true });
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+			scrollIntoViewMock.mockClear();
+
+			// Subsequent new-message scrolls use the hasNewContent path.
+			rerender({ messageCount: 8, enabled: true });
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -746,7 +864,7 @@ describe('useAutoScroll', () => {
 					containerRef,
 					endRef,
 					enabled: true,
-					messageCount: 5,
+					messageCount: 0,
 				})
 			);
 
@@ -778,8 +896,9 @@ describe('useAutoScroll', () => {
 					useAutoScroll({
 						containerRef,
 						endRef,
-						enabled: true,
+						enabled: false,
 						messageCount: 5,
+						isInitialLoad: true,
 						loadingOlder,
 					}),
 				{ initialProps: { loadingOlder: false } }
@@ -814,7 +933,7 @@ describe('useAutoScroll', () => {
 					containerRef,
 					endRef,
 					enabled: true,
-					messageCount: 5,
+					messageCount: 0,
 				})
 			);
 

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -23,6 +23,7 @@ function createMockRefs() {
 	const removeEventListenerMock = vi.fn(() => {});
 	const scrollToMock = scrollIntoViewMock;
 
+	const contentWrapper = {} as HTMLDivElement;
 	const containerRef = {
 		current: {
 			scrollTop: 0,
@@ -36,6 +37,7 @@ function createMockRefs() {
 
 	const endRef = {
 		current: {
+			parentElement: contentWrapper,
 			scrollIntoView: scrollIntoViewMock,
 		} as unknown as HTMLDivElement,
 	} as RefObject<HTMLDivElement>;
@@ -56,12 +58,15 @@ let resizeObserverInstances: MockResizeObserver[] = [];
 // Mock ResizeObserver
 class MockResizeObserver {
 	callback: ResizeObserverCallback;
+	observedTargets: Element[] = [];
 
 	constructor(callback: ResizeObserverCallback) {
 		this.callback = callback;
 		resizeObserverInstances.push(this);
 	}
-	observe() {}
+	observe(target: Element) {
+		this.observedTargets.push(target);
+	}
 	unobserve() {}
 	disconnect() {}
 	// Helper to trigger resize callback
@@ -180,6 +185,21 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('auto-scroll behavior', () => {
+		it('should observe the content wrapper for markdown height changes', () => {
+			const { containerRef, endRef } = createMockRefs();
+
+			renderHook(() =>
+				useAutoScroll({
+					containerRef,
+					endRef,
+					enabled: true,
+					messageCount: 0,
+				})
+			);
+
+			expect(resizeObserverInstances[0]?.observedTargets).toEqual([endRef.current!.parentElement]);
+		});
+
 		it('should scroll on initial load when messages arrive', () => {
 			vi.useFakeTimers();
 			const { containerRef, endRef } = createMockRefs();

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -119,7 +119,7 @@ describe('useAutoScroll', () => {
 
 	describe('scrollToBottom', () => {
 		it('should scroll the container to its scrollHeight with instant behavior by default', () => {
-			const { containerRef, endRef, scrollToMock, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef, scrollToMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -134,12 +134,13 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom();
 			});
 
-			expect(scrollToMock).toHaveBeenCalledWith({ top: 1000, behavior: 'instant' });
+			// Instant path uses direct property assignment, not scrollTo().
+			expect(scrollToMock).not.toHaveBeenCalled();
 			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll the container to its scrollHeight with smooth behavior when specified', () => {
-			const { containerRef, endRef, scrollToMock, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef, scrollToMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -180,7 +181,7 @@ describe('useAutoScroll', () => {
 
 	describe('auto-scroll behavior', () => {
 		it('should scroll on initial load when messages arrive', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			// Start with isInitialLoad=true and 0 messages
 			const { rerender } = renderHook(
@@ -200,7 +201,7 @@ describe('useAutoScroll', () => {
 			// Rerender with messages arriving
 			rerender({ messageCount: 5, isInitialLoad: true });
 
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should NOT force-scroll on initial load when enabled=false (deep-link case)', () => {
@@ -208,7 +209,7 @@ describe('useAutoScroll', () => {
 			// `useScrollToMessage` hook), it sets `enabled: false` so the
 			// initial-load forced scroll-to-bottom does not race with — and
 			// override — the deep-link `scrollIntoView`.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad, enabled }) =>
@@ -226,11 +227,11 @@ describe('useAutoScroll', () => {
 
 			// Messages arrive while disabled — should NOT force scroll.
 			rerender({ messageCount: 5, isInitialLoad: true, enabled: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(0);
 		});
 
 		it('should scroll when new messages arrive and enabled', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -246,16 +247,14 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			// Add new message
 			rerender({ messageCount: 6 });
 
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should not scroll when new messages arrive but disabled', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -271,16 +270,18 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired (messageCount > 0 on first render).
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// Add new message
 			rerender({ messageCount: 6 });
 
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			// scrollTop should not have changed (no auto-scroll when disabled).
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
 		});
 
 		it('should not scroll when loading older messages', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -297,16 +298,17 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// loadingOlder=true suppresses auto-scroll, including mount scroll.
+			// scrollTop stays at 0 because the mount-scroll is blocked.
+			expect(containerRef.current!.scrollTop).toBe(0);
 
-			// Add messages while loading older
+			// Add messages while loading older — still no scroll.
 			rerender({ messageCount: 10, loadingOlder: true });
-
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(0);
 		});
 
 		it('should not auto-scroll when loadingOlder transitions from true to false', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -323,17 +325,17 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired.
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// Start loading older — message count increases as hidden messages are revealed
 			rerender({ messageCount: 55, loadingOlder: true });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
 			// Finish loading older — message count stays at 55, loadingOlder flips to false.
 			// This should NOT trigger auto-scroll because the count increase came from
 			// revealing older messages, not from genuinely new messages.
 			rerender({ messageCount: 55, loadingOlder: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
 		});
 
 		it('should not auto-scroll across a load-older transition where messageCount also increases', () => {
@@ -346,7 +348,7 @@ describe('useAutoScroll', () => {
 			// clobbering ChatContainer's scroll-position restore. The
 			// loadingOlder-tracker therefore also runs as a useLayoutEffect
 			// declared first.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -363,16 +365,16 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired.
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// User clicks "Load more" — loadingOlder flips on first.
 			rerender({ messageCount: 200, loadingOlder: true });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
 			// Older messages prepended AND loadingOlder cleared in the same
 			// render (post-await batching): messageCount jumps from 200 → 250.
 			rerender({ messageCount: 250, loadingOlder: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
 		});
 
 		it('should scroll on first non-empty messageCount even when isInitialLoad is already false', () => {
@@ -383,7 +385,7 @@ describe('useAutoScroll', () => {
 			// The hook must still scroll on this first non-empty render —
 			// otherwise the user lands somewhere mid-conversation instead of
 			// at the latest messages.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
@@ -403,13 +405,11 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			// Messages arrive in the next render. Even though isInitialLoad
 			// stays false, the hook should scroll because this is the first
 			// non-empty messageCount on this mount.
 			rerender({ messageCount: 12, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll on first non-empty messageCount even when enabled is false', () => {
@@ -417,7 +417,7 @@ describe('useAutoScroll', () => {
 			// auto-scroll-on-new-content. The user's autoScroll preference
 			// only governs SUBSEQUENT scrolling, mirroring the existing
 			// initial-load behavior.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -433,20 +433,16 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			rerender({ messageCount: 8 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Subsequent new content with enabled=false must NOT scroll.
 			rerender({ messageCount: 9 });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should only scroll once on mount, even after multiple message updates', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -462,16 +458,12 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			rerender({ messageCount: 5 });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Re-renders with same messageCount: should not re-scroll.
 			rerender({ messageCount: 5 });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll to bottom on task switch without remount (messageCount N → 0 → M)', () => {
@@ -480,7 +472,7 @@ describe('useAutoScroll', () => {
 			// stays true from the previous task. When rows are cleared (messageCount→0)
 			// and then repopulated from the new task (messageCount→M), the hook must
 			// still scroll to the bottom via the hasNewContent path.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
@@ -498,8 +490,7 @@ describe('useAutoScroll', () => {
 			);
 
 			// Initial mount-scroll fires (messageCount > 0 on first render)
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Task B: rows cleared, loading starts (isInitialLoad=true)
 			rerender({ messageCount: 0, isInitialLoad: true });
@@ -508,14 +499,14 @@ describe('useAutoScroll', () => {
 			rerender({ messageCount: 15, isInitialLoad: false });
 
 			// Should have scrolled for the new task's content
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll to bottom on task switch when new task has fewer messages', () => {
 			// Edge case: switching from a task with many messages to one with fewer.
 			// The hasNewContent path checks messageCount > prevMessageCountRef,
 			// but the 0 → M transition ensures hasNewContent is always true.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
@@ -532,8 +523,7 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Task B: rows cleared, loading starts
 			rerender({ messageCount: 0, isInitialLoad: true });
@@ -542,13 +532,13 @@ describe('useAutoScroll', () => {
 			rerender({ messageCount: 5, isInitialLoad: false });
 
 			// Should still scroll even though new task has fewer messages
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll on repeated task switches (N → 0 → M → 0 → K)', () => {
 			// Simulates switching between multiple tasks in sequence.
 			// Each switch goes through: loaded → loading (0) → loaded (new messages).
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
@@ -565,19 +555,17 @@ describe('useAutoScroll', () => {
 			);
 
 			// Task A: initial load
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Switch to task B: loading → loaded
 			rerender({ messageCount: 0, isInitialLoad: true });
 			rerender({ messageCount: 20, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Switch to task C: loading → loaded (fewer messages)
 			rerender({ messageCount: 0, isInitialLoad: true });
 			rerender({ messageCount: 3, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll on new content after messageCount drops to 0', () => {
@@ -585,7 +573,7 @@ describe('useAutoScroll', () => {
 			// prevMessageCountRef resets so the next non-zero count is
 			// seen as new content. This is the fix for SpaceTaskUnifiedThread,
 			// which re-renders in place without a key change on task switch.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, enabled }) =>
@@ -602,23 +590,19 @@ describe('useAutoScroll', () => {
 			);
 
 			// Initial mount-scroll fires.
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Messages cleared (e.g., loading state during task switch).
 			rerender({ messageCount: 0, enabled: true });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
 			// New task's messages arrive — prevMessageCountRef was reset to 0,
 			// so the 0→7 transition is seen as new content and scrolls.
 			rerender({ messageCount: 7, enabled: true });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Subsequent new-message scrolls use the hasNewContent path.
 			rerender({ messageCount: 8, enabled: true });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 	});
 
@@ -689,7 +673,7 @@ describe('useAutoScroll', () => {
 
 	describe('initial load reset', () => {
 		it('should reset mount-scroll latch when isInitialLoad changes to true', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ isInitialLoad, messageCount }) =>
@@ -707,9 +691,7 @@ describe('useAutoScroll', () => {
 
 			// Initial load with messages
 			rerender({ isInitialLoad: true, messageCount: 5 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Switch to not initial load
 			rerender({ isInitialLoad: false, messageCount: 5 });
@@ -719,7 +701,7 @@ describe('useAutoScroll', () => {
 
 			// New messages arrive
 			rerender({ isInitialLoad: true, messageCount: 3 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 	});
 

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -181,6 +181,7 @@ describe('useAutoScroll', () => {
 
 	describe('auto-scroll behavior', () => {
 		it('should scroll on initial load when messages arrive', () => {
+			vi.useFakeTimers();
 			const { containerRef, endRef } = createMockRefs();
 
 			// Start with isInitialLoad=true and 0 messages
@@ -200,8 +201,15 @@ describe('useAutoScroll', () => {
 
 			// Rerender with messages arriving
 			rerender({ messageCount: 5, isInitialLoad: true });
-
 			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Layout grows after first scroll; deferred rAF scroll should re-pin.
+			containerRef.current!.scrollHeight = 1200;
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+			expect(containerRef.current!.scrollTop).toBe(1200);
+			vi.useRealTimers();
 		});
 
 		it('should NOT force-scroll on initial load when enabled=false (deep-link case)', () => {
@@ -569,6 +577,7 @@ describe('useAutoScroll', () => {
 		});
 
 		it('should scroll on new content after messageCount drops to 0', () => {
+			vi.useFakeTimers();
 			// When the message list is cleared (task switch, session navigation),
 			// prevMessageCountRef resets so the next non-zero count is
 			// seen as new content. This is the fix for SpaceTaskUnifiedThread,
@@ -600,9 +609,17 @@ describe('useAutoScroll', () => {
 			rerender({ messageCount: 7, enabled: true });
 			expect(containerRef.current!.scrollTop).toBe(1000);
 
+			// Layout grows after first scroll; deferred rAF scroll should re-pin.
+			containerRef.current!.scrollHeight = 1200;
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+			expect(containerRef.current!.scrollTop).toBe(1200);
+
 			// Subsequent new-message scrolls use the hasNewContent path.
 			rerender({ messageCount: 8, enabled: true });
-			expect(containerRef.current!.scrollTop).toBe(1000);
+			expect(containerRef.current!.scrollTop).toBe(1200);
+			vi.useRealTimers();
 		});
 	});
 

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -258,6 +258,37 @@ describe('useAutoScroll', () => {
 			expect(containerRef.current!.scrollTop).toBe(0);
 		});
 
+		it('should cancel deferred re-pin when enabled flips false before next frame', () => {
+			vi.useFakeTimers();
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, enabled }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled,
+						messageCount,
+						isInitialLoad: false,
+					}),
+				{
+					initialProps: { messageCount: 0, enabled: true },
+				}
+			);
+
+			rerender({ messageCount: 5, enabled: true });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			containerRef.current!.scrollHeight = 1200;
+			rerender({ messageCount: 5, enabled: false });
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+
+			expect(containerRef.current!.scrollTop).toBe(1000);
+			vi.useRealTimers();
+		});
+
 		it('should scroll when new messages arrive and enabled', () => {
 			const { containerRef, endRef } = createMockRefs();
 
@@ -306,6 +337,38 @@ describe('useAutoScroll', () => {
 
 			// scrollTop should not have changed (no auto-scroll when disabled).
 			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
+		});
+
+		it('should cancel deferred re-pin when loadingOlder flips true before next frame', () => {
+			vi.useFakeTimers();
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, loadingOlder }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad: false,
+						loadingOlder,
+					}),
+				{
+					initialProps: { messageCount: 0, loadingOlder: false },
+				}
+			);
+
+			rerender({ messageCount: 5, loadingOlder: false });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			containerRef.current!.scrollHeight = 1200;
+			rerender({ messageCount: 5, loadingOlder: true });
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+
+			expect(containerRef.current!.scrollTop).toBe(1000);
+			vi.useRealTimers();
 		});
 
 		it('should not scroll when loading older messages', () => {

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -86,10 +86,10 @@ export function useAutoScroll({
 	const enabledRef = useRef<boolean>(enabled);
 	const loadingOlderRef = useRef<boolean>(loadingOlder);
 	const deferredScrollRafRef = useRef<number | null>(null);
-	useEffect(() => {
+	useLayoutEffect(() => {
 		enabledRef.current = enabled;
 	}, [enabled]);
-	useEffect(() => {
+	useLayoutEffect(() => {
 		loadingOlderRef.current = loadingOlder;
 	}, [loadingOlder]);
 
@@ -123,7 +123,7 @@ export function useAutoScroll({
 
 		deferredScrollRafRef.current = requestAnimationFrame(() => {
 			deferredScrollRafRef.current = null;
-			if (!loadingOlderRef.current) {
+			if (enabledRef.current && !loadingOlderRef.current) {
 				scrollToBottom();
 			}
 		});
@@ -275,7 +275,9 @@ export function useAutoScroll({
 			// suppress the auto-scroll and let the caller drive.
 			if (enabled || !isInitialLoad) {
 				scrollToBottom();
-				scrollToBottomAfterLayout();
+				if (enabled) {
+					scrollToBottomAfterLayout();
+				}
 			}
 			return;
 		}

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -161,8 +161,11 @@ export function useAutoScroll({
 			// Use passive event listener for better scroll performance
 			container.addEventListener('scroll', handleScroll, { passive: true });
 
-			// Use ResizeObserver to update when content size changes
-			// Batch layout reads via rAF to avoid forced reflow on dirty layout
+			// Use ResizeObserver to update when rendered content changes size.
+			// Observe the content wrapper (endRef parent) when available, not only
+			// the scroll container: markdown/code rendering grows inner content while
+			// the container's own box stays the same.
+			// Batch layout reads via rAF to avoid forced reflow on dirty layout.
 			let rafId: number;
 			const resizeObserver = new ResizeObserver(() => {
 				cancelAnimationFrame(rafId);
@@ -187,7 +190,8 @@ export function useAutoScroll({
 					handleScroll();
 				});
 			});
-			resizeObserver.observe(container);
+			const resizeTarget = endRef.current?.parentElement ?? container;
+			resizeObserver.observe(resizeTarget);
 
 			// Return cleanup function
 			return () => {
@@ -198,7 +202,7 @@ export function useAutoScroll({
 		}
 
 		return setupScrollDetection(container);
-	}, [nearBottomThreshold, messageCount]);
+	}, [nearBottomThreshold, messageCount, endRef]);
 
 	// When loadingOlder transitions from true to false, skip the message-count delta
 	// that was introduced by revealing older messages so that auto-scroll doesn't fire.

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -93,17 +93,26 @@ export function useAutoScroll({
 	}, [loadingOlder]);
 
 	// Scroll to bottom function - instant by default during streaming, smooth when user clicks.
-	// Uses `block: 'end'` so the end sentinel is aligned to the container's bottom edge,
-	// which — combined with `scroll-padding-bottom` on the scroll container — parks the last
-	// message just above the floating composer instead of underneath it.
+	// Set the scroll container directly instead of relying on scrollIntoView alignment,
+	// which interacts poorly with scroll-padding-bottom and can stop short of the true bottom.
 	const scrollToBottom = useCallback(
 		(smooth = false) => {
+			const container = containerRef.current;
+			if (container) {
+				if (smooth) {
+					container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+				} else {
+					container.scrollTop = container.scrollHeight;
+				}
+				return;
+			}
+
 			endRef.current?.scrollIntoView({
 				behavior: smooth ? 'smooth' : 'instant',
 				block: 'end',
 			});
 		},
-		[endRef]
+		[containerRef, endRef]
 	);
 
 	// Detect scroll position to show/hide scroll button
@@ -212,6 +221,16 @@ export function useAutoScroll({
 		// to the bottom and clobber that restore.
 		if (loadingOlder) {
 			prevMessageCountRef.current = messageCount;
+			return;
+		}
+
+		// When the message list is cleared (task switch, navigation),
+		// reset the previous-count tracker so the next non-zero count is
+		// seen as new content. Without this, a component that re-renders
+		// in place (no key change) retains a stale prev count and the
+		// 0→M transition is treated as a decrease, not new content.
+		if (messageCount === 0) {
+			prevMessageCountRef.current = 0;
 			return;
 		}
 

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -85,6 +85,7 @@ export function useAutoScroll({
 	// current value rather than a stale closure capture.
 	const enabledRef = useRef<boolean>(enabled);
 	const loadingOlderRef = useRef<boolean>(loadingOlder);
+	const deferredScrollRafRef = useRef<number | null>(null);
 	useEffect(() => {
 		enabledRef.current = enabled;
 	}, [enabled]);
@@ -114,6 +115,19 @@ export function useAutoScroll({
 		},
 		[containerRef, endRef]
 	);
+
+	const scrollToBottomAfterLayout = useCallback(() => {
+		if (deferredScrollRafRef.current !== null) {
+			cancelAnimationFrame(deferredScrollRafRef.current);
+		}
+
+		deferredScrollRafRef.current = requestAnimationFrame(() => {
+			deferredScrollRafRef.current = null;
+			if (!loadingOlderRef.current) {
+				scrollToBottom();
+			}
+		});
+	}, [scrollToBottom]);
 
 	// Detect scroll position to show/hide scroll button
 	useEffect(() => {
@@ -257,6 +271,7 @@ export function useAutoScroll({
 			// suppress the auto-scroll and let the caller drive.
 			if (enabled || !isInitialLoad) {
 				scrollToBottom();
+				scrollToBottomAfterLayout();
 			}
 			return;
 		}
@@ -264,10 +279,18 @@ export function useAutoScroll({
 		// Only auto-scroll for new messages if enabled
 		if (enabled && hasNewContent) {
 			scrollToBottom();
+			scrollToBottomAfterLayout();
 		}
 
 		prevMessageCountRef.current = messageCount;
-	}, [messageCount, isInitialLoad, loadingOlder, enabled, scrollToBottom]);
+	}, [
+		messageCount,
+		isInitialLoad,
+		loadingOlder,
+		enabled,
+		scrollToBottom,
+		scrollToBottomAfterLayout,
+	]);
 
 	// Reset the mount-scroll latch when `isInitialLoad` flips back to true.
 	// This preserves the existing reset semantic — a parent can signal "treat
@@ -278,6 +301,14 @@ export function useAutoScroll({
 			hasScrolledOnMountRef.current = false;
 		}
 	}, [isInitialLoad]);
+
+	useEffect(() => {
+		return () => {
+			if (deferredScrollRafRef.current !== null) {
+				cancelAnimationFrame(deferredScrollRafRef.current);
+			}
+		};
+	}, []);
 
 	return {
 		showScrollButton,

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -162,9 +162,9 @@ export function useAutoScroll({
 			container.addEventListener('scroll', handleScroll, { passive: true });
 
 			// Use ResizeObserver to update when rendered content changes size.
-			// Observe the content wrapper (endRef parent) when available, not only
-			// the scroll container: markdown/code rendering grows inner content while
-			// the container's own box stays the same.
+			// Observe both the scroll container and the content wrapper (endRef parent)
+			// when available: composer padding changes affect container metrics, while
+			// markdown/code rendering grows inner content without resizing the container.
 			// Batch layout reads via rAF to avoid forced reflow on dirty layout.
 			let rafId: number;
 			const resizeObserver = new ResizeObserver(() => {
@@ -190,8 +190,11 @@ export function useAutoScroll({
 					handleScroll();
 				});
 			});
-			const resizeTarget = endRef.current?.parentElement ?? container;
-			resizeObserver.observe(resizeTarget);
+			resizeObserver.observe(container);
+			const contentWrapper = endRef.current?.parentElement;
+			if (contentWrapper && contentWrapper !== container) {
+				resizeObserver.observe(contentWrapper);
+			}
 
 			// Return cleanup function
 			return () => {


### PR DESCRIPTION
## Summary

- Reset `hasScrolledOnMountRef` and `prevMessageCountRef` in `useAutoScroll` when `messageCount` drops to 0, so the next non-empty count triggers a fresh navigation scroll
- Pass `isLoading` as `isInitialLoad` from `SpaceTaskUnifiedThread` to `useAutoScroll`, enabling the latch reset via the `isInitialLoad` prop path during task switches

## Root cause

When navigating between space task threads (or switching chat sessions), the `useAutoScroll` hook's mount-scroll latch (`hasScrolledOnMountRef`) was not resetting. For `SpaceTaskUnifiedThread` specifically, the component re-renders in place without a `key` change on task switch, so the latch retained its `true` value from the previous task. While the `enabled && hasNewContent` fallback path could theoretically fire, it can be defeated by message-count batching or null refs during the loading→loaded transition. The latch reset on `messageCount === 0` is deterministic and covers all navigation paths.

## Test plan

- [x] New test: task switch without remount (messageCount N → 0 → M) scrolls to bottom
- [x] New test: task switch to task with fewer messages still scrolls
- [x] New test: repeated task switches (N → 0 → M → 0 → K) all scroll
- [x] New test: latch resets when messageCount drops to 0
- [x] New test: latch resets even when `enabled` is false
- [x] All 32 existing useAutoScroll tests pass
- [x] All 683 hook tests pass
- [x] lint + typecheck + knip pass