### PR TITLE
feat: add sub-agent tools to all preset agent toolsets

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -42,10 +42,8 @@ export const SUB_SESSION_FEATURES = {
 // Tool defaults per preset agent
 // ---------------------------------------------------------------------------
 
-/** Full coding toolset: read, write, shell, search, web */
-const CODER_TOOLS = KNOWN_TOOLS.filter(
-	(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
-) as string[];
+/** Full coding toolset: read, write, shell, search, web, sub-agent */
+const CODER_TOOLS = [...KNOWN_TOOLS];
 
 /** General-purpose worker: full coding toolset */
 const GENERAL_TOOLS = CODER_TOOLS;
@@ -77,7 +75,7 @@ const REVIEWER_TOOLS: string[] = [
 	'TaskStop',
 ];
 
-/** QA: read-only + bash for running tests — no Write or Edit */
+/** QA: read-only + bash for running tests + sub-agent — no Write or Edit */
 const QA_TOOLS: string[] = [
 	'Read',
 	'Bash',
@@ -87,6 +85,9 @@ const QA_TOOLS: string[] = [
 	'WebSearch',
 	'Skill',
 	'ToolSearch',
+	'Task',
+	'TaskOutput',
+	'TaskStop',
 ];
 
 /**


### PR DESCRIPTION
All six preset agents now include `Task`, `TaskOutput`, and `TaskStop` so they can delegate work to Claude's built-in sub-agent.

- **Coder, General, Planner, Research**: removed the filter that stripped these tools from `KNOWN_TOOLS`
- **QA**: added the three tools to the existing explicit list
- **Reviewer**: already had them (unchanged)