### PR TITLE
fix: route task/node agent replies to originating session

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -477,8 +477,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		message: string,
 		replyToSessionId?: string | null
 	): Promise<void> => {
-		const sessionId = replyToSessionId || `space:chat:${spaceId}`;
-		const session = await sessionManagerRef.getSessionAsync(sessionId);
+		let sessionId = replyToSessionId || `space:chat:${spaceId}`;
+		let session = await sessionManagerRef.getSessionAsync(sessionId);
+		// Fallback: if the routed-to session no longer exists (e.g. ad-hoc member
+		// session ended), fall back to the canonical space chat session so the
+		// reply is not silently dropped.
+		if (!session && replyToSessionId) {
+			sessionId = `space:chat:${spaceId}`;
+			session = await sessionManagerRef.getSessionAsync(sessionId);
+		}
 		if (!session) {
 			throw new Error(`Session not found for Space Agent reply routing: ${sessionId}`);
 		}

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -42,6 +42,7 @@ import { setupSpaceTaskHandlers, type SpaceTaskManagerFactory } from './space-ta
 import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
+import { ReplyRoutingRegistry } from '../space/runtime/reply-routing-registry';
 import { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
 import {
 	setupSpaceWorkflowHandlers,
@@ -393,6 +394,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// sessionManager and internalEventBus are injected so space:chat:${spaceId} sessions are
 	// provisioned with MCP tools and system prompts on startup and on space.created.
 	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
+	// Reply Routing Registry — shared between space-agent-tools (register)
+	// and task-agent-tools / node-agent-tools (lookup).
+	const replyRoutingRegistry = new ReplyRoutingRegistry();
+
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		dbPath: deps.db.getDatabasePath(),
@@ -413,6 +418,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleService,
 		commandBus: deps.commandBus,
 		externalEventStore: deps.externalEventStore,
+		replyRoutingRegistry,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -466,11 +472,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// `space:chat:${spaceId}` session via SessionManager. Shared between
 	// TaskAgentManager (for queue flush) and task-agent tool wiring.
 	const sessionManagerRef = deps.sessionManager;
-	const spaceAgentInjector = async (spaceId: string, message: string): Promise<void> => {
-		const sessionId = `space:chat:${spaceId}`;
+	const spaceAgentInjector = async (
+		spaceId: string,
+		message: string,
+		replyToSessionId?: string | null
+	): Promise<void> => {
+		const sessionId = replyToSessionId || `space:chat:${spaceId}`;
 		const session = await sessionManagerRef.getSessionAsync(sessionId);
 		if (!session) {
-			throw new Error(`Space Agent chat session not found: ${sessionId}`);
+			throw new Error(`Session not found for Space Agent reply routing: ${sessionId}`);
 		}
 		const messageId = generateUUID();
 		const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
@@ -520,6 +530,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceAgentInjector,
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
+		replyRoutingRegistry,
 	});
 
 	deps.commandBus.register('agent.message.inject', async (command) => {

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -11,6 +11,13 @@ export interface FormatAgentMessageOptions {
 	taskNumber?: number | null;
 	/** Sender/target node agent name for reply routing. */
 	nodeId?: string | null;
+	/**
+	 * Session ID that should receive the reply when the target agent responds
+	 * via `send_message({ target: 'space-agent' })`. When set, the routing
+	 * layer delivers the reply to this session instead of the default
+	 * `space:chat:${spaceId}`. Null/undefined means "use default routing".
+	 */
+	replyToSessionId?: string | null;
 }
 
 function taskLabel(taskNumber?: number | null): string {
@@ -24,14 +31,31 @@ function replyTargetSuffix(options: FormatAgentMessageOptions): string {
 }
 
 /**
+ * Build the reply-routing metadata footer appended to messages that carry
+ * `replyToSessionId`. The footer is a machine-readable XML block that the
+ * routing layer parses when the receiving agent replies via
+ * `send_message({ target: 'space-agent' })`.
+ */
+function replyRoutingFooter(options: FormatAgentMessageOptions): string {
+	if (!options.replyToSessionId) return '';
+	return `\n\n<reply-routing replyToSessionId="${options.replyToSessionId}" />`;
+}
+
+/**
  * Format an inter-agent runtime message envelope.
  *
  * Agents pass only the raw body to their messaging tools; runtime delivery code
  * calls this helper immediately before injecting the message into the receiver's
  * session so the transcript records sender identity and concise reply guidance.
+ *
+ * When `replyToSessionId` is set, a `<reply-routing>` XML block is appended.
+ * The routing layer extracts this when the agent replies via
+ * `send_message({ target: 'space-agent' })` to deliver the reply back to the
+ * originating session instead of the default `space:chat:${spaceId}`.
  */
 export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 	const body = options.body;
+	const footer = replyRoutingFooter(options);
 
 	if (options.toLevel === 'space-agent') {
 		const task = taskLabel(options.taskNumber);
@@ -47,20 +71,20 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 	if (options.fromLevel === 'space-agent') {
 		return (
 			`─── Message from Space Agent ───\n\n` +
-			`${body}\n\n` +
+			`${body}${footer}\n\n` +
 			`─── Reply ───\n` +
 			`To reply, use: send_message with target "space-agent"`
 		);
 	}
 
 	if (options.fromLevel === 'node-agent' && options.toLevel === 'node-agent') {
-		return `─── Message from ${options.fromAgentName} ───\n\n${body}`;
+		return `─── Message from ${options.fromAgentName} ───\n\n${body}${footer}`;
 	}
 
 	if (options.fromLevel === 'node-agent' && options.toLevel === 'task-agent') {
 		return (
 			`─── Message from ${options.fromAgentName}${taskLabel(options.taskNumber)} ───\n\n` +
-			`${body}\n\n` +
+			`${body}${footer}\n\n` +
 			`─── Reply ───\n` +
 			`To reply, use: send_message with target "${options.fromAgentName}"`
 		);
@@ -69,11 +93,11 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 	if (options.fromLevel === 'task-agent' && options.toLevel === 'node-agent') {
 		return (
 			`─── Message from task-agent${taskLabel(options.taskNumber)} ───\n\n` +
-			`${body}\n\n` +
+			`${body}${footer}\n\n` +
 			`─── Reply ───\n` +
 			`To reply, use: send_message with target "task-agent"`
 		);
 	}
 
-	return `─── Message from ${options.fromAgentName} ───\n\n${body}`;
+	return `─── Message from ${options.fromAgentName} ───\n\n${body}${footer}`;
 }

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -62,7 +62,7 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 		const taskId = options.taskId ? ` with task_id="${options.taskId}"` : '';
 		return (
 			`─── Message from ${options.fromAgentName}${task} ───\n\n` +
-			`${body}\n\n` +
+			`${body}${footer}\n\n` +
 			`─── Reply ───\n` +
 			`To reply, use: send_message_to_task${taskId}${replyTargetSuffix(options)}`
 		);
@@ -100,4 +100,14 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 	}
 
 	return `─── Message from ${options.fromAgentName} ───\n\n${body}${footer}`;
+}
+
+/**
+ * Extract `replyToSessionId` from a message envelope's `<reply-routing>` footer.
+ * Returns `null` when the footer is absent (no routing metadata).
+ * Used by the pending-message flush path to recover routing after daemon restart.
+ */
+export function extractReplyToSessionId(message: string): string | null {
+	const match = message.match(/<reply-routing replyToSessionId="([^"]+)" \/>/);
+	return match ? match[1] : null;
 }

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -62,9 +62,9 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 		const taskId = options.taskId ? ` with task_id="${options.taskId}"` : '';
 		return (
 			`─── Message from ${options.fromAgentName}${task} ───\n\n` +
-			`${body}${footer}\n\n` +
+			`${body}\n\n` +
 			`─── Reply ───\n` +
-			`To reply, use: send_message_to_task${taskId}${replyTargetSuffix(options)}`
+			`To reply, use: send_message_to_task${taskId}${replyTargetSuffix(options)}${footer}`
 		);
 	}
 
@@ -106,8 +106,11 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
  * Extract `replyToSessionId` from a message envelope's `<reply-routing>` footer.
  * Returns `null` when the footer is absent (no routing metadata).
  * Used by the pending-message flush path to recover routing after daemon restart.
+ *
+ * Only matches the tag when it appears as a trailing footer (last non-whitespace
+ * content), preventing a forged tag in the message body from controlling routing.
  */
 export function extractReplyToSessionId(message: string): string | null {
-	const match = message.match(/<reply-routing replyToSessionId="([^"]+)" \/>/);
+	const match = message.match(/<reply-routing replyToSessionId="([^"]+)" \/>\s*$/);
 	return match ? match[1] : null;
 }

--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -52,7 +52,11 @@ export interface AgentMessageRouterConfig {
 	 * Optional injector for routing messages to the Space Agent chat session.
 	 * Used when a node agent explicitly targets `space-agent`.
 	 */
-	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
+	spaceAgentInjector?: (
+		spaceId: string,
+		message: string,
+		replyToSessionId?: string | null
+	) => Promise<void>;
 	/** Space-scoped task number for message envelopes. */
 	taskNumber?: number | null;
 	/**
@@ -87,6 +91,13 @@ export interface AgentMessageRouterConfig {
 	 * Fires only for non-deduped enqueues (deduped = message already in queue).
 	 */
 	onMessageQueued?: (agentName: string) => void;
+	/**
+	 * Optional lookup callback for reply-to-session routing.
+	 * When a node agent sends to `space-agent`, this callback is invoked to
+	 * determine whether the reply should go to a specific session (instead of
+	 * the default `space:chat:${spaceId}`). Returns `null` for default routing.
+	 */
+	replyRoutingLookup?: (agentName?: string | null) => string | null;
 }
 
 export interface AgentMessageParams {
@@ -175,6 +186,7 @@ export class AgentMessageRouter {
 			taskNumber,
 			activateTargetSession,
 			onMessageQueued,
+			replyRoutingLookup,
 		} = this.config;
 
 		// --- Build channel resolver + slot-to-node translation map ---
@@ -461,6 +473,9 @@ export class AgentMessageRouter {
 					notFound.push(agentName);
 					continue;
 				}
+				// Check if this node agent should route its reply to a specific
+				// originating session (symmetric reply routing for ad-hoc members).
+				const replyTo = replyRoutingLookup ? replyRoutingLookup(fromAgentName) : null;
 				const envelopedMessage = formatAgentMessage({
 					fromLevel: 'node-agent',
 					fromAgentName,
@@ -471,13 +486,16 @@ export class AgentMessageRouter {
 					nodeId: fromAgentName,
 				});
 				try {
-					await spaceAgentInjector(spaceId, envelopedMessage);
-					delivered.push({ agentName, sessionId: `space:chat:${spaceId}` });
+					await spaceAgentInjector(spaceId, envelopedMessage, replyTo);
+					delivered.push({
+						agentName,
+						sessionId: replyTo || `space:chat:${spaceId}`,
+					});
 				} catch (err) {
 					const errMsg = err instanceof Error ? err.message : String(err);
 					failed.push({
 						agentName,
-						sessionId: `space:chat:${spaceId}`,
+						sessionId: replyTo || `space:chat:${spaceId}`,
 						error: errMsg,
 					});
 				}

--- a/packages/daemon/src/lib/space/runtime/reply-routing-registry.ts
+++ b/packages/daemon/src/lib/space/runtime/reply-routing-registry.ts
@@ -21,6 +21,7 @@ interface RoutingEntry {
 export class ReplyRoutingRegistry {
 	private readonly ttlMs: number;
 	private readonly entries = new Map<string, RoutingEntry>();
+	private writeCount = 0;
 
 	constructor(ttlMs = DEFAULT_TTL_MS) {
 		this.ttlMs = ttlMs;
@@ -41,6 +42,12 @@ export class ReplyRoutingRegistry {
 	set(taskId: string, replyToSessionId: string, agentName?: string | null): void {
 		const key = ReplyRoutingRegistry.key(taskId, agentName);
 		this.entries.set(key, { replyToSessionId, updatedAt: Date.now() });
+		this.writeCount++;
+		// Opportunistic purge: sweep expired entries every 100 writes to prevent
+		// unbounded growth from entries that are never looked up again.
+		if (this.writeCount % 100 === 0) {
+			this.purgeExpired();
+		}
 	}
 
 	/**
@@ -82,5 +89,20 @@ export class ReplyRoutingRegistry {
 	/** Expose current size for diagnostics / testing. */
 	get size(): number {
 		return this.entries.size;
+	}
+
+	/**
+	 * Remove all expired entries. Called opportunistically on write (every 100th
+	 * set) and can be called explicitly by the runtime (e.g. on task completion
+	 * sweeps). Keeps memory bounded in long-running daemons even when entries
+	 * are never looked up via `get`.
+	 */
+	purgeExpired(): void {
+		const now = Date.now();
+		for (const [key, entry] of this.entries) {
+			if (now - entry.updatedAt > this.ttlMs) {
+				this.entries.delete(key);
+			}
+		}
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/reply-routing-registry.ts
+++ b/packages/daemon/src/lib/space/runtime/reply-routing-registry.ts
@@ -1,0 +1,86 @@
+/**
+ * ReplyRoutingRegistry — tracks which session sent a message to each task
+ * so that task-agent and node-agent replies via `send_message({ target: 'space-agent' })`
+ * route back to the originating session instead of always going to `space:chat:${spaceId}`.
+ *
+ * The registry is keyed by `(taskId, agentName)` to handle per-node routing within
+ * a task's workflow. Each entry stores the most recent `replyToSessionId` for that
+ * combination, enabling the routing layer to look up where to send the reply.
+ *
+ * Entries expire after a configurable TTL (default 30 minutes) to prevent stale
+ * routing after conversations end.
+ */
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+interface RoutingEntry {
+	replyToSessionId: string;
+	updatedAt: number;
+}
+
+export class ReplyRoutingRegistry {
+	private readonly ttlMs: number;
+	private readonly entries = new Map<string, RoutingEntry>();
+
+	constructor(ttlMs = DEFAULT_TTL_MS) {
+		this.ttlMs = ttlMs;
+	}
+
+	/**
+	 * Build the composite key from taskId and optional agentName.
+	 * agentName is used for node-agent targets within a task's workflow.
+	 */
+	private static key(taskId: string, agentName?: string | null): string {
+		return agentName ? `${taskId}:${agentName}` : taskId;
+	}
+
+	/**
+	 * Register that a message sent to the given task/node should route
+	 * replies back to `replyToSessionId`.
+	 */
+	set(taskId: string, replyToSessionId: string, agentName?: string | null): void {
+		const key = ReplyRoutingRegistry.key(taskId, agentName);
+		this.entries.set(key, { replyToSessionId, updatedAt: Date.now() });
+	}
+
+	/**
+	 * Look up the `replyToSessionId` for a given task/node combination.
+	 * Returns `null` when no routing entry exists (meaning "use default routing").
+	 * Expired entries are pruned on access.
+	 */
+	get(taskId: string, agentName?: string | null): string | null {
+		const key = ReplyRoutingRegistry.key(taskId, agentName);
+		const entry = this.entries.get(key);
+		if (!entry) return null;
+
+		if (Date.now() - entry.updatedAt > this.ttlMs) {
+			this.entries.delete(key);
+			return null;
+		}
+		return entry.replyToSessionId;
+	}
+
+	/**
+	 * Remove all entries for a given task (e.g., on task completion).
+	 */
+	deleteByTask(taskId: string): void {
+		for (const key of this.entries.keys()) {
+			if (key === taskId || key.startsWith(`${taskId}:`)) {
+				this.entries.delete(key);
+			}
+		}
+	}
+
+	/**
+	 * Remove a specific entry.
+	 */
+	delete(taskId: string, agentName?: string | null): void {
+		const key = ReplyRoutingRegistry.key(taskId, agentName);
+		this.entries.delete(key);
+	}
+
+	/** Expose current size for diagnostics / testing. */
+	get size(): number {
+		return this.entries.size;
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -877,6 +877,7 @@ export class SpaceRuntimeService {
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -32,6 +32,7 @@ import { selectWorkflowWithLlmDefault } from './llm-workflow-selector';
 import { ChannelRouter } from './channel-router';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
+import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
@@ -118,6 +119,12 @@ export interface SpaceRuntimeServiceConfig {
 	internalEventBus?: InternalEventBus<DaemonInternalEventMap>;
 	commandBus?: InternalCommandBus<DaemonCommandMap>;
 	externalEventStore?: ExternalEventStore;
+	/**
+	 * Reply routing registry for symmetric message routing.
+	 * Passed to space-agent-tools so member sessions can register their
+	 * session ID as the reply target when sending messages to task/node agents.
+	 */
+	replyRoutingRegistry?: ReplyRoutingRegistry;
 }
 
 export class SpaceRuntimeService {
@@ -775,6 +782,7 @@ export class SpaceRuntimeService {
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
 		const additional: Record<string, McpServerConfig> = {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3180,6 +3180,10 @@ export class TaskAgentManager {
 			spaceAgentInjector: this.config.spaceAgentInjector,
 			taskAgentManager: this,
 			artifactRepo: this.config.artifactRepo,
+			replyRoutingLookup: () => {
+				const registry = this.config.replyRoutingRegistry;
+				return registry ? registry.get(taskId) : null;
+			},
 		});
 
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
@@ -3256,6 +3260,7 @@ export class TaskAgentManager {
 			myAgentName: 'task-agent',
 			mySessionId: sessionId,
 			auditLogRepo: this.auditLogRepo,
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 		rehydrateMcpServers['space-agent-tools'] =
 			rehydrateSpaceAgentMcpServer as unknown as McpServerConfig;
@@ -4318,6 +4323,7 @@ export class TaskAgentManager {
 					workflowNodeId: ctx.workflowNodeId,
 				});
 			},
+			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 	}
 
@@ -4409,6 +4415,12 @@ export class TaskAgentManager {
 				return { sessionId: ensuredTask.taskAgentSessionId ?? '' };
 			},
 			spaceAgentInjector: this.config.spaceAgentInjector,
+			// Wire reply routing so node-agent replies to space-agent route back
+			// to the originating ad-hoc member session instead of space:chat:.
+			replyRoutingLookup: (fromAgentName) => {
+				const registry = this.config.replyRoutingRegistry;
+				return registry ? registry.get(taskId, fromAgentName) : null;
+			},
 			// Wire up the pending-message queue so node agents can queue messages for
 			// peers that haven't spawned yet (declared but inactive). The queue is
 			// drained by flushPendingMessagesForTarget() when the target session activates.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -105,7 +105,11 @@ import {
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
-import { formatAgentMessage, type AgentMessageLevel } from '../agent-message-envelope';
+import {
+	formatAgentMessage,
+	extractReplyToSessionId,
+	type AgentMessageLevel,
+} from '../agent-message-envelope';
 
 const log = new Logger('task-agent-manager');
 const AGENT_MESSAGE_ENVELOPE_HEADER = /^─── Message from ([^\n]+) ───\n\n/;
@@ -1810,8 +1814,12 @@ export class TaskAgentManager {
 				// Look up reply routing at flush time so queued messages retain
 				// their original reply-to target (ad-hoc member session) instead
 				// of always going to the canonical space:chat: session.
+				// Dual strategy: (1) in-memory registry (same-process retries),
+				// (2) extract from message envelope footer (survives daemon restart).
 				const registry = this.config.replyRoutingRegistry;
-				const replyTo = registry && row.taskId ? registry.get(row.taskId) : null;
+				const replyTo =
+					(registry && row.taskId ? registry.get(row.taskId) : null) ??
+					extractReplyToSessionId(message);
 				await inject(spaceId, message, replyTo);
 				repo.markDelivered(row.id, spaceChatSessionId);
 				this.emitPendingDelivered(row.id, spaceChatSessionId, row);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -92,6 +92,7 @@ import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-m
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
 import { AgentMessageRouter } from './agent-message-router';
+import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import { RUNTIME_ESCALATION_REASONS } from './escalation-reasons';
 import { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { executeGateScript } from './gate-script-executor';
@@ -232,7 +233,11 @@ export interface TaskAgentManagerConfig {
 	 * Callback to inject a message into the Space Agent chat session for a space.
 	 * Used for Task Agent → Space Agent escalation via `send_message`.
 	 */
-	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
+	spaceAgentInjector?: (
+		spaceId: string,
+		message: string,
+		replyToSessionId?: string | null
+	) => Promise<void>;
 	/**
 	 * Schedule service — shared business logic for managing task schedules.
 	 * Injected into `space-agent-tools` so task agent sessions can create /
@@ -241,6 +246,11 @@ export interface TaskAgentManagerConfig {
 	 * registered.
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
+	/**
+	 * Reply routing registry for symmetric message routing.
+	 * Shared between space-agent-tools (register) and task/node-agent-tools (lookup).
+	 */
+	replyRoutingRegistry?: ReplyRoutingRegistry;
 }
 
 // ---------------------------------------------------------------------------
@@ -758,6 +768,10 @@ export class TaskAgentManager {
 				spaceAgentInjector: this.config.spaceAgentInjector,
 				taskAgentManager: this,
 				artifactRepo: this.config.artifactRepo,
+				replyRoutingLookup: () => {
+					const registry = this.config.replyRoutingRegistry;
+					return registry ? registry.get(taskId) : null;
+				},
 			});
 
 			// mergeRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -851,6 +851,7 @@ export class TaskAgentManager {
 				myAgentName: 'task-agent',
 				mySessionId: sessionId,
 				auditLogRepo: this.auditLogRepo,
+				replyRoutingRegistry: this.config.replyRoutingRegistry,
 			});
 			taskMcpServers['space-agent-tools'] = spaceAgentMcpServer as unknown as McpServerConfig;
 
@@ -1814,12 +1815,15 @@ export class TaskAgentManager {
 				// Look up reply routing at flush time so queued messages retain
 				// their original reply-to target (ad-hoc member session) instead
 				// of always going to the canonical space:chat: session.
-				// Dual strategy: (1) in-memory registry (same-process retries),
-				// (2) extract from message envelope footer (survives daemon restart).
+				// Dual strategy: (1) extract from message envelope footer (per-message,
+				//     immutable, survives daemon restart),
+				// (2) in-memory registry (fallback for older rows without footer).
+				// Footer takes priority to prevent a newer sender from overwriting
+				// the routing of a previously queued message.
 				const registry = this.config.replyRoutingRegistry;
 				const replyTo =
-					(registry && row.taskId ? registry.get(row.taskId) : null) ??
-					extractReplyToSessionId(message);
+					extractReplyToSessionId(message) ??
+					(registry && row.taskId ? registry.get(row.taskId) : null);
 				await inject(spaceId, message, replyTo);
 				repo.markDelivered(row.id, spaceChatSessionId);
 				this.emitPendingDelivered(row.id, spaceChatSessionId, row);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1807,7 +1807,12 @@ export class TaskAgentManager {
 						taskId: row.taskId,
 					});
 			try {
-				await inject(spaceId, message);
+				// Look up reply routing at flush time so queued messages retain
+				// their original reply-to target (ad-hoc member session) instead
+				// of always going to the canonical space:chat: session.
+				const registry = this.config.replyRoutingRegistry;
+				const replyTo = registry && row.taskId ? registry.get(row.taskId) : null;
+				await inject(spaceId, message, replyTo);
 				repo.markDelivered(row.id, spaceChatSessionId);
 				this.emitPendingDelivered(row.id, spaceChatSessionId, row);
 			} catch (err) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -48,6 +48,7 @@ import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import { Logger } from '../../logger';
 import { formatAgentMessage } from '../agent-message-envelope';
+import type { ReplyRoutingRegistry } from '../runtime/reply-routing-registry';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 const log = new Logger('space-agent-tools');
 
@@ -181,6 +182,13 @@ export interface SpaceAgentToolsConfig {
 	 * Optional — when absent, schedule tools are not registered.
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
+	/**
+	 * Reply routing registry for symmetric message routing. When a member session
+	 * sends a message to a task/node agent, the registry records the sender's
+	 * session ID so that replies via 'space-agent' route back to the originating
+	 * session instead of the canonical space:chat: session.
+	 */
+	replyRoutingRegistry?: ReplyRoutingRegistry;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -219,6 +219,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		myAgentName,
 		myAgentNameAliases,
 		mySessionId,
+		replyRoutingRegistry,
 	} = config;
 
 	const agentNameAliases = new Set(
@@ -954,6 +955,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			// --- Path A: no node_id — send to the Task Agent (auto-spawn if needed) ---
 			if (!args.node_id) {
 				try {
+					// Record reply route so task-agent replies go back to this session.
+					if (replyRoutingRegistry && mySessionId) {
+						replyRoutingRegistry.set(task.id, mySessionId);
+					}
 					await taskAgentManager.ensureTaskAgentSession(task.id);
 					await taskAgentManager.injectTaskAgentMessage(
 						task.id,
@@ -964,6 +969,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							body: args.message,
 							taskId: task.id,
 							taskNumber: task.taskNumber,
+							replyToSessionId: mySessionId,
 						}),
 						true
 					);
@@ -992,6 +998,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				});
 			}
 
+			// Record reply route so node-agent replies go back to this session.
+			if (replyRoutingRegistry && mySessionId) {
+				replyRoutingRegistry.set(task.id, mySessionId, resolved.agentName);
+			}
+
 			// Attempt direct injection when the execution already has a live session.
 			if (resolved.agentSessionId) {
 				try {
@@ -1005,6 +1016,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							taskId: task.id,
 							taskNumber: task.taskNumber,
 							nodeId: resolved.agentName,
+							replyToSessionId: mySessionId,
 						}),
 						true
 					);
@@ -1054,6 +1066,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							taskId: task.id,
 							taskNumber: task.taskNumber,
 							nodeId: resolved.agentName,
+							replyToSessionId: mySessionId,
 						}),
 						true
 					);
@@ -1091,6 +1104,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 						taskId: task.id,
 						taskNumber: task.taskNumber,
 						nodeId: resolved.agentName,
+						replyToSessionId: mySessionId,
 					}),
 				});
 				queuedMessageId = record.id;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -745,10 +745,10 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			for (const targetAgentName of targetAgentNames) {
 				// --- Space Agent escalation path --------------------------------
 				if (targetAgentName === SPACE_AGENT_TARGET) {
+					// Check if this Task Agent should route its reply to a specific
+					// originating session (symmetric reply routing for ad-hoc members).
+					const replyTo = replyRoutingLookup ? replyRoutingLookup() : null;
 					if (spaceAgentInjector) {
-						// Check if this Task Agent should route its reply to a specific
-						// originating session (symmetric reply routing for ad-hoc members).
-						const replyTo = replyRoutingLookup ? replyRoutingLookup() : null;
 						try {
 							await spaceAgentInjector(
 								space.id,
@@ -783,6 +783,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 										body: message,
 										taskId,
 										taskNumber,
+										replyToSessionId: replyTo,
 									}),
 									idempotencyKey,
 								});
@@ -816,6 +817,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 								body: message,
 								taskId,
 								taskNumber,
+								replyToSessionId: replyTo,
 							}),
 							idempotencyKey,
 						});

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -164,7 +164,11 @@ export interface TaskAgentToolsConfig {
 	 * When provided, `send_message({ target: 'space-agent', ... })` escalates
 	 * directly to the Space Agent without routing through a human.
 	 */
-	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
+	spaceAgentInjector?: (
+		spaceId: string,
+		message: string,
+		replyToSessionId?: string | null
+	) => Promise<void>;
 	/**
 	 * Optional observability hook — fired whenever a message is queued for
 	 * later delivery via `pendingMessageRepo`. Tests can capture this to
@@ -184,6 +188,13 @@ export interface TaskAgentToolsConfig {
 	 * Optional — when absent, artifact tools are not registered.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Optional lookup callback for reply-to-session routing.
+	 * When the Task Agent sends to 'space-agent', this callback is invoked to
+	 * determine whether the reply should go to a specific session (instead of
+	 * the default space:chat:\${spaceId}). Returns null for default routing.
+	 */
+	replyRoutingLookup?: () => string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -215,6 +226,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		spaceAgentInjector,
 		onMessageQueued,
 		taskAgentManager,
+		replyRoutingLookup,
 	} = config;
 
 	const agentNameAliases = new Set(
@@ -734,6 +746,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				// --- Space Agent escalation path --------------------------------
 				if (targetAgentName === SPACE_AGENT_TARGET) {
 					if (spaceAgentInjector) {
+						// Check if this Task Agent should route its reply to a specific
+						// originating session (symmetric reply routing for ad-hoc members).
+						const replyTo = replyRoutingLookup ? replyRoutingLookup() : null;
 						try {
 							await spaceAgentInjector(
 								space.id,
@@ -744,11 +759,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 									body: message,
 									taskId,
 									taskNumber,
-								})
+								}),
+								replyTo
 							);
 							delivered.push({
 								agentName: targetAgentName,
-								sessionId: `space:chat:${space.id}`,
+								sessionId: replyTo || `space:chat:${space.id}`,
 							});
 						} catch (err) {
 							const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/tests/unit/1-core/agent/session-config-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/session-config-handler.test.ts
@@ -21,15 +21,18 @@ describe('SessionConfigHandler', () => {
 	let mockSession: Session;
 	let mockDb: Database;
 	let mockDaemonHub: DaemonHub;
+	let updateSessionSpy: ReturnType<typeof mock>;
+	let emitSpy: ReturnType<typeof mock>;
 	const mockInternalEventBus = {
-		publish: emitSpy,
-		publishAsync: emitSpy,
+		get publish() {
+			return emitSpy;
+		},
+		get publishAsync() {
+			return emitSpy;
+		},
 		subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
 	} as unknown as InternalEventBus<any>;
 	let mockSettingsManager: SettingsManager;
-
-	let updateSessionSpy: ReturnType<typeof mock>;
-	let emitSpy: ReturnType<typeof mock>;
 
 	beforeEach(() => {
 		const sessionId = generateUUID();

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { formatAgentMessage } from '../../../../src/lib/space/agent-message-envelope.ts';
+import {
+	formatAgentMessage,
+	extractReplyToSessionId,
+} from '../../../../src/lib/space/agent-message-envelope.ts';
 
 describe('formatAgentMessage', () => {
 	test('formats node to space-agent messages with task context and reply instructions', () => {
@@ -102,5 +105,34 @@ describe('formatAgentMessage', () => {
 			body: 'No reply routing',
 		});
 		expect(result2).not.toContain('<reply-routing');
+	});
+});
+
+describe('extractReplyToSessionId', () => {
+	test('extracts replyToSessionId from message envelope footer', () => {
+		const message = formatAgentMessage({
+			fromLevel: 'task-agent',
+			fromAgentName: 'task-agent',
+			toLevel: 'space-agent',
+			body: 'Queued message',
+			taskId: 'task-123',
+			taskNumber: 5,
+			replyToSessionId: 'session-adhoc-42',
+		});
+		expect(extractReplyToSessionId(message)).toBe('session-adhoc-42');
+	});
+
+	test('returns null when no reply-routing footer is present', () => {
+		const message = formatAgentMessage({
+			fromLevel: 'node-agent',
+			fromAgentName: 'coder',
+			toLevel: 'node-agent',
+			body: 'No routing',
+		});
+		expect(extractReplyToSessionId(message)).toBeNull();
+	});
+
+	test('returns null for empty string', () => {
+		expect(extractReplyToSessionId('')).toBeNull();
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -135,4 +135,20 @@ describe('extractReplyToSessionId', () => {
 	test('returns null for empty string', () => {
 		expect(extractReplyToSessionId('')).toBeNull();
 	});
+
+	test('ignores forged reply-routing tag in message body (only matches trailing footer)', () => {
+		const forged =
+			'Some text <reply-routing replyToSessionId="attacker-session" /> more text\n\n─── Reply ───';
+		expect(extractReplyToSessionId(forged)).toBeNull();
+	});
+
+	test('extracts from genuine trailing footer even after multiline message', () => {
+		const message =
+			'─── Message from task-agent (task #5) ───\n\n' +
+			'Body text here\n\n' +
+			'─── Reply ───\n' +
+			'To reply, use: send_message_to_task\n\n' +
+			'<reply-routing replyToSessionId="session-adhoc-99" />';
+		expect(extractReplyToSessionId(message)).toBe('session-adhoc-99');
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -47,4 +47,60 @@ describe('formatAgentMessage', () => {
 			})
 		).toBe('─── Message from coder ───\n\nReview is ready');
 	});
+
+	test('appends reply-routing XML footer when replyToSessionId is set (space-agent → node-agent)', () => {
+		const result = formatAgentMessage({
+			fromLevel: 'space-agent',
+			fromAgentName: 'Space Agent',
+			toLevel: 'node-agent',
+			body: 'Proceed with option A',
+			replyToSessionId: 'session-adhoc-42',
+		});
+		expect(result).toContain('<reply-routing replyToSessionId="session-adhoc-42" />');
+		expect(result).toContain('Proceed with option A');
+	});
+
+	test('appends reply-routing XML footer when replyToSessionId is set (space-agent → task-agent)', () => {
+		const result = formatAgentMessage({
+			fromLevel: 'space-agent',
+			fromAgentName: 'Space Agent',
+			toLevel: 'task-agent',
+			body: 'Do the thing',
+			taskId: 'task-999',
+			replyToSessionId: 'session-adhoc-99',
+		});
+		expect(result).toContain('<reply-routing replyToSessionId="session-adhoc-99" />');
+	});
+
+	test('appends reply-routing XML footer when replyToSessionId is set (node-agent → task-agent)', () => {
+		const result = formatAgentMessage({
+			fromLevel: 'node-agent',
+			fromAgentName: 'reviewer',
+			toLevel: 'task-agent',
+			body: 'Here is my review',
+			taskId: 'task-888',
+			taskNumber: 42,
+			replyToSessionId: 'session-adhoc-88',
+		});
+		expect(result).toContain('<reply-routing replyToSessionId="session-adhoc-88" />');
+	});
+
+	test('does not append reply-routing footer when replyToSessionId is null or undefined', () => {
+		const result1 = formatAgentMessage({
+			fromLevel: 'space-agent',
+			fromAgentName: 'Space Agent',
+			toLevel: 'node-agent',
+			body: 'No reply routing',
+			replyToSessionId: null,
+		});
+		expect(result1).not.toContain('<reply-routing');
+
+		const result2 = formatAgentMessage({
+			fromLevel: 'space-agent',
+			fromAgentName: 'Space Agent',
+			toLevel: 'node-agent',
+			body: 'No reply routing',
+		});
+		expect(result2).not.toContain('<reply-routing');
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1653,3 +1653,149 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 		expect(resumedAgents).toHaveLength(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: replyRoutingLookup — symmetric reply routing for ad-hoc sessions
+// ---------------------------------------------------------------------------
+
+describe('AgentMessageRouter: replyRoutingLookup routes space-agent replies to originating session', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('routes space-agent message to replyToSessionId when lookup returns a value', async () => {
+		const { runId: workflowRunId, channels: runChannels } = seedWorkflowRunWithChannels(
+			ctx.db,
+			ctx.spaceId,
+			[]
+		);
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+
+		const injected: Array<{ spaceId: string; message: string; replyTo?: string | null }> = [];
+		const router = makeRouter(ctx, workflowRunId, [], runChannels, {
+			spaceId: ctx.spaceId,
+			taskId: 'task-123',
+			taskNumber: 42,
+			spaceAgentInjector: async (spaceId, message, replyTo) => {
+				injected.push({ spaceId, message, replyTo });
+			},
+			replyRoutingLookup: () => 'session-adhoc-member-1',
+		});
+
+		const result = await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'space-agent',
+			message: 'Blocked on decision',
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.delivered).toEqual([
+			{ agentName: 'space-agent', sessionId: 'session-adhoc-member-1' },
+		]);
+		expect(injected).toHaveLength(1);
+		expect(injected[0].replyTo).toBe('session-adhoc-member-1');
+	});
+
+	test('routes space-agent message to default space:chat: when lookup returns null', async () => {
+		const { runId: workflowRunId, channels: runChannels } = seedWorkflowRunWithChannels(
+			ctx.db,
+			ctx.spaceId,
+			[]
+		);
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+
+		const injected: Array<{ spaceId: string; message: string; replyTo?: string | null }> = [];
+		const router = makeRouter(ctx, workflowRunId, [], runChannels, {
+			spaceId: ctx.spaceId,
+			taskId: 'task-123',
+			taskNumber: 42,
+			spaceAgentInjector: async (spaceId, message, replyTo) => {
+				injected.push({ spaceId, message, replyTo });
+			},
+			replyRoutingLookup: () => null,
+		});
+
+		const result = await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'space-agent',
+			message: 'Default routing',
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.delivered).toEqual([
+			{ agentName: 'space-agent', sessionId: `space:chat:${ctx.spaceId}` },
+		]);
+		expect(injected).toHaveLength(1);
+		expect(injected[0].replyTo).toBeNull();
+	});
+
+	test('routes space-agent message to default space:chat: when no replyRoutingLookup provided', async () => {
+		const { runId: workflowRunId, channels: runChannels } = seedWorkflowRunWithChannels(
+			ctx.db,
+			ctx.spaceId,
+			[]
+		);
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+
+		const injected: Array<{ spaceId: string; message: string; replyTo?: string | null }> = [];
+		const router = makeRouter(ctx, workflowRunId, [], runChannels, {
+			spaceId: ctx.spaceId,
+			taskId: 'task-123',
+			spaceAgentInjector: async (spaceId, message, replyTo) => {
+				injected.push({ spaceId, message, replyTo });
+			},
+			// No replyRoutingLookup — backward compat
+		});
+
+		const result = await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'space-agent',
+			message: 'No lookup configured',
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.delivered).toEqual([
+			{ agentName: 'space-agent', sessionId: `space:chat:${ctx.spaceId}` },
+		]);
+		expect(injected).toHaveLength(1);
+		expect(injected[0].replyTo).toBeNull();
+	});
+
+	test('passes sender agentName to replyRoutingLookup for per-node resolution', async () => {
+		const { runId: workflowRunId, channels: runChannels } = seedWorkflowRunWithChannels(
+			ctx.db,
+			ctx.spaceId,
+			[]
+		);
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+
+		const lookupCalls: Array<string | null | undefined> = [];
+		const router = makeRouter(ctx, workflowRunId, [], runChannels, {
+			spaceId: ctx.spaceId,
+			taskId: 'task-123',
+			spaceAgentInjector: async () => {},
+			replyRoutingLookup: (agentName) => {
+				lookupCalls.push(agentName ?? null);
+				return agentName === 'coder' ? 'session-adhoc-coder' : null;
+			},
+		});
+
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'space-agent',
+			message: 'Node-specific routing',
+		});
+
+		expect(lookupCalls).toEqual(['coder']);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/reply-routing-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reply-routing-registry.test.ts
@@ -78,4 +78,23 @@ describe('ReplyRoutingRegistry', () => {
 		registry.deleteByTask('task-1');
 		expect(registry.size).toBe(0);
 	});
+
+	test('purgeExpired removes stale entries without requiring get()', async () => {
+		const registry = new ReplyRoutingRegistry(100); // 100ms TTL
+		registry.set('task-1', 'session-a');
+		registry.set('task-2', 'session-b');
+		expect(registry.size).toBe(2);
+
+		// Wait for expiry
+		await new Promise((resolve) => setTimeout(resolve, 150));
+
+		// Entries are still in the map (not accessed via get)
+		expect(registry.size).toBe(2);
+
+		// Explicit purge removes them
+		registry.purgeExpired();
+		expect(registry.size).toBe(0);
+		expect(registry.get('task-1')).toBeNull();
+		expect(registry.get('task-2')).toBeNull();
+	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/reply-routing-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reply-routing-registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { ReplyRoutingRegistry } from '../../../../src/lib/space/runtime/reply-routing-registry.ts';
+
+describe('ReplyRoutingRegistry', () => {
+	test('returns null when no entry exists', () => {
+		const registry = new ReplyRoutingRegistry();
+		expect(registry.get('task-1')).toBeNull();
+		expect(registry.get('task-1', 'coder')).toBeNull();
+	});
+
+	test('stores and retrieves replyToSessionId by taskId', () => {
+		const registry = new ReplyRoutingRegistry();
+		registry.set('task-1', 'session-adhoc-1');
+		expect(registry.get('task-1')).toBe('session-adhoc-1');
+	});
+
+	test('stores and retrieves replyToSessionId by taskId + agentName', () => {
+		const registry = new ReplyRoutingRegistry();
+		registry.set('task-1', 'session-adhoc-1', 'coder');
+		expect(registry.get('task-1', 'coder')).toBe('session-adhoc-1');
+		// Without agentName, should return null (different key)
+		expect(registry.get('task-1')).toBeNull();
+	});
+
+	test('overwrites previous entry for same key', () => {
+		const registry = new ReplyRoutingRegistry();
+		registry.set('task-1', 'session-adhoc-1');
+		registry.set('task-1', 'session-adhoc-2');
+		expect(registry.get('task-1')).toBe('session-adhoc-2');
+	});
+
+	test('deleteByTask removes all entries for a task', () => {
+		const registry = new ReplyRoutingRegistry();
+		registry.set('task-1', 'session-a');
+		registry.set('task-1', 'session-b', 'coder');
+		registry.set('task-1', 'session-c', 'reviewer');
+		registry.set('task-2', 'session-d');
+
+		registry.deleteByTask('task-1');
+
+		expect(registry.get('task-1')).toBeNull();
+		expect(registry.get('task-1', 'coder')).toBeNull();
+		expect(registry.get('task-1', 'reviewer')).toBeNull();
+		// task-2 should be unaffected
+		expect(registry.get('task-2')).toBe('session-d');
+	});
+
+	test('delete removes a specific entry', () => {
+		const registry = new ReplyRoutingRegistry();
+		registry.set('task-1', 'session-a');
+		registry.set('task-1', 'session-b', 'coder');
+
+		registry.delete('task-1', 'coder');
+
+		expect(registry.get('task-1')).toBe('session-a');
+		expect(registry.get('task-1', 'coder')).toBeNull();
+	});
+
+	test('expired entries return null', async () => {
+		const registry = new ReplyRoutingRegistry(100); // 100ms TTL
+		registry.set('task-1', 'session-adhoc-1');
+
+		// Immediately available
+		expect(registry.get('task-1')).toBe('session-adhoc-1');
+
+		// Wait for expiry
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(registry.get('task-1')).toBeNull();
+	});
+
+	test('size reports correct count', () => {
+		const registry = new ReplyRoutingRegistry();
+		expect(registry.size).toBe(0);
+		registry.set('task-1', 'session-a');
+		expect(registry.size).toBe(1);
+		registry.set('task-1', 'session-b', 'coder');
+		expect(registry.size).toBe(2);
+		registry.deleteByTask('task-1');
+		expect(registry.size).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- When an ad-hoc space member session sends a message to a task/node agent via `send_message_to_task`, the reply now routes back to the originating session instead of always going to `space:chat:${spaceId}`
- Adds `ReplyRoutingRegistry` to track which session sent messages to each task/node
- Updates `spaceAgentInjector`, `AgentMessageRouter`, and `task-agent-tools` to accept and use `replyToSessionId`
- Full backward compatibility: canonical `space:chat:` sessions continue routing to `space:chat:` (no behavior change)

## Test plan
- [x] Unit tests for `ReplyRoutingRegistry` (set, get, delete, expiry)
- [x] Unit tests for `formatAgentMessage` with `replyToSessionId` envelope
- [x] Unit tests for `AgentMessageRouter` `replyRoutingLookup` (routes to originating session, falls back to default)
- [x] All 9643 daemon tests pass
- [x] `bun run check` (lint + typecheck + knip) passes