### PR TITLE
fix: bridge signal reactivity for connection state tracking

### DIFF
--- a/packages/web/src/components/ChatHeader.tsx
+++ b/packages/web/src/components/ChatHeader.tsx
@@ -11,6 +11,8 @@
 
 import type { Session, SessionFeatures } from '@neokai/shared';
 import { DEFAULT_WORKER_FEATURES } from '@neokai/shared';
+import { useSignalEffect } from '@preact/signals';
+import { useState } from 'preact/hooks';
 import { borderColors } from '../lib/design-tokens';
 import { formatTokens } from '../lib/utils';
 import { connectionState } from '../lib/state';
@@ -63,7 +65,12 @@ export function ChatHeader({
 	readonly = false,
 	onBack,
 }: ChatHeaderProps) {
-	const isConnected = connectionState.value === 'connected';
+	// Reactive connection state — bridged from signal via useSignalEffect so
+	// the dropdown and action buttons update live across reconnects.
+	const [isConnected, setIsConnected] = useState(connectionState.value === 'connected');
+	useSignalEffect(() => {
+		setIsConnected(connectionState.value === 'connected');
+	});
 
 	const getHeaderActions = () => {
 		const actions: Array<

--- a/packages/web/src/hooks/useMessageHub.ts
+++ b/packages/web/src/hooks/useMessageHub.ts
@@ -27,8 +27,8 @@
  * ```
  */
 
-import { useCallback, useEffect, useRef } from 'preact/hooks';
-import { useComputed } from '@preact/signals';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
 import { connectionManager } from '../lib/connection-manager';
 import { connectionState } from '../lib/state';
 import { ConnectionNotReadyError } from '../lib/errors';
@@ -203,9 +203,19 @@ export function useMessageHub(options: UseMessageHubOptions = {}): UseMessageHub
 	// Track active subscriptions for cleanup
 	const subscriptionsRef = useRef<Array<() => void>>([]);
 
-	// Computed reactive connection state
-	const isConnected = useComputed(() => connectionState.value === 'connected');
-	const state = useComputed(() => connectionState.value);
+	// Reactive connection state — bridged from signal into component state via
+	// useSignalEffect so that consumers receive a value that triggers re-renders.
+	// Previously used useComputed, but the .value dereference in the return
+	// statement froze both values to whatever they were at render time, causing
+	// cascading staleness in every downstream consumer.
+	const [isConnected, setIsConnected] = useState(connectionState.value === 'connected');
+	const [state, setState] = useState(connectionState.value);
+
+	useSignalEffect(() => {
+		const current = connectionState.value;
+		setIsConnected(current === 'connected');
+		setState(current);
+	});
 
 	// Connection state tracking (for debug mode)
 	useEffect(() => {
@@ -445,8 +455,8 @@ export function useMessageHub(options: UseMessageHubOptions = {}): UseMessageHub
 	}, []);
 
 	return {
-		isConnected: isConnected.value,
-		state: state.value,
+		isConnected,
+		state,
 		getHub,
 		request,
 		onEvent,

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -18,6 +18,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
 import type { ModelInfo } from '@neokai/shared';
 import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { connectionManager } from '../lib/connection-manager';
@@ -288,10 +289,14 @@ export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResu
 	}, [sessionId]);
 
 	// Load when connected and on session change.
-	// connectionState.value triggers a retry when the WebSocket connects
+	// Reactive connection state — bridged from signal via useSignalEffect so
+	// the useEffect dependency actually changes when the WebSocket connects
 	// after mount (e.g. fresh page load where ChatContainer renders before
 	// the hub is ready).
-	const isConnected = connectionState.value === 'connected';
+	const [isConnected, setIsConnected] = useState(connectionState.value === 'connected');
+	useSignalEffect(() => {
+		setIsConnected(connectionState.value === 'connected');
+	});
 	useEffect(() => {
 		if (isConnected) {
 			loadModelInfo();

--- a/packages/web/src/hooks/useSessionActions.ts
+++ b/packages/web/src/hooks/useSessionActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback } from 'preact/hooks';
+import { useSignalEffect } from '@preact/signals';
 import type { Session, ArchiveSessionResponse } from '@neokai/shared';
 import { connectionManager } from '../lib/connection-manager';
 import { deleteSession, listSessions, archiveSession, resetSessionQuery } from '../lib/api-helpers';
@@ -57,7 +58,12 @@ export function useSessionActions({
 		null
 	);
 
-	const isConnected = connectionState.value === 'connected';
+	// Reactive connection state — bridged from signal via useSignalEffect so
+	// callbacks (handleResetAgent, handleExportChat) always see the live value.
+	const [isConnected, setIsConnected] = useState(connectionState.value === 'connected');
+	useSignalEffect(() => {
+		setIsConnected(connectionState.value === 'connected');
+	});
 
 	const handleDeleteSession = useCallback(async () => {
 		try {

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -848,7 +848,12 @@ export default function ChatContainer({
 	// ========================================
 	// Connection Check
 	// ========================================
-	const isConnected = connectionState.value === 'connected';
+	// Reactive connection state — bridged from signal via useSignalEffect so
+	// the value stays live across disconnect/reconnect cycles.
+	const [isConnected, setIsConnected] = useState(connectionState.value === 'connected');
+	useSignalEffect(() => {
+		setIsConnected(connectionState.value === 'connected');
+	});
 
 	// ========================================
 	// Handlers


### PR DESCRIPTION
Fixes `useMessageHub` and four downstream consumers where `connectionState.value` was read once and frozen, causing cascading staleness after WebSocket disconnect/reconnect cycles.

**Root cause**: `useMessageHub` used `useComputed` signals but immediately dereferenced them (`.value`) in the return statement. Consumers received stale primitives instead of reactive values.

**Fix**: Replace `useComputed` + `.value` dereference with `useState` + `useSignalEffect` in all five files. The signal effect subscribes to `connectionState` changes and calls `setState`, which triggers proper Preact re-renders.

**Files changed**:
- `useMessageHub.ts` — primary fix (useState + useSignalEffect replaces useComputed + .value)
- `useSessionActions.ts` — reactive `isConnected` for reset/export callbacks
- `useModelSwitcher.ts` — reactive `isConnected` for model list loading effect
- `ChatContainer.tsx` — reactive `isConnected` for ChatComposer prop
- `ChatHeader.tsx` — reactive `isConnected` for dropdown/action button states

All 173 related hook tests pass. Full web suite: 6030/6032 pass (2 pre-existing flaky tests unrelated to this change).