### PR TITLE
fix: remove SessionCache.get() DB-load path to prevent duplicate AgentSession instances

### DIFF
--- a/packages/daemon/src/lib/session/session-cache.ts
+++ b/packages/daemon/src/lib/session/session-cache.ts
@@ -3,8 +3,11 @@
  *
  * In-memory session caching with lazy loading and race condition prevention:
  * - Map-based storage of AgentSession instances
- * - Lazy loading from database with locking to prevent duplicate SDK connections
+ * - Async lazy loading from database with locking to prevent duplicate SDK connections
  * - Cache invalidation on session deletion
+ *
+ * IMPORTANT: The synchronous `get()` only checks the in-memory map. It never
+ * loads from DB. Callers that need lazy-loading must use `getAsync()`.
  */
 
 import type { Session } from '@neokai/shared';
@@ -41,38 +44,14 @@ export class SessionCache {
 	) {}
 
 	/**
-	 * Get session synchronously (with lazy-loading race condition fix)
+	 * Get session synchronously — in-memory cache only.
 	 *
-	 * FIX: Prevents multiple simultaneous loads of the same session
-	 * which would create duplicate Claude API connections
-	 *
-	 * @throws Error if session is currently being loaded - use getAsync() instead
+	 * Returns the cached `AgentSession` if present, otherwise `null`.
+	 * Does NOT load from the database. Callers that need lazy-loading
+	 * must use `getAsync()` instead.
 	 */
 	get(sessionId: string): AgentSession | null {
-		// Check in-memory first
-		if (this.sessions.has(sessionId)) {
-			return this.sessions.get(sessionId)!;
-		}
-
-		// Check if load already in progress
-		const loadInProgress = this.sessionLoadLocks.get(sessionId);
-		if (loadInProgress) {
-			// Wait for the load to complete (this is sync, so we throw an error)
-			// Callers should use getAsync() for concurrent access
-			throw new Error(
-				`Session ${sessionId} is being loaded. Use getAsync() for concurrent access.`
-			);
-		}
-
-		// Load synchronously (for backward compatibility)
-		const session = this.loadFromDB(sessionId);
-		if (!session) return null;
-
-		// Create agent session
-		const agentSession = this.createAgentSession(session);
-		this.sessions.set(sessionId, agentSession);
-
-		return agentSession;
+		return this.sessions.get(sessionId) ?? null;
 	}
 
 	/**

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -396,10 +396,11 @@ export class SessionManager {
 	}
 
 	/**
-	 * Get session (with lazy-loading race condition fix)
+	 * Get session synchronously — in-memory cache only.
 	 *
-	 * FIX: Prevents multiple simultaneous loads of the same session
-	 * which would create duplicate Claude API connections
+	 * Returns the cached AgentSession if present, otherwise null.
+	 * Does NOT load from the database. Callers that need lazy-loading
+	 * must use getSessionAsync() instead.
 	 */
 	getSession(sessionId: string): AgentSession | null {
 		return this.sessionCache.get(sessionId);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3387,7 +3387,7 @@ export class SpaceRuntime {
 				// rather than rendering a permanently-frozen card. Best-effort:
 				// the AgentSession instance may already be gone from every map.
 				try {
-					const liveSession = tam.getAgentSessionById(execution.agentSessionId);
+					const liveSession = await tam.getAgentSessionById(execution.agentSessionId);
 					if (liveSession) {
 						await liveSession.markPendingQuestionOrphaned('agent_session_terminated');
 					}
@@ -3464,7 +3464,7 @@ export class SpaceRuntime {
 
 				// Part D guard: spare sessions waiting for user input. The agent is
 				// not stuck — a human is.
-				const liveSession = tam.getAgentSessionById(execution.agentSessionId);
+				const liveSession = await tam.getAgentSessionById(execution.agentSessionId);
 				if (liveSession?.getProcessingState().status === 'waiting_for_input') {
 					skippedWaitingForInput++;
 					continue;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2257,7 +2257,7 @@ export class TaskAgentManager {
 	 * Lookup order (mirrors `isSessionAlive`):
 	 *  1. `agentSessionIndex` (fast reverse index for sub-sessions)
 	 *  2. `taskAgentSessions` map (Task Agents)
-	 *  3. `SessionManager.getSession()` (general session cache)
+	 *  3. `SessionManager.getSessionAsync()` (general session cache, may lazy-load from DB)
 	 *
 	 * Step 3 may **lazy-hydrate** an AgentSession from the database if it's
 	 * not currently in any in-memory map — this is intentional, because:
@@ -2281,7 +2281,7 @@ export class TaskAgentManager {
 	 * Returns undefined when the session is not in memory and either does
 	 * not exist in the DB or fails to load.
 	 */
-	getAgentSessionById(sessionId: string): AgentSession | undefined {
+	async getAgentSessionById(sessionId: string): Promise<AgentSession | undefined> {
 		const indexed = this.agentSessionIndex.get(sessionId);
 		if (indexed) return indexed;
 
@@ -2289,10 +2289,9 @@ export class TaskAgentManager {
 			if (taskAgent.session.id === sessionId) return taskAgent;
 		}
 
-		// SessionManager.getSession may hydrate a fresh AgentSession from DB;
-		// that's intentional — see method JSDoc for why. Normalize null → undefined
-		// so the return contract stays uniform.
-		return this.config.sessionManager.getSession(sessionId) ?? undefined;
+		// Use getSessionAsync for safe DB hydration with race-condition protection.
+		// Normalize null → undefined so the return contract stays uniform.
+		return (await this.config.sessionManager.getSessionAsync(sessionId)) ?? undefined;
 	}
 
 	/**
@@ -2305,7 +2304,7 @@ export class TaskAgentManager {
 	 */
 	async prepareSubSessionForWorkflowResume(sessionId: string): Promise<boolean> {
 		if (!this.isSessionAlive(sessionId)) return false;
-		const session = this.getAgentSessionById(sessionId);
+		const session = await this.getAgentSessionById(sessionId);
 		if (!session) return false;
 		await this.mcpSelfHeal(sessionId, ['node-agent']);
 		return true;

--- a/packages/daemon/tests/unit/1-core/session/session-cache.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-cache.test.ts
@@ -73,44 +73,33 @@ describe('SessionCache', () => {
 		it('should return null for non-existent session', () => {
 			const result = cache.get('nonexistent');
 			expect(result).toBeNull();
-			expect(mockLoadFromDB).toHaveBeenCalledWith('nonexistent');
+			// get() no longer loads from DB — only checks in-memory cache
+			expect(mockLoadFromDB).not.toHaveBeenCalled();
 		});
 
-		it('should load session from database on first access', () => {
+		it('should return null for uncached session (no DB loading)', () => {
 			const result = cache.get('test-session-id');
-
-			expect(mockLoadFromDB).toHaveBeenCalledWith('test-session-id');
-			expect(mockCreateAgentSession).toHaveBeenCalledWith(mockSession);
-			expect(result).toBe(mockAgentSession);
+			expect(result).toBeNull();
+			expect(mockLoadFromDB).not.toHaveBeenCalled();
+			expect(mockCreateAgentSession).not.toHaveBeenCalled();
 		});
 
-		it('should cache session after first load', () => {
-			// First access loads from DB
-			const result1 = cache.get('test-session-id');
-			expect(mockLoadFromDB).toHaveBeenCalledTimes(1);
+		it('should return cached session without hitting DB', async () => {
+			// Load via getAsync first
+			await cache.getAsync('test-session-id');
 
-			// Second access uses cache
-			const result2 = cache.get('test-session-id');
-			expect(mockLoadFromDB).toHaveBeenCalledTimes(1); // Still 1, not called again
-
-			expect(result1).toBe(result2);
-		});
-
-		it('should throw error if session is being loaded concurrently', async () => {
-			// Start async load
-			const loadPromise = cache.getAsync('test-session-id');
-
-			// Try sync access while async is in progress
-			expect(() => cache.get('test-session-id')).toThrow(
-				'Session test-session-id is being loaded. Use getAsync() for concurrent access.'
-			);
-
-			// Wait for async to complete
-			await loadPromise;
-
-			// Now sync access should work
+			// Now get() should return the cached session without DB call
+			(mockLoadFromDB as ReturnType<typeof mock>).mockClear();
 			const result = cache.get('test-session-id');
 			expect(result).toBe(mockAgentSession);
+			expect(mockLoadFromDB).not.toHaveBeenCalled();
+		});
+
+		it('should return session set via set() without DB call', () => {
+			cache.set('manual-id', mockAgentSession);
+			const result = cache.get('manual-id');
+			expect(result).toBe(mockAgentSession);
+			expect(mockLoadFromDB).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -248,7 +248,7 @@ describe('SessionManager', () => {
 			expect(result).toBeNull();
 		});
 
-		it('should return cached session', async () => {
+		it('should return cached session (loaded via getSessionAsync)', async () => {
 			const mockSession: Session = {
 				id: 'test-session-id',
 				title: 'Test',
@@ -259,7 +259,10 @@ describe('SessionManager', () => {
 			};
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(mockSession);
 
-			// First access loads and caches
+			// Load via getAsync first
+			await sessionManager.getSessionAsync('test-session-id');
+
+			// Now getSession should return the cached session
 			const result = sessionManager.getSession('test-session-id');
 
 			expect(result).not.toBeNull();
@@ -978,8 +981,8 @@ describe('SessionManager', () => {
 			};
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(mockSession);
 
-			// Access session to cache it
-			sessionManager.getSession('test-id');
+			// Load session into cache via getAsync
+			await sessionManager.getSessionAsync('test-id');
 
 			const result = await sessionManager.generateTitleAndRenameBranch('test-id', 'test message');
 
@@ -1000,8 +1003,8 @@ describe('SessionManager', () => {
 			};
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(mockSession);
 
-			// Access session to cache it
-			sessionManager.getSession('test-id');
+			// Load session into cache via getAsync
+			await sessionManager.getSessionAsync('test-id');
 
 			const result = await sessionManager.initializeSessionWorkspace('test-id', 'test message');
 
@@ -1072,7 +1075,7 @@ describe('SessionManager', () => {
 			const persistedSession = makePersistedSession();
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
-			const oldSession = sessionManager.getSession('test-id');
+			const oldSession = await sessionManager.getSessionAsync('test-id');
 			expect(oldSession).toBeInstanceOf(AgentSession);
 			const lifecycleResetSpy = mock(async () => ({ success: true }));
 			// biome-ignore lint: test mock access
@@ -1094,7 +1097,7 @@ describe('SessionManager', () => {
 			const persistedSession = makePersistedSession();
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
-			const oldSession = sessionManager.getSession('test-id');
+			const oldSession = await sessionManager.getSessionAsync('test-id');
 			expect(oldSession).toBeInstanceOf(AgentSession);
 			const cleanupSpy = spyOn(oldSession!, 'cleanup');
 
@@ -1137,7 +1140,7 @@ describe('SessionManager', () => {
 			});
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
-			const oldSession = sessionManager.getSession('test-id');
+			const oldSession = await sessionManager.getSessionAsync('test-id');
 			await oldSession!.resetQuery({ restartQuery: false, hardReset: true });
 
 			expect(mockDb.updateSession).toHaveBeenCalledWith(
@@ -1164,7 +1167,7 @@ describe('SessionManager', () => {
 			const persistedSession = makePersistedSession();
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
-			const oldSession = sessionManager.getSession('test-id');
+			const oldSession = await sessionManager.getSessionAsync('test-id');
 			const order: string[] = [];
 			const unregister = sessionManager.registerSessionResetSubscriber(async () => {
 				order.push('subscriber:start');
@@ -1205,7 +1208,7 @@ describe('SessionManager', () => {
 			const persistedSession = makePersistedSession();
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
-			const oldSession = sessionManager.getSession('test-id');
+			const oldSession = await sessionManager.getSessionAsync('test-id');
 			expect(oldSession).toBeInstanceOf(AgentSession);
 			(mockDb.getSession as ReturnType<typeof mock>).mockClear();
 			const replaySpy = spyOn(


### PR DESCRIPTION
## Summary

- Remove the synchronous DB-loading path from `SessionCache.get()` — it now returns only from the in-memory cache (`null` if absent), eliminating the class of bugs where a concurrent `getAsync()` could produce a duplicate `AgentSession` with orphaned event subscriptions and SDK subprocesses.
- Convert `TaskAgentManager.getAgentSessionById()` to async (uses `getSessionAsync` for DB hydration with proper race-condition protection).
- Update all callers and tests to use `getAsync`/`getSessionAsync` where lazy-loading was needed.

## Test plan

- [x] `./scripts/test-daemon.sh` — all 9712 tests pass
- [x] `bun run check` — lint, typecheck, knip, session-guards all clean
- [x] Session-cache unit tests updated for new cache-only `get()` semantics
- [x] Session-manager tests updated: all `getSession` cache-seeding calls converted to `getSessionAsync`