### PR TITLE
Add Space-native goal backend

### DIFF
--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -193,6 +193,7 @@ export async function handleTaskScheduleFire(
 				preferredWorkflowId: schedule.preferredWorkflowId,
 				labels: schedule.labels,
 				createdByTaskScheduleId: schedule.id,
+				goalId: schedule.goalId,
 			});
 
 			let computedNextRunAt: number | null = null;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -99,7 +99,10 @@ import type { NeoActionToolsConfig, NeoWorkflowRun } from '../neo/tools/neo-acti
 import { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
 import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
+import { setupSpaceGoalHandlers } from './space-goal-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
+import { SpaceGoalRepository } from '../../storage/repositories/space-goal-repository';
+import { SpaceGoalService } from '../space/goals/goal-service';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -272,6 +275,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
 	const pendingMessageRepo = new PendingAgentMessageRepository(deps.db.getDatabase());
 	const taskScheduleRepo = new TaskScheduleRepository(deps.db.getDatabase());
+	const spaceGoalRepo = new SpaceGoalRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const spaceRepo = new SpaceRepository(deps.db.getDatabase());
 
 	// Centralised TaskSchedule lifecycle service — used by both the RPC
@@ -283,6 +287,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleRepo: taskScheduleRepo,
 		jobQueue: deps.jobQueue,
 		spaceRepo,
+	});
+	const spaceGoalService = new SpaceGoalService({
+		goalRepo: spaceGoalRepo,
+		taskRepo: spaceTaskRepo,
+		spaceRepo,
+		scheduleService,
 	});
 
 	// When a space is resumed/started, re-seed any of its active schedules
@@ -416,6 +426,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		artifactRepo,
 		pendingMessageRepo,
 		scheduleService,
+		goalService: spaceGoalService,
 		commandBus: deps.commandBus,
 		externalEventStore: deps.externalEventStore,
 		replyRoutingRegistry,
@@ -441,12 +452,19 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceManager,
 		spaceTaskManagerFactory,
 		deps.internalEventBus,
-		spaceRuntimeService
+		spaceRuntimeService,
+		spaceGoalService
 	);
 
 	// Task schedule handlers — create/list/get/update/pause/resume/delete schedules.
 	setupTaskScheduleHandlers(deps.messageHub, {
 		scheduleService,
+		spaceManager: deps.spaceManager,
+	});
+
+	// Space goal handlers — create/list/get/update/pause/resume/trigger long-horizon goals.
+	setupSpaceGoalHandlers(deps.messageHub, {
+		goalService: spaceGoalService,
 		spaceManager: deps.spaceManager,
 	});
 

--- a/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
@@ -1,0 +1,81 @@
+import type { MessageHub, SpaceGoalStatus } from '@neokai/shared';
+import type { SpaceGoalService } from '../space/goals/goal-service';
+import type { SpaceManager } from '../space/managers/space-manager';
+
+export interface SpaceGoalHandlerDeps {
+	goalService: SpaceGoalService;
+	spaceManager: SpaceManager;
+}
+
+export function setupSpaceGoalHandlers(messageHub: MessageHub, deps: SpaceGoalHandlerDeps): void {
+	const { goalService, spaceManager } = deps;
+
+	async function requireSpace(spaceId: string) {
+		if (!spaceId) throw new Error('spaceId is required');
+		const space = await spaceManager.getSpace(spaceId);
+		if (!space) throw new Error(`Space not found: ${spaceId}`);
+		return space;
+	}
+
+	function requireGoalInSpace(goalId: string, spaceId: string) {
+		if (!goalId) throw new Error('goalId is required');
+		const goal = goalService.getGoal(goalId);
+		if (!goal || goal.spaceId !== spaceId) throw new Error(`Goal not found: ${goalId}`);
+		return goal;
+	}
+
+	messageHub.onRequest('spaceGoal.create', async (data) => {
+		const params = data as Parameters<SpaceGoalService['createGoal']>[0];
+		await requireSpace(params.spaceId);
+		return { goal: goalService.createGoal(params) };
+	});
+
+	messageHub.onRequest('spaceGoal.list', async (data) => {
+		const params = data as {
+			spaceId: string;
+			status?: SpaceGoalStatus;
+			includeArchived?: boolean;
+			label?: string;
+			search?: string;
+		};
+		await requireSpace(params.spaceId);
+		return { goals: goalService.listGoals(params) };
+	});
+
+	messageHub.onRequest('spaceGoal.get', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		return { goal: requireGoalInSpace(params.goalId, params.spaceId) };
+	});
+
+	messageHub.onRequest('spaceGoal.update', async (data) => {
+		const params = data as { spaceId: string; goalId: string } & Parameters<
+			SpaceGoalService['updateGoal']
+		>[1];
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		const { goalId, spaceId: _spaceId, ...updates } = params;
+		return { goal: goalService.updateGoal(goalId, updates) };
+	});
+
+	messageHub.onRequest('spaceGoal.pause', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return { goal: goalService.pauseGoal(params.goalId) };
+	});
+
+	messageHub.onRequest('spaceGoal.resume', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return { goal: goalService.resumeGoal(params.goalId) };
+	});
+
+	messageHub.onRequest('spaceGoal.createImmediateTask', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return goalService.createImmediateTask(params.goalId);
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -23,8 +23,15 @@ import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import type { SpaceGoalService } from '../space/goals/goal-service';
 
 const log = new Logger('space-task-handlers');
+
+function isTerminalSpaceTaskStatus(status: SpaceTaskStatus): boolean {
+	return (
+		status === 'done' || status === 'blocked' || status === 'cancelled' || status === 'archived'
+	);
+}
 
 /**
  * Factory that creates a SpaceTaskManager bound to a specific spaceId.
@@ -37,7 +44,8 @@ export function setupSpaceTaskHandlers(
 	spaceManager: SpaceManager,
 	taskManagerFactory: SpaceTaskManagerFactory,
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>,
-	spaceRuntimeService?: SpaceRuntimeService
+	spaceRuntimeService?: SpaceRuntimeService,
+	spaceGoalService?: SpaceGoalService
 ): void {
 	// ─── spaceTask.create ───────────────────────────────────────────────────────
 	messageHub.onRequest('spaceTask.create', async (data) => {
@@ -383,6 +391,10 @@ export function setupSpaceTaskHandlers(
 			task = await taskManager.updateTask(taskId, updateParams, {
 				onCascadedTasks: emitCascadedTasks,
 			});
+		}
+
+		if (spaceGoalService && isTerminalSpaceTaskStatus(task.status)) {
+			spaceGoalService.handleTaskTerminal(task.id);
 		}
 
 		if (emitTaskUpdated) {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -1,0 +1,183 @@
+import type {
+	CreateSpaceGoalParams,
+	SpaceGoal,
+	SpaceGoalListParams,
+	SpaceTask,
+	UpdateSpaceGoalParams,
+} from '@neokai/shared';
+import type { SpaceRepository } from '../../../storage/repositories/space-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
+import type { ScheduleService } from '../schedule/schedule-service';
+
+export interface SpaceGoalServiceDeps {
+	goalRepo: SpaceGoalRepository;
+	taskRepo: SpaceTaskRepository;
+	spaceRepo: SpaceRepository;
+	scheduleService: ScheduleService;
+}
+
+export class SpaceGoalService {
+	constructor(private readonly deps: SpaceGoalServiceDeps) {}
+
+	createGoal(params: CreateSpaceGoalParams): SpaceGoal {
+		this.validateCreate(params);
+		const space = this.deps.spaceRepo.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+		if (space.status !== 'active') {
+			throw new Error(`Cannot create goal in a non-active space (current: ${space.status})`);
+		}
+
+		const goal = this.deps.goalRepo.create(params);
+		if (params.checkInCronExpression) {
+			const schedule = this.deps.scheduleService.createSchedule({
+				spaceId: params.spaceId,
+				title: `Goal check-in: ${params.title}`,
+				description: this.buildTaskDescription(goal),
+				priority: goal.priority,
+				preferredWorkflowId: goal.preferredWorkflowId,
+				labels: this.goalTaskLabels(goal),
+				triggerType: 'cron',
+				cronExpression: params.checkInCronExpression,
+				timezone: params.checkInTimezone ?? 'UTC',
+				createdByAgent: 'space-goal-service',
+				goalId: goal.id,
+			});
+			this.deps.goalRepo.setTaskScheduleId(goal.id, schedule.id);
+			this.deps.goalRepo.update(goal.id, { nextCheckInAt: schedule.nextRunAt });
+		}
+
+		if (params.triggerImmediately) return this.createImmediateTask(goal.id).goal;
+		return this.getGoal(goal.id) as SpaceGoal;
+	}
+
+	listGoals(params: SpaceGoalListParams): SpaceGoal[] {
+		if (!params.spaceId) throw new Error('spaceId is required');
+		return this.deps.goalRepo.list(params);
+	}
+
+	getGoal(goalId: string): SpaceGoal | null {
+		return this.deps.goalRepo.getById(goalId);
+	}
+
+	updateGoal(goalId: string, params: UpdateSpaceGoalParams): SpaceGoal {
+		const existing = this.requireGoal(goalId);
+		if (
+			existing.status === 'archived' &&
+			params.status !== undefined &&
+			params.status !== 'archived'
+		) {
+			throw new Error('Archived goals cannot be reactivated');
+		}
+		if (params.title !== undefined && !params.title.trim()) throw new Error('title is required');
+		const updated = this.deps.goalRepo.update(goalId, params);
+		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		return updated;
+	}
+
+	pauseGoal(goalId: string): SpaceGoal {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'active') throw new Error(`Goal is not active (current: ${goal.status})`);
+		if (goal.taskScheduleId) this.deps.scheduleService.pauseSchedule(goal.taskScheduleId);
+		return this.updateGoal(goalId, { status: 'paused' });
+	}
+
+	resumeGoal(goalId: string): SpaceGoal {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'paused') throw new Error(`Goal is not paused (current: ${goal.status})`);
+		let nextCheckInAt = goal.nextCheckInAt;
+		if (goal.taskScheduleId) {
+			const schedule = this.deps.scheduleService.resumeSchedule(goal.taskScheduleId);
+			nextCheckInAt = schedule.nextRunAt;
+		}
+		return this.updateGoal(goalId, { status: 'active', nextCheckInAt });
+	}
+
+	createImmediateTask(goalId: string): {
+		goal: SpaceGoal;
+		task: SpaceTask | null;
+		queued: boolean;
+	} {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'active') {
+			throw new Error(`Cannot trigger goal in '${goal.status}' status`);
+		}
+		if (goal.activeTaskId) {
+			const active = this.deps.taskRepo.getTask(goal.activeTaskId);
+			if (active && isActiveTaskStatus(active.status)) {
+				return {
+					goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+					task: null,
+					queued: true,
+				};
+			}
+			this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, goal.activeTaskId);
+		}
+
+		const task = this.deps.taskRepo.createTask({
+			spaceId: goal.spaceId,
+			title: `Goal task: ${goal.title}`,
+			description: this.buildTaskDescription(goal),
+			priority: goal.priority,
+			labels: this.goalTaskLabels(goal),
+			preferredWorkflowId: goal.preferredWorkflowId,
+			goalId: goal.id,
+		});
+		if (!this.deps.goalRepo.claimActiveTask(goal.id, task.id)) {
+			this.deps.taskRepo.deleteTask(task.id);
+			return {
+				goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+				task: null,
+				queued: true,
+			};
+		}
+		return { goal: this.requireGoal(goal.id), task, queued: false };
+	}
+
+	handleTaskTerminal(taskId: string): { goal: SpaceGoal; nextTask: SpaceTask | null } | null {
+		const task = this.deps.taskRepo.getTask(taskId);
+		if (!task?.goalId) return null;
+		const goal = this.deps.goalRepo.getById(task.goalId);
+		if (!goal) return null;
+		this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
+		const fresh = this.requireGoal(goal.id);
+		if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
+			return { goal: fresh, nextTask: null };
+		}
+		const created = this.createImmediateTask(fresh.id);
+		return { goal: created.goal, nextTask: created.task };
+	}
+
+	private requireGoal(goalId: string): SpaceGoal {
+		const goal = this.deps.goalRepo.getById(goalId);
+		if (!goal) throw new Error(`Goal not found: ${goalId}`);
+		return goal;
+	}
+
+	private validateCreate(params: CreateSpaceGoalParams): void {
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.title?.trim()) throw new Error('title is required');
+	}
+
+	private goalTaskLabels(goal: SpaceGoal): string[] {
+		return Array.from(new Set(['goal', `goal:${goal.id}`, ...goal.labels]));
+	}
+
+	private buildTaskDescription(goal: SpaceGoal): string {
+		const sections = [
+			`Goal: ${goal.title}`,
+			goal.description,
+			goal.summary ? `Current summary:\n${goal.summary}` : '',
+			goal.nextSteps.length > 0
+				? `Next steps:\n${goal.nextSteps.map((s) => `- ${s}`).join('\n')}`
+				: '',
+		].filter(Boolean);
+		return sections.join('\n\n');
+	}
+}
+
+function isActiveTaskStatus(status: SpaceTask['status']): boolean {
+	return (
+		status === 'open' || status === 'in_progress' || status === 'review' || status === 'approved'
+	);
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -109,6 +109,12 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 	/**
+	 * Space-native goal service — shared business logic for long-horizon goals.
+	 * Passed to space-agent-tools so agents can create/list/update goals and
+	 * trigger concrete goal tasks. Optional.
+	 */
+	goalService?: import('../goals/goal-service').SpaceGoalService;
+	/**
 	 * Optional InternalEventBus for publishing Space runtime domain events.
 	 * When provided, SpaceRuntime publishes typed events alongside the legacy
 	 * NotificationSink path, and SpaceAgentNotificationService is wired per-space
@@ -782,6 +788,7 @@ export class SpaceRuntimeService {
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			goalService: this.config.goalService,
 			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 
@@ -877,6 +884,7 @@ export class SpaceRuntimeService {
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			goalService: this.config.goalService,
 			replyRoutingRegistry: this.config.replyRoutingRegistry,
 		});
 

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -39,6 +39,7 @@ export interface CreateScheduleInput {
 	timezone?: string;
 	createdByAgent?: string | null;
 	createdBySession?: string | null;
+	goalId?: string | null;
 }
 
 export interface UpdateScheduleInput {
@@ -152,6 +153,7 @@ export class ScheduleService {
 				nextRunAt,
 				createdByAgent: input.createdByAgent,
 				createdBySession: input.createdBySession,
+				goalId: input.goalId,
 			});
 
 			const job = jobQueue.enqueue({

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -25,6 +25,10 @@ import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type {
 	NodeExecution,
+	SpaceGoalListParams,
+	SpaceGoalMetrics,
+	SpaceGoalStatus,
+	SpaceGoalType,
 	SpaceTask,
 	SpaceTaskStatus,
 	SpaceTaskPriority,
@@ -182,6 +186,8 @@ export interface SpaceAgentToolsConfig {
 	 * Optional — when absent, schedule tools are not registered.
 	 */
 	scheduleService?: import('../schedule/schedule-service').ScheduleService;
+	/** Space-native goal lifecycle service. */
+	goalService?: import('../goals/goal-service').SpaceGoalService;
 	/**
 	 * Reply routing registry for symmetric message routing. When a member session
 	 * sends a message to a task/node agent, the registry records the sender's
@@ -221,6 +227,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		mySessionId,
 		replyRoutingRegistry,
 	} = config;
+	const goalService = config.goalService;
 
 	const agentNameAliases = new Set(
 		[myAgentName, ...(myAgentNameAliases ?? [])]
@@ -1553,6 +1560,188 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 		},
+
+		async create_goal(args: {
+			title: string;
+			description?: string;
+			type?: SpaceGoalType;
+			priority?: SpaceTaskPriority;
+			labels?: string[];
+			metrics?: SpaceGoalMetrics;
+			summary?: string;
+			progress?: number;
+			next_steps?: string[];
+			workflow_id?: string | null;
+			check_in_cron_expression?: string | null;
+			check_in_timezone?: string | null;
+			auto_trigger_next?: boolean;
+			trigger_immediately?: boolean;
+		}): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const goal = goalService.createGoal({
+					spaceId,
+					title: args.title,
+					description: args.description,
+					type: args.type,
+					priority: args.priority,
+					labels: args.labels,
+					metrics: args.metrics,
+					summary: args.summary,
+					progress: args.progress,
+					nextSteps: args.next_steps,
+					preferredWorkflowId: args.workflow_id ?? null,
+					checkInCronExpression: args.check_in_cron_expression ?? null,
+					checkInTimezone: args.check_in_timezone ?? undefined,
+					autoTriggerNext: args.auto_trigger_next,
+					triggerImmediately: args.trigger_immediately,
+				});
+				logAudit('create_goal', {
+					title: args.title,
+					trigger_immediately: args.trigger_immediately,
+				});
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_goals(args: {
+			status?: SpaceGoalStatus;
+			include_archived?: boolean;
+			label?: string;
+			search?: string;
+		}): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const params: SpaceGoalListParams = {
+					spaceId,
+					status: args.status,
+					includeArchived: args.include_archived,
+					label: args.label,
+					search: args.search,
+				};
+				return jsonResult({ success: true, goals: goalService.listGoals(params) });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async get_goal(args: { goal_id: string }): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const goal = goalService.getGoal(args.goal_id);
+				if (!goal || goal.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+				}
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async update_goal(args: {
+			goal_id: string;
+			title?: string;
+			description?: string;
+			status?: SpaceGoalStatus;
+			type?: SpaceGoalType;
+			priority?: SpaceTaskPriority;
+			labels?: string[];
+			metrics?: SpaceGoalMetrics;
+			summary?: string;
+			progress?: number;
+			next_steps?: string[];
+			workflow_id?: string | null;
+			auto_trigger_next?: boolean;
+			pending_next_run?: boolean;
+		}): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const existing = goalService.getGoal(args.goal_id);
+				if (!existing || existing.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+				}
+				const goal = goalService.updateGoal(args.goal_id, {
+					title: args.title,
+					description: args.description,
+					status: args.status,
+					type: args.type,
+					priority: args.priority,
+					labels: args.labels,
+					metrics: args.metrics,
+					summary: args.summary,
+					progress: args.progress,
+					nextSteps: args.next_steps,
+					preferredWorkflowId: args.workflow_id,
+					autoTriggerNext: args.auto_trigger_next,
+					pendingNextRun: args.pending_next_run,
+				});
+				logAudit('update_goal', { goal_id: args.goal_id });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async pause_goal(args: { goal_id: string }): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const existing = goalService.getGoal(args.goal_id);
+				if (!existing || existing.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+				}
+				const goal = goalService.pauseGoal(args.goal_id);
+				logAudit('pause_goal', { goal_id: args.goal_id });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async resume_goal(args: { goal_id: string }): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const existing = goalService.getGoal(args.goal_id);
+				if (!existing || existing.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+				}
+				const goal = goalService.resumeGoal(args.goal_id);
+				logAudit('resume_goal', { goal_id: args.goal_id });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async create_goal_task(args: { goal_id: string }): Promise<ToolResult> {
+			if (!goalService)
+				return jsonResult({ success: false, error: 'Goal management not available' });
+			try {
+				const existing = goalService.getGoal(args.goal_id);
+				if (!existing || existing.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Goal not found: ${args.goal_id}` });
+				}
+				const result = goalService.createImmediateTask(args.goal_id);
+				logAudit('create_goal_task', { goal_id: args.goal_id, queued: result.queued });
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -1946,6 +2135,100 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					schedule_id: z.string().describe('ID of the scheduled task to delete'),
 				},
 				(args) => handlers.delete_scheduled_task(args)
+			)
+		);
+	}
+
+	// Goal lifecycle tools — only registered when goalService is provided.
+	if (config.goalService) {
+		tools.push(
+			tool(
+				'create_goal',
+				'Create a long-horizon Space goal. Goals track rolling state; concrete work is executed through SpaceTasks. Optionally set check_in_cron_expression for recurring check-ins or trigger_immediately to create the first task now.',
+				{
+					title: z.string().describe('Short title for the goal'),
+					description: z.string().optional().describe('Detailed goal description'),
+					type: z.enum(['one_shot', 'measurable', 'recurring']).optional(),
+					priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+					labels: z
+						.array(z.string())
+						.optional()
+						.describe('Labels for filtering and task propagation'),
+					metrics: z
+						.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+						.optional(),
+					summary: z.string().optional().describe('Current rolling summary'),
+					progress: z.number().int().min(0).max(100).optional(),
+					next_steps: z.array(z.string()).optional(),
+					workflow_id: z
+						.string()
+						.nullable()
+						.optional()
+						.describe('Preferred workflow for goal tasks'),
+					check_in_cron_expression: z.string().nullable().optional(),
+					check_in_timezone: z.string().nullable().optional(),
+					auto_trigger_next: z.boolean().optional(),
+					trigger_immediately: z.boolean().optional(),
+				},
+				(args) => handlers.create_goal(args)
+			),
+			tool(
+				'list_goals',
+				'List long-horizon Space goals. Supports filtering by status, label, and search text.',
+				{
+					status: z.enum(['active', 'paused', 'completed', 'archived']).optional(),
+					include_archived: z.boolean().optional(),
+					label: z.string().optional(),
+					search: z.string().optional(),
+				},
+				(args) => handlers.list_goals(args)
+			),
+			tool(
+				'get_goal',
+				'Retrieve a long-horizon Space goal by ID.',
+				{ goal_id: z.string().describe('ID of the goal to retrieve') },
+				(args) => handlers.get_goal(args)
+			),
+			tool(
+				'update_goal',
+				'Update goal metadata or rolling state such as summary, progress, metrics, next steps, labels, status, or preferred workflow.',
+				{
+					goal_id: z.string().describe('ID of the goal to update'),
+					title: z.string().min(1).optional(),
+					description: z.string().optional(),
+					status: z.enum(['active', 'paused', 'completed', 'archived']).optional(),
+					type: z.enum(['one_shot', 'measurable', 'recurring']).optional(),
+					priority: z.enum(['low', 'normal', 'high', 'urgent']).optional(),
+					labels: z.array(z.string()).optional(),
+					metrics: z
+						.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+						.optional(),
+					summary: z.string().optional(),
+					progress: z.number().int().min(0).max(100).optional(),
+					next_steps: z.array(z.string()).optional(),
+					workflow_id: z.string().nullable().optional(),
+					auto_trigger_next: z.boolean().optional(),
+					pending_next_run: z.boolean().optional(),
+				},
+				(args) => handlers.update_goal(args)
+			),
+			tool(
+				'pause_goal',
+				'Pause an active goal and its recurring check-in schedule, if any.',
+				{ goal_id: z.string().describe('ID of the goal to pause') },
+				(args) => handlers.pause_goal(args)
+			),
+			tool(
+				'resume_goal',
+				'Resume a paused goal and its recurring check-in schedule, if any.',
+				{ goal_id: z.string().describe('ID of the goal to resume') },
+				(args) => handlers.resume_goal(args)
+			),
+			tool(
+				'create_goal_task',
+				'Create an immediate concrete SpaceTask for a goal. If another active goal task exists, the trigger is queued instead of creating a concurrent task.',
+				{ goal_id: z.string().describe('ID of the goal to trigger') },
+				(args) => handlers.create_goal_task(args)
 			)
 		);
 	}

--- a/packages/daemon/src/storage/repositories/space-goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-repository.ts
@@ -1,0 +1,214 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	CreateSpaceGoalParams,
+	SpaceGoal,
+	SpaceGoalListParams,
+	SpaceGoalMetrics,
+	SpaceGoalStatus,
+	UpdateSpaceGoalParams,
+} from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+import type { SQLiteValue } from '../types';
+
+export class SpaceGoalRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
+
+	create(params: CreateSpaceGoalParams): SpaceGoal {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_goals (
+					id, space_id, title, description, status, type, priority, labels, metrics,
+					summary, progress, next_steps, preferred_workflow_id, auto_trigger_next,
+					pending_next_run, active_task_id, last_task_id, last_check_in_at,
+					next_check_in_at, created_at, updated_at, completed_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.title,
+				params.description ?? '',
+				'active',
+				params.type ?? 'one_shot',
+				params.priority ?? 'normal',
+				JSON.stringify(params.labels ?? []),
+				JSON.stringify(params.metrics ?? {}),
+				params.summary ?? '',
+				clampProgress(params.progress ?? 0),
+				JSON.stringify(params.nextSteps ?? []),
+				params.preferredWorkflowId ?? null,
+				params.autoTriggerNext ? 1 : 0,
+				0,
+				null,
+				null,
+				null,
+				null,
+				now,
+				now,
+				null
+			);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id) as SpaceGoal;
+	}
+
+	getById(id: string): SpaceGoal | null {
+		const row = this.db.prepare(`SELECT * FROM space_goals WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? this.rowToGoal(row) : null;
+	}
+
+	list(params: SpaceGoalListParams): SpaceGoal[] {
+		const values: SQLiteValue[] = [params.spaceId];
+		let where = `WHERE space_id = ?`;
+		if (params.status) {
+			where += ` AND status = ?`;
+			values.push(params.status);
+		} else if (!params.includeArchived) {
+			where += ` AND status != 'archived'`;
+		}
+		const rows = this.db
+			.prepare(`SELECT * FROM space_goals ${where} ORDER BY updated_at DESC, id DESC`)
+			.all(...values) as Record<string, unknown>[];
+		let goals = rows.map((r) => this.rowToGoal(r));
+		if (params.label) {
+			goals = goals.filter((goal) => goal.labels.includes(params.label as string));
+		}
+		if (params.search) {
+			const q = params.search.toLowerCase();
+			goals = goals.filter(
+				(goal) => goal.title.toLowerCase().includes(q) || goal.description.toLowerCase().includes(q)
+			);
+		}
+		return goals;
+	}
+
+	update(id: string, params: UpdateSpaceGoalParams): SpaceGoal | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+
+		if (params.title !== undefined) add('title', params.title);
+		if (params.description !== undefined) add('description', params.description);
+		if (params.status !== undefined) add('status', params.status);
+		if (params.type !== undefined) add('type', params.type);
+		if (params.priority !== undefined) add('priority', params.priority);
+		if (params.labels !== undefined) add('labels', JSON.stringify(params.labels));
+		if (params.metrics !== undefined) add('metrics', JSON.stringify(params.metrics));
+		if (params.summary !== undefined) add('summary', params.summary);
+		if (params.progress !== undefined) add('progress', clampProgress(params.progress));
+		if (params.nextSteps !== undefined) add('next_steps', JSON.stringify(params.nextSteps));
+		if (params.preferredWorkflowId !== undefined) {
+			add('preferred_workflow_id', params.preferredWorkflowId ?? null);
+		}
+		if (params.autoTriggerNext !== undefined)
+			add('auto_trigger_next', params.autoTriggerNext ? 1 : 0);
+		if (params.pendingNextRun !== undefined) add('pending_next_run', params.pendingNextRun ? 1 : 0);
+		if (params.activeTaskId !== undefined) add('active_task_id', params.activeTaskId ?? null);
+		if (params.lastTaskId !== undefined) add('last_task_id', params.lastTaskId ?? null);
+		if (params.lastCheckInAt !== undefined) add('last_check_in_at', params.lastCheckInAt ?? null);
+		if (params.nextCheckInAt !== undefined) add('next_check_in_at', params.nextCheckInAt ?? null);
+		if (params.completedAt !== undefined) add('completed_at', params.completedAt ?? null);
+
+		if (params.status === 'completed' && params.completedAt === undefined)
+			add('completed_at', Date.now());
+		if (params.status && params.status !== 'completed' && params.completedAt === undefined) {
+			add('completed_at', null);
+		}
+
+		if (sets.length === 0) return this.getById(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db.prepare(`UPDATE space_goals SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id);
+	}
+
+	setTaskScheduleId(id: string, scheduleId: string | null): SpaceGoal | null {
+		this.db
+			.prepare(`UPDATE space_goals SET task_schedule_id = ?, updated_at = ? WHERE id = ?`)
+			.run(scheduleId, Date.now(), id);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id);
+	}
+
+	claimActiveTask(goalId: string, taskId: string): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE space_goals
+				 SET active_task_id = ?, last_task_id = ?, pending_next_run = 0,
+				     last_check_in_at = ?, updated_at = ?
+				 WHERE id = ? AND status = 'active' AND active_task_id IS NULL`
+			)
+			.run(taskId, taskId, Date.now(), Date.now(), goalId);
+		if (result.changes > 0) this.reactiveDb?.notifyChange('space_goals');
+		return result.changes > 0;
+	}
+
+	queueNextRun(goalId: string): SpaceGoal | null {
+		return this.update(goalId, { pendingNextRun: true });
+	}
+
+	clearActiveTaskIfMatches(goalId: string, taskId: string): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE space_goals
+				 SET active_task_id = NULL, last_task_id = ?, updated_at = ?
+				 WHERE id = ? AND active_task_id = ?`
+			)
+			.run(taskId, Date.now(), goalId, taskId);
+		if (result.changes > 0) this.reactiveDb?.notifyChange('space_goals');
+		return result.changes > 0;
+	}
+
+	private rowToGoal(row: Record<string, unknown>): SpaceGoal {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			title: row.title as string,
+			description: (row.description as string) ?? '',
+			status: row.status as SpaceGoalStatus,
+			type: row.type as SpaceGoal['type'],
+			priority: row.priority as SpaceGoal['priority'],
+			labels: parseJson<string[]>(row.labels, []),
+			metrics: parseJson<SpaceGoalMetrics>(row.metrics, {}),
+			summary: (row.summary as string) ?? '',
+			progress: (row.progress as number | null) ?? 0,
+			nextSteps: parseJson<string[]>(row.next_steps, []),
+			preferredWorkflowId: (row.preferred_workflow_id as string | null) ?? null,
+			taskScheduleId: (row.task_schedule_id as string | null) ?? null,
+			autoTriggerNext: row.auto_trigger_next === 1,
+			pendingNextRun: row.pending_next_run === 1,
+			activeTaskId: (row.active_task_id as string | null) ?? null,
+			lastTaskId: (row.last_task_id as string | null) ?? null,
+			lastCheckInAt: (row.last_check_in_at as number | null) ?? null,
+			nextCheckInAt: (row.next_check_in_at as number | null) ?? null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+			completedAt: (row.completed_at as number | null) ?? null,
+		};
+	}
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+	if (typeof value !== 'string') return fallback;
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function clampProgress(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.min(100, Math.round(value)));
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -44,8 +44,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -59,6 +59,7 @@ export class SpaceTaskRepository {
 					params.workflowRunId ?? null,
 					params.preferredWorkflowId ?? null,
 					params.createdByTaskId ?? null,
+					params.goalId ?? null,
 					JSON.stringify(params.dependsOn ?? []),
 					params.taskAgentSessionId ?? null,
 					params.createdBy ?? null,
@@ -323,6 +324,10 @@ export class SpaceTaskRepository {
 			fields.push('preferred_workflow_id = ?');
 			values.push(params.preferredWorkflowId ?? null);
 		}
+		if (params.goalId !== undefined) {
+			fields.push('goal_id = ?');
+			values.push(params.goalId ?? null);
+		}
 		if (params.createdByTaskId !== undefined) {
 			fields.push('created_by_task_id = ?');
 			values.push(params.createdByTaskId ?? null);
@@ -575,6 +580,7 @@ export class SpaceTaskRepository {
 			createdBy: (row.created_by as string | null) ?? undefined,
 			createdBySession: (row.created_by_session as string | null) ?? undefined,
 			createdByTaskScheduleId: (row.created_by_task_schedule_id as string | null) ?? undefined,
+			goalId: (row.goal_id as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -28,6 +28,7 @@ export interface CreateTaskScheduleParams {
 	nextRunAt?: number | null;
 	createdByAgent?: string | null;
 	createdBySession?: string | null;
+	goalId?: string | null;
 }
 
 export interface UpdateTaskScheduleParams {
@@ -57,8 +58,8 @@ export class TaskScheduleRepository {
 					id, space_id, title, description, priority, preferred_workflow_id,
 					labels, trigger_type, cron_expression, run_at, timezone,
 					next_run_at, last_run_at, last_created_task_id, pending_job_id,
-					status, created_by_agent, created_by_session, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					status, created_by_agent, created_by_session, goal_id, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				id,
@@ -79,6 +80,7 @@ export class TaskScheduleRepository {
 				'active',
 				params.createdByAgent ?? null,
 				params.createdBySession ?? null,
+				params.goalId ?? null,
 				now,
 				now
 			);
@@ -385,6 +387,7 @@ export class TaskScheduleRepository {
 			status: row.status as TaskScheduleStatus,
 			createdByAgent: (row.created_by_agent as string | null) ?? null,
 			createdBySession: (row.created_by_session as string | null) ?? null,
+			goalId: (row.goal_id as string | null) ?? null,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 		};

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -97,6 +97,10 @@ export { runMigration127 } from './migrations';
 export { runMigration128 } from './migrations';
 // knip-ignore-next-line
 export { runMigration129 } from './migrations';
+// knip-ignore-next-line
+export { runMigration130 } from './migrations';
+// knip-ignore-next-line
+export { runMigration131 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -260,6 +264,41 @@ export function createTables(db: BunDatabase): void {
         short_id TEXT,
         restrictions TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+      )
+    `);
+
+	// Space-native long-horizon goals. These intentionally do not couple to
+	// the legacy room `goals` / mission execution tables above: goal state lives
+	// here, concrete execution happens through linked `space_tasks` rows.
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS space_goals (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+        type TEXT NOT NULL DEFAULT 'one_shot'
+          CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+        priority TEXT NOT NULL DEFAULT 'normal'
+          CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+        labels TEXT NOT NULL DEFAULT '[]',
+        metrics TEXT NOT NULL DEFAULT '{}',
+        summary TEXT NOT NULL DEFAULT '',
+        progress INTEGER NOT NULL DEFAULT 0,
+        next_steps TEXT NOT NULL DEFAULT '[]',
+        preferred_workflow_id TEXT,
+        task_schedule_id TEXT,
+        auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+        pending_next_run INTEGER NOT NULL DEFAULT 0,
+        active_task_id TEXT,
+        last_task_id TEXT,
+        last_check_in_at INTEGER,
+        next_check_in_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
       )
     `);
 
@@ -681,6 +720,12 @@ function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goals_next_check_in ON space_goals(status, next_check_in_at)`
+	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
 	db.exec(

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -623,6 +623,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 130: Add gate_open_state table for persisting gate-open cache across daemon restarts.
 	runMigration130(db);
+
+	// Migration 131: Add Space-native goals and goal linkage on space_tasks/task_schedules.
+	runMigration131(db);
 }
 
 /**
@@ -8868,6 +8871,60 @@ export function runMigration130(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`CREATE INDEX idx_gate_open_state_run ON gate_open_state(run_id)`);
+}
+
+export function runMigration131(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goals (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+			type TEXT NOT NULL DEFAULT 'one_shot'
+				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			summary TEXT NOT NULL DEFAULT '',
+			progress INTEGER NOT NULL DEFAULT 0,
+			next_steps TEXT NOT NULL DEFAULT '[]',
+			preferred_workflow_id TEXT,
+			task_schedule_id TEXT,
+			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+			pending_next_run INTEGER NOT NULL DEFAULT 0,
+			active_task_id TEXT,
+			last_task_id TEXT,
+			last_check_in_at INTEGER,
+			next_check_in_at INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goals_next_check_in ON space_goals(status, next_check_in_at)`
+	);
+
+	if (tableExists(db, 'space_tasks') && !tableHasColumn(db, 'space_tasks', 'goal_id')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN goal_id TEXT DEFAULT NULL`);
+	}
+	if (tableExists(db, 'space_tasks')) {
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+	}
+
+	if (tableExists(db, 'task_schedules') && !tableHasColumn(db, 'task_schedules', 'goal_id')) {
+		db.exec(`ALTER TABLE task_schedules ADD COLUMN goal_id TEXT DEFAULT NULL`);
+	}
+	if (tableExists(db, 'task_schedules')) {
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_task_schedules_goal ON task_schedules(goal_id)`);
+	}
 }
 
 export function runMigration129(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -91,7 +91,7 @@ describe('handleTaskScheduleFire', () => {
 		return { db: db as never, scheduleRepo, jobQueue, spaceRepo, taskRepo, eventHub };
 	}
 
-	function createCronSchedule(): string {
+	function createCronSchedule(goalId?: string): string {
 		const future = Date.now() + 60_000;
 		const schedule = scheduleRepo.create({
 			spaceId,
@@ -101,6 +101,7 @@ describe('handleTaskScheduleFire', () => {
 			cronExpression: '0 9 * * 1-5',
 			timezone: 'UTC',
 			nextRunAt: future,
+			goalId,
 		});
 		return schedule.id;
 	}
@@ -117,7 +118,7 @@ describe('handleTaskScheduleFire', () => {
 	}
 
 	it('creates a SpaceTask from the cron schedule template and re-enqueues itself', async () => {
-		const scheduleId = createCronSchedule();
+		const scheduleId = createCronSchedule('goal-1');
 		// Set pendingJobId so idempotency check sees a match.
 		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
 
@@ -132,6 +133,7 @@ describe('handleTaskScheduleFire', () => {
 		const task = taskRepo.getTask(result.taskId as string);
 		expect(task).not.toBeNull();
 		expect(task?.createdByTaskScheduleId).toBe(scheduleId);
+		expect(task?.goalId).toBe('goal-1');
 		expect(task?.title).toBe('Daily Standup');
 
 		// A new fire job was enqueued.

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -71,9 +71,11 @@ describe('ScheduleService', () => {
 				triggerType: 'cron',
 				cronExpression: '0 9 * * 1-5',
 				timezone: 'UTC',
+				goalId: 'goal-1',
 			});
 
 			expect(schedule.status).toBe('active');
+			expect(schedule.goalId).toBe('goal-1');
 			expect(schedule.nextRunAt).not.toBeNull();
 			expect(schedule.pendingJobId).not.toBeNull();
 

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceGoalService } from '../../../src/lib/space/goals/goal-service';
+import { ScheduleService } from '../../../src/lib/space/schedule/schedule-service';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { TaskScheduleRepository } from '../../../src/storage/repositories/task-schedule-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+function createJobQueueTable(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS job_queue (
+			id TEXT PRIMARY KEY,
+			queue TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+			payload TEXT NOT NULL DEFAULT '{}',
+			result TEXT,
+			error TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
+			max_retries INTEGER NOT NULL DEFAULT 3,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			run_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	`);
+}
+
+describe('SpaceGoalService', () => {
+	let db: Database;
+	let goalRepo: SpaceGoalRepository;
+	let taskRepo: SpaceTaskRepository;
+	let spaceRepo: SpaceRepository;
+	let scheduleRepo: TaskScheduleRepository;
+	let service: SpaceGoalService;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		createJobQueueTable(db);
+
+		goalRepo = new SpaceGoalRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+		spaceRepo = new SpaceRepository(db as never);
+		scheduleRepo = new TaskScheduleRepository(db as never);
+		const scheduleService = new ScheduleService({
+			db: db as never,
+			scheduleRepo,
+			jobQueue: new JobQueueRepository(db as never),
+			spaceRepo,
+		});
+		service = new SpaceGoalService({ goalRepo, taskRepo, spaceRepo, scheduleService });
+
+		const space = spaceRepo.createSpace({
+			slug: 'test',
+			workspacePath: '/workspace/test',
+			name: 'Test Space',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('creates a goal with rolling state and an optional recurring check-in schedule', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Improve onboarding',
+			description: 'Make first-run experience smoother',
+			type: 'recurring',
+			priority: 'high',
+			labels: ['product'],
+			metrics: { activated: 10 },
+			summary: 'Initial state',
+			progress: 35,
+			nextSteps: ['Audit current flow'],
+			preferredWorkflowId: 'workflow-1',
+			checkInCronExpression: '0 9 * * 1',
+			checkInTimezone: 'UTC',
+		});
+
+		expect(goal.title).toBe('Improve onboarding');
+		expect(goal.type).toBe('recurring');
+		expect(goal.priority).toBe('high');
+		expect(goal.labels).toEqual(['product']);
+		expect(goal.metrics).toEqual({ activated: 10 });
+		expect(goal.summary).toBe('Initial state');
+		expect(goal.progress).toBe(35);
+		expect(goal.nextSteps).toEqual(['Audit current flow']);
+		expect(goal.taskScheduleId).toBeString();
+		expect(goal.nextCheckInAt).not.toBeNull();
+
+		const schedule = scheduleRepo.getById(goal.taskScheduleId as string);
+		expect(schedule?.goalId).toBe(goal.id);
+		expect(schedule?.preferredWorkflowId).toBe('workflow-1');
+		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'product']);
+	});
+
+	it('creates an immediate goal task and queues concurrent triggers', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Ship docs',
+			labels: ['docs'],
+			preferredWorkflowId: 'workflow-docs',
+			autoTriggerNext: true,
+		});
+
+		const first = service.createImmediateTask(goal.id);
+		expect(first.queued).toBe(false);
+		expect(first.task?.goalId).toBe(goal.id);
+		expect(first.task?.preferredWorkflowId).toBe('workflow-docs');
+		expect(first.task?.labels).toEqual(['goal', `goal:${goal.id}`, 'docs']);
+		expect(first.goal.activeTaskId).toBe(first.task?.id);
+
+		const second = service.createImmediateTask(goal.id);
+		expect(second.queued).toBe(true);
+		expect(second.task).toBeNull();
+		expect(second.goal.pendingNextRun).toBe(true);
+	});
+
+	it('auto-triggers one queued task after the active task reaches a terminal status', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Keep improving',
+			autoTriggerNext: true,
+		});
+		const first = service.createImmediateTask(goal.id);
+		expect(first.task).not.toBeNull();
+		service.createImmediateTask(goal.id);
+
+		taskRepo.updateTask(first.task!.id, { status: 'done' });
+		const terminal = service.handleTaskTerminal(first.task!.id);
+
+		expect(terminal?.nextTask).not.toBeNull();
+		expect(terminal?.nextTask?.goalId).toBe(goal.id);
+		const updated = goalRepo.getById(goal.id);
+		expect(updated?.activeTaskId).toBe(terminal?.nextTask?.id);
+		expect(updated?.pendingNextRun).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-45_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-45_test.ts
@@ -100,9 +100,10 @@ describe('Migration 45: rename step to node in workflow tables', () => {
 		expect(nodeIndexes).toContain('idx_space_workflow_nodes_workflow_id');
 
 		const taskIndexes = getIndexes(db, 'space_tasks');
-		// Post-M71: workflow_node_id and goal_id columns were removed, so no indexes on them
+		// Post-M71: workflow_node_id was removed, so no index remains on it.
+		// M131 reintroduces goal linkage for Space-native goals.
 		expect(taskIndexes).not.toContain('idx_space_tasks_workflow_node_id');
-		expect(taskIndexes).not.toContain('idx_space_tasks_goal_id');
+		expect(taskIndexes).toContain('idx_space_tasks_goal_id');
 		// These indexes do exist post-M71
 		expect(taskIndexes).toContain('idx_space_tasks_space_id');
 		expect(taskIndexes).toContain('idx_space_tasks_workflow_run_id');

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-51_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-51_test.ts
@@ -73,10 +73,11 @@ describe('Migration 51: slot_role → agent_name + completion_summary on space_t
 		const indexes = getIndexes(db, 'space_tasks');
 		expect(indexes).toContain('idx_space_tasks_space_id');
 		expect(indexes).toContain('idx_space_tasks_workflow_run_id');
-		// Post-M71: these indexes were removed (their columns were dropped)
+		// Post-M71: these indexes were removed (their columns were dropped).
+		// M131 reintroduces goal linkage for Space-native goals.
 		expect(indexes).not.toContain('idx_space_tasks_status');
 		expect(indexes).not.toContain('idx_space_tasks_workflow_node_id');
-		expect(indexes).not.toContain('idx_space_tasks_goal_id');
+		expect(indexes).toContain('idx_space_tasks_goal_id');
 		expect(indexes).not.toContain('idx_space_tasks_custom_agent_id');
 		expect(indexes).not.toContain('idx_space_tasks_task_agent_session_id');
 	});

--- a/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
@@ -93,6 +93,7 @@ describe('TaskScheduleRepository', () => {
 			expect(schedule.status).toBe('active');
 			expect(schedule.createdByAgent).toBeNull();
 			expect(schedule.createdBySession).toBeNull();
+			expect(schedule.goalId).toBeNull();
 			expect(schedule.createdAt).toBeGreaterThan(0);
 			expect(schedule.updatedAt).toBeGreaterThan(0);
 		});
@@ -104,6 +105,13 @@ describe('TaskScheduleRepository', () => {
 			expect(schedule.triggerType).toBe('at');
 			expect(schedule.runAt).toBe(runAt);
 			expect(schedule.cronExpression).toBeNull();
+		});
+
+		it('persists goal linkage', () => {
+			const schedule = repo.create(makeCronParams({ spaceId, goalId: 'goal-1' }));
+
+			expect(schedule.goalId).toBe('goal-1');
+			expect(repo.getById(schedule.id)?.goalId).toBe('goal-1');
 		});
 
 		it('applies defaults for optional fields', () => {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -218,6 +218,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_run_id TEXT,
 			preferred_workflow_id TEXT,
 			created_by_task_id TEXT,
+			goal_id TEXT DEFAULT NULL,
 			result TEXT,
 			depends_on TEXT NOT NULL DEFAULT '[]',
 			active_session TEXT
@@ -254,6 +255,7 @@ export function createSpaceTables(db: BunDatabase): void {
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
 	);
@@ -508,6 +510,7 @@ export function createSpaceTables(db: BunDatabase): void {
 				CHECK(status IN ('active', 'paused', 'completed')),
 			created_by_agent TEXT DEFAULT NULL,
 			created_by_session TEXT DEFAULT NULL,
+			goal_id TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -522,4 +525,40 @@ export function createSpaceTables(db: BunDatabase): void {
 		ON task_schedules(status, next_run_at)
 		WHERE status = 'active'
 	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_task_schedules_goal ON task_schedules(goal_id)`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goals (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+			type TEXT NOT NULL DEFAULT 'one_shot'
+				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			summary TEXT NOT NULL DEFAULT '',
+			progress INTEGER NOT NULL DEFAULT 0,
+			next_steps TEXT NOT NULL DEFAULT '[]',
+			preferred_workflow_id TEXT,
+			task_schedule_id TEXT,
+			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+			pending_next_run INTEGER NOT NULL DEFAULT 0,
+			active_task_id TEXT,
+			last_task_id TEXT,
+			last_check_in_at INTEGER,
+			next_check_in_at INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -266,6 +266,88 @@ export type SpaceBlockReason =
 export type SpaceTaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 // ============================================================================
+// SpaceGoal Types
+// ============================================================================
+
+export type SpaceGoalStatus = 'active' | 'paused' | 'completed' | 'archived';
+export type SpaceGoalType = 'one_shot' | 'measurable' | 'recurring';
+
+export type SpaceGoalMetrics = Record<string, string | number | boolean | null>;
+
+export interface SpaceGoal {
+	id: string;
+	spaceId: string;
+	title: string;
+	description: string;
+	status: SpaceGoalStatus;
+	type: SpaceGoalType;
+	priority: SpaceTaskPriority;
+	labels: string[];
+	metrics: SpaceGoalMetrics;
+	summary: string;
+	progress: number;
+	nextSteps: string[];
+	preferredWorkflowId: string | null;
+	taskScheduleId: string | null;
+	autoTriggerNext: boolean;
+	pendingNextRun: boolean;
+	activeTaskId: string | null;
+	lastTaskId: string | null;
+	lastCheckInAt: number | null;
+	nextCheckInAt: number | null;
+	createdAt: number;
+	updatedAt: number;
+	completedAt: number | null;
+}
+
+export interface CreateSpaceGoalParams {
+	spaceId: string;
+	title: string;
+	description?: string;
+	type?: SpaceGoalType;
+	priority?: SpaceTaskPriority;
+	labels?: string[];
+	metrics?: SpaceGoalMetrics;
+	summary?: string;
+	progress?: number;
+	nextSteps?: string[];
+	preferredWorkflowId?: string | null;
+	autoTriggerNext?: boolean;
+	checkInCronExpression?: string | null;
+	checkInTimezone?: string;
+	triggerImmediately?: boolean;
+}
+
+export interface UpdateSpaceGoalParams {
+	title?: string;
+	description?: string;
+	status?: SpaceGoalStatus;
+	type?: SpaceGoalType;
+	priority?: SpaceTaskPriority;
+	labels?: string[];
+	metrics?: SpaceGoalMetrics;
+	summary?: string;
+	progress?: number;
+	nextSteps?: string[];
+	preferredWorkflowId?: string | null;
+	autoTriggerNext?: boolean;
+	pendingNextRun?: boolean;
+	activeTaskId?: string | null;
+	lastTaskId?: string | null;
+	lastCheckInAt?: number | null;
+	nextCheckInAt?: number | null;
+	completedAt?: number | null;
+}
+
+export interface SpaceGoalListParams {
+	spaceId: string;
+	status?: SpaceGoalStatus;
+	includeArchived?: boolean;
+	label?: string;
+	search?: string;
+}
+
+// ============================================================================
 // TaskSchedule Types
 // ============================================================================
 
@@ -318,6 +400,8 @@ export interface TaskSchedule {
 	createdBySession: string | null;
 	/** Creation timestamp (ms since epoch) */
 	createdAt: number;
+	/** SpaceGoal this schedule belongs to, when used for recurring goal check-ins. */
+	goalId?: string | null;
 	/** Last update timestamp (ms since epoch) */
 	updatedAt: number;
 }
@@ -387,6 +471,8 @@ export interface SpaceTask {
 	 * Null for manually created tasks.
 	 */
 	createdByTaskScheduleId?: string | null;
+	/** ID of the SpaceGoal this task is executing toward. */
+	goalId?: string | null;
 	/**
 	 * Which agent session is currently active (generating output).
 	 * Cleared when the session reaches a terminal state.
@@ -581,6 +667,8 @@ export interface CreateSpaceTaskParams {
 	 * Set by the task-schedule.fire job handler.
 	 */
 	createdByTaskScheduleId?: string | null;
+	/** ID of the SpaceGoal this task should be linked to. */
+	goalId?: string | null;
 }
 
 /**
@@ -596,6 +684,8 @@ export interface UpdateSpaceTaskParams {
 	result?: string | null;
 	workflowRunId?: string | null;
 	preferredWorkflowId?: string | null;
+	/** ID of the SpaceGoal this task is linked to; null to clear. */
+	goalId?: string | null;
 	createdByTaskId?: string | null;
 	activeSession?: 'worker' | 'leader' | null;
 	/**


### PR DESCRIPTION
Adds a lightweight Space-scoped goal model with RPC/MCP lifecycle operations and rolling state fields.

Reuses existing SpaceTasks and task schedules for immediate work, recurring check-ins, workflow routing, and queued auto-trigger concurrency.

Tests: bun run check; focused daemon goal/schedule tests.