### PR TITLE
Add Space-native goal backend

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -502,7 +502,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		skillsManager,
 		mcpImportService,
 	});
-	const { cleanup: rpcHandlerCleanup, spaceRuntimeService, spaceWorktreeManager } = rpcHandlers;
+	const {
+		cleanup: rpcHandlerCleanup,
+		spaceRuntimeService,
+		spaceWorktreeManager,
+		spaceGoalService,
+	} = rpcHandlers;
 	taskAgentManager = rpcHandlers.taskAgentManager;
 
 	// Wait for SpaceRuntimeService startup provisioning to complete before we
@@ -657,6 +662,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			spaceRepo: taskScheduleSpaceRepo,
 			taskRepo: taskScheduleTaskRepo,
 			eventHub: internalEventBus,
+			goalService: spaceGoalService,
 		});
 	});
 

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -262,6 +262,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 			'Space-native long-horizon goals with rolling state, progress, and recurring check-in schedules.',
 	},
 	{
+		tableName: 'space_goal_events',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Append-only history events for Space goals, including state diffs, source metadata, and linked task IDs.',
+	},
+	{
 		tableName: 'space_worktrees',
 		scopeColumn: 'space_id',
 		blacklistedColumns: [],

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -255,6 +255,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 			'Tasks within a space with numbering, status, PR tracking, and workflow run associations.',
 	},
 	{
+		tableName: 'space_goals',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Space-native long-horizon goals with rolling state, progress, and recurring check-in schedules.',
+	},
+	{
 		tableName: 'space_worktrees',
 		scopeColumn: 'space_id',
 		blacklistedColumns: [],

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -24,6 +24,7 @@ import type { TaskScheduleRepository } from '../../storage/repositories/task-sch
 import type { JobQueueRepository, Job } from '../../storage/repositories/job-queue-repository';
 import type { SpaceRepository } from '../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import type { SpaceGoalService } from '../space/goals/goal-service';
 
 const log = new Logger('task-schedule-fire-handler');
 
@@ -59,6 +60,7 @@ export interface TaskScheduleFireHandlerDeps {
 	jobQueue: JobQueueRepository;
 	spaceRepo: SpaceRepository;
 	taskRepo: SpaceTaskRepository;
+	goalService?: SpaceGoalService;
 	/**
 	 * Optional event emitter for broadcasting schedule/task changes.
 	 * When provided, the handler emits `space.task.created` and
@@ -76,7 +78,7 @@ export async function handleTaskScheduleFire(
 	deps: TaskScheduleFireHandlerDeps
 ): Promise<TaskScheduleFireResult> {
 	const { scheduleId } = job.payload as TaskScheduleFirePayload;
-	const { db, scheduleRepo, jobQueue, spaceRepo, taskRepo, eventHub } = deps;
+	const { db, scheduleRepo, jobQueue, spaceRepo, taskRepo, goalService, eventHub } = deps;
 
 	const schedule = scheduleRepo.getById(scheduleId);
 
@@ -185,16 +187,6 @@ export async function handleTaskScheduleFire(
 
 	try {
 		const result = db.transaction(() => {
-			const task = taskRepo.createTask({
-				spaceId: schedule.spaceId,
-				title: schedule.title,
-				description: schedule.description,
-				priority: schedule.priority,
-				preferredWorkflowId: schedule.preferredWorkflowId,
-				labels: schedule.labels,
-				createdByTaskScheduleId: schedule.id,
-			});
-
 			let computedNextRunAt: number | null = null;
 			let pendingJobId: string | null = null;
 			let nextStatus: 'active' | 'completed' = 'completed';
@@ -213,6 +205,40 @@ export async function handleTaskScheduleFire(
 				}
 			}
 
+			if (goalService && schedule.goalId) {
+				const claimCheck = goalService.canClaimScheduledTask({
+					spaceId: schedule.spaceId,
+					goalId: schedule.goalId,
+				});
+				if (!claimCheck.claimable) {
+					const applied = scheduleRepo.updateAfterFireIfPending(scheduleId, job.id, {
+						lastCreatedTaskId: schedule.lastCreatedTaskId,
+						lastRunAt: now,
+						nextRunAt: computedNextRunAt,
+						status: nextStatus,
+						pendingJobId,
+					});
+					if (!applied) {
+						throw new ScheduleSupersededError(scheduleId, job.id);
+					}
+					if (claimCheck.goal && computedNextRunAt !== claimCheck.goal.nextCheckInAt) {
+						goalService.updateScheduledCheckIn(claimCheck.goal.id, computedNextRunAt);
+					}
+					return { taskId: null, nextRunAt: computedNextRunAt, skipped: true as const };
+				}
+			}
+
+			const task = taskRepo.createTask({
+				spaceId: schedule.spaceId,
+				title: schedule.title,
+				description: schedule.description,
+				priority: schedule.priority,
+				preferredWorkflowId: schedule.preferredWorkflowId,
+				labels: schedule.labels,
+				createdByTaskScheduleId: schedule.id,
+				goalId: schedule.goalId,
+			});
+
 			// Compare-and-swap: only commit if the schedule's pending_job_id is
 			// still our job id. If a concurrent pause/delete/reschedule happened
 			// between the initial read and now, the precondition fails and we
@@ -228,29 +254,41 @@ export async function handleTaskScheduleFire(
 			if (!applied) {
 				throw new ScheduleSupersededError(scheduleId, job.id);
 			}
+			if (goalService && schedule.goalId) {
+				const claimed = goalService.claimScheduledTask(task.id, computedNextRunAt);
+				if (!claimed.claimed) {
+					throw new Error(`Goal ${schedule.goalId} already has an active task`);
+				}
+			}
 
-			return { taskId: task.id, nextRunAt: computedNextRunAt };
+			return { taskId: task.id, nextRunAt: computedNextRunAt, skipped: false as const };
 		})();
 
 		taskId = result.taskId;
 		nextRunAt = result.nextRunAt;
-		log.debug('task-schedule-fire: created task', { scheduleId, taskId, nextRunAt });
+		if (result.skipped) {
+			log.debug('task-schedule-fire: skipped goal contention', { scheduleId, nextRunAt });
+		} else {
+			log.debug('task-schedule-fire: created task', { scheduleId, taskId, nextRunAt });
+		}
 
 		// Emit events so the web client can refresh its state without polling.
 		// Fire-and-forget — handler success must not depend on event delivery.
 		if (eventHub) {
-			const emittedTask = taskRepo.getTask(taskId);
-			if (emittedTask) {
-				eventHub
-					.publish('space.task.created', {
-						sessionId: 'global',
-						spaceId: schedule.spaceId,
-						taskId,
-						task: emittedTask,
-					})
-					.catch(() => {
-						// Swallow — event emission is best-effort.
-					});
+			if (taskId) {
+				const emittedTask = taskRepo.getTask(taskId);
+				if (emittedTask) {
+					eventHub
+						.publish('space.task.created', {
+							sessionId: 'global',
+							spaceId: schedule.spaceId,
+							taskId,
+							task: emittedTask,
+						})
+						.catch(() => {
+							// Swallow — event emission is best-effort.
+						});
+				}
 			}
 			const emittedSchedule = scheduleRepo.getById(scheduleId);
 			if (emittedSchedule) {
@@ -295,8 +333,13 @@ export async function handleTaskScheduleFire(
 	}
 
 	if (taskId === null) {
-		// Defensive: the transaction body always assigns taskId on the success path.
-		throw new Error(`task-schedule-fire: taskId unexpectedly null for ${scheduleId}`);
+		return {
+			scheduleId,
+			taskId: null,
+			skipped: true,
+			skipReason: 'goal_task_already_active',
+			nextRunAt,
+		};
 	}
 
 	return { scheduleId, taskId, skipped: false, nextRunAt };

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -280,6 +280,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceRepo,
 		scheduleService,
 		db: deps.db.getDatabase(),
+		eventHub: {
+			publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
+		},
 	});
 
 	// When a space is resumed/started, re-seed any of its active schedules

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -95,7 +95,10 @@ import { TaskScheduleRepository } from '../../storage/repositories/task-schedule
 import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { setupAgentMemoryHandlers } from './agent-memory-handlers';
+import { setupSpaceGoalHandlers } from './space-goal-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
+import { SpaceGoalRepository } from '../../storage/repositories/space-goal-repository';
+import { SpaceGoalService } from '../space/goals/goal-service';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -159,6 +162,7 @@ export interface RPCHandlerSetupResult {
 	spaceRuntimeService: SpaceRuntimeService;
 	taskAgentManager: TaskAgentManager;
 	spaceWorktreeManager: SpaceWorktreeManager;
+	spaceGoalService: SpaceGoalService;
 }
 
 /**
@@ -266,6 +270,16 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleRepo: taskScheduleRepo,
 		jobQueue: deps.jobQueue,
 		spaceRepo,
+	});
+
+	// Space Goal service — goal lifecycle, terminal handling, schedule sync.
+	const spaceGoalRepo = new SpaceGoalRepository(deps.db.getDatabase(), deps.reactiveDb);
+	const spaceGoalService = new SpaceGoalService({
+		goalRepo: spaceGoalRepo,
+		taskRepo: spaceTaskRepo,
+		spaceRepo,
+		scheduleService,
+		db: deps.db.getDatabase(),
 	});
 
 	// When a space is resumed/started, re-seed any of its active schedules
@@ -403,12 +417,19 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceManager,
 		spaceTaskManagerFactory,
 		deps.internalEventBus,
-		spaceRuntimeService
+		spaceRuntimeService,
+		spaceGoalService
 	);
 
 	// Task schedule handlers — create/list/get/update/pause/resume/delete schedules.
 	setupTaskScheduleHandlers(deps.messageHub, {
 		scheduleService,
+		spaceManager: deps.spaceManager,
+	});
+
+	// Space goal handlers — create/list/get/update/pause/resume/createImmediateTask.
+	setupSpaceGoalHandlers(deps.messageHub, {
+		goalService: spaceGoalService,
 		spaceManager: deps.spaceManager,
 	});
 
@@ -500,7 +521,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
 		replyRoutingRegistry,
-		memoryRepo: deps.db.agentMemory,
+			memoryRepo: deps.db.agentMemory,
+			goalService: spaceGoalService,
 	});
 
 	deps.commandBus.register('agent.message.inject', async (command) => {
@@ -607,5 +629,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceRuntimeService,
 		taskAgentManager,
 		spaceWorktreeManager,
+		spaceGoalService,
 	};
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -97,6 +97,7 @@ import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { setupAgentMemoryHandlers } from './agent-memory-handlers';
 import { setupSpaceGoalHandlers } from './space-goal-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
+import { SpaceGoalEventRepository } from '../../storage/repositories/space-goal-event-repository';
 import { SpaceGoalRepository } from '../../storage/repositories/space-goal-repository';
 import { SpaceGoalService } from '../space/goals/goal-service';
 
@@ -274,8 +275,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space Goal service — goal lifecycle, terminal handling, schedule sync.
 	const spaceGoalRepo = new SpaceGoalRepository(deps.db.getDatabase(), deps.reactiveDb);
+	const spaceGoalEventRepo = new SpaceGoalEventRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const spaceGoalService = new SpaceGoalService({
 		goalRepo: spaceGoalRepo,
+		goalEventRepo: spaceGoalEventRepo,
 		taskRepo: spaceTaskRepo,
 		spaceRepo,
 		scheduleService,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -400,8 +400,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		externalEventStore: deps.externalEventStore,
 		externalEventService: deps.externalEventService,
 		replyRoutingRegistry,
-			memoryRepo: deps.db.agentMemory,
-			goalService: spaceGoalService,
+		memoryRepo: deps.db.agentMemory,
+		goalService: spaceGoalService,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -528,8 +528,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
 		replyRoutingRegistry,
-			memoryRepo: deps.db.agentMemory,
-			goalService: spaceGoalService,
+		memoryRepo: deps.db.agentMemory,
+		goalService: spaceGoalService,
 	});
 
 	deps.commandBus.register('agent.message.inject', async (command) => {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -394,7 +394,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		externalEventStore: deps.externalEventStore,
 		externalEventService: deps.externalEventService,
 		replyRoutingRegistry,
-		memoryRepo: deps.db.agentMemory,
+			memoryRepo: deps.db.agentMemory,
+			goalService: spaceGoalService,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so

--- a/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
@@ -93,7 +93,13 @@ export function setupSpaceGoalHandlers(messageHub: MessageHub, deps: SpaceGoalHa
 	});
 
 	messageHub.onRequest('spaceGoal.listEvents', async (data) => {
-		const params = data as { spaceId: string; goalId: string; limit?: number; before?: number };
+		const params = data as {
+			spaceId: string;
+			goalId: string;
+			limit?: number;
+			before?: number;
+			beforeId?: string;
+		};
 		await requireSpace(params.spaceId);
 		requireGoalInSpace(params.goalId, params.spaceId);
 		return { events: goalService.listGoalEvents(params.goalId, params) };

--- a/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
@@ -27,7 +27,7 @@ export function setupSpaceGoalHandlers(messageHub: MessageHub, deps: SpaceGoalHa
 	messageHub.onRequest('spaceGoal.create', async (data) => {
 		const params = data as Parameters<SpaceGoalService['createGoal']>[0];
 		await requireSpace(params.spaceId);
-		return { goal: goalService.createGoal(params) };
+		return { goal: goalService.createGoal(params, { source: 'rpc' }) };
 	});
 
 	messageHub.onRequest('spaceGoal.list', async (data) => {
@@ -68,27 +68,34 @@ export function setupSpaceGoalHandlers(messageHub: MessageHub, deps: SpaceGoalHa
 			preferredWorkflowId: params.preferredWorkflowId,
 			autoTriggerNext: params.autoTriggerNext,
 		};
-		return { goal: goalService.updateGoal(params.goalId, updates) };
+		return { goal: goalService.updateGoal(params.goalId, updates, { source: 'rpc' }) };
 	});
 
 	messageHub.onRequest('spaceGoal.pause', async (data) => {
 		const params = data as { spaceId: string; goalId: string };
 		await requireSpace(params.spaceId);
 		requireGoalInSpace(params.goalId, params.spaceId);
-		return { goal: goalService.pauseGoal(params.goalId) };
+		return { goal: goalService.pauseGoal(params.goalId, { source: 'rpc' }) };
 	});
 
 	messageHub.onRequest('spaceGoal.resume', async (data) => {
 		const params = data as { spaceId: string; goalId: string };
 		await requireSpace(params.spaceId);
 		requireGoalInSpace(params.goalId, params.spaceId);
-		return { goal: goalService.resumeGoal(params.goalId) };
+		return { goal: goalService.resumeGoal(params.goalId, { source: 'rpc' }) };
 	});
 
 	messageHub.onRequest('spaceGoal.createImmediateTask', async (data) => {
 		const params = data as { spaceId: string; goalId: string };
 		await requireSpace(params.spaceId);
 		requireGoalInSpace(params.goalId, params.spaceId);
-		return goalService.createImmediateTask(params.goalId);
+		return goalService.createImmediateTask(params.goalId, { source: 'rpc' });
+	});
+
+	messageHub.onRequest('spaceGoal.listEvents', async (data) => {
+		const params = data as { spaceId: string; goalId: string; limit?: number; before?: number };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return { events: goalService.listGoalEvents(params.goalId, params) };
 	});
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-goal-handlers.ts
@@ -1,0 +1,94 @@
+import type { MessageHub, SpaceGoalStatus } from '@neokai/shared';
+import type { PublicSpaceGoalUpdateParams, SpaceGoalService } from '../space/goals/goal-service';
+import type { SpaceManager } from '../space/managers/space-manager';
+
+export interface SpaceGoalHandlerDeps {
+	goalService: SpaceGoalService;
+	spaceManager: SpaceManager;
+}
+
+export function setupSpaceGoalHandlers(messageHub: MessageHub, deps: SpaceGoalHandlerDeps): void {
+	const { goalService, spaceManager } = deps;
+
+	async function requireSpace(spaceId: string) {
+		if (!spaceId) throw new Error('spaceId is required');
+		const space = await spaceManager.getSpace(spaceId);
+		if (!space) throw new Error(`Space not found: ${spaceId}`);
+		return space;
+	}
+
+	function requireGoalInSpace(goalId: string, spaceId: string) {
+		if (!goalId) throw new Error('goalId is required');
+		const goal = goalService.getGoal(goalId);
+		if (!goal || goal.spaceId !== spaceId) throw new Error(`Goal not found: ${goalId}`);
+		return goal;
+	}
+
+	messageHub.onRequest('spaceGoal.create', async (data) => {
+		const params = data as Parameters<SpaceGoalService['createGoal']>[0];
+		await requireSpace(params.spaceId);
+		return { goal: goalService.createGoal(params) };
+	});
+
+	messageHub.onRequest('spaceGoal.list', async (data) => {
+		const params = data as {
+			spaceId: string;
+			status?: SpaceGoalStatus;
+			includeArchived?: boolean;
+			label?: string;
+			search?: string;
+		};
+		await requireSpace(params.spaceId);
+		return { goals: goalService.listGoals(params) };
+	});
+
+	messageHub.onRequest('spaceGoal.get', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		return { goal: requireGoalInSpace(params.goalId, params.spaceId) };
+	});
+
+	messageHub.onRequest('spaceGoal.update', async (data) => {
+		const params = data as { spaceId: string; goalId: string } & Parameters<
+			SpaceGoalService['updateGoal']
+		>[1];
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		const updates: PublicSpaceGoalUpdateParams = {
+			title: params.title,
+			description: params.description,
+			status: params.status,
+			type: params.type,
+			priority: params.priority,
+			labels: params.labels,
+			metrics: params.metrics,
+			summary: params.summary,
+			progress: params.progress,
+			nextSteps: params.nextSteps,
+			preferredWorkflowId: params.preferredWorkflowId,
+			autoTriggerNext: params.autoTriggerNext,
+		};
+		return { goal: goalService.updateGoal(params.goalId, updates) };
+	});
+
+	messageHub.onRequest('spaceGoal.pause', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return { goal: goalService.pauseGoal(params.goalId) };
+	});
+
+	messageHub.onRequest('spaceGoal.resume', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return { goal: goalService.resumeGoal(params.goalId) };
+	});
+
+	messageHub.onRequest('spaceGoal.createImmediateTask', async (data) => {
+		const params = data as { spaceId: string; goalId: string };
+		await requireSpace(params.spaceId);
+		requireGoalInSpace(params.goalId, params.spaceId);
+		return goalService.createImmediateTask(params.goalId);
+	});
+}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -18,11 +18,14 @@ import {
 	type SpaceTaskStatus,
 	type UpdateSpaceTaskParams,
 } from '@neokai/shared';
+
+const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>(['done', 'cancelled', 'archived']);
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import type { SpaceGoalService } from '../space/goals/goal-service';
 
 const log = new Logger('space-task-handlers');
 
@@ -37,11 +40,12 @@ export function setupSpaceTaskHandlers(
 	spaceManager: SpaceManager,
 	taskManagerFactory: SpaceTaskManagerFactory,
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>,
-	spaceRuntimeService?: SpaceRuntimeService
+	spaceRuntimeService?: SpaceRuntimeService,
+	spaceGoalService?: Pick<SpaceGoalService, 'handleTaskTerminal'>
 ): void {
 	// ─── spaceTask.create ───────────────────────────────────────────────────────
 	messageHub.onRequest('spaceTask.create', async (data) => {
-		const params = data as CreateSpaceTaskParams & { draft?: boolean };
+		const params = data as CreateSpaceTaskParams & { draft?: boolean; goalId?: unknown };
 
 		if (!params.spaceId) {
 			throw new Error('spaceId is required');
@@ -61,7 +65,14 @@ export function setupSpaceTaskHandlers(
 		}
 
 		const taskManager = taskManagerFactory(params.spaceId);
-		const { spaceId, draft, createdBy: _cb, createdBySession: _cbs, ...rest } = params;
+		const {
+			spaceId,
+			draft,
+			goalId: _goalId,
+			createdBy: _cb,
+			createdBySession: _cbs,
+			...rest
+		} = params;
 
 		// The draft flag is an alias for status: 'draft'. Reject contradictory
 		// input instead of silently allowing status to override draft: true.
@@ -201,7 +212,11 @@ export function setupSpaceTaskHandlers(
 
 	// ─── spaceTask.update ───────────────────────────────────────────────────────
 	messageHub.onRequest('spaceTask.update', async (data) => {
-		const params = data as { spaceId: string; taskId: string } & UpdateSpaceTaskParams;
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			goalId?: unknown;
+		} & UpdateSpaceTaskParams;
 
 		if (!params.spaceId) {
 			throw new Error('spaceId is required');
@@ -210,7 +225,7 @@ export function setupSpaceTaskHandlers(
 			throw new Error('taskId is required');
 		}
 
-		const { spaceId, taskId, ...updateParams } = params;
+		const { spaceId, taskId, goalId: _goalId, ...updateParams } = params;
 
 		// Verify space exists — consistent with create/list/get validation.
 		// Without this check, a bad spaceId would surface as "Task not found" rather
@@ -383,6 +398,17 @@ export function setupSpaceTaskHandlers(
 			task = await taskManager.updateTask(taskId, updateParams, {
 				onCascadedTasks: emitCascadedTasks,
 			});
+		}
+
+		// Best-effort goal terminal handling — must not abort the RPC response.
+		if (spaceGoalService && TERMINAL_TASK_STATUSES.has(task.status)) {
+			try {
+				spaceGoalService.handleTaskTerminal(task.id);
+			} catch (err) {
+				log.warn(
+					`Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
 		}
 
 		if (emitTaskUpdated) {

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -19,7 +19,12 @@ import {
 	type UpdateSpaceTaskParams,
 } from '@neokai/shared';
 
-const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>(['done', 'cancelled', 'archived']);
+const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>([
+	'done',
+	'blocked',
+	'cancelled',
+	'archived',
+]);
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -13,6 +13,7 @@ import type {
 	McpServerConfig,
 	Space,
 	SpaceAgent,
+	SpaceGoal,
 	SpaceTask,
 	SpaceWorkflow,
 	SpaceWorkflowRun,
@@ -135,6 +136,8 @@ export interface CustomAgentConfig {
 	sessionId: string;
 	/** Workspace path (typically `space.workspacePath`) */
 	workspacePath: string;
+	/** Linked long-horizon goal for this task, when present. */
+	goal?: SpaceGoal | null;
 	/** Summaries of previously completed tasks for context */
 	previousTaskSummaries?: string[];
 	/** Optional per-slot workflow overrides */
@@ -240,6 +243,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		workflow,
 		space,
 		workspacePath,
+		goal,
 		previousTaskSummaries,
 		nodeId,
 		agentSlotName,
@@ -264,7 +268,32 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 	sections.push(`- Worktree: ${workspacePath}`);
 	sections.push(`- PR: ${prUrl ?? 'none yet'}`);
 
-	// 3. Your Role in This Workflow — scoped to the current node when known.
+	// 3. Linked Goal — rolling state for long-horizon work.
+	if (goal) {
+		sections.push('');
+		sections.push('## Linked Goal');
+		sections.push('');
+		sections.push(`**Title:** ${goal.title}`);
+		if (goal.description) sections.push(`**Description:** ${goal.description}`);
+		sections.push(`**Status:** ${goal.status}`);
+		sections.push(`**Type:** ${goal.type}`);
+		sections.push(`**Priority:** ${goal.priority}`);
+		if (goal.labels.length > 0) sections.push(`**Labels:** ${goal.labels.join(', ')}`);
+		sections.push(`**Progress:** ${goal.progress}%`);
+		if (goal.summary) sections.push(`**Current Summary:** ${goal.summary}`);
+		if (Object.keys(goal.metrics).length > 0) {
+			sections.push(`**Metrics:** ${JSON.stringify(goal.metrics)}`);
+		}
+		if (goal.nextSteps.length > 0) {
+			sections.push('**Next Steps:**');
+			for (const step of goal.nextSteps) sections.push(`- ${step}`);
+		}
+		sections.push(
+			'When your work changes long-horizon state, update this goal via goal tools or mark_complete goal_update with a concise summary, progress, metrics, and next steps.'
+		);
+	}
+
+	// 4. Your Role in This Workflow — scoped to the current node when known.
 	const roleLines = buildRoleSection(workflow, nodeId, agentSlotName);
 	if (roleLines.length > 0) {
 		sections.push('');

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -66,7 +66,6 @@ export class SpaceGoalService {
 
 		const result = this.runAtomic(() => {
 			const goal = this.deps.goalRepo.create(params);
-			this.recordGoalEvent(goal, 'created', null, goal, context);
 			if (params.checkInCronExpression) {
 				const schedule = this.deps.scheduleService.createGoalSchedule({
 					spaceId: params.spaceId,
@@ -85,8 +84,9 @@ export class SpaceGoalService {
 				this.deps.goalRepo.update(goal.id, { nextCheckInAt: schedule.nextRunAt });
 			}
 
-			if (!params.triggerImmediately)
-				return { goal: this.getGoal(goal.id) as SpaceGoal, task: null };
+			const createdGoal = this.getGoal(goal.id) as SpaceGoal;
+			this.recordGoalEvent(createdGoal, 'created', null, createdGoal, context);
+			if (!params.triggerImmediately) return { goal: createdGoal, task: null };
 			const created = this.createImmediateTaskInternal(goal.id, undefined, {
 				emitTaskCreated: false,
 			});

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -1,6 +1,12 @@
 import type {
 	CreateSpaceGoalParams,
 	SpaceGoal,
+	SpaceGoalEvent,
+	SpaceGoalEventDiff,
+	SpaceGoalEventListParams,
+	SpaceGoalEventSnapshot,
+	SpaceGoalEventSource,
+	SpaceGoalEventType,
 	SpaceGoalListParams,
 	SpaceTask,
 	UpdateSpaceGoalParams,
@@ -8,6 +14,7 @@ import type {
 import type { Database as BunDatabase } from 'bun:sqlite';
 import type { SpaceRepository } from '../../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceGoalEventRepository } from '../../../storage/repositories/space-goal-event-repository';
 import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
 import type { ScheduleService } from '../schedule/schedule-service';
 
@@ -27,8 +34,16 @@ export type PublicSpaceGoalUpdateParams = Pick<
 	| 'autoTriggerNext'
 >;
 
+export interface SpaceGoalMutationContext {
+	source?: SpaceGoalEventSource;
+	sourceTaskId?: string | null;
+	sourceSessionId?: string | null;
+	note?: string | null;
+}
+
 export interface SpaceGoalServiceDeps {
 	goalRepo: SpaceGoalRepository;
+	goalEventRepo?: SpaceGoalEventRepository;
 	taskRepo: SpaceTaskRepository;
 	spaceRepo: SpaceRepository;
 	scheduleService: ScheduleService;
@@ -41,7 +56,7 @@ export interface SpaceGoalServiceDeps {
 export class SpaceGoalService {
 	constructor(private readonly deps: SpaceGoalServiceDeps) {}
 
-	createGoal(params: CreateSpaceGoalParams): SpaceGoal {
+	createGoal(params: CreateSpaceGoalParams, context?: SpaceGoalMutationContext): SpaceGoal {
 		this.validateCreate(params);
 		const space = this.deps.spaceRepo.getSpace(params.spaceId);
 		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
@@ -51,6 +66,7 @@ export class SpaceGoalService {
 
 		return this.runAtomic(() => {
 			const goal = this.deps.goalRepo.create(params);
+			this.recordGoalEvent(goal, 'created', null, goal, context);
 			if (params.checkInCronExpression) {
 				const schedule = this.deps.scheduleService.createGoalSchedule({
 					spaceId: params.spaceId,
@@ -83,7 +99,11 @@ export class SpaceGoalService {
 		return this.deps.goalRepo.getById(goalId);
 	}
 
-	updateGoal(goalId: string, params: PublicSpaceGoalUpdateParams): SpaceGoal {
+	updateGoal(
+		goalId: string,
+		params: PublicSpaceGoalUpdateParams,
+		context?: SpaceGoalMutationContext
+	): SpaceGoal {
 		const existing = this.requireGoal(goalId);
 		if (
 			existing.status === 'archived' &&
@@ -109,19 +129,29 @@ export class SpaceGoalService {
 
 		const updated = this.deps.goalRepo.update(goalId, updateParams);
 		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		this.recordGoalEvent(
+			updated,
+			params.status !== undefined && params.status !== existing.status
+				? 'status_changed'
+				: 'updated',
+			existing,
+			updated,
+			context
+		);
 		return updated;
 	}
 
-	pauseGoal(goalId: string): SpaceGoal {
+	pauseGoal(goalId: string, context?: SpaceGoalMutationContext): SpaceGoal {
 		const goal = this.requireGoal(goalId);
 		if (goal.status !== 'active') throw new Error(`Goal is not active (current: ${goal.status})`);
 		if (goal.taskScheduleId) this.pauseLinkedScheduleOrClear(goal);
 		const updated = this.deps.goalRepo.update(goalId, { status: 'paused', nextCheckInAt: null });
 		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		this.recordGoalEvent(updated, 'status_changed', goal, updated, context);
 		return updated;
 	}
 
-	resumeGoal(goalId: string): SpaceGoal {
+	resumeGoal(goalId: string, context?: SpaceGoalMutationContext): SpaceGoal {
 		const goal = this.requireGoal(goalId);
 		if (goal.status !== 'paused') throw new Error(`Goal is not paused (current: ${goal.status})`);
 		let nextCheckInAt = goal.nextCheckInAt;
@@ -131,10 +161,14 @@ export class SpaceGoalService {
 		}
 		const updated = this.deps.goalRepo.update(goalId, { status: 'active', nextCheckInAt });
 		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		this.recordGoalEvent(updated, 'status_changed', goal, updated, context);
 		return updated;
 	}
 
-	createImmediateTask(goalId: string): {
+	createImmediateTask(
+		goalId: string,
+		context?: SpaceGoalMutationContext
+	): {
 		goal: SpaceGoal;
 		task: SpaceTask | null;
 		queued: boolean;
@@ -150,8 +184,10 @@ export class SpaceGoalService {
 				if (!goal.autoTriggerNext) {
 					throw new Error('Goal already has an active task and autoTriggerNext is disabled');
 				}
+				const queuedGoal = this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal;
+				this.recordGoalEvent(queuedGoal, 'task_queued', goal, queuedGoal, context);
 				return {
-					goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+					goal: queuedGoal,
 					task: null,
 					queued: true,
 				};
@@ -173,13 +209,19 @@ export class SpaceGoalService {
 			if (!goal.autoTriggerNext) {
 				throw new Error('Goal already has an active task and autoTriggerNext is disabled');
 			}
+			const queuedGoal = this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal;
+			this.recordGoalEvent(queuedGoal, 'task_queued', goal, queuedGoal, context);
 			return {
-				goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+				goal: queuedGoal,
 				task: null,
 				queued: true,
 			};
 		}
 		const updatedGoal = this.requireGoal(goal.id);
+		this.recordGoalEvent(updatedGoal, 'task_triggered', goal, updatedGoal, {
+			...context,
+			sourceTaskId: context?.sourceTaskId ?? task.id,
+		});
 		this.emitTaskCreated(task);
 		return { goal: updatedGoal, task, queued: false };
 	}
@@ -192,10 +234,15 @@ export class SpaceGoalService {
 		if (!goal || goal.spaceId !== task.spaceId) return null;
 		this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
 		const fresh = this.requireGoal(goal.id);
+		this.recordGoalEvent(fresh, 'task_terminal', goal, fresh, {
+			source: 'system',
+			sourceTaskId: taskId,
+			note: `Task reached terminal status: ${task.status}`,
+		});
 		if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
 			return { goal: fresh, nextTask: null };
 		}
-		const created = this.createImmediateTask(fresh.id);
+		const created = this.createImmediateTask(fresh.id, { source: 'system' });
 		return { goal: created.goal, nextTask: created.task };
 	}
 
@@ -235,8 +282,25 @@ export class SpaceGoalService {
 		return { goal: updated, claimed };
 	}
 
-	updateScheduledCheckIn(goalId: string, nextCheckInAt: number | null): SpaceGoal | null {
-		return this.deps.goalRepo.update(goalId, { nextCheckInAt });
+	updateScheduledCheckIn(
+		goalId: string,
+		nextCheckInAt: number | null,
+		context?: SpaceGoalMutationContext
+	): SpaceGoal | null {
+		const previous = this.deps.goalRepo.getById(goalId);
+		const updated = this.deps.goalRepo.update(goalId, { nextCheckInAt });
+		if (previous && updated) {
+			this.recordGoalEvent(updated, 'schedule_updated', previous, updated, {
+				source: 'scheduler',
+				...context,
+			});
+		}
+		return updated;
+	}
+
+	listGoalEvents(goalId: string, params: SpaceGoalEventListParams = {}): SpaceGoalEvent[] {
+		this.requireGoal(goalId);
+		return this.deps.goalEventRepo?.listByGoal(goalId, params) ?? [];
 	}
 
 	private requireGoal(goalId: string): SpaceGoal {
@@ -337,6 +401,31 @@ export class SpaceGoalService {
 		this.deps.scheduleService.updateSchedule(schedule.id, scheduleUpdate);
 	}
 
+	private recordGoalEvent(
+		goal: SpaceGoal,
+		eventType: SpaceGoalEventType,
+		previous: SpaceGoal | null,
+		current: SpaceGoal,
+		context?: SpaceGoalMutationContext
+	): void {
+		if (!this.deps.goalEventRepo) return;
+		const previousState = previous ? snapshotGoal(previous) : null;
+		const newState = snapshotGoal(current);
+		const diff = previousState ? diffSnapshots(previousState, newState) : null;
+		this.deps.goalEventRepo.create({
+			spaceId: goal.spaceId,
+			goalId: goal.id,
+			eventType,
+			source: context?.source ?? 'system',
+			sourceTaskId: context?.sourceTaskId ?? null,
+			sourceSessionId: context?.sourceSessionId ?? null,
+			previousState,
+			newState,
+			diff,
+			note: context?.note ?? null,
+		});
+	}
+
 	private emitTaskCreated(task: SpaceTask): void {
 		if (!this.deps.eventHub) return;
 		this.deps.eventHub
@@ -371,6 +460,45 @@ export class SpaceGoalService {
 		].filter(Boolean);
 		return sections.join('\n\n');
 	}
+}
+
+function snapshotGoal(goal: SpaceGoal): SpaceGoalEventSnapshot {
+	return {
+		title: goal.title,
+		description: goal.description,
+		status: goal.status,
+		type: goal.type,
+		priority: goal.priority,
+		labels: goal.labels,
+		metrics: goal.metrics,
+		summary: goal.summary,
+		progress: goal.progress,
+		nextSteps: goal.nextSteps,
+		preferredWorkflowId: goal.preferredWorkflowId,
+		taskScheduleId: goal.taskScheduleId,
+		autoTriggerNext: goal.autoTriggerNext,
+		pendingNextRun: goal.pendingNextRun,
+		activeTaskId: goal.activeTaskId,
+		lastTaskId: goal.lastTaskId,
+		lastCheckInAt: goal.lastCheckInAt,
+		nextCheckInAt: goal.nextCheckInAt,
+		completedAt: goal.completedAt,
+	};
+}
+
+function diffSnapshots(
+	previous: SpaceGoalEventSnapshot,
+	current: SpaceGoalEventSnapshot
+): SpaceGoalEventDiff {
+	const diff: SpaceGoalEventDiff = {};
+	for (const key of Object.keys(current) as Array<keyof SpaceGoalEventSnapshot>) {
+		const previousValue = previous[key];
+		const currentValue = current[key];
+		if (JSON.stringify(previousValue) !== JSON.stringify(currentValue)) {
+			diff[key] = { previous: previousValue, current: currentValue };
+		}
+	}
+	return diff;
 }
 
 function isActiveTaskStatus(status: SpaceTask['status']): boolean {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -64,7 +64,7 @@ export class SpaceGoalService {
 			throw new Error(`Cannot create goal in a non-active space (current: ${space.status})`);
 		}
 
-		return this.runAtomic(() => {
+		const result = this.runAtomic(() => {
 			const goal = this.deps.goalRepo.create(params);
 			this.recordGoalEvent(goal, 'created', null, goal, context);
 			if (params.checkInCronExpression) {
@@ -85,9 +85,15 @@ export class SpaceGoalService {
 				this.deps.goalRepo.update(goal.id, { nextCheckInAt: schedule.nextRunAt });
 			}
 
-			if (params.triggerImmediately) return this.createImmediateTask(goal.id).goal;
-			return this.getGoal(goal.id) as SpaceGoal;
+			if (!params.triggerImmediately)
+				return { goal: this.getGoal(goal.id) as SpaceGoal, task: null };
+			const created = this.createImmediateTaskInternal(goal.id, undefined, {
+				emitTaskCreated: false,
+			});
+			return { goal: created.goal, task: created.task };
 		});
+		if (result.task) this.emitTaskCreated(result.task);
+		return result.goal;
 	}
 
 	listGoals(params: SpaceGoalListParams): SpaceGoal[] {
@@ -173,6 +179,18 @@ export class SpaceGoalService {
 		task: SpaceTask | null;
 		queued: boolean;
 	} {
+		return this.createImmediateTaskInternal(goalId, context);
+	}
+
+	private createImmediateTaskInternal(
+		goalId: string,
+		context?: SpaceGoalMutationContext,
+		options: { emitTaskCreated?: boolean } = {}
+	): {
+		goal: SpaceGoal;
+		task: SpaceTask | null;
+		queued: boolean;
+	} {
 		const goal = this.requireGoal(goalId);
 		if (goal.status !== 'active') {
 			throw new Error(`Cannot trigger goal in '${goal.status}' status`);
@@ -222,7 +240,7 @@ export class SpaceGoalService {
 			...context,
 			sourceTaskId: context?.sourceTaskId ?? task.id,
 		});
-		this.emitTaskCreated(task);
+		if (options.emitTaskCreated !== false) this.emitTaskCreated(task);
 		return { goal: updatedGoal, task, queued: false };
 	}
 

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -1,0 +1,386 @@
+import type {
+	CreateSpaceGoalParams,
+	SpaceGoal,
+	SpaceGoalListParams,
+	SpaceTask,
+	UpdateSpaceGoalParams,
+} from '@neokai/shared';
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { SpaceRepository } from '../../../storage/repositories/space-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
+import type { ScheduleService } from '../schedule/schedule-service';
+
+export type PublicSpaceGoalUpdateParams = Pick<
+	UpdateSpaceGoalParams,
+	| 'title'
+	| 'description'
+	| 'status'
+	| 'type'
+	| 'priority'
+	| 'labels'
+	| 'metrics'
+	| 'summary'
+	| 'progress'
+	| 'nextSteps'
+	| 'preferredWorkflowId'
+	| 'autoTriggerNext'
+>;
+
+export interface SpaceGoalServiceDeps {
+	goalRepo: SpaceGoalRepository;
+	taskRepo: SpaceTaskRepository;
+	spaceRepo: SpaceRepository;
+	scheduleService: ScheduleService;
+	db?: BunDatabase;
+	eventHub?: {
+		publish: (event: string, data: Record<string, unknown>) => Promise<unknown>;
+	};
+}
+
+export class SpaceGoalService {
+	constructor(private readonly deps: SpaceGoalServiceDeps) {}
+
+	createGoal(params: CreateSpaceGoalParams): SpaceGoal {
+		this.validateCreate(params);
+		const space = this.deps.spaceRepo.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+		if (space.status !== 'active') {
+			throw new Error(`Cannot create goal in a non-active space (current: ${space.status})`);
+		}
+
+		return this.runAtomic(() => {
+			const goal = this.deps.goalRepo.create(params);
+			if (params.checkInCronExpression) {
+				const schedule = this.deps.scheduleService.createGoalSchedule({
+					spaceId: params.spaceId,
+					title: `Goal check-in: ${params.title}`,
+					description: this.buildTaskDescription(goal),
+					priority: goal.priority,
+					preferredWorkflowId: goal.preferredWorkflowId,
+					labels: this.goalTaskLabels(goal),
+					triggerType: 'cron',
+					cronExpression: params.checkInCronExpression,
+					timezone: params.checkInTimezone ?? 'UTC',
+					createdByAgent: 'space-goal-service',
+					goalId: goal.id,
+				});
+				this.deps.goalRepo.setTaskScheduleId(goal.id, schedule.id);
+				this.deps.goalRepo.update(goal.id, { nextCheckInAt: schedule.nextRunAt });
+			}
+
+			if (params.triggerImmediately) return this.createImmediateTask(goal.id).goal;
+			return this.getGoal(goal.id) as SpaceGoal;
+		});
+	}
+
+	listGoals(params: SpaceGoalListParams): SpaceGoal[] {
+		if (!params.spaceId) throw new Error('spaceId is required');
+		return this.deps.goalRepo.list(params);
+	}
+
+	getGoal(goalId: string): SpaceGoal | null {
+		return this.deps.goalRepo.getById(goalId);
+	}
+
+	updateGoal(goalId: string, params: PublicSpaceGoalUpdateParams): SpaceGoal {
+		const existing = this.requireGoal(goalId);
+		if (
+			existing.status === 'archived' &&
+			params.status !== undefined &&
+			params.status !== 'archived'
+		) {
+			throw new Error('Archived goals cannot be reactivated');
+		}
+		if (params.title !== undefined && !params.title.trim()) throw new Error('title is required');
+
+		const updateParams: UpdateSpaceGoalParams = { ...params };
+		if (params.status !== undefined && params.status !== existing.status) {
+			this.synchronizeScheduleForStatus(existing, params.status);
+			if (params.status !== 'active') {
+				updateParams.nextCheckInAt = null;
+			} else {
+				const refreshed = this.deps.goalRepo.getById(goalId) ?? existing;
+				updateParams.nextCheckInAt = refreshed.nextCheckInAt;
+			}
+		}
+
+		this.syncScheduleTemplateIfNeeded(existing, updateParams);
+
+		const updated = this.deps.goalRepo.update(goalId, updateParams);
+		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		return updated;
+	}
+
+	pauseGoal(goalId: string): SpaceGoal {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'active') throw new Error(`Goal is not active (current: ${goal.status})`);
+		if (goal.taskScheduleId) this.pauseLinkedScheduleOrClear(goal);
+		const updated = this.deps.goalRepo.update(goalId, { status: 'paused', nextCheckInAt: null });
+		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		return updated;
+	}
+
+	resumeGoal(goalId: string): SpaceGoal {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'paused') throw new Error(`Goal is not paused (current: ${goal.status})`);
+		let nextCheckInAt = goal.nextCheckInAt;
+		if (goal.taskScheduleId) {
+			const schedule = this.resumeLinkedScheduleOrClear(goal);
+			nextCheckInAt = schedule?.nextRunAt ?? null;
+		}
+		const updated = this.deps.goalRepo.update(goalId, { status: 'active', nextCheckInAt });
+		if (!updated) throw new Error(`Goal not found: ${goalId}`);
+		return updated;
+	}
+
+	createImmediateTask(goalId: string): {
+		goal: SpaceGoal;
+		task: SpaceTask | null;
+		queued: boolean;
+	} {
+		const goal = this.requireGoal(goalId);
+		if (goal.status !== 'active') {
+			throw new Error(`Cannot trigger goal in '${goal.status}' status`);
+		}
+		this.requireActiveSpaceForTaskCreation(goal);
+		if (goal.activeTaskId) {
+			const active = this.deps.taskRepo.getTask(goal.activeTaskId);
+			if (active && isActiveTaskStatus(active.status)) {
+				if (!goal.autoTriggerNext) {
+					throw new Error('Goal already has an active task and autoTriggerNext is disabled');
+				}
+				return {
+					goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+					task: null,
+					queued: true,
+				};
+			}
+			this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, goal.activeTaskId);
+		}
+
+		const task = this.deps.taskRepo.createTask({
+			spaceId: goal.spaceId,
+			title: `Goal task: ${goal.title}`,
+			description: this.buildTaskDescription(goal),
+			priority: goal.priority,
+			labels: this.goalTaskLabels(goal),
+			preferredWorkflowId: goal.preferredWorkflowId,
+			goalId: goal.id,
+		});
+		if (!this.deps.goalRepo.claimActiveTask(goal.id, task.id)) {
+			this.deps.taskRepo.deleteTask(task.id);
+			if (!goal.autoTriggerNext) {
+				throw new Error('Goal already has an active task and autoTriggerNext is disabled');
+			}
+			return {
+				goal: this.deps.goalRepo.queueNextRun(goal.id) as SpaceGoal,
+				task: null,
+				queued: true,
+			};
+		}
+		const updatedGoal = this.requireGoal(goal.id);
+		this.emitTaskCreated(task);
+		return { goal: updatedGoal, task, queued: false };
+	}
+
+	handleTaskTerminal(taskId: string): { goal: SpaceGoal; nextTask: SpaceTask | null } | null {
+		const task = this.deps.taskRepo.getTask(taskId);
+		if (!task?.goalId) return null;
+		if (!isTerminalTaskStatus(task.status)) return null;
+		const goal = this.deps.goalRepo.getById(task.goalId);
+		if (!goal || goal.spaceId !== task.spaceId) return null;
+		this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
+		const fresh = this.requireGoal(goal.id);
+		if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
+			return { goal: fresh, nextTask: null };
+		}
+		const created = this.createImmediateTask(fresh.id);
+		return { goal: created.goal, nextTask: created.task };
+	}
+
+	canClaimScheduledTask(task: Pick<SpaceTask, 'spaceId' | 'goalId'>): {
+		goal: SpaceGoal | null;
+		claimable: boolean;
+	} {
+		if (!task.goalId) return { goal: null, claimable: false };
+		const goal = this.deps.goalRepo.getById(task.goalId);
+		if (!goal || goal.spaceId !== task.spaceId || goal.status !== 'active') {
+			return { goal: null, claimable: false };
+		}
+		if (!goal.activeTaskId) return { goal, claimable: true };
+		const active = this.deps.taskRepo.getTask(goal.activeTaskId);
+		return { goal, claimable: !active || !isActiveTaskStatus(active.status) };
+	}
+
+	claimScheduledTask(
+		taskId: string,
+		nextCheckInAt: number | null
+	): { goal: SpaceGoal | null; claimed: boolean } {
+		const task = this.deps.taskRepo.getTask(taskId);
+		if (!task?.goalId) return { goal: null, claimed: false };
+		const goal = this.deps.goalRepo.getById(task.goalId);
+		if (!goal || goal.spaceId !== task.spaceId) return { goal: null, claimed: false };
+		if (nextCheckInAt !== goal.nextCheckInAt) {
+			this.deps.goalRepo.update(goal.id, { nextCheckInAt });
+		}
+		if (goal.activeTaskId) {
+			const active = this.deps.taskRepo.getTask(goal.activeTaskId);
+			if (!active || !isActiveTaskStatus(active.status)) {
+				this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, goal.activeTaskId);
+			}
+		}
+		const claimed = this.deps.goalRepo.claimActiveTask(goal.id, taskId);
+		const updated = this.deps.goalRepo.getById(goal.id);
+		return { goal: updated, claimed };
+	}
+
+	updateScheduledCheckIn(goalId: string, nextCheckInAt: number | null): SpaceGoal | null {
+		return this.deps.goalRepo.update(goalId, { nextCheckInAt });
+	}
+
+	private requireGoal(goalId: string): SpaceGoal {
+		const goal = this.deps.goalRepo.getById(goalId);
+		if (!goal) throw new Error(`Goal not found: ${goalId}`);
+		return goal;
+	}
+
+	private requireActiveSpaceForTaskCreation(goal: SpaceGoal): void {
+		const space = this.deps.spaceRepo.getSpace(goal.spaceId);
+		if (!space) throw new Error(`Space not found: ${goal.spaceId}`);
+		if (space.status !== 'active' || space.paused || space.stopped) {
+			throw new Error('Cannot create goal task in a non-active space');
+		}
+	}
+
+	private runAtomic<T>(fn: () => T): T {
+		if (!this.deps.db) return fn();
+		return this.deps.db.transaction(fn)();
+	}
+
+	private pauseLinkedScheduleOrClear(goal: SpaceGoal): void {
+		if (!goal.taskScheduleId) return;
+		const schedule = this.deps.scheduleService.getSchedule(goal.taskScheduleId);
+		if (!schedule) {
+			this.deps.goalRepo.setTaskScheduleId(goal.id, null);
+			return;
+		}
+		if (schedule.status === 'active') {
+			const paused = this.deps.scheduleService.pauseSchedule(schedule.id);
+			if (paused.status !== 'paused') {
+				throw new Error(`Could not pause linked schedule (current: ${paused.status})`);
+			}
+		}
+	}
+
+	private resumeLinkedScheduleOrClear(goal: SpaceGoal): { nextRunAt: number | null } | null {
+		if (!goal.taskScheduleId) return null;
+		const schedule = this.deps.scheduleService.getSchedule(goal.taskScheduleId);
+		if (!schedule) {
+			this.deps.goalRepo.setTaskScheduleId(goal.id, null);
+			return null;
+		}
+		if (schedule.status === 'paused') {
+			const resumed = this.deps.scheduleService.resumeSchedule(schedule.id);
+			if (resumed.status !== 'active') {
+				throw new Error(`Could not resume linked schedule (current: ${resumed.status})`);
+			}
+			return resumed;
+		}
+		if (schedule.status === 'active') return schedule;
+		throw new Error(`Linked schedule is not resumable (current: ${schedule.status})`);
+	}
+
+	private synchronizeScheduleForStatus(goal: SpaceGoal, status: SpaceGoal['status']): void {
+		if (!goal.taskScheduleId) return;
+		if (status === 'paused' || status === 'completed' || status === 'archived') {
+			this.pauseLinkedScheduleOrClear(goal);
+			return;
+		}
+		if (status === 'active' && (goal.status === 'paused' || goal.status === 'completed')) {
+			const schedule = this.resumeLinkedScheduleOrClear(goal);
+			if (schedule) this.deps.goalRepo.update(goal.id, { nextCheckInAt: schedule.nextRunAt });
+		}
+	}
+
+	private syncScheduleTemplateIfNeeded(goal: SpaceGoal, params: PublicSpaceGoalUpdateParams): void {
+		if (!goal.taskScheduleId) return;
+		const hasTemplateChange =
+			params.title !== undefined ||
+			params.description !== undefined ||
+			params.priority !== undefined ||
+			params.labels !== undefined ||
+			params.summary !== undefined ||
+			params.nextSteps !== undefined ||
+			params.preferredWorkflowId !== undefined;
+		if (!hasTemplateChange) return;
+
+		const schedule = this.deps.scheduleService.getSchedule(goal.taskScheduleId);
+		if (!schedule) {
+			this.deps.goalRepo.setTaskScheduleId(goal.id, null);
+			return;
+		}
+
+		const definedParams = Object.fromEntries(
+			Object.entries(params).filter(([, value]) => value !== undefined)
+		) as PublicSpaceGoalUpdateParams;
+		const nextGoal: SpaceGoal = { ...goal, ...definedParams };
+		const scheduleUpdate: Parameters<ScheduleService['updateSchedule']>[1] = {
+			description: this.buildTaskDescription(nextGoal),
+		};
+		if (params.title !== undefined) scheduleUpdate.title = `Goal check-in: ${params.title}`;
+		if (params.priority !== undefined) scheduleUpdate.priority = params.priority;
+		if ('preferredWorkflowId' in definedParams) {
+			scheduleUpdate.preferredWorkflowId = definedParams.preferredWorkflowId;
+		}
+		if (params.labels !== undefined) scheduleUpdate.labels = this.goalTaskLabels(nextGoal);
+		this.deps.scheduleService.updateSchedule(schedule.id, scheduleUpdate);
+	}
+
+	private emitTaskCreated(task: SpaceTask): void {
+		if (!this.deps.eventHub) return;
+		this.deps.eventHub
+			.publish('space.task.created', {
+				sessionId: 'global',
+				spaceId: task.spaceId,
+				taskId: task.id,
+				task,
+			})
+			.catch(() => {
+				// Best-effort event; goal task creation must not fail because listeners fail.
+			});
+	}
+
+	private validateCreate(params: CreateSpaceGoalParams): void {
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.title?.trim()) throw new Error('title is required');
+	}
+
+	private goalTaskLabels(goal: SpaceGoal): string[] {
+		return Array.from(new Set(['goal', `goal:${goal.id}`, ...goal.labels]));
+	}
+
+	private buildTaskDescription(goal: SpaceGoal): string {
+		const sections = [
+			`Goal: ${goal.title}`,
+			goal.description,
+			goal.summary ? `Current summary:\n${goal.summary}` : '',
+			goal.nextSteps.length > 0
+				? `Next steps:\n${goal.nextSteps.map((s) => `- ${s}`).join('\n')}`
+				: '',
+		].filter(Boolean);
+		return sections.join('\n\n');
+	}
+}
+
+function isActiveTaskStatus(status: SpaceTask['status']): boolean {
+	return (
+		status === 'open' || status === 'in_progress' || status === 'review' || status === 'approved'
+	);
+}
+
+function isTerminalTaskStatus(status: SpaceTask['status']): boolean {
+	return (
+		status === 'done' || status === 'blocked' || status === 'cancelled' || status === 'archived'
+	);
+}

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -9,7 +9,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
-	CreateSpaceTaskParams,
+	InternalCreateSpaceTaskParams,
 	SpaceApprovalSource,
 	SpaceBlockReason,
 	SpaceTask,
@@ -74,7 +74,7 @@ export class SpaceTaskManager {
 	/**
 	 * Create a task in this space
 	 */
-	async createTask(params: Omit<CreateSpaceTaskParams, 'spaceId'>): Promise<SpaceTask> {
+	async createTask(params: Omit<InternalCreateSpaceTaskParams, 'spaceId'>): Promise<SpaceTask> {
 		// Validate dependency task IDs exist in this space
 		if (params.dependsOn && params.dependsOn.length > 0) {
 			await this.validateDependencyIds(params.dependsOn);

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -133,6 +133,8 @@ export interface PostApprovalRouterDeps {
 	taskRepo: Pick<SpaceTaskRepository, 'updateTask' | 'getTask'>;
 	spawner: PostApprovalSubSessionSpawner;
 	livenessProbe?: SessionLivenessProbe;
+	/** Optional goal service for processing terminal goal-task side effects. */
+	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +265,14 @@ export class PostApprovalRouter {
 				postApprovalBlockedReason: null,
 			};
 			this.deps.taskRepo.updateTask(task.id, updates);
+			// Best-effort goal terminal handling — must not block approval routing.
+			try {
+				this.deps.goalService?.handleTaskTerminal(task.id);
+			} catch (err) {
+				log.warn(
+					`Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
 			log.info(
 				`post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} targetAgent=none mode=none autonomyLevel=${context.autonomyLevel ?? 'unknown'}`
 			);

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -132,6 +132,8 @@ export interface SpaceRuntimeServiceConfig {
 	replyRoutingRegistry?: ReplyRoutingRegistry;
 	/** Persistent per-space agent memory repository. */
 	memoryRepo?: AgentMemoryRepository;
+	/** Optional goal service for processing terminal goal-task side effects. */
+	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
 }
 
 export class SpaceRuntimeService {
@@ -190,6 +192,7 @@ export class SpaceRuntimeService {
 			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
 			internalEventBus: config.internalEventBus,
 			onTaskUpdated: async ({ spaceId, task, archiveSource }) => {
+				this.config.goalService?.handleTaskTerminal(task.id);
 				if (!this.config.internalEventBus) return;
 				await this.config.internalEventBus.publish('space.task.updated', {
 					sessionId: 'global',

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -192,7 +192,11 @@ export class SpaceRuntimeService {
 			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
 			internalEventBus: config.internalEventBus,
 			onTaskUpdated: async ({ spaceId, task, archiveSource }) => {
-				this.config.goalService?.handleTaskTerminal(task.id);
+				try {
+					this.config.goalService?.handleTaskTerminal(task.id);
+				} catch (err) {
+					log.warn(`goal terminal handling failed for task ${task.id}:`, err);
+				}
 				if (!this.config.internalEventBus) return;
 				await this.config.internalEventBus.publish('space.task.updated', {
 					sessionId: 'global',

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -231,6 +231,8 @@ export interface SpaceRuntimeConfig {
 	 * `selectWorkflowWithLlmDefault` from `./llm-workflow-selector`.
 	 */
 	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
+	/** Optional goal service for processing terminal goal-task side effects. */
+	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
 }
 
 interface StartWorkflowRunOptions {
@@ -1378,6 +1380,7 @@ export class SpaceRuntime {
 			livenessProbe: {
 				isSessionAlive: (sessionId) => manager.isSessionAlive(sessionId),
 			},
+			goalService: this.config.goalService,
 		});
 		return this.postApprovalRouter;
 	}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -261,6 +261,8 @@ export interface TaskAgentManagerConfig {
 	replyRoutingRegistry?: ReplyRoutingRegistry;
 	/** Persistent per-space agent memory repository. */
 	memoryRepo?: AgentMemoryRepository;
+	/** Goal service for terminal goal-task side effects. */
+	goalService?: import('../goals/goal-service').SpaceGoalService;
 }
 
 // ---------------------------------------------------------------------------
@@ -3636,6 +3638,7 @@ export class TaskAgentManager {
 			taskRepo: this.config.taskRepo,
 			taskManager: boundTaskManager,
 			internalEventBus: this.config.internalEventBus,
+			goalService: this.config.goalService,
 		});
 
 		// Self-heal callback for the agent-callable `restore_node_agent` tool.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -718,6 +718,8 @@ export class TaskAgentManager {
 				const gateDataSnapshot = this.config.gateDataRepo
 					.listByRun(workflowRun.id)
 					.map((record) => ({ gateId: record.gateId, data: record.data }));
+				const goal = task.goalId ? this.config.goalService?.getGoal(task.goalId) : null;
+				const linkedGoal = goal?.spaceId === task.spaceId ? goal : null;
 
 				const memoryQuery = `${task.title}\n${task.description}`;
 				const relevantMemories = this.config.memoryRepo
@@ -731,6 +733,7 @@ export class TaskAgentManager {
 					space,
 					sessionId: actualSessionId,
 					workspacePath,
+					goal: linkedGoal,
 					slotOverrides,
 					nodeId: execution.workflowNodeId,
 					agentSlotName: execution.agentName,
@@ -743,7 +746,6 @@ export class TaskAgentManager {
 					: initialMessage;
 				await this.injectMessageIntoSession(spawned, kickoffMessage);
 			}
-
 			return actualSessionId;
 		} catch (err) {
 			// Roll back partially-created sessions so executions do not get stuck as pending with a stale session.

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -41,6 +41,10 @@ export interface CreateScheduleInput {
 	createdBySession?: string | null;
 }
 
+export interface CreateGoalScheduleInput extends CreateScheduleInput {
+	goalId: string;
+}
+
 export interface UpdateScheduleInput {
 	title?: string;
 	description?: string;
@@ -121,6 +125,14 @@ export class ScheduleService {
 	 * schedule (row + job + pendingJobId) or a clean failure.
 	 */
 	createSchedule(input: CreateScheduleInput): TaskSchedule {
+		return this.createScheduleInternal(input, null);
+	}
+
+	createGoalSchedule(input: CreateGoalScheduleInput): TaskSchedule {
+		return this.createScheduleInternal(input, input.goalId);
+	}
+
+	private createScheduleInternal(input: CreateScheduleInput, goalId: string | null): TaskSchedule {
 		this.validateCreateTrigger(input);
 
 		const { spaceRepo, db, scheduleRepo, jobQueue } = this.deps;
@@ -152,6 +164,7 @@ export class ScheduleService {
 				nextRunAt,
 				createdByAgent: input.createdByAgent,
 				createdBySession: input.createdBySession,
+				goalId,
 			});
 
 			const job = jobQueue.enqueue({

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -94,7 +94,7 @@ export interface MarkCompleteHandlerDeps {
 	/** Optional hub for emitting `space.task.updated` events. */
 	internalEventBus?: Pick<InternalEventBus<DaemonInternalEventMap>, 'publish'>;
 	/** Optional goal service for processing terminal goal-task side effects. */
-	goalService?: Pick<SpaceGoalService, 'handleTaskTerminal'>;
+	goalService?: Pick<SpaceGoalService, 'getGoal' | 'updateGoal' | 'handleTaskTerminal'>;
 }
 
 /**
@@ -129,7 +129,7 @@ export function createMarkCompleteHandler(
 			});
 	};
 
-	return async (_args: MarkCompleteInput): Promise<ToolResult> => {
+	return async (args: MarkCompleteInput): Promise<ToolResult> => {
 		const task = taskRepo.getTask(taskId);
 		if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 
@@ -139,6 +139,31 @@ export function createMarkCompleteHandler(
 				error:
 					`task is not in \`approved\` status (current: \`${task.status}\`); did you mean \`approve_task\`? ` +
 					`mark_complete only transitions an already-approved task from 'approved' to 'done'.`,
+			});
+		}
+
+		if (args.goal_update) {
+			if (!goalService) {
+				return jsonResult({
+					success: false,
+					error: 'Goal update is not available in this context.',
+				});
+			}
+			if (!task.goalId) {
+				return jsonResult({
+					success: false,
+					error: 'Cannot apply goal_update: this task is not linked to a goal.',
+				});
+			}
+			const goal = goalService.getGoal(task.goalId);
+			if (!goal || goal.spaceId !== task.spaceId) {
+				return jsonResult({ success: false, error: `Goal not found: ${task.goalId}` });
+			}
+			goalService.updateGoal(goal.id, {
+				summary: args.goal_update.summary,
+				progress: args.goal_update.progress,
+				metrics: args.goal_update.metrics,
+				nextSteps: args.goal_update.nextSteps,
 			});
 		}
 

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -159,12 +159,16 @@ export function createMarkCompleteHandler(
 			if (!goal || goal.spaceId !== task.spaceId) {
 				return jsonResult({ success: false, error: `Goal not found: ${task.goalId}` });
 			}
-			goalService.updateGoal(goal.id, {
-				summary: args.goal_update.summary,
-				progress: args.goal_update.progress,
-				metrics: args.goal_update.metrics,
-				nextSteps: args.goal_update.nextSteps,
-			});
+			goalService.updateGoal(
+				goal.id,
+				{
+					summary: args.goal_update.summary,
+					progress: args.goal_update.progress,
+					metrics: args.goal_update.metrics,
+					nextSteps: args.goal_update.nextSteps,
+				},
+				{ source: 'workflow_node_agent', sourceTaskId: taskId }
+			);
 		}
 
 		try {

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -142,6 +142,10 @@ export function createMarkCompleteHandler(
 			});
 		}
 
+		let goalUpdate: {
+			goalId: string;
+			updates: NonNullable<MarkCompleteInput['goal_update']>;
+		} | null = null;
 		if (args.goal_update) {
 			if (!goalService) {
 				return jsonResult({
@@ -159,16 +163,7 @@ export function createMarkCompleteHandler(
 			if (!goal || goal.spaceId !== task.spaceId) {
 				return jsonResult({ success: false, error: `Goal not found: ${task.goalId}` });
 			}
-			goalService.updateGoal(
-				goal.id,
-				{
-					summary: args.goal_update.summary,
-					progress: args.goal_update.progress,
-					metrics: args.goal_update.metrics,
-					nextSteps: args.goal_update.nextSteps,
-				},
-				{ source: 'workflow_node_agent', sourceTaskId: taskId }
-			);
+			goalUpdate = { goalId: goal.id, updates: args.goal_update };
 		}
 
 		try {
@@ -182,6 +177,18 @@ export function createMarkCompleteHandler(
 					for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
 				},
 			});
+			if (goalUpdate) {
+				goalService?.updateGoal(
+					goalUpdate.goalId,
+					{
+						summary: goalUpdate.updates.summary,
+						progress: goalUpdate.updates.progress,
+						metrics: goalUpdate.updates.metrics,
+						nextSteps: goalUpdate.updates.nextSteps,
+					},
+					{ source: 'workflow_node_agent', sourceTaskId: taskId }
+				);
+			}
 			handleGoalTerminal(updated);
 			emitTaskUpdated(updated);
 			log.info(

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -27,6 +27,7 @@ import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-ev
 import { Logger } from '../../logger';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
+import type { SpaceGoalService } from '../goals/goal-service';
 import type {
 	ApproveTaskInput,
 	MarkCompleteInput,
@@ -92,6 +93,8 @@ export interface MarkCompleteHandlerDeps {
 	taskManager: Pick<SpaceTaskManager, 'setTaskStatus' | 'updateTask'>;
 	/** Optional hub for emitting `space.task.updated` events. */
 	internalEventBus?: Pick<InternalEventBus<DaemonInternalEventMap>, 'publish'>;
+	/** Optional goal service for processing terminal goal-task side effects. */
+	goalService?: Pick<SpaceGoalService, 'handleTaskTerminal'>;
 }
 
 /**
@@ -102,7 +105,18 @@ export interface MarkCompleteHandlerDeps {
 export function createMarkCompleteHandler(
 	deps: MarkCompleteHandlerDeps
 ): (args: MarkCompleteInput) => Promise<ToolResult> {
-	const { taskId, spaceId, taskRepo, taskManager, internalEventBus } = deps;
+	const { taskId, spaceId, taskRepo, taskManager, internalEventBus, goalService } = deps;
+
+	const handleGoalTerminal = (task: SpaceTask): void => {
+		if (!goalService) return;
+		try {
+			goalService.handleTaskTerminal(task.id);
+		} catch (err) {
+			log.warn(
+				`Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+	};
 
 	const emitTaskUpdated = (task: SpaceTask): void => {
 		if (!internalEventBus) return;
@@ -139,6 +153,7 @@ export function createMarkCompleteHandler(
 					for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
 				},
 			});
+			handleGoalTerminal(updated);
 			emitTaskUpdated(updated);
 			log.info(
 				`post-approval.complete: spaceId=${spaceId} taskId=${taskId} outcome=done mode=${task.postApprovalSessionId ? 'spawn' : 'inline'}`

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1584,7 +1584,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			try {
 				requireGoalInSpace(args.goal_id);
 				const tasks = taskRepo
-					.listBySpace(spaceId)
+					.listBySpace(spaceId, args.status === 'archived')
 					.filter((task) => task.goalId === args.goal_id)
 					.filter((task) => (args.status ? task.status === args.status : true));
 				return jsonResult({ success: true, total: tasks.length, tasks });

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -24,6 +24,8 @@ import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type {
 	NodeExecution,
+	SpaceGoalStatus,
+	SpaceGoalType,
 	SpaceTask,
 	SpaceTaskPriority,
 	SpaceTaskStatus,
@@ -52,6 +54,38 @@ import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
 
 const log = new Logger('space-agent-tools');
+
+type GoalToolUpdateArgs = {
+	title?: string;
+	description?: string;
+	status?: SpaceGoalStatus;
+	type?: SpaceGoalType;
+	priority?: SpaceTaskPriority;
+	labels?: string[];
+	metrics?: Record<string, string | number | boolean | null>;
+	summary?: string;
+	progress?: number;
+	next_steps?: string[];
+	preferred_workflow_id?: string | null;
+	auto_trigger_next?: boolean;
+};
+
+function normalizeGoalUpdateArgs(args: GoalToolUpdateArgs) {
+	return {
+		title: args.title,
+		description: args.description,
+		status: args.status,
+		type: args.type,
+		priority: args.priority,
+		labels: args.labels,
+		metrics: args.metrics,
+		summary: args.summary,
+		progress: args.progress,
+		nextSteps: args.next_steps,
+		preferredWorkflowId: args.preferred_workflow_id,
+		autoTriggerNext: args.auto_trigger_next,
+	};
+}
 
 function normalizeAgentNameToken(value: string): string {
 	return value.trim().toLowerCase();
@@ -235,6 +269,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 	const outboundSenderLevel = outboundSenderName === 'task-agent' ? 'task-agent' : 'space-agent';
 	const outboundSenderDisplayName =
 		outboundSenderName === 'space-agent' ? 'Space Agent' : outboundSenderName;
+
+	function requireGoalService() {
+		if (!config.goalService) throw new Error('Goal management not available');
+		return config.goalService;
+	}
+
+	function requireGoalInSpace(goalId: string) {
+		const goal = requireGoalService().getGoal(goalId);
+		if (!goal || goal.spaceId !== spaceId) throw new Error(`Goal not found: ${goalId}`);
+		return goal;
+	}
 
 	function emitTaskUpdated(task: SpaceTask): void {
 		if (!internalEventBus) return;
@@ -1392,6 +1437,152 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		},
 
 		/**
+		 * List goals for this space, optionally filtered by status.
+		 */
+		async list_goals(args: { status?: SpaceGoalStatus } = {}): Promise<ToolResult> {
+			try {
+				const goals = requireGoalService().listGoals({ spaceId, status: args.status });
+				return jsonResult({ success: true, goals });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Get one goal in this space.
+		 */
+		async get_goal(args: { goal_id: string }): Promise<ToolResult> {
+			try {
+				const goal = requireGoalInSpace(args.goal_id);
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Create a long-horizon goal in this space.
+		 */
+		async create_goal(args: {
+			title: string;
+			description?: string;
+			type?: SpaceGoalType;
+			priority?: SpaceTaskPriority;
+			labels?: string[];
+			metrics?: Record<string, string | number | boolean | null>;
+			summary?: string;
+			progress?: number;
+			next_steps?: string[];
+			preferred_workflow_id?: string | null;
+			auto_trigger_next?: boolean;
+			check_in_cron_expression?: string;
+			check_in_timezone?: string;
+			trigger_immediately?: boolean;
+		}): Promise<ToolResult> {
+			try {
+				const goal = requireGoalService().createGoal({
+					spaceId,
+					title: args.title,
+					description: args.description,
+					type: args.type,
+					priority: args.priority,
+					labels: args.labels,
+					metrics: args.metrics,
+					summary: args.summary,
+					progress: args.progress,
+					nextSteps: args.next_steps,
+					preferredWorkflowId: args.preferred_workflow_id,
+					autoTriggerNext: args.auto_trigger_next,
+					checkInCronExpression: args.check_in_cron_expression,
+					checkInTimezone: args.check_in_timezone,
+					triggerImmediately: args.trigger_immediately,
+				});
+				logAudit('create_goal', {
+					title: args.title,
+					type: args.type,
+					priority: args.priority,
+					trigger_immediately: args.trigger_immediately,
+					check_in_cron_expression: args.check_in_cron_expression,
+				});
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Update public goal fields and rolling state.
+		 */
+		async update_goal(args: { goal_id: string } & GoalToolUpdateArgs): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const { goal_id: goalId, ...updates } = args;
+				const goal = requireGoalService().updateGoal(goalId, normalizeGoalUpdateArgs(updates));
+				logAudit('update_goal', { goal_id: goalId, fields: Object.keys(updates) });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async pause_goal(args: { goal_id: string }): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const goal = requireGoalService().pauseGoal(args.goal_id);
+				logAudit('pause_goal', { goal_id: args.goal_id });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async resume_goal(args: { goal_id: string }): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const goal = requireGoalService().resumeGoal(args.goal_id);
+				logAudit('resume_goal', { goal_id: args.goal_id });
+				return jsonResult({ success: true, goal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async trigger_goal_task(args: { goal_id: string }): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const result = requireGoalService().createImmediateTask(args.goal_id);
+				logAudit('trigger_goal_task', { goal_id: args.goal_id }, result.task?.id);
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_goal_tasks(args: {
+			goal_id: string;
+			status?: SpaceTaskStatus;
+		}): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const tasks = taskRepo
+					.listBySpace(spaceId)
+					.filter((task) => task.goalId === args.goal_id)
+					.filter((task) => (args.status ? task.status === args.status : true));
+				return jsonResult({ success: true, total: tasks.length, tasks });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
 		 * Create a recurring (cron) or one-shot (at) scheduled task.
 		 */
 		async create_scheduled_task(args: {
@@ -1851,6 +2042,137 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 			(args) => handlers.approve_task(args)
 		),
 	];
+
+	// Goal management tools — only registered when goalService is provided.
+	if (config.goalService) {
+		const goalStatusSchema = z.enum(['active', 'paused', 'completed', 'archived']);
+		const goalTypeSchema = z.enum(['one_shot', 'measurable', 'recurring']);
+		const goalMetricsSchema = z.record(
+			z.string(),
+			z.union([z.string(), z.number(), z.boolean(), z.null()])
+		);
+		const goalUpdateShape = {
+			title: z.string().min(1).optional().describe('New goal title'),
+			description: z.string().optional().describe('New goal description'),
+			status: goalStatusSchema.optional().describe('New lifecycle status'),
+			type: goalTypeSchema.optional().describe('Goal type'),
+			priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('Goal priority'),
+			labels: z.array(z.string()).optional().describe('Labels for future goal tasks'),
+			metrics: goalMetricsSchema.optional().describe('Structured measurement state'),
+			summary: z.string().optional().describe('Rolling summary of current goal state'),
+			progress: z.number().int().min(0).max(100).optional().describe('Progress percentage 0-100'),
+			next_steps: z.array(z.string()).optional().describe('Rolling list of next steps'),
+			preferred_workflow_id: z
+				.string()
+				.nullable()
+				.optional()
+				.describe('Preferred workflow ID for future goal tasks'),
+			auto_trigger_next: z
+				.boolean()
+				.optional()
+				.describe(
+					'Queue one follow-up run when trigger is called while another goal task is active'
+				),
+		};
+
+		tools.push(
+			tool(
+				'list_goals',
+				'List long-horizon goals in this space. Use this before changing goal progress or creating goal tasks.',
+				{ status: goalStatusSchema.optional().describe('Filter by goal status') },
+				(args) => handlers.list_goals(args)
+			),
+			tool(
+				'get_goal',
+				'Get one goal with rolling state, active task pointers, next check-in, metrics, and next steps.',
+				{ goal_id: z.string().describe('Goal ID') },
+				(args) => handlers.get_goal(args)
+			),
+			tool(
+				'create_goal',
+				'Create a long-horizon goal in this space. Optionally schedule recurring check-ins or trigger the first task immediately.',
+				{
+					title: z.string().min(1).describe('Goal title'),
+					description: z.string().optional().describe('Goal description'),
+					type: goalTypeSchema.optional().describe('Goal type'),
+					priority: z
+						.enum(['low', 'normal', 'high', 'urgent'])
+						.optional()
+						.describe('Goal priority'),
+					labels: z.array(z.string()).optional().describe('Labels for future goal tasks'),
+					metrics: goalMetricsSchema.optional().describe('Initial structured metric state'),
+					summary: z.string().optional().describe('Initial rolling summary'),
+					progress: z.number().int().min(0).max(100).optional().describe('Initial progress 0-100'),
+					next_steps: z.array(z.string()).optional().describe('Initial next steps'),
+					preferred_workflow_id: z
+						.string()
+						.nullable()
+						.optional()
+						.describe('Preferred workflow ID for goal tasks'),
+					auto_trigger_next: z
+						.boolean()
+						.optional()
+						.describe('Queue one follow-up run when a trigger happens while active task exists'),
+					check_in_cron_expression: z
+						.string()
+						.optional()
+						.describe('Cron expression for recurring check-in task creation'),
+					check_in_timezone: z.string().optional().describe('IANA timezone for check-ins'),
+					trigger_immediately: z
+						.boolean()
+						.optional()
+						.describe('Create first goal task immediately'),
+				},
+				(args) => handlers.create_goal(args)
+			),
+			tool(
+				'update_goal',
+				'Update public goal fields and rolling state. Use summary/progress/metrics/next_steps to keep long-horizon state current; internal fields like activeTaskId and taskScheduleId are not writable.',
+				{ goal_id: z.string().describe('Goal ID'), ...goalUpdateShape },
+				(args) => handlers.update_goal(args)
+			),
+			tool(
+				'pause_goal',
+				'Pause an active goal and its linked check-in schedule if present.',
+				{ goal_id: z.string().describe('Goal ID') },
+				(args) => handlers.pause_goal(args)
+			),
+			tool(
+				'resume_goal',
+				'Resume a paused goal and re-enable its linked check-in schedule if present.',
+				{ goal_id: z.string().describe('Goal ID') },
+				(args) => handlers.resume_goal(args)
+			),
+			tool(
+				'trigger_goal_task',
+				'Create an immediate task for a goal. If another goal task is active and auto_trigger_next is true, queues one follow-up instead of overlapping work.',
+				{ goal_id: z.string().describe('Goal ID') },
+				(args) => handlers.trigger_goal_task(args)
+			),
+			tool(
+				'list_goal_tasks',
+				'List tasks linked to a goal in this space, optionally filtered by status.',
+				{
+					goal_id: z.string().describe('Goal ID'),
+					status: z
+						.enum([
+							'draft',
+							'open',
+							'in_progress',
+							'review',
+							'approved',
+							'done',
+							'blocked',
+							'cancelled',
+							'archived',
+						])
+						.optional()
+						.describe('Filter by linked task status'),
+				},
+				(args) => handlers.list_goal_tasks(args)
+			)
+		);
+	}
 
 	// Schedule management tools — only registered when scheduleService is provided.
 	if (config.scheduleService) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1598,12 +1598,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			goal_id: string;
 			limit?: number;
 			before?: number;
+			before_id?: string;
 		}): Promise<ToolResult> {
 			try {
 				requireGoalInSpace(args.goal_id);
 				const events = requireGoalService().listGoalEvents(args.goal_id, {
 					limit: args.limit,
 					before: args.before,
+					beforeId: args.before_id,
 				});
 				return jsonResult({ success: true, total: events.length, events });
 			} catch (err) {
@@ -2208,6 +2210,10 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					goal_id: z.string().describe('Goal ID'),
 					limit: z.number().int().min(1).max(100).optional().describe('Max events to return'),
 					before: z.number().int().optional().describe('Return events before this timestamp'),
+					before_id: z
+						.string()
+						.optional()
+						.describe('Cursor event ID for same-timestamp pagination'),
 				},
 				(args) => handlers.list_goal_events(args)
 			)

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -190,6 +190,8 @@ export interface SpaceAgentToolsConfig {
 	 * session instead of the canonical space:chat: session.
 	 */
 	replyRoutingRegistry?: ReplyRoutingRegistry;
+	/** Goal service for terminal goal-task side effects. */
+	goalService?: import('../goals/goal-service').SpaceGoalService;
 }
 
 // ---------------------------------------------------------------------------
@@ -1361,6 +1363,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 						for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
 					},
 				});
+
+				// Best-effort goal terminal handling — must not block approve_task.
+				try {
+					config.goalService?.handleTaskTerminal(updated.id);
+				} catch (err) {
+					log.warn(
+						`Goal terminal handling threw for task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
 
 				logAudit(
 					'approve_task',

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -281,6 +281,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		return goal;
 	}
 
+	const goalToolContext = {
+		source: 'space_agent_tool' as const,
+		sourceSessionId: mySessionId ?? null,
+	};
+
 	function emitTaskUpdated(task: SpaceTask): void {
 		if (!internalEventBus) return;
 		void internalEventBus
@@ -1482,23 +1487,26 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			trigger_immediately?: boolean;
 		}): Promise<ToolResult> {
 			try {
-				const goal = requireGoalService().createGoal({
-					spaceId,
-					title: args.title,
-					description: args.description,
-					type: args.type,
-					priority: args.priority,
-					labels: args.labels,
-					metrics: args.metrics,
-					summary: args.summary,
-					progress: args.progress,
-					nextSteps: args.next_steps,
-					preferredWorkflowId: args.preferred_workflow_id,
-					autoTriggerNext: args.auto_trigger_next,
-					checkInCronExpression: args.check_in_cron_expression,
-					checkInTimezone: args.check_in_timezone,
-					triggerImmediately: args.trigger_immediately,
-				});
+				const goal = requireGoalService().createGoal(
+					{
+						spaceId,
+						title: args.title,
+						description: args.description,
+						type: args.type,
+						priority: args.priority,
+						labels: args.labels,
+						metrics: args.metrics,
+						summary: args.summary,
+						progress: args.progress,
+						nextSteps: args.next_steps,
+						preferredWorkflowId: args.preferred_workflow_id,
+						autoTriggerNext: args.auto_trigger_next,
+						checkInCronExpression: args.check_in_cron_expression,
+						checkInTimezone: args.check_in_timezone,
+						triggerImmediately: args.trigger_immediately,
+					},
+					goalToolContext
+				);
 				logAudit('create_goal', {
 					title: args.title,
 					type: args.type,
@@ -1520,7 +1528,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			try {
 				requireGoalInSpace(args.goal_id);
 				const { goal_id: goalId, ...updates } = args;
-				const goal = requireGoalService().updateGoal(goalId, normalizeGoalUpdateArgs(updates));
+				const goal = requireGoalService().updateGoal(
+					goalId,
+					normalizeGoalUpdateArgs(updates),
+					goalToolContext
+				);
 				logAudit('update_goal', { goal_id: goalId, fields: Object.keys(updates) });
 				return jsonResult({ success: true, goal });
 			} catch (err) {
@@ -1532,7 +1544,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		async pause_goal(args: { goal_id: string }): Promise<ToolResult> {
 			try {
 				requireGoalInSpace(args.goal_id);
-				const goal = requireGoalService().pauseGoal(args.goal_id);
+				const goal = requireGoalService().pauseGoal(args.goal_id, goalToolContext);
 				logAudit('pause_goal', { goal_id: args.goal_id });
 				return jsonResult({ success: true, goal });
 			} catch (err) {
@@ -1544,7 +1556,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		async resume_goal(args: { goal_id: string }): Promise<ToolResult> {
 			try {
 				requireGoalInSpace(args.goal_id);
-				const goal = requireGoalService().resumeGoal(args.goal_id);
+				const goal = requireGoalService().resumeGoal(args.goal_id, goalToolContext);
 				logAudit('resume_goal', { goal_id: args.goal_id });
 				return jsonResult({ success: true, goal });
 			} catch (err) {
@@ -1556,7 +1568,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		async trigger_goal_task(args: { goal_id: string }): Promise<ToolResult> {
 			try {
 				requireGoalInSpace(args.goal_id);
-				const result = requireGoalService().createImmediateTask(args.goal_id);
+				const result = requireGoalService().createImmediateTask(args.goal_id, goalToolContext);
 				logAudit('trigger_goal_task', { goal_id: args.goal_id }, result.task?.id);
 				return jsonResult({ success: true, ...result });
 			} catch (err) {
@@ -1576,6 +1588,24 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					.filter((task) => task.goalId === args.goal_id)
 					.filter((task) => (args.status ? task.status === args.status : true));
 				return jsonResult({ success: true, total: tasks.length, tasks });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_goal_events(args: {
+			goal_id: string;
+			limit?: number;
+			before?: number;
+		}): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const events = requireGoalService().listGoalEvents(args.goal_id, {
+					limit: args.limit,
+					before: args.before,
+				});
+				return jsonResult({ success: true, total: events.length, events });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
@@ -2170,6 +2200,16 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 						.describe('Filter by linked task status'),
 				},
 				(args) => handlers.list_goal_tasks(args)
+			),
+			tool(
+				'list_goal_events',
+				'List append-only history events for a goal. Use this to understand why the current rolling state changed before updating it.',
+				{
+					goal_id: z.string().describe('Goal ID'),
+					limit: z.number().int().min(1).max(100).optional().describe('Max events to return'),
+					before: z.number().int().optional().describe('Return events before this timestamp'),
+				},
+				(args) => handlers.list_goal_events(args)
 			)
 		);
 	}

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -120,7 +120,34 @@ export type SubmitForApprovalInput = z.infer<typeof SubmitForApprovalSchema>;
  * Takes no arguments — the task is implicit from the calling session's
  * context. Strict schema so future fields fail fast until explicitly added.
  */
-export const MarkCompleteSchema = z.object({}).strict();
+export const GoalUpdateSchema = z
+	.object({
+		summary: z.string().describe('Updated rolling summary for the linked goal').optional(),
+		progress: z
+			.number()
+			.int()
+			.min(0)
+			.max(100)
+			.describe('Updated goal progress percentage from 0 to 100')
+			.optional(),
+		metrics: z
+			.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+			.describe('Updated structured metric state for the linked goal')
+			.optional(),
+		nextSteps: z
+			.array(z.string())
+			.describe('Updated list of next steps for the linked goal')
+			.optional(),
+	})
+	.strict();
+
+export const MarkCompleteSchema = z
+	.object({
+		goal_update: GoalUpdateSchema.describe(
+			"Optional rolling-state update for the task's linked goal. Provide this when completed work changes long-horizon goal state."
+		).optional(),
+	})
+	.strict();
 
 export type MarkCompleteInput = z.infer<typeof MarkCompleteSchema>;
 

--- a/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
@@ -57,12 +57,22 @@ export class SpaceGoalEventRepository {
 
 	listByGoal(goalId: string, params: SpaceGoalEventListParams = {}): SpaceGoalEvent[] {
 		const limit = normalizeLimit(params.limit);
+		const cursorId = normalizeCursorId(params.beforeId);
 		const rows = params.before
-			? (this.db
-					.prepare(
-						`SELECT * FROM space_goal_events WHERE goal_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
-					)
-					.all(goalId, params.before, limit) as Record<string, unknown>[])
+			? cursorId
+				? (this.db
+						.prepare(
+							`SELECT * FROM space_goal_events WHERE goal_id = ? AND (created_at < ? OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?`
+						)
+						.all(goalId, params.before, params.before, cursorId, limit) as Record<
+						string,
+						unknown
+					>[])
+				: (this.db
+						.prepare(
+							`SELECT * FROM space_goal_events WHERE goal_id = ? AND created_at <= ? ORDER BY created_at DESC, id DESC LIMIT ?`
+						)
+						.all(goalId, params.before, limit) as Record<string, unknown>[])
 			: (this.db
 					.prepare(
 						`SELECT * FROM space_goal_events WHERE goal_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`
@@ -73,12 +83,22 @@ export class SpaceGoalEventRepository {
 
 	listBySpace(spaceId: string, params: SpaceGoalEventListParams = {}): SpaceGoalEvent[] {
 		const limit = normalizeLimit(params.limit);
+		const cursorId = normalizeCursorId(params.beforeId);
 		const rows = params.before
-			? (this.db
-					.prepare(
-						`SELECT * FROM space_goal_events WHERE space_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
-					)
-					.all(spaceId, params.before, limit) as Record<string, unknown>[])
+			? cursorId
+				? (this.db
+						.prepare(
+							`SELECT * FROM space_goal_events WHERE space_id = ? AND (created_at < ? OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?`
+						)
+						.all(spaceId, params.before, params.before, cursorId, limit) as Record<
+						string,
+						unknown
+					>[])
+				: (this.db
+						.prepare(
+							`SELECT * FROM space_goal_events WHERE space_id = ? AND created_at <= ? ORDER BY created_at DESC, id DESC LIMIT ?`
+						)
+						.all(spaceId, params.before, limit) as Record<string, unknown>[])
 			: (this.db
 					.prepare(
 						`SELECT * FROM space_goal_events WHERE space_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`
@@ -121,4 +141,8 @@ function parseJson<T>(value: unknown, fallback: T | null): T | null {
 function normalizeLimit(limit: number | undefined): number {
 	if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
 	return Math.max(1, Math.min(MAX_LIMIT, Math.trunc(limit as number)));
+}
+
+function normalizeCursorId(id: string | undefined): string | null {
+	return typeof id === 'string' && id.length > 0 ? id : null;
 }

--- a/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
@@ -70,7 +70,7 @@ export class SpaceGoalEventRepository {
 					>[])
 				: (this.db
 						.prepare(
-							`SELECT * FROM space_goal_events WHERE goal_id = ? AND created_at <= ? ORDER BY created_at DESC, id DESC LIMIT ?`
+							`SELECT * FROM space_goal_events WHERE goal_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
 						)
 						.all(goalId, params.before, limit) as Record<string, unknown>[])
 			: (this.db
@@ -96,7 +96,7 @@ export class SpaceGoalEventRepository {
 					>[])
 				: (this.db
 						.prepare(
-							`SELECT * FROM space_goal_events WHERE space_id = ? AND created_at <= ? ORDER BY created_at DESC, id DESC LIMIT ?`
+							`SELECT * FROM space_goal_events WHERE space_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
 						)
 						.all(spaceId, params.before, limit) as Record<string, unknown>[])
 			: (this.db

--- a/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-event-repository.ts
@@ -1,0 +1,124 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	CreateSpaceGoalEventParams,
+	SpaceGoalEvent,
+	SpaceGoalEventDiff,
+	SpaceGoalEventListParams,
+	SpaceGoalEventSnapshot,
+	SpaceGoalEventSource,
+	SpaceGoalEventType,
+} from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export class SpaceGoalEventRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
+
+	create(params: CreateSpaceGoalEventParams): SpaceGoalEvent {
+		const id = generateUUID();
+		const createdAt = params.createdAt ?? Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_goal_events (
+					id, space_id, goal_id, event_type, source, source_task_id, source_session_id,
+					previous_state, new_state, diff, note, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.goalId,
+				params.eventType,
+				params.source,
+				params.sourceTaskId ?? null,
+				params.sourceSessionId ?? null,
+				stringifyNullable(params.previousState),
+				stringifyNullable(params.newState),
+				stringifyNullable(params.diff),
+				params.note ?? null,
+				createdAt
+			);
+		this.reactiveDb?.notifyChange('space_goal_events');
+		return this.getById(id) as SpaceGoalEvent;
+	}
+
+	getById(id: string): SpaceGoalEvent | null {
+		const row = this.db.prepare(`SELECT * FROM space_goal_events WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToEvent(row) : null;
+	}
+
+	listByGoal(goalId: string, params: SpaceGoalEventListParams = {}): SpaceGoalEvent[] {
+		const limit = normalizeLimit(params.limit);
+		const rows = params.before
+			? (this.db
+					.prepare(
+						`SELECT * FROM space_goal_events WHERE goal_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
+					)
+					.all(goalId, params.before, limit) as Record<string, unknown>[])
+			: (this.db
+					.prepare(
+						`SELECT * FROM space_goal_events WHERE goal_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`
+					)
+					.all(goalId, limit) as Record<string, unknown>[]);
+		return rows.map(rowToEvent);
+	}
+
+	listBySpace(spaceId: string, params: SpaceGoalEventListParams = {}): SpaceGoalEvent[] {
+		const limit = normalizeLimit(params.limit);
+		const rows = params.before
+			? (this.db
+					.prepare(
+						`SELECT * FROM space_goal_events WHERE space_id = ? AND created_at < ? ORDER BY created_at DESC, id DESC LIMIT ?`
+					)
+					.all(spaceId, params.before, limit) as Record<string, unknown>[])
+			: (this.db
+					.prepare(
+						`SELECT * FROM space_goal_events WHERE space_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`
+					)
+					.all(spaceId, limit) as Record<string, unknown>[]);
+		return rows.map(rowToEvent);
+	}
+}
+
+function rowToEvent(row: Record<string, unknown>): SpaceGoalEvent {
+	return {
+		id: row.id as string,
+		spaceId: row.space_id as string,
+		goalId: row.goal_id as string,
+		eventType: row.event_type as SpaceGoalEventType,
+		source: row.source as SpaceGoalEventSource,
+		sourceTaskId: (row.source_task_id as string | null) ?? null,
+		sourceSessionId: (row.source_session_id as string | null) ?? null,
+		previousState: parseJson<SpaceGoalEventSnapshot>(row.previous_state, null),
+		newState: parseJson<SpaceGoalEventSnapshot>(row.new_state, null),
+		diff: parseJson<SpaceGoalEventDiff>(row.diff, null),
+		note: (row.note as string | null) ?? null,
+		createdAt: row.created_at as number,
+	};
+}
+
+function stringifyNullable(value: unknown): string | null {
+	return value == null ? null : JSON.stringify(value);
+}
+
+function parseJson<T>(value: unknown, fallback: T | null): T | null {
+	if (typeof value !== 'string') return fallback;
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function normalizeLimit(limit: number | undefined): number {
+	if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+	return Math.max(1, Math.min(MAX_LIMIT, Math.trunc(limit as number)));
+}

--- a/packages/daemon/src/storage/repositories/space-goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-repository.ts
@@ -1,0 +1,222 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	CreateSpaceGoalParams,
+	SpaceGoal,
+	SpaceGoalListParams,
+	SpaceGoalMetrics,
+	SpaceGoalStatus,
+	UpdateSpaceGoalParams,
+} from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+import type { SQLiteValue } from '../types';
+
+export class SpaceGoalRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
+
+	create(params: CreateSpaceGoalParams): SpaceGoal {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO space_goals (
+					id, space_id, title, description, status, type, priority, labels, metrics,
+					summary, progress, next_steps, preferred_workflow_id, auto_trigger_next,
+					pending_next_run, active_task_id, last_task_id, last_check_in_at,
+					next_check_in_at, created_at, updated_at, completed_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.title,
+				params.description ?? '',
+				'active',
+				params.type ?? 'one_shot',
+				params.priority ?? 'normal',
+				JSON.stringify(params.labels ?? []),
+				JSON.stringify(params.metrics ?? {}),
+				params.summary ?? '',
+				clampProgress(params.progress ?? 0),
+				JSON.stringify(params.nextSteps ?? []),
+				params.preferredWorkflowId ?? null,
+				params.autoTriggerNext ? 1 : 0,
+				0,
+				null,
+				null,
+				null,
+				null,
+				now,
+				now,
+				null
+			);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id) as SpaceGoal;
+	}
+
+	getById(id: string): SpaceGoal | null {
+		const row = this.db.prepare(`SELECT * FROM space_goals WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? this.rowToGoal(row) : null;
+	}
+
+	list(params: SpaceGoalListParams): SpaceGoal[] {
+		const values: SQLiteValue[] = [params.spaceId];
+		let where = `WHERE space_id = ?`;
+		if (params.status) {
+			where += ` AND status = ?`;
+			values.push(params.status);
+		} else if (!params.includeArchived) {
+			where += ` AND status != 'archived'`;
+		}
+		const rows = this.db
+			.prepare(`SELECT * FROM space_goals ${where} ORDER BY updated_at DESC, id DESC`)
+			.all(...values) as Record<string, unknown>[];
+		let goals = rows.map((r) => this.rowToGoal(r));
+		if (params.label) {
+			goals = goals.filter((goal) => goal.labels.includes(params.label as string));
+		}
+		if (params.search) {
+			const q = params.search.toLowerCase();
+			goals = goals.filter(
+				(goal) => goal.title.toLowerCase().includes(q) || goal.description.toLowerCase().includes(q)
+			);
+		}
+		return goals;
+	}
+
+	update(id: string, params: UpdateSpaceGoalParams): SpaceGoal | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+
+		if (params.title !== undefined) add('title', params.title);
+		if (params.description !== undefined) add('description', params.description);
+		if (params.status !== undefined) add('status', params.status);
+		if (params.type !== undefined) add('type', params.type);
+		if (params.priority !== undefined) add('priority', params.priority);
+		if (params.labels !== undefined) add('labels', JSON.stringify(params.labels));
+		if (params.metrics !== undefined) add('metrics', JSON.stringify(params.metrics));
+		if (params.summary !== undefined) add('summary', params.summary);
+		if (params.progress !== undefined) add('progress', clampProgress(params.progress));
+		if (params.nextSteps !== undefined) add('next_steps', JSON.stringify(params.nextSteps));
+		if (params.preferredWorkflowId !== undefined) {
+			add('preferred_workflow_id', params.preferredWorkflowId ?? null);
+		}
+		if (params.autoTriggerNext !== undefined)
+			add('auto_trigger_next', params.autoTriggerNext ? 1 : 0);
+		if (params.pendingNextRun !== undefined) add('pending_next_run', params.pendingNextRun ? 1 : 0);
+		if (params.activeTaskId !== undefined) add('active_task_id', params.activeTaskId ?? null);
+		if (params.lastTaskId !== undefined) add('last_task_id', params.lastTaskId ?? null);
+		if (params.lastCheckInAt !== undefined) add('last_check_in_at', params.lastCheckInAt ?? null);
+		if (params.nextCheckInAt !== undefined) add('next_check_in_at', params.nextCheckInAt ?? null);
+		if (params.completedAt !== undefined) add('completed_at', params.completedAt ?? null);
+
+		const existingForStatus =
+			params.status !== undefined && params.completedAt === undefined ? this.getById(id) : null;
+		if (params.status === 'completed' && params.completedAt === undefined) {
+			if (!existingForStatus?.completedAt) add('completed_at', Date.now());
+		}
+		if (
+			params.status &&
+			params.status !== 'completed' &&
+			params.completedAt === undefined &&
+			!(params.status === 'archived' && existingForStatus?.completedAt)
+		) {
+			add('completed_at', null);
+		}
+
+		if (sets.length === 0) return this.getById(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db.prepare(`UPDATE space_goals SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id);
+	}
+
+	setTaskScheduleId(id: string, scheduleId: string | null): SpaceGoal | null {
+		this.db
+			.prepare(`UPDATE space_goals SET task_schedule_id = ?, updated_at = ? WHERE id = ?`)
+			.run(scheduleId, Date.now(), id);
+		this.reactiveDb?.notifyChange('space_goals');
+		return this.getById(id);
+	}
+
+	claimActiveTask(goalId: string, taskId: string): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE space_goals
+				 SET active_task_id = ?, last_task_id = ?, pending_next_run = 0,
+				     last_check_in_at = ?, updated_at = ?
+				 WHERE id = ? AND status = 'active' AND active_task_id IS NULL`
+			)
+			.run(taskId, taskId, Date.now(), Date.now(), goalId);
+		if (result.changes > 0) this.reactiveDb?.notifyChange('space_goals');
+		return result.changes > 0;
+	}
+
+	queueNextRun(goalId: string): SpaceGoal | null {
+		return this.update(goalId, { pendingNextRun: true });
+	}
+
+	clearActiveTaskIfMatches(goalId: string, taskId: string): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE space_goals
+				 SET active_task_id = NULL, last_task_id = ?, updated_at = ?
+				 WHERE id = ? AND active_task_id = ?`
+			)
+			.run(taskId, Date.now(), goalId, taskId);
+		if (result.changes > 0) this.reactiveDb?.notifyChange('space_goals');
+		return result.changes > 0;
+	}
+
+	private rowToGoal(row: Record<string, unknown>): SpaceGoal {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			title: row.title as string,
+			description: (row.description as string) ?? '',
+			status: row.status as SpaceGoalStatus,
+			type: row.type as SpaceGoal['type'],
+			priority: row.priority as SpaceGoal['priority'],
+			labels: parseJson<string[]>(row.labels, []),
+			metrics: parseJson<SpaceGoalMetrics>(row.metrics, {}),
+			summary: (row.summary as string) ?? '',
+			progress: (row.progress as number | null) ?? 0,
+			nextSteps: parseJson<string[]>(row.next_steps, []),
+			preferredWorkflowId: (row.preferred_workflow_id as string | null) ?? null,
+			taskScheduleId: (row.task_schedule_id as string | null) ?? null,
+			autoTriggerNext: row.auto_trigger_next === 1,
+			pendingNextRun: row.pending_next_run === 1,
+			activeTaskId: (row.active_task_id as string | null) ?? null,
+			lastTaskId: (row.last_task_id as string | null) ?? null,
+			lastCheckInAt: (row.last_check_in_at as number | null) ?? null,
+			nextCheckInAt: (row.next_check_in_at as number | null) ?? null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+			completedAt: (row.completed_at as number | null) ?? null,
+		};
+	}
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+	if (typeof value !== 'string') return fallback;
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function clampProgress(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.min(100, Math.round(value)));
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -10,8 +10,8 @@ import type {
 	SpaceTask,
 	SpaceBlockReason,
 	SpaceTaskStatus,
-	CreateSpaceTaskParams,
-	UpdateSpaceTaskParams,
+	InternalCreateSpaceTaskParams,
+	InternalUpdateSpaceTaskParams,
 } from '@neokai/shared';
 import type { ReactiveDatabase } from '../reactive-database';
 import type { SQLiteValue } from '../types';
@@ -25,7 +25,7 @@ export class SpaceTaskRepository {
 	/**
 	 * Create a new space task
 	 */
-	createTask(params: CreateSpaceTaskParams): SpaceTask {
+	createTask(params: InternalCreateSpaceTaskParams): SpaceTask {
 		const id = generateUUID();
 		const now = Date.now();
 
@@ -44,8 +44,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -59,6 +59,7 @@ export class SpaceTaskRepository {
 					params.workflowRunId ?? null,
 					params.preferredWorkflowId ?? null,
 					params.createdByTaskId ?? null,
+					params.goalId ?? null,
 					JSON.stringify(params.dependsOn ?? []),
 					params.taskAgentSessionId ?? null,
 					params.createdBy ?? null,
@@ -264,7 +265,7 @@ export class SpaceTaskRepository {
 	/**
 	 * Update a task with partial updates
 	 */
-	updateTask(id: string, params: UpdateSpaceTaskParams): SpaceTask | null {
+	updateTask(id: string, params: InternalUpdateSpaceTaskParams): SpaceTask | null {
 		const fields: string[] = [];
 		const values: SQLiteValue[] = [];
 
@@ -322,6 +323,10 @@ export class SpaceTaskRepository {
 		if (params.preferredWorkflowId !== undefined) {
 			fields.push('preferred_workflow_id = ?');
 			values.push(params.preferredWorkflowId ?? null);
+		}
+		if (params.goalId !== undefined) {
+			fields.push('goal_id = ?');
+			values.push(params.goalId ?? null);
 		}
 		if (params.createdByTaskId !== undefined) {
 			fields.push('created_by_task_id = ?');
@@ -513,22 +518,18 @@ export class SpaceTaskRepository {
 	 * terminal states have their sessions torn down, and `'open'` tasks have
 	 * no Task Agent yet.
 	 */
-	listActiveWithTaskAgentSession(): SpaceTask[] {
+	/** List all tasks with non-terminal statuses (in_progress, review, blocked, approved). */
+	listActive(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'review', 'blocked', 'approved') AND task_agent_session_id IS NOT NULL`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'review', 'blocked', 'approved')`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
 	}
 
-	/**
-	 * List all active (non-terminal) tasks regardless of task_agent_session_id.
-	 * Used by TaskAgentManager.rehydrate() to restore sub-sessions for all
-	 * active workflow runs after a daemon restart.
-	 */
-	listActive(): SpaceTask[] {
+	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'review', 'blocked', 'approved')`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'review', 'blocked', 'approved') AND task_agent_session_id IS NOT NULL`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
@@ -588,6 +589,7 @@ export class SpaceTaskRepository {
 			createdBy: (row.created_by as string | null) ?? undefined,
 			createdBySession: (row.created_by_session as string | null) ?? undefined,
 			createdByTaskScheduleId: (row.created_by_task_schedule_id as string | null) ?? undefined,
+			goalId: (row.goal_id as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -28,6 +28,7 @@ export interface CreateTaskScheduleParams {
 	nextRunAt?: number | null;
 	createdByAgent?: string | null;
 	createdBySession?: string | null;
+	goalId?: string | null;
 }
 
 export interface UpdateTaskScheduleParams {
@@ -57,8 +58,8 @@ export class TaskScheduleRepository {
 					id, space_id, title, description, priority, preferred_workflow_id,
 					labels, trigger_type, cron_expression, run_at, timezone,
 					next_run_at, last_run_at, last_created_task_id, pending_job_id,
-					status, created_by_agent, created_by_session, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					status, created_by_agent, created_by_session, goal_id, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				id,
@@ -79,6 +80,7 @@ export class TaskScheduleRepository {
 				'active',
 				params.createdByAgent ?? null,
 				params.createdBySession ?? null,
+				params.goalId ?? null,
 				now,
 				now
 			);
@@ -273,7 +275,7 @@ export class TaskScheduleRepository {
 		id: string,
 		expectedPendingJobId: string,
 		opts: {
-			lastCreatedTaskId: string;
+			lastCreatedTaskId: string | null;
 			lastRunAt: number;
 			nextRunAt: number | null;
 			status: TaskScheduleStatus;
@@ -385,6 +387,7 @@ export class TaskScheduleRepository {
 			status: row.status as TaskScheduleStatus,
 			createdByAgent: (row.created_by_agent as string | null) ?? null,
 			createdBySession: (row.created_by_session as string | null) ?? null,
+			goalId: (row.goal_id as string | null) ?? null,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 		};

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -103,6 +103,8 @@ export { runMigration130 } from './migrations';
 export { runMigration131 } from './migrations';
 // knip-ignore-next-line
 export { runMigration132 } from './migrations';
+// knip-ignore-next-line
+export { runMigration133 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -339,6 +341,28 @@ export function createTables(db: BunDatabase): void {
         FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
       )
     `);
+
+	db.exec(`
+	      CREATE TABLE IF NOT EXISTS space_goal_events (
+	        id TEXT PRIMARY KEY,
+	        space_id TEXT NOT NULL,
+	        goal_id TEXT NOT NULL,
+	        event_type TEXT NOT NULL
+	          CHECK(event_type IN ('created', 'updated', 'status_changed', 'task_triggered', 'task_queued', 'task_terminal', 'schedule_updated')),
+	        source TEXT NOT NULL
+	          CHECK(source IN ('rpc', 'space_agent_tool', 'workflow_node_agent', 'scheduler', 'system')),
+	        source_task_id TEXT,
+	        source_session_id TEXT,
+	        previous_state TEXT,
+	        new_state TEXT,
+	        diff TEXT,
+	        note TEXT,
+	        created_at INTEGER NOT NULL,
+	        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+	        FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+	        FOREIGN KEY (source_task_id) REFERENCES space_tasks(id) ON DELETE SET NULL
+	      )
+	    `);
 
 	// Short ID counters — per-(entity_type, scope_id) monotonic counter for short ID allocation
 	db.exec(`
@@ -786,6 +810,16 @@ function createIndexes(db: BunDatabase): void {
 	);
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_mission_executions_one_running ON mission_executions(goal_id) WHERE status = 'running'`
+	);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_goal_created ON space_goal_events(goal_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_space_created ON space_goal_events(space_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_source_task ON space_goal_events(source_task_id, created_at DESC)`
 	);
 
 	// GitHub integration indexes

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -98,6 +98,8 @@ export { runMigration128 } from './migrations';
 // knip-ignore-next-line
 export { runMigration129 } from './migrations';
 // knip-ignore-next-line
+export { runMigration130 } from './migrations';
+// knip-ignore-next-line
 export { runMigration131 } from './migrations';
 // knip-ignore-next-line
 export { runMigration132 } from './migrations';
@@ -128,7 +130,7 @@ export function createTables(db: BunDatabase): void {
         processing_state TEXT,
         archived_at TEXT,
         parent_id TEXT,
-        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat')),
+        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat', 'neo')),
         session_context TEXT
       )
     `);
@@ -168,7 +170,7 @@ export function createTables(db: BunDatabase): void {
         sdk_message TEXT NOT NULL,
         timestamp TEXT NOT NULL,
         send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed')),
-        origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'system')),
+        origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system')),
         is_renderable INTEGER NOT NULL DEFAULT 1,
         is_terminal INTEGER NOT NULL DEFAULT 0,
         parent_tool_use_id TEXT,
@@ -264,6 +266,41 @@ export function createTables(db: BunDatabase): void {
         short_id TEXT,
         restrictions TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+      )
+    `);
+
+	// Space-native long-horizon goals. These intentionally do not couple to
+	// the legacy room `goals` / mission execution tables above: goal state lives
+	// here, concrete execution happens through linked `space_tasks` rows.
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS space_goals (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+        type TEXT NOT NULL DEFAULT 'one_shot'
+          CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+        priority TEXT NOT NULL DEFAULT 'normal'
+          CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+        labels TEXT NOT NULL DEFAULT '[]',
+        metrics TEXT NOT NULL DEFAULT '{}',
+        summary TEXT NOT NULL DEFAULT '',
+        progress INTEGER NOT NULL DEFAULT 0,
+        next_steps TEXT NOT NULL DEFAULT '[]',
+        preferred_workflow_id TEXT,
+        task_schedule_id TEXT,
+        auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+        pending_next_run INTEGER NOT NULL DEFAULT 0,
+        active_task_id TEXT,
+        last_task_id TEXT,
+        last_check_in_at INTEGER,
+        next_check_in_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
       )
     `);
 
@@ -562,6 +599,23 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
+	// Neo activity log — audit log of all Neo agent tool invocations
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS neo_activity_log (
+        id          TEXT PRIMARY KEY,
+        tool_name   TEXT NOT NULL,
+        input       TEXT,
+        output      TEXT,
+        status      TEXT NOT NULL DEFAULT 'success' CHECK(status IN ('success', 'error', 'cancelled')),
+        error       TEXT,
+        target_type TEXT,
+        target_id   TEXT,
+        undoable    INTEGER DEFAULT 0,
+        undo_data   TEXT,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,
@@ -733,6 +787,12 @@ function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goals_next_check_in ON space_goals(status, next_check_in_at)`
+	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
 	db.exec(
@@ -778,6 +838,9 @@ function createIndexes(db: BunDatabase): void {
 		`CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC)`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_neo_activity_log_created_at ON neo_activity_log(created_at)`
+	);
 	// Workspace history index — supports ORDER BY last_used_at DESC in list()
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_workspace_history_last_used_at ON workspace_history(last_used_at DESC)`

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -130,7 +130,7 @@ export function createTables(db: BunDatabase): void {
         processing_state TEXT,
         archived_at TEXT,
         parent_id TEXT,
-        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat', 'neo')),
+        type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat')),
         session_context TEXT
       )
     `);
@@ -170,7 +170,7 @@ export function createTables(db: BunDatabase): void {
         sdk_message TEXT NOT NULL,
         timestamp TEXT NOT NULL,
         send_status TEXT DEFAULT 'consumed' CHECK(send_status IN ('deferred', 'enqueued', 'consumed', 'failed')),
-        origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system')),
+        origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'system')),
         is_renderable INTEGER NOT NULL DEFAULT 1,
         is_terminal INTEGER NOT NULL DEFAULT 0,
         parent_tool_use_id TEXT,
@@ -269,41 +269,6 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
-	// Space-native long-horizon goals. These intentionally do not couple to
-	// the legacy room `goals` / mission execution tables above: goal state lives
-	// here, concrete execution happens through linked `space_tasks` rows.
-	db.exec(`
-      CREATE TABLE IF NOT EXISTS space_goals (
-        id TEXT PRIMARY KEY,
-        space_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        status TEXT NOT NULL DEFAULT 'active'
-          CHECK(status IN ('active', 'paused', 'completed', 'archived')),
-        type TEXT NOT NULL DEFAULT 'one_shot'
-          CHECK(type IN ('one_shot', 'measurable', 'recurring')),
-        priority TEXT NOT NULL DEFAULT 'normal'
-          CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
-        labels TEXT NOT NULL DEFAULT '[]',
-        metrics TEXT NOT NULL DEFAULT '{}',
-        summary TEXT NOT NULL DEFAULT '',
-        progress INTEGER NOT NULL DEFAULT 0,
-        next_steps TEXT NOT NULL DEFAULT '[]',
-        preferred_workflow_id TEXT,
-        task_schedule_id TEXT,
-        auto_trigger_next INTEGER NOT NULL DEFAULT 0,
-        pending_next_run INTEGER NOT NULL DEFAULT 0,
-        active_task_id TEXT,
-        last_task_id TEXT,
-        last_check_in_at INTEGER,
-        next_check_in_at INTEGER,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        completed_at INTEGER,
-        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
-      )
-    `);
-
 	// Goals table
 	db.exec(`
       CREATE TABLE IF NOT EXISTS goals (
@@ -337,6 +302,41 @@ export function createTables(db: BunDatabase): void {
         replan_count INTEGER NOT NULL DEFAULT 0,
         short_id TEXT,
         FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE
+      )
+    `);
+
+	// Space-native long-horizon goals. These intentionally do not couple to
+	// the legacy room `goals` / mission execution tables above: goal state lives
+	// here, concrete execution happens through linked `space_tasks` rows.
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS space_goals (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'active'
+          CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+        type TEXT NOT NULL DEFAULT 'one_shot'
+          CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+        priority TEXT NOT NULL DEFAULT 'normal'
+          CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+        labels TEXT NOT NULL DEFAULT '[]',
+        metrics TEXT NOT NULL DEFAULT '{}',
+        summary TEXT NOT NULL DEFAULT '',
+        progress INTEGER NOT NULL DEFAULT 0,
+        next_steps TEXT NOT NULL DEFAULT '[]',
+        preferred_workflow_id TEXT,
+        task_schedule_id TEXT,
+        auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+        pending_next_run INTEGER NOT NULL DEFAULT 0,
+        active_task_id TEXT,
+        last_task_id TEXT,
+        last_check_in_at INTEGER,
+        next_check_in_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
       )
     `);
 
@@ -599,23 +599,6 @@ export function createTables(db: BunDatabase): void {
       )
     `);
 
-	// Neo activity log — audit log of all Neo agent tool invocations
-	db.exec(`
-      CREATE TABLE IF NOT EXISTS neo_activity_log (
-        id          TEXT PRIMARY KEY,
-        tool_name   TEXT NOT NULL,
-        input       TEXT,
-        output      TEXT,
-        status      TEXT NOT NULL DEFAULT 'success' CHECK(status IN ('success', 'error', 'cancelled')),
-        error       TEXT,
-        target_type TEXT,
-        target_id   TEXT,
-        undoable    INTEGER DEFAULT 0,
-        undo_data   TEXT,
-        created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-      )
-    `);
-
 	db.exec(`
       CREATE TABLE IF NOT EXISTS job_queue (
         id TEXT PRIMARY KEY,
@@ -787,14 +770,14 @@ function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room_updated ON tasks(room_id, updated_at DESC)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_goals_next_check_in ON space_goals(status, next_check_in_at)`
 	);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_room ON goals(room_id)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status)`);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_goals_mission_scheduler ON goals(mission_type, schedule_paused, next_run_at)`
 	);
@@ -838,9 +821,6 @@ function createIndexes(db: BunDatabase): void {
 		`CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC)`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_job_queue_status ON job_queue(status)`);
-	db.exec(
-		`CREATE INDEX IF NOT EXISTS idx_neo_activity_log_created_at ON neo_activity_log(created_at)`
-	);
 	// Workspace history index — supports ORDER BY last_used_at DESC in list()
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_workspace_history_last_used_at ON workspace_history(last_used_at DESC)`

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -5002,6 +5002,18 @@ function runMigration65(db: BunDatabase): void {
  *   created_at  - ISO 8601 timestamp (default: current UTC time)
  */
 export function runMigration66(db: BunDatabase): void {
+	// Skip the entire migration if Neo support has already been removed by M131
+	// (or the table was created fresh at the M131 tip without 'neo' in the CHECK).
+	// Re-running the legacy probe-and-rebuild here would rebuild `sessions` with a
+	// stale CHECK that rejects post-M66 types like 'space_chat', crashing startup
+	// on any DB created or upgraded under the M131 schema.
+	if (tableExists(db, 'sessions')) {
+		const sessionsSql = tableCreateSql(db, 'sessions');
+		if (sessionsSql && !sessionsSql.includes("'neo'")) {
+			return;
+		}
+	}
+
 	// --- Part 1: Expand sessions.type CHECK constraint to include 'neo' ---
 	if (tableExists(db, 'sessions')) {
 		try {
@@ -8817,17 +8829,45 @@ export function runMigration127(db: BunDatabase): void {
  * extension configuration.
  */
 export function runMigration128(db: BunDatabase): void {
+	const hadLegacyGlobalConfigTable = tableExists(db, 'external_event_source_configs');
+
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS external_event_source_configs (
+		CREATE TABLE IF NOT EXISTS external_event_extension_configs (
 			source TEXT PRIMARY KEY,
-			globally_enabled INTEGER NOT NULL DEFAULT 0,
-			capabilities_json TEXT NOT NULL,
-			secrets_ref TEXT,
-			settings_json TEXT,
+			globally_enabled INTEGER NOT NULL DEFAULT 0 CHECK(globally_enabled IN (0, 1)),
+			capabilities_json TEXT NOT NULL DEFAULT '{}',
+			secrets_ref TEXT DEFAULT NULL,
+			settings_json TEXT NOT NULL DEFAULT '{}',
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
 	`);
+
+	if (hadLegacyGlobalConfigTable) {
+		db.exec(`
+			INSERT OR IGNORE INTO external_event_extension_configs (
+				source, globally_enabled, capabilities_json, secrets_ref,
+				settings_json, created_at, updated_at
+			)
+			SELECT
+				source,
+				globally_enabled,
+				json_set(
+						CASE
+							WHEN json_valid(capabilities_json) AND json_type(capabilities_json) = 'object'
+								THEN capabilities_json
+							ELSE '{}'
+						END,
+						'$.rpcConfig',
+						json('true')
+					),
+				secrets_ref,
+				COALESCE(settings_json, '{}'),
+				created_at,
+				updated_at
+			FROM external_event_source_configs
+		`);
+	}
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
@@ -8841,6 +8881,13 @@ export function runMigration128(db: BunDatabase): void {
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
+
+	const now = Date.now();
+	db.prepare(
+		`INSERT OR IGNORE INTO external_event_extension_configs
+		 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
+		 VALUES ('github', 1, ?, NULL, '{}', ?, ?)`
+	).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }), now, now);
 }
 
 /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -629,6 +629,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 132: Add per-space persistent agent memory with FTS5 search.
 	runMigration132(db);
+
+	// Migration 133: Add append-only Space goal event history.
+	runMigration133(db);
 }
 
 /**
@@ -8938,16 +8941,6 @@ export function runMigration130(db: BunDatabase): void {
 	db.exec(`CREATE INDEX idx_gate_open_state_run ON gate_open_state(run_id)`);
 }
 
-/**
- * Migration 131: Remove global Neo prototype schema surface + add Space-native goals.
- *
- * Drops the Neo activity log table, converts any legacy `neo` session rows to
- * archived workers so existing messages remain reachable, and removes `neo`
- * from persisted CHECK constraints.
- *
- * Also creates the `space_goals` table and adds `goal_id` columns to
- * `space_tasks` and `task_schedules` for goal-task-schedule linkage.
- */
 export function runMigration131(db: BunDatabase): void {
 	if (tableExists(db, 'neo_activity_log')) {
 		db.exec(`DROP TABLE neo_activity_log`);
@@ -9071,6 +9064,47 @@ function migrateNeoSessions(db: BunDatabase): void {
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
 	}
+}
+
+/**
+ * Migration 133: Add append-only Space goal event history.
+ *
+ * Stores lifecycle and state-change events for Space goals so agents and
+ * humans can inspect why the current rolling goal state changed.
+ */
+export function runMigration133(db: BunDatabase): void {
+	if (!tableExists(db, 'space_goals')) return;
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goal_events (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			goal_id TEXT NOT NULL,
+			event_type TEXT NOT NULL
+				CHECK(event_type IN ('created', 'updated', 'status_changed', 'task_triggered', 'task_queued', 'task_terminal', 'schedule_updated')),
+			source TEXT NOT NULL
+				CHECK(source IN ('rpc', 'space_agent_tool', 'workflow_node_agent', 'scheduler', 'system')),
+			source_task_id TEXT,
+			source_session_id TEXT,
+			previous_state TEXT,
+			new_state TEXT,
+			diff TEXT,
+			note TEXT,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+			FOREIGN KEY (source_task_id) REFERENCES space_tasks(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_goal_created ON space_goal_events(goal_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_space_created ON space_goal_events(space_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_source_task ON space_goal_events(source_task_id, created_at DESC)`
+	);
 }
 
 export function runMigration132(db: BunDatabase): void {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -624,7 +624,7 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 130: Add gate_open_state table for persisting gate-open cache across daemon restarts.
 	runMigration130(db);
 
-	// Migration 131: Remove global Neo prototype schema surface.
+	// Migration 131: Add Space-native goals and goal linkage on space_tasks/task_schedules.
 	runMigration131(db);
 
 	// Migration 132: Add per-space persistent agent memory with FTS5 search.
@@ -5002,18 +5002,6 @@ function runMigration65(db: BunDatabase): void {
  *   created_at  - ISO 8601 timestamp (default: current UTC time)
  */
 export function runMigration66(db: BunDatabase): void {
-	// Skip the entire migration if Neo support has already been removed by M131
-	// (or the table was created fresh at the M131 tip without 'neo' in the CHECK).
-	// Re-running the legacy probe-and-rebuild here would rebuild `sessions` with a
-	// stale CHECK that rejects post-M66 types like 'space_chat', crashing startup
-	// on any DB created or upgraded under the M131 schema.
-	if (tableExists(db, 'sessions')) {
-		const sessionsSql = tableCreateSql(db, 'sessions');
-		if (sessionsSql && !sessionsSql.includes("'neo'")) {
-			return;
-		}
-	}
-
 	// --- Part 1: Expand sessions.type CHECK constraint to include 'neo' ---
 	if (tableExists(db, 'sessions')) {
 		try {
@@ -5175,6 +5163,7 @@ function runMigration67(db: BunDatabase): void {
  * This is an app-level metadata column alongside the opaque sdk_message blob.
  * It is NOT part of the SDK message format — room/space agents do not see it.
  * NULL (default) is treated as 'human' by the frontend.
+ * 'neo' marks messages injected by the Neo global AI agent.
  * 'system' marks messages injected by the daemon system internally.
  */
 /**
@@ -5211,7 +5200,7 @@ export function runMigration68(db: BunDatabase): void {
 	const hasOrigin = columns.some((col) => col.name === 'origin');
 	if (!hasOrigin) {
 		db.exec(
-			`ALTER TABLE sdk_messages ADD COLUMN origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'system'))`
+			`ALTER TABLE sdk_messages ADD COLUMN origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'neo', 'system'))`
 		);
 	}
 }
@@ -8237,7 +8226,7 @@ export function runMigration122(db: BunDatabase): void {
 		// `session_context.taskId`. Both the Task Agent and node-agent sub-sessions
 		// stamp this at creation, so a JOIN on `sessions` covers every Space
 		// session that ever produced messages. Sessions without a task context
-		// (worker sessions outside the Space system, lobby, etc.) get NULL —
+		// (worker sessions outside the Space system, lobby/neo, etc.) get NULL —
 		// the column is nullable on purpose.
 		//
 		// Runs whenever rows with `task_id IS NULL` remain for an allowed session
@@ -8820,7 +8809,7 @@ export function runMigration127(db: BunDatabase): void {
 /**
  * Migration 128: Add external-event extension configuration tables.
  *
- * external_event_extension_configs stores global source enablement, capabilities,
+ * external_event_source_configs stores global source enablement, capabilities,
  * secrets references, and source-level settings.
  *
  * space_external_event_source_configs stores per-space source enablement and
@@ -8828,45 +8817,17 @@ export function runMigration127(db: BunDatabase): void {
  * extension configuration.
  */
 export function runMigration128(db: BunDatabase): void {
-	const hadLegacyGlobalConfigTable = tableExists(db, 'external_event_source_configs');
-
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS external_event_extension_configs (
+		CREATE TABLE IF NOT EXISTS external_event_source_configs (
 			source TEXT PRIMARY KEY,
-			globally_enabled INTEGER NOT NULL DEFAULT 0 CHECK(globally_enabled IN (0, 1)),
-			capabilities_json TEXT NOT NULL DEFAULT '{}',
-			secrets_ref TEXT DEFAULT NULL,
-			settings_json TEXT NOT NULL DEFAULT '{}',
+			globally_enabled INTEGER NOT NULL DEFAULT 0,
+			capabilities_json TEXT NOT NULL,
+			secrets_ref TEXT,
+			settings_json TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
 	`);
-
-	if (hadLegacyGlobalConfigTable) {
-		db.exec(`
-			INSERT OR IGNORE INTO external_event_extension_configs (
-				source, globally_enabled, capabilities_json, secrets_ref,
-				settings_json, created_at, updated_at
-			)
-			SELECT
-				source,
-				globally_enabled,
-				json_set(
-						CASE
-							WHEN json_valid(capabilities_json) AND json_type(capabilities_json) = 'object'
-								THEN capabilities_json
-							ELSE '{}'
-						END,
-						'$.rpcConfig',
-						json('true')
-					),
-				secrets_ref,
-				COALESCE(settings_json, '{}'),
-				created_at,
-				updated_at
-			FROM external_event_source_configs
-		`);
-	}
 
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_external_event_source_configs (
@@ -8880,13 +8841,6 @@ export function runMigration128(db: BunDatabase): void {
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
-
-	const now = Date.now();
-	db.prepare(
-		`INSERT OR IGNORE INTO external_event_extension_configs
-		 (source, globally_enabled, capabilities_json, secrets_ref, settings_json, created_at, updated_at)
-		 VALUES ('github', 1, ?, NULL, '{}', ?, ?)`
-	).run(JSON.stringify({ webhooks: true, polling: false, rpcConfig: true }), now, now);
 }
 
 /**
@@ -8938,11 +8892,14 @@ export function runMigration130(db: BunDatabase): void {
 }
 
 /**
- * Migration 131: Remove global Neo prototype schema surface.
+ * Migration 131: Remove global Neo prototype schema surface + add Space-native goals.
  *
  * Drops the Neo activity log table, converts any legacy `neo` session rows to
  * archived workers so existing messages remain reachable, and removes `neo`
  * from persisted CHECK constraints.
+ *
+ * Also creates the `space_goals` table and adds `goal_id` columns to
+ * `space_tasks` and `task_schedules` for goal-task-schedule linkage.
  */
 export function runMigration131(db: BunDatabase): void {
 	if (tableExists(db, 'neo_activity_log')) {
@@ -8951,6 +8908,59 @@ export function runMigration131(db: BunDatabase): void {
 
 	migrateNeoSessions(db);
 	migrateNeoMessageOrigins(db);
+
+	// ── Space-native goals ───────────────────────────────────────────────────
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goals (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+			type TEXT NOT NULL DEFAULT 'one_shot'
+				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			summary TEXT NOT NULL DEFAULT '',
+			progress INTEGER NOT NULL DEFAULT 0,
+			next_steps TEXT NOT NULL DEFAULT '[]',
+			preferred_workflow_id TEXT,
+			task_schedule_id TEXT,
+			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+			pending_next_run INTEGER NOT NULL DEFAULT 0,
+			active_task_id TEXT,
+			last_task_id TEXT,
+			last_check_in_at INTEGER,
+			next_check_in_at INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goals_next_check_in ON space_goals(status, next_check_in_at)`
+	);
+
+	if (tableExists(db, 'space_tasks') && !tableHasColumn(db, 'space_tasks', 'goal_id')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN goal_id TEXT DEFAULT NULL`);
+	}
+	if (tableExists(db, 'space_tasks')) {
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+	}
+
+	if (tableExists(db, 'task_schedules') && !tableHasColumn(db, 'task_schedules', 'goal_id')) {
+		db.exec(`ALTER TABLE task_schedules ADD COLUMN goal_id TEXT DEFAULT NULL`);
+	}
+	if (tableExists(db, 'task_schedules')) {
+		db.exec(`CREATE INDEX IF NOT EXISTS idx_task_schedules_goal ON task_schedules(goal_id)`);
+	}
 }
 
 function migrateNeoSessions(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -79,7 +79,7 @@ describe('scope-config', () => {
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(18);
+			expect(names).toHaveLength(19);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -63,6 +63,7 @@ describe('scope-config', () => {
 				'space_workflow_nodes',
 				'space_workflow_runs',
 				'space_tasks',
+				'space_goals',
 				'space_worktrees',
 				'gate_data',
 				'channel_cycles',

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -64,6 +64,7 @@ describe('scope-config', () => {
 				'space_workflow_runs',
 				'space_tasks',
 				'space_goals',
+				'space_goal_events',
 				'space_worktrees',
 				'gate_data',
 				'channel_cycles',
@@ -78,7 +79,7 @@ describe('scope-config', () => {
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(17);
+			expect(names).toHaveLength(18);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -11,6 +11,9 @@ import { JobQueueRepository } from '../../../../src/storage/repositories/job-que
 import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository';
 import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
+import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository';
+import { ScheduleService } from '../../../../src/lib/space/schedule/schedule-service';
+import { SpaceGoalService } from '../../../../src/lib/space/goals/goal-service';
 import {
 	createInternalEventBus,
 	type DaemonInternalEventMap,
@@ -42,6 +45,8 @@ describe('handleTaskScheduleFire', () => {
 	let jobQueue: JobQueueRepository;
 	let spaceRepo: SpaceRepository;
 	let taskRepo: SpaceTaskRepository;
+	let goalRepo: SpaceGoalRepository;
+	let goalService: SpaceGoalService;
 	let spaceId: string;
 
 	beforeEach(() => {
@@ -73,6 +78,20 @@ describe('handleTaskScheduleFire', () => {
 		scheduleRepo = new TaskScheduleRepository(db as never);
 		jobQueue = new JobQueueRepository(db as never);
 		taskRepo = new SpaceTaskRepository(db as never);
+		goalRepo = new SpaceGoalRepository(db as never);
+		const scheduleService = new ScheduleService({
+			db: db as never,
+			scheduleRepo,
+			jobQueue,
+			spaceRepo,
+		});
+		goalService = new SpaceGoalService({
+			goalRepo,
+			taskRepo,
+			spaceRepo,
+			scheduleService,
+			db: db as never,
+		});
 
 		const space = spaceRepo.createSpace({
 			slug: 'test',
@@ -91,7 +110,13 @@ describe('handleTaskScheduleFire', () => {
 		return { db: db as never, scheduleRepo, jobQueue, spaceRepo, taskRepo, eventHub };
 	}
 
-	function createCronSchedule(): string {
+	function makeGoalDeps(eventHub?: {
+		publish: (event: string, data: unknown) => Promise<unknown>;
+	}) {
+		return { ...makeDeps(eventHub), goalService };
+	}
+
+	function createCronSchedule(goalId?: string): string {
 		const future = Date.now() + 60_000;
 		const schedule = scheduleRepo.create({
 			spaceId,
@@ -101,6 +126,7 @@ describe('handleTaskScheduleFire', () => {
 			cronExpression: '0 9 * * 1-5',
 			timezone: 'UTC',
 			nextRunAt: future,
+			goalId,
 		});
 		return schedule.id;
 	}
@@ -117,7 +143,7 @@ describe('handleTaskScheduleFire', () => {
 	}
 
 	it('creates a SpaceTask from the cron schedule template and re-enqueues itself', async () => {
-		const scheduleId = createCronSchedule();
+		const scheduleId = createCronSchedule('goal-1');
 		// Set pendingJobId so idempotency check sees a match.
 		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
 
@@ -132,6 +158,7 @@ describe('handleTaskScheduleFire', () => {
 		const task = taskRepo.getTask(result.taskId as string);
 		expect(task).not.toBeNull();
 		expect(task?.createdByTaskScheduleId).toBe(scheduleId);
+		expect(task?.goalId).toBe('goal-1');
 		expect(task?.title).toBe('Daily Standup');
 
 		// A new fire job was enqueued.
@@ -140,6 +167,62 @@ describe('handleTaskScheduleFire', () => {
 		expect(updated?.pendingJobId).not.toBe('job-1');
 		expect(updated?.lastCreatedTaskId).toBe(result.taskId);
 		expect(updated?.status).toBe('active');
+	});
+
+	it('claims scheduled goal tasks and syncs the next check-in time', async () => {
+		const goal = goalRepo.create({
+			spaceId,
+			title: 'Scheduled Goal',
+			autoTriggerNext: true,
+		});
+		const scheduleId = createCronSchedule(goal.id);
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+		goalRepo.setTaskScheduleId(goal.id, scheduleId);
+		goalRepo.update(goal.id, { nextCheckInAt: Date.now() + 1_000 });
+
+		const result = await handleTaskScheduleFire(
+			makeJob({ payload: { scheduleId } }),
+			makeGoalDeps()
+		);
+
+		expect(result.skipped).toBe(false);
+		expect(result.taskId).not.toBeNull();
+		const updated = goalRepo.getById(goal.id);
+		expect(updated?.activeTaskId).toBe(result.taskId);
+		expect(updated?.lastTaskId).toBe(result.taskId);
+		expect(updated?.nextCheckInAt).toBe(result.nextRunAt);
+	});
+
+	it('advances the schedule without creating a task when another goal task is active', async () => {
+		const goal = goalRepo.create({
+			spaceId,
+			title: 'Busy Goal',
+			autoTriggerNext: true,
+		});
+		const activeTask = taskRepo.createTask({
+			spaceId,
+			title: 'Existing goal task',
+			goalId: goal.id,
+		});
+		expect(goalRepo.claimActiveTask(goal.id, activeTask.id)).toBe(true);
+
+		const scheduleId = createCronSchedule(goal.id);
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+
+		const result = await handleTaskScheduleFire(
+			makeJob({ payload: { scheduleId } }),
+			makeGoalDeps()
+		);
+
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('goal_task_already_active');
+		expect(result.taskId).toBeNull();
+		expect(taskRepo.listBySpace(spaceId).map((task) => task.id)).toEqual([activeTask.id]);
+		const updated = scheduleRepo.getById(scheduleId);
+		expect(updated?.lastCreatedTaskId).toBeNull();
+		expect(updated?.pendingJobId).not.toBe('job-1');
+		expect(updated?.pendingJobId).not.toBeNull();
+		expect(goalRepo.getById(goal.id)?.activeTaskId).toBe(activeTask.id);
 	});
 
 	it('marks one-shot schedule as completed and does not re-enqueue', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -74,6 +74,7 @@ describe('ScheduleService', () => {
 			});
 
 			expect(schedule.status).toBe('active');
+			expect(schedule.goalId).toBeNull();
 			expect(schedule.nextRunAt).not.toBeNull();
 			expect(schedule.pendingJobId).not.toBeNull();
 
@@ -82,6 +83,30 @@ describe('ScheduleService', () => {
 			expect(job).not.toBeNull();
 			expect(job?.queue).toBe('taskSchedule.fire');
 			expect((job?.payload as { scheduleId: string }).scheduleId).toBe(schedule.id);
+		});
+
+		it('ignores hidden goalId fields on public schedule creation', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Public schedule',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				goalId: 'goal-1',
+			} as Parameters<ScheduleService['createSchedule']>[0] & { goalId: string });
+
+			expect(schedule.goalId).toBeNull();
+		});
+
+		it('links goals only through the internal goal schedule path', () => {
+			const schedule = service.createGoalSchedule({
+				spaceId,
+				title: 'Goal schedule',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				goalId: 'goal-1',
+			});
+
+			expect(schedule.goalId).toBe('goal-1');
 		});
 
 		it('rejects an invalid cron expression', () => {

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceGoalService } from '../../../src/lib/space/goals/goal-service';
+import { ScheduleService } from '../../../src/lib/space/schedule/schedule-service';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { TaskScheduleRepository } from '../../../src/storage/repositories/task-schedule-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+function createJobQueueTable(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS job_queue (
+			id TEXT PRIMARY KEY,
+			queue TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+			payload TEXT NOT NULL DEFAULT '{}',
+			result TEXT,
+			error TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
+			max_retries INTEGER NOT NULL DEFAULT 3,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			run_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+	`);
+}
+
+describe('SpaceGoalService', () => {
+	let db: Database;
+	let goalRepo: SpaceGoalRepository;
+	let taskRepo: SpaceTaskRepository;
+	let spaceRepo: SpaceRepository;
+	let scheduleRepo: TaskScheduleRepository;
+	let service: SpaceGoalService;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		createJobQueueTable(db);
+
+		goalRepo = new SpaceGoalRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+		spaceRepo = new SpaceRepository(db as never);
+		scheduleRepo = new TaskScheduleRepository(db as never);
+		const scheduleService = new ScheduleService({
+			db: db as never,
+			scheduleRepo,
+			jobQueue: new JobQueueRepository(db as never),
+			spaceRepo,
+		});
+		service = new SpaceGoalService({
+			goalRepo,
+			taskRepo,
+			spaceRepo,
+			scheduleService,
+			db: db as never,
+		});
+
+		const space = spaceRepo.createSpace({
+			slug: 'test',
+			workspacePath: '/workspace/test',
+			name: 'Test Space',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('creates a goal with rolling state and an optional recurring check-in schedule', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Improve onboarding',
+			description: 'Make first-run experience smoother',
+			type: 'recurring',
+			priority: 'high',
+			labels: ['product'],
+			metrics: { activated: 10 },
+			summary: 'Initial state',
+			progress: 35,
+			nextSteps: ['Audit current flow'],
+			preferredWorkflowId: 'workflow-1',
+			checkInCronExpression: '0 9 * * 1',
+			checkInTimezone: 'UTC',
+		});
+
+		expect(goal.title).toBe('Improve onboarding');
+		expect(goal.type).toBe('recurring');
+		expect(goal.priority).toBe('high');
+		expect(goal.labels).toEqual(['product']);
+		expect(goal.metrics).toEqual({ activated: 10 });
+		expect(goal.summary).toBe('Initial state');
+		expect(goal.progress).toBe(35);
+		expect(goal.nextSteps).toEqual(['Audit current flow']);
+		expect(goal.taskScheduleId).toBeString();
+		expect(goal.nextCheckInAt).not.toBeNull();
+
+		const schedule = scheduleRepo.getById(goal.taskScheduleId as string);
+		expect(schedule?.goalId).toBe(goal.id);
+		expect(schedule?.preferredWorkflowId).toBe('workflow-1');
+		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'product']);
+	});
+
+	it('creates an immediate goal task and queues concurrent triggers', () => {
+		const events: Array<{ event: string; taskId?: string }> = [];
+		service = new SpaceGoalService({
+			goalRepo,
+			taskRepo,
+			spaceRepo,
+			scheduleService: new ScheduleService({
+				db: db as never,
+				scheduleRepo,
+				jobQueue: new JobQueueRepository(db as never),
+				spaceRepo,
+			}),
+			db: db as never,
+			eventHub: {
+				publish: async (event, data) => {
+					events.push({ event, taskId: (data as { taskId?: string }).taskId });
+				},
+			},
+		});
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Ship docs',
+			labels: ['docs'],
+			preferredWorkflowId: 'workflow-docs',
+			autoTriggerNext: true,
+		});
+
+		const first = service.createImmediateTask(goal.id);
+		expect(first.queued).toBe(false);
+		expect(first.task?.goalId).toBe(goal.id);
+		expect(first.task?.preferredWorkflowId).toBe('workflow-docs');
+		expect(first.task?.labels).toEqual(['goal', `goal:${goal.id}`, 'docs']);
+		expect(first.goal.activeTaskId).toBe(first.task?.id);
+		expect(events).toEqual([{ event: 'space.task.created', taskId: first.task?.id }]);
+
+		const second = service.createImmediateTask(goal.id);
+		expect(second.queued).toBe(true);
+		expect(second.task).toBeNull();
+		expect(second.goal.pendingNextRun).toBe(true);
+	});
+
+	it('rejects concurrent manual triggers when auto-trigger is disabled', () => {
+		const goal = service.createGoal({ spaceId, title: 'Manual only' });
+		const first = service.createImmediateTask(goal.id);
+		expect(first.task).not.toBeNull();
+
+		expect(() => service.createImmediateTask(goal.id)).toThrow(
+			'Goal already has an active task and autoTriggerNext is disabled'
+		);
+		expect(goalRepo.getById(goal.id)?.pendingNextRun).toBe(false);
+	});
+
+	it('blocks immediate and auto-triggered goal tasks when host space is paused', () => {
+		const manualGoal = service.createGoal({ spaceId, title: 'Paused manual task' });
+		spaceRepo.pauseSpace(spaceId);
+		expect(() => service.createImmediateTask(manualGoal.id)).toThrow(
+			'Cannot create goal task in a non-active space'
+		);
+
+		spaceRepo.resumeSpace(spaceId);
+		const autoGoal = service.createGoal({
+			spaceId,
+			title: 'Paused auto task',
+			autoTriggerNext: true,
+		});
+		const first = service.createImmediateTask(autoGoal.id);
+		expect(first.task).not.toBeNull();
+		service.createImmediateTask(autoGoal.id);
+		spaceRepo.pauseSpace(spaceId);
+		taskRepo.updateTask(first.task!.id, { status: 'done' });
+
+		expect(() => service.handleTaskTerminal(first.task!.id)).toThrow(
+			'Cannot create goal task in a non-active space'
+		);
+		expect(taskRepo.listBySpace(spaceId).map((task) => task.id)).toEqual([first.task!.id]);
+	});
+
+	it('auto-triggers one queued task after the active task reaches a terminal status', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Keep improving',
+			autoTriggerNext: true,
+		});
+		const first = service.createImmediateTask(goal.id);
+		expect(first.task).not.toBeNull();
+		service.createImmediateTask(goal.id);
+
+		taskRepo.updateTask(first.task!.id, { status: 'done' });
+		const terminal = service.handleTaskTerminal(first.task!.id);
+
+		expect(terminal?.nextTask).not.toBeNull();
+		expect(terminal?.nextTask?.goalId).toBe(goal.id);
+		const updated = goalRepo.getById(goal.id);
+		expect(updated?.activeTaskId).toBe(terminal?.nextTask?.id);
+		expect(updated?.pendingNextRun).toBe(false);
+	});
+
+	it('ignores terminal and scheduled tasks linked to goals in another space', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Scoped goal',
+		});
+		const otherSpace = spaceRepo.createSpace({
+			slug: 'other',
+			workspacePath: '/workspace/other',
+			name: 'Other Space',
+		});
+		const task = taskRepo.createTask({
+			spaceId: otherSpace.id,
+			title: 'Cross-space task',
+			goalId: goal.id,
+		});
+		expect(goalRepo.claimActiveTask(goal.id, task.id)).toBe(true);
+
+		taskRepo.updateTask(task.id, { status: 'done' });
+
+		expect(service.handleTaskTerminal(task.id)).toBeNull();
+		expect(service.canClaimScheduledTask({ spaceId: otherSpace.id, goalId: goal.id })).toEqual({
+			goal: null,
+			claimable: false,
+		});
+		expect(service.claimScheduledTask(task.id, Date.now() + 60_000)).toEqual({
+			goal: null,
+			claimed: false,
+		});
+		expect(goalRepo.getById(goal.id)?.activeTaskId).toBe(task.id);
+	});
+
+	it('clears stale active task pointers before claiming scheduled goal tasks', () => {
+		const goal = service.createGoal({ spaceId, title: 'Recover stale active task' });
+		const staleTask = taskRepo.createTask({
+			spaceId,
+			title: 'Already finished',
+			goalId: goal.id,
+		});
+		expect(goalRepo.claimActiveTask(goal.id, staleTask.id)).toBe(true);
+		taskRepo.updateTask(staleTask.id, { status: 'done' });
+
+		const scheduledTask = taskRepo.createTask({
+			spaceId,
+			title: 'Scheduled follow-up',
+			goalId: goal.id,
+		});
+
+		expect(service.canClaimScheduledTask({ spaceId, goalId: goal.id }).claimable).toBe(true);
+		expect(service.claimScheduledTask(scheduledTask.id, Date.now() + 60_000).claimed).toBe(true);
+		expect(goalRepo.getById(goal.id)?.activeTaskId).toBe(scheduledTask.id);
+	});
+
+	it('keeps linked schedules in sync with goal lifecycle changes', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Weekly check-in',
+			checkInCronExpression: '0 9 * * 1',
+		});
+		const scheduleId = goal.taskScheduleId as string;
+
+		const paused = service.pauseGoal(goal.id);
+		expect(paused.status).toBe('paused');
+		expect(paused.nextCheckInAt).toBeNull();
+		expect(scheduleRepo.getById(scheduleId)?.status).toBe('paused');
+
+		const resumed = service.resumeGoal(goal.id);
+		expect(resumed.status).toBe('active');
+		expect(resumed.nextCheckInAt).not.toBeNull();
+		expect(scheduleRepo.getById(scheduleId)?.status).toBe('active');
+
+		const completed = service.updateGoal(goal.id, { status: 'completed' });
+		expect(completed.status).toBe('completed');
+		expect(completed.nextCheckInAt).toBeNull();
+		expect(scheduleRepo.getById(scheduleId)?.status).toBe('paused');
+
+		const reactivated = service.updateGoal(goal.id, { status: 'active' });
+		expect(reactivated.status).toBe('active');
+		expect(reactivated.nextCheckInAt).not.toBeNull();
+		expect(scheduleRepo.getById(scheduleId)?.status).toBe('active');
+	});
+
+	it('syncs linked schedule template fields after goal updates', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Weekly check-in',
+			description: 'Old description',
+			labels: ['old'],
+			preferredWorkflowId: 'workflow-old',
+			checkInCronExpression: '0 9 * * 1',
+		});
+		const scheduleId = goal.taskScheduleId as string;
+
+		service.updateGoal(goal.id, {
+			title: 'Updated check-in',
+			description: 'New description',
+			priority: 'high',
+			labels: ['new'],
+			summary: 'Fresh state',
+			nextSteps: ['Do next thing'],
+			preferredWorkflowId: 'workflow-new',
+		});
+
+		const schedule = scheduleRepo.getById(scheduleId);
+		expect(schedule?.title).toBe('Goal check-in: Updated check-in');
+		expect(schedule?.description).toContain('New description');
+		expect(schedule?.description).toContain('Fresh state');
+		expect(schedule?.description).toContain('Do next thing');
+		expect(schedule?.priority).toBe('high');
+		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'new']);
+		expect(schedule?.preferredWorkflowId).toBe('workflow-new');
+
+		service.updateGoal(goal.id, { title: 'Title only' });
+		const titleOnlySchedule = scheduleRepo.getById(scheduleId);
+		expect(titleOnlySchedule?.description).toContain('Do next thing');
+		expect(titleOnlySchedule?.preferredWorkflowId).toBe('workflow-new');
+	});
+
+	it('clears a missing linked schedule instead of blocking lifecycle changes', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Schedule drift',
+			checkInCronExpression: '0 9 * * 1',
+		});
+		scheduleRepo.delete(goal.taskScheduleId as string);
+
+		const paused = service.pauseGoal(goal.id);
+		expect(paused.status).toBe('paused');
+		expect(paused.taskScheduleId).toBeNull();
+	});
+
+	it('clears a missing linked schedule instead of blocking template updates', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Template drift',
+			checkInCronExpression: '0 9 * * 1',
+		});
+		scheduleRepo.delete(goal.taskScheduleId as string);
+
+		const updated = service.updateGoal(goal.id, { title: 'Updated after drift' });
+		expect(updated.title).toBe('Updated after drift');
+		expect(updated.taskScheduleId).toBeNull();
+	});
+
+	it('skips linked schedule template sync when update omits template fields', () => {
+		const goal = service.createGoal({
+			spaceId,
+			title: 'Schedule drift update',
+			checkInCronExpression: '0 9 * * 1',
+		});
+		scheduleRepo.delete(goal.taskScheduleId as string);
+
+		const updated = service.updateGoal(goal.id, { autoTriggerNext: true });
+		expect(updated.autoTriggerNext).toBe(true);
+		expect(updated.taskScheduleId).toBe(goal.taskScheduleId);
+	});
+
+	it('preserves completedAt when completed goals are updated again', () => {
+		const goal = service.createGoal({ spaceId, title: 'Complete once' });
+		const completed = service.updateGoal(goal.id, { status: 'completed' });
+		const completedAt = completed.completedAt;
+		expect(completedAt).not.toBeNull();
+
+		const updated = service.updateGoal(goal.id, { status: 'completed', summary: 'More detail' });
+		expect(updated.completedAt).toBe(completedAt);
+	});
+
+	it('preserves completedAt when completed goals are archived', () => {
+		const goal = service.createGoal({ spaceId, title: 'Archive after completion' });
+		const completed = service.updateGoal(goal.id, { status: 'completed' });
+		const completedAt = completed.completedAt;
+		expect(completedAt).not.toBeNull();
+
+		const archived = service.updateGoal(goal.id, { status: 'archived' });
+		expect(archived.status).toBe('archived');
+		expect(archived.completedAt).toBe(completedAt);
+	});
+
+	it('preserves completedAt when archived completed goals are edited again', () => {
+		const goal = service.createGoal({ spaceId, title: 'Edit archived completion' });
+		const completed = service.updateGoal(goal.id, { status: 'completed' });
+		const completedAt = completed.completedAt;
+		expect(completedAt).not.toBeNull();
+
+		service.updateGoal(goal.id, { status: 'archived' });
+		const edited = service.updateGoal(goal.id, {
+			status: 'archived',
+			summary: 'Archived goal still has completion timestamp',
+		});
+
+		expect(edited.status).toBe('archived');
+		expect(edited.completedAt).toBe(completedAt);
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -3,6 +3,7 @@ import { Database } from 'bun:sqlite';
 import { SpaceGoalService } from '../../../src/lib/space/goals/goal-service';
 import { ScheduleService } from '../../../src/lib/space/schedule/schedule-service';
 import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { SpaceGoalEventRepository } from '../../../src/storage/repositories/space-goal-event-repository';
 import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
@@ -34,6 +35,7 @@ function createJobQueueTable(db: Database): void {
 describe('SpaceGoalService', () => {
 	let db: Database;
 	let goalRepo: SpaceGoalRepository;
+	let goalEventRepo: SpaceGoalEventRepository;
 	let taskRepo: SpaceTaskRepository;
 	let spaceRepo: SpaceRepository;
 	let scheduleRepo: TaskScheduleRepository;
@@ -46,6 +48,7 @@ describe('SpaceGoalService', () => {
 		createJobQueueTable(db);
 
 		goalRepo = new SpaceGoalRepository(db as never);
+		goalEventRepo = new SpaceGoalEventRepository(db as never);
 		taskRepo = new SpaceTaskRepository(db as never);
 		spaceRepo = new SpaceRepository(db as never);
 		scheduleRepo = new TaskScheduleRepository(db as never);
@@ -57,6 +60,7 @@ describe('SpaceGoalService', () => {
 		});
 		service = new SpaceGoalService({
 			goalRepo,
+			goalEventRepo,
 			taskRepo,
 			spaceRepo,
 			scheduleService,
@@ -109,10 +113,51 @@ describe('SpaceGoalService', () => {
 		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'product']);
 	});
 
+	it('records goal update, status, task, and schedule events', () => {
+		const goal = service.createGoal({ spaceId, title: 'Audit me', autoTriggerNext: true });
+		const createdEvents = goalEventRepo.listByGoal(goal.id);
+		expect(createdEvents).toHaveLength(1);
+		expect(createdEvents[0]?.eventType).toBe('created');
+		expect(createdEvents[0]?.newState?.title).toBe('Audit me');
+
+		const updated = service.updateGoal(
+			goal.id,
+			{ summary: 'Moved forward', progress: 50 },
+			{ source: 'space_agent_tool', sourceSessionId: 'session-1' }
+		);
+		expect(updated.progress).toBe(50);
+
+		const paused = service.pauseGoal(goal.id, { source: 'rpc' });
+		expect(paused.status).toBe('paused');
+		service.resumeGoal(goal.id, { source: 'rpc' });
+		service.updateScheduledCheckIn(goal.id, Date.now() + 60_000);
+
+		const first = service.createImmediateTask(goal.id);
+		service.createImmediateTask(goal.id);
+		taskRepo.updateTask(first.task!.id, { status: 'done' });
+		service.handleTaskTerminal(first.task!.id);
+
+		const events = goalEventRepo.listByGoal(goal.id, { limit: 20 });
+		expect(events.map((event) => event.eventType)).toContain('created');
+		expect(events.map((event) => event.eventType)).toContain('updated');
+		expect(events.map((event) => event.eventType)).toContain('status_changed');
+		expect(events.map((event) => event.eventType)).toContain('schedule_updated');
+		expect(events.map((event) => event.eventType)).toContain('task_triggered');
+		expect(events.map((event) => event.eventType)).toContain('task_queued');
+		expect(events.map((event) => event.eventType)).toContain('task_terminal');
+		const updateEvent = events.find((event) => event.eventType === 'updated');
+		expect(updateEvent?.source).toBe('space_agent_tool');
+		expect(updateEvent?.sourceSessionId).toBe('session-1');
+		expect(updateEvent?.diff?.progress).toEqual({ previous: 0, current: 50 });
+		const terminalEvent = events.find((event) => event.eventType === 'task_terminal');
+		expect(terminalEvent?.sourceTaskId).toBe(first.task?.id);
+	});
+
 	it('creates an immediate goal task and queues concurrent triggers', () => {
 		const events: Array<{ event: string; taskId?: string }> = [];
 		service = new SpaceGoalService({
 			goalRepo,
+			goalEventRepo,
 			taskRepo,
 			spaceRepo,
 			scheduleService: new ScheduleService({

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -111,6 +111,12 @@ describe('SpaceGoalService', () => {
 		expect(schedule?.goalId).toBe(goal.id);
 		expect(schedule?.preferredWorkflowId).toBe('workflow-1');
 		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'product']);
+
+		const createdEvent = goalEventRepo
+			.listByGoal(goal.id)
+			.find((event) => event.eventType === 'created');
+		expect(createdEvent?.newState?.taskScheduleId).toBe(goal.taskScheduleId);
+		expect(createdEvent?.newState?.nextCheckInAt).toBe(goal.nextCheckInAt);
 	});
 
 	it('paginates same-timestamp goal events with id cursor', () => {
@@ -150,6 +156,17 @@ describe('SpaceGoalService', () => {
 			beforeId: page1[0]!.id,
 		});
 		expect(page2.map((event) => event.id)).toEqual([ordered[1]!.id, ordered[2]!.id]);
+
+		const timestampOnlyGoalPage = goalEventRepo.listByGoal(goal.id, { before: timestamp });
+		expect(timestampOnlyGoalPage.every((event) => event.createdAt < timestamp)).toBe(true);
+		expect(timestampOnlyGoalPage.map((event) => event.id)).not.toContain(first.id);
+		expect(timestampOnlyGoalPage.map((event) => event.id)).not.toContain(second.id);
+		expect(timestampOnlyGoalPage.map((event) => event.id)).not.toContain(third.id);
+		const timestampOnlySpacePage = goalEventRepo.listBySpace(spaceId, { before: timestamp });
+		expect(timestampOnlySpacePage.every((event) => event.createdAt < timestamp)).toBe(true);
+		expect(timestampOnlySpacePage.map((event) => event.id)).not.toContain(first.id);
+		expect(timestampOnlySpacePage.map((event) => event.id)).not.toContain(second.id);
+		expect(timestampOnlySpacePage.map((event) => event.id)).not.toContain(third.id);
 	});
 
 	it('records goal update, status, task, and schedule events', () => {

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -206,6 +206,20 @@ describe('SpaceGoalService', () => {
 		expect(updated?.pendingNextRun).toBe(false);
 	});
 
+	it('clears active task pointer for all terminal statuses', () => {
+		for (const status of ['done', 'blocked', 'cancelled', 'archived'] as const) {
+			const goal = service.createGoal({ spaceId, title: `Terminal ${status}` });
+			const created = service.createImmediateTask(goal.id);
+			expect(created.task).not.toBeNull();
+
+			taskRepo.updateTask(created.task!.id, { status });
+			const terminal = service.handleTaskTerminal(created.task!.id);
+
+			expect(terminal?.goal.id).toBe(goal.id);
+			expect(goalRepo.getById(goal.id)?.activeTaskId).toBeNull();
+		}
+	});
+
 	it('ignores terminal and scheduled tasks linked to goals in another space', () => {
 		const goal = service.createGoal({
 			spaceId,

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -113,6 +113,45 @@ describe('SpaceGoalService', () => {
 		expect(schedule?.labels).toEqual(['goal', `goal:${goal.id}`, 'product']);
 	});
 
+	it('paginates same-timestamp goal events with id cursor', () => {
+		const goal = service.createGoal({ spaceId, title: 'Cursor goal' });
+		const timestamp = Date.now() + 1000;
+		const first = goalEventRepo.create({
+			spaceId,
+			goalId: goal.id,
+			eventType: 'updated',
+			source: 'system',
+			createdAt: timestamp,
+			note: 'first',
+		});
+		const second = goalEventRepo.create({
+			spaceId,
+			goalId: goal.id,
+			eventType: 'updated',
+			source: 'system',
+			createdAt: timestamp,
+			note: 'second',
+		});
+		const third = goalEventRepo.create({
+			spaceId,
+			goalId: goal.id,
+			eventType: 'updated',
+			source: 'system',
+			createdAt: timestamp,
+			note: 'third',
+		});
+		const ordered = [first, second, third].sort((a, b) => b.id.localeCompare(a.id));
+
+		const page1 = goalEventRepo.listByGoal(goal.id, { limit: 1, before: timestamp, beforeId: '~' });
+		expect(page1.map((event) => event.id)).toEqual([ordered[0]!.id]);
+		const page2 = goalEventRepo.listByGoal(goal.id, {
+			limit: 2,
+			before: page1[0]!.createdAt,
+			beforeId: page1[0]!.id,
+		});
+		expect(page2.map((event) => event.id)).toEqual([ordered[1]!.id, ordered[2]!.id]);
+	});
+
 	it('records goal update, status, task, and schedule events', () => {
 		const goal = service.createGoal({ spaceId, title: 'Audit me', autoTriggerNext: true });
 		const createdEvents = goalEventRepo.listByGoal(goal.id);
@@ -151,6 +190,33 @@ describe('SpaceGoalService', () => {
 		expect(updateEvent?.diff?.progress).toEqual({ previous: 0, current: 50 });
 		const terminalEvent = events.find((event) => event.eventType === 'task_terminal');
 		expect(terminalEvent?.sourceTaskId).toBe(first.task?.id);
+	});
+
+	it('publishes triggerImmediately task-created events after create transaction commits', () => {
+		const visibleDuringPublish: boolean[] = [];
+		service = new SpaceGoalService({
+			goalRepo,
+			goalEventRepo,
+			taskRepo,
+			spaceRepo,
+			scheduleService: new ScheduleService({
+				db: db as never,
+				scheduleRepo,
+				jobQueue: new JobQueueRepository(db as never),
+				spaceRepo,
+			}),
+			db: db as never,
+			eventHub: {
+				publish: async (_event, data) => {
+					visibleDuringPublish.push(Boolean(taskRepo.getTask((data as { taskId: string }).taskId)));
+				},
+			},
+		});
+
+		const goal = service.createGoal({ spaceId, title: 'Trigger now', triggerImmediately: true });
+
+		expect(goal.activeTaskId).toBeString();
+		expect(visibleDuringPublish).toEqual([true]);
 	});
 
 	it('creates an immediate goal task and queues concurrent triggers', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-45_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-45_test.ts
@@ -100,9 +100,10 @@ describe('Migration 45: rename step to node in workflow tables', () => {
 		expect(nodeIndexes).toContain('idx_space_workflow_nodes_workflow_id');
 
 		const taskIndexes = getIndexes(db, 'space_tasks');
-		// Post-M71: workflow_node_id and goal_id columns were removed, so no indexes on them
+		// Post-M71: workflow_node_id column was removed, so no index on it
 		expect(taskIndexes).not.toContain('idx_space_tasks_workflow_node_id');
-		expect(taskIndexes).not.toContain('idx_space_tasks_goal_id');
+		// M131 re-adds goal_id to space_tasks for space-native goals
+		expect(taskIndexes).toContain('idx_space_tasks_goal_id');
 		// These indexes do exist post-M71
 		expect(taskIndexes).toContain('idx_space_tasks_space_id');
 		expect(taskIndexes).toContain('idx_space_tasks_workflow_run_id');

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-51_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-51_test.ts
@@ -76,7 +76,8 @@ describe('Migration 51: slot_role → agent_name + completion_summary on space_t
 		// Post-M71: these indexes were removed (their columns were dropped)
 		expect(indexes).not.toContain('idx_space_tasks_status');
 		expect(indexes).not.toContain('idx_space_tasks_workflow_node_id');
-		expect(indexes).not.toContain('idx_space_tasks_goal_id');
+		// M131 re-adds goal_id to space_tasks for space-native goals
+		expect(indexes).toContain('idx_space_tasks_goal_id');
 		expect(indexes).not.toContain('idx_space_tasks_custom_agent_id');
 		expect(indexes).not.toContain('idx_space_tasks_task_agent_session_id');
 	});

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, mock } from 'bun:test';
-import type { Space, SpaceAgent, SpaceTask, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+import type {
+	Space,
+	SpaceAgent,
+	SpaceGoal,
+	SpaceTask,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
 import type { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
 import {
 	buildCustomAgentSystemPrompt,
@@ -52,6 +59,35 @@ function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
 		dependsOn: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeGoal(overrides?: Partial<SpaceGoal>): SpaceGoal {
+	return {
+		id: 'goal-1',
+		spaceId: 'space-1',
+		title: 'Improve onboarding',
+		description: 'Make first-run smoother',
+		status: 'active',
+		type: 'recurring',
+		priority: 'high',
+		labels: ['product'],
+		metrics: { activated: 10 },
+		summary: 'Initial state',
+		progress: 35,
+		nextSteps: ['Audit current flow'],
+		preferredWorkflowId: null,
+		taskScheduleId: null,
+		autoTriggerNext: false,
+		pendingNextRun: false,
+		activeTaskId: null,
+		lastTaskId: null,
+		lastCheckInAt: null,
+		nextCheckInAt: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		completedAt: null,
 		...overrides,
 	};
 }
@@ -262,6 +298,21 @@ describe('buildCustomAgentTaskMessage', () => {
 
 		const head = message.slice(0, 500);
 		expect(head).toContain('Implement passwordless auth end-to-end.');
+	});
+
+	it('renders linked goal state when provided', () => {
+		const message = buildCustomAgentTaskMessage(
+			makeConfig({
+				goal: makeGoal(),
+			})
+		);
+
+		expect(message).toContain('## Linked Goal');
+		expect(message).toContain('Improve onboarding');
+		expect(message).toContain('**Progress:** 35%');
+		expect(message).toContain('**Metrics:** {"activated":10}');
+		expect(message).toContain('- Audit current flow');
+		expect(message).toContain('mark_complete goal_update');
 	});
 
 	it('renders PR URL from gate data when present', () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -14,7 +14,13 @@ import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository.ts';
+import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository.ts';
+import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository.ts';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
+import { ScheduleService } from '../../../../src/lib/space/schedule/schedule-service.ts';
+import { SpaceGoalService } from '../../../../src/lib/space/goals/goal-service.ts';
 import {
 	createEndNodeHandlers,
 	createMarkCompleteHandler,
@@ -101,20 +107,37 @@ interface TestCtx {
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
+	goalService: SpaceGoalService;
 }
 
 function makeCtx(autonomyLevel = 1): TestCtx {
 	const db = makeDb();
 	const spaceId = 'space-end-node-test';
 	seedSpaceRow(db, spaceId, autonomyLevel);
+	const taskRepo = new SpaceTaskRepository(db);
+	const spaceRepo = new SpaceRepository(db);
+	const scheduleRepo = new TaskScheduleRepository(db);
+	const scheduleService = new ScheduleService({
+		db,
+		scheduleRepo,
+		jobQueue: new JobQueueRepository(db),
+		spaceRepo,
+	});
 	return {
 		db,
 		spaceId,
-		taskRepo: new SpaceTaskRepository(db),
+		taskRepo,
 		// Real SpaceTaskManager so the centralised transition validator runs
 		// inside `submitTaskForReview` — exercises the same code path that the
 		// production wiring takes from `task-agent-manager.ts`.
 		taskManager: new SpaceTaskManager(db, spaceId),
+		goalService: new SpaceGoalService({
+			goalRepo: new SpaceGoalRepository(db),
+			taskRepo,
+			spaceRepo,
+			scheduleService,
+			db,
+		}),
 	};
 }
 
@@ -150,6 +173,66 @@ describe('createMarkCompleteHandler', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
+	});
+
+	test('applies goal_update before marking a linked task complete', async () => {
+		const goal = ctx.goalService.createGoal({
+			spaceId: ctx.spaceId,
+			title: 'Improve onboarding',
+		});
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'approved',
+			goalId: goal.id,
+		});
+		const handler = createMarkCompleteHandler({
+			taskId: task.id,
+			spaceId: ctx.spaceId,
+			taskRepo: ctx.taskRepo,
+			taskManager: ctx.taskManager,
+			goalService: ctx.goalService,
+		});
+
+		const out = await handler({
+			goal_update: {
+				summary: 'First milestone shipped',
+				progress: 55,
+				metrics: { activated: 20 },
+				nextSteps: ['Measure adoption'],
+			},
+		});
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		const updatedGoal = ctx.goalService.getGoal(goal.id);
+		expect(updatedGoal?.summary).toBe('First milestone shipped');
+		expect(updatedGoal?.progress).toBe(55);
+		expect(updatedGoal?.metrics).toEqual({ activated: 20 });
+		expect(updatedGoal?.nextSteps).toEqual(['Measure adoption']);
+	});
+
+	test('rejects goal_update on a task without a linked goal', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'approved',
+		});
+		const handler = createMarkCompleteHandler({
+			taskId: task.id,
+			spaceId: ctx.spaceId,
+			taskRepo: ctx.taskRepo,
+			taskManager: ctx.taskManager,
+			goalService: ctx.goalService,
+		});
+
+		const out = await handler({ goal_update: { summary: 'No linked goal' } });
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not linked to a goal');
+		expect(ctx.taskRepo.getTask(task.id)?.status).toBe('approved');
 	});
 
 	test('emits space.task.updated for cascaded dependent tasks', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -14,6 +14,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceGoalEventRepository } from '../../../../src/storage/repositories/space-goal-event-repository.ts';
 import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository.ts';
 import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository.ts';
 import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository.ts';
@@ -107,6 +108,7 @@ interface TestCtx {
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
+	goalEventRepo: SpaceGoalEventRepository;
 	goalService: SpaceGoalService;
 }
 
@@ -117,6 +119,7 @@ function makeCtx(autonomyLevel = 1): TestCtx {
 	const taskRepo = new SpaceTaskRepository(db);
 	const spaceRepo = new SpaceRepository(db);
 	const scheduleRepo = new TaskScheduleRepository(db);
+	const goalEventRepo = new SpaceGoalEventRepository(db);
 	const scheduleService = new ScheduleService({
 		db,
 		scheduleRepo,
@@ -131,8 +134,10 @@ function makeCtx(autonomyLevel = 1): TestCtx {
 		// inside `submitTaskForReview` — exercises the same code path that the
 		// production wiring takes from `task-agent-manager.ts`.
 		taskManager: new SpaceTaskManager(db, spaceId),
+		goalEventRepo,
 		goalService: new SpaceGoalService({
 			goalRepo: new SpaceGoalRepository(db),
+			goalEventRepo,
 			taskRepo,
 			spaceRepo,
 			scheduleService,
@@ -211,6 +216,13 @@ describe('createMarkCompleteHandler', () => {
 		expect(updatedGoal?.progress).toBe(55);
 		expect(updatedGoal?.metrics).toEqual({ activated: 20 });
 		expect(updatedGoal?.nextSteps).toEqual(['Measure adoption']);
+
+		const updateEvent = ctx.goalEventRepo
+			.listByGoal(goal.id)
+			.find((event) => event.eventType === 'updated');
+		expect(updateEvent?.source).toBe('workflow_node_agent');
+		expect(updateEvent?.sourceTaskId).toBe(task.id);
+		expect(updateEvent?.diff?.progress).toEqual({ previous: 0, current: 55 });
 	});
 
 	test('rejects goal_update on a task without a linked goal', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -180,7 +180,7 @@ describe('createMarkCompleteHandler', () => {
 		ctx.db.close();
 	});
 
-	test('applies goal_update before marking a linked task complete', async () => {
+	test('applies goal_update after marking a linked task complete', async () => {
 		const goal = ctx.goalService.createGoal({
 			spaceId: ctx.spaceId,
 			title: 'Improve onboarding',
@@ -223,6 +223,43 @@ describe('createMarkCompleteHandler', () => {
 		expect(updateEvent?.source).toBe('workflow_node_agent');
 		expect(updateEvent?.sourceTaskId).toBe(task.id);
 		expect(updateEvent?.diff?.progress).toEqual({ previous: 0, current: 55 });
+	});
+
+	test('does not persist goal_update when marking the task complete fails', async () => {
+		const goal = ctx.goalService.createGoal({
+			spaceId: ctx.spaceId,
+			title: 'Keep consistent',
+		});
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'approved',
+			goalId: goal.id,
+		});
+		const setTaskStatus = mock(async () => {
+			throw new Error('transition raced');
+		});
+		const handler = createMarkCompleteHandler({
+			taskId: task.id,
+			spaceId: ctx.spaceId,
+			taskRepo: ctx.taskRepo,
+			taskManager: { setTaskStatus, updateTask: ctx.taskManager.updateTask.bind(ctx.taskManager) },
+			goalService: ctx.goalService,
+		});
+
+		const out = await handler({ goal_update: { summary: 'Should not persist', progress: 90 } });
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toBe('transition raced');
+		expect(ctx.taskRepo.getTask(task.id)?.status).toBe('approved');
+		const unchangedGoal = ctx.goalService.getGoal(goal.id);
+		expect(unchangedGoal?.summary).toBe('');
+		expect(unchangedGoal?.progress).toBe(0);
+		expect(ctx.goalEventRepo.listByGoal(goal.id).map((event) => event.eventType)).toEqual([
+			'created',
+		]);
 	});
 
 	test('rejects goal_update on a task without a linked goal', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -180,9 +180,28 @@ describe('MarkCompleteSchema', () => {
 		expect(result.success).toBe(true);
 	});
 
+	test('accepts rolling goal_update fields', () => {
+		const result = MarkCompleteSchema.safeParse({
+			goal_update: {
+				summary: 'Shipped first milestone',
+				progress: 50,
+				metrics: { activated: 12, healthy: true, note: 'ok', stale: null },
+				nextSteps: ['Measure adoption'],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
 	test('rejects extra fields (strict schema)', () => {
 		const result = MarkCompleteSchema.safeParse({ reason: 'done' });
 		expect(result.success).toBe(false);
+	});
+
+	test('rejects invalid goal_update payloads', () => {
+		expect(MarkCompleteSchema.safeParse({ goal_update: { progress: 101 } }).success).toBe(false);
+		expect(MarkCompleteSchema.safeParse({ goal_update: { status: 'completed' } }).success).toBe(
+			false
+		);
 	});
 
 	test('rejects non-object input', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -15,6 +15,7 @@ import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceGoalEventRepository } from '../../../../src/storage/repositories/space-goal-event-repository.ts';
 import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository.ts';
 import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
 import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository.ts';
@@ -171,6 +172,7 @@ function makeCtx(): TestCtx {
 	});
 	const goalService = new SpaceGoalService({
 		goalRepo: new SpaceGoalRepository(db),
+		goalEventRepo: new SpaceGoalEventRepository(db),
 		taskRepo,
 		spaceRepo,
 		scheduleService,
@@ -278,6 +280,7 @@ describe('createSpaceAgentMcpServer — tool registration', () => {
 		expect(names).toContain('update_goal');
 		expect(names).toContain('trigger_goal_task');
 		expect(names).toContain('list_goal_tasks');
+		expect(names).toContain('list_goal_events');
 	});
 });
 
@@ -348,6 +351,24 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
 		);
 		expect(tasks.total).toBe(1);
 		expect(tasks.tasks[0].id).toBe(triggered.task.id);
+
+		const events = JSON.parse(
+			(await handlers.list_goal_events({ goal_id: created.goal.id })).content[0].text
+		);
+		expect(events.success).toBe(true);
+		expect(events.total).toBeGreaterThanOrEqual(5);
+		expect(events.events.map((event: { eventType: string }) => event.eventType)).toContain(
+			'created'
+		);
+		expect(events.events.map((event: { eventType: string }) => event.eventType)).toContain(
+			'updated'
+		);
+		expect(events.events.map((event: { eventType: string }) => event.eventType)).toContain(
+			'status_changed'
+		);
+		expect(events.events.map((event: { eventType: string }) => event.eventType)).toContain(
+			'task_triggered'
+		);
 	});
 
 	test('rejects cross-space goal access', async () => {
@@ -361,10 +382,16 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
 			.prepare(`UPDATE space_goals SET space_id = ? WHERE id = ?`)
 			.run(otherSpaceId, otherGoal.id);
 
-		const out = await makeHandlers(ctx).get_goal({ goal_id: otherGoal.id });
+		const handlers = makeHandlers(ctx);
+		const out = await handlers.get_goal({ goal_id: otherGoal.id });
 		const parsed = JSON.parse(out.content[0].text);
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('Goal not found');
+
+		const eventsOut = await handlers.list_goal_events({ goal_id: otherGoal.id });
+		const events = JSON.parse(eventsOut.content[0].text);
+		expect(events.success).toBe(false);
+		expect(events.error).toContain('Goal not found');
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -15,6 +15,10 @@ import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository.ts';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
+import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository.ts';
+import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
@@ -22,6 +26,8 @@ import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-w
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { ScheduleService } from '../../../../src/lib/space/schedule/schedule-service.ts';
+import { SpaceGoalService } from '../../../../src/lib/space/goals/goal-service.ts';
 import {
 	createSpaceAgentMcpServer,
 	createSpaceAgentToolHandlers,
@@ -120,6 +126,7 @@ interface TestCtx {
 	runtime: SpaceRuntime;
 	nodeExecutionRepo: NodeExecutionRepository;
 	spaceManager: SpaceManager;
+	goalService: SpaceGoalService;
 }
 
 function makeCtx(): TestCtx {
@@ -154,6 +161,21 @@ function makeCtx(): TestCtx {
 	});
 
 	const taskManager = new SpaceTaskManager(db, spaceId);
+	const spaceRepo = new SpaceRepository(db);
+	const scheduleRepo = new TaskScheduleRepository(db);
+	const scheduleService = new ScheduleService({
+		db,
+		scheduleRepo,
+		jobQueue: new JobQueueRepository(db),
+		spaceRepo,
+	});
+	const goalService = new SpaceGoalService({
+		goalRepo: new SpaceGoalRepository(db),
+		taskRepo,
+		spaceRepo,
+		scheduleService,
+		db,
+	});
 
 	return {
 		db,
@@ -167,6 +189,7 @@ function makeCtx(): TestCtx {
 		runtime,
 		nodeExecutionRepo,
 		spaceManager,
+		goalService,
 	};
 }
 
@@ -181,6 +204,7 @@ function makeHandlers(ctx: TestCtx) {
 		spaceAgentManager: ctx.agentManager,
 		nodeExecutionRepo: ctx.nodeExecutionRepo,
 		spaceManager: ctx.spaceManager,
+		goalService: ctx.goalService,
 	});
 }
 
@@ -233,6 +257,114 @@ describe('createSpaceAgentMcpServer — tool registration', () => {
 		const names = getRegisteredToolNames(server);
 		expect(names).not.toContain('start_workflow_run');
 		expect(names).toContain('create_standalone_task');
+		expect(names).not.toContain('create_goal');
+	});
+
+	test('registers goal tools when goalService is configured', () => {
+		const server = createSpaceAgentMcpServer({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			goalService: ctx.goalService,
+		});
+
+		const names = getRegisteredToolNames(server);
+		expect(names).toContain('create_goal');
+		expect(names).toContain('update_goal');
+		expect(names).toContain('trigger_goal_task');
+		expect(names).toContain('list_goal_tasks');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// goal tools
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — goal tools', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('creates, lists, updates, pauses, resumes, triggers, and lists goal tasks', async () => {
+		const handlers = makeHandlers(ctx);
+
+		const createdOut = await handlers.create_goal({
+			title: 'Improve onboarding',
+			description: 'Make first run smoother',
+			type: 'recurring',
+			priority: 'high',
+			labels: ['product'],
+			summary: 'Initial state',
+			progress: 10,
+			next_steps: ['Audit current flow'],
+		});
+		const created = JSON.parse(createdOut.content[0].text);
+		expect(created.success).toBe(true);
+		expect(created.goal.title).toBe('Improve onboarding');
+
+		const listOut = await handlers.list_goals({ status: 'active' });
+		const listed = JSON.parse(listOut.content[0].text);
+		expect(listed.goals.map((goal: { id: string }) => goal.id)).toContain(created.goal.id);
+
+		const updatedOut = await handlers.update_goal({
+			goal_id: created.goal.id,
+			summary: 'Audit finished',
+			progress: 40,
+			metrics: { activated: 12 },
+			next_steps: ['Ship improvements'],
+		});
+		const updated = JSON.parse(updatedOut.content[0].text);
+		expect(updated.success).toBe(true);
+		expect(updated.goal.summary).toBe('Audit finished');
+		expect(updated.goal.progress).toBe(40);
+		expect(updated.goal.nextSteps).toEqual(['Ship improvements']);
+
+		const paused = JSON.parse(
+			(await handlers.pause_goal({ goal_id: created.goal.id })).content[0].text
+		);
+		expect(paused.goal.status).toBe('paused');
+		const resumed = JSON.parse(
+			(await handlers.resume_goal({ goal_id: created.goal.id })).content[0].text
+		);
+		expect(resumed.goal.status).toBe('active');
+
+		const triggered = JSON.parse(
+			(await handlers.trigger_goal_task({ goal_id: created.goal.id })).content[0].text
+		);
+		expect(triggered.success).toBe(true);
+		expect(triggered.task.goalId).toBe(created.goal.id);
+
+		const tasks = JSON.parse(
+			(await handlers.list_goal_tasks({ goal_id: created.goal.id })).content[0].text
+		);
+		expect(tasks.total).toBe(1);
+		expect(tasks.tasks[0].id).toBe(triggered.task.id);
+	});
+
+	test('rejects cross-space goal access', async () => {
+		const otherGoal = ctx.goalService.createGoal({
+			spaceId: ctx.spaceId,
+			title: 'Other-space goal',
+		});
+		const otherSpaceId = 'other-space-tools-test';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-workspace');
+		ctx.db
+			.prepare(`UPDATE space_goals SET space_id = ? WHERE id = ?`)
+			.run(otherSpaceId, otherGoal.id);
+
+		const out = await makeHandlers(ctx).get_goal({ goal_id: otherGoal.id });
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Goal not found');
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -352,6 +352,18 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
 		expect(tasks.total).toBe(1);
 		expect(tasks.tasks[0].id).toBe(triggered.task.id);
 
+		ctx.taskRepo.archiveTask(triggered.task.id);
+		const archivedTasks = JSON.parse(
+			(
+				await handlers.list_goal_tasks({
+					goal_id: created.goal.id,
+					status: 'archived',
+				})
+			).content[0].text
+		);
+		expect(archivedTasks.total).toBe(1);
+		expect(archivedTasks.tasks[0].id).toBe(triggered.task.id);
+
 		const events = JSON.parse(
 			(await handlers.list_goal_events({ goal_id: created.goal.id })).content[0].text
 		);

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -561,4 +561,34 @@ export function createSpaceTables(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goal_events (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			goal_id TEXT NOT NULL,
+			event_type TEXT NOT NULL
+				CHECK(event_type IN ('created', 'updated', 'status_changed', 'task_triggered', 'task_queued', 'task_terminal', 'schedule_updated')),
+			source TEXT NOT NULL
+				CHECK(source IN ('rpc', 'space_agent_tool', 'workflow_node_agent', 'scheduler', 'system')),
+			source_task_id TEXT,
+			source_session_id TEXT,
+			previous_state TEXT,
+			new_state TEXT,
+			diff TEXT,
+			note TEXT,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+			FOREIGN KEY (source_task_id) REFERENCES space_tasks(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_goal_created ON space_goal_events(goal_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_space_created ON space_goal_events(space_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_goal_events_source_task ON space_goal_events(source_task_id, created_at DESC)`
+	);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -218,6 +218,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_run_id TEXT,
 			preferred_workflow_id TEXT,
 			created_by_task_id TEXT,
+			goal_id TEXT DEFAULT NULL,
 			result TEXT,
 			depends_on TEXT NOT NULL DEFAULT '[]',
 			active_session TEXT
@@ -254,6 +255,7 @@ export function createSpaceTables(db: BunDatabase): void {
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
 	);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
 	);
@@ -508,6 +510,7 @@ export function createSpaceTables(db: BunDatabase): void {
 				CHECK(status IN ('active', 'paused', 'completed')),
 			created_by_agent TEXT DEFAULT NULL,
 			created_by_session TEXT DEFAULT NULL,
+			goal_id TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -522,4 +525,40 @@ export function createSpaceTables(db: BunDatabase): void {
 		ON task_schedules(status, next_run_at)
 		WHERE status = 'active'
 	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_task_schedules_goal ON task_schedules(goal_id)`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goals (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+			type TEXT NOT NULL DEFAULT 'one_shot'
+				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			summary TEXT NOT NULL DEFAULT '',
+			progress INTEGER NOT NULL DEFAULT 0,
+			next_steps TEXT NOT NULL DEFAULT '[]',
+			preferred_workflow_id TEXT,
+			task_schedule_id TEXT,
+			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+			pending_next_run INTEGER NOT NULL DEFAULT 0,
+			active_task_id TEXT,
+			last_task_id TEXT,
+			last_check_in_at INTEGER,
+			next_check_in_at INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -352,6 +352,7 @@ export interface CreateSpaceGoalEventParams {
 export interface SpaceGoalEventListParams {
 	limit?: number;
 	before?: number;
+	beforeId?: string;
 }
 
 export interface SpaceGoal {
@@ -671,7 +672,14 @@ export interface SpaceTaskActivityMember {
 	/** Derived user-facing activity state */
 	state: SpaceTaskActivityState;
 	/** Raw session processing status when the session is live in memory */
-	processingStatus?: 'idle' | 'queued' | 'processing' | 'waiting_for_input' | 'interrupted' | null;
+	processingStatus?:
+		| 'idle'
+		| 'queued'
+		| 'processing'
+		| 'waiting_for_input'
+		| 'rate_limit_cooldown'
+		| 'interrupted'
+		| null;
 	/** Raw processing phase when the session is actively processing */
 	processingPhase?: 'initializing' | 'thinking' | 'streaming' | 'finalizing' | null;
 	/** Number of persisted SDK messages seen in the backing session */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -274,6 +274,86 @@ export type SpaceGoalType = 'one_shot' | 'measurable' | 'recurring';
 
 export type SpaceGoalMetrics = Record<string, string | number | boolean | null>;
 
+export type SpaceGoalEventType =
+	| 'created'
+	| 'updated'
+	| 'status_changed'
+	| 'task_triggered'
+	| 'task_queued'
+	| 'task_terminal'
+	| 'schedule_updated';
+
+export type SpaceGoalEventSource =
+	| 'rpc'
+	| 'space_agent_tool'
+	| 'workflow_node_agent'
+	| 'scheduler'
+	| 'system';
+
+export type SpaceGoalEventSnapshot = Partial<{
+	title: string;
+	description: string;
+	status: SpaceGoalStatus;
+	type: SpaceGoalType;
+	priority: SpaceTaskPriority;
+	labels: string[];
+	metrics: SpaceGoalMetrics;
+	summary: string;
+	progress: number;
+	nextSteps: string[];
+	preferredWorkflowId: string | null;
+	taskScheduleId: string | null;
+	autoTriggerNext: boolean;
+	pendingNextRun: boolean;
+	activeTaskId: string | null;
+	lastTaskId: string | null;
+	lastCheckInAt: number | null;
+	nextCheckInAt: number | null;
+	completedAt: number | null;
+}>;
+
+export type SpaceGoalEventDiff = Record<
+	string,
+	{
+		previous: unknown;
+		current: unknown;
+	}
+>;
+
+export interface SpaceGoalEvent {
+	id: string;
+	spaceId: string;
+	goalId: string;
+	eventType: SpaceGoalEventType;
+	source: SpaceGoalEventSource;
+	sourceTaskId: string | null;
+	sourceSessionId: string | null;
+	previousState: SpaceGoalEventSnapshot | null;
+	newState: SpaceGoalEventSnapshot | null;
+	diff: SpaceGoalEventDiff | null;
+	note: string | null;
+	createdAt: number;
+}
+
+export interface CreateSpaceGoalEventParams {
+	spaceId: string;
+	goalId: string;
+	eventType: SpaceGoalEventType;
+	source: SpaceGoalEventSource;
+	sourceTaskId?: string | null;
+	sourceSessionId?: string | null;
+	previousState?: SpaceGoalEventSnapshot | null;
+	newState?: SpaceGoalEventSnapshot | null;
+	diff?: SpaceGoalEventDiff | null;
+	note?: string | null;
+	createdAt?: number;
+}
+
+export interface SpaceGoalEventListParams {
+	limit?: number;
+	before?: number;
+}
+
 export interface SpaceGoal {
 	id: string;
 	spaceId: string;

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -56,6 +56,27 @@ export interface SpaceConfig {
 }
 
 /**
+ * Per-space overrides for the built-in Task Agent.
+ *
+ * The Task Agent is not a seeded SpaceAgent — it has no row in the `space_agents`
+ * table. Its prompt is generated in code at `task-agent.ts`. This config allows
+ * per-space customization of model and prompt additions without mutating code.
+ */
+export interface TaskAgentConfig {
+	/** Model override for the Task Agent. Falls back to `space.defaultModel` then `DEFAULT_TASK_AGENT_MODEL`. */
+	model?: string;
+	/** Thinking-level override for the Task Agent. Falls back to the app default when unset. */
+	thinkingLevel?: ThinkingLevel;
+	/** Custom prompt additions appended after the contract sections (similar to SpaceAgent.customPrompt). */
+	customPrompt?: string;
+	/**
+	 * Setting sources to load for the Task Agent.
+	 * Falls back to the global default (['user', 'project', 'local']) when unset.
+	 */
+	settingSources?: SettingSource[];
+}
+
+/**
  * A Space — a workspace-first context for multi-agent workflows.
  * Unlike Rooms, a Space has a single required workspace path and is
  * designed around workflow execution with customizable agents.
@@ -96,6 +117,8 @@ export interface Space {
 	maxConcurrentTasks: number;
 	/** Runtime configuration (taskTimeoutMs, legacy maxConcurrentTasks, etc.) */
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent (model and custom prompt). */
+	taskAgentConfig?: TaskAgentConfig;
 	/**
 	 * Default setting sources for all agents in this Space.
 	 * Used as fallback when an agent (task or custom) does not define its own.
@@ -145,6 +168,8 @@ export interface CreateSpaceParams {
 	maxConcurrentTasks?: number;
 	/** Runtime configuration */
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent */
+	taskAgentConfig?: TaskAgentConfig;
 	/**
 	 * Default setting sources for all agents in this Space.
 	 * Pass `null` to explicitly clear (revert to global default).
@@ -166,6 +191,8 @@ export interface UpdateSpaceParams {
 	/** Maximum number of Space tasks that may run concurrently (1–10) */
 	maxConcurrentTasks?: number;
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent. Pass null to clear. */
+	taskAgentConfig?: TaskAgentConfig | null;
 	/**
 	 * Default setting sources for all agents in this Space.
 	 * Pass null to clear (revert to global default).
@@ -239,6 +266,88 @@ export type SpaceBlockReason =
 export type SpaceTaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 // ============================================================================
+// SpaceGoal Types
+// ============================================================================
+
+export type SpaceGoalStatus = 'active' | 'paused' | 'completed' | 'archived';
+export type SpaceGoalType = 'one_shot' | 'measurable' | 'recurring';
+
+export type SpaceGoalMetrics = Record<string, string | number | boolean | null>;
+
+export interface SpaceGoal {
+	id: string;
+	spaceId: string;
+	title: string;
+	description: string;
+	status: SpaceGoalStatus;
+	type: SpaceGoalType;
+	priority: SpaceTaskPriority;
+	labels: string[];
+	metrics: SpaceGoalMetrics;
+	summary: string;
+	progress: number;
+	nextSteps: string[];
+	preferredWorkflowId: string | null;
+	taskScheduleId: string | null;
+	autoTriggerNext: boolean;
+	pendingNextRun: boolean;
+	activeTaskId: string | null;
+	lastTaskId: string | null;
+	lastCheckInAt: number | null;
+	nextCheckInAt: number | null;
+	createdAt: number;
+	updatedAt: number;
+	completedAt: number | null;
+}
+
+export interface CreateSpaceGoalParams {
+	spaceId: string;
+	title: string;
+	description?: string;
+	type?: SpaceGoalType;
+	priority?: SpaceTaskPriority;
+	labels?: string[];
+	metrics?: SpaceGoalMetrics;
+	summary?: string;
+	progress?: number;
+	nextSteps?: string[];
+	preferredWorkflowId?: string | null;
+	autoTriggerNext?: boolean;
+	checkInCronExpression?: string | null;
+	checkInTimezone?: string;
+	triggerImmediately?: boolean;
+}
+
+export interface UpdateSpaceGoalParams {
+	title?: string;
+	description?: string;
+	status?: SpaceGoalStatus;
+	type?: SpaceGoalType;
+	priority?: SpaceTaskPriority;
+	labels?: string[];
+	metrics?: SpaceGoalMetrics;
+	summary?: string;
+	progress?: number;
+	nextSteps?: string[];
+	preferredWorkflowId?: string | null;
+	autoTriggerNext?: boolean;
+	pendingNextRun?: boolean;
+	activeTaskId?: string | null;
+	lastTaskId?: string | null;
+	lastCheckInAt?: number | null;
+	nextCheckInAt?: number | null;
+	completedAt?: number | null;
+}
+
+export interface SpaceGoalListParams {
+	spaceId: string;
+	status?: SpaceGoalStatus;
+	includeArchived?: boolean;
+	label?: string;
+	search?: string;
+}
+
+// ============================================================================
 // TaskSchedule Types
 // ============================================================================
 
@@ -291,12 +400,14 @@ export interface TaskSchedule {
 	createdBySession: string | null;
 	/** Creation timestamp (ms since epoch) */
 	createdAt: number;
+	/** SpaceGoal this schedule belongs to, when used for recurring goal check-ins. */
+	goalId?: string | null;
 	/** Last update timestamp (ms since epoch) */
 	updatedAt: number;
 }
 
 /**
- * Runtime activity state for a live task activity member.
+ * Runtime activity state for a live task-agent member.
  * This is more user-facing than raw session processing states.
  */
 export type SpaceTaskActivityState =
@@ -304,7 +415,6 @@ export type SpaceTaskActivityState =
 	| 'queued'
 	| 'idle'
 	| 'waiting_for_input'
-	| 'cooldown'
 	| 'completed'
 	| 'failed'
 	| 'interrupted';
@@ -361,6 +471,8 @@ export interface SpaceTask {
 	 * Null for manually created tasks.
 	 */
 	createdByTaskScheduleId?: string | null;
+	/** ID of the SpaceGoal this task is executing toward. */
+	goalId?: string | null;
 	/**
 	 * Which agent session is currently active (generating output).
 	 * Cleared when the session reaches a terminal state.
@@ -478,14 +590,7 @@ export interface SpaceTaskActivityMember {
 	/** Derived user-facing activity state */
 	state: SpaceTaskActivityState;
 	/** Raw session processing status when the session is live in memory */
-	processingStatus?:
-		| 'idle'
-		| 'queued'
-		| 'processing'
-		| 'waiting_for_input'
-		| 'rate_limit_cooldown'
-		| 'interrupted'
-		| null;
+	processingStatus?: 'idle' | 'queued' | 'processing' | 'waiting_for_input' | 'interrupted' | null;
 	/** Raw processing phase when the session is actively processing */
 	processingPhase?: 'initializing' | 'thinking' | 'streaming' | 'finalizing' | null;
 	/** Number of persisted SDK messages seen in the backing session */
@@ -565,6 +670,14 @@ export interface CreateSpaceTaskParams {
 }
 
 /**
+ * Internal parameters for creating SpaceTask rows with system-owned linkage.
+ */
+export interface InternalCreateSpaceTaskParams extends CreateSpaceTaskParams {
+	/** ID of the SpaceGoal this task should be linked to. */
+	goalId?: string | null;
+}
+
+/**
  * Parameters for updating a SpaceTask
  */
 export interface UpdateSpaceTaskParams {
@@ -636,6 +749,14 @@ export interface UpdateSpaceTaskParams {
 	 * Schema only in PR 1; no runtime consumer yet.
 	 */
 	postApprovalBlockedReason?: string | null;
+}
+
+/**
+ * Internal parameters for updating SpaceTask rows with system-owned linkage.
+ */
+export interface InternalUpdateSpaceTaskParams extends UpdateSpaceTaskParams {
+	/** ID of the SpaceGoal this task is linked to; null to clear. */
+	goalId?: string | null;
 }
 
 // ============================================================================
@@ -1248,7 +1369,15 @@ export interface WorkflowNodeAgent {
 	 */
 	extraMcpServers?: Record<string, McpServerConfig>;
 	/**
-	 * Optional per-slot timeout (milliseconds) for runtime monitoring.
+	 * Optional per-slot timeout (milliseconds) used by the runtime to decide
+	 * when an agent that is still alive but apparently stuck should be
+	 * auto-completed.
+	 *
+	 * When unset, the runtime falls back to its `DEFAULT_NODE_TIMEOUT_MS`
+	 * default. Per-node overrides belong with the workflow definition itself —
+	 * the runtime does not embed a role-name → timeout lookup. To give a
+	 * specific node a longer or shorter timeout than the default, set this on
+	 * the agent slot in the workflow definition.
 	 *
 	 * Must be a positive integer when present.
 	 */
@@ -1764,8 +1893,9 @@ export interface ExportedWorkflowNodeAgent {
 	 */
 	extraMcpServers?: Record<string, unknown>;
 	/**
-	 * Optional per-slot timeout (milliseconds) for runtime monitoring.
-	 * Mirrors `WorkflowNodeAgent.timeoutMs`.
+	 * Optional per-slot timeout (milliseconds) for runtime auto-completion of
+	 * stuck-but-alive agents. Mirrors `WorkflowNodeAgent.timeoutMs`. When unset,
+	 * the runtime applies its `DEFAULT_NODE_TIMEOUT_MS` default.
 	 *
 	 * Must be a positive integer when present.
 	 */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -494,6 +494,7 @@ export type SpaceTaskActivityState =
 	| 'active'
 	| 'queued'
 	| 'idle'
+	| 'cooldown'
 	| 'waiting_for_input'
 	| 'completed'
 	| 'failed'

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -67,7 +67,6 @@ const ACTIVITY_STATE_LABELS: Record<SpaceTaskActivityState, string> = {
 	queued: 'Queued',
 	idle: 'Idle',
 	waiting_for_input: 'Waiting',
-	cooldown: 'Cooldown',
 	completed: 'Done',
 	failed: 'Failed',
 	interrupted: 'Interrupted',

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -66,6 +66,7 @@ const ACTIVITY_STATE_LABELS: Record<SpaceTaskActivityState, string> = {
 	active: 'Active',
 	queued: 'Queued',
 	idle: 'Idle',
+	cooldown: 'Cooldown',
 	waiting_for_input: 'Waiting',
 	completed: 'Done',
 	failed: 'Failed',

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -14,15 +14,22 @@ import { useAutoScroll } from '../useAutoScroll.ts';
 
 // Helper to create mock refs
 function createMockRefs() {
-	const scrollIntoViewMock = vi.fn(() => {});
+	const scrollIntoViewMock = vi.fn(function (this: HTMLDivElement, options?: ScrollToOptions) {
+		if (typeof options?.top === 'number') {
+			this.scrollTop = options.top;
+		}
+	});
 	const addEventListenerMock = vi.fn(() => {});
 	const removeEventListenerMock = vi.fn(() => {});
+	const scrollToMock = scrollIntoViewMock;
 
+	const contentWrapper = {} as HTMLDivElement;
 	const containerRef = {
 		current: {
 			scrollTop: 0,
 			scrollHeight: 1000,
 			clientHeight: 500,
+			scrollTo: scrollToMock,
 			addEventListener: addEventListenerMock,
 			removeEventListener: removeEventListenerMock,
 		} as unknown as HTMLDivElement,
@@ -30,6 +37,7 @@ function createMockRefs() {
 
 	const endRef = {
 		current: {
+			parentElement: contentWrapper,
 			scrollIntoView: scrollIntoViewMock,
 		} as unknown as HTMLDivElement,
 	} as RefObject<HTMLDivElement>;
@@ -38,6 +46,7 @@ function createMockRefs() {
 		containerRef,
 		endRef,
 		scrollIntoViewMock,
+		scrollToMock,
 		addEventListenerMock,
 		removeEventListenerMock,
 	};
@@ -49,12 +58,15 @@ let resizeObserverInstances: MockResizeObserver[] = [];
 // Mock ResizeObserver
 class MockResizeObserver {
 	callback: ResizeObserverCallback;
+	observedTargets: Element[] = [];
 
 	constructor(callback: ResizeObserverCallback) {
 		this.callback = callback;
 		resizeObserverInstances.push(this);
 	}
-	observe() {}
+	observe(target: Element) {
+		this.observedTargets.push(target);
+	}
 	unobserve() {}
 	disconnect() {}
 	// Helper to trigger resize callback
@@ -111,8 +123,8 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('scrollToBottom', () => {
-		it('should call scrollIntoView with instant behavior and block: end by default', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+		it('should scroll the container to its scrollHeight with instant behavior by default', () => {
+			const { containerRef, endRef, scrollToMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -127,13 +139,13 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom();
 			});
 
-			// block: 'end' combined with the container's scroll-padding-bottom keeps
-			// the last message above the floating composer rather than behind it.
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant', block: 'end' });
+			// Instant path uses direct property assignment, not scrollTo().
+			expect(scrollToMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
-		it('should call scrollIntoView with smooth behavior and block: end when specified', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+		it('should scroll the container to its scrollHeight with smooth behavior when specified', () => {
+			const { containerRef, endRef, scrollToMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
 				useAutoScroll({
@@ -148,7 +160,8 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom(true);
 			});
 
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
+			expect(scrollToMock).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should handle null endRef gracefully', () => {
@@ -172,8 +185,27 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('auto-scroll behavior', () => {
+		it('should observe the container and content wrapper for resize-driven anchoring', () => {
+			const { containerRef, endRef } = createMockRefs();
+
+			renderHook(() =>
+				useAutoScroll({
+					containerRef,
+					endRef,
+					enabled: true,
+					messageCount: 0,
+				})
+			);
+
+			expect(resizeObserverInstances[0]?.observedTargets).toEqual([
+				containerRef.current,
+				endRef.current!.parentElement,
+			]);
+		});
+
 		it('should scroll on initial load when messages arrive', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			vi.useFakeTimers();
+			const { containerRef, endRef } = createMockRefs();
 
 			// Start with isInitialLoad=true and 0 messages
 			const { rerender } = renderHook(
@@ -192,8 +224,15 @@ describe('useAutoScroll', () => {
 
 			// Rerender with messages arriving
 			rerender({ messageCount: 5, isInitialLoad: true });
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			// Layout grows after first scroll; deferred rAF scroll should re-pin.
+			containerRef.current!.scrollHeight = 1200;
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+			expect(containerRef.current!.scrollTop).toBe(1200);
+			vi.useRealTimers();
 		});
 
 		it('should NOT force-scroll on initial load when enabled=false (deep-link case)', () => {
@@ -201,7 +240,7 @@ describe('useAutoScroll', () => {
 			// `useScrollToMessage` hook), it sets `enabled: false` so the
 			// initial-load forced scroll-to-bottom does not race with — and
 			// override — the deep-link `scrollIntoView`.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad, enabled }) =>
@@ -219,11 +258,42 @@ describe('useAutoScroll', () => {
 
 			// Messages arrive while disabled — should NOT force scroll.
 			rerender({ messageCount: 5, isInitialLoad: true, enabled: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(0);
+		});
+
+		it('should cancel deferred re-pin when enabled flips false before next frame', () => {
+			vi.useFakeTimers();
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, enabled }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled,
+						messageCount,
+						isInitialLoad: false,
+					}),
+				{
+					initialProps: { messageCount: 0, enabled: true },
+				}
+			);
+
+			rerender({ messageCount: 5, enabled: true });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			containerRef.current!.scrollHeight = 1200;
+			rerender({ messageCount: 5, enabled: false });
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+
+			expect(containerRef.current!.scrollTop).toBe(1000);
+			vi.useRealTimers();
 		});
 
 		it('should scroll when new messages arrive and enabled', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -239,16 +309,14 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			// Add new message
 			rerender({ messageCount: 6 });
 
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should not scroll when new messages arrive but disabled', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -264,16 +332,50 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired (messageCount > 0 on first render).
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// Add new message
 			rerender({ messageCount: 6 });
 
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			// scrollTop should not have changed (no auto-scroll when disabled).
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
+		});
+
+		it('should cancel deferred re-pin when loadingOlder flips true before next frame', () => {
+			vi.useFakeTimers();
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, loadingOlder }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad: false,
+						loadingOlder,
+					}),
+				{
+					initialProps: { messageCount: 0, loadingOlder: false },
+				}
+			);
+
+			rerender({ messageCount: 5, loadingOlder: false });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			containerRef.current!.scrollHeight = 1200;
+			rerender({ messageCount: 5, loadingOlder: true });
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+
+			expect(containerRef.current!.scrollTop).toBe(1000);
+			vi.useRealTimers();
 		});
 
 		it('should not scroll when loading older messages', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -290,16 +392,17 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// loadingOlder=true suppresses auto-scroll, including mount scroll.
+			// scrollTop stays at 0 because the mount-scroll is blocked.
+			expect(containerRef.current!.scrollTop).toBe(0);
 
-			// Add messages while loading older
+			// Add messages while loading older — still no scroll.
 			rerender({ messageCount: 10, loadingOlder: true });
-
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(0);
 		});
 
 		it('should not auto-scroll when loadingOlder transitions from true to false', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -316,17 +419,17 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired.
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// Start loading older — message count increases as hidden messages are revealed
 			rerender({ messageCount: 55, loadingOlder: true });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
 			// Finish loading older — message count stays at 55, loadingOlder flips to false.
 			// This should NOT trigger auto-scroll because the count increase came from
 			// revealing older messages, not from genuinely new messages.
 			rerender({ messageCount: 55, loadingOlder: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
 		});
 
 		it('should not auto-scroll across a load-older transition where messageCount also increases', () => {
@@ -339,7 +442,7 @@ describe('useAutoScroll', () => {
 			// clobbering ChatContainer's scroll-position restore. The
 			// loadingOlder-tracker therefore also runs as a useLayoutEffect
 			// declared first.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, loadingOlder }) =>
@@ -356,16 +459,16 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll already fired.
+			const baselineScroll = containerRef.current!.scrollTop;
 
 			// User clicks "Load more" — loadingOlder flips on first.
 			rerender({ messageCount: 200, loadingOlder: true });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
 			// Older messages prepended AND loadingOlder cleared in the same
 			// render (post-await batching): messageCount jumps from 200 → 250.
 			rerender({ messageCount: 250, loadingOlder: false });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(baselineScroll);
 		});
 
 		it('should scroll on first non-empty messageCount even when isInitialLoad is already false', () => {
@@ -376,7 +479,7 @@ describe('useAutoScroll', () => {
 			// The hook must still scroll on this first non-empty render —
 			// otherwise the user lands somewhere mid-conversation instead of
 			// at the latest messages.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
@@ -396,13 +499,11 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			// Messages arrive in the next render. Even though isInitialLoad
 			// stays false, the hook should scroll because this is the first
 			// non-empty messageCount on this mount.
 			rerender({ messageCount: 12, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should scroll on first non-empty messageCount even when enabled is false', () => {
@@ -410,7 +511,7 @@ describe('useAutoScroll', () => {
 			// auto-scroll-on-new-content. The user's autoScroll preference
 			// only governs SUBSEQUENT scrolling, mirroring the existing
 			// initial-load behavior.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -426,20 +527,16 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			rerender({ messageCount: 8 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Subsequent new content with enabled=false must NOT scroll.
 			rerender({ messageCount: 9 });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
 		it('should only scroll once on mount, even after multiple message updates', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount }) =>
@@ -455,52 +552,160 @@ describe('useAutoScroll', () => {
 				}
 			);
 
-			scrollIntoViewMock.mockClear();
-
 			rerender({ messageCount: 5 });
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Re-renders with same messageCount: should not re-scroll.
 			rerender({ messageCount: 5 });
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 
-		it('should reset mount-scroll latch when isInitialLoad flips back to true', () => {
-			// Preserves the existing reset semantic — a parent can signal
-			// "treat the next non-empty messageCount as a fresh load" by
-			// toggling the prop. Used for in-place session swaps that don't
-			// remount the hook.
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+		it('should scroll to bottom on task switch without remount (messageCount N → 0 → M)', () => {
+			// Reproduces the SpaceTaskUnifiedThread task-switch scenario:
+			// Component re-renders in place (no key change), so hasScrolledOnMountRef
+			// stays true from the previous task. When rows are cleared (messageCount→0)
+			// and then repopulated from the new task (messageCount→M), the hook must
+			// still scroll to the bottom via the hasNewContent path.
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ messageCount, isInitialLoad }) =>
 					useAutoScroll({
 						containerRef,
 						endRef,
-						enabled: false,
+						enabled: true,
 						messageCount,
 						isInitialLoad,
 					}),
 				{
-					initialProps: { messageCount: 5, isInitialLoad: false },
+					// Task A: loaded with 10 messages, isInitialLoad=false (loaded)
+					initialProps: { messageCount: 10, isInitialLoad: false },
 				}
 			);
 
-			// Initial mount-scroll fires (messageCount > 0).
-			expect(scrollIntoViewMock).toHaveBeenCalled();
-			scrollIntoViewMock.mockClear();
+			// Initial mount-scroll fires (messageCount > 0 on first render)
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
-			// Parent signals "fresh session" by toggling isInitialLoad back to
-			// true with a fresh (empty) messageCount.
+			// Task B: rows cleared, loading starts (isInitialLoad=true)
 			rerender({ messageCount: 0, isInitialLoad: true });
-			rerender({ messageCount: 0, isInitialLoad: false });
 
-			// New session's messages arrive — should scroll again because the
-			// mount-scroll latch was reset by the isInitialLoad → true edge.
-			rerender({ messageCount: 7, isInitialLoad: false });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			// Task B: snapshot arrives, loading done (isInitialLoad=false)
+			rerender({ messageCount: 15, isInitialLoad: false });
+
+			// Should have scrolled for the new task's content
+			expect(containerRef.current!.scrollTop).toBe(1000);
+		});
+
+		it('should scroll to bottom on task switch when new task has fewer messages', () => {
+			// Edge case: switching from a task with many messages to one with fewer.
+			// The hasNewContent path checks messageCount > prevMessageCountRef,
+			// but the 0 → M transition ensures hasNewContent is always true.
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, isInitialLoad }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad,
+					}),
+				{
+					// Task A has 50 messages
+					initialProps: { messageCount: 50, isInitialLoad: false },
+				}
+			);
+
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Task B: rows cleared, loading starts
+			rerender({ messageCount: 0, isInitialLoad: true });
+
+			// Task B: only 5 messages (fewer than task A's 50)
+			rerender({ messageCount: 5, isInitialLoad: false });
+
+			// Should still scroll even though new task has fewer messages
+			expect(containerRef.current!.scrollTop).toBe(1000);
+		});
+
+		it('should scroll on repeated task switches (N → 0 → M → 0 → K)', () => {
+			// Simulates switching between multiple tasks in sequence.
+			// Each switch goes through: loaded → loading (0) → loaded (new messages).
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, isInitialLoad }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled: true,
+						messageCount,
+						isInitialLoad,
+					}),
+				{
+					initialProps: { messageCount: 10, isInitialLoad: false },
+				}
+			);
+
+			// Task A: initial load
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Switch to task B: loading → loaded
+			rerender({ messageCount: 0, isInitialLoad: true });
+			rerender({ messageCount: 20, isInitialLoad: false });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Switch to task C: loading → loaded (fewer messages)
+			rerender({ messageCount: 0, isInitialLoad: true });
+			rerender({ messageCount: 3, isInitialLoad: false });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+		});
+
+		it('should scroll on new content after messageCount drops to 0', () => {
+			vi.useFakeTimers();
+			// When the message list is cleared (task switch, session navigation),
+			// prevMessageCountRef resets so the next non-zero count is
+			// seen as new content. This is the fix for SpaceTaskUnifiedThread,
+			// which re-renders in place without a key change on task switch.
+			const { containerRef, endRef } = createMockRefs();
+
+			const { rerender } = renderHook(
+				({ messageCount, enabled }) =>
+					useAutoScroll({
+						containerRef,
+						endRef,
+						enabled,
+						messageCount,
+						isInitialLoad: false,
+					}),
+				{
+					initialProps: { messageCount: 10, enabled: true },
+				}
+			);
+
+			// Initial mount-scroll fires.
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Messages cleared (e.g., loading state during task switch).
+			rerender({ messageCount: 0, enabled: true });
+
+			// New task's messages arrive — prevMessageCountRef was reset to 0,
+			// so the 0→7 transition is seen as new content and scrolls.
+			rerender({ messageCount: 7, enabled: true });
+			expect(containerRef.current!.scrollTop).toBe(1000);
+
+			// Layout grows after first scroll; deferred rAF scroll should re-pin.
+			containerRef.current!.scrollHeight = 1200;
+			act(() => {
+				vi.advanceTimersByTime(16);
+			});
+			expect(containerRef.current!.scrollTop).toBe(1200);
+
+			// Subsequent new-message scrolls use the hasNewContent path.
+			rerender({ messageCount: 8, enabled: true });
+			expect(containerRef.current!.scrollTop).toBe(1200);
+			vi.useRealTimers();
 		});
 	});
 
@@ -571,7 +776,7 @@ describe('useAutoScroll', () => {
 
 	describe('initial load reset', () => {
 		it('should reset mount-scroll latch when isInitialLoad changes to true', () => {
-			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
+			const { containerRef, endRef } = createMockRefs();
 
 			const { rerender } = renderHook(
 				({ isInitialLoad, messageCount }) =>
@@ -589,9 +794,7 @@ describe('useAutoScroll', () => {
 
 			// Initial load with messages
 			rerender({ isInitialLoad: true, messageCount: 5 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
-
-			scrollIntoViewMock.mockClear();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 
 			// Switch to not initial load
 			rerender({ isInitialLoad: false, messageCount: 5 });
@@ -601,7 +804,7 @@ describe('useAutoScroll', () => {
 
 			// New messages arrive
 			rerender({ isInitialLoad: true, messageCount: 3 });
-			expect(scrollIntoViewMock).toHaveBeenCalled();
+			expect(containerRef.current!.scrollTop).toBe(1000);
 		});
 	});
 
@@ -746,7 +949,7 @@ describe('useAutoScroll', () => {
 					containerRef,
 					endRef,
 					enabled: true,
-					messageCount: 5,
+					messageCount: 0,
 				})
 			);
 
@@ -778,8 +981,9 @@ describe('useAutoScroll', () => {
 					useAutoScroll({
 						containerRef,
 						endRef,
-						enabled: true,
+						enabled: false,
 						messageCount: 5,
+						isInitialLoad: true,
 						loadingOlder,
 					}),
 				{ initialProps: { loadingOlder: false } }
@@ -814,7 +1018,7 @@ describe('useAutoScroll', () => {
 					containerRef,
 					endRef,
 					enabled: true,
-					messageCount: 5,
+					messageCount: 0,
 				})
 			);
 

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -85,26 +85,49 @@ export function useAutoScroll({
 	// current value rather than a stale closure capture.
 	const enabledRef = useRef<boolean>(enabled);
 	const loadingOlderRef = useRef<boolean>(loadingOlder);
-	useEffect(() => {
+	const deferredScrollRafRef = useRef<number | null>(null);
+	useLayoutEffect(() => {
 		enabledRef.current = enabled;
 	}, [enabled]);
-	useEffect(() => {
+	useLayoutEffect(() => {
 		loadingOlderRef.current = loadingOlder;
 	}, [loadingOlder]);
 
 	// Scroll to bottom function - instant by default during streaming, smooth when user clicks.
-	// Uses `block: 'end'` so the end sentinel is aligned to the container's bottom edge,
-	// which — combined with `scroll-padding-bottom` on the scroll container — parks the last
-	// message just above the floating composer instead of underneath it.
+	// Set the scroll container directly instead of relying on scrollIntoView alignment,
+	// which interacts poorly with scroll-padding-bottom and can stop short of the true bottom.
 	const scrollToBottom = useCallback(
 		(smooth = false) => {
+			const container = containerRef.current;
+			if (container) {
+				if (smooth) {
+					container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+				} else {
+					container.scrollTop = container.scrollHeight;
+				}
+				return;
+			}
+
 			endRef.current?.scrollIntoView({
 				behavior: smooth ? 'smooth' : 'instant',
 				block: 'end',
 			});
 		},
-		[endRef]
+		[containerRef, endRef]
 	);
+
+	const scrollToBottomAfterLayout = useCallback(() => {
+		if (deferredScrollRafRef.current !== null) {
+			cancelAnimationFrame(deferredScrollRafRef.current);
+		}
+
+		deferredScrollRafRef.current = requestAnimationFrame(() => {
+			deferredScrollRafRef.current = null;
+			if (enabledRef.current && !loadingOlderRef.current) {
+				scrollToBottom();
+			}
+		});
+	}, [scrollToBottom]);
 
 	// Detect scroll position to show/hide scroll button
 	useEffect(() => {
@@ -138,8 +161,11 @@ export function useAutoScroll({
 			// Use passive event listener for better scroll performance
 			container.addEventListener('scroll', handleScroll, { passive: true });
 
-			// Use ResizeObserver to update when content size changes
-			// Batch layout reads via rAF to avoid forced reflow on dirty layout
+			// Use ResizeObserver to update when rendered content changes size.
+			// Observe both the scroll container and the content wrapper (endRef parent)
+			// when available: composer padding changes affect container metrics, while
+			// markdown/code rendering grows inner content without resizing the container.
+			// Batch layout reads via rAF to avoid forced reflow on dirty layout.
 			let rafId: number;
 			const resizeObserver = new ResizeObserver(() => {
 				cancelAnimationFrame(rafId);
@@ -165,6 +191,10 @@ export function useAutoScroll({
 				});
 			});
 			resizeObserver.observe(container);
+			const contentWrapper = endRef.current?.parentElement;
+			if (contentWrapper && contentWrapper !== container) {
+				resizeObserver.observe(contentWrapper);
+			}
 
 			// Return cleanup function
 			return () => {
@@ -175,7 +205,7 @@ export function useAutoScroll({
 		}
 
 		return setupScrollDetection(container);
-	}, [nearBottomThreshold, messageCount]);
+	}, [nearBottomThreshold, messageCount, endRef]);
 
 	// When loadingOlder transitions from true to false, skip the message-count delta
 	// that was introduced by revealing older messages so that auto-scroll doesn't fire.
@@ -215,6 +245,16 @@ export function useAutoScroll({
 			return;
 		}
 
+		// When the message list is cleared (task switch, navigation),
+		// reset the previous-count tracker so the next non-zero count is
+		// seen as new content. Without this, a component that re-renders
+		// in place (no key change) retains a stale prev count and the
+		// 0→M transition is treated as a decrease, not new content.
+		if (messageCount === 0) {
+			prevMessageCountRef.current = 0;
+			return;
+		}
+
 		// First scroll on mount: when messages first become non-empty on this
 		// mount, scroll to the bottom — even if `enabled` is false. This is a
 		// "navigation/visit" scroll, not an auto-scroll on new content; the
@@ -238,6 +278,9 @@ export function useAutoScroll({
 			// suppress the auto-scroll and let the caller drive.
 			if (enabled || !isInitialLoad) {
 				scrollToBottom();
+				if (enabled) {
+					scrollToBottomAfterLayout();
+				}
 			}
 			return;
 		}
@@ -245,10 +288,18 @@ export function useAutoScroll({
 		// Only auto-scroll for new messages if enabled
 		if (enabled && hasNewContent) {
 			scrollToBottom();
+			scrollToBottomAfterLayout();
 		}
 
 		prevMessageCountRef.current = messageCount;
-	}, [messageCount, isInitialLoad, loadingOlder, enabled, scrollToBottom]);
+	}, [
+		messageCount,
+		isInitialLoad,
+		loadingOlder,
+		enabled,
+		scrollToBottom,
+		scrollToBottomAfterLayout,
+	]);
 
 	// Reset the mount-scroll latch when `isInitialLoad` flips back to true.
 	// This preserves the existing reset semantic — a parent can signal "treat
@@ -259,6 +310,14 @@ export function useAutoScroll({
 			hasScrolledOnMountRef.current = false;
 		}
 	}, [isInitialLoad]);
+
+	useEffect(() => {
+		return () => {
+			if (deferredScrollRafRef.current !== null) {
+				cancelAnimationFrame(deferredScrollRafRef.current);
+			}
+		};
+	}, []);
 
 	return {
 		showScrollButton,


### PR DESCRIPTION
Adds Space-native goal support plus agent-facing goal tools and append-only goal history.

Includes:
- Space goal CRUD/trigger tooling for Space agents
- linked goal context for workflow node agents
- mark_complete goal updates
- append-only goal event history exposed through RPC and list_goal_events

Verified with focused goal tests, 4-space-storage and 5-space daemon shards, and bun run check.