### PR TITLE
feat(web): add user-facing edit task description mid-flight

### DIFF
--- a/packages/web/src/components/space/EditTaskModal.tsx
+++ b/packages/web/src/components/space/EditTaskModal.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { SpaceTaskPriority } from '@neokai/shared';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { Modal } from '../ui/Modal.tsx';
 
 const PRIORITY_OPTIONS: Array<{ value: SpaceTaskPriority; label: string }> = [
@@ -48,21 +48,34 @@ export function EditTaskModal({
 	const [description, setDescription] = useState(initialDescription);
 	const [priority, setPriority] = useState(initialPriority);
 
-	// Reset form when the modal opens. Only depend on `isOpen` so concurrent
-	// store updates (e.g. space.task.updated events) don't overwrite in-progress
-	// edits while the user is typing.
+	// Snapshot the initial values at modal-open time. This freezes the diff
+	// baseline so concurrent store updates to untouched fields don't cause
+	// the stale local value to be sent back, overwriting the concurrent edit.
+	const baselineRef = useRef({
+		title: initialTitle,
+		description: initialDescription,
+		priority: initialPriority,
+	});
+
 	useEffect(() => {
 		if (isOpen) {
 			setTitle(initialTitle);
 			setDescription(initialDescription);
 			setPriority(initialPriority);
+			baselineRef.current = {
+				title: initialTitle,
+				description: initialDescription,
+				priority: initialPriority,
+			};
 		}
 	}, [isOpen]);
 
+	const baseline = baselineRef.current;
+
 	const hasChanges =
-		title.trim() !== initialTitle.trim() ||
-		description.trim() !== initialDescription.trim() ||
-		priority !== initialPriority;
+		title.trim() !== baseline.title.trim() ||
+		description.trim() !== baseline.description.trim() ||
+		priority !== baseline.priority;
 
 	const trimmedTitle = title.trim();
 	const canConfirm = hasChanges && trimmedTitle.length > 0 && !busy;
@@ -70,15 +83,16 @@ export function EditTaskModal({
 	const handleConfirm = (): void => {
 		if (!canConfirm) return;
 		// Only send changed fields to avoid overwriting concurrent edits
-		// on untouched fields.
+		// on untouched fields. Compare against the frozen baseline, not live props.
 		const updates: Partial<{
 			title: string;
 			description: string;
 			priority: SpaceTaskPriority;
 		}> = {};
-		if (title.trim() !== initialTitle.trim()) updates.title = trimmedTitle;
-		if (description.trim() !== initialDescription.trim()) updates.description = description.trim();
-		if (priority !== initialPriority) updates.priority = priority;
+		if (title.trim() !== baseline.title.trim()) updates.title = trimmedTitle;
+		if (description.trim() !== baseline.description.trim())
+			updates.description = description.trim();
+		if (priority !== baseline.priority) updates.priority = priority;
 		if (Object.keys(updates).length === 0) return;
 		void onConfirm(updates);
 	};

--- a/packages/web/src/components/space/EditTaskModal.tsx
+++ b/packages/web/src/components/space/EditTaskModal.tsx
@@ -24,11 +24,13 @@ export interface EditTaskModalProps {
 	initialDescription: string;
 	initialPriority: SpaceTaskPriority;
 	onCancel: () => void;
-	onConfirm: (updates: {
-		title: string;
-		description: string;
-		priority: SpaceTaskPriority;
-	}) => void | Promise<void>;
+	onConfirm: (
+		updates: Partial<{
+			title: string;
+			description: string;
+			priority: SpaceTaskPriority;
+		}>
+	) => void | Promise<void>;
 	error?: string | null;
 }
 
@@ -67,11 +69,18 @@ export function EditTaskModal({
 
 	const handleConfirm = (): void => {
 		if (!canConfirm) return;
-		void onConfirm({
-			title: trimmedTitle,
-			description: description.trim(),
-			priority,
-		});
+		// Only send changed fields to avoid overwriting concurrent edits
+		// on untouched fields.
+		const updates: Partial<{
+			title: string;
+			description: string;
+			priority: SpaceTaskPriority;
+		}> = {};
+		if (title.trim() !== initialTitle.trim()) updates.title = trimmedTitle;
+		if (description.trim() !== initialDescription.trim()) updates.description = description.trim();
+		if (priority !== initialPriority) updates.priority = priority;
+		if (Object.keys(updates).length === 0) return;
+		void onConfirm(updates);
 	};
 
 	return (

--- a/packages/web/src/components/space/EditTaskModal.tsx
+++ b/packages/web/src/components/space/EditTaskModal.tsx
@@ -1,0 +1,168 @@
+/**
+ * EditTaskModal — inline editor for task title, description, and priority.
+ *
+ * Opens from the "Edit" button in the SpaceTaskPane header. Calls
+ * `spaceStore.updateTask` on confirm, which routes through the existing
+ * `spaceTask.update` RPC handler. Available for non-terminal tasks only.
+ */
+
+import type { SpaceTaskPriority } from '@neokai/shared';
+import { useEffect, useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal.tsx';
+
+const PRIORITY_OPTIONS: Array<{ value: SpaceTaskPriority; label: string }> = [
+	{ value: 'low', label: 'Low' },
+	{ value: 'normal', label: 'Normal' },
+	{ value: 'high', label: 'High' },
+	{ value: 'urgent', label: 'Urgent' },
+];
+
+export interface EditTaskModalProps {
+	isOpen: boolean;
+	busy: boolean;
+	initialTitle: string;
+	initialDescription: string;
+	initialPriority: SpaceTaskPriority;
+	onCancel: () => void;
+	onConfirm: (updates: {
+		title: string;
+		description: string;
+		priority: SpaceTaskPriority;
+	}) => void | Promise<void>;
+	error?: string | null;
+}
+
+export function EditTaskModal({
+	isOpen,
+	busy,
+	initialTitle,
+	initialDescription,
+	initialPriority,
+	onCancel,
+	onConfirm,
+	error,
+}: EditTaskModalProps) {
+	const [title, setTitle] = useState(initialTitle);
+	const [description, setDescription] = useState(initialDescription);
+	const [priority, setPriority] = useState(initialPriority);
+
+	// Reset form when modal opens with fresh values
+	useEffect(() => {
+		if (isOpen) {
+			setTitle(initialTitle);
+			setDescription(initialDescription);
+			setPriority(initialPriority);
+		}
+	}, [isOpen, initialTitle, initialDescription, initialPriority]);
+
+	const hasChanges =
+		title !== initialTitle || description !== initialDescription || priority !== initialPriority;
+
+	const trimmedTitle = title.trim();
+	const canConfirm = hasChanges && trimmedTitle.length > 0 && !busy;
+
+	const handleConfirm = (): void => {
+		if (!canConfirm) return;
+		void onConfirm({
+			title: trimmedTitle,
+			description: description.trim(),
+			priority,
+		});
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={() => {
+				if (!busy) onCancel();
+			}}
+			title="Edit Task"
+			size="md"
+		>
+			<div class="space-y-4" data-testid="edit-task-modal-content">
+				<div>
+					<label class="block text-[11px] text-gray-400 mb-1" for="edit-task-title-input">
+						Title
+					</label>
+					<input
+						id="edit-task-title-input"
+						data-testid="edit-task-title"
+						type="text"
+						value={title}
+						onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
+						disabled={busy}
+						maxLength={200}
+					/>
+				</div>
+
+				<div>
+					<label class="block text-[11px] text-gray-400 mb-1" for="edit-task-description-input">
+						Description
+					</label>
+					<textarea
+						id="edit-task-description-input"
+						data-testid="edit-task-description"
+						value={description}
+						onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none min-h-[120px] resize-y"
+						rows={6}
+						disabled={busy}
+						placeholder="Describe what this task should accomplish..."
+					/>
+				</div>
+
+				<div>
+					<label class="block text-[11px] text-gray-400 mb-1" for="edit-task-priority-select">
+						Priority
+					</label>
+					<select
+						id="edit-task-priority-select"
+						data-testid="edit-task-priority"
+						value={priority}
+						onChange={(e) =>
+							setPriority((e.target as HTMLSelectElement).value as SpaceTaskPriority)
+						}
+						onInput={(e) => setPriority((e.target as HTMLSelectElement).value as SpaceTaskPriority)}
+						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
+						disabled={busy}
+					>
+						{PRIORITY_OPTIONS.map((opt) => (
+							<option key={opt.value} value={opt.value}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{error && (
+					<p class="text-xs text-red-400" role="alert" data-testid="edit-task-error">
+						{error}
+					</p>
+				)}
+
+				<div class="flex items-center justify-end gap-3 pt-1">
+					<button
+						type="button"
+						onClick={() => {
+							if (!busy) onCancel();
+						}}
+						disabled={busy}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={!canConfirm}
+						data-testid="edit-task-confirm"
+						class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-blue-600 hover:bg-blue-700 text-white disabled:bg-blue-600/50 disabled:cursor-not-allowed"
+					>
+						{busy ? 'Saving...' : 'Save Changes'}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/EditTaskModal.tsx
+++ b/packages/web/src/components/space/EditTaskModal.tsx
@@ -56,7 +56,9 @@ export function EditTaskModal({
 	}, [isOpen, initialTitle, initialDescription, initialPriority]);
 
 	const hasChanges =
-		title !== initialTitle || description !== initialDescription || priority !== initialPriority;
+		title.trim() !== initialTitle.trim() ||
+		description.trim() !== initialDescription.trim() ||
+		priority !== initialPriority;
 
 	const trimmedTitle = title.trim();
 	const canConfirm = hasChanges && trimmedTitle.length > 0 && !busy;

--- a/packages/web/src/components/space/EditTaskModal.tsx
+++ b/packages/web/src/components/space/EditTaskModal.tsx
@@ -46,14 +46,16 @@ export function EditTaskModal({
 	const [description, setDescription] = useState(initialDescription);
 	const [priority, setPriority] = useState(initialPriority);
 
-	// Reset form when modal opens with fresh values
+	// Reset form when the modal opens. Only depend on `isOpen` so concurrent
+	// store updates (e.g. space.task.updated events) don't overwrite in-progress
+	// edits while the user is typing.
 	useEffect(() => {
 		if (isOpen) {
 			setTitle(initialTitle);
 			setDescription(initialDescription);
 			setPriority(initialPriority);
 		}
-	}, [isOpen, initialTitle, initialDescription, initialPriority]);
+	}, [isOpen]);
 
 	const hasChanges =
 		title.trim() !== initialTitle.trim() ||

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -25,6 +25,7 @@ import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
 import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
+import { EditTaskModal } from './EditTaskModal';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
@@ -188,6 +189,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	// review RPC needs to surface inside the modal regardless of composer
 	// visibility — see `SubmitForReviewModalProps.error`.
 	const [submitForReviewError, setSubmitForReviewError] = useState<string | null>(null);
+	const [showEditTaskModal, setShowEditTaskModal] = useState(false);
+	const [editTaskError, setEditTaskError] = useState<string | null>(null);
 	const [fullWorkflow, setFullWorkflow] = useState<import('@neokai/shared').SpaceWorkflow | null>(
 		null
 	);
@@ -657,6 +660,23 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
+	const handleEditTaskConfirm = async (updates: {
+		title: string;
+		description: string;
+		priority: import('@neokai/shared').SpaceTaskPriority;
+	}) => {
+		try {
+			setStatusTransitioning(true);
+			setEditTaskError(null);
+			await spaceStore.updateTask(task.id, updates);
+			setShowEditTaskModal(false);
+		} catch (err) {
+			setEditTaskError(formatTaskThreadError(err));
+		} finally {
+			setStatusTransitioning(false);
+		}
+	};
+
 	const allTransitionActions = getTransitionActions(task.status);
 	// Mirrors the filter in `TaskStatusActions`: any task in `review` is
 	// "awaiting human approval via a dedicated banner" — the bare review→done /
@@ -801,6 +821,33 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							)}
 						</div>
 					</div>
+					{!isTerminalTask && (
+						<button
+							type="button"
+							onClick={() => {
+								setEditTaskError(null);
+								setShowEditTaskModal(true);
+							}}
+							class="flex-shrink-0 rounded-md p-1.5 text-gray-400 hover:bg-dark-800 hover:text-gray-200 transition-colors"
+							data-testid="task-edit-button"
+							aria-label="Edit Task"
+							title="Edit title, description, or priority"
+						>
+							<svg
+								class="w-4 h-4"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+								stroke-width={2}
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+								/>
+							</svg>
+						</button>
+					)}
 					{taskActionItems.length > 0 && (
 						<Dropdown
 							items={taskActionItems}
@@ -1034,6 +1081,18 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				}}
 				onConfirm={handleSubmitForReviewConfirm}
 				error={submitForReviewError}
+			/>
+			<EditTaskModal
+				isOpen={showEditTaskModal}
+				busy={statusTransitioning}
+				initialTitle={task.title}
+				initialDescription={task.description ?? ''}
+				initialPriority={task.priority}
+				onCancel={() => {
+					if (!statusTransitioning) setShowEditTaskModal(false);
+				}}
+				onConfirm={handleEditTaskConfirm}
+				error={editTaskError}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -672,20 +672,34 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
-	const handleEditTaskConfirm = async (updates: {
-		title: string;
-		description: string;
-		priority: import('@neokai/shared').SpaceTaskPriority;
-	}) => {
+	const handleEditTaskConfirm = async (
+		updates: Partial<{
+			title: string;
+			description: string;
+			priority: import('@neokai/shared').SpaceTaskPriority;
+		}>
+	) => {
+		// Capture the current taskId before the async gap. If the user
+		// switches tasks while the save is in-flight, the stale callback
+		// must not mutate the new task's modal state.
+		const savedTaskId = task.id;
 		try {
 			setEditTaskBusy(true);
 			setEditTaskError(null);
-			await spaceStore.updateTask(task.id, updates);
-			setShowEditTaskModal(false);
+			await spaceStore.updateTask(savedTaskId, updates);
+			// Only close the modal if we're still on the same task.
+			if (task.id === savedTaskId) {
+				setShowEditTaskModal(false);
+			}
 		} catch (err) {
-			setEditTaskError(formatTaskThreadError(err));
+			// Only surface the error if we're still on the same task.
+			if (task.id === savedTaskId) {
+				setEditTaskError(formatTaskThreadError(err));
+			}
 		} finally {
-			setEditTaskBusy(false);
+			if (task.id === savedTaskId) {
+				setEditTaskBusy(false);
+			}
 		}
 	};
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -8,6 +8,7 @@ import {
 } from '@neokai/shared';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { TaskComposerTarget } from '../../hooks';
 import { borderColors } from '../../lib/design-tokens';
 import {
 	navigateToSpaceTask,
@@ -20,17 +21,16 @@ import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
 import { cn } from '../../lib/utils';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
+import { EditTaskModal } from './EditTaskModal';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
 import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
-import { EditTaskModal } from './EditTaskModal';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { TaskSessionChatComposer } from './TaskSessionChatComposer';
-import { type TaskComposerTarget } from '../../hooks';
 import { getTransitionActions } from './TaskStatusActions';
 import { useRunGateSummaries } from './use-run-gate-summaries.ts';
 
@@ -189,6 +189,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const threadPanelRef = useRef<HTMLDivElement>(null);
 	const scrollToBottomRef = useRef<((smooth?: boolean) => void) | null>(null);
 	const draftWasActiveRef = useRef(false);
+	const currentTaskIdRef = useRef<string | null>(taskId);
+	currentTaskIdRef.current = taskId;
 	// Modal-local error feedback. Separate from `threadSendError` because
 	// `threadSendError` is rendered inside `TaskSessionChatComposer`, which is
 	// only mounted when the inline composer is visible. A failed submit-for-
@@ -685,25 +687,23 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			priority: import('@neokai/shared').SpaceTaskPriority;
 		}>
 	) => {
-		// Capture the current taskId before the async gap. If the user
-		// switches tasks while the save is in-flight, the stale callback
-		// must not mutate the new task's modal state.
+		// Capture the current taskId before the async gap. After `await`,
+		// the closure's `task` is stale (captured at render time), so we
+		// read `currentTaskIdRef.current` which is updated on each render.
 		const savedTaskId = task.id;
 		try {
 			setEditTaskBusy(true);
 			setEditTaskError(null);
 			await spaceStore.updateTask(savedTaskId, updates);
-			// Only close the modal if we're still on the same task.
-			if (task.id === savedTaskId) {
+			if (currentTaskIdRef.current === savedTaskId) {
 				setShowEditTaskModal(false);
 			}
 		} catch (err) {
-			// Only surface the error if we're still on the same task.
-			if (task.id === savedTaskId) {
+			if (currentTaskIdRef.current === savedTaskId) {
 				setEditTaskError(formatEditTaskError(err));
 			}
 		} finally {
-			if (task.id === savedTaskId) {
+			if (currentTaskIdRef.current === savedTaskId) {
 				setEditTaskBusy(false);
 			}
 		}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -151,6 +151,11 @@ function formatTaskThreadError(err: unknown): string {
 	if (message.includes('Session not found')) {
 		return 'Task thread points to a stale session. Keep this pane open while it reconnects.';
 	}
+	return message || 'Failed to update task thread';
+}
+
+function formatEditTaskError(err: unknown): string {
+	const message = err instanceof Error ? err.message : String(err);
 	return message || 'Failed to update task';
 }
 
@@ -695,7 +700,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		} catch (err) {
 			// Only surface the error if we're still on the same task.
 			if (task.id === savedTaskId) {
-				setEditTaskError(formatTaskThreadError(err));
+				setEditTaskError(formatEditTaskError(err));
 			}
 		} finally {
 			if (task.id === savedTaskId) {

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -150,7 +150,7 @@ function formatTaskThreadError(err: unknown): string {
 	if (message.includes('Session not found')) {
 		return 'Task thread points to a stale session. Keep this pane open while it reconnects.';
 	}
-	return message || 'Failed to update task thread';
+	return message || 'Failed to update task';
 }
 
 export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) {
@@ -190,6 +190,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	// visibility — see `SubmitForReviewModalProps.error`.
 	const [submitForReviewError, setSubmitForReviewError] = useState<string | null>(null);
 	const [showEditTaskModal, setShowEditTaskModal] = useState(false);
+	const [editTaskBusy, setEditTaskBusy] = useState(false);
 	const [editTaskError, setEditTaskError] = useState<string | null>(null);
 	const [fullWorkflow, setFullWorkflow] = useState<import('@neokai/shared').SpaceWorkflow | null>(
 		null
@@ -666,14 +667,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		priority: import('@neokai/shared').SpaceTaskPriority;
 	}) => {
 		try {
-			setStatusTransitioning(true);
+			setEditTaskBusy(true);
 			setEditTaskError(null);
 			await spaceStore.updateTask(task.id, updates);
 			setShowEditTaskModal(false);
 		} catch (err) {
 			setEditTaskError(formatTaskThreadError(err));
 		} finally {
-			setStatusTransitioning(false);
+			setEditTaskBusy(false);
 		}
 	};
 
@@ -1084,12 +1085,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			/>
 			<EditTaskModal
 				isOpen={showEditTaskModal}
-				busy={statusTransitioning}
+				busy={editTaskBusy}
 				initialTitle={task.title}
 				initialDescription={task.description ?? ''}
 				initialPriority={task.priority}
 				onCancel={() => {
-					if (!statusTransitioning) setShowEditTaskModal(false);
+					if (!editTaskBusy) setShowEditTaskModal(false);
 				}}
 				onConfirm={handleEditTaskConfirm}
 				error={editTaskError}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -359,6 +359,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const isTerminalTask =
 		task.status === 'done' || task.status === 'cancelled' || task.status === 'archived';
 
+	// Close edit modal if the task becomes terminal while the modal is open
+	// (e.g. another client transitions the task to done/cancelled/archived).
+	useEffect(() => {
+		if (isTerminalTask && showEditTaskModal) {
+			setShowEditTaskModal(false);
+		}
+	}, [isTerminalTask]);
+
 	// Per-agent activity. Each member that's currently executing (not idle /
 	// completed / failed / interrupted) contributes its label to the active set.
 	// The thread feed keys the live rail off this set so that, in multi-session

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -208,6 +208,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		setThreadScroller(null);
 		scrollToBottomRef.current = null;
 		draftWasActiveRef.current = false;
+		setShowEditTaskModal(false);
+		setEditTaskBusy(false);
+		setEditTaskError(null);
 	}, [taskId]);
 
 	useEffect(() => {

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -745,6 +745,15 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	}
 
 	const taskActionItems: DropdownMenuItem[] = [];
+	if (!isTerminalTask) {
+		taskActionItems.push({
+			label: 'Edit title, description, or priority',
+			onClick: () => {
+				setEditTaskError(null);
+				setShowEditTaskModal(true);
+			},
+		});
+	}
 	if (activityMembers.length > 0) {
 		taskActionItems.push(
 			...activityMembers.map((member) => ({
@@ -853,33 +862,6 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							)}
 						</div>
 					</div>
-					{!isTerminalTask && (
-						<button
-							type="button"
-							onClick={() => {
-								setEditTaskError(null);
-								setShowEditTaskModal(true);
-							}}
-							class="flex-shrink-0 rounded-md p-1.5 text-gray-400 hover:bg-dark-800 hover:text-gray-200 transition-colors"
-							data-testid="task-edit-button"
-							aria-label="Edit Task"
-							title="Edit title, description, or priority"
-						>
-							<svg
-								class="w-4 h-4"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-								stroke-width={2}
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-								/>
-							</svg>
-						</button>
-					)}
 					{taskActionItems.length > 0 && (
 						<Dropdown
 							items={taskActionItems}

--- a/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
@@ -113,6 +113,17 @@ describe('EditTaskModal', () => {
 		expect(confirm.disabled).toBe(true);
 	});
 
+	it('confirm is disabled when only whitespace changes are made (semantic no-op)', () => {
+		const { getByTestId } = renderModal();
+		// Add surrounding whitespace — after trim, value equals initial
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: '  My Task  ' } });
+		fireEvent.input(getByTestId('edit-task-description'), {
+			target: { value: '  Do the thing  ' },
+		});
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(true);
+	});
+
 	it('confirm forwards trimmed title and description', () => {
 		const { getByTestId, onConfirm } = renderModal();
 		fireEvent.input(getByTestId('edit-task-title'), {

--- a/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
@@ -99,6 +99,15 @@ describe('EditTaskModal', () => {
 		expect(confirm.disabled).toBe(false);
 	});
 
+	it('confirm sends only the changed title, not untouched fields', () => {
+		const { getByTestId, onConfirm } = renderModal();
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: 'New Title' } });
+		fireEvent.click(getByTestId('edit-task-confirm'));
+		expect(onConfirm).toHaveBeenCalledWith({
+			title: 'New Title',
+		});
+	});
+
 	it('confirm is disabled when title is emptied', () => {
 		const { getByTestId } = renderModal();
 		fireEvent.input(getByTestId('edit-task-title'), { target: { value: '' } });
@@ -124,7 +133,7 @@ describe('EditTaskModal', () => {
 		expect(confirm.disabled).toBe(true);
 	});
 
-	it('confirm forwards trimmed title and description', () => {
+	it('confirm forwards only changed fields', () => {
 		const { getByTestId, onConfirm } = renderModal();
 		fireEvent.input(getByTestId('edit-task-title'), {
 			target: { value: '  Updated Title  ' },
@@ -137,17 +146,14 @@ describe('EditTaskModal', () => {
 		expect(onConfirm).toHaveBeenCalledWith({
 			title: 'Updated Title',
 			description: 'New desc',
-			priority: 'normal',
 		});
 	});
 
-	it('confirm forwards priority change', () => {
+	it('confirm forwards priority change only', () => {
 		const { getByTestId, onConfirm } = renderModal();
 		fireEvent.change(getByTestId('edit-task-priority'), { target: { value: 'urgent' } });
 		fireEvent.click(getByTestId('edit-task-confirm'));
 		expect(onConfirm).toHaveBeenCalledWith({
-			title: 'My Task',
-			description: 'Do the thing',
 			priority: 'urgent',
 		});
 	});

--- a/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
@@ -228,4 +228,37 @@ describe('EditTaskModal', () => {
 		const { queryByTestId } = renderModal({ error: null });
 		expect(queryByTestId('edit-task-error')).toBeNull();
 	});
+
+	it('does not overwrite user edits when initial props change while open', () => {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const { rerender, getByTestId } = render(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+			/>
+		);
+		// User types a new title
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: 'My New Title' } });
+
+		// Simulate external update changing the initial title (e.g. space.task.updated event)
+		rerender(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				initialTitle="Changed Externally"
+				initialDescription="Do the thing"
+				initialPriority="normal"
+			/>
+		);
+
+		// User's edit should be preserved — not overwritten by the prop change
+		const title = getByTestId('edit-task-title') as HTMLInputElement;
+		expect(title.value).toBe('My New Title');
+	});
 });

--- a/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
@@ -1,0 +1,220 @@
+// @ts-nocheck
+
+/**
+ * Unit tests for EditTaskModal — the inline editor for task title,
+ * description, and priority. Tests pin the contract that:
+ *   - it only renders when `isOpen` is true
+ *   - confirm forwards the edited fields (title trimmed, description trimmed)
+ *   - confirm is disabled when no changes are made
+ *   - confirm is disabled when title is empty after trimming
+ *   - cancel fires `onCancel` and respects `busy`
+ *   - `busy` disables all inputs and buttons
+ *   - the form resets between opens (no stale values leak)
+ *   - the `error` prop renders inline
+ */
+
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditTaskModal } from '../EditTaskModal';
+
+const DEFAULT_PROPS = {
+	initialTitle: 'My Task',
+	initialDescription: 'Do the thing',
+	initialPriority: 'normal' as const,
+};
+
+describe('EditTaskModal', () => {
+	beforeEach(() => {
+		cleanup();
+	});
+	afterEach(() => {
+		cleanup();
+	});
+
+	function renderModal(overrides: Partial<Parameters<typeof EditTaskModal>[0]> = {}) {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const utils = render(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+				{...overrides}
+			/>
+		);
+		return { ...utils, onCancel, onConfirm };
+	}
+
+	it('does not render when isOpen is false', () => {
+		const { queryByTestId } = render(
+			<EditTaskModal
+				isOpen={false}
+				busy={false}
+				onCancel={vi.fn()}
+				onConfirm={vi.fn()}
+				{...DEFAULT_PROPS}
+			/>
+		);
+		expect(queryByTestId('edit-task-modal-content')).toBeNull();
+	});
+
+	it('renders title input, description textarea, priority select, and buttons when open', () => {
+		const { getByTestId, getByText } = renderModal();
+		expect(getByTestId('edit-task-modal-content')).toBeTruthy();
+		expect(getByTestId('edit-task-title')).toBeTruthy();
+		expect(getByTestId('edit-task-description')).toBeTruthy();
+		expect(getByTestId('edit-task-priority')).toBeTruthy();
+		expect(getByTestId('edit-task-confirm')).toBeTruthy();
+		expect(getByText('Cancel')).toBeTruthy();
+	});
+
+	it('confirm button is disabled when no changes are made', () => {
+		const { getByTestId } = renderModal();
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(true);
+	});
+
+	it('confirm button is enabled when title changes', () => {
+		const { getByTestId } = renderModal();
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: 'New Title' } });
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(false);
+	});
+
+	it('confirm button is enabled when description changes', () => {
+		const { getByTestId } = renderModal();
+		fireEvent.input(getByTestId('edit-task-description'), {
+			target: { value: 'New description' },
+		});
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(false);
+	});
+
+	it('confirm button is enabled when priority changes', () => {
+		const { getByTestId } = renderModal();
+		fireEvent.input(getByTestId('edit-task-priority'), { target: { value: 'high' } });
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(false);
+	});
+
+	it('confirm is disabled when title is emptied', () => {
+		const { getByTestId } = renderModal();
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: '' } });
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(true);
+	});
+
+	it('confirm is disabled when title is whitespace-only', () => {
+		const { getByTestId } = renderModal();
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: '   ' } });
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(true);
+	});
+
+	it('confirm forwards trimmed title and description', () => {
+		const { getByTestId, onConfirm } = renderModal();
+		fireEvent.input(getByTestId('edit-task-title'), {
+			target: { value: '  Updated Title  ' },
+		});
+		fireEvent.input(getByTestId('edit-task-description'), {
+			target: { value: '  New desc  ' },
+		});
+		fireEvent.click(getByTestId('edit-task-confirm'));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith({
+			title: 'Updated Title',
+			description: 'New desc',
+			priority: 'normal',
+		});
+	});
+
+	it('confirm forwards priority change', () => {
+		const { getByTestId, onConfirm } = renderModal();
+		fireEvent.change(getByTestId('edit-task-priority'), { target: { value: 'urgent' } });
+		fireEvent.click(getByTestId('edit-task-confirm'));
+		expect(onConfirm).toHaveBeenCalledWith({
+			title: 'My Task',
+			description: 'Do the thing',
+			priority: 'urgent',
+		});
+	});
+
+	it('cancel button fires onCancel', () => {
+		const { getByText, onCancel } = renderModal();
+		fireEvent.click(getByText('Cancel'));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it('busy=true disables confirm, cancel, and all inputs', () => {
+		const { getByTestId, getByText } = renderModal({ busy: true });
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		const cancel = getByText('Cancel') as HTMLButtonElement;
+		const title = getByTestId('edit-task-title') as HTMLInputElement;
+		const description = getByTestId('edit-task-description') as HTMLTextAreaElement;
+		const priority = getByTestId('edit-task-priority') as HTMLSelectElement;
+		expect(confirm.disabled).toBe(true);
+		expect(cancel.disabled).toBe(true);
+		expect(title.disabled).toBe(true);
+		expect(description.disabled).toBe(true);
+		expect(priority.disabled).toBe(true);
+		expect(confirm.textContent).toContain('Saving');
+	});
+
+	it('busy=true does not call onCancel when cancel is clicked', () => {
+		const { getByText, onCancel } = renderModal({ busy: true });
+		fireEvent.click(getByText('Cancel'));
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it('resets form fields between opens', () => {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const { rerender, getByTestId } = render(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+			/>
+		);
+		fireEvent.input(getByTestId('edit-task-title'), { target: { value: 'Stale Title' } });
+
+		// Close
+		rerender(
+			<EditTaskModal
+				isOpen={false}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+			/>
+		);
+		// Reopen — form should reset to initial values
+		rerender(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+			/>
+		);
+		const title = getByTestId('edit-task-title') as HTMLInputElement;
+		expect(title.value).toBe('My Task');
+	});
+
+	it('renders the inline error when the error prop is set', () => {
+		const { getByTestId } = renderModal({ error: 'Update failed — try again' });
+		const errEl = getByTestId('edit-task-error');
+		expect(errEl.textContent).toContain('Update failed — try again');
+		expect(errEl.getAttribute('role')).toBe('alert');
+	});
+
+	it('does not render the error region when error is null', () => {
+		const { queryByTestId } = renderModal({ error: null });
+		expect(queryByTestId('edit-task-error')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/EditTaskModal.test.tsx
@@ -267,4 +267,36 @@ describe('EditTaskModal', () => {
 		const title = getByTestId('edit-task-title') as HTMLInputElement;
 		expect(title.value).toBe('My New Title');
 	});
+
+	it('compares against frozen baseline, not live props, to avoid sending stale values', () => {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const { rerender, getByTestId } = render(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...DEFAULT_PROPS}
+			/>
+		);
+
+		// Simulate external update changing the description while modal is open
+		rerender(
+			<EditTaskModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				initialTitle="My Task"
+				initialDescription="Updated externally"
+				initialPriority="high"
+			/>
+		);
+
+		// Confirm button should stay disabled — user made no local edits,
+		// and the baseline is frozen from modal-open time (same as local state).
+		const confirm = getByTestId('edit-task-confirm') as HTMLButtonElement;
+		expect(confirm.disabled).toBe(true);
+	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -735,6 +735,24 @@ describe('SpaceTaskPane — canvas toggle', () => {
 			expect(getByTestId('task-edit-button')).toBeTruthy();
 		});
 
+		it('shows the edit button for blocked tasks', () => {
+			mockTasks.value = [makeTask({ status: 'blocked' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
+		it('shows the edit button for review tasks', () => {
+			mockTasks.value = [makeTask({ status: 'review', taskAgentSessionId: 'session-abc' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
+		it('shows the edit button for approved tasks', () => {
+			mockTasks.value = [makeTask({ status: 'approved', taskAgentSessionId: 'session-abc' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
 		it('hides the edit button for terminal tasks (done)', () => {
 			mockTasks.value = [makeTask({ status: 'done' })];
 			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -815,6 +815,21 @@ describe('SpaceTaskPane — canvas toggle', () => {
 			const errEl = await findByTestId('edit-task-error');
 			expect(errEl.textContent).toContain('Server error');
 		});
+
+		it('closes edit modal when task becomes terminal', async () => {
+			mockTasks.value = [makeTask({ status: 'in_progress' })];
+			const { getByTestId, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-edit-button'));
+			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
+
+			// Simulate task transitioning to done via another client
+			mockTasks.value = [makeTask({ status: 'done' })];
+
+			// Modal should be closed after the effect processes the status change
+			await waitFor(() => {
+				expect(queryByTestId('edit-task-modal-content')).toBeNull();
+			});
+		});
 	});
 	it('canvas node click matches by role (slot name), not by label — regression for Review node bug', () => {
 		// This test reproduces the bug where clicking a "Review" node opened the Task Agent

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -716,6 +716,88 @@ describe('SpaceTaskPane — canvas toggle', () => {
 		});
 	});
 
+	describe('edit task button', () => {
+		it('shows the edit button for in_progress tasks', () => {
+			mockTasks.value = [makeTask({ status: 'in_progress' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
+		it('shows the edit button for open tasks', () => {
+			mockTasks.value = [makeTask({ status: 'open' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
+		it('shows the edit button for draft tasks', () => {
+			mockTasks.value = [makeTask({ status: 'draft' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(getByTestId('task-edit-button')).toBeTruthy();
+		});
+
+		it('hides the edit button for terminal tasks (done)', () => {
+			mockTasks.value = [makeTask({ status: 'done' })];
+			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByTestId('task-edit-button')).toBeNull();
+		});
+
+		it('hides the edit button for terminal tasks (cancelled)', () => {
+			mockTasks.value = [makeTask({ status: 'cancelled' })];
+			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByTestId('task-edit-button')).toBeNull();
+		});
+
+		it('hides the edit button for terminal tasks (archived)', () => {
+			mockTasks.value = [makeTask({ status: 'archived' })];
+			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByTestId('task-edit-button')).toBeNull();
+		});
+
+		it('opens the edit modal when clicked', () => {
+			mockTasks.value = [makeTask({ status: 'in_progress' })];
+			const { getByTestId, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByTestId('edit-task-modal-content')).toBeNull();
+			fireEvent.click(getByTestId('task-edit-button'));
+			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
+		});
+
+		it('calls spaceStore.updateTask when edit is confirmed', async () => {
+			mockTasks.value = [makeTask({ status: 'in_progress', title: 'Old Title' })];
+			mockUpdateTask.mockResolvedValueOnce(makeTask({ status: 'in_progress', title: 'New Title' }));
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-edit-button'));
+
+			// Change the title
+			fireEvent.input(getByTestId('edit-task-title'), {
+				target: { value: 'New Title' },
+			});
+			fireEvent.click(getByTestId('edit-task-confirm'));
+
+			await waitFor(() => {
+				expect(mockUpdateTask).toHaveBeenCalledWith('task-1', {
+					title: 'New Title',
+					description: 'Task description',
+					priority: 'normal',
+				});
+			});
+		});
+
+		it('shows inline error when updateTask fails', async () => {
+			mockTasks.value = [makeTask({ status: 'in_progress', title: 'Old Title' })];
+			mockUpdateTask.mockRejectedValueOnce(new Error('Server error'));
+
+			const { getByTestId, findByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-edit-button'));
+
+			fireEvent.input(getByTestId('edit-task-title'), {
+				target: { value: 'New Title' },
+			});
+			fireEvent.click(getByTestId('edit-task-confirm'));
+
+			const errEl = await findByTestId('edit-task-error');
+			expect(errEl.textContent).toContain('Server error');
+		});
+	});
 	it('canvas node click matches by role (slot name), not by label — regression for Review node bug', () => {
 		// This test reproduces the bug where clicking a "Review" node opened the Task Agent
 		// session instead of the Reviewer session. The root cause was matching m.label against

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -830,6 +830,23 @@ describe('SpaceTaskPane — canvas toggle', () => {
 				expect(queryByTestId('edit-task-modal-content')).toBeNull();
 			});
 		});
+
+		it('clears edit modal state on task switch', () => {
+			mockTasks.value = [
+				makeTask({ id: 'task-1', status: 'in_progress' }),
+				makeTask({ id: 'task-2', status: 'in_progress', taskNumber: 2 }),
+			];
+			const { getByTestId, queryByTestId, rerender } = render(<SpaceTaskPane taskId="task-1" />);
+			// Open edit modal for task-1
+			fireEvent.click(getByTestId('task-edit-button'));
+			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
+
+			// Switch to task-2
+			rerender(<SpaceTaskPane taskId="task-2" />);
+
+			// Edit modal should be closed
+			expect(queryByTestId('edit-task-modal-content')).toBeNull();
+		});
 	});
 	it('canvas node click matches by role (slot name), not by label — regression for Review node bug', () => {
 		// This test reproduces the bug where clicking a "Review" node opened the Task Agent

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -794,8 +794,6 @@ describe('SpaceTaskPane — canvas toggle', () => {
 			await waitFor(() => {
 				expect(mockUpdateTask).toHaveBeenCalledWith('task-1', {
 					title: 'New Title',
-					description: 'Task description',
-					priority: 'normal',
 				});
 			});
 		});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -716,74 +716,82 @@ describe('SpaceTaskPane — canvas toggle', () => {
 		});
 	});
 
-	describe('edit task button', () => {
-		it('shows the edit button for in_progress tasks', () => {
+	describe('edit task menu item', () => {
+		it('shows edit item in dropdown for in_progress tasks', () => {
 			mockTasks.value = [makeTask({ status: 'in_progress' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('shows the edit button for open tasks', () => {
+		it('shows edit item in dropdown for open tasks', () => {
 			mockTasks.value = [makeTask({ status: 'open' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('shows the edit button for draft tasks', () => {
+		it('shows edit item in dropdown for draft tasks', () => {
 			mockTasks.value = [makeTask({ status: 'draft' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('shows the edit button for blocked tasks', () => {
+		it('shows edit item in dropdown for blocked tasks', () => {
 			mockTasks.value = [makeTask({ status: 'blocked' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('shows the edit button for review tasks', () => {
+		it('shows edit item in dropdown for review tasks', () => {
 			mockTasks.value = [makeTask({ status: 'review', taskAgentSessionId: 'session-abc' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('shows the edit button for approved tasks', () => {
+		it('shows edit item in dropdown for approved tasks', () => {
 			mockTasks.value = [makeTask({ status: 'approved', taskAgentSessionId: 'session-abc' })];
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(getByTestId('task-edit-button')).toBeTruthy();
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			expect(getByText('Edit title, description, or priority')).toBeTruthy();
 		});
 
-		it('hides the edit button for terminal tasks (done)', () => {
+		it('edit item is absent for terminal tasks (done)', () => {
 			mockTasks.value = [makeTask({ status: 'done' })];
-			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(queryByTestId('task-edit-button')).toBeNull();
+			const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByText('Edit title, description, or priority')).toBeNull();
 		});
 
-		it('hides the edit button for terminal tasks (cancelled)', () => {
+		it('edit item is absent for terminal tasks (cancelled)', () => {
 			mockTasks.value = [makeTask({ status: 'cancelled' })];
-			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(queryByTestId('task-edit-button')).toBeNull();
+			const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByText('Edit title, description, or priority')).toBeNull();
 		});
 
-		it('hides the edit button for terminal tasks (archived)', () => {
+		it('edit item is absent for terminal tasks (archived)', () => {
 			mockTasks.value = [makeTask({ status: 'archived' })];
-			const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			expect(queryByTestId('task-edit-button')).toBeNull();
+			const { queryByText } = render(<SpaceTaskPane taskId="task-1" />);
+			expect(queryByText('Edit title, description, or priority')).toBeNull();
 		});
 
 		it('opens the edit modal when clicked', () => {
 			mockTasks.value = [makeTask({ status: 'in_progress' })];
-			const { getByTestId, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			const { getByTestId, getByText, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
 			expect(queryByTestId('edit-task-modal-content')).toBeNull();
-			fireEvent.click(getByTestId('task-edit-button'));
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			fireEvent.click(getByText('Edit title, description, or priority'));
 			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
 		});
 
 		it('calls spaceStore.updateTask when edit is confirmed', async () => {
 			mockTasks.value = [makeTask({ status: 'in_progress', title: 'Old Title' })];
 			mockUpdateTask.mockResolvedValueOnce(makeTask({ status: 'in_progress', title: 'New Title' }));
-			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			fireEvent.click(getByTestId('task-edit-button'));
+			const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			fireEvent.click(getByText('Edit title, description, or priority'));
 
 			// Change the title
 			fireEvent.input(getByTestId('edit-task-title'), {
@@ -802,8 +810,9 @@ describe('SpaceTaskPane — canvas toggle', () => {
 			mockTasks.value = [makeTask({ status: 'in_progress', title: 'Old Title' })];
 			mockUpdateTask.mockRejectedValueOnce(new Error('Server error'));
 
-			const { getByTestId, findByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			fireEvent.click(getByTestId('task-edit-button'));
+			const { getByTestId, getByText, findByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			fireEvent.click(getByText('Edit title, description, or priority'));
 
 			fireEvent.input(getByTestId('edit-task-title'), {
 				target: { value: 'New Title' },
@@ -816,8 +825,9 @@ describe('SpaceTaskPane — canvas toggle', () => {
 
 		it('closes edit modal when task becomes terminal', async () => {
 			mockTasks.value = [makeTask({ status: 'in_progress' })];
-			const { getByTestId, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-			fireEvent.click(getByTestId('task-edit-button'));
+			const { getByTestId, getByText, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			fireEvent.click(getByText('Edit title, description, or priority'));
 			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
 
 			// Simulate task transitioning to done via another client
@@ -834,9 +844,12 @@ describe('SpaceTaskPane — canvas toggle', () => {
 				makeTask({ id: 'task-1', status: 'in_progress' }),
 				makeTask({ id: 'task-2', status: 'in_progress', taskNumber: 2 }),
 			];
-			const { getByTestId, queryByTestId, rerender } = render(<SpaceTaskPane taskId="task-1" />);
+			const { getByTestId, getByText, queryByTestId, rerender } = render(
+				<SpaceTaskPane taskId="task-1" />
+			);
 			// Open edit modal for task-1
-			fireEvent.click(getByTestId('task-edit-button'));
+			fireEvent.click(getByTestId('task-actions-menu-trigger'));
+			fireEvent.click(getByText('Edit title, description, or priority'));
 			expect(getByTestId('edit-task-modal-content')).toBeTruthy();
 
 			// Switch to task-2


### PR DESCRIPTION
## Summary

- Adds an "Edit" button (pencil icon) to the SpaceTaskPane header for non-terminal tasks (draft, open, in_progress, blocked, review)
- New `EditTaskModal` component for editing title, description, and priority via the existing `spaceTask.update` RPC
- Changes are immediately reflected in the reactive store — no page reload needed
- Inline error display for RPC failures; form resets between opens to prevent stale value leaks

## Test plan

- [x] 16 unit tests for `EditTaskModal` (render, confirm, cancel, busy, reset, error)
- [x] 9 integration tests in `SpaceTaskPane` (edit button visibility, modal open, `updateTask` call, error handling)
- [x] All 87 web tests pass
- [x] lint, typecheck, knip all green