### PR TITLE
feat: add 429 retry exhaustion detection and auto-recovery

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1320,12 +1320,13 @@ export class AgentSession
 	/**
 	 * Called by QueryRunner when 429 rate limit exhaustion is detected.
 	 * Delegates to the RateLimitWatchdog to schedule auto-retry.
+	 * @returns true if cooldown was scheduled, false if max retries exceeded.
 	 */
 	onRateLimitExhausted(
 		errorMessage: string,
 		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
-	): void {
-		this.rateLimitWatchdog.scheduleRetry(errorMessage, lastUserMessage);
+	): boolean {
+		return this.rateLimitWatchdog.scheduleRetry(errorMessage, lastUserMessage);
 	}
 
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -732,6 +732,10 @@ export class AgentSession
 		restartQuery?: boolean;
 		hardReset?: boolean;
 	}): Promise<{ success: boolean; error?: string }> {
+		// Cancel any pending rate-limit cooldown timer so it doesn't
+		// inject stale messages into the reset session.
+		this.rateLimitWatchdog.cancel();
+
 		const restartQuery = options?.restartQuery ?? true;
 		if (options?.hardReset && this.runtimeOptions.hardReset) {
 			return await this.runtimeOptions.hardReset(this, { restartQuery });
@@ -1228,6 +1232,7 @@ export class AgentSession
 	 * while preserving conversation history.
 	 */
 	async restart(): Promise<void> {
+		this.rateLimitWatchdog.cancel();
 		await this.lifecycleManager.restart();
 	}
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -242,6 +242,7 @@ import { SlashCommandManager, type SlashCommandManagerContext } from './slash-co
 import { MessageRecoveryHandler } from './message-recovery-handler';
 import { RewindHandler, type RewindHandlerContext, type RewindPoint } from './rewind-handler';
 import { SessionConfigHandler, type SessionConfigHandlerContext } from './session-config-handler';
+import { RateLimitWatchdog } from './rate-limit-watchdog';
 
 /**
  * AgentSession - Pure facade that delegates to specialized handlers
@@ -288,6 +289,9 @@ export class AgentSession
 
 	// Config handler
 	private sessionConfigHandler: SessionConfigHandler;
+
+	// Rate limit auto-retry watchdog
+	private rateLimitWatchdog: RateLimitWatchdog;
 
 	// SDK query state (accessible to handlers via context interfaces)
 	queryObject: Query | null = null;
@@ -408,6 +412,12 @@ export class AgentSession
 
 		// Initialize SessionConfigHandler (handlers take AgentSession context directly)
 		this.sessionConfigHandler = new SessionConfigHandler(this);
+
+		// Initialize RateLimitWatchdog — detects 429 exhaustion and schedules auto-retry
+		this.rateLimitWatchdog = new RateLimitWatchdog(session.id, this.stateManager);
+		this.rateLimitWatchdog.setRetryCallback(async (lastUserMessage) => {
+			await this.executeRateLimitAutoRetry(lastUserMessage);
+		});
 
 		// Initialize EventSubscriptionSetup (handlers take AgentSession context directly)
 		// Must be last since it needs other handlers to be initialized
@@ -705,6 +715,8 @@ export class AgentSession
 		messageId: string,
 		messageContent: string | MessageContent[]
 	): Promise<void> {
+		// Cancel any pending rate limit auto-retry — user sent a new message
+		this.rateLimitWatchdog.cancel();
 		await this.lifecycleManager.startQueryAndEnqueue(messageId, messageContent);
 	}
 
@@ -726,6 +738,75 @@ export class AgentSession
 		}
 
 		return await this.lifecycleManager.reset({ restartAfter: restartQuery });
+	}
+
+	// ============================================================================
+	// Rate Limit Auto-Retry
+	// ============================================================================
+
+	/**
+	 * Execute auto-retry after rate limit cooldown.
+	 * Re-enqueues the last user message and starts a new query.
+	 */
+	private async executeRateLimitAutoRetry(
+		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
+	): Promise<void> {
+		if (!lastUserMessage) {
+			this.logger.warn('Rate limit auto-retry skipped: no last user message available.');
+			await this.stateManager.setIdle();
+			return;
+		}
+
+		this.logger.info(
+			`Rate limit auto-retry: re-enqueueing user message ${lastUserMessage.uuid} ` +
+				`and restarting query.`
+		);
+
+		try {
+			// Ensure the session is idle before starting a new query
+			await this.stateManager.setIdle();
+
+			// Re-enqueue the last user message and start the query
+			await this.startQueryAndEnqueue(lastUserMessage.uuid, lastUserMessage.content);
+		} catch (error) {
+			this.logger.error('Rate limit auto-retry failed:', error);
+			await this.stateManager.setIdle();
+		}
+	}
+
+	/**
+	 * Cancel a pending rate limit auto-retry.
+	 * Called when the user explicitly cancels or sends a new message.
+	 */
+	cancelRateLimitRetry(): void {
+		this.rateLimitWatchdog.cancel();
+		// Transition from rate_limit_cooldown to idle
+		if (this.stateManager.getState().status === 'rate_limit_cooldown') {
+			void this.stateManager.setIdle();
+		}
+	}
+
+	/**
+	 * Immediately retry after a rate limit (bypassing the cooldown timer).
+	 * Called when the user clicks "Retry Now" in the UI.
+	 */
+	async retryNowAfterRateLimit(): Promise<void> {
+		const state = this.rateLimitWatchdog.getState();
+		if (state.status !== 'cooldown') {
+			this.logger.warn('retryNowAfterRateLimit: no cooldown pending.');
+			return;
+		}
+
+		const lastUserMessage = state.lastUserMessage;
+		this.rateLimitWatchdog.cancel();
+		await this.executeRateLimitAutoRetry(lastUserMessage);
+	}
+
+	/**
+	 * Get current rate limit watchdog state (for RPC responses).
+	 */
+	getRateLimitWatchdogState() {
+		return this.rateLimitWatchdog.getState();
 	}
 
 	// ============================================================================
@@ -1232,6 +1313,19 @@ export class AgentSession
 
 	async onMarkApiSuccess(): Promise<void> {
 		this.errorManager.markApiSuccess();
+		// Reset rate limit watchdog on successful API call
+		this.rateLimitWatchdog.reset();
+	}
+
+	/**
+	 * Called by QueryRunner when 429 rate limit exhaustion is detected.
+	 * Delegates to the RateLimitWatchdog to schedule auto-retry.
+	 */
+	onRateLimitExhausted(
+		errorMessage: string,
+		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
+	): void {
+		this.rateLimitWatchdog.scheduleRetry(errorMessage, lastUserMessage);
 	}
 
 	// ============================================================================
@@ -1428,6 +1522,7 @@ export class AgentSession
 	// ============================================================================
 
 	async cleanup(): Promise<void> {
+		this.rateLimitWatchdog.destroy();
 		await this.lifecycleManager.cleanup();
 	}
 }

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1322,10 +1322,10 @@ export class AgentSession
 	 * Delegates to the RateLimitWatchdog to schedule auto-retry.
 	 * @returns true if cooldown was scheduled, false if max retries exceeded.
 	 */
-	onRateLimitExhausted(
+	async onRateLimitExhausted(
 		errorMessage: string,
 		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
-	): boolean {
+	): Promise<boolean> {
 		return this.rateLimitWatchdog.scheduleRetry(errorMessage, lastUserMessage);
 	}
 

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -8,7 +8,7 @@
  * Now persists state to database for recovery after restarts.
  */
 
-import type { AgentProcessingState, PendingUserQuestion } from '@neokai/shared';
+import type { AgentProcessingState, MessageContent, PendingUserQuestion } from '@neokai/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SDKAssistantMessage, SDKMessage } from '@neokai/shared/sdk';
 import { isToolUseBlock } from '@neokai/shared/sdk/type-guards';
@@ -58,6 +58,10 @@ export class ProcessingStateManager {
 			if (restoredState.status === 'processing' || restoredState.status === 'queued') {
 				// Active processing states should reset to idle after restart
 				// The SDK query will need to be restarted anyway
+				this.processingState = { status: 'idle' };
+			} else if (restoredState.status === 'rate_limit_cooldown') {
+				// Cooldown timers are not persisted; reset to idle so the user
+				// can manually retry or send a new message.
 				this.processingState = { status: 'idle' };
 			} else if (restoredState.status === 'waiting_for_input') {
 				// IMPORTANT: Preserve waiting_for_input state across restarts
@@ -163,6 +167,25 @@ export class ProcessingStateManager {
 	 */
 	async setWaitingForInput(pendingQuestion: PendingUserQuestion): Promise<void> {
 		await this.setState({ status: 'waiting_for_input', pendingQuestion });
+	}
+
+	/**
+	 * Set state to rate_limit_cooldown
+	 * Called when 429 retry exhaustion is detected and auto-retry is scheduled
+	 */
+	async setRateLimitCooldown(state: {
+		retryCount: number;
+		maxRetries: number;
+		retryAt: number;
+		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null;
+	}): Promise<void> {
+		await this.setState({
+			status: 'rate_limit_cooldown',
+			retryCount: state.retryCount,
+			maxRetries: state.maxRetries,
+			retryAt: state.retryAt,
+			lastUserMessage: state.lastUserMessage,
+		});
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -8,7 +8,7 @@
  * Now persists state to database for recovery after restarts.
  */
 
-import type { AgentProcessingState, MessageContent, PendingUserQuestion } from '@neokai/shared';
+import type { AgentProcessingState, PendingUserQuestion } from '@neokai/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SDKAssistantMessage, SDKMessage } from '@neokai/shared/sdk';
 import { isToolUseBlock } from '@neokai/shared/sdk/type-guards';
@@ -177,14 +177,12 @@ export class ProcessingStateManager {
 		retryCount: number;
 		maxRetries: number;
 		retryAt: number;
-		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null;
 	}): Promise<void> {
 		await this.setState({
 			status: 'rate_limit_cooldown',
 			retryCount: state.retryCount,
 			maxRetries: state.maxRetries,
 			retryAt: state.retryAt,
-			lastUserMessage: state.lastUserMessage,
 		});
 	}
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -161,6 +161,17 @@ export interface QueryRunnerContext {
 
 	/** Consume (clear) the one-shot resumeSessionAt after the query has started. */
 	consumePendingResumeSessionAt?(): string | undefined;
+
+	/**
+	 * Called when a 429 rate limit exhaustion error is detected (all SDK retries exhausted).
+	 * The RateLimitWatchdog uses this to schedule an automatic retry after cooldown.
+	 * @param errorMessage - The error message from the SDK
+	 * @param lastUserMessage - The last consumed user message for re-enqueue on retry
+	 */
+	onRateLimitExhausted?: (
+		errorMessage: string,
+		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
+	) => void;
 }
 
 /**
@@ -169,13 +180,22 @@ export interface QueryRunnerContext {
 export class QueryRunner {
 	/**
 	 * Last non-internal user message consumed by the generator, for re-enqueue
-	 * on transient connection error retry.  Set by createMessageGeneratorWrapper()
-	 * when a message is yielded to the SDK; cleared after re-enqueue or on cleanup.
+	 * on transient connection error retry or rate limit auto-retry.
+	 * Set by createMessageGeneratorWrapper() when a message is yielded to the SDK;
+	 * cleared after re-enqueue or on cleanup.
 	 */
-	private lastConsumedUserMessage: {
+	private _lastConsumedUserMessage: {
 		uuid: string;
 		content: string | MessageContent[];
 	} | null = null;
+
+	/**
+	 * Public accessor for the last consumed user message.
+	 * Used by RateLimitWatchdog to re-enqueue on auto-retry.
+	 */
+	get lastConsumedUserMessage() {
+		return this._lastConsumedUserMessage;
+	}
 
 	constructor(private ctx: QueryRunnerContext) {}
 
@@ -737,7 +757,7 @@ export class QueryRunner {
 				// process.  Without this, the message was already shifted out of
 				// MessageQueue by messageGenerator() and the retry starts with an
 				// empty queue, silently dropping the user's request.
-				const lastMsg = this.lastConsumedUserMessage;
+				const lastMsg = this._lastConsumedUserMessage;
 				if (lastMsg) {
 					logger.warn(
 						`Re-enqueueing user message ${lastMsg.uuid} for transient connection error retry.`
@@ -745,7 +765,7 @@ export class QueryRunner {
 					// Fire-and-forget: the promise resolves when the retry's generator
 					// consumes the message, or rejects on timeout/interrupt (harmless).
 					messageQueue.enqueueWithId(lastMsg.uuid, lastMsg.content).catch(() => {});
-					this.lastConsumedUserMessage = null;
+					this._lastConsumedUserMessage = null;
 				}
 
 				// Display a sanitized retry message so the user knows what's happening,
@@ -851,6 +871,16 @@ export class QueryRunner {
 					}
 
 					const processingState = stateManager.getState();
+
+					// Notify rate limit watchdog when 429 exhaustion is detected.
+					// Only trigger for 429/rate limit errors (not 402/quota which are
+					// non-retryable billing issues).
+					const is429Error =
+						category === ErrorCategory.RATE_LIMIT &&
+						(errorMessage.includes('429') || errorMessage.includes('rate limit'));
+					if (is429Error && this.ctx.onRateLimitExhausted) {
+						this.ctx.onRateLimitExhausted(errorMessage, this._lastConsumedUserMessage);
+					}
 
 					// For startup timeouts / resume failures, provide actionable recovery hints.
 					// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
@@ -1046,7 +1076,7 @@ export class QueryRunner {
 				// already been shifted out of MessageQueue by messageGenerator(),
 				// so without re-enqueue the retry starts with an empty queue and
 				// the user's request is silently dropped.
-				this.lastConsumedUserMessage = {
+				this._lastConsumedUserMessage = {
 					uuid: message.uuid ?? '',
 					content: message.message?.content ?? '',
 				};

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -165,13 +165,13 @@ export interface QueryRunnerContext {
 	/**
 	 * Called when a 429 rate limit exhaustion error is detected (all SDK retries exhausted).
 	 * The RateLimitWatchdog uses this to schedule an automatic retry after cooldown.
-	 * @param errorMessage - The error message from the SDK
-	 * @param lastUserMessage - The last consumed user message for re-enqueue on retry
+	 * @returns true if cooldown was scheduled (caller should skip setIdle),
+	 *          false if max retries exceeded or callback is unset.
 	 */
 	onRateLimitExhausted?: (
 		errorMessage: string,
 		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
-	) => void;
+	) => boolean;
 }
 
 /**
@@ -805,6 +805,10 @@ export class QueryRunner {
 			if (!isAbortError) {
 				const apiErrorHandled = await this.handleApiValidationError(error);
 
+				// Track whether rate limit cooldown was scheduled; if so, skip setIdle
+				// below to preserve the rate_limit_cooldown processing state.
+				let rateLimitCooldownScheduled = false;
+
 				if (!apiErrorHandled) {
 					let category = ErrorCategory.SYSTEM;
 					const providerId = session.config.provider as string | undefined;
@@ -874,13 +878,13 @@ export class QueryRunner {
 
 					// Notify rate limit watchdog when 429 exhaustion is detected.
 					// Only trigger for 429/rate limit errors (not 402/quota which are
-					// non-retryable billing issues).
+					// non-retryable billing issues). Returns true if cooldown was scheduled.
 					const is429Error =
 						category === ErrorCategory.RATE_LIMIT &&
 						(errorMessage.includes('429') || errorMessage.includes('rate limit'));
-					if (is429Error && this.ctx.onRateLimitExhausted) {
-						this.ctx.onRateLimitExhausted(errorMessage, this._lastConsumedUserMessage);
-					}
+					rateLimitCooldownScheduled =
+						is429Error &&
+						!!this.ctx.onRateLimitExhausted?.(errorMessage, this._lastConsumedUserMessage);
 
 					// For startup timeouts / resume failures, provide actionable recovery hints.
 					// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
@@ -923,7 +927,12 @@ export class QueryRunner {
 						}
 					);
 				}
-				await stateManager.setIdle();
+				// Skip idle transition when rate limit cooldown was scheduled —
+				// the watchdog already set rate_limit_cooldown state and will
+				// transition to idle when the user cancels or the retry fires.
+				if (!rateLimitCooldownScheduled) {
+					await stateManager.setIdle();
+				}
 			}
 		} finally {
 			// Check for stale query FIRST to avoid race conditions.

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -877,11 +877,18 @@ export class QueryRunner {
 					const processingState = stateManager.getState();
 
 					// Notify rate limit watchdog when 429 exhaustion is detected.
-					// Only trigger for 429/rate limit errors (not 402/quota which are
-					// non-retryable billing issues). Returns true if cooldown was scheduled.
+					// Only trigger for genuine 429 rate-limit errors, not 402/quota/billing
+					// issues (which are non-retryable). Use case-insensitive matching.
+					const lowerMsg = errorMessage.toLowerCase();
+					const isBillingError =
+						errorMessage.includes('402') ||
+						lowerMsg.includes('no quota') ||
+						lowerMsg.includes('quota exceeded') ||
+						lowerMsg.includes('insufficient_quota');
 					const is429Error =
 						category === ErrorCategory.RATE_LIMIT &&
-						(errorMessage.includes('429') || errorMessage.includes('rate limit'));
+						!isBillingError &&
+						(errorMessage.includes('429') || lowerMsg.includes('rate limit'));
 					rateLimitCooldownScheduled =
 						is429Error &&
 						!!this.ctx.onRateLimitExhausted?.(errorMessage, this._lastConsumedUserMessage);
@@ -911,21 +918,26 @@ export class QueryRunner {
 								: isTransientConnectionError && isRetry
 									? 'Could not get a response. The connection was interrupted. Please try again.'
 									: undefined;
-					await errorManager.handleError(
-						session.id,
-						error as Error,
-						category,
-						startupTimeoutUserMessage,
-						processingState,
-						{
-							errorMessage,
-							queueSize: messageQueue.size(),
-							providerId: providerId ?? 'anthropic',
-							workspacePath: session.workspacePath ?? undefined,
-							isRootWorkspace: !session.worktree,
-							startupTimeoutMs: STARTUP_TIMEOUT_MS,
-						}
-					);
+					// Skip error broadcast when rate-limit cooldown is scheduled —
+					// the session.error event is terminal in Space workflows and would
+					// prematurely mark the task as failed before the auto-retry fires.
+					if (!rateLimitCooldownScheduled) {
+						await errorManager.handleError(
+							session.id,
+							error as Error,
+							category,
+							startupTimeoutUserMessage,
+							processingState,
+							{
+								errorMessage,
+								queueSize: messageQueue.size(),
+								providerId: providerId ?? 'anthropic',
+								workspacePath: session.workspacePath ?? undefined,
+								isRootWorkspace: !session.worktree,
+								startupTimeoutMs: STARTUP_TIMEOUT_MS,
+							}
+						);
+					}
 				}
 				// Skip idle transition when rate limit cooldown was scheduled —
 				// the watchdog already set rate_limit_cooldown state and will

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -171,7 +171,7 @@ export interface QueryRunnerContext {
 	onRateLimitExhausted?: (
 		errorMessage: string,
 		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
-	) => boolean;
+	) => Promise<boolean>;
 }
 
 /**
@@ -891,7 +891,7 @@ export class QueryRunner {
 						(errorMessage.includes('429') || lowerMsg.includes('rate limit'));
 					rateLimitCooldownScheduled =
 						is429Error &&
-						!!this.ctx.onRateLimitExhausted?.(errorMessage, this._lastConsumedUserMessage);
+						!!(await this.ctx.onRateLimitExhausted?.(errorMessage, this._lastConsumedUserMessage));
 
 					// For startup timeouts / resume failures, provide actionable recovery hints.
 					// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -92,10 +92,10 @@ export class RateLimitWatchdog {
 	 *
 	 * @returns true if scheduled, false if max retries exceeded
 	 */
-	scheduleRetry(
+	async scheduleRetry(
 		errorMessage: string,
 		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
-	): boolean {
+	): Promise<boolean> {
 		// Cancel any existing timer
 		this.cancel();
 
@@ -124,8 +124,9 @@ export class RateLimitWatchdog {
 				`in ${this.config.cooldownMs}ms. Error: ${errorMessage}`
 		);
 
-		// Set processing state to rate_limit_cooldown
-		void this.stateManager.setRateLimitCooldown({
+		// Set processing state to rate_limit_cooldown (awaited to prevent
+		// race with user messages or retry-now overwriting the state).
+		await this.stateManager.setRateLimitCooldown({
 			retryCount: this.retryCount,
 			maxRetries: this.config.maxAutoRetries,
 			retryAt,

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -1,0 +1,227 @@
+/**
+ * RateLimitWatchdog - Auto-retry after 429 rate limit exhaustion
+ *
+ * When the Claude SDK exhausts all retries on a 429 (rate limited) error,
+ * the session stalls. This watchdog detects that state and schedules an
+ * automatic retry after a cooldown period.
+ *
+ * Behavior:
+ * - Schedules a retry timer (default 10 minutes) when 429 exhaustion is detected
+ * - Max 3 auto-retry cycles before giving up entirely
+ * - Cancelable: if the user sends a new message, the timer is cleared
+ * - Fires the retry by re-enqueueing the last user message and restarting the query
+ */
+
+import type { MessageContent } from '@neokai/shared';
+import type { ProcessingStateManager } from './processing-state-manager';
+import { Logger } from '../logger';
+
+export interface RateLimitWatchdogConfig {
+	/** Cooldown period in ms before auto-retry (default: 600000 = 10 min) */
+	cooldownMs: number;
+	/** Maximum number of auto-retry cycles (default: 3) */
+	maxAutoRetries: number;
+}
+
+const DEFAULT_CONFIG: RateLimitWatchdogConfig = {
+	cooldownMs: 10 * 60 * 1000, // 10 minutes
+	maxAutoRetries: 3,
+};
+
+export interface RateLimitWatchdogState {
+	status: 'idle' | 'cooldown';
+	retryCount: number;
+	maxRetries: number;
+	retryAt: number | null;
+	lastUserMessage: { uuid: string; content: string | MessageContent[] } | null;
+}
+
+/**
+ * Callback type for when the cooldown timer fires and a retry should be attempted.
+ * The implementor (AgentSession) is responsible for re-enqueueing the message
+ * and restarting the query.
+ */
+export type RateLimitRetryCallback = (
+	lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
+) => Promise<void>;
+
+export class RateLimitWatchdog {
+	private logger: Logger;
+	private config: RateLimitWatchdogConfig;
+	private retryCount = 0;
+	private cooldownTimer: ReturnType<typeof setTimeout> | null = null;
+	private lastUserMessage: { uuid: string; content: string | MessageContent[] } | null = null;
+	private retryCallback: RateLimitRetryCallback | null = null;
+	private stateManager: ProcessingStateManager;
+
+	constructor(
+		sessionId: string,
+		stateManager: ProcessingStateManager,
+		config?: Partial<RateLimitWatchdogConfig>
+	) {
+		this.logger = new Logger(`RateLimitWatchdog ${sessionId}`);
+		this.config = { ...DEFAULT_CONFIG, ...config };
+		this.stateManager = stateManager;
+	}
+
+	/**
+	 * Set the callback invoked when the cooldown timer fires.
+	 */
+	setRetryCallback(callback: RateLimitRetryCallback): void {
+		this.retryCallback = callback;
+	}
+
+	/**
+	 * Get current watchdog state (for serialization / UI).
+	 */
+	getState(): RateLimitWatchdogState {
+		const retryAt = this.cooldownTimer !== null ? Date.now() + this.getRemainingMs() : null;
+
+		return {
+			status: this.cooldownTimer !== null ? 'cooldown' : 'idle',
+			retryCount: this.retryCount,
+			maxRetries: this.config.maxAutoRetries,
+			retryAt,
+			lastUserMessage: this.lastUserMessage,
+		};
+	}
+
+	/**
+	 * Schedule an auto-retry after cooldown. Called when a 429 exhaustion error
+	 * is detected in QueryRunner's error handling.
+	 *
+	 * @returns true if scheduled, false if max retries exceeded
+	 */
+	scheduleRetry(
+		errorMessage: string,
+		lastUserMessage: { uuid: string; content: string | MessageContent[] } | null
+	): boolean {
+		// Cancel any existing timer
+		this.cancel();
+
+		if (this.retryCount >= this.config.maxAutoRetries) {
+			this.logger.warn(
+				`Max auto-retries (${this.config.maxAutoRetries}) exceeded for 429 error. ` +
+					`Giving up. Error: ${errorMessage}`
+			);
+			return false;
+		}
+
+		this.lastUserMessage = lastUserMessage;
+		this.retryCount++;
+
+		const retryAt = Date.now() + this.config.cooldownMs;
+
+		this.logger.info(
+			`Scheduling auto-retry #${this.retryCount}/${this.config.maxAutoRetries} ` +
+				`in ${this.config.cooldownMs}ms. Error: ${errorMessage}`
+		);
+
+		// Set processing state to rate_limit_cooldown
+		void this.stateManager.setRateLimitCooldown({
+			retryCount: this.retryCount,
+			maxRetries: this.config.maxAutoRetries,
+			retryAt,
+			lastUserMessage: this.lastUserMessage,
+		});
+
+		this.cooldownTimer = setTimeout(() => {
+			this.cooldownTimer = null;
+			this.logger.info(
+				`Cooldown elapsed for auto-retry #${this.retryCount}/${this.config.maxAutoRetries}. Firing retry.`
+			);
+			if (this.retryCallback) {
+				void this.retryCallback(this.lastUserMessage);
+			}
+		}, this.config.cooldownMs);
+
+		// Unref so the timer doesn't keep the process alive
+		if (
+			this.cooldownTimer &&
+			typeof this.cooldownTimer === 'object' &&
+			'unref' in this.cooldownTimer
+		) {
+			this.cooldownTimer.unref();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Cancel any pending auto-retry. Called when:
+	 * - User sends a new message before the retry fires
+	 * - User explicitly cancels the auto-retry
+	 * - Session is cleaned up
+	 */
+	cancel(): void {
+		if (this.cooldownTimer !== null) {
+			clearTimeout(this.cooldownTimer);
+			this.cooldownTimer = null;
+			this.logger.info('Cancelled pending rate limit auto-retry.');
+		}
+	}
+
+	/**
+	 * Immediately trigger the retry (bypassing the cooldown).
+	 * Used when the user clicks "Retry Now" in the UI.
+	 *
+	 * @returns true if a retry was pending and fired, false if no retry was pending
+	 */
+	retryNow(): boolean {
+		if (this.cooldownTimer === null) {
+			return false;
+		}
+
+		clearTimeout(this.cooldownTimer);
+		this.cooldownTimer = null;
+
+		this.logger.info(
+			`Immediate retry triggered for auto-retry #${this.retryCount}/${this.config.maxAutoRetries}.`
+		);
+
+		if (this.retryCallback) {
+			void this.retryCallback(this.lastUserMessage);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Reset the watchdog entirely (e.g., on successful API call).
+	 */
+	reset(): void {
+		this.cancel();
+		this.retryCount = 0;
+		this.lastUserMessage = null;
+	}
+
+	/**
+	 * Get remaining milliseconds until the retry fires.
+	 * Returns 0 if no retry is scheduled.
+	 */
+	private getRemainingMs(): number {
+		// Approximation — the timer was set with config.cooldownMs,
+		// so remaining time is tracked via the scheduled retryAt from the state.
+		const state = this.stateManager.getState();
+		if (state.status === 'rate_limit_cooldown') {
+			const remaining = state.retryAt - Date.now();
+			return Math.max(0, remaining);
+		}
+		return 0;
+	}
+
+	/**
+	 * Check if a cooldown auto-retry is currently scheduled.
+	 */
+	isPending(): boolean {
+		return this.cooldownTimer !== null;
+	}
+
+	/**
+	 * Cleanup (called during session cleanup).
+	 */
+	destroy(): void {
+		this.cancel();
+		this.retryCallback = null;
+	}
+}

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -99,6 +99,13 @@ export class RateLimitWatchdog {
 		// Cancel any existing timer
 		this.cancel();
 
+		// Cannot retry without a message to re-enqueue — fail fast instead of
+		// scheduling a no-op cooldown timer that would abort on fire.
+		if (!lastUserMessage) {
+			this.logger.warn('Cannot schedule rate limit auto-retry: no user message to retry.');
+			return false;
+		}
+
 		if (this.retryCount >= this.config.maxAutoRetries) {
 			this.logger.warn(
 				`Max auto-retries (${this.config.maxAutoRetries}) exceeded for 429 error. ` +

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -122,7 +122,6 @@ export class RateLimitWatchdog {
 			retryCount: this.retryCount,
 			maxRetries: this.config.maxAutoRetries,
 			retryAt,
-			lastUserMessage: this.lastUserMessage,
 		});
 
 		this.cooldownTimer = setTimeout(() => {

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -774,6 +774,7 @@ SELECT
     WHEN json_extract(s.processing_state, '$.status') = 'processing' THEN 'active'
     WHEN json_extract(s.processing_state, '$.status') = 'queued' THEN 'queued'
     WHEN json_extract(s.processing_state, '$.status') = 'waiting_for_input' THEN 'waiting_for_input'
+    WHEN json_extract(s.processing_state, '$.status') = 'rate_limit_cooldown' THEN 'cooldown'
     WHEN json_extract(s.processing_state, '$.status') = 'interrupted' THEN 'interrupted'
     WHEN ase.task_status = 'open' THEN 'queued'
     ELSE 'idle'

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -917,6 +917,28 @@ export function setupSessionHandlers(
 		}
 	});
 
+	// Handle cancelling a pending rate limit auto-retry
+	messageHub.onRequest('session.cancelRateLimitRetry', async (data) => {
+		const { sessionId: targetSessionId } = data as { sessionId: string };
+		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
+		if (!agentSession) {
+			throw new Error('Session not found');
+		}
+		agentSession.cancelRateLimitRetry();
+		return { success: true };
+	});
+
+	// Handle immediately retrying after a rate limit (bypassing cooldown)
+	messageHub.onRequest('session.retryNowAfterRateLimit', async (data) => {
+		const { sessionId: targetSessionId } = data as { sessionId: string };
+		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
+		if (!agentSession) {
+			throw new Error('Session not found');
+		}
+		await agentSession.retryNowAfterRateLimit();
+		return { success: true };
+	});
+
 	// Handle triggering deferred messages to be sent (manual mode)
 	// Use case: When user wants to manually send all deferred messages
 	// ARCHITECTURE: Fire-and-forget via EventBus, AgentSession handles the actual sending

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3891,7 +3891,8 @@ export class TaskAgentManager {
 			state.status === 'processing' ||
 			state.status === 'queued' ||
 			state.status === 'waiting_for_input' ||
-			state.status === 'interrupted';
+			state.status === 'interrupted' ||
+			state.status === 'rate_limit_cooldown';
 
 		const messageId = generateUUID();
 		const hasImages = !!images && images.length > 0;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2255,7 +2255,8 @@ export class TaskAgentManager {
 			state.status === 'queued' ||
 			state.status === 'processing' ||
 			state.status === 'waiting_for_input' ||
-			state.status === 'interrupted'
+			state.status === 'interrupted' ||
+			state.status === 'rate_limit_cooldown'
 		);
 	}
 

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -1560,7 +1560,7 @@ describe('QueryRunner', () => {
 
 			// Pre-set the tracked message (simulates createMessageGeneratorWrapper having
 			// consumed a user message before the transient error occurred).
-			(runner as unknown as { lastConsumedUserMessage: unknown }).lastConsumedUserMessage = {
+			(runner as unknown as { _lastConsumedUserMessage: unknown })._lastConsumedUserMessage = {
 				uuid: consumedUuid,
 				content: consumedContent,
 			};
@@ -1583,7 +1583,7 @@ describe('QueryRunner', () => {
 			const ctx = createContext();
 			runner = new QueryRunner(ctx);
 
-			(runner as unknown as { lastConsumedUserMessage: unknown }).lastConsumedUserMessage = {
+			(runner as unknown as { _lastConsumedUserMessage: unknown })._lastConsumedUserMessage = {
 				uuid: consumedUuid,
 				content: consumedContent,
 			};
@@ -1593,7 +1593,7 @@ describe('QueryRunner', () => {
 
 			// After re-enqueue, the tracking field should be cleared
 			expect(
-				(runner as unknown as { lastConsumedUserMessage: unknown }).lastConsumedUserMessage
+				(runner as unknown as { _lastConsumedUserMessage: unknown })._lastConsumedUserMessage
 			).toBeNull();
 		});
 

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -7,6 +7,7 @@
  * - Max retries exceeded
  * - RetryNow bypasses cooldown
  * - Reset clears state
+ * - Null message guard
  */
 
 import { describe, expect, it, beforeEach, mock } from 'bun:test';
@@ -64,8 +65,8 @@ describe('RateLimitWatchdog', () => {
 	});
 
 	describe('scheduleRetry', () => {
-		it('schedules a retry and sets rate_limit_cooldown state', () => {
-			const result = watchdog.scheduleRetry('429 rate limit', {
+		it('schedules a retry and sets rate_limit_cooldown state', async () => {
+			const result = await watchdog.scheduleRetry('429 rate limit', {
 				uuid: 'msg-1',
 				content: 'hello',
 			});
@@ -80,29 +81,36 @@ describe('RateLimitWatchdog', () => {
 			expect(state.retryAt).toBeGreaterThan(Date.now() - 1000);
 		});
 
-		it('increments retryCount on subsequent calls', () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+		it('increments retryCount on subsequent calls', async () => {
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 			watchdog.cancel(); // Cancel before scheduling next
 
-			watchdog.scheduleRetry('429', { uuid: 'msg-2', content: 'world' });
+			await watchdog.scheduleRetry('429', { uuid: 'msg-2', content: 'world' });
 
 			expect(watchdog.getState().retryCount).toBe(2);
 		});
 
-		it('returns false when max retries exceeded', () => {
+		it('returns false when max retries exceeded', async () => {
 			for (let i = 0; i < 3; i++) {
-				watchdog.scheduleRetry('429', { uuid: `msg-${i}`, content: `test-${i}` });
+				await watchdog.scheduleRetry('429', { uuid: `msg-${i}`, content: `test-${i}` });
 				watchdog.cancel();
 			}
 
 			// 4th attempt should fail
-			const result = watchdog.scheduleRetry('429', { uuid: 'msg-4', content: 'nope' });
+			const result = await watchdog.scheduleRetry('429', { uuid: 'msg-4', content: 'nope' });
 			expect(result).toBe(false);
 			expect(watchdog.getState().retryCount).toBe(3);
 		});
 
+		it('returns false when lastUserMessage is null', async () => {
+			const result = await watchdog.scheduleRetry('429', null);
+			expect(result).toBe(false);
+			expect(watchdog.getState().status).toBe('idle');
+			expect(watchdog.isPending()).toBe(false);
+		});
+
 		it('fires the retry callback after cooldown', async () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 
 			// Wait for cooldown (100ms) + buffer
 			await new Promise((resolve) => setTimeout(resolve, 200));
@@ -114,8 +122,8 @@ describe('RateLimitWatchdog', () => {
 	});
 
 	describe('cancel', () => {
-		it('cancels a pending retry', () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+		it('cancels a pending retry', async () => {
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 			expect(watchdog.isPending()).toBe(true);
 
 			watchdog.cancel();
@@ -125,7 +133,7 @@ describe('RateLimitWatchdog', () => {
 		});
 
 		it('does not fire callback after cancellation', async () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 			watchdog.cancel();
 
 			// Wait past cooldown
@@ -136,8 +144,8 @@ describe('RateLimitWatchdog', () => {
 	});
 
 	describe('retryNow', () => {
-		it('immediately fires the retry callback', () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+		it('immediately fires the retry callback', async () => {
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 
 			const result = watchdog.retryNow();
 
@@ -154,8 +162,8 @@ describe('RateLimitWatchdog', () => {
 	});
 
 	describe('reset', () => {
-		it('clears all state', () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+		it('clears all state', async () => {
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 			watchdog.reset();
 
 			expect(watchdog.getState().status).toBe('idle');
@@ -167,7 +175,7 @@ describe('RateLimitWatchdog', () => {
 
 	describe('destroy', () => {
 		it('cancels timers and clears callback', async () => {
-			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			await watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
 			watchdog.destroy();
 
 			// Wait past cooldown

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -1,0 +1,181 @@
+/**
+ * RateLimitWatchdog Tests
+ *
+ * Tests for the rate limit auto-retry watchdog:
+ * - Schedule retry with cooldown
+ * - Cancel pending retry
+ * - Max retries exceeded
+ * - RetryNow bypasses cooldown
+ * - Reset clears state
+ */
+
+import { describe, expect, it, beforeEach, mock, jest } from 'bun:test';
+import { RateLimitWatchdog } from '../../../../src/lib/agent/rate-limit-watchdog';
+import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
+
+// Helper to create a mock ProcessingStateManager
+function createMockStateManager(): ProcessingStateManager {
+	return {
+		getState: mock(() => ({ status: 'idle' })),
+		setIdle: mock(async () => {}),
+		setRateLimitCooldown: mock(async () => {}),
+		setProcessing: mock(async () => {}),
+		setQueued: mock(async () => {}),
+		setInterrupted: mock(async () => {}),
+		setWaitingForInput: mock(async () => {}),
+		setCompacting: mock(async () => {}),
+		updatePhase: mock(async () => {}),
+		detectPhaseFromMessage: mock(async () => {}),
+		isProcessing: mock(() => false),
+		isIdle: mock(() => true),
+		isWaitingForInput: mock(() => false),
+		getPendingQuestion: mock(() => null),
+		updateQuestionDraft: mock(async () => {}),
+		setOnIdleCallback: mock(() => {}),
+		restoreFromDatabase: mock(() => {}),
+		getIsCompacting: mock(() => false),
+	} as unknown as ProcessingStateManager;
+}
+
+describe('RateLimitWatchdog', () => {
+	let watchdog: RateLimitWatchdog;
+	let stateManager: ProcessingStateManager;
+	let retryCallback: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		stateManager = createMockStateManager();
+		retryCallback = mock(async () => {});
+		watchdog = new RateLimitWatchdog('test-session', stateManager, {
+			cooldownMs: 100, // Fast cooldown for tests
+			maxAutoRetries: 3,
+		});
+		watchdog.setRetryCallback(retryCallback);
+	});
+
+	describe('getState', () => {
+		it('returns idle state initially', () => {
+			const state = watchdog.getState();
+			expect(state.status).toBe('idle');
+			expect(state.retryCount).toBe(0);
+			expect(state.maxRetries).toBe(3);
+			expect(state.retryAt).toBeNull();
+			expect(state.lastUserMessage).toBeNull();
+		});
+	});
+
+	describe('scheduleRetry', () => {
+		it('schedules a retry and sets rate_limit_cooldown state', () => {
+			const result = watchdog.scheduleRetry('429 rate limit', {
+				uuid: 'msg-1',
+				content: 'hello',
+			});
+
+			expect(result).toBe(true);
+			expect(stateManager.setRateLimitCooldown).toHaveBeenCalledTimes(1);
+
+			const state = watchdog.getState();
+			expect(state.status).toBe('cooldown');
+			expect(state.retryCount).toBe(1);
+			expect(state.lastUserMessage).toEqual({ uuid: 'msg-1', content: 'hello' });
+			expect(state.retryAt).toBeGreaterThan(Date.now() - 1000);
+		});
+
+		it('increments retryCount on subsequent calls', () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			watchdog.cancel(); // Cancel before scheduling next
+
+			watchdog.scheduleRetry('429', { uuid: 'msg-2', content: 'world' });
+
+			expect(watchdog.getState().retryCount).toBe(2);
+		});
+
+		it('returns false when max retries exceeded', () => {
+			for (let i = 0; i < 3; i++) {
+				watchdog.scheduleRetry('429', { uuid: `msg-${i}`, content: `test-${i}` });
+				watchdog.cancel();
+			}
+
+			// 4th attempt should fail
+			const result = watchdog.scheduleRetry('429', { uuid: 'msg-4', content: 'nope' });
+			expect(result).toBe(false);
+			expect(watchdog.getState().retryCount).toBe(3);
+		});
+
+		it('fires the retry callback after cooldown', async () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+
+			// Wait for cooldown (100ms) + buffer
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(retryCallback).toHaveBeenCalledTimes(1);
+			expect(retryCallback).toHaveBeenCalledWith({ uuid: 'msg-1', content: 'hello' });
+			expect(watchdog.isPending()).toBe(false);
+		});
+	});
+
+	describe('cancel', () => {
+		it('cancels a pending retry', () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			expect(watchdog.isPending()).toBe(true);
+
+			watchdog.cancel();
+
+			expect(watchdog.isPending()).toBe(false);
+			expect(watchdog.getState().status).toBe('idle');
+		});
+
+		it('does not fire callback after cancellation', async () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			watchdog.cancel();
+
+			// Wait past cooldown
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(retryCallback).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('retryNow', () => {
+		it('immediately fires the retry callback', () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+
+			const result = watchdog.retryNow();
+
+			expect(result).toBe(true);
+			expect(retryCallback).toHaveBeenCalledTimes(1);
+			expect(retryCallback).toHaveBeenCalledWith({ uuid: 'msg-1', content: 'hello' });
+			expect(watchdog.isPending()).toBe(false);
+		});
+
+		it('returns false if no retry is pending', () => {
+			const result = watchdog.retryNow();
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('reset', () => {
+		it('clears all state', () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			watchdog.reset();
+
+			expect(watchdog.getState().status).toBe('idle');
+			expect(watchdog.getState().retryCount).toBe(0);
+			expect(watchdog.getState().lastUserMessage).toBeNull();
+			expect(watchdog.isPending()).toBe(false);
+		});
+	});
+
+	describe('destroy', () => {
+		it('cancels timers and clears callback', async () => {
+			watchdog.scheduleRetry('429', { uuid: 'msg-1', content: 'hello' });
+			watchdog.destroy();
+
+			// Wait past cooldown
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			// Callback was cleared, so even though timer might have been set,
+			// destroy sets retryCallback to null
+			expect(retryCallback).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -9,7 +9,7 @@
  * - Reset clears state
  */
 
-import { describe, expect, it, beforeEach, mock, jest } from 'bun:test';
+import { describe, expect, it, beforeEach, mock } from 'bun:test';
 import { RateLimitWatchdog } from '../../../../src/lib/agent/rate-limit-watchdog';
 import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
 

--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -4,13 +4,7 @@
  * Fine-grained state channels - each property has its own channel
  */
 
-import type {
-	AuthStatus,
-	MessageContent,
-	SessionInfo,
-	HealthStatus,
-	NeokaiActionMessage,
-} from './types.ts';
+import type { AuthStatus, SessionInfo, HealthStatus, NeokaiActionMessage } from './types.ts';
 import type { SDKMessage } from './sdk/sdk.d.ts';
 import type { GlobalSettings } from './types/settings.ts';
 
@@ -180,7 +174,6 @@ export type AgentProcessingState =
 			retryCount: number;
 			maxRetries: number;
 			retryAt: number;
-			lastUserMessage: { uuid: string; content: string | MessageContent[] } | null;
 	  }
 	| { status: 'interrupted' };
 

--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -4,7 +4,13 @@
  * Fine-grained state channels - each property has its own channel
  */
 
-import type { AuthStatus, SessionInfo, HealthStatus, NeokaiActionMessage } from './types.ts';
+import type {
+	AuthStatus,
+	MessageContent,
+	SessionInfo,
+	HealthStatus,
+	NeokaiActionMessage,
+} from './types.ts';
 import type { SDKMessage } from './sdk/sdk.d.ts';
 import type { GlobalSettings } from './types/settings.ts';
 
@@ -169,6 +175,13 @@ export type AgentProcessingState =
 			isCompacting?: boolean; // True during context compaction
 	  }
 	| { status: 'waiting_for_input'; pendingQuestion: PendingUserQuestion }
+	| {
+			status: 'rate_limit_cooldown';
+			retryCount: number;
+			maxRetries: number;
+			retryAt: number;
+			lastUserMessage: { uuid: string; content: string | MessageContent[] } | null;
+	  }
 	| { status: 'interrupted' };
 
 /**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -331,6 +331,7 @@ export type SpaceTaskActivityState =
 	| 'queued'
 	| 'idle'
 	| 'waiting_for_input'
+	| 'cooldown'
 	| 'completed'
 	| 'failed'
 	| 'interrupted';
@@ -504,7 +505,14 @@ export interface SpaceTaskActivityMember {
 	/** Derived user-facing activity state */
 	state: SpaceTaskActivityState;
 	/** Raw session processing status when the session is live in memory */
-	processingStatus?: 'idle' | 'queued' | 'processing' | 'waiting_for_input' | 'interrupted' | null;
+	processingStatus?:
+		| 'idle'
+		| 'queued'
+		| 'processing'
+		| 'waiting_for_input'
+		| 'rate_limit_cooldown'
+		| 'interrupted'
+		| null;
 	/** Raw processing phase when the session is actively processing */
 	processingPhase?: 'initializing' | 'thinking' | 'streaming' | 'finalizing' | null;
 	/** Number of persisted SDK messages seen in the backing session */

--- a/packages/web/src/components/sdk/RateLimitCooldownBanner.tsx
+++ b/packages/web/src/components/sdk/RateLimitCooldownBanner.tsx
@@ -49,6 +49,8 @@ export function RateLimitCooldownBanner({ sessionId, retryCount, maxRetries, ret
 			await cancelRateLimitRetry(sessionId);
 		} catch {
 			// Session may have already transitioned
+		} finally {
+			setCancelling(false);
 		}
 	}, [sessionId]);
 
@@ -58,6 +60,8 @@ export function RateLimitCooldownBanner({ sessionId, retryCount, maxRetries, ret
 			await retryNowAfterRateLimit(sessionId);
 		} catch {
 			// Session may have already transitioned
+		} finally {
+			setRetrying(false);
 		}
 	}, [sessionId]);
 

--- a/packages/web/src/components/sdk/RateLimitCooldownBanner.tsx
+++ b/packages/web/src/components/sdk/RateLimitCooldownBanner.tsx
@@ -1,0 +1,106 @@
+/**
+ * RateLimitCooldownBanner - Shows when the session is in rate limit cooldown
+ *
+ * Displays a countdown timer and actions to retry immediately or cancel.
+ * Rendered inside ChatContainer when agentState.status === 'rate_limit_cooldown'.
+ */
+
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { cancelRateLimitRetry, retryNowAfterRateLimit } from '../../lib/api-helpers.ts';
+
+interface Props {
+	sessionId: string;
+	retryCount: number;
+	maxRetries: number;
+	retryAt: number;
+}
+
+export function RateLimitCooldownBanner({ sessionId, retryCount, maxRetries, retryAt }: Props) {
+	const [remaining, setRemaining] = useState(Math.max(0, retryAt - Date.now()));
+	const [cancelling, setCancelling] = useState(false);
+	const [retrying, setRetrying] = useState(false);
+
+	// Countdown timer
+	useEffect(() => {
+		const interval = setInterval(() => {
+			const ms = Math.max(0, retryAt - Date.now());
+			setRemaining(ms);
+			if (ms <= 0) {
+				clearInterval(interval);
+			}
+		}, 1000);
+		return () => clearInterval(interval);
+	}, [retryAt]);
+
+	const formatCountdown = (ms: number): string => {
+		if (ms <= 0) return 'now';
+		const totalSeconds = Math.ceil(ms / 1000);
+		const minutes = Math.floor(totalSeconds / 60);
+		const seconds = totalSeconds % 60;
+		if (minutes > 0) {
+			return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+		}
+		return `${seconds}s`;
+	};
+
+	const handleCancel = useCallback(async () => {
+		setCancelling(true);
+		try {
+			await cancelRateLimitRetry(sessionId);
+		} catch {
+			// Session may have already transitioned
+		}
+	}, [sessionId]);
+
+	const handleRetryNow = useCallback(async () => {
+		setRetrying(true);
+		try {
+			await retryNowAfterRateLimit(sessionId);
+		} catch {
+			// Session may have already transitioned
+		}
+	}, [sessionId]);
+
+	return (
+		<div class="flex items-center gap-2 px-3 py-2 mb-2 rounded border bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-800 text-amber-900 dark:text-amber-100">
+			<svg
+				class="w-3.5 h-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+				/>
+			</svg>
+			<span class="text-xs flex-1">
+				<span class="font-medium">Rate limit reached.</span> Auto-retry in{' '}
+				<span class="font-mono font-medium">{formatCountdown(remaining)}</span>{' '}
+				<span class="text-amber-700/60 dark:text-amber-300/60">
+					(attempt {retryCount}/{maxRetries})
+				</span>
+			</span>
+			<div class="flex items-center gap-1.5">
+				<button
+					type="button"
+					onClick={handleRetryNow}
+					disabled={retrying}
+					class="text-xs font-medium px-2 py-0.5 rounded bg-amber-600 hover:bg-amber-700 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				>
+					{retrying ? 'Retrying…' : 'Retry Now'}
+				</button>
+				<button
+					type="button"
+					onClick={handleCancel}
+					disabled={cancelling}
+					class="text-xs font-medium px-2 py-0.5 rounded bg-transparent hover:bg-amber-100 dark:hover:bg-amber-900/30 text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				>
+					{cancelling ? 'Cancelling…' : 'Cancel'}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -66,6 +66,7 @@ const ACTIVITY_STATE_LABELS: Record<SpaceTaskActivityState, string> = {
 	queued: 'Queued',
 	idle: 'Idle',
 	waiting_for_input: 'Waiting',
+	cooldown: 'Cooldown',
 	completed: 'Done',
 	failed: 'Failed',
 	interrupted: 'Interrupted',

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -42,6 +42,7 @@ import { ErrorDialog } from '../components/ErrorDialog.tsx';
 import { ScrollToBottomButton } from '../components/ScrollToBottomButton.tsx';
 import { SessionInfoModal } from '../components/SessionInfoModal.tsx';
 import { SDKMessageRenderer } from '../components/sdk/SDKMessageRenderer.tsx';
+import { RateLimitCooldownBanner } from '../components/sdk/RateLimitCooldownBanner.tsx';
 import { ToolsModal } from '../components/ToolsModal.tsx';
 import { Button } from '../components/ui/Button.tsx';
 import { ContentContainer } from '../components/ui/ContentContainer.tsx';
@@ -1191,6 +1192,16 @@ export default function ChatContainer({
 						sessionStore.clearError();
 					}}
 					actions={errorActions.length > 0 ? errorActions : undefined}
+				/>
+			)}
+
+			{/* Rate Limit Cooldown Banner */}
+			{agentState.status === 'rate_limit_cooldown' && session && (
+				<RateLimitCooldownBanner
+					sessionId={session.id}
+					retryCount={agentState.retryCount}
+					maxRetries={agentState.maxRetries}
+					retryAt={agentState.retryAt}
 				/>
 			)}
 

--- a/packages/web/src/lib/api-helpers.ts
+++ b/packages/web/src/lib/api-helpers.ts
@@ -89,6 +89,16 @@ export async function resetSessionQuery(
 	});
 }
 
+export async function cancelRateLimitRetry(sessionId: string): Promise<{ success: boolean }> {
+	const hub = getHubOrThrow();
+	return await hub.request<{ success: boolean }>('session.cancelRateLimitRetry', { sessionId });
+}
+
+export async function retryNowAfterRateLimit(sessionId: string): Promise<{ success: boolean }> {
+	const hub = getHubOrThrow();
+	return await hub.request<{ success: boolean }>('session.retryNowAfterRateLimit', { sessionId });
+}
+
 export async function switchCoordinatorMode(
 	sessionId: string,
 	coordinatorMode: boolean


### PR DESCRIPTION
## Summary

When providers return 429 (rate limited), the SDK retries with exponential backoff. When all retries exhaust, the session previously stalled indefinitely — users had to manually re-send their message. This PR adds automatic detection and recovery.

## Changes

- **RateLimitWatchdog** (`packages/daemon/src/lib/agent/rate-limit-watchdog.ts`): Detects 429 exhaustion and schedules auto-retry after a 10-minute cooldown, up to 3 cycles. Cancelable when user sends a new message.
- **`rate_limit_cooldown` processing state** (`packages/shared/src/state-types.ts`): New `AgentProcessingState` variant that flows through the existing state pipeline for UI visibility.
- **ProcessingStateManager**: Added `setRateLimitCooldown()` method; auto-clears on state transitions.
- **QueryRunner**: Calls `onRateLimitExhausted` callback when 429 is detected in the error catch path.
- **AgentSession**: Wires watchdog lifecycle — instantiates in constructor, cancels on new messages, destroys on cleanup.
- **RPC handlers**: `session.cancelRateLimitRetry` and `session.retryNowAfterRateLimit` for UI control.
- **RateLimitCooldownBanner** (`packages/web/src/components/sdk/RateLimitCooldownBanner.tsx`): Shows countdown timer, retry-now, and cancel buttons in the chat UI.

## Test plan

- [x] Unit tests for `RateLimitWatchdog` (11 tests: schedule, cancel, max retries, timer fires, retryNow, reset, destroy)
- [x] Updated `query-runner.test.ts` to use renamed private field
- [x] `bun run check` passes (lint, typecheck, knip, format)
- [x] All daemon unit tests pass (10,020 tests)
- [x] Web tests pass (6,037/6,038 — 1 pre-existing flaky test unrelated to this change)