### PR TITLE
fix: deterministic MCP guard for Space member sessions before query start

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -338,6 +338,15 @@ export class AgentSession
 	onMissingSpaceChatMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
 	/**
+	 * Self-heal callback for Space member sessions (ad-hoc worker sessions with
+	 * `context.spaceId`): invoked by `QueryRunner.start()` when it detects that
+	 * the `space-agent-tools` MCP server is absent before a turn starts (notably
+	 * after cache eviction / DB reload). Set by SpaceRuntimeService in
+	 * `attachSpaceToolsToMemberSession()`.
+	 */
+	onMissingMemberSpaceMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
+
+	/**
 	 * Unified per-scope MCP enablement repo — exposed on the context so the
 	 * QueryOptionsBuilder can resolve the session > space > registry
 	 * precedence for skill-wrapped MCP servers (MCP M6).

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -97,6 +97,7 @@ const REQUIRED_SPACE_CHAT_COORDINATION_TOOLS = [
 	'suggest_workflow',
 	'get_workflow_detail',
 ] as const;
+const REQUIRED_MEMBER_SPACE_MCP_SERVERS = ['space-agent-tools'] as const;
 
 /**
  * Context interface - what QueryRunner needs from AgentSession
@@ -158,6 +159,14 @@ export interface QueryRunnerContext {
 	 * resume cannot silently start a degraded Space Agent turn.
 	 */
 	onMissingSpaceChatMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
+
+	/**
+	 * Self-heal hook for Space member sessions (ad-hoc worker sessions with
+	 * `context.spaceId`) missing their `space-agent-tools` MCP server.
+	 * SpaceRuntimeService wires this in `attachSpaceToolsToMemberSession()` so
+	 * cache eviction / DB reload cannot silently start a degraded turn.
+	 */
+	onMissingMemberSpaceMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
 	/** Consume (clear) the one-shot resumeSessionAt after the query has started. */
 	consumePendingResumeSessionAt?(): string | undefined;
@@ -357,6 +366,7 @@ export class QueryRunner {
 			);
 
 			queryOptions = await this.ensureSpaceChatMcpInvariant(queryOptions);
+			queryOptions = await this.ensureMemberSpaceMcpInvariant(queryOptions);
 			// P2-6 / P1-5: Self-heal — detect a missing required MCP server for
 			// workflow sub-sessions and recover via the registered callback.
 			// Required server:
@@ -1076,6 +1086,80 @@ export class QueryRunner {
 			`[MCP invariant] Space chat session ${session.id} missing required MCP servers: ` +
 				`[${missingServers.join(', ')}]. Refusing to start a degraded Space Agent turn. ` +
 				`Expected coordination tools: ${REQUIRED_SPACE_CHAT_COORDINATION_TOOLS.join(', ')}.`
+		);
+	}
+
+	/**
+	 * Ensure Space member sessions (ad-hoc worker sessions with `context.spaceId`)
+	 * have their required `space-agent-tools` MCP server attached before the SDK
+	 * query starts.
+	 *
+	 * This is the member-session counterpart to `ensureSpaceChatMcpInvariant`.
+	 * Space chat sessions get their tools + system prompt from
+	 * `setupSpaceAgentSession`; member sessions get only the MCP tools from
+	 * `attachSpaceToolsToMemberSession`. Both paths are vulnerable to losing
+	 * runtime-only MCP config after cache eviction / DB reload, so both need a
+	 * deterministic pre-query guard.
+	 *
+	 * Skipped for:
+	 *   - space_chat sessions (handled by ensureSpaceChatMcpInvariant)
+	 *   - workflow sub-sessions (handled by node-agent self-heal)
+	 *   - sessions without context.spaceId
+	 */
+	private async ensureMemberSpaceMcpInvariant(queryOptions: Options): Promise<Options> {
+		const { session, logger } = this.ctx;
+
+		// Only applies to member sessions that belong to a Space but are not the
+		// Space chat session itself or a workflow sub-session.
+		if (!session.context?.spaceId) return queryOptions;
+		if (session.type === 'space_chat') return queryOptions;
+		if (session.id.includes(':task:') && session.id.includes(':exec:')) return queryOptions;
+
+		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
+		const missingServers = REQUIRED_MEMBER_SPACE_MCP_SERVERS.filter(
+			(name) => !serverNames.includes(name)
+		);
+		if (missingServers.length === 0) return queryOptions;
+
+		const payload = {
+			event: 'member_space.mcp.missing',
+			sessionId: session.id,
+			spaceId: session.context.spaceId,
+			sessionType: session.type,
+			requiredServers: REQUIRED_MEMBER_SPACE_MCP_SERVERS,
+			missingServers,
+			presentServers: serverNames,
+			liveSdkServers: this.getLiveSdkMcpServerNames(queryOptions),
+			selfHealAttempted: !!this.ctx.onMissingMemberSpaceMcpServers,
+		};
+
+		logger.error(
+			`QueryRunner.start(): Space member session ${session.id} is MISSING required MCP servers. ` +
+				`Missing: [${missingServers.join(', ')}]. Present: [${serverNames.join(', ')}]. ` +
+				`This would remove Space coordination tools after cache eviction / DB reload. ${JSON.stringify(payload)}`
+		);
+
+		if (this.ctx.onMissingMemberSpaceMcpServers) {
+			await this.ctx.onMissingMemberSpaceMcpServers(session.id, missingServers);
+			const rebuilt = await this.ctx.optionsBuilder.build();
+			const repairedOptions = this.ctx.optionsBuilder.addSessionStateOptions(rebuilt);
+			const repairedServerNames = Object.keys(repairedOptions.mcpServers ?? {});
+			const stillMissing = REQUIRED_MEMBER_SPACE_MCP_SERVERS.filter(
+				(name) => !repairedServerNames.includes(name)
+			);
+			if (stillMissing.length > 0) {
+				throw new Error(
+					`[MCP invariant] Space member session ${session.id} still missing required MCP servers ` +
+						`after self-heal: [${stillMissing.join(', ')}]. Refusing to start a degraded ` +
+						`Space member turn.`
+				);
+			}
+			return repairedOptions;
+		}
+
+		throw new Error(
+			`[MCP invariant] Space member session ${session.id} missing required MCP servers: ` +
+				`[${missingServers.join(', ')}]. Refusing to start a degraded Space member turn.`
 		);
 	}
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -1103,16 +1103,18 @@ export class QueryRunner {
 	 *
 	 * Skipped for:
 	 *   - space_chat sessions (handled by ensureSpaceChatMcpInvariant)
+	 *   - space_task_agent sessions (legacy, intentionally not provisioned by
+	 *     attachSpaceToolsToMemberSession)
 	 *   - workflow sub-sessions (handled by node-agent self-heal)
 	 *   - sessions without context.spaceId
 	 */
 	private async ensureMemberSpaceMcpInvariant(queryOptions: Options): Promise<Options> {
 		const { session, logger } = this.ctx;
-
 		// Only applies to member sessions that belong to a Space but are not the
-		// Space chat session itself or a workflow sub-session.
+		// Space chat session itself, a legacy task-agent session, or a workflow sub-session.
 		if (!session.context?.spaceId) return queryOptions;
 		if (session.type === 'space_chat') return queryOptions;
+		if (session.type === 'space_task_agent') return queryOptions;
 		if (session.id.includes(':task:') && session.id.includes(':exec:')) return queryOptions;
 
 		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -809,6 +809,16 @@ export class SpaceRuntimeService {
 		// Merge rather than replace — other subsystems (e.g., room tools) may
 		// have already attached their own MCP servers on this session.
 		agentSession.mergeRuntimeMcpServers(additional);
+
+		// Wire self-heal callback so QueryRunner can recover if this session is
+		// evicted from cache and reloaded from DB (losing runtime-only MCP config).
+		agentSession.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
+			log.warn(
+				`Space member session ${session.id} missing MCP servers [${missing.join(', ')}]; re-attaching space-agent-tools before query start`
+			);
+			await this.attachSpaceToolsToMemberSession(session, { replayPendingMessages: false });
+		};
+
 		if (options.replayPendingMessages !== false) {
 			await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
 		}

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -425,6 +425,151 @@ describe('QueryRunner', () => {
 				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
 			});
 		});
+
+		it('rebuilds query options after member Space MCP self-heal before SDK query creation', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'worker-session-1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.config.mcpServers = {};
+
+				const repairedServers = {
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				buildSpy
+					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: repairedServers,
+					});
+				stopAfterRebuiltOptions();
+				const onMissingMemberSpaceMcpServers = mock(async () => {
+					mockSession.config.mcpServers =
+						repairedServers as unknown as Session['config']['mcpServers'];
+				});
+
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).toHaveBeenCalledWith('worker-session-1', [
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
+			});
+		});
+
+		it('throws when a member Space MCP invariant is missing and no self-heal callback exists', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'worker-session-1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.config.mcpServers = {};
+				buildSpy.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} });
+
+				const ctx = createContext();
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+				expect(handleErrorSpy).toHaveBeenCalled();
+				const error = handleErrorSpy.mock.calls[0][1] as Error;
+				expect(error.message).toContain('[MCP invariant]');
+				expect(error.message).toContain('space-agent-tools');
+				expect(error.message).toContain('member session');
+			});
+		});
+
+		it('does not self-heal when a member Space already has its required MCP server', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'worker-session-1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1' };
+				const servers = {
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				mockSession.config.mcpServers = servers as unknown as Session['config']['mcpServers'];
+				buildSpy.mockResolvedValueOnce({
+					model: 'claude-sonnet-4-20250514',
+					mcpServers: servers,
+				});
+				const onMissingMemberSpaceMcpServers = mock(async () => {});
+
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it('skips member Space MCP invariant for sessions without spaceId', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'plain-worker-1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = {};
+				mockSession.config.mcpServers = {};
+				buildSpy.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} });
+				// Force early exit: make message generator throw so the query fails fast.
+				mockMessageQueue.messageGenerator = mock(async function* () {
+					throw new Error('generator abort for test');
+				});
+
+				const onMissingMemberSpaceMcpServers = mock(async () => {});
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it('skips member Space MCP invariant for workflow sub-sessions', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'space:s1:task:t1:exec:e1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1', taskId: 't1' };
+				mockSession.config.mcpServers = {};
+				buildSpy.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} });
+				// Force early exit: make message generator throw so the query fails fast.
+				mockMessageQueue.messageGenerator = mock(async function* () {
+					throw new Error('generator abort for test');
+				});
+
+				const onMissingMemberSpaceMcpServers = mock(async () => {});
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 
 	describe('displayErrorAsAssistantMessage', () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -521,6 +521,41 @@ describe('QueryRunner', () => {
 			});
 		});
 
+		it('throws when member Space MCP still missing after self-heal callback', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'worker-session-1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.config.mcpServers = {};
+				buildSpy
+					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: {},
+					});
+
+				const onMissingMemberSpaceMcpServers = mock(async () => {
+					// Self-heal callback runs but does NOT fix the servers
+				});
+
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).toHaveBeenCalledWith('worker-session-1', [
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(handleErrorSpy).toHaveBeenCalled();
+				const error = handleErrorSpy.mock.calls[0][1] as Error;
+				expect(error.message).toContain('[MCP invariant]');
+				expect(error.message).toContain('still missing');
+				expect(error.message).toContain('member session');
+			});
+		});
+
 		it('skips member Space MCP invariant for sessions without spaceId', async () => {
 			await withAnthropicApiKey(async () => {
 				mockSession.id = 'plain-worker-1';

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -840,6 +840,39 @@ describe('SpaceRuntimeService', () => {
 
 			await svc.stop();
 		});
+
+		test('sets onMissingMemberSpaceMcpServers self-heal callback on member sessions', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(makeMemberSession());
+
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			expect(typeof (agent as unknown as AgentSession).onMissingMemberSpaceMcpServers).toBe(
+				'function'
+			);
+		});
+
+		test('onMissingMemberSpaceMcpServers self-heal callback re-attaches tools', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(makeMemberSession());
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			expect(typeof (agent as unknown as AgentSession).onMissingMemberSpaceMcpServers).toBe(
+				'function'
+			);
+
+			await (agent as unknown as AgentSession).onMissingMemberSpaceMcpServers?.(
+				'worker-session-1',
+				['space-agent-tools']
+			);
+
+			// Self-heal should re-call attachSpaceToolsToMemberSession, which calls merge again
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	// ─── internalEventBus session.created subscription regression (Task #137) ───────


### PR DESCRIPTION
Fixes intermittent loss of space-agent MCP tools in Space ad-hoc sessions after daemon restart or cache eviction.

**Root cause**: Runtime-only MCP attachments (`space-agent-tools`, `db-query`) are stored on the in-memory `AgentSession` instance, not in the DB. When a session is evicted from `SessionCache` and reloaded via `getSessionAsync()`, the fresh `AgentSession` created from DB state has no runtime MCP servers attached. The existing `ensureSpaceChatMcpInvariant` only protected `space_chat` sessions, leaving ad-hoc member sessions unguarded.

**Fix**: Add a deterministic pre-query invariant check for member sessions:
- `QueryRunner.ensureMemberSpaceMcpInvariant()` detects missing `space-agent-tools` on space-bound member sessions before the SDK query starts
- `AgentSession.onMissingMemberSpaceMcpServers` self-heal callback is wired by `SpaceRuntimeService.attachSpaceToolsToMemberSession()`
- On detection, the callback re-attaches tools and query options are rebuilt before SDK query creation
- If tools are still missing after self-heal, a hard error is thrown — never silently start a degraded turn

**Test coverage**:
- Rebuilds query options after member Space MCP self-heal
- Throws when member Space MCP invariant is missing and no self-heal callback exists
- Skips self-heal when member Space already has required MCP server
- Skips invariant for sessions without `spaceId` and for workflow sub-sessions
- `SpaceRuntimeService` sets the self-heal callback and re-attaches tools on invocation