### PR TITLE
Add generic messaging contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "bin": {
         "kai": "./main.ts",
       },
@@ -32,7 +32,7 @@
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.141",
         "@github/copilot-sdk": "0.3.0",
@@ -51,23 +51,30 @@
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
         "monocart-reporter": "2.11.2",
       },
     },
+    "packages/messaging": {
+      "name": "@neokai/messaging",
+      "version": "0.25.0",
+      "devDependencies": {
+        "@types/bun": "1.3.13",
+      },
+    },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
     },
     "packages/ui": {
       "name": "@neokai/ui",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "preact": "10.29.1",
@@ -87,7 +94,7 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "dependencies": {
         "@preact/signals": "2.9.0",
         "clsx": "2.1.1",
@@ -250,6 +257,8 @@
     "@neokai/desktop": ["@neokai/desktop@workspace:packages/desktop"],
 
     "@neokai/e2e": ["@neokai/e2e@workspace:packages/e2e"],
+
+    "@neokai/messaging": ["@neokai/messaging@workspace:packages/messaging"],
 
     "@neokai/shared": ["@neokai/shared@workspace:packages/shared"],
 
@@ -1139,6 +1148,8 @@
 
     "@neokai/daemon/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@neokai/messaging/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@neokai/shared/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@neokai/ui/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
@@ -1201,6 +1212,8 @@
 
     "@neokai/daemon/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@neokai/messaging/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@neokai/shared/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@neokai/ui/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
@@ -1234,6 +1247,8 @@
     "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "@neokai/daemon/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@neokai/messaging/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@neokai/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -1312,6 +1327,8 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
     "@neokai/daemon/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@neokai/messaging/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@neokai/shared/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,7 @@
 		"**/packages/daemon/tests/**",
 		"**/packages/e2e/tests/**",
 		"**/packages/shared/tests/**",
+		"**/packages/messaging/tests/**",
 		"**/packages/ui/tests/**",
 		"**/packages/ui/demo/**",
 		"packages/shared/src/neo-prompt/**",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@neokai/messaging",
+	"version": "0.25.0",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "src/mod.ts",
+	"exports": {
+		".": "./src/mod.ts",
+		"./types": "./src/types.ts",
+		"./address": "./src/address.ts",
+		"./contracts": "./src/contracts.ts"
+	},
+	"scripts": {
+		"test": "bun test ./tests"
+	},
+	"devDependencies": {
+		"@types/bun": "1.3.13"
+	}
+}

--- a/packages/messaging/src/address.ts
+++ b/packages/messaging/src/address.ts
@@ -44,6 +44,9 @@ export function parseAddress(target: string): ParsedAddress {
 	if (target.startsWith('#')) {
 		const name = target.slice(1);
 		assertSegment(name, 'channel name');
+		if (name.startsWith('#')) {
+			throw new Error(`Channel address cannot contain extra # prefix: ${target}`);
+		}
 		return { kind: 'channel', name };
 	}
 
@@ -69,8 +72,8 @@ export function parseAddress(target: string): ParsedAddress {
 
 	const handle = target.slice(1);
 	assertSegment(handle, 'handle');
-	if (handle.includes(':') || handle.includes('/')) {
-		throw new Error(`Handle address cannot contain ':' or '/': ${target}`);
+	if (handle.includes('@') || handle.includes(':') || handle.includes('/')) {
+		throw new Error(`Handle address cannot contain '@', ':', or '/': ${target}`);
 	}
 	return { kind: 'handle', handle };
 }
@@ -79,8 +82,12 @@ export function formatAddress(address: ParsedAddress): string {
 	switch (address.kind) {
 		case 'handle':
 			assertSegment(address.handle, 'handle');
-			if (address.handle.includes(':') || address.handle.includes('/')) {
-				throw new Error(`Handle address cannot contain ':' or '/': @${address.handle}`);
+			if (
+				address.handle.includes('@') ||
+				address.handle.includes(':') ||
+				address.handle.includes('/')
+			) {
+				throw new Error(`Handle address cannot contain '@', ':', or '/': @${address.handle}`);
 			}
 			return `@${address.handle}`;
 		case 'role':
@@ -93,6 +100,9 @@ export function formatAddress(address: ParsedAddress): string {
 			return formatWorkerAddress(address);
 		case 'channel':
 			assertSegment(address.name, 'channel name');
+			if (address.name.startsWith('#')) {
+				throw new Error(`Channel address cannot contain extra # prefix: #${address.name}`);
+			}
 			return `#${address.name}`;
 	}
 }

--- a/packages/messaging/src/address.ts
+++ b/packages/messaging/src/address.ts
@@ -1,0 +1,157 @@
+export type HandleAddress = {
+	kind: 'handle';
+	handle: string;
+};
+
+export type RoleAddress = {
+	kind: 'role';
+	role: string;
+};
+
+export type SessionAddress = {
+	kind: 'session';
+	sessionId: string;
+};
+
+export type WorkerAddress = {
+	kind: 'worker';
+	workflowRunId?: string;
+	nodeId: string;
+	agentName?: string;
+};
+
+export type ChannelAddress = {
+	kind: 'channel';
+	name: string;
+};
+
+export type ParsedAddress =
+	| HandleAddress
+	| RoleAddress
+	| SessionAddress
+	| WorkerAddress
+	| ChannelAddress;
+
+const WORKER_PREFIX = '@worker:';
+const ROLE_PREFIX = '@role:';
+const SESSION_PREFIX = '@session:';
+
+export function parseAddress(target: string): ParsedAddress {
+	if (target.length === 0) {
+		throw new Error('Address cannot be empty');
+	}
+
+	if (target.startsWith('#')) {
+		const name = target.slice(1);
+		assertSegment(name, 'channel name');
+		return { kind: 'channel', name };
+	}
+
+	if (!target.startsWith('@')) {
+		throw new Error(`Address must start with @ or #: ${target}`);
+	}
+
+	if (target.startsWith(ROLE_PREFIX)) {
+		const role = target.slice(ROLE_PREFIX.length);
+		assertSegment(role, 'role');
+		return { kind: 'role', role };
+	}
+
+	if (target.startsWith(SESSION_PREFIX)) {
+		const sessionId = target.slice(SESSION_PREFIX.length);
+		assertSegment(sessionId, 'session id');
+		return { kind: 'session', sessionId };
+	}
+
+	if (target.startsWith(WORKER_PREFIX)) {
+		return parseWorkerAddress(target.slice(WORKER_PREFIX.length), target);
+	}
+
+	const handle = target.slice(1);
+	assertSegment(handle, 'handle');
+	if (handle.includes(':') || handle.includes('/')) {
+		throw new Error(`Handle address cannot contain ':' or '/': ${target}`);
+	}
+	return { kind: 'handle', handle };
+}
+
+export function formatAddress(address: ParsedAddress): string {
+	switch (address.kind) {
+		case 'handle':
+			assertSegment(address.handle, 'handle');
+			if (address.handle.includes(':') || address.handle.includes('/')) {
+				throw new Error(`Handle address cannot contain ':' or '/': @${address.handle}`);
+			}
+			return `@${address.handle}`;
+		case 'role':
+			assertSegment(address.role, 'role');
+			return `${ROLE_PREFIX}${address.role}`;
+		case 'session':
+			assertSegment(address.sessionId, 'session id');
+			return `${SESSION_PREFIX}${address.sessionId}`;
+		case 'worker':
+			return formatWorkerAddress(address);
+		case 'channel':
+			assertSegment(address.name, 'channel name');
+			return `#${address.name}`;
+	}
+}
+
+export function isAddress(target: string): boolean {
+	try {
+		parseAddress(target);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function parseWorkerAddress(value: string, rawTarget: string): WorkerAddress {
+	const parts = value.split('/');
+	if (parts.length !== 1 && parts.length !== 2 && parts.length !== 3) {
+		throw new Error(
+			`Worker address must use @worker:<node>, @worker:<node>/<agent>, or @worker:<run>/<node>/<agent>: ${rawTarget}`
+		);
+	}
+
+	for (const part of parts) {
+		assertSegment(part, 'worker segment');
+	}
+
+	if (parts.length === 1) {
+		return { kind: 'worker', nodeId: parts[0] };
+	}
+
+	if (parts.length === 2) {
+		return { kind: 'worker', nodeId: parts[0], agentName: parts[1] };
+	}
+
+	return { kind: 'worker', workflowRunId: parts[0], nodeId: parts[1], agentName: parts[2] };
+}
+
+function formatWorkerAddress(address: WorkerAddress): string {
+	assertSegment(address.nodeId, 'worker node');
+
+	if (address.workflowRunId !== undefined) {
+		assertSegment(address.workflowRunId, 'workflow run id');
+		assertSegment(address.agentName, 'worker agent');
+		return `${WORKER_PREFIX}${address.workflowRunId}/${address.nodeId}/${address.agentName}`;
+	}
+
+	if (address.agentName !== undefined) {
+		assertSegment(address.agentName, 'worker agent');
+		return `${WORKER_PREFIX}${address.nodeId}/${address.agentName}`;
+	}
+
+	return `${WORKER_PREFIX}${address.nodeId}`;
+}
+
+function assertSegment(value: string | undefined, label: string): asserts value is string {
+	if (value === undefined || value.length === 0) {
+		throw new Error(`Address ${label} cannot be empty`);
+	}
+
+	if (value.trim() !== value) {
+		throw new Error(`Address ${label} cannot contain surrounding whitespace: ${value}`);
+	}
+}

--- a/packages/messaging/src/contracts.ts
+++ b/packages/messaging/src/contracts.ts
@@ -1,0 +1,57 @@
+import type { ParsedAddress } from './address.ts';
+import type { ActorRef, DeliveryRecord, MessageRecord } from './types.ts';
+
+export type ResolvedTarget = {
+	targetRef: string;
+	address: ParsedAddress;
+	actor: ActorRef;
+};
+
+export type UnresolvedTarget = {
+	targetRef: string;
+	address?: ParsedAddress;
+	reason: string;
+};
+
+export type ResolveTargetsResult = {
+	resolved: ResolvedTarget[];
+	unresolved: UnresolvedTarget[];
+};
+
+export interface ActorResolver {
+	resolveTargets(message: MessageRecord): Promise<ResolveTargetsResult>;
+}
+
+export type RouteMessageResult = {
+	message: MessageRecord;
+	deliveries: DeliveryRecord[];
+};
+
+export interface MessageRouter {
+	routeMessage(message: MessageRecord): Promise<RouteMessageResult>;
+}
+
+export type CreateMessageInput = Omit<MessageRecord, 'messageId' | 'createdAt'> & {
+	messageId?: string;
+	createdAt?: number;
+};
+
+export type CreateDeliveryInput = Omit<DeliveryRecord, 'deliveryId' | 'createdAt'> & {
+	deliveryId?: string;
+	createdAt?: number;
+};
+
+export interface MessageStore {
+	createMessage(input: CreateMessageInput): Promise<MessageRecord>;
+	getMessage(messageId: string): Promise<MessageRecord | undefined>;
+	listMessagesByConversation(conversationId: string): Promise<MessageRecord[]>;
+}
+
+export interface DeliveryStore {
+	createDelivery(input: CreateDeliveryInput): Promise<DeliveryRecord>;
+	getDelivery(deliveryId: string): Promise<DeliveryRecord | undefined>;
+	listDeliveriesByMessage(messageId: string): Promise<DeliveryRecord[]>;
+	updateDelivery(delivery: DeliveryRecord): Promise<DeliveryRecord>;
+}
+
+export interface MessagingStorage extends MessageStore, DeliveryStore {}

--- a/packages/messaging/src/contracts.ts
+++ b/packages/messaging/src/contracts.ts
@@ -44,7 +44,7 @@ export type CreateDeliveryInput = Omit<DeliveryRecord, 'deliveryId' | 'createdAt
 export interface MessageStore {
 	createMessage(input: CreateMessageInput): Promise<MessageRecord>;
 	getMessage(messageId: string): Promise<MessageRecord | undefined>;
-	listMessagesByConversation(conversationId: string): Promise<MessageRecord[]>;
+	listMessagesByConversation(spaceId: string, conversationId: string): Promise<MessageRecord[]>;
 }
 
 export interface DeliveryStore {

--- a/packages/messaging/src/mod.ts
+++ b/packages/messaging/src/mod.ts
@@ -1,0 +1,3 @@
+export * from './types.ts';
+export * from './address.ts';
+export * from './contracts.ts';

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -1,0 +1,59 @@
+export type ActorKind = 'human' | 'session' | 'agent' | 'worker' | 'system';
+
+export type ActorStatus = 'active' | 'inactive' | 'archived' | 'deleted';
+
+export type ActorRef = {
+	actorId: string;
+	kind: ActorKind;
+	spaceId: string;
+	handle?: string;
+	roles?: string[];
+	status: ActorStatus;
+};
+
+export type MessageKind = 'message' | 'system';
+
+export type MessageAttachmentKind = 'image' | 'file' | 'url';
+
+export type MessageAttachment = {
+	id?: string;
+	type: MessageAttachmentKind;
+	mimeType?: string;
+	name?: string;
+	url?: string;
+	storageKey?: string;
+};
+
+export type MessageRecord = {
+	messageId: string;
+	spaceId: string;
+	senderActorId: string;
+	targets: string[];
+	body: string;
+	kind: MessageKind;
+	workflowRunId?: string;
+	taskId?: string;
+	conversationId?: string;
+	replyToMessageId?: string;
+	attachments?: MessageAttachment[];
+	data?: Record<string, unknown>;
+	idempotencyKey?: string;
+	createdAt: number;
+};
+
+export type DeliveryState = 'queued' | 'delivered' | 'failed' | 'expired' | 'skipped';
+
+export type DeliveryRecord = {
+	deliveryId: string;
+	messageId: string;
+	targetActorId?: string;
+	targetRef: string;
+	state: DeliveryState;
+	attemptCount: number;
+	maxAttempts: number;
+	createdAt: number;
+	expiresAt?: number;
+	lastError?: string;
+	deliveredSessionId?: string;
+	deliveredAt?: number;
+};

--- a/packages/messaging/tests/address.test.ts
+++ b/packages/messaging/tests/address.test.ts
@@ -52,6 +52,8 @@ describe('address parsing', () => {
 			'@worker:Review/',
 			'@worker:/reviewer',
 			'#',
+			'##deployments',
+			'@@coordinator',
 			'@bad:prefix',
 			'@bad/handle',
 			'@ leading-space',
@@ -69,7 +71,13 @@ describe('address parsing', () => {
 		}
 	});
 
-	test('requires explicit agent when formatting explicit worker run addresses', () => {
+	test('rejects malformed formatted address parts', () => {
+		expect(() => formatAddress({ kind: 'handle', handle: '@coordinator' })).toThrow(
+			"Handle address cannot contain '@', ':', or '/'"
+		);
+		expect(() => formatAddress({ kind: 'channel', name: '#deployments' })).toThrow(
+			'Channel address cannot contain extra # prefix'
+		);
 		expect(() =>
 			formatAddress({ kind: 'worker', workflowRunId: 'f1089', nodeId: 'Review' })
 		).toThrow('Address worker agent cannot be empty');

--- a/packages/messaging/tests/address.test.ts
+++ b/packages/messaging/tests/address.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { formatAddress, isAddress, parseAddress } from '../src/address.ts';
+
+const roundTrips = [
+	'@coordinator',
+	'@role:task-manager',
+	'@session:abc123',
+	'@worker:Review',
+	'@worker:Review/reviewer',
+	'@worker:f1089/Review/reviewer',
+	'#deployments',
+];
+
+describe('address parsing', () => {
+	test('parses supported v1 address forms', () => {
+		expect(parseAddress('@coordinator')).toEqual({ kind: 'handle', handle: 'coordinator' });
+		expect(parseAddress('@role:task-manager')).toEqual({
+			kind: 'role',
+			role: 'task-manager',
+		});
+		expect(parseAddress('@session:abc123')).toEqual({ kind: 'session', sessionId: 'abc123' });
+		expect(parseAddress('@worker:Review')).toEqual({ kind: 'worker', nodeId: 'Review' });
+		expect(parseAddress('@worker:Review/reviewer')).toEqual({
+			kind: 'worker',
+			nodeId: 'Review',
+			agentName: 'reviewer',
+		});
+		expect(parseAddress('@worker:f1089/Review/reviewer')).toEqual({
+			kind: 'worker',
+			workflowRunId: 'f1089',
+			nodeId: 'Review',
+			agentName: 'reviewer',
+		});
+		expect(parseAddress('#deployments')).toEqual({ kind: 'channel', name: 'deployments' });
+	});
+
+	test('formats parsed addresses back to target strings', () => {
+		for (const target of roundTrips) {
+			expect(formatAddress(parseAddress(target))).toBe(target);
+		}
+	});
+
+	test('rejects unsupported or ambiguous target forms', () => {
+		const invalidTargets = [
+			'',
+			'coordinator',
+			'session:abc123',
+			'@session:',
+			'@role:',
+			'@worker:',
+			'@worker:run/node/agent/extra',
+			'@worker:Review/',
+			'@worker:/reviewer',
+			'#',
+			'@bad:prefix',
+			'@bad/handle',
+			'@ leading-space',
+		];
+
+		for (const target of invalidTargets) {
+			expect(() => parseAddress(target), target).toThrow();
+			expect(isAddress(target), target).toBe(false);
+		}
+	});
+
+	test('returns true for supported address strings', () => {
+		for (const target of roundTrips) {
+			expect(isAddress(target), target).toBe(true);
+		}
+	});
+
+	test('requires explicit agent when formatting explicit worker run addresses', () => {
+		expect(() =>
+			formatAddress({ kind: 'worker', workflowRunId: 'f1089', nodeId: 'Review' })
+		).toThrow('Address worker agent cannot be empty');
+	});
+});

--- a/packages/messaging/tsconfig.json
+++ b/packages/messaging/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"module": "ESNext",
+		"target": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["src/**/*", "tests/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"references": [
 		{ "path": "./packages/cli" },
 		{ "path": "./packages/daemon" },
+		{ "path": "./packages/messaging" },
 		{ "path": "./packages/shared" },
 		{ "path": "./packages/ui" },
 		{ "path": "./packages/web" }


### PR DESCRIPTION
Adds a new `@neokai/messaging` package with pure Space actor messaging foundations:

- actor/message/delivery record types
- v1 address parser/formatter for handles, roles, sessions, workers, and channels
- resolver/router/storage contracts for daemon-side adapters

Tests cover supported address forms, formatting round-trips, and invalid targets.