### PR TITLE
Add persistent agent memory

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -320,6 +320,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 		description:
 			'Recurring (cron) and one-shot (at) task schedule templates with trigger config, status, and last-run tracking.',
 	},
+	{
+		tableName: 'space_agent_memory',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Persistent agent-written Space memories with keys, content, tags, and access metadata.',
+	},
 	// ── Main-DB tables exposed with space-scoped filtering via session ID prefix ──
 	{
 		tableName: 'sessions',
@@ -402,6 +409,12 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	'space_external_event_source_configs',
 	'space_external_events',
 	'space_external_event_deliveries',
+	// FTS5 shadow tables for space_agent_memory — query through space_agent_memory instead.
+	'space_agent_memory_fts',
+	'space_agent_memory_fts_config',
+	'space_agent_memory_fts_data',
+	'space_agent_memory_fts_docsize',
+	'space_agent_memory_fts_idx',
 	// Dropped tables (no longer exist in schema)
 	'space_session_groups',
 	'space_session_group_members',

--- a/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
@@ -81,7 +81,9 @@ function readStringArray(payload: unknown, key: string): string[] {
 function readOptionalNumber(payload: unknown, key: string): number | undefined {
 	const value = readRecord(payload)[key];
 	if (value == null) return undefined;
-	if (typeof value !== 'number') throw new Error(`${key} must be a number.`);
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		throw new Error(`${key} must be a finite number.`);
+	}
 	return value;
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
@@ -1,0 +1,93 @@
+import type { MessageHub } from '@neokai/shared';
+import type { AgentMemoryRepository } from '../../storage/repositories/agent-memory-repository';
+
+export interface AgentMemoryHandlerDeps {
+	memoryRepo: AgentMemoryRepository;
+}
+
+export function setupAgentMemoryHandlers(
+	messageHub: MessageHub,
+	deps: AgentMemoryHandlerDeps
+): void {
+	messageHub.onRequest('agentMemory.write', async (payload: unknown) => {
+		const request = parseSpaceScopedRequest(payload);
+		return deps.memoryRepo.write({
+			spaceId: request.spaceId,
+			key: readRequiredString(payload, 'key'),
+			content: readRequiredString(payload, 'content'),
+			tags: readStringArray(payload, 'tags'),
+			createdBySession: readOptionalString(payload, 'createdBySession'),
+		});
+	});
+
+	messageHub.onRequest('agentMemory.search', async (payload: unknown) => {
+		const request = parseSpaceScopedRequest(payload);
+		return deps.memoryRepo.search(
+			request.spaceId,
+			readRequiredString(payload, 'query'),
+			readOptionalNumber(payload, 'limit') ?? 10
+		);
+	});
+
+	messageHub.onRequest('agentMemory.read', async (payload: unknown) => {
+		const request = parseSpaceScopedRequest(payload);
+		return deps.memoryRepo.read(request.spaceId, readRequiredString(payload, 'key'));
+	});
+
+	messageHub.onRequest('agentMemory.delete', async (payload: unknown) => {
+		const request = parseSpaceScopedRequest(payload);
+		return { deleted: deps.memoryRepo.delete(request.spaceId, readRequiredString(payload, 'key')) };
+	});
+
+	messageHub.onRequest('agentMemory.list', async (payload: unknown) => {
+		const request = parseSpaceScopedRequest(payload);
+		return deps.memoryRepo.list(request.spaceId, {
+			query: readOptionalString(payload, 'query') ?? undefined,
+			limit: readOptionalNumber(payload, 'limit') ?? 50,
+			offset: readOptionalNumber(payload, 'offset') ?? 0,
+		});
+	});
+}
+
+function parseSpaceScopedRequest(payload: unknown): { spaceId: string } {
+	return { spaceId: readRequiredString(payload, 'spaceId') };
+}
+
+function readRequiredString(payload: unknown, key: string): string {
+	const value = readRecord(payload)[key];
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new Error(`${key} must be a non-empty string.`);
+	}
+	return value.trim();
+}
+
+function readOptionalString(payload: unknown, key: string): string | null {
+	const value = readRecord(payload)[key];
+	if (value == null) return null;
+	if (typeof value !== 'string') throw new Error(`${key} must be a string.`);
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function readStringArray(payload: unknown, key: string): string[] {
+	const value = readRecord(payload)[key];
+	if (value == null) return [];
+	if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+		throw new Error(`${key} must be an array of strings.`);
+	}
+	return value;
+}
+
+function readOptionalNumber(payload: unknown, key: string): number | undefined {
+	const value = readRecord(payload)[key];
+	if (value == null) return undefined;
+	if (typeof value !== 'number') throw new Error(`${key} must be a number.`);
+	return value;
+}
+
+function readRecord(payload: unknown): Record<string, unknown> {
+	if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+		throw new Error('Request payload must be an object.');
+	}
+	return payload as Record<string, unknown>;
+}

--- a/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/agent-memory-handlers.ts
@@ -15,8 +15,14 @@ export function setupAgentMemoryHandlers(
 			spaceId: request.spaceId,
 			key: readRequiredString(payload, 'key'),
 			content: readRequiredString(payload, 'content'),
-			tags: readStringArray(payload, 'tags'),
-			createdBySession: readOptionalString(payload, 'createdBySession'),
+			// Forward `tags` only when the caller actually sent it so the repository
+			// can preserve previously stored tags on content-only updates instead of
+			// silently clearing them.
+			tags: readOptionalStringArray(payload, 'tags'),
+			// Provenance is never trusted from RPC payloads — RPC writes have no
+			// agent-session attribution. Agent-authored writes flow through the MCP
+			// tool, which supplies the session id from the runtime.
+			createdBySession: null,
 		});
 	});
 
@@ -25,7 +31,7 @@ export function setupAgentMemoryHandlers(
 		return deps.memoryRepo.search(
 			request.spaceId,
 			readRequiredString(payload, 'query'),
-			readOptionalNumber(payload, 'limit') ?? 10
+			readOptionalInteger(payload, 'limit') ?? 10
 		);
 	});
 
@@ -43,8 +49,8 @@ export function setupAgentMemoryHandlers(
 		const request = parseSpaceScopedRequest(payload);
 		return deps.memoryRepo.list(request.spaceId, {
 			query: readOptionalString(payload, 'query') ?? undefined,
-			limit: readOptionalNumber(payload, 'limit') ?? 50,
-			offset: readOptionalNumber(payload, 'offset') ?? 0,
+			limit: readOptionalInteger(payload, 'limit') ?? 50,
+			offset: readOptionalInteger(payload, 'offset') ?? 0,
 		});
 	});
 }
@@ -69,20 +75,27 @@ function readOptionalString(payload: unknown, key: string): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function readStringArray(payload: unknown, key: string): string[] {
+function readOptionalStringArray(payload: unknown, key: string): string[] | undefined {
 	const value = readRecord(payload)[key];
-	if (value == null) return [];
+	if (value === undefined) return undefined;
+	if (value === null) return [];
 	if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
 		throw new Error(`${key} must be an array of strings.`);
 	}
 	return value;
 }
 
-function readOptionalNumber(payload: unknown, key: string): number | undefined {
+function readOptionalInteger(payload: unknown, key: string): number | undefined {
 	const value = readRecord(payload)[key];
 	if (value == null) return undefined;
 	if (typeof value !== 'number' || !Number.isFinite(value)) {
 		throw new Error(`${key} must be a finite number.`);
+	}
+	// SQLite stores integers as int64, but any value outside the JS safe-integer
+	// range loses precision before reaching the driver and is rejected with a
+	// datatype-mismatch error. Validate up-front so callers see a clean message.
+	if (!Number.isSafeInteger(value)) {
+		throw new Error(`${key} must be a safe integer.`);
 	}
 	return value;
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -93,6 +93,7 @@ import { WorkspaceHistoryRepository } from '../../storage/repositories/workspace
 import { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
 import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
+import { setupAgentMemoryHandlers } from './agent-memory-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
 
 export interface RPCHandlerDependencies {
@@ -225,6 +226,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Per-space MCP enablement RPC handlers + `.mcp.json` import refresh.
 	setupSpaceMcpHandlers(deps.messageHub, deps.internalEventBus, deps.db, deps.spaceManager);
+	setupAgentMemoryHandlers(deps.messageHub, { memoryRepo: deps.db.agentMemory });
 
 	// Skills registry RPC handlers
 	registerSkillHandlers(deps.messageHub, deps.skillsManager, deps.internalEventBus, undefined);
@@ -376,6 +378,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		externalEventStore: deps.externalEventStore,
 		externalEventService: deps.externalEventService,
 		replyRoutingRegistry,
+		memoryRepo: deps.db.agentMemory,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -495,6 +498,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		scheduleService,
 		internalEventBus: deps.internalEventBus,
 		replyRoutingRegistry,
+		memoryRepo: deps.db.agentMemory,
 	});
 
 	deps.commandBus.register('agent.message.inject', async (command) => {

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -21,6 +21,7 @@ import type {
 } from '@neokai/shared';
 import type { SkillEnablementOverride } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
+import type { AgentMemorySearchResult } from '../../../storage/repositories/agent-memory-repository';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { inferProviderForModel } from '../../providers/registry';
 import { Logger } from '../../logger';
@@ -155,6 +156,8 @@ export interface CustomAgentConfig {
 	 * Absent when running outside a workflow or when no data has been written.
 	 */
 	gateData?: GateDataSnapshot[];
+	/** Relevant persistent memories to inject into the task prompt. */
+	relevantMemories?: AgentMemorySearchResult[];
 }
 
 /**
@@ -240,6 +243,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		nodeId,
 		agentSlotName,
 		gateData,
+		relevantMemories,
 	} = config;
 
 	const sections: string[] = [];
@@ -278,7 +282,18 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		}
 	}
 
-	// 5. Project context from the Space.
+	// 5. Relevant persistent memories.
+	if (relevantMemories && relevantMemories.length > 0) {
+		sections.push('');
+		sections.push('## Relevant Memories');
+		sections.push('');
+		for (const result of relevantMemories) {
+			const tags = result.memory.tags.length > 0 ? ` [${result.memory.tags.join(', ')}]` : '';
+			sections.push(`- ${result.memory.key}${tags}: ${result.memory.content}`);
+		}
+	}
+
+	// 6. Project context from the Space.
 	if (space.backgroundContext) {
 		sections.push('');
 		sections.push('## Project Context');
@@ -286,7 +301,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		sections.push(space.backgroundContext);
 	}
 
-	// 6. Standing instructions — space + workflow combined under one heading.
+	// 7. Standing instructions — space + workflow combined under one heading.
 	const standingLines: string[] = [];
 	if (space.instructions?.trim()) standingLines.push(space.instructions.trim());
 	if (workflow?.instructions?.trim()) standingLines.push(workflow.instructions.trim());

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -45,6 +45,7 @@ const CLAUDE_CODE_BUILTIN_TOOLS = [
  * logged so future prompt bloat is caught during development. Never fails.
  */
 const USER_MESSAGE_SOFT_LIMIT_BYTES = 4 * 1024;
+const MEMORY_PROMPT_CONTENT_LIMIT = 500;
 
 const log = new Logger('custom-agent');
 
@@ -289,7 +290,9 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		sections.push('');
 		for (const result of relevantMemories) {
 			const tags = result.memory.tags.length > 0 ? ` [${result.memory.tags.join(', ')}]` : '';
-			sections.push(`- ${result.memory.key}${tags}: ${result.memory.content}`);
+			sections.push(
+				`- ${result.memory.key}${tags}: ${truncateMemoryPromptContent(result.memory.content)}`
+			);
 		}
 	}
 
@@ -345,6 +348,11 @@ function derivePrUrlFromGateData(gateData: GateDataSnapshot[] | undefined): stri
 		}
 	}
 	return undefined;
+}
+
+function truncateMemoryPromptContent(content: string): string {
+	if (content.length <= MEMORY_PROMPT_CONTENT_LIMIT) return content;
+	return `${content.slice(0, MEMORY_PROMPT_CONTENT_LIMIT)}…`;
 }
 
 /**

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -36,6 +36,7 @@ import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import { buildSpaceChatSystemPrompt } from '../agents/space-chat-agent';
 import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
+import { createAgentMemoryMcpServer } from '../tools/agent-memory-tools';
 import {
 	SpaceAgentNotificationService,
 	type SpaceAgentNotificationServiceConfig,
@@ -43,6 +44,7 @@ import {
 import type { DaemonCommandMap, InternalCommandBus } from '../../internal-command-bus';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
 import type { ExternalEventService } from '../../external-events/external-event-service';
+import type { AgentMemoryRepository } from '../../../storage/repositories/agent-memory-repository';
 
 const log = new Logger('space-runtime-service');
 
@@ -128,6 +130,8 @@ export interface SpaceRuntimeServiceConfig {
 	 * session ID as the reply target when sending messages to task/node agents.
 	 */
 	replyRoutingRegistry?: ReplyRoutingRegistry;
+	/** Persistent per-space agent memory repository. */
+	memoryRepo?: AgentMemoryRepository;
 }
 
 export class SpaceRuntimeService {
@@ -792,6 +796,13 @@ export class SpaceRuntimeService {
 		const additional: Record<string, McpServerConfig> = {
 			'space-agent-tools': mcpServer as unknown as McpServerConfig,
 		};
+		if (this.config.memoryRepo) {
+			additional['agent-memory'] = createAgentMemoryMcpServer({
+				spaceId: space.id,
+				memoryRepo: this.config.memoryRepo,
+				mySessionId: session.id,
+			}) as unknown as McpServerConfig;
+		}
 
 		if (this.config.dbPath) {
 			// Close any stale instance for this session (e.g., on re-provision
@@ -908,6 +919,13 @@ export class SpaceRuntimeService {
 		const mcpServers: Record<string, McpServerConfig> = {
 			'space-agent-tools': mcpServer as unknown as McpServerConfig,
 		};
+		if (this.config.memoryRepo) {
+			mcpServers['agent-memory'] = createAgentMemoryMcpServer({
+				spaceId: space.id,
+				memoryRepo: this.config.memoryRepo,
+				mySessionId: spaceChatSessionId,
+			}) as unknown as McpServerConfig;
+		}
 		if (this.config.dbPath) {
 			const dbQueryServer = createDbQueryMcpServer({
 				dbPath: this.config.dbPath,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -633,15 +633,7 @@ export class TaskAgentManager {
 				mcpServers: {
 					...init.mcpServers,
 					'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
-					...(this.config.memoryRepo
-						? {
-								'agent-memory': createAgentMemoryMcpServer({
-									spaceId: space.id,
-									memoryRepo: this.config.memoryRepo,
-									mySessionId: sessionId,
-								}) as unknown as McpServerConfig,
-							}
-						: {}),
+					...this.buildAgentMemoryMcpServers(space.id, sessionId),
 				},
 			};
 
@@ -2635,6 +2627,7 @@ export class TaskAgentManager {
 		const mergedMcpServers: Record<string, McpServerConfig> = {
 			...registryMcpServers,
 			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+			...this.buildAgentMemoryMcpServers(spaceId, subSessionId),
 		};
 
 		// Use merge semantics: the restored session has no in-memory MCP servers
@@ -3076,7 +3069,10 @@ export class TaskAgentManager {
 	 *   Without this the Coder→Reviewer handoff dies silently with "No such tool
 	 *   available" (PR #1535 failure mode).
 	 */
-	private static readonly REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS = ['node-agent'] as const;
+	private static readonly REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS = [
+		'node-agent',
+		'agent-memory',
+	] as const;
 
 	/**
 	 * Verify that a workflow node sub-session has its required MCP server
@@ -3141,10 +3137,12 @@ export class TaskAgentManager {
 				`Self-healing by re-injecting before first turn — but this indicates a regression in the spawn/rehydrate merge logic.`
 		);
 
-		// Re-attach the missing required server while preserving other runtime servers.
+		// Re-attach missing required servers while preserving other runtime servers.
 		for (const name of missing) {
 			if (name === 'node-agent') {
 				await this.reinjectNodeAgentMcpServer(session, ctx);
+			} else if (name === 'agent-memory') {
+				await this.reinjectAgentMemoryMcpServer(session, ctx);
 			}
 		}
 
@@ -3312,6 +3310,16 @@ export class TaskAgentManager {
 		await session.restartQuery();
 	}
 
+	async reinjectAgentMemoryMcpServer(
+		session: AgentSession,
+		ctx: { subSessionId: string; spaceId: string }
+	): Promise<void> {
+		const mcpServers = this.buildAgentMemoryMcpServers(ctx.spaceId, ctx.subSessionId);
+		if (Object.keys(mcpServers).length === 0) return;
+		session.mergeRuntimeMcpServers(mcpServers);
+		await session.restartQuery();
+	}
+
 	/**
 	 * Build (or re-build) the per-session `space-agent-tools` MCP server and merge
 	 * it into the session's runtime MCP map, preserving any other MCP servers
@@ -3447,7 +3455,18 @@ export class TaskAgentManager {
 	 * The server gives the node agent peer communication tools (list_peers, send_message,
 	 * save_artifact) that are scoped to its group, channel topology, and node task.
 	 */
-	private buildNodeAgentMcpServerForSession(
+	buildAgentMemoryMcpServers(spaceId: string, sessionId: string): Record<string, McpServerConfig> {
+		if (!this.config.memoryRepo) return {};
+		return {
+			'agent-memory': createAgentMemoryMcpServer({
+				spaceId,
+				memoryRepo: this.config.memoryRepo,
+				mySessionId: sessionId,
+			}) as unknown as McpServerConfig,
+		};
+	}
+
+	buildNodeAgentMcpServerForSession(
 		taskId: string,
 		subSessionId: string,
 		agentName: string,
@@ -3872,6 +3891,7 @@ export class TaskAgentManager {
 			mcpServers: {
 				...init.mcpServers,
 				'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+				...this.buildAgentMemoryMcpServers(spaceId, sessionId),
 			},
 		};
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3069,10 +3069,7 @@ export class TaskAgentManager {
 	 *   Without this the Coder→Reviewer handoff dies silently with "No such tool
 	 *   available" (PR #1535 failure mode).
 	 */
-	private static readonly REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS = [
-		'node-agent',
-		'agent-memory',
-	] as const;
+	private static readonly REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS = ['node-agent'] as const;
 
 	/**
 	 * Verify that a workflow node sub-session has its required MCP server
@@ -3100,6 +3097,12 @@ export class TaskAgentManager {
 	 * existing callers and tests; `ensureRequiredMcpServersAttached` is the
 	 * preferred alias for new code.
 	 */
+	requiredWorkflowSubSessionMcpServers(): string[] {
+		return this.config.memoryRepo
+			? [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS, 'agent-memory']
+			: [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS];
+	}
+
 	async ensureNodeAgentAttached(
 		session: AgentSession,
 		ctx: {
@@ -3118,7 +3121,7 @@ export class TaskAgentManager {
 		const currentMcpServers =
 			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
 
-		const required = TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS;
+		const required = this.requiredWorkflowSubSessionMcpServers();
 		const missing = required.filter((name) => !currentMcpServers[name]);
 
 		if (missing.length === 0) {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -96,6 +96,8 @@ import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
 import { AgentMessageRouter } from './agent-message-router';
 import type { ReplyRoutingRegistry } from './reply-routing-registry';
+import type { AgentMemoryRepository } from '../../../storage/repositories/agent-memory-repository';
+import { createAgentMemoryMcpServer } from '../tools/agent-memory-tools';
 import { RUNTIME_ESCALATION_REASONS } from './escalation-reasons';
 import { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { executeGateScript } from './gate-script-executor';
@@ -257,6 +259,8 @@ export interface TaskAgentManagerConfig {
 	 * Shared between space-agent-tools (register) and task/node-agent-tools (lookup).
 	 */
 	replyRoutingRegistry?: ReplyRoutingRegistry;
+	/** Persistent per-space agent memory repository. */
+	memoryRepo?: AgentMemoryRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -629,6 +633,15 @@ export class TaskAgentManager {
 				mcpServers: {
 					...init.mcpServers,
 					'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+					...(this.config.memoryRepo
+						? {
+								'agent-memory': createAgentMemoryMcpServer({
+									spaceId: space.id,
+									memoryRepo: this.config.memoryRepo,
+									mySessionId: sessionId,
+								}) as unknown as McpServerConfig,
+							}
+						: {}),
 				},
 			};
 
@@ -712,6 +725,10 @@ export class TaskAgentManager {
 					.listByRun(workflowRun.id)
 					.map((record) => ({ gateId: record.gateId, data: record.data }));
 
+				const memoryQuery = `${task.title}\n${task.description}`;
+				const relevantMemories = this.config.memoryRepo
+					? this.config.memoryRepo.search(space.id, memoryQuery, 5)
+					: [];
 				const initialMessage = buildCustomAgentTaskMessage({
 					customAgent: customAgent!,
 					task,
@@ -724,6 +741,7 @@ export class TaskAgentManager {
 					nodeId: execution.workflowNodeId,
 					agentSlotName: execution.agentName,
 					gateData: gateDataSnapshot,
+					relevantMemories,
 				});
 				const runtimeContract = this.buildNodeExecutionRuntimeContract(workflow, execution, space);
 				const kickoffMessage = runtimeContract

--- a/packages/daemon/src/lib/space/tools/agent-memory-tools.ts
+++ b/packages/daemon/src/lib/space/tools/agent-memory-tools.ts
@@ -40,7 +40,10 @@ export function createAgentMemoryToolHandlers(config: AgentMemoryToolsConfig) {
 				spaceId,
 				key: args.key,
 				content: args.content,
-				tags: args.tags ?? [],
+				// Pass `tags` through verbatim — including `undefined` — so the
+				// repository can preserve previously stored tags on content-only
+				// updates instead of clearing them with an explicit empty array.
+				tags: args.tags,
 				createdBySession: mySessionId ?? null,
 			});
 			return jsonResult({ success: true, memory });

--- a/packages/daemon/src/lib/space/tools/agent-memory-tools.ts
+++ b/packages/daemon/src/lib/space/tools/agent-memory-tools.ts
@@ -1,0 +1,97 @@
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import type { AgentMemoryRepository } from '../../../storage/repositories/agent-memory-repository';
+import type { ToolResult } from './tool-result';
+import { jsonResult } from './tool-result';
+
+const MemoryWriteSchema = z.object({
+	key: z.string().min(1).max(200).describe('Stable memory key, unique within this Space.'),
+	content: z
+		.string()
+		.min(1)
+		.describe('Fact, convention, decision, or project knowledge to persist.'),
+	tags: z.array(z.string()).optional().describe('Keyword tags that improve retrieval.'),
+});
+
+const MemorySearchSchema = z.object({
+	query: z.string().min(1).describe('Natural language query or code identifier.'),
+	limit: z.number().int().min(1).max(20).default(10),
+});
+
+const MemoryReadSchema = z.object({
+	key: z.string().min(1).max(200).describe('Memory key to read.'),
+});
+
+const MemoryDeleteSchema = z.object({
+	key: z.string().min(1).max(200).describe('Memory key to delete.'),
+});
+
+export interface AgentMemoryToolsConfig {
+	spaceId: string;
+	memoryRepo: AgentMemoryRepository;
+	mySessionId?: string;
+}
+
+export function createAgentMemoryToolHandlers(config: AgentMemoryToolsConfig) {
+	const { spaceId, memoryRepo, mySessionId } = config;
+	return {
+		async 'memory.write'(args: z.infer<typeof MemoryWriteSchema>): Promise<ToolResult> {
+			const memory = memoryRepo.write({
+				spaceId,
+				key: args.key,
+				content: args.content,
+				tags: args.tags ?? [],
+				createdBySession: mySessionId ?? null,
+			});
+			return jsonResult({ success: true, memory });
+		},
+
+		async 'memory.search'(args: z.infer<typeof MemorySearchSchema>): Promise<ToolResult> {
+			const results = memoryRepo.search(spaceId, args.query, args.limit);
+			return jsonResult({ success: true, results });
+		},
+
+		async 'memory.read'(args: z.infer<typeof MemoryReadSchema>): Promise<ToolResult> {
+			const memory = memoryRepo.read(spaceId, args.key);
+			if (!memory) return jsonResult({ success: false, error: `Memory not found: ${args.key}` });
+			return jsonResult({ success: true, memory });
+		},
+
+		async 'memory.delete'(args: z.infer<typeof MemoryDeleteSchema>): Promise<ToolResult> {
+			return jsonResult({ success: true, deleted: memoryRepo.delete(spaceId, args.key) });
+		},
+	};
+}
+
+export function createAgentMemoryMcpServer(config: AgentMemoryToolsConfig) {
+	const handlers = createAgentMemoryToolHandlers(config);
+	return createSdkMcpServer({
+		name: 'agent-memory',
+		tools: [
+			tool(
+				'memory.write',
+				'Save a fact, convention, decision, or project knowledge to persistent Space memory for future agent sessions.',
+				MemoryWriteSchema.shape,
+				(args) => handlers['memory.write'](args)
+			),
+			tool(
+				'memory.search',
+				'Search persistent Space memory for relevant facts, conventions, decisions, or project knowledge from previous sessions.',
+				MemorySearchSchema.shape,
+				(args) => handlers['memory.search'](args)
+			),
+			tool(
+				'memory.read',
+				'Read one persistent Space memory by key.',
+				MemoryReadSchema.shape,
+				(args) => handlers['memory.read'](args)
+			),
+			tool(
+				'memory.delete',
+				'Delete one persistent Space memory by key when it is obsolete or wrong.',
+				MemoryDeleteSchema.shape,
+				(args) => handlers['memory.delete'](args)
+			),
+		],
+	});
+}

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -41,6 +41,7 @@ import { TaskRepository } from './repositories/task-repository';
 import { McpEnablementRepository } from './repositories/mcp-enablement-repository';
 import { SkillRepository } from './repositories/skill-repository';
 import { WorkspaceHistoryRepository } from './repositories/workspace-history-repository';
+import { AgentMemoryRepository } from './repositories/agent-memory-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -66,6 +67,11 @@ export { AppMcpServerRepository } from './repositories/app-mcp-server-repository
 export { McpEnablementRepository } from './repositories/mcp-enablement-repository';
 export { SkillRepository } from './repositories/skill-repository';
 export { WorkspaceHistoryRepository } from './repositories/workspace-history-repository';
+export { AgentMemoryRepository } from './repositories/agent-memory-repository';
+export type {
+	AgentMemoryEntry,
+	AgentMemorySearchResult,
+} from './repositories/agent-memory-repository';
 export type { WorkspaceHistoryRow } from './repositories/workspace-history-repository';
 
 /**
@@ -88,6 +94,7 @@ export class Database {
 	private mcpEnablementRepo!: McpEnablementRepository;
 	private skillRepo!: SkillRepository;
 	private workspaceHistoryRepo!: WorkspaceHistoryRepository;
+	private agentMemoryRepo!: AgentMemoryRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -113,6 +120,7 @@ export class Database {
 		this.mcpEnablementRepo = new McpEnablementRepository(db, reactiveDb);
 		this.skillRepo = new SkillRepository(db, reactiveDb);
 		this.workspaceHistoryRepo = new WorkspaceHistoryRepository(db);
+		this.agentMemoryRepo = new AgentMemoryRepository(db, reactiveDb);
 	}
 
 	// ============================================================================
@@ -519,6 +527,10 @@ export class Database {
 	 */
 	get workspaceHistory(): WorkspaceHistoryRepository {
 		return this.workspaceHistoryRepo;
+	}
+
+	get agentMemory(): AgentMemoryRepository {
+		return this.agentMemoryRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -51,9 +51,13 @@ export class AgentMemoryRepository {
 	}): AgentMemoryEntry {
 		const key = normalizeKey(params.key);
 		const content = normalizeContent(params.content);
+		const tagsProvided = params.tags !== undefined;
 		const tags = normalizeTags(params.tags ?? []);
 		const now = Date.now();
 
+		// On conflict (existing row): preserve `tags` when caller did not supply them
+		// and never overwrite `created_by_session` so provenance stays with the
+		// original author.
 		const row = this.db
 			.prepare(
 				`INSERT INTO space_agent_memory
@@ -61,8 +65,7 @@ export class AgentMemoryRepository {
 				 VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL)
 				 ON CONFLICT(space_id, key) DO UPDATE SET
 					content = excluded.content,
-					tags = excluded.tags,
-					created_by_session = COALESCE(excluded.created_by_session, space_agent_memory.created_by_session),
+					tags = CASE WHEN ? = 1 THEN excluded.tags ELSE space_agent_memory.tags END,
 					updated_at = excluded.updated_at
 				 RETURNING *`
 			)
@@ -73,7 +76,8 @@ export class AgentMemoryRepository {
 				serializeTags(tags),
 				params.createdBySession ?? null,
 				now,
-				now
+				now,
+				tagsProvided ? 1 : 0
 			) as AgentMemoryRow;
 
 		this.reactiveDb?.notifyChange('space_agent_memory');
@@ -246,7 +250,10 @@ function buildFtsQuery(query: string): string | null {
 		.trim()
 		.toLowerCase()
 		.split(/\s+/)
-		.map((term) => term.replace(/[^\p{L}\p{N}_.-]/gu, ''))
+		// Preserve hyphens, dots, slashes, and colons so paths, URLs, and
+		// dashed identifiers (e.g. `src/lib/main.ts`, `pre-commit`) remain
+		// intact for trigram matching.
+		.map((term) => term.replace(/[^\p{L}\p{N}_./:-]/gu, ''))
 		// Trigram FTS cannot match terms shorter than three characters.
 		.filter((term) => term.length >= 3);
 	if (terms.length === 0) return null;

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -241,8 +241,7 @@ function buildFtsQuery(query: string): string | null {
 		.trim()
 		.toLowerCase()
 		.split(/\s+/)
-		.map((term) => term.replace(/[^\p{L}\p{N}_-]/gu, ''))
-		.map((term) => term.replace(/-/g, ''))
+		.map((term) => term.replace(/[^\p{L}\p{N}_.-]/gu, ''))
 		.filter((term) => term.length >= 3);
 	if (terms.length === 0) return null;
 	return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ');

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -102,39 +102,10 @@ export class AgentMemoryRepository {
 	}
 
 	search(spaceId: string, query: string, limit = 10): AgentMemorySearchResult[] {
-		const searchTerms = parseSearchTerms(query);
-		const safeLimit = normalizeLimit(limit);
-		if (searchTerms.length === 0) return [];
-
-		const rows = this.db
-			.prepare(
-				`SELECT *, 1000.0 AS rank FROM space_agent_memory
-				 WHERE space_id = ?
-				 ORDER BY updated_at DESC, key ASC`
-			)
-			.all(spaceId) as AgentMemorySearchRow[];
-		const matchedRows = rows
-			.filter((row) => {
-				const haystack = `${row.content} ${row.tags}`.toLowerCase();
-				return searchTerms.some((term) => haystack.includes(term));
-			})
-			.slice(0, safeLimit);
-
-		if (matchedRows.length > 0) {
-			const now = Date.now();
-			const bump = this.db.prepare(
-				`UPDATE space_agent_memory
-				 SET access_count = access_count + 1, last_accessed_at = ?
-				 WHERE space_id = ? AND key = ?`
-			);
-			const updateAccess = this.db.transaction((items: AgentMemorySearchRow[]) => {
-				for (const row of items) bump.run(now, row.space_id, row.key);
-			});
-			updateAccess(matchedRows);
-			this.reactiveDb?.notifyChange('space_agent_memory');
-		}
-
-		return matchedRows.map((row) => ({ memory: rowToEntry(row), rank: row.rank }));
+		return this.searchWithOptions(spaceId, query, { limit }).map((row) => ({
+			memory: rowToEntry(row),
+			rank: row.rank,
+		}));
 	}
 
 	list(
@@ -146,7 +117,9 @@ export class AgentMemoryRepository {
 		const query = options?.query?.trim();
 
 		if (query) {
-			return this.search(spaceId, query, limit).map((result) => result.memory);
+			return this.searchWithOptions(spaceId, query, { limit, offset, maxLimit: 100 }).map(
+				rowToEntry
+			);
 		}
 
 		const rows = this.db
@@ -169,6 +142,44 @@ export class AgentMemoryRepository {
 			)
 			.run(Date.now(), spaceId, normalizeKey(key));
 		this.reactiveDb?.notifyChange('space_agent_memory');
+	}
+
+	private searchWithOptions(
+		spaceId: string,
+		query: string,
+		options?: { limit?: number; offset?: number; maxLimit?: number }
+	): AgentMemorySearchRow[] {
+		const ftsQuery = buildFtsQuery(query);
+		const limit = normalizeLimit(options?.limit ?? 10, options?.maxLimit ?? 20);
+		const offset = Math.max(0, Math.trunc(options?.offset ?? 0));
+		if (!ftsQuery) return [];
+
+		const rows = this.db
+			.prepare(
+				`SELECT m.*, bm25(space_agent_memory_fts) AS rank
+				 FROM space_agent_memory_fts
+				 JOIN space_agent_memory m ON m.rowid = space_agent_memory_fts.rowid
+				 WHERE space_agent_memory_fts MATCH ? AND m.space_id = ?
+				 ORDER BY rank ASC, m.updated_at DESC, m.key ASC
+				 LIMIT ? OFFSET ?`
+			)
+			.all(ftsQuery, spaceId, limit, offset) as AgentMemorySearchRow[];
+
+		if (rows.length > 0) {
+			const now = Date.now();
+			const bump = this.db.prepare(
+				`UPDATE space_agent_memory
+				 SET access_count = access_count + 1, last_accessed_at = ?
+				 WHERE space_id = ? AND key = ?`
+			);
+			const updateAccess = this.db.transaction((items: AgentMemorySearchRow[]) => {
+				for (const row of items) bump.run(now, row.space_id, row.key);
+			});
+			updateAccess(rows);
+			this.reactiveDb?.notifyChange('space_agent_memory');
+		}
+
+		return rows;
 	}
 }
 
@@ -204,10 +215,19 @@ function normalizeTags(tags: string[]): string[] {
 }
 
 function serializeTags(tags: string[]): string {
-	return tags.join(' ');
+	return JSON.stringify(tags);
 }
 
 function parseTags(tags: string): string[] {
+	if (!tags) return [];
+	try {
+		const parsed = JSON.parse(tags) as unknown;
+		if (Array.isArray(parsed)) {
+			return parsed.filter((tag): tag is string => typeof tag === 'string');
+		}
+	} catch {
+		// Pre-JSON rows used whitespace-delimited tags.
+	}
 	return tags.split(/\s+/).filter(Boolean);
 }
 
@@ -216,11 +236,14 @@ function normalizeLimit(limit: number, max = 20): number {
 	return Math.min(Math.max(1, Math.trunc(limit)), max);
 }
 
-function parseSearchTerms(query: string): string[] {
-	return query
+function buildFtsQuery(query: string): string | null {
+	const terms = query
 		.trim()
 		.toLowerCase()
 		.split(/\s+/)
 		.map((term) => term.replace(/[^\p{L}\p{N}_-]/gu, ''))
-		.filter(Boolean);
+		.map((term) => term.replace(/-/g, ''))
+		.filter((term) => term.length >= 3);
+	if (terms.length === 0) return null;
+	return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ');
 }

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -1,0 +1,226 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { ReactiveDatabase } from '../reactive-database';
+
+export interface AgentMemoryEntry {
+	key: string;
+	spaceId: string;
+	content: string;
+	tags: string[];
+	createdBySession: string | null;
+	createdAt: number;
+	updatedAt: number;
+	accessCount: number;
+	lastAccessedAt: number | null;
+}
+
+export interface AgentMemorySearchResult {
+	memory: AgentMemoryEntry;
+	rank: number;
+}
+
+interface AgentMemoryRow {
+	key: string;
+	space_id: string;
+	content: string;
+	tags: string;
+	created_by_session: string | null;
+	created_at: number;
+	updated_at: number;
+	access_count: number;
+	last_accessed_at: number | null;
+}
+
+interface AgentMemorySearchRow extends AgentMemoryRow {
+	rank: number;
+}
+
+export class AgentMemoryRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
+
+	write(params: {
+		spaceId: string;
+		key: string;
+		content: string;
+		tags?: string[];
+		createdBySession?: string | null;
+	}): AgentMemoryEntry {
+		const key = normalizeKey(params.key);
+		const content = normalizeContent(params.content);
+		const tags = normalizeTags(params.tags ?? []);
+		const now = Date.now();
+
+		const row = this.db
+			.prepare(
+				`INSERT INTO space_agent_memory
+					(key, space_id, content, tags, created_by_session, created_at, updated_at, access_count, last_accessed_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL)
+				 ON CONFLICT(space_id, key) DO UPDATE SET
+					content = excluded.content,
+					tags = excluded.tags,
+					created_by_session = COALESCE(excluded.created_by_session, space_agent_memory.created_by_session),
+					updated_at = excluded.updated_at
+				 RETURNING *`
+			)
+			.get(
+				key,
+				params.spaceId,
+				content,
+				serializeTags(tags),
+				params.createdBySession ?? null,
+				now,
+				now
+			) as AgentMemoryRow;
+
+		this.reactiveDb?.notifyChange('space_agent_memory');
+		return rowToEntry(row);
+	}
+
+	read(
+		spaceId: string,
+		key: string,
+		options?: { recordAccess?: boolean }
+	): AgentMemoryEntry | null {
+		const normalizedKey = normalizeKey(key);
+		const row = this.db
+			.prepare(`SELECT * FROM space_agent_memory WHERE space_id = ? AND key = ?`)
+			.get(spaceId, normalizedKey) as AgentMemoryRow | undefined;
+		if (!row) return null;
+		if (options?.recordAccess !== false) this.recordAccess(spaceId, normalizedKey);
+		return rowToEntry(row);
+	}
+
+	delete(spaceId: string, key: string): boolean {
+		const normalizedKey = normalizeKey(key);
+		const result = this.db
+			.prepare(`DELETE FROM space_agent_memory WHERE space_id = ? AND key = ?`)
+			.run(spaceId, normalizedKey);
+		if (result.changes > 0) this.reactiveDb?.notifyChange('space_agent_memory');
+		return result.changes > 0;
+	}
+
+	search(spaceId: string, query: string, limit = 10): AgentMemorySearchResult[] {
+		const searchTerms = parseSearchTerms(query);
+		const safeLimit = normalizeLimit(limit);
+		if (searchTerms.length === 0) return [];
+
+		const rows = this.db
+			.prepare(
+				`SELECT *, 1000.0 AS rank FROM space_agent_memory
+				 WHERE space_id = ?
+				 ORDER BY updated_at DESC, key ASC`
+			)
+			.all(spaceId) as AgentMemorySearchRow[];
+		const matchedRows = rows
+			.filter((row) => {
+				const haystack = `${row.content} ${row.tags}`.toLowerCase();
+				return searchTerms.some((term) => haystack.includes(term));
+			})
+			.slice(0, safeLimit);
+
+		if (matchedRows.length > 0) {
+			const now = Date.now();
+			const bump = this.db.prepare(
+				`UPDATE space_agent_memory
+				 SET access_count = access_count + 1, last_accessed_at = ?
+				 WHERE space_id = ? AND key = ?`
+			);
+			const updateAccess = this.db.transaction((items: AgentMemorySearchRow[]) => {
+				for (const row of items) bump.run(now, row.space_id, row.key);
+			});
+			updateAccess(matchedRows);
+			this.reactiveDb?.notifyChange('space_agent_memory');
+		}
+
+		return matchedRows.map((row) => ({ memory: rowToEntry(row), rank: row.rank }));
+	}
+
+	list(
+		spaceId: string,
+		options?: { query?: string; limit?: number; offset?: number }
+	): AgentMemoryEntry[] {
+		const limit = normalizeLimit(options?.limit ?? 50, 100);
+		const offset = Math.max(0, Math.trunc(options?.offset ?? 0));
+		const query = options?.query?.trim();
+
+		if (query) {
+			return this.search(spaceId, query, limit).map((result) => result.memory);
+		}
+
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_agent_memory
+				 WHERE space_id = ?
+				 ORDER BY updated_at DESC, key ASC
+				 LIMIT ? OFFSET ?`
+			)
+			.all(spaceId, limit, offset) as AgentMemoryRow[];
+		return rows.map(rowToEntry);
+	}
+
+	recordAccess(spaceId: string, key: string): void {
+		this.db
+			.prepare(
+				`UPDATE space_agent_memory
+				 SET access_count = access_count + 1, last_accessed_at = ?
+				 WHERE space_id = ? AND key = ?`
+			)
+			.run(Date.now(), spaceId, normalizeKey(key));
+		this.reactiveDb?.notifyChange('space_agent_memory');
+	}
+}
+
+function rowToEntry(row: AgentMemoryRow): AgentMemoryEntry {
+	return {
+		key: row.key,
+		spaceId: row.space_id,
+		content: row.content,
+		tags: parseTags(row.tags),
+		createdBySession: row.created_by_session,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+		accessCount: row.access_count,
+		lastAccessedAt: row.last_accessed_at,
+	};
+}
+
+function normalizeKey(key: string): string {
+	const trimmed = key.trim();
+	if (!trimmed) throw new Error('Memory key must be a non-empty string.');
+	if (trimmed.length > 200) throw new Error('Memory key must be 200 characters or fewer.');
+	return trimmed;
+}
+
+function normalizeContent(content: string): string {
+	const trimmed = content.trim();
+	if (!trimmed) throw new Error('Memory content must be a non-empty string.');
+	return trimmed;
+}
+
+function normalizeTags(tags: string[]): string[] {
+	return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))].slice(0, 50);
+}
+
+function serializeTags(tags: string[]): string {
+	return tags.join(' ');
+}
+
+function parseTags(tags: string): string[] {
+	return tags.split(/\s+/).filter(Boolean);
+}
+
+function normalizeLimit(limit: number, max = 20): number {
+	if (!Number.isFinite(limit)) return Math.min(10, max);
+	return Math.min(Math.max(1, Math.trunc(limit)), max);
+}
+
+function parseSearchTerms(query: string): string[] {
+	return query
+		.trim()
+		.toLowerCase()
+		.split(/\s+/)
+		.map((term) => term.replace(/[^\p{L}\p{N}_-]/gu, ''))
+		.filter(Boolean);
+}

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -35,6 +35,8 @@ interface AgentMemorySearchRow extends AgentMemoryRow {
 }
 
 const MEMORY_CONTENT_MAX_LENGTH = 10_000;
+const MEMORY_TAG_MAX_LENGTH = 50;
+const MEMORY_TAG_MAX_COUNT = 50;
 
 export class AgentMemoryRepository {
 	constructor(
@@ -220,7 +222,19 @@ function normalizeContent(content: string): string {
 }
 
 function normalizeTags(tags: string[]): string[] {
-	return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))].slice(0, 50);
+	const normalized: string[] = [];
+	for (const raw of tags) {
+		const tag = raw.trim();
+		if (!tag) continue;
+		// Tags are rendered verbatim into agent prompts via `tags.join(', ')`, so a
+		// single oversized tag would balloon the prompt past the memory-content cap.
+		// Bound per-tag length here to keep the prompt-size budget enforceable.
+		if (tag.length > MEMORY_TAG_MAX_LENGTH) {
+			throw new Error(`Memory tags must be ${MEMORY_TAG_MAX_LENGTH} characters or fewer.`);
+		}
+		normalized.push(tag);
+	}
+	return [...new Set(normalized)].slice(0, MEMORY_TAG_MAX_COUNT);
 }
 
 function serializeTags(tags: string[]): string {

--- a/packages/daemon/src/storage/repositories/agent-memory-repository.ts
+++ b/packages/daemon/src/storage/repositories/agent-memory-repository.ts
@@ -34,6 +34,8 @@ interface AgentMemorySearchRow extends AgentMemoryRow {
 	rank: number;
 }
 
+const MEMORY_CONTENT_MAX_LENGTH = 10_000;
+
 export class AgentMemoryRepository {
 	constructor(
 		private db: BunDatabase,
@@ -207,6 +209,9 @@ function normalizeKey(key: string): string {
 function normalizeContent(content: string): string {
 	const trimmed = content.trim();
 	if (!trimmed) throw new Error('Memory content must be a non-empty string.');
+	if (trimmed.length > MEMORY_CONTENT_MAX_LENGTH) {
+		throw new Error(`Memory content must be ${MEMORY_CONTENT_MAX_LENGTH} characters or fewer.`);
+	}
 	return trimmed;
 }
 
@@ -242,6 +247,7 @@ function buildFtsQuery(query: string): string | null {
 		.toLowerCase()
 		.split(/\s+/)
 		.map((term) => term.replace(/[^\p{L}\p{N}_.-]/gu, ''))
+		// Trigram FTS cannot match terms shorter than three characters.
 		.filter((term) => term.length >= 3);
 	if (terms.length === 0) return null;
 	return terms.map((term) => `"${term.replace(/"/g, '""')}"`).join(' ');

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -99,6 +99,8 @@ export { runMigration128 } from './migrations';
 export { runMigration129 } from './migrations';
 // knip-ignore-next-line
 export { runMigration131 } from './migrations';
+// knip-ignore-next-line
+export { runMigration132 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -624,8 +626,61 @@ export function createTables(db: BunDatabase): void {
 	      )
 	    `);
 
+	createAgentMemoryTables(db);
+
 	// Create indexes
 	createIndexes(db);
+}
+
+function createAgentMemoryTables(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_agent_memory (
+			rowid INTEGER PRIMARY KEY,
+			key TEXT NOT NULL,
+			space_id TEXT NOT NULL,
+			content TEXT NOT NULL,
+			tags TEXT NOT NULL DEFAULT '',
+			created_by_session TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			access_count INTEGER NOT NULL DEFAULT 0,
+			last_accessed_at INTEGER,
+			UNIQUE(space_id, key),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS space_agent_memory_fts USING fts5(
+			content,
+			tags,
+			content='space_agent_memory',
+			content_rowid='rowid',
+			tokenize='trigram'
+		)
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ai
+		AFTER INSERT ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(rowid, content, tags)
+			VALUES (new.rowid, new.content, new.tags);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ad
+		AFTER DELETE ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
+			VALUES ('delete', old.rowid, old.content, old.tags);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_au
+		AFTER UPDATE ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
+			VALUES ('delete', old.rowid, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(rowid, content, tags)
+			VALUES (new.rowid, new.content, new.tags);
+		END
+	`);
 }
 
 /**
@@ -661,6 +716,17 @@ function createIndexes(db: BunDatabase): void {
 
 	// Legacy `task_session_map` indexes no longer exist — see the
 	// `sdk_messages.task_id` column above for the replacement.
+
+	// Agent memory indexes
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_space ON space_agent_memory(space_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_updated ON space_agent_memory(space_id, updated_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_access ON space_agent_memory(space_id, last_accessed_at DESC)`
+	);
 
 	// Room indexes
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_room ON tasks(room_id)`);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -651,6 +651,7 @@ function createAgentMemoryTables(db: BunDatabase): void {
 	`);
 	db.exec(`
 		CREATE VIRTUAL TABLE IF NOT EXISTS space_agent_memory_fts USING fts5(
+			key,
 			content,
 			tags,
 			content='space_agent_memory',
@@ -661,24 +662,24 @@ function createAgentMemoryTables(db: BunDatabase): void {
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ai
 		AFTER INSERT ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(rowid, content, tags)
-			VALUES (new.rowid, new.content, new.tags);
+			INSERT INTO space_agent_memory_fts(rowid, key, content, tags)
+			VALUES (new.rowid, new.key, new.content, new.tags);
 		END
 	`);
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ad
 		AFTER DELETE ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
-			VALUES ('delete', old.rowid, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, key, content, tags)
+			VALUES ('delete', old.rowid, old.key, old.content, old.tags);
 		END
 	`);
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_au
-		AFTER UPDATE ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
-			VALUES ('delete', old.rowid, old.content, old.tags);
-			INSERT INTO space_agent_memory_fts(rowid, content, tags)
-			VALUES (new.rowid, new.content, new.tags);
+		AFTER UPDATE OF key, content, tags ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, key, content, tags)
+			VALUES ('delete', old.rowid, old.key, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(rowid, key, content, tags)
+			VALUES (new.rowid, new.key, new.content, new.tags);
 		END
 	`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9042,6 +9042,7 @@ function createAgentMemoryTables(db: BunDatabase): void {
 
 	db.exec(`
 		CREATE VIRTUAL TABLE IF NOT EXISTS space_agent_memory_fts USING fts5(
+			key,
 			content,
 			tags,
 			content='space_agent_memory',
@@ -9053,24 +9054,24 @@ function createAgentMemoryTables(db: BunDatabase): void {
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ai
 		AFTER INSERT ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(rowid, content, tags)
-			VALUES (new.rowid, new.content, new.tags);
+			INSERT INTO space_agent_memory_fts(rowid, key, content, tags)
+			VALUES (new.rowid, new.key, new.content, new.tags);
 		END
 	`);
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ad
 		AFTER DELETE ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
-			VALUES ('delete', old.rowid, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, key, content, tags)
+			VALUES ('delete', old.rowid, old.key, old.content, old.tags);
 		END
 	`);
 	db.exec(`
 		CREATE TRIGGER IF NOT EXISTS space_agent_memory_au
-		AFTER UPDATE ON space_agent_memory BEGIN
-			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
-			VALUES ('delete', old.rowid, old.content, old.tags);
-			INSERT INTO space_agent_memory_fts(rowid, content, tags)
-			VALUES (new.rowid, new.content, new.tags);
+		AFTER UPDATE OF key, content, tags ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, key, content, tags)
+			VALUES ('delete', old.rowid, old.key, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(rowid, key, content, tags)
+			VALUES (new.rowid, new.key, new.content, new.tags);
 		END
 	`);
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9021,6 +9021,8 @@ export function runMigration132(db: BunDatabase): void {
 }
 
 function createAgentMemoryTables(db: BunDatabase): void {
+	const shouldRebuildFts = !tableExists(db, 'space_agent_memory_fts');
+
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_agent_memory (
 			rowid INTEGER PRIMARY KEY,
@@ -9081,7 +9083,9 @@ function createAgentMemoryTables(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_access ON space_agent_memory(space_id, last_accessed_at DESC)`
 	);
-	db.exec(`INSERT INTO space_agent_memory_fts(space_agent_memory_fts) VALUES ('rebuild')`);
+	if (shouldRebuildFts) {
+		db.exec(`INSERT INTO space_agent_memory_fts(space_agent_memory_fts) VALUES ('rebuild')`);
+	}
 }
 
 function migrateNeoMessageOrigins(db: BunDatabase): void {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -626,6 +626,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 131: Remove global Neo prototype schema surface.
 	runMigration131(db);
+
+	// Migration 132: Add per-space persistent agent memory with FTS5 search.
+	runMigration132(db);
 }
 
 /**
@@ -9011,6 +9014,74 @@ function migrateNeoSessions(db: BunDatabase): void {
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
 	}
+}
+
+export function runMigration132(db: BunDatabase): void {
+	createAgentMemoryTables(db);
+}
+
+function createAgentMemoryTables(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_agent_memory (
+			rowid INTEGER PRIMARY KEY,
+			key TEXT NOT NULL,
+			space_id TEXT NOT NULL,
+			content TEXT NOT NULL,
+			tags TEXT NOT NULL DEFAULT '',
+			created_by_session TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			access_count INTEGER NOT NULL DEFAULT 0,
+			last_accessed_at INTEGER,
+			UNIQUE(space_id, key),
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS space_agent_memory_fts USING fts5(
+			content,
+			tags,
+			content='space_agent_memory',
+			content_rowid='rowid',
+			tokenize='trigram'
+		)
+	`);
+
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ai
+		AFTER INSERT ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(rowid, content, tags)
+			VALUES (new.rowid, new.content, new.tags);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_ad
+		AFTER DELETE ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
+			VALUES ('delete', old.rowid, old.content, old.tags);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS space_agent_memory_au
+		AFTER UPDATE ON space_agent_memory BEGIN
+			INSERT INTO space_agent_memory_fts(space_agent_memory_fts, rowid, content, tags)
+			VALUES ('delete', old.rowid, old.content, old.tags);
+			INSERT INTO space_agent_memory_fts(rowid, content, tags)
+			VALUES (new.rowid, new.content, new.tags);
+		END
+	`);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_space ON space_agent_memory(space_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_updated ON space_agent_memory(space_id, updated_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_agent_memory_access ON space_agent_memory(space_id, last_accessed_at DESC)`
+	);
+	db.exec(`INSERT INTO space_agent_memory_fts(space_agent_memory_fts) VALUES ('rebuild')`);
 }
 
 function migrateNeoMessageOrigins(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -70,13 +70,14 @@ describe('scope-config', () => {
 				'workflow_run_artifact_cache',
 				'mcp_audit_log',
 				'task_schedules',
+				'space_agent_memory',
 				// Main-DB tables exposed with space-scoped filtering via session ID prefix:
 				'sessions',
 				'sdk_messages',
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(16);
+			expect(names).toHaveLength(17);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/agent-memory-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/agent-memory-handlers.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test';
+import { setupAgentMemoryHandlers } from '../../../../src/lib/rpc-handlers/agent-memory-handlers.ts';
+
+function createMessageHubStub() {
+	const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+	return {
+		messageHub: {
+			onRequest(name: string, handler: (payload: unknown) => Promise<unknown>) {
+				handlers.set(name, handler);
+			},
+		},
+		handlers,
+	};
+}
+
+describe('agent memory RPC handlers', () => {
+	test('rejects non-finite numeric params', async () => {
+		const { messageHub, handlers } = createMessageHubStub();
+		setupAgentMemoryHandlers(messageHub as never, {
+			memoryRepo: {
+				list: () => [],
+			} as never,
+		});
+
+		await expect(
+			handlers.get('agentMemory.list')?.({ spaceId: 'space-a', offset: Infinity })
+		).rejects.toThrow('offset must be a finite number.');
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/agent-memory-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/agent-memory-handlers.test.ts
@@ -26,4 +26,60 @@ describe('agent memory RPC handlers', () => {
 			handlers.get('agentMemory.list')?.({ spaceId: 'space-a', offset: Infinity })
 		).rejects.toThrow('offset must be a finite number.');
 	});
+
+	test('rejects offsets outside safe integer range', async () => {
+		const { messageHub, handlers } = createMessageHubStub();
+		setupAgentMemoryHandlers(messageHub as never, {
+			memoryRepo: {
+				list: () => [],
+			} as never,
+		});
+
+		await expect(
+			handlers.get('agentMemory.list')?.({ spaceId: 'space-a', offset: 1e308 })
+		).rejects.toThrow('offset must be a safe integer.');
+	});
+
+	test('write preserves tags when payload omits them', async () => {
+		const { messageHub, handlers } = createMessageHubStub();
+		const writes: Array<Record<string, unknown>> = [];
+		setupAgentMemoryHandlers(messageHub as never, {
+			memoryRepo: {
+				write: (params: Record<string, unknown>) => {
+					writes.push(params);
+					return params;
+				},
+			} as never,
+		});
+
+		await handlers.get('agentMemory.write')?.({
+			spaceId: 'space-a',
+			key: 'conventions.api',
+			content: 'Content only.',
+		});
+
+		expect(writes[0]?.tags).toBeUndefined();
+	});
+
+	test('write ignores caller-supplied createdBySession', async () => {
+		const { messageHub, handlers } = createMessageHubStub();
+		const writes: Array<Record<string, unknown>> = [];
+		setupAgentMemoryHandlers(messageHub as never, {
+			memoryRepo: {
+				write: (params: Record<string, unknown>) => {
+					writes.push(params);
+					return params;
+				},
+			} as never,
+		});
+
+		await handlers.get('agentMemory.write')?.({
+			spaceId: 'space-a',
+			key: 'conventions.api',
+			content: 'Body',
+			createdBySession: 'forged-session',
+		});
+
+		expect(writes[0]?.createdBySession).toBeNull();
+	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../src/storage/schema/index.ts';
+import { AgentMemoryRepository } from '../../../src/storage/repositories/agent-memory-repository.ts';
+
+let db: BunDatabase;
+let repo: AgentMemoryRepository;
+
+function seedSpace(spaceId: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+	     allowed_models, session_ids, slug, status, created_at, updated_at)
+	     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/${spaceId}`, spaceId, spaceId, now, now);
+}
+
+describe('AgentMemoryRepository', () => {
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		repo = new AgentMemoryRepository(db);
+		seedSpace('space-a');
+		seedSpace('space-b');
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('writes and reads memory by space/key', () => {
+		const memory = repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.test',
+			content: 'Use Bun native tests for daemon code.',
+			tags: ['testing', 'bun'],
+			createdBySession: 'session-1',
+		});
+
+		expect(memory.key).toBe('conventions.test');
+		expect(memory.spaceId).toBe('space-a');
+		expect(memory.tags).toEqual(['testing', 'bun']);
+		expect(repo.list('space-a')).toHaveLength(1);
+
+		const read = repo.read('space-a', 'conventions.test');
+		expect(read?.content).toBe('Use Bun native tests for daemon code.');
+		expect(read?.createdBySession).toBe('session-1');
+	});
+
+	test('search returns FTS-ranked results', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'alpha',
+			content: 'React components use hooks.',
+		});
+		repo.write({
+			spaceId: 'space-a',
+			key: 'preact',
+			content: 'Preact Signals are required for web state management.',
+			tags: ['preact', 'signals'],
+		});
+
+		const results = repo.search('space-a', 'preact signals', 5);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0].memory.key).toBe('preact');
+		expect(results[0].rank).toBeTypeOf('number');
+	});
+
+	test('search is scoped by space', () => {
+		repo.write({ spaceId: 'space-a', key: 'shared', content: 'Use tabs for formatting.' });
+		repo.write({ spaceId: 'space-b', key: 'shared', content: 'Use spaces for formatting.' });
+
+		const results = repo.search('space-a', 'formatting', 10);
+		expect(results.map((result) => result.memory.content)).toEqual(['Use tabs for formatting.']);
+	});
+
+	test('delete removes memory from FTS index', () => {
+		repo.write({ spaceId: 'space-a', key: 'obsolete', content: 'Old Flowbite convention.' });
+		expect(repo.search('space-a', 'Flowbite', 10)).toHaveLength(1);
+
+		expect(repo.delete('space-a', 'obsolete')).toBe(true);
+		expect(repo.read('space-a', 'obsolete')).toBeNull();
+		expect(repo.search('space-a', 'Flowbite', 10)).toHaveLength(0);
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -122,6 +122,49 @@ describe('AgentMemoryRepository', () => {
 		expect(results[0].rank).not.toBe(1000);
 	});
 
+	test('search matches hyphenated identifiers', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'tooling.hooks',
+			content: 'Run pre-commit before pushing.',
+		});
+
+		const results = repo.search('space-a', 'pre-commit', 5);
+		expect(results.map((result) => result.memory.key)).toEqual(['tooling.hooks']);
+	});
+
+	test('search matches memory keys', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.forms',
+			content: 'Use zod schemas.',
+		});
+
+		const results = repo.search('space-a', 'conventions.forms', 5);
+		expect(results.map((result) => result.memory.key)).toEqual(['conventions.forms']);
+	});
+
+	test('access updates do not rewrite FTS rows', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'access.fts',
+			content: 'Keep access telemetry cheap.',
+		});
+		const before = db
+			.prepare(`SELECT count(*) AS count FROM space_agent_memory_fts_data`)
+			.get() as {
+			count: number;
+		};
+
+		repo.read('space-a', 'access.fts');
+		repo.search('space-a', 'telemetry', 5);
+
+		const after = db.prepare(`SELECT count(*) AS count FROM space_agent_memory_fts_data`).get() as {
+			count: number;
+		};
+		expect(after.count).toBe(before.count);
+	});
+
 	test('delete removes memory from FTS index', () => {
 		repo.write({ spaceId: 'space-a', key: 'obsolete', content: 'Old Flowbite convention.' });
 		expect(repo.search('space-a', 'Flowbite', 10)).toHaveLength(1);

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -96,6 +96,17 @@ describe('AgentMemoryRepository', () => {
 		).toThrow('Memory content must be 10000 characters or fewer.');
 	});
 
+	test('rejects oversized memory tags', () => {
+		expect(() =>
+			repo.write({
+				spaceId: 'space-a',
+				key: 'oversized.tag',
+				content: 'Tag length must be bounded for prompt safety.',
+				tags: ['x'.repeat(51)],
+			})
+		).toThrow('Memory tags must be 50 characters or fewer.');
+	});
+
 	test('preserves existing tags when update omits tags', () => {
 		repo.write({
 			spaceId: 'space-a',

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -75,6 +75,53 @@ describe('AgentMemoryRepository', () => {
 		expect(results.map((result) => result.memory.content)).toEqual(['Use tabs for formatting.']);
 	});
 
+	test('preserves tags with whitespace', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'release.process',
+			content: 'Release process notes.',
+			tags: ['release notes', 'phase 1'],
+		});
+
+		expect(repo.read('space-a', 'release.process')?.tags).toEqual(['release notes', 'phase 1']);
+	});
+
+	test('filtered list honors limit and offset above search limit', () => {
+		for (let index = 0; index < 25; index++) {
+			repo.write({
+				spaceId: 'space-a',
+				key: `memory.${index.toString().padStart(2, '0')}`,
+				content: `Shared pagination topic ${index}`,
+			});
+		}
+
+		const firstPage = repo.list('space-a', { query: 'pagination topic', limit: 25 });
+		const secondPage = repo.list('space-a', { query: 'pagination topic', limit: 5, offset: 5 });
+
+		expect(firstPage).toHaveLength(25);
+		expect(secondPage).toHaveLength(5);
+		expect(secondPage.map((memory) => memory.key)).toEqual(
+			firstPage.slice(5, 10).map((memory) => memory.key)
+		);
+	});
+
+	test('search orders by FTS rank before recency', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'focused',
+			content: 'Preact preact preact signals signals signals.',
+		});
+		repo.write({
+			spaceId: 'space-a',
+			key: 'recent',
+			content: 'Preact signals mixed with unrelated routing and styling notes.',
+		});
+
+		const results = repo.search('space-a', 'preact signals', 1);
+		expect(results.map((result) => result.memory.key)).toEqual(['focused']);
+		expect(results[0].rank).not.toBe(1000);
+	});
+
 	test('delete removes memory from FTS index', () => {
 		repo.write({ spaceId: 'space-a', key: 'obsolete', content: 'Old Flowbite convention.' });
 		expect(repo.search('space-a', 'Flowbite', 10)).toHaveLength(1);

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -86,6 +86,16 @@ describe('AgentMemoryRepository', () => {
 		expect(repo.read('space-a', 'release.process')?.tags).toEqual(['release notes', 'phase 1']);
 	});
 
+	test('rejects oversized memory content', () => {
+		expect(() =>
+			repo.write({
+				spaceId: 'space-a',
+				key: 'oversized',
+				content: 'x'.repeat(10_001),
+			})
+		).toThrow('Memory content must be 10000 characters or fewer.');
+	});
+
 	test('filtered list honors limit and offset above search limit', () => {
 		for (let index = 0; index < 25; index++) {
 			repo.write({

--- a/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/agent-memory-repository.test.ts
@@ -96,6 +96,71 @@ describe('AgentMemoryRepository', () => {
 		).toThrow('Memory content must be 10000 characters or fewer.');
 	});
 
+	test('preserves existing tags when update omits tags', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.api',
+			content: 'Original content.',
+			tags: ['api', 'http'],
+		});
+
+		const updated = repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.api',
+			content: 'Updated content without tag changes.',
+		});
+
+		expect(updated.content).toBe('Updated content without tag changes.');
+		expect(updated.tags).toEqual(['api', 'http']);
+	});
+
+	test('clears tags when update explicitly passes empty array', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.lint',
+			content: 'Original.',
+			tags: ['lint'],
+		});
+
+		const updated = repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.lint',
+			content: 'Original.',
+			tags: [],
+		});
+
+		expect(updated.tags).toEqual([]);
+	});
+
+	test('keeps original creator session when later sessions update', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.auth',
+			content: 'Initial note.',
+			createdBySession: 'session-original',
+		});
+
+		const updated = repo.write({
+			spaceId: 'space-a',
+			key: 'conventions.auth',
+			content: 'Revised note.',
+			createdBySession: 'session-later',
+		});
+
+		expect(updated.createdBySession).toBe('session-original');
+	});
+
+	test('search matches path identifiers', () => {
+		repo.write({
+			spaceId: 'space-a',
+			key: 'modules.entry',
+			content: 'Entry point is src/lib/main.ts.',
+		});
+
+		const results = repo.search('space-a', 'src/lib/main.ts', 5);
+		expect(results.map((result) => result.memory.key)).toEqual(['modules.entry']);
+	});
+
 	test('filtered list honors limit and offset above search limit', () => {
 		for (let index = 0; index < 25; index++) {
 			repo.write({

--- a/packages/daemon/tests/unit/5-space/agent/agent-memory-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-memory-tools.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { AgentMemoryRepository } from '../../../../src/storage/repositories/agent-memory-repository.ts';
+import { createAgentMemoryToolHandlers } from '../../../../src/lib/space/tools/agent-memory-tools.ts';
+
+let db: BunDatabase;
+let repo: AgentMemoryRepository;
+
+function seedSpace(spaceId: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+	     allowed_models, session_ids, slug, status, created_at, updated_at)
+	     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/${spaceId}`, spaceId, spaceId, now, now);
+}
+
+function parseResult(result: { content: Array<{ text: string }> }): Record<string, unknown> {
+	return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+describe('agent memory MCP tool handlers', () => {
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		repo = new AgentMemoryRepository(db);
+		seedSpace('space-a');
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('writes and retrieves memory within same space', async () => {
+		const handlers = createAgentMemoryToolHandlers({
+			spaceId: 'space-a',
+			memoryRepo: repo,
+			mySessionId: 'session-1',
+		});
+
+		const write = parseResult(
+			await handlers['memory.write']({
+				key: 'decision.build',
+				content: 'Use make build for web bundle verification.',
+				tags: ['build'],
+			})
+		);
+		expect(write.success).toBe(true);
+
+		const search = parseResult(
+			await handlers['memory.search']({ query: 'bundle verification', limit: 5 })
+		);
+		const results = search.results as Array<{ memory: { key: string; createdBySession: string } }>;
+		expect(results[0].memory.key).toBe('decision.build');
+		expect(results[0].memory.createdBySession).toBe('session-1');
+
+		const read = parseResult(await handlers['memory.read']({ key: 'decision.build' }));
+		expect((read.memory as { content: string }).content).toContain('make build');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/agent-memory-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-memory-tools.test.ts
@@ -59,4 +59,27 @@ describe('agent memory MCP tool handlers', () => {
 		const read = parseResult(await handlers['memory.read']({ key: 'decision.build' }));
 		expect((read.memory as { content: string }).content).toContain('make build');
 	});
+
+	test('memory.write preserves existing tags when caller omits tags', async () => {
+		const handlers = createAgentMemoryToolHandlers({
+			spaceId: 'space-a',
+			memoryRepo: repo,
+			mySessionId: 'session-1',
+		});
+
+		await handlers['memory.write']({
+			key: 'decision.format',
+			content: 'Initial decision.',
+			tags: ['formatting', 'biome'],
+		});
+
+		const update = parseResult(
+			await handlers['memory.write']({
+				key: 'decision.format',
+				content: 'Updated decision body.',
+			})
+		);
+		const memory = update.memory as { tags: string[] };
+		expect(memory.tags).toEqual(['formatting', 'biome']);
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent-memory.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent-memory.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test';
+import { buildCustomAgentTaskMessage } from '../../../../src/lib/space/agents/custom-agent.ts';
+import type { Space, SpaceAgent, SpaceTask } from '@neokai/shared';
+import type { AgentMemorySearchResult } from '../../../../src/storage/repositories/agent-memory-repository.ts';
+
+const space: Space = {
+	id: 'space-1',
+	slug: 'space-1',
+	workspacePath: '/tmp/space-1',
+	name: 'Space 1',
+	description: '',
+	backgroundContext: 'Static project context.',
+	instructions: '',
+	sessionIds: [],
+	status: 'active',
+	paused: false,
+	stopped: false,
+	maxConcurrentTasks: 1,
+	createdAt: 1,
+	updatedAt: 1,
+};
+
+const task: SpaceTask = {
+	id: 'task-1',
+	spaceId: 'space-1',
+	taskNumber: 1,
+	title: 'Add validation',
+	description: 'Add validation for settings form.',
+	status: 'open',
+	priority: 'normal',
+	dependsOn: [],
+	blockedBy: [],
+	createdAt: 1,
+	updatedAt: 1,
+};
+
+const agent: SpaceAgent = {
+	id: 'agent-1',
+	spaceId: 'space-1',
+	name: 'coder',
+	description: '',
+	customPrompt: '',
+	tools: [],
+	createdAt: 1,
+	updatedAt: 1,
+};
+
+const memories: AgentMemorySearchResult[] = [
+	{
+		rank: -1,
+		memory: {
+			key: 'conventions.forms',
+			spaceId: 'space-1',
+			content: 'Use zod schemas for form validation.',
+			tags: ['forms', 'validation'],
+			createdBySession: null,
+			createdAt: 1,
+			updatedAt: 1,
+			accessCount: 0,
+			lastAccessedAt: null,
+		},
+	},
+];
+
+describe('buildCustomAgentTaskMessage memory injection', () => {
+	test('includes relevant memories before project context', () => {
+		const message = buildCustomAgentTaskMessage({
+			customAgent: agent,
+			task,
+			workflowRun: null,
+			workflow: null,
+			space,
+			sessionId: 'session-1',
+			workspacePath: '/tmp/space-1',
+			relevantMemories: memories,
+		});
+
+		expect(message).toContain('## Relevant Memories');
+		expect(message).toContain('- conventions.forms [forms, validation]: Use zod schemas');
+		expect(message.indexOf('## Relevant Memories')).toBeLessThan(
+			message.indexOf('## Project Context')
+		);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent-memory.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent-memory.test.ts
@@ -81,4 +81,28 @@ describe('buildCustomAgentTaskMessage memory injection', () => {
 			message.indexOf('## Project Context')
 		);
 	});
+
+	test('truncates long memory content in prompt', () => {
+		const message = buildCustomAgentTaskMessage({
+			customAgent: agent,
+			task,
+			workflowRun: null,
+			workflow: null,
+			space,
+			sessionId: 'session-1',
+			workspacePath: '/tmp/space-1',
+			relevantMemories: [
+				{
+					rank: -1,
+					memory: {
+						...memories[0].memory,
+						content: 'x'.repeat(600),
+					},
+				},
+			],
+		});
+
+		expect(message).toContain(`${'x'.repeat(500)}…`);
+		expect(message).not.toContain('x'.repeat(501));
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'bun:test';
+import type { McpServerConfig } from '@neokai/shared';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 
 function makeManager(memoryRepo?: unknown): TaskAgentManager {
@@ -7,6 +8,25 @@ function makeManager(memoryRepo?: unknown): TaskAgentManager {
 			value: { memoryRepo },
 		},
 	}) as TaskAgentManager;
+}
+
+function makeSession(mcpServers: Record<string, McpServerConfig>) {
+	let restartCount = 0;
+	return {
+		session: { config: { mcpServers } },
+		mergeRuntimeMcpServers(servers: Record<string, McpServerConfig>) {
+			this.session.config.mcpServers = {
+				...this.session.config.mcpServers,
+				...servers,
+			};
+		},
+		async restartQuery() {
+			restartCount += 1;
+		},
+		get restartCount() {
+			return restartCount;
+		},
+	};
 }
 
 describe('TaskAgentManager agent-memory MCP wiring', () => {
@@ -30,5 +50,29 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 			'node-agent',
 			'agent-memory',
 		]);
+	});
+
+	test('reattaches agent-memory when missing during rehydrate self-heal', async () => {
+		const manager = makeManager({});
+		const session = makeSession({
+			'node-agent': { type: 'sdk' } as McpServerConfig,
+		});
+
+		await manager.ensureNodeAgentAttached(session as never, {
+			taskId: 'task-a',
+			subSessionId: 'session-a',
+			agentName: 'coder',
+			spaceId: 'space-a',
+			workflowRunId: 'run-a',
+			workspacePath: '/tmp/space-a',
+			workflowNodeId: 'node-a',
+			phase: 'rehydrate',
+		});
+
+		expect(Object.keys(session.session.config.mcpServers).sort()).toEqual([
+			'agent-memory',
+			'node-agent',
+		]);
+		expect(session.restartCount).toBe(1);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
@@ -23,4 +23,12 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 
 		expect(servers).toEqual({});
 	});
+
+	test('requires agent-memory only when memory repo is configured', () => {
+		expect(makeManager().requiredWorkflowSubSessionMcpServers()).toEqual(['node-agent']);
+		expect(makeManager({}).requiredWorkflowSubSessionMcpServers()).toEqual([
+			'node-agent',
+			'agent-memory',
+		]);
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'bun:test';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+
+function makeManager(memoryRepo?: unknown): TaskAgentManager {
+	return Object.create(TaskAgentManager.prototype, {
+		config: {
+			value: { memoryRepo },
+		},
+	}) as TaskAgentManager;
+}
+
+describe('TaskAgentManager agent-memory MCP wiring', () => {
+	test('builds agent-memory server when memory repo is configured', () => {
+		const manager = makeManager({});
+		const servers = manager.buildAgentMemoryMcpServers('space-a', 'session-a');
+
+		expect(Object.keys(servers)).toContain('agent-memory');
+	});
+
+	test('omits agent-memory server when memory repo is absent', () => {
+		const manager = makeManager();
+		const servers = manager.buildAgentMemoryMcpServers('space-a', 'session-a');
+
+		expect(servers).toEqual({});
+	});
+});


### PR DESCRIPTION
Adds Phase 1 persistent Space agent memory with SQLite storage, MCP tools, RPC browse/search handlers, db-query visibility, and relevant-memory prompt injection.

Tests:
- bun test tests/unit/4-space-storage/agent-memory-repository.test.ts tests/unit/5-space/agent/agent-memory-tools.test.ts tests/unit/5-space/agent/custom-agent-memory.test.ts
- ./scripts/test-daemon.sh
- bun run check