### PR TITLE
Add Space goals UI

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
 	navigateToSpace,
 	navigateToSpaceConfigure,
 	navigateToSpaceSessions,
+	navigateToSpaceGoals,
 	navigateToSpaceTasks,
 	navigateToSpaceAgent,
 	navigateToSpaceSession,
@@ -46,6 +47,7 @@ import {
 	createSpacePath,
 	createSpaceConfigurePath,
 	createSpaceSessionsPath,
+	createSpaceGoalsPath,
 	createSpaceTasksPath,
 	createSpaceAgentPath,
 	createSpaceSessionPath,
@@ -148,23 +150,25 @@ export function App() {
 							? createSpaceSessionPath(spaceId, spaceSessionId)
 							: spaceId && spaceViewMode === 'sessions'
 								? createSpaceSessionsPath(spaceId)
-								: spaceId && spaceViewMode === 'tasks'
-									? createSpaceTasksPath(
-											spaceId,
-											spaceTasksFilterTab !== 'active' ? spaceTasksFilterTab : undefined
-										)
-									: spaceId && spaceViewMode === 'configure'
-										? createSpaceConfigurePath(
+								: spaceId && spaceViewMode === 'goals'
+									? createSpaceGoalsPath(spaceId)
+									: spaceId && spaceViewMode === 'tasks'
+										? createSpaceTasksPath(
 												spaceId,
-												spaceConfigureTab !== 'agents' ? spaceConfigureTab : undefined
+												spaceTasksFilterTab !== 'active' ? spaceTasksFilterTab : undefined
 											)
-										: spaceId
-											? createSpacePath(spaceId)
-											: navSection === 'chats'
-												? '/sessions'
-												: navSection === 'settings'
-													? '/settings'
-													: '/spaces';
+										: spaceId && spaceViewMode === 'configure'
+											? createSpaceConfigurePath(
+													spaceId,
+													spaceConfigureTab !== 'agents' ? spaceConfigureTab : undefined
+												)
+											: spaceId
+												? createSpacePath(spaceId)
+												: navSection === 'chats'
+													? '/sessions'
+													: navSection === 'settings'
+														? '/settings'
+														: '/spaces';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops
@@ -184,6 +188,8 @@ export function App() {
 					navigateToSpaceSession(spaceId, spaceSessionId, true);
 				} else if (spaceId && spaceViewMode === 'sessions') {
 					navigateToSpaceSessions(spaceId, true);
+				} else if (spaceId && spaceViewMode === 'goals') {
+					navigateToSpaceGoals(spaceId, true);
 				} else if (spaceId && spaceViewMode === 'tasks') {
 					navigateToSpaceTasks(spaceId, undefined, true);
 				} else if (spaceId && spaceViewMode === 'configure') {

--- a/packages/web/src/components/space/SpaceGoalDialog.tsx
+++ b/packages/web/src/components/space/SpaceGoalDialog.tsx
@@ -60,6 +60,15 @@ function formatMetricValue(value: SpaceGoalMetrics[string]): string {
 	return String(value ?? '');
 }
 
+function isMetricScalar(value: unknown): value is SpaceGoalMetrics[string] {
+	return (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	);
+}
+
 function parseMetrics(value: string): SpaceGoalMetrics {
 	const metrics: SpaceGoalMetrics = {};
 	for (const line of parseLines(value)) {
@@ -68,7 +77,8 @@ function parseMetrics(value: string): SpaceGoalMetrics {
 		if (!key) continue;
 		const rawValue = rest.join(':').trim();
 		try {
-			metrics[key] = JSON.parse(rawValue) as SpaceGoalMetrics[string];
+			const parsed = JSON.parse(rawValue) as unknown;
+			metrics[key] = isMetricScalar(parsed) ? parsed : rawValue;
 		} catch {
 			metrics[key] = rawValue;
 		}

--- a/packages/web/src/components/space/SpaceGoalDialog.tsx
+++ b/packages/web/src/components/space/SpaceGoalDialog.tsx
@@ -1,0 +1,376 @@
+import type { SpaceGoal, SpaceGoalMetrics, SpaceGoalType, SpaceTaskPriority } from '@neokai/shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
+import { Button } from '../ui/Button';
+import { Modal } from '../ui/Modal';
+
+interface SpaceGoalDialogProps {
+	isOpen: boolean;
+	goal?: SpaceGoal | null;
+	onClose: () => void;
+	onSaved?: (goal: SpaceGoal) => void;
+}
+
+const TYPE_OPTIONS: { value: SpaceGoalType; label: string }[] = [
+	{ value: 'one_shot', label: 'One-shot' },
+	{ value: 'measurable', label: 'Measurable' },
+	{ value: 'recurring', label: 'Recurring' },
+];
+
+const PRIORITY_OPTIONS: { value: SpaceTaskPriority; label: string }[] = [
+	{ value: 'low', label: 'Low' },
+	{ value: 'normal', label: 'Normal' },
+	{ value: 'high', label: 'High' },
+	{ value: 'urgent', label: 'Urgent' },
+];
+
+const COMMON_TIMEZONES = [
+	'UTC',
+	'America/New_York',
+	'America/Los_Angeles',
+	'America/Chicago',
+	'Europe/London',
+	'Europe/Paris',
+	'Europe/Berlin',
+	'Asia/Tokyo',
+	'Asia/Shanghai',
+	'Asia/Singapore',
+	'Australia/Sydney',
+	'Pacific/Auckland',
+];
+
+function parseLines(value: string): string[] {
+	return value
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+function parseLabels(value: string): string[] {
+	return value
+		.split(',')
+		.map((label) => label.trim())
+		.filter(Boolean);
+}
+
+function formatMetrics(metrics: SpaceGoalMetrics): string {
+	return Object.entries(metrics)
+		.map(([key, value]) => `${key}: ${value ?? ''}`)
+		.join('\n');
+}
+
+function parseMetrics(value: string): SpaceGoalMetrics {
+	const metrics: SpaceGoalMetrics = {};
+	for (const line of parseLines(value)) {
+		const [rawKey, ...rest] = line.split(':');
+		const key = rawKey?.trim();
+		if (!key) continue;
+		const rawValue = rest.join(':').trim();
+		if (rawValue === 'true') metrics[key] = true;
+		else if (rawValue === 'false') metrics[key] = false;
+		else if (rawValue !== '' && Number.isFinite(Number(rawValue))) metrics[key] = Number(rawValue);
+		else metrics[key] = rawValue;
+	}
+	return metrics;
+}
+
+export function SpaceGoalDialog({ isOpen, goal, onClose, onSaved }: SpaceGoalDialogProps) {
+	const [title, setTitle] = useState('');
+	const [description, setDescription] = useState('');
+	const [type, setType] = useState<SpaceGoalType>('one_shot');
+	const [priority, setPriority] = useState<SpaceTaskPriority>('normal');
+	const [summary, setSummary] = useState('');
+	const [progress, setProgress] = useState('0');
+	const [labels, setLabels] = useState('');
+	const [metrics, setMetrics] = useState('');
+	const [nextSteps, setNextSteps] = useState('');
+	const [preferredWorkflowId, setPreferredWorkflowId] = useState('');
+	const [autoTriggerNext, setAutoTriggerNext] = useState(false);
+	const [checkInCronExpression, setCheckInCronExpression] = useState('');
+	const [checkInTimezone, setCheckInTimezone] = useState('UTC');
+	const [triggerImmediately, setTriggerImmediately] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const isEditing = Boolean(goal);
+	const workflows = spaceStore.workflows.value.filter((workflow) => !workflow.disabled);
+
+	useEffect(() => {
+		if (!isOpen) return;
+		setTitle(goal?.title ?? '');
+		setDescription(goal?.description ?? '');
+		setType(goal?.type ?? 'one_shot');
+		setPriority(goal?.priority ?? 'normal');
+		setSummary(goal?.summary ?? '');
+		setProgress(String(goal?.progress ?? 0));
+		setLabels(goal?.labels.join(', ') ?? '');
+		setMetrics(goal ? formatMetrics(goal.metrics) : '');
+		setNextSteps(goal?.nextSteps.join('\n') ?? '');
+		setPreferredWorkflowId(goal?.preferredWorkflowId ?? '');
+		setAutoTriggerNext(goal?.autoTriggerNext ?? false);
+		setCheckInCronExpression('');
+		setCheckInTimezone('UTC');
+		setTriggerImmediately(false);
+		setError(null);
+	}, [isOpen, goal?.id]);
+
+	const parsedProgress = useMemo(() => {
+		const next = Number(progress);
+		if (!Number.isFinite(next)) return null;
+		return Math.max(0, Math.min(100, Math.round(next)));
+	}, [progress]);
+
+	const handleSubmit = async (event: Event) => {
+		event.preventDefault();
+		if (!title.trim()) {
+			setError('Goal title is required');
+			return;
+		}
+		if (parsedProgress === null) {
+			setError('Progress must be a number');
+			return;
+		}
+
+		try {
+			setSubmitting(true);
+			setError(null);
+			const payload = {
+				title: title.trim(),
+				description: description.trim(),
+				type,
+				priority,
+				labels: parseLabels(labels),
+				metrics: parseMetrics(metrics),
+				summary: summary.trim(),
+				progress: parsedProgress,
+				nextSteps: parseLines(nextSteps),
+				preferredWorkflowId: preferredWorkflowId || null,
+				autoTriggerNext,
+			};
+			const saved = goal
+				? await spaceStore.updateGoal(goal.id, payload)
+				: await spaceStore.createGoal({
+						...payload,
+						checkInCronExpression: checkInCronExpression.trim() || null,
+						checkInTimezone,
+						triggerImmediately,
+					});
+			toast.success(`Goal "${saved.title}" ${goal ? 'updated' : 'created'}`);
+			onSaved?.(saved);
+			onClose();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to save goal');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={onClose}
+			title={isEditing ? 'Edit Goal' : 'Create Goal'}
+			size="lg"
+		>
+			<form onSubmit={handleSubmit} class="space-y-4">
+				{error && (
+					<div class="rounded-lg border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-400">
+						{error}
+					</div>
+				)}
+
+				<div>
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-200">
+							Title<span class="ml-1 text-red-400">*</span>
+						</span>
+						<input
+							type="text"
+							value={title}
+							onInput={(e) => setTitle((e.target as HTMLInputElement).value)}
+							placeholder="Keep release train healthy"
+							class="w-full rounded-lg border border-dark-600 bg-dark-800 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-600 focus:border-blue-500 focus:outline-none"
+						/>
+					</label>
+				</div>
+
+				<div>
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Description</span>
+						<textarea
+							value={description}
+							onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+							rows={3}
+							placeholder="What should agents keep driving toward?"
+							class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+						/>
+					</label>
+				</div>
+
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Type</span>
+						<select
+							value={type}
+							onChange={(e) => setType((e.target as HTMLSelectElement).value as SpaceGoalType)}
+							class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+						>
+							{TYPE_OPTIONS.map((option) => (
+								<option key={option.value} value={option.value}>
+									{option.label}
+								</option>
+							))}
+						</select>
+					</label>
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Priority</span>
+						<select
+							value={priority}
+							onChange={(e) =>
+								setPriority((e.target as HTMLSelectElement).value as SpaceTaskPriority)
+							}
+							class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+						>
+							{PRIORITY_OPTIONS.map((option) => (
+								<option key={option.value} value={option.value}>
+									{option.label}
+								</option>
+							))}
+						</select>
+					</label>
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Progress</span>
+						<input
+							type="number"
+							min={0}
+							max={100}
+							value={progress}
+							onInput={(e) => setProgress((e.target as HTMLInputElement).value)}
+							class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+						/>
+					</label>
+				</div>
+
+				<label class="block">
+					<span class="mb-1.5 block text-sm font-medium text-gray-300">Preferred workflow</span>
+					<select
+						value={preferredWorkflowId}
+						onChange={(e) => setPreferredWorkflowId((e.target as HTMLSelectElement).value)}
+						class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+					>
+						<option value="">Auto-select workflow</option>
+						{workflows.map((workflow) => (
+							<option key={workflow.id} value={workflow.id}>
+								{workflow.name}
+							</option>
+						))}
+					</select>
+				</label>
+
+				<label class="block">
+					<span class="mb-1.5 block text-sm font-medium text-gray-300">Summary</span>
+					<textarea
+						value={summary}
+						onInput={(e) => setSummary((e.target as HTMLTextAreaElement).value)}
+						rows={2}
+						placeholder="Rolling state summary"
+						class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+					/>
+				</label>
+
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Labels</span>
+						<input
+							value={labels}
+							onInput={(e) => setLabels((e.target as HTMLInputElement).value)}
+							placeholder="release, health"
+							class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+						/>
+					</label>
+					<label class="block">
+						<span class="mb-1.5 block text-sm font-medium text-gray-300">Metrics</span>
+						<textarea
+							value={metrics}
+							onInput={(e) => setMetrics((e.target as HTMLTextAreaElement).value)}
+							rows={2}
+							placeholder={'build_health: green\nopen_bugs: 3'}
+							class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+						/>
+					</label>
+				</div>
+
+				<label class="block">
+					<span class="mb-1.5 block text-sm font-medium text-gray-300">Next steps</span>
+					<textarea
+						value={nextSteps}
+						onInput={(e) => setNextSteps((e.target as HTMLTextAreaElement).value)}
+						rows={3}
+						placeholder="One next step per line"
+						class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+					/>
+				</label>
+
+				<label class="flex items-center gap-2 text-sm text-gray-300">
+					<input
+						type="checkbox"
+						checked={autoTriggerNext}
+						onChange={(e) => setAutoTriggerNext((e.target as HTMLInputElement).checked)}
+						class="h-4 w-4 rounded border-dark-600 bg-dark-800 text-blue-600"
+					/>
+					Auto-trigger next task when current task finishes
+				</label>
+
+				{!isEditing && (
+					<div class="space-y-3 rounded-lg border border-dark-700 bg-dark-800/50 p-4">
+						<p class="text-xs font-semibold uppercase tracking-wider text-gray-500">Check-in</p>
+						<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+							<label class="block">
+								<span class="mb-1.5 block text-sm font-medium text-gray-300">Cron expression</span>
+								<input
+									value={checkInCronExpression}
+									onInput={(e) => setCheckInCronExpression((e.target as HTMLInputElement).value)}
+									placeholder="@daily or 0 9 * * 1"
+									class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+								/>
+							</label>
+							<label class="block">
+								<span class="mb-1.5 block text-sm font-medium text-gray-300">Timezone</span>
+								<select
+									value={checkInTimezone}
+									onChange={(e) => setCheckInTimezone((e.target as HTMLSelectElement).value)}
+									class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+								>
+									{COMMON_TIMEZONES.map((timezone) => (
+										<option key={timezone} value={timezone}>
+											{timezone}
+										</option>
+									))}
+								</select>
+							</label>
+						</div>
+						<label class="flex items-center gap-2 text-sm text-gray-300">
+							<input
+								type="checkbox"
+								checked={triggerImmediately}
+								onChange={(e) => setTriggerImmediately((e.target as HTMLInputElement).checked)}
+								class="h-4 w-4 rounded border-dark-600 bg-dark-800 text-blue-600"
+							/>
+							Create first task immediately
+						</label>
+					</div>
+				)}
+
+				<div class="flex gap-3 pt-1">
+					<Button type="button" variant="secondary" onClick={onClose} fullWidth>
+						Cancel
+					</Button>
+					<Button type="submit" loading={submitting} fullWidth>
+						{isEditing ? 'Save Goal' : 'Create Goal'}
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/SpaceGoalDialog.tsx
+++ b/packages/web/src/components/space/SpaceGoalDialog.tsx
@@ -55,13 +55,9 @@ function parseLabels(value: string): string[] {
 }
 
 function formatMetricValue(value: SpaceGoalMetrics[string]): string {
-	return value === null ? 'null' : String(value ?? '');
-}
-
-function formatMetrics(metrics: SpaceGoalMetrics): string {
-	return Object.entries(metrics)
-		.map(([key, value]) => `${key}: ${formatMetricValue(value)}`)
-		.join('\n');
+	if (value === null) return 'null';
+	if (typeof value === 'string') return JSON.stringify(value);
+	return String(value ?? '');
 }
 
 function parseMetrics(value: string): SpaceGoalMetrics {
@@ -71,13 +67,19 @@ function parseMetrics(value: string): SpaceGoalMetrics {
 		const key = rawKey?.trim();
 		if (!key) continue;
 		const rawValue = rest.join(':').trim();
-		if (rawValue === 'null') metrics[key] = null;
-		else if (rawValue === 'true') metrics[key] = true;
-		else if (rawValue === 'false') metrics[key] = false;
-		else if (rawValue !== '' && Number.isFinite(Number(rawValue))) metrics[key] = Number(rawValue);
-		else metrics[key] = rawValue;
+		try {
+			metrics[key] = JSON.parse(rawValue) as SpaceGoalMetrics[string];
+		} catch {
+			metrics[key] = rawValue;
+		}
 	}
 	return metrics;
+}
+
+function formatMetrics(metrics: SpaceGoalMetrics): string {
+	return Object.entries(metrics)
+		.map(([key, value]) => `${key}: ${formatMetricValue(value)}`)
+		.join('\n');
 }
 
 export function SpaceGoalDialog({ isOpen, goal, onClose, onSaved }: SpaceGoalDialogProps) {

--- a/packages/web/src/components/space/SpaceGoalDialog.tsx
+++ b/packages/web/src/components/space/SpaceGoalDialog.tsx
@@ -54,9 +54,13 @@ function parseLabels(value: string): string[] {
 		.filter(Boolean);
 }
 
+function formatMetricValue(value: SpaceGoalMetrics[string]): string {
+	return value === null ? 'null' : String(value ?? '');
+}
+
 function formatMetrics(metrics: SpaceGoalMetrics): string {
 	return Object.entries(metrics)
-		.map(([key, value]) => `${key}: ${value ?? ''}`)
+		.map(([key, value]) => `${key}: ${formatMetricValue(value)}`)
 		.join('\n');
 }
 
@@ -67,7 +71,8 @@ function parseMetrics(value: string): SpaceGoalMetrics {
 		const key = rawKey?.trim();
 		if (!key) continue;
 		const rawValue = rest.join(':').trim();
-		if (rawValue === 'true') metrics[key] = true;
+		if (rawValue === 'null') metrics[key] = null;
+		else if (rawValue === 'true') metrics[key] = true;
 		else if (rawValue === 'false') metrics[key] = false;
 		else if (rawValue !== '' && Number.isFinite(Number(rawValue))) metrics[key] = Number(rawValue);
 		else metrics[key] = rawValue;

--- a/packages/web/src/components/space/SpaceGoals.tsx
+++ b/packages/web/src/components/space/SpaceGoals.tsx
@@ -359,8 +359,10 @@ export function SpaceGoals({ spaceId }: SpaceGoalsProps) {
 		let cancelled = false;
 		setLoading(true);
 		setError(null);
-		spaceStore
-			.listGoals({ includeArchived: showArchived })
+		Promise.all([
+			spaceStore.listGoals({ includeArchived: showArchived }),
+			spaceStore.ensureConfigData(),
+		])
 			.catch((err) => {
 				if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load goals');
 			})

--- a/packages/web/src/components/space/SpaceGoals.tsx
+++ b/packages/web/src/components/space/SpaceGoals.tsx
@@ -412,8 +412,8 @@ export function SpaceGoals({ spaceId }: SpaceGoalsProps) {
 	};
 
 	return (
-		<div class="flex h-full min-h-0 overflow-hidden">
-			<div class="flex w-full flex-col border-r border-dark-700 lg:w-[420px]">
+		<div class="flex h-full min-h-0 flex-col overflow-hidden lg:flex-row">
+			<div class="flex min-h-0 w-full flex-col border-b border-dark-700 lg:w-[420px] lg:border-r lg:border-b-0">
 				<div class="flex items-center justify-between gap-3 border-b border-dark-700 p-4">
 					<div>
 						<h2 class="text-sm font-semibold text-gray-100">Goals</h2>
@@ -460,7 +460,7 @@ export function SpaceGoals({ spaceId }: SpaceGoalsProps) {
 				</div>
 			</div>
 
-			<div class="hidden min-w-0 flex-1 lg:block">
+			<div class="min-h-[420px] min-w-0 flex-1 border-t border-dark-700 lg:min-h-0 lg:border-t-0">
 				{selectedGoal ? (
 					<GoalDetail
 						goal={selectedGoal}

--- a/packages/web/src/components/space/SpaceGoals.tsx
+++ b/packages/web/src/components/space/SpaceGoals.tsx
@@ -1,0 +1,494 @@
+import type { SpaceGoal, SpaceGoalEvent, SpaceGoalStatus, SpaceTask } from '@neokai/shared';
+import type { ComponentChildren } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { navigateToSpaceTask } from '../../lib/router';
+import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
+import { cn, getRelativeTime } from '../../lib/utils';
+import { SpaceGoalDialog } from './SpaceGoalDialog';
+
+interface SpaceGoalsProps {
+	spaceId: string;
+}
+
+const STATUS_STYLES: Record<SpaceGoalStatus, string> = {
+	active: 'border-green-800/40 bg-green-950/20 text-green-300',
+	paused: 'border-amber-800/40 bg-amber-950/20 text-amber-300',
+	completed: 'border-blue-800/40 bg-blue-950/20 text-blue-300',
+	archived: 'border-gray-700 bg-gray-900/40 text-gray-400',
+};
+
+const TYPE_LABELS: Record<SpaceGoal['type'], string> = {
+	one_shot: 'One-shot',
+	measurable: 'Measurable',
+	recurring: 'Recurring',
+};
+
+function formatDate(ts: number | null): string {
+	if (!ts) return '—';
+	return new Date(ts).toLocaleString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+	});
+}
+
+function goalTask(tasks: SpaceTask[], taskId: string | null): SpaceTask | null {
+	if (!taskId) return null;
+	return tasks.find((task) => task.id === taskId) ?? null;
+}
+
+function eventLabel(event: SpaceGoalEvent): string {
+	return event.eventType.replace(/_/g, ' ');
+}
+
+function GoalStatusBadge({ status }: { status: SpaceGoalStatus }) {
+	return (
+		<span class={cn('rounded-full border px-2 py-0.5 text-xs font-medium', STATUS_STYLES[status])}>
+			{status.replace(/_/g, ' ')}
+		</span>
+	);
+}
+
+function ProgressBar({ value }: { value: number }) {
+	const safeValue = Math.max(0, Math.min(100, value));
+	return (
+		<div class="h-2 rounded-full bg-dark-700">
+			<div class="h-2 rounded-full bg-blue-500" style={{ width: `${safeValue}%` }} />
+		</div>
+	);
+}
+
+function GoalCard({
+	goal,
+	selected,
+	lastTask,
+	onSelect,
+}: {
+	goal: SpaceGoal;
+	selected: boolean;
+	lastTask: SpaceTask | null;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			class={cn(
+				'w-full rounded-xl border p-4 text-left transition-colors',
+				selected
+					? 'border-blue-500/60 bg-blue-950/20'
+					: 'border-dark-700 bg-dark-900/50 hover:border-dark-600 hover:bg-dark-850/80'
+			)}
+		>
+			<div class="flex items-start justify-between gap-3">
+				<div class="min-w-0 flex-1">
+					<div class="flex items-center gap-2">
+						<h3 class="truncate text-sm font-semibold text-gray-100">{goal.title}</h3>
+						{goal.pendingNextRun && (
+							<span class="rounded-full border border-amber-800/40 bg-amber-950/20 px-2 py-0.5 text-xs text-amber-300">
+								Pending next
+							</span>
+						)}
+					</div>
+					<p class="mt-1 line-clamp-2 text-xs text-gray-500">{goal.summary || goal.description}</p>
+				</div>
+				<GoalStatusBadge status={goal.status} />
+			</div>
+
+			<div class="mt-3 space-y-2">
+				<div class="flex items-center justify-between text-xs text-gray-500">
+					<span>{goal.progress}% complete</span>
+					<span class="capitalize">{goal.priority}</span>
+				</div>
+				<ProgressBar value={goal.progress} />
+			</div>
+
+			<div class="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-500">
+				<div>
+					<span class="block text-gray-600">Next check-in</span>
+					<span class="text-gray-300">{formatDate(goal.nextCheckInAt)}</span>
+				</div>
+				<div>
+					<span class="block text-gray-600">Last task</span>
+					<span class="truncate text-gray-300">{lastTask?.title ?? goal.lastTaskId ?? '—'}</span>
+				</div>
+			</div>
+		</button>
+	);
+}
+
+function DetailSection({ title, children }: { title: string; children: ComponentChildren }) {
+	return (
+		<section class="rounded-xl border border-dark-700 bg-dark-900/50 p-4">
+			<h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">{title}</h3>
+			{children}
+		</section>
+	);
+}
+
+function GoalDetail({
+	goal,
+	tasks,
+	events,
+	onEdit,
+	onRunAction,
+	actionLoading,
+	spaceId,
+}: {
+	goal: SpaceGoal;
+	tasks: SpaceTask[];
+	events: SpaceGoalEvent[];
+	onEdit: () => void;
+	onRunAction: (action: 'pause' | 'resume' | 'archive' | 'trigger') => void;
+	actionLoading: boolean;
+	spaceId: string;
+}) {
+	const linkedTasks = tasks
+		.filter(
+			(task) =>
+				task.goalId === goal.id || task.id === goal.activeTaskId || task.id === goal.lastTaskId
+		)
+		.sort((a, b) => b.updatedAt - a.updatedAt);
+	const activeTask = goalTask(tasks, goal.activeTaskId);
+	const lastTask = goalTask(tasks, goal.lastTaskId);
+
+	return (
+		<div class="flex h-full flex-col overflow-hidden">
+			<div class="border-b border-dark-700 p-5">
+				<div class="flex items-start justify-between gap-3">
+					<div class="min-w-0">
+						<div class="mb-2 flex flex-wrap items-center gap-2">
+							<GoalStatusBadge status={goal.status} />
+							<span class="rounded-full border border-dark-600 px-2 py-0.5 text-xs text-gray-400">
+								{TYPE_LABELS[goal.type]}
+							</span>
+							<span class="rounded-full border border-dark-600 px-2 py-0.5 text-xs capitalize text-gray-400">
+								{goal.priority}
+							</span>
+						</div>
+						<h2 class="text-lg font-semibold text-gray-100">{goal.title}</h2>
+						<p class="mt-1 text-sm text-gray-500">{goal.description || 'No description'}</p>
+					</div>
+					<button
+						type="button"
+						onClick={onEdit}
+						class="rounded-lg border border-dark-600 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-dark-800"
+					>
+						Edit
+					</button>
+				</div>
+
+				<div class="mt-4 flex flex-wrap gap-2">
+					{goal.status === 'active' && (
+						<button
+							type="button"
+							disabled={actionLoading}
+							onClick={() => onRunAction('pause')}
+							class="rounded-lg border border-amber-800/40 bg-amber-950/20 px-3 py-1.5 text-xs font-medium text-amber-300 disabled:opacity-50"
+						>
+							Pause
+						</button>
+					)}
+					{goal.status === 'paused' && (
+						<button
+							type="button"
+							disabled={actionLoading}
+							onClick={() => onRunAction('resume')}
+							class="rounded-lg border border-green-800/40 bg-green-950/20 px-3 py-1.5 text-xs font-medium text-green-300 disabled:opacity-50"
+						>
+							Resume
+						</button>
+					)}
+					<button
+						type="button"
+						disabled={actionLoading || goal.status !== 'active'}
+						onClick={() => onRunAction('trigger')}
+						class="rounded-lg border border-blue-800/40 bg-blue-950/20 px-3 py-1.5 text-xs font-medium text-blue-300 disabled:opacity-50"
+					>
+						Create task now
+					</button>
+					{goal.status !== 'archived' && (
+						<button
+							type="button"
+							disabled={actionLoading}
+							onClick={() => onRunAction('archive')}
+							class="rounded-lg border border-red-800/40 bg-red-950/20 px-3 py-1.5 text-xs font-medium text-red-300 disabled:opacity-50"
+						>
+							Archive
+						</button>
+					)}
+				</div>
+			</div>
+
+			<div class="flex-1 space-y-4 overflow-y-auto p-5">
+				<DetailSection title="Rolling state">
+					<div class="space-y-3">
+						<p class="text-sm text-gray-300">{goal.summary || 'No summary yet'}</p>
+						<div>
+							<div class="mb-1 flex justify-between text-xs text-gray-500">
+								<span>Progress</span>
+								<span>{goal.progress}%</span>
+							</div>
+							<ProgressBar value={goal.progress} />
+						</div>
+						<div class="grid grid-cols-2 gap-3 text-xs text-gray-500">
+							<div>
+								<span class="block text-gray-600">Last check-in</span>
+								<span class="text-gray-300">{formatDate(goal.lastCheckInAt)}</span>
+							</div>
+							<div>
+								<span class="block text-gray-600">Next check-in</span>
+								<span class="text-gray-300">{formatDate(goal.nextCheckInAt)}</span>
+							</div>
+							<div>
+								<span class="block text-gray-600">Auto trigger next</span>
+								<span class="text-gray-300">{goal.autoTriggerNext ? 'Enabled' : 'Off'}</span>
+							</div>
+							<div>
+								<span class="block text-gray-600">Concurrency state</span>
+								<span class="text-gray-300">
+									{activeTask
+										? 'Active task running'
+										: goal.pendingNextRun
+											? 'Pending next run'
+											: 'Idle'}
+								</span>
+							</div>
+						</div>
+					</div>
+				</DetailSection>
+
+				<DetailSection title="Metrics">
+					{Object.keys(goal.metrics).length === 0 ? (
+						<p class="text-sm text-gray-500">No metrics recorded</p>
+					) : (
+						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+							{Object.entries(goal.metrics).map(([key, value]) => (
+								<div key={key} class="rounded-lg border border-dark-700 bg-dark-800/60 px-3 py-2">
+									<span class="block text-xs text-gray-500">{key}</span>
+									<span class="text-sm text-gray-200">{String(value ?? '—')}</span>
+								</div>
+							))}
+						</div>
+					)}
+				</DetailSection>
+
+				<DetailSection title="Next steps">
+					{goal.nextSteps.length === 0 ? (
+						<p class="text-sm text-gray-500">No next steps recorded</p>
+					) : (
+						<ul class="space-y-2 text-sm text-gray-300">
+							{goal.nextSteps.map((step) => (
+								<li key={step} class="flex gap-2">
+									<span class="text-gray-600">•</span>
+									<span>{step}</span>
+								</li>
+							))}
+						</ul>
+					)}
+				</DetailSection>
+
+				<DetailSection title="Linked tasks">
+					{linkedTasks.length === 0 ? (
+						<p class="text-sm text-gray-500">No linked tasks yet</p>
+					) : (
+						<div class="space-y-2">
+							{linkedTasks.map((task) => (
+								<button
+									key={task.id}
+									type="button"
+									onClick={() => navigateToSpaceTask(spaceId, task.id)}
+									class="w-full rounded-lg border border-dark-700 bg-dark-800/60 px-3 py-2 text-left hover:border-dark-600"
+								>
+									<div class="flex items-center justify-between gap-2">
+										<span class="truncate text-sm text-gray-200">{task.title}</span>
+										<span class="text-xs text-gray-500">#{task.taskNumber}</span>
+									</div>
+									<div class="mt-1 flex items-center gap-2 text-xs text-gray-500">
+										<span>{task.status}</span>
+										{task.result && <span class="truncate">{task.result}</span>}
+									</div>
+								</button>
+							))}
+						</div>
+					)}
+					{lastTask && !linkedTasks.some((task) => task.id === lastTask.id) && (
+						<p class="mt-2 text-xs text-gray-500">Last task: {lastTask.title}</p>
+					)}
+				</DetailSection>
+
+				<DetailSection title="Recent goal events">
+					{events.length === 0 ? (
+						<p class="text-sm text-gray-500">No events loaded</p>
+					) : (
+						<div class="space-y-2">
+							{events.slice(0, 6).map((event) => (
+								<div
+									key={event.id}
+									class="rounded-lg border border-dark-700 bg-dark-800/60 px-3 py-2"
+								>
+									<div class="flex items-center justify-between gap-2 text-xs">
+										<span class="capitalize text-gray-300">{eventLabel(event)}</span>
+										<span class="text-gray-500">{getRelativeTime(event.createdAt)}</span>
+									</div>
+									{event.note && <p class="mt-1 text-xs text-gray-500">{event.note}</p>}
+								</div>
+							))}
+						</div>
+					)}
+				</DetailSection>
+			</div>
+		</div>
+	);
+}
+
+export function SpaceGoals({ spaceId }: SpaceGoalsProps) {
+	const goals = spaceStore.goals.value;
+	const tasks = spaceStore.tasks.value;
+	const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null);
+	const [showArchived, setShowArchived] = useState(false);
+	const [editingGoal, setEditingGoal] = useState<SpaceGoal | null>(null);
+	const [createOpen, setCreateOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [actionLoading, setActionLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		spaceStore
+			.listGoals({ includeArchived: showArchived })
+			.catch((err) => {
+				if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load goals');
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [spaceId, showArchived]);
+
+	const visibleGoals = useMemo(() => {
+		const filtered = showArchived ? goals : goals.filter((goal) => goal.status !== 'archived');
+		return [...filtered].sort((a, b) => {
+			if (a.status === 'active' && b.status !== 'active') return -1;
+			if (a.status !== 'active' && b.status === 'active') return 1;
+			return b.updatedAt - a.updatedAt;
+		});
+	}, [goals, showArchived]);
+
+	const selectedGoal =
+		visibleGoals.find((goal) => goal.id === selectedGoalId) ?? visibleGoals[0] ?? null;
+	const selectedEvents = selectedGoal
+		? (spaceStore.goalEvents.value.get(selectedGoal.id) ?? [])
+		: [];
+
+	useEffect(() => {
+		if (!selectedGoal) return;
+		spaceStore.listGoalEvents(selectedGoal.id).catch(() => {});
+	}, [selectedGoal?.id]);
+
+	const runAction = async (action: 'pause' | 'resume' | 'archive' | 'trigger') => {
+		if (!selectedGoal) return;
+		setActionLoading(true);
+		try {
+			if (action === 'pause') await spaceStore.pauseGoal(selectedGoal.id);
+			else if (action === 'resume') await spaceStore.resumeGoal(selectedGoal.id);
+			else if (action === 'archive') await spaceStore.archiveGoal(selectedGoal.id);
+			else {
+				const result = await spaceStore.createImmediateGoalTask(selectedGoal.id);
+				if (result.queued) toast.success('Next goal task queued');
+				else toast.success('Goal task created');
+			}
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Goal action failed');
+		} finally {
+			setActionLoading(false);
+		}
+	};
+
+	return (
+		<div class="flex h-full min-h-0 overflow-hidden">
+			<div class="flex w-full flex-col border-r border-dark-700 lg:w-[420px]">
+				<div class="flex items-center justify-between gap-3 border-b border-dark-700 p-4">
+					<div>
+						<h2 class="text-sm font-semibold text-gray-100">Goals</h2>
+						<p class="text-xs text-gray-500">Long-horizon Space objectives</p>
+					</div>
+					<div class="flex items-center gap-2">
+						<label class="flex items-center gap-1.5 text-xs text-gray-500">
+							<input
+								type="checkbox"
+								checked={showArchived}
+								onChange={(e) => setShowArchived((e.target as HTMLInputElement).checked)}
+								class="h-3.5 w-3.5 rounded border-dark-600 bg-dark-800"
+							/>
+							Archived
+						</label>
+						<button
+							type="button"
+							onClick={() => setCreateOpen(true)}
+							class="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500"
+						>
+							Create
+						</button>
+					</div>
+				</div>
+
+				<div class="flex-1 space-y-3 overflow-y-auto p-4">
+					{loading && <p class="text-sm text-gray-500">Loading goals...</p>}
+					{error && <p class="text-sm text-red-400">{error}</p>}
+					{!loading && visibleGoals.length === 0 && (
+						<div class="rounded-xl border border-dashed border-dark-700 p-8 text-center">
+							<p class="text-sm text-gray-400">No goals yet</p>
+							<p class="mt-1 text-xs text-gray-600">Create a goal to track long-horizon work.</p>
+						</div>
+					)}
+					{visibleGoals.map((goal) => (
+						<GoalCard
+							key={goal.id}
+							goal={goal}
+							selected={selectedGoal?.id === goal.id}
+							lastTask={goalTask(tasks, goal.lastTaskId)}
+							onSelect={() => setSelectedGoalId(goal.id)}
+						/>
+					))}
+				</div>
+			</div>
+
+			<div class="hidden min-w-0 flex-1 lg:block">
+				{selectedGoal ? (
+					<GoalDetail
+						goal={selectedGoal}
+						tasks={tasks}
+						events={selectedEvents}
+						onEdit={() => setEditingGoal(selectedGoal)}
+						onRunAction={(action) => void runAction(action)}
+						actionLoading={actionLoading}
+						spaceId={spaceId}
+					/>
+				) : (
+					<div class="flex h-full items-center justify-center text-sm text-gray-500">
+						Select a goal
+					</div>
+				)}
+			</div>
+
+			<SpaceGoalDialog
+				isOpen={createOpen}
+				onClose={() => setCreateOpen(false)}
+				onSaved={(goal) => setSelectedGoalId(goal.id)}
+			/>
+			<SpaceGoalDialog
+				isOpen={Boolean(editingGoal)}
+				goal={editingGoal}
+				onClose={() => setEditingGoal(null)}
+				onSaved={(goal) => setSelectedGoalId(goal.id)}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -235,7 +235,10 @@ describe('SpaceGoals', () => {
 			target: { value: 'beta, launch' },
 		});
 		fireEvent.input(screen.getByPlaceholderText(/build_health: green/), {
-			target: { value: 'open_bugs: 2\nhealthy: true\nunset: null\ncode: "0012"' },
+			target: {
+				value:
+					'open_bugs: 2\nhealthy: true\nunset: null\ncode: "0012"\nobject: {"foo": 1}\narray: [1,2]',
+			},
 		});
 		fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
 
@@ -244,7 +247,14 @@ describe('SpaceGoals', () => {
 			expect.objectContaining({
 				title: 'Ship beta',
 				labels: ['beta', 'launch'],
-				metrics: { open_bugs: 2, healthy: true, unset: null, code: '0012' },
+				metrics: {
+					open_bugs: 2,
+					healthy: true,
+					unset: null,
+					code: '0012',
+					object: '{"foo": 1}',
+					array: '[1,2]',
+				},
 			})
 		);
 	});

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -1,0 +1,251 @@
+import type { SpaceGoal, SpaceGoalEvent, SpaceTask } from '@neokai/shared';
+import type { Signal } from '@preact/signals';
+import { signal } from '@preact/signals';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGoals = signal<SpaceGoal[]>([]);
+const mockGoalEvents = signal<Map<string, SpaceGoalEvent[]>>(new Map());
+const mockTasks = signal<SpaceTask[]>([]);
+const mockWorkflows = signal<unknown[]>([]);
+const mockListGoals = vi.fn(async () => [] as SpaceGoal[]);
+const mockListGoalEvents = vi.fn(async () => [] as SpaceGoalEvent[]);
+const mockPauseGoal = vi.fn();
+const mockResumeGoal = vi.fn();
+const mockArchiveGoal = vi.fn();
+const mockCreateImmediateGoalTask = vi.fn();
+const mockCreateGoal = vi.fn();
+const mockUpdateGoal = vi.fn();
+
+const { mockNavigateToSpaceTask, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+	mockNavigateToSpaceTask: vi.fn(),
+	mockToastSuccess: vi.fn(),
+	mockToastError: vi.fn(),
+}));
+
+vi.mock('../../../lib/router', () => ({
+	navigateToSpaceTask: mockNavigateToSpaceTask,
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		success: mockToastSuccess,
+		error: mockToastError,
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: (string | false | null | undefined)[]) => args.filter(Boolean).join(' '),
+	getRelativeTime: () => '1m ago',
+}));
+
+import { spaceStore } from '../../../lib/space-store';
+import { SpaceGoals } from '../SpaceGoals';
+
+const mutableSpaceStore = spaceStore as unknown as {
+	goals: Signal<SpaceGoal[]>;
+	goalEvents: Signal<Map<string, SpaceGoalEvent[]>>;
+	tasks: Signal<SpaceTask[]>;
+	workflows: Signal<unknown[]>;
+	listGoals: typeof mockListGoals;
+	listGoalEvents: typeof mockListGoalEvents;
+	pauseGoal: typeof mockPauseGoal;
+	resumeGoal: typeof mockResumeGoal;
+	archiveGoal: typeof mockArchiveGoal;
+	createImmediateGoalTask: typeof mockCreateImmediateGoalTask;
+	createGoal: typeof mockCreateGoal;
+	updateGoal: typeof mockUpdateGoal;
+};
+
+mutableSpaceStore.goals = mockGoals;
+mutableSpaceStore.goalEvents = mockGoalEvents;
+mutableSpaceStore.tasks = mockTasks;
+mutableSpaceStore.workflows = mockWorkflows;
+mutableSpaceStore.listGoals = mockListGoals;
+mutableSpaceStore.listGoalEvents = mockListGoalEvents;
+mutableSpaceStore.pauseGoal = mockPauseGoal;
+mutableSpaceStore.resumeGoal = mockResumeGoal;
+mutableSpaceStore.archiveGoal = mockArchiveGoal;
+mutableSpaceStore.createImmediateGoalTask = mockCreateImmediateGoalTask;
+mutableSpaceStore.createGoal = mockCreateGoal;
+mutableSpaceStore.updateGoal = mockUpdateGoal;
+
+function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
+	const now = Date.now();
+	return {
+		id: 'goal-1',
+		spaceId: 'space-1',
+		title: 'Keep release healthy',
+		description: 'Maintain release train',
+		status: 'active',
+		type: 'recurring',
+		priority: 'high',
+		labels: ['release'],
+		metrics: { open_bugs: 3 },
+		summary: 'Builds are green',
+		progress: 45,
+		nextSteps: ['Watch CI'],
+		preferredWorkflowId: null,
+		taskScheduleId: 'schedule-1',
+		autoTriggerNext: true,
+		pendingNextRun: false,
+		activeTaskId: null,
+		lastTaskId: 'task-1',
+		lastCheckInAt: now - 60_000,
+		nextCheckInAt: now + 60_000,
+		createdAt: now - 120_000,
+		updatedAt: now,
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	const now = Date.now();
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		taskNumber: 42,
+		title: 'Investigate flaky build',
+		description: '',
+		status: 'done',
+		priority: 'high',
+		labels: ['goal'],
+		dependsOn: [],
+		goalId: 'goal-1',
+		result: 'Fixed retry path',
+		startedAt: now - 120_000,
+		completedAt: now - 60_000,
+		archivedAt: null,
+		blockReason: null,
+		approvalSource: null,
+		approvalReason: null,
+		approvedAt: null,
+		pendingCheckpointType: null,
+		reportedStatus: null,
+		reportedSummary: null,
+		createdAt: now - 180_000,
+		updatedAt: now - 60_000,
+		...overrides,
+	};
+}
+
+function makeEvent(overrides: Partial<SpaceGoalEvent> = {}): SpaceGoalEvent {
+	return {
+		id: 'event-1',
+		spaceId: 'space-1',
+		goalId: 'goal-1',
+		eventType: 'task_terminal',
+		source: 'system',
+		sourceTaskId: 'task-1',
+		sourceSessionId: null,
+		previousState: null,
+		newState: null,
+		diff: null,
+		note: 'Task completed',
+		createdAt: Date.now(),
+		...overrides,
+	};
+}
+
+describe('SpaceGoals', () => {
+	beforeEach(() => {
+		mockGoals.value = [];
+		mockGoalEvents.value = new Map();
+		mockTasks.value = [];
+		mockWorkflows.value = [];
+		mockListGoals.mockResolvedValue([]);
+		mockListGoalEvents.mockResolvedValue([]);
+		mockPauseGoal.mockImplementation(async (goalId: string) =>
+			makeGoal({ id: goalId, status: 'paused' })
+		);
+		mockResumeGoal.mockImplementation(async (goalId: string) =>
+			makeGoal({ id: goalId, status: 'active' })
+		);
+		mockArchiveGoal.mockImplementation(async (goalId: string) =>
+			makeGoal({ id: goalId, status: 'archived' })
+		);
+		mockCreateImmediateGoalTask.mockImplementation(async (goalId: string) => ({
+			goal: makeGoal({ id: goalId }),
+			task: null,
+			queued: false,
+		}));
+		mockCreateGoal.mockImplementation(async (params: Partial<SpaceGoal>) =>
+			makeGoal({ id: 'goal-created', title: params.title ?? 'Created goal' })
+		);
+		mockUpdateGoal.mockImplementation(async (goalId: string, params: Partial<SpaceGoal>) =>
+			makeGoal({ id: goalId, title: params.title ?? 'Updated goal' })
+		);
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => cleanup());
+
+	it('renders goal cards, detail state, linked tasks, and recent events', async () => {
+		const goal = makeGoal();
+		mockGoals.value = [goal];
+		mockTasks.value = [makeTask()];
+		mockGoalEvents.value = new Map([[goal.id, [makeEvent()]]]);
+
+		render(<SpaceGoals spaceId="space-1" />);
+
+		expect(await screen.findAllByText('Keep release healthy')).toHaveLength(2);
+		expect(screen.getByText('45% complete')).toBeTruthy();
+		expect(screen.getAllByText('Builds are green')).toHaveLength(2);
+		expect(screen.getByText('Auto trigger next')).toBeTruthy();
+		expect(screen.getByText('Enabled')).toBeTruthy();
+		expect(screen.getByText('Idle')).toBeTruthy();
+		expect(screen.getByText('open_bugs')).toBeTruthy();
+		expect(screen.getByText('Watch CI')).toBeTruthy();
+		expect(screen.getAllByText('Investigate flaky build')).toHaveLength(2);
+		expect(screen.getByText('Task completed')).toBeTruthy();
+		expect(mockListGoals).toHaveBeenCalledWith({ includeArchived: false });
+		expect(mockListGoalEvents).toHaveBeenCalledWith(goal.id);
+	});
+
+	it('runs pause, resume, archive, and immediate task actions', async () => {
+		mockGoals.value = [makeGoal({ status: 'active' })];
+
+		render(<SpaceGoals spaceId="space-1" />);
+
+		fireEvent.click(await screen.findByText('Pause'));
+		await waitFor(() => expect(mockPauseGoal).toHaveBeenCalledWith('goal-1'));
+
+		mockGoals.value = [makeGoal({ status: 'paused' })];
+		fireEvent.click(await screen.findByText('Resume'));
+		await waitFor(() => expect(mockResumeGoal).toHaveBeenCalledWith('goal-1'));
+
+		mockGoals.value = [makeGoal({ status: 'active' })];
+		fireEvent.click(await screen.findByText('Create task now'));
+		await waitFor(() => expect(mockCreateImmediateGoalTask).toHaveBeenCalledWith('goal-1'));
+		expect(mockToastSuccess).toHaveBeenCalledWith('Goal task created');
+
+		fireEvent.click(await screen.findByText('Archive'));
+		await waitFor(() => expect(mockArchiveGoal).toHaveBeenCalledWith('goal-1'));
+	});
+
+	it('creates a goal from the dialog payload', async () => {
+		render(<SpaceGoals spaceId="space-1" />);
+
+		fireEvent.click(await screen.findByText('Create'));
+		fireEvent.input(screen.getByPlaceholderText('Keep release train healthy'), {
+			target: { value: 'Ship beta' },
+		});
+		fireEvent.input(screen.getByPlaceholderText('release, health'), {
+			target: { value: 'beta, launch' },
+		});
+		fireEvent.input(screen.getByPlaceholderText(/build_health: green/), {
+			target: { value: 'open_bugs: 2\nhealthy: true' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
+
+		await waitFor(() => expect(mockCreateGoal).toHaveBeenCalled());
+		expect(mockCreateGoal).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: 'Ship beta',
+				labels: ['beta', 'launch'],
+				metrics: { open_bugs: 2, healthy: true },
+			})
+		);
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -235,7 +235,7 @@ describe('SpaceGoals', () => {
 			target: { value: 'beta, launch' },
 		});
 		fireEvent.input(screen.getByPlaceholderText(/build_health: green/), {
-			target: { value: 'open_bugs: 2\nhealthy: true\nunset: null' },
+			target: { value: 'open_bugs: 2\nhealthy: true\nunset: null\ncode: "0012"' },
 		});
 		fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
 
@@ -244,7 +244,7 @@ describe('SpaceGoals', () => {
 			expect.objectContaining({
 				title: 'Ship beta',
 				labels: ['beta', 'launch'],
-				metrics: { open_bugs: 2, healthy: true, unset: null },
+				metrics: { open_bugs: 2, healthy: true, unset: null, code: '0012' },
 			})
 		);
 	});

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -235,7 +235,7 @@ describe('SpaceGoals', () => {
 			target: { value: 'beta, launch' },
 		});
 		fireEvent.input(screen.getByPlaceholderText(/build_health: green/), {
-			target: { value: 'open_bugs: 2\nhealthy: true' },
+			target: { value: 'open_bugs: 2\nhealthy: true\nunset: null' },
 		});
 		fireEvent.click(screen.getByRole('button', { name: 'Create Goal' }));
 
@@ -244,7 +244,7 @@ describe('SpaceGoals', () => {
 			expect.objectContaining({
 				title: 'Ship beta',
 				labels: ['beta', 'launch'],
-				metrics: { open_bugs: 2, healthy: true },
+				metrics: { open_bugs: 2, healthy: true, unset: null },
 			})
 		);
 	});

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -17,6 +17,7 @@ import {
 	navigateToSpaceAgent,
 	navigateToSpaceConfigure,
 	navigateToSpaceSessions,
+	navigateToSpaceGoals,
 	navigateToSpaceTasks,
 } from '../lib/router.ts';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -209,6 +210,9 @@ export function ContextPanel() {
 					break;
 				case 'sessions':
 					navigateToSpaceSessions(spaceId);
+					break;
+				case 'goals':
+					navigateToSpaceGoals(spaceId);
 					break;
 				case 'configure':
 					navigateToSpaceConfigure(spaceId, currentSpaceConfigureTab);

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -9,10 +9,10 @@ import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import { CollapsibleSection } from '../components/ui/CollapsibleSection';
 import { createSession } from '../lib/api-helpers';
-import { spaceStore } from '../lib/space-store';
 import {
 	navigateToSpace,
 	navigateToSpaceAgent,
+	navigateToSpaceGoals,
 	navigateToSpaceSession,
 	navigateToSpaceSessions,
 	navigateToSpaceTask,
@@ -23,6 +23,7 @@ import {
 	currentSpaceTaskIdSignal,
 	currentSpaceViewModeSignal,
 } from '../lib/signals';
+import { spaceStore } from '../lib/space-store';
 import { isActionRequired, isActiveTask, isDraftTask } from '../lib/task-filters';
 import { cn } from '../lib/utils';
 
@@ -134,6 +135,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	const isLoading = spaceStore.loading.value;
 	const loadedSpaceId = spaceStore.spaceId.value;
 	const tasks = spaceStore.tasks.value;
+	const goals = spaceStore.goals.value;
 	const space = spaceStore.space.value;
 
 	const isReady = !isLoading && loadedSpaceId === spaceId;
@@ -168,6 +170,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		selectedTaskId === null &&
 		currentSpaceViewModeSignal.value === 'overview';
 	const isSpaceAgentSelected = selectedSessionId === spaceAgentSessionId;
+	const isGoalsSelected = currentSpaceViewModeSignal.value === 'goals';
 	const isTasksSelected = currentSpaceViewModeSignal.value === 'tasks';
 	const isSessionsSelected = currentSpaceViewModeSignal.value === 'sessions';
 
@@ -209,6 +212,11 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 
 	const handleSpaceAgentClick = useCallback(() => {
 		navigateToSpaceAgent(spaceId);
+		onNavigate?.();
+	}, [spaceId, onNavigate]);
+
+	const handleGoalsClick = useCallback(() => {
+		navigateToSpaceGoals(spaceId);
 		onNavigate?.();
 	}, [spaceId, onNavigate]);
 
@@ -265,7 +273,13 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					testId="space-detail-dashboard"
 					accentClass="text-blue-400"
 					icon={
-						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -282,7 +296,13 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					testId="space-detail-agent"
 					accentClass="text-purple-400"
 					icon={
-						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -292,6 +312,37 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 						</svg>
 					}
 				/>
+
+				<SpaceNavItem
+					label="Goals"
+					active={isGoalsSelected}
+					onClick={handleGoalsClick}
+					testId="space-detail-goals"
+					accentClass="text-blue-400"
+					icon={
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z"
+							/>
+						</svg>
+					}
+					badge={
+						goals.length > 0 ? (
+							<span class="flex-shrink-0 text-xs tabular-nums text-gray-500">
+								{goals.filter((goal) => goal.status !== 'archived').length}
+							</span>
+						) : undefined
+					}
+				/>
 				<SpaceNavItem
 					label="Tasks"
 					active={isTasksSelected}
@@ -299,7 +350,13 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					testId="space-detail-tasks"
 					accentClass="text-green-400"
 					icon={
-						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -323,7 +380,13 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					testId="space-detail-sessions"
 					accentClass="text-amber-400"
 					icon={
-						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<svg
+							class="w-4 h-4"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -376,6 +439,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 						tasksForTab.map((task) => (
 							<button
 								key={task.id}
+								type="button"
 								onClick={() => handleTaskClick(task.id)}
 								class={cn(
 									'w-full px-3 py-1.5 flex items-center gap-2 rounded-lg transition-colors text-left',
@@ -397,11 +461,18 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					defaultExpanded={true}
 					headerRight={
 						<button
+							type="button"
 							onClick={handleCreateSession}
 							class="rounded-md p-0.5 text-gray-500 transition-colors hover:bg-white/5 hover:text-gray-300"
 							aria-label="Create session"
 						>
-							<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<svg
+								class="w-3.5 h-3.5"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+								aria-hidden="true"
+							>
 								<path
 									stroke-linecap="round"
 									stroke-linejoin="round"
@@ -418,6 +489,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 						sessions.map((session) => (
 							<button
 								key={session.id}
+								type="button"
 								onClick={() => handleSessionClick(session.id)}
 								class={cn(
 									'w-full px-3 py-2 flex items-center gap-2.5 rounded-lg transition-colors',

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -10,31 +10,31 @@
  * Space navigation is handled by the Context Panel sidebar.
  */
 
-import { useCallback, useEffect, useState } from 'preact/hooks';
 import { lazy, Suspense } from 'preact/compat';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
+import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
+import { SpacePageHeader } from '../components/space/SpacePageHeader';
+import { createSession } from '../lib/api-helpers';
+import {
+	closeOverlayHistory,
+	navigateToSpace,
+	navigateToSpaceSession,
+	navigateToSpaceTask,
+	pushOverlayHistory,
+} from '../lib/router';
 import type { SpaceViewMode } from '../lib/signals';
 import {
-	spaceOverlaySessionIdSignal,
+	currentSpaceIdSignal,
+	currentSpaceViewModeSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
-	spaceOverlayTaskContextSignal,
-	spaceOverlayPendingTaskIdSignal,
 	spaceOverlayPendingAgentNameSignal,
-	currentSpaceViewModeSignal,
-	currentSpaceIdSignal,
+	spaceOverlayPendingTaskIdSignal,
+	spaceOverlaySessionIdSignal,
+	spaceOverlayTaskContextSignal,
 } from '../lib/signals';
-import { SpacePageHeader } from '../components/space/SpacePageHeader';
-import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
-import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
-import {
-	navigateToSpace,
-	navigateToSpaceTask,
-	navigateToSpaceSession,
-	pushOverlayHistory,
-	closeOverlayHistory,
-} from '../lib/router';
-import { createSession } from '../lib/api-helpers';
 import { toast } from '../lib/toast';
 import ChatContainer from './ChatContainer';
 
@@ -46,6 +46,9 @@ const SpaceSessionsPage = lazy(() =>
 );
 const SpaceTasks = lazy(() =>
 	import('../components/space/SpaceTasks').then((m) => ({ default: m.SpaceTasks }))
+);
+const SpaceGoals = lazy(() =>
+	import('../components/space/SpaceGoals').then((m) => ({ default: m.SpaceGoals }))
 );
 const SpaceOverview = lazy(() =>
 	import('../components/space/SpaceOverview').then((m) => ({ default: m.SpaceOverview }))
@@ -268,12 +271,19 @@ export default function SpaceIsland({
 						pageTitle="Tasks"
 						actions={
 							<button
+								type="button"
 								onClick={() => setCreateTaskOpen(true)}
 								class="flex-shrink-0 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-white/5 hover:text-gray-100"
 								aria-label="Create task"
 								title="Create task"
 							>
-								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<svg
+									class="w-4 h-4"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
 									<path
 										stroke-linecap="round"
 										stroke-linejoin="round"
@@ -312,6 +322,25 @@ export default function SpaceIsland({
 		);
 	}
 
+	if (viewMode === 'goals' && space) {
+		return (
+			<>
+				<div
+					class="flex-1 flex flex-col overflow-hidden bg-app-content"
+					data-testid="space-goals-view"
+				>
+					<SpacePageHeader pageTitle="Goals" />
+					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
+						<Suspense fallback={lazyFallback}>
+							<SpaceGoals spaceId={spaceId} />
+						</Suspense>
+					</div>
+				</div>
+				{overlay}
+			</>
+		);
+	}
+
 	if (viewMode === 'sessions' && space) {
 		return (
 			<>
@@ -323,13 +352,20 @@ export default function SpaceIsland({
 						pageTitle="Sessions"
 						actions={
 							<button
+								type="button"
 								onClick={handleCreateSession}
 								disabled={creatingSession}
 								class="flex-shrink-0 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-white/5 hover:text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
 								aria-label="Create session"
 								title="Create session"
 							>
-								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<svg
+									class="w-4 h-4"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
 									<path
 										stroke-linecap="round"
 										stroke-linejoin="round"

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -9,6 +9,7 @@ const {
 	mockNavigateToSpaceAgent,
 	mockNavigateToSpaceConfigure,
 	mockNavigateToSpaceSessions,
+	mockNavigateToSpaceGoals,
 	mockNavigateToSpaceTasks,
 	mockNavigateToSession,
 	mockNavigateToSessions,
@@ -19,6 +20,7 @@ const {
 	mockNavigateToSpaceAgent: vi.fn(),
 	mockNavigateToSpaceConfigure: vi.fn(),
 	mockNavigateToSpaceSessions: vi.fn(),
+	mockNavigateToSpaceGoals: vi.fn(),
 	mockNavigateToSpaceTasks: vi.fn(),
 	mockNavigateToSession: vi.fn(),
 	mockNavigateToSessions: vi.fn(),
@@ -34,7 +36,9 @@ let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTasksFilterTabSignal!: Signal<
 	'action' | 'active' | 'completed' | 'archived' | 'draft'
 >;
-let mockCurrentSpaceViewModeSignal!: Signal<'overview' | 'tasks' | 'sessions' | 'configure'>;
+let mockCurrentSpaceViewModeSignal!: Signal<
+	'overview' | 'goals' | 'tasks' | 'sessions' | 'configure'
+>;
 let mockSettingsSectionSignal!: Signal<
 	'general' | 'providers' | 'app-mcp-servers' | 'skills' | 'models' | 'usage' | 'about'
 >;
@@ -140,6 +144,7 @@ vi.mock('../../lib/router.ts', () => ({
 	navigateToSpaceAgent: mockNavigateToSpaceAgent,
 	navigateToSpaceConfigure: mockNavigateToSpaceConfigure,
 	navigateToSpaceSessions: mockNavigateToSpaceSessions,
+	navigateToSpaceGoals: mockNavigateToSpaceGoals,
 	navigateToSpaceTasks: mockNavigateToSpaceTasks,
 }));
 
@@ -217,6 +222,7 @@ describe('ContextPanel', () => {
 
 	it.each([
 		['overview', mockNavigateToSpace, ['space-2']],
+		['goals', mockNavigateToSpaceGoals, ['space-2']],
 		['tasks', mockNavigateToSpaceTasks, ['space-2', 'active']],
 		['sessions', mockNavigateToSpaceSessions, ['space-2']],
 		['configure', mockNavigateToSpaceConfigure, ['space-2', 'agents']],

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -14,12 +14,14 @@ const {
 	mockNavigateToSpaceAgent,
 	mockNavigateToSpaceTask,
 	mockNavigateToSpaceSession,
+	mockNavigateToSpaceGoals,
 	mockNavigateToSpaceTasks,
 } = vi.hoisted(() => ({
 	mockNavigateToSpace: vi.fn(),
 	mockNavigateToSpaceAgent: vi.fn(),
 	mockNavigateToSpaceTask: vi.fn(),
 	mockNavigateToSpaceSession: vi.fn(),
+	mockNavigateToSpaceGoals: vi.fn(),
 	mockNavigateToSpaceTasks: vi.fn(),
 }));
 
@@ -30,6 +32,7 @@ let mockSpaceIdSignal!: Signal<string | null>;
 let mockSessionsSignal!: Signal<
 	Array<{ id: string; title: string; status: string; lastActiveAt: number }>
 >;
+let mockGoalsSignal!: Signal<[]>;
 let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
 let mockSpaceOverlaySessionIdSignal!: Signal<string | null>;
@@ -41,6 +44,7 @@ function initSignals() {
 	mockLoadingSignal = signal(false);
 	mockSpaceIdSignal = signal('space-1');
 	mockSessionsSignal = signal([]);
+	mockGoalsSignal = signal([]);
 	mockCurrentSpaceSessionIdSignal = signal(null);
 	mockCurrentSpaceTaskIdSignal = signal(null);
 	mockSpaceOverlaySessionIdSignal = signal(null);
@@ -57,6 +61,7 @@ vi.mock('../../lib/space-store.ts', () => ({
 			loading: mockLoadingSignal,
 			spaceId: mockSpaceIdSignal,
 			sessions: mockSessionsSignal,
+			goals: mockGoalsSignal,
 		};
 	},
 }));
@@ -66,6 +71,7 @@ vi.mock('../../lib/router.ts', () => ({
 	navigateToSpaceAgent: mockNavigateToSpaceAgent,
 	navigateToSpaceTask: mockNavigateToSpaceTask,
 	navigateToSpaceSession: mockNavigateToSpaceSession,
+	navigateToSpaceGoals: mockNavigateToSpaceGoals,
 	navigateToSpaceTasks: mockNavigateToSpaceTasks,
 }));
 

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -4,6 +4,7 @@ import {
 	createSessionPath,
 	createSpaceAgentPath,
 	createSpaceConfigurePath,
+	createSpaceGoalsPath,
 	createSpacePath,
 	createSpaceSessionPath,
 	createSpaceSessionsPath,
@@ -12,21 +13,22 @@ import {
 	getSessionIdFromPath,
 	getSpaceAgentFromPath,
 	getSpaceConfigureTabFromPath,
+	getSpaceGoalsFromPath,
 	getSpaceIdFromPath,
-	getSpaceSessionIdFromPath,
 	getSpaceTaskIdFromPath,
 	getSpaceTaskViewFromPath,
 	initializeRouter,
 	navigateToHome,
 	navigateToSession,
+	navigateToSettings,
 	navigateToSpace,
 	navigateToSpaceAgent,
 	navigateToSpaceConfigure,
+	navigateToSpaceGoals,
 	navigateToSpaceSession,
+	navigateToSpacesPage,
 	navigateToSpaceTask,
 	navigateToSpaceTasks,
-	navigateToSpacesPage,
-	navigateToSettings,
 } from '../router';
 import {
 	currentSessionIdSignal,
@@ -94,6 +96,8 @@ describe('router', () => {
 		expect(createSpaceConfigurePath(SPACE_ID, 'settings')).toBe(
 			`/space/${SPACE_ID}/configure/settings`
 		);
+		expect(createSpaceGoalsPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/goals`);
+		expect(getSpaceGoalsFromPath(`/space/${SPACE_ID}/goals`)).toBe(SPACE_ID);
 		expect(createSpaceTasksPath(SPACE_ID, 'action')).toBe(`/space/${SPACE_ID}/tasks/action`);
 		expect(createSpaceSessionsPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/sessions`);
 		expect(createSpaceAgentPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/agent`);
@@ -156,6 +160,15 @@ describe('router', () => {
 
 		expect(currentSpaceViewModeSignal.value).toBe('tasks');
 		expect(currentSpaceTasksFilterTabSignal.value).toBe('completed');
+
+		cleanupRouter();
+		setPath(`/space/${SPACE_ID}/goals`);
+		initializeRouter();
+
+		expect(currentSpaceIdSignal.value).toBe(SPACE_ID);
+		expect(currentSpaceViewModeSignal.value).toBe('goals');
+		expect(currentSpaceSessionIdSignal.value).toBeNull();
+		expect(currentSpaceTaskIdSignal.value).toBeNull();
 	});
 
 	it('redirects legacy archived task tabs to completed', () => {
@@ -245,6 +258,12 @@ describe('router', () => {
 		navigateToSpaceTasks(SPACE_ID, 'action');
 		expect(currentSpaceViewModeSignal.value).toBe('tasks');
 		expect(currentSpaceTasksFilterTabSignal.value).toBe('action');
+		finishNavigation();
+
+		navigateToSpaceGoals(SPACE_ID);
+		expect(currentSpaceViewModeSignal.value).toBe('goals');
+		expect(currentSpaceSessionIdSignal.value).toBeNull();
+		expect(currentSpaceTaskIdSignal.value).toBeNull();
 		finishNavigation();
 
 		navigateToSpaceConfigure(SPACE_ID, 'settings');

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -1103,6 +1103,30 @@ describe('SpaceStore — CRUD methods', () => {
 		expect(spaceStore.goals.value).toEqual([goal]);
 	});
 
+	it('listGoals ignores stale responses from older filter requests', async () => {
+		await spaceStore.selectSpace('space-1');
+		const activeGoal = makeGoal({ id: 'active-goal', status: 'active' });
+		const archivedGoal = makeGoal({ id: 'archived-goal', status: 'archived' });
+		let resolveFirst: (value: { goals: SpaceGoal[] }) => void = () => {};
+		mockHub.request.mockImplementationOnce(
+			() =>
+				new Promise<Awaited<ReturnType<typeof mockHub.request>>>((resolve) => {
+					resolveFirst = (value) => resolve(value as Awaited<ReturnType<typeof mockHub.request>>);
+				})
+		);
+		mockHub.request.mockResolvedValueOnce({ goals: [activeGoal, archivedGoal] } as Awaited<
+			ReturnType<typeof mockHub.request>
+		>);
+
+		const first = spaceStore.listGoals({ includeArchived: false });
+		const second = await spaceStore.listGoals({ includeArchived: true });
+		resolveFirst({ goals: [activeGoal] });
+		await first;
+
+		expect(second).toEqual([activeGoal, archivedGoal]);
+		expect(spaceStore.goals.value).toEqual([activeGoal, archivedGoal]);
+	});
+
 	it('createGoal and updateGoal call goal RPCs with current space', async () => {
 		await spaceStore.selectSpace('space-1');
 

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -1127,6 +1127,25 @@ describe('SpaceStore — CRUD methods', () => {
 		expect(spaceStore.goals.value).toEqual([activeGoal, archivedGoal]);
 	});
 
+	it('listGoals ignores stale responses after newer goal mutations', async () => {
+		await spaceStore.selectSpace('space-1');
+		const staleGoal = makeGoal({ id: 'goal-1', title: 'Before update' });
+		let resolveList: (value: { goals: SpaceGoal[] }) => void = () => {};
+		mockHub.request.mockImplementationOnce(
+			() =>
+				new Promise<Awaited<ReturnType<typeof mockHub.request>>>((resolve) => {
+					resolveList = (value) => resolve(value as Awaited<ReturnType<typeof mockHub.request>>);
+				})
+		);
+		const listPromise = spaceStore.listGoals({ includeArchived: false });
+
+		await spaceStore.updateGoal('goal-1', { title: 'After update' });
+		resolveList({ goals: [staleGoal] });
+		await listPromise;
+
+		expect(spaceStore.goals.value).toMatchObject([{ id: 'goal-1', title: 'After update' }]);
+	});
+
 	it('createGoal and updateGoal call goal RPCs with current space', async () => {
 		await spaceStore.selectSpace('space-1');
 

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -11,16 +11,18 @@
  * - CRUD methods call correct RPC endpoints
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
 	NodeExecution,
 	Space,
-	SpaceTask,
-	SpaceWorkflowRun,
 	SpaceAgent,
-	SpaceWorkflow,
+	SpaceGoal,
+	SpaceGoalEvent,
+	SpaceTask,
 	SpaceTaskActivityMember,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
 } from '@neokai/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // -------------------------------------------------------
 // Mocks — declared before imports so vi.mock hoisting works
@@ -33,7 +35,9 @@ let mockHub: ReturnType<typeof makeMockHub>;
 
 /** Fire all registered handlers for an event (both single and multi-handler maps) */
 function fireMockEvent(eventName: string, data: unknown): void {
-	mockEventHandlerSets.get(eventName)?.forEach((h) => h(data));
+	mockEventHandlerSets.get(eventName)?.forEach((h) => {
+		h(data);
+	});
 }
 
 function makeSpace(id = 'space-1'): Space {
@@ -81,6 +85,53 @@ function makeTask(id: string, status = 'open', workflowRunId?: string): SpaceTas
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...(workflowRunId ? { workflowRunId } : {}),
+	};
+}
+
+function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
+	return {
+		id: 'goal-1',
+		spaceId: 'space-1',
+		title: 'Goal 1',
+		description: '',
+		status: 'active',
+		type: 'one_shot',
+		priority: 'normal',
+		labels: [],
+		metrics: {},
+		summary: '',
+		progress: 0,
+		nextSteps: [],
+		preferredWorkflowId: null,
+		taskScheduleId: null,
+		autoTriggerNext: false,
+		pendingNextRun: false,
+		activeTaskId: null,
+		lastTaskId: null,
+		lastCheckInAt: null,
+		nextCheckInAt: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeGoalEvent(overrides: Partial<SpaceGoalEvent> = {}): SpaceGoalEvent {
+	return {
+		id: 'goal-event-1',
+		spaceId: 'space-1',
+		goalId: 'goal-1',
+		eventType: 'created',
+		source: 'rpc',
+		sourceTaskId: null,
+		sourceSessionId: null,
+		previousState: null,
+		newState: null,
+		diff: null,
+		note: null,
+		createdAt: Date.now(),
+		...overrides,
 	};
 }
 
@@ -169,7 +220,7 @@ function makeMockHub() {
 			if (!mockEventHandlerSets.has(eventName)) {
 				mockEventHandlerSets.set(eventName, new Set());
 			}
-			mockEventHandlerSets.get(eventName)!.add(handler);
+			mockEventHandlerSets.get(eventName)?.add(handler);
 			return () => {
 				mockEventHandlers.delete(eventName);
 				mockEventHandlerSets.get(eventName)?.delete(handler);
@@ -205,6 +256,26 @@ function makeMockHub() {
 			if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
 			if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
 			if (method === 'nodeExecution.list') return { executions: [] };
+			if (method === 'spaceGoal.list') return { goals: [] };
+			if (method === 'spaceGoal.get') return { goal: makeGoal({ id: params?.goalId as string }) };
+			if (method === 'spaceGoal.create') return { goal: makeGoal({ id: 'new-goal' }) };
+			if (method === 'spaceGoal.update') {
+				return { goal: makeGoal({ id: params?.goalId as string, ...(params ?? {}) }) };
+			}
+			if (method === 'spaceGoal.pause') {
+				return { goal: makeGoal({ id: params?.goalId as string, status: 'paused' }) };
+			}
+			if (method === 'spaceGoal.resume') {
+				return { goal: makeGoal({ id: params?.goalId as string, status: 'active' }) };
+			}
+			if (method === 'spaceGoal.createImmediateTask') {
+				return {
+					goal: makeGoal({ id: params?.goalId as string, activeTaskId: 'goal-task' }),
+					task: makeTask('goal-task'),
+					queued: false,
+				};
+			}
+			if (method === 'spaceGoal.listEvents') return { events: [makeGoalEvent()] };
 			// space.listWithTasks returns array of spaces enriched with tasks
 			if (method === 'space.listWithTasks')
 				return [
@@ -457,7 +528,7 @@ describe('SpaceStore — space.updated event', () => {
 		const handler = mockEventHandlers.get('space.updated');
 		expect(handler).toBeDefined();
 
-		handler!({ sessionId: 'global', spaceId: 'space-1', space: { name: 'Renamed Space' } });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', space: { name: 'Renamed Space' } });
 
 		expect(spaceStore.space.value?.name).toBe('Renamed Space');
 		// Other fields preserved
@@ -469,7 +540,7 @@ describe('SpaceStore — space.updated event', () => {
 		const originalName = spaceStore.space.value?.name;
 
 		const handler = mockEventHandlers.get('space.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-1' });
 
 		expect(spaceStore.space.value?.name).toBe(originalName);
 	});
@@ -479,7 +550,7 @@ describe('SpaceStore — space.updated event', () => {
 		const originalName = spaceStore.space.value?.name;
 
 		const handler = mockEventHandlers.get('space.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-99', space: { name: 'Other' } });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', space: { name: 'Other' } });
 
 		expect(spaceStore.space.value?.name).toBe(originalName);
 	});
@@ -494,7 +565,7 @@ describe('SpaceStore — space.archived event', () => {
 		expect(spaceStore.spaceId.value).toBe('space-1');
 
 		const handler = mockEventHandlers.get('space.archived');
-		handler!({ sessionId: 'global', spaceId: 'space-1', space: makeSpace() });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', space: makeSpace() });
 
 		// Allow the async clearSpace to run
 		await new Promise((r) => setTimeout(r, 0));
@@ -506,7 +577,7 @@ describe('SpaceStore — space.archived event', () => {
 		await spaceStore.selectSpace('space-1');
 
 		const handler = mockEventHandlers.get('space.archived');
-		handler!({ sessionId: 'global', spaceId: 'space-99', space: makeSpace('space-99') });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', space: makeSpace('space-99') });
 
 		await new Promise((r) => setTimeout(r, 0));
 
@@ -523,7 +594,7 @@ describe('SpaceStore — space.deleted event', () => {
 		expect(spaceStore.spaceId.value).toBe('space-1');
 
 		const handler = mockEventHandlers.get('space.deleted');
-		handler!({ sessionId: 'global', spaceId: 'space-1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-1' });
 
 		await new Promise((r) => setTimeout(r, 0));
 
@@ -534,7 +605,7 @@ describe('SpaceStore — space.deleted event', () => {
 		await spaceStore.selectSpace('space-1');
 
 		const handler = mockEventHandlers.get('space.deleted');
-		handler!({ sessionId: 'global', spaceId: 'space-99' });
+		handler?.({ sessionId: 'global', spaceId: 'space-99' });
 
 		await new Promise((r) => setTimeout(r, 0));
 
@@ -553,7 +624,7 @@ describe('SpaceStore — space.task.created event', () => {
 		expect(handler).toBeDefined();
 
 		const task = makeTask('new-t');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 'new-t', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 'new-t', task });
 
 		expect(spaceStore.tasks.value).toContainEqual(task);
 	});
@@ -564,7 +635,7 @@ describe('SpaceStore — space.task.created event', () => {
 		spaceStore.tasks.value = [task];
 
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 'dup', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 'dup', task });
 
 		expect(spaceStore.tasks.value.length).toBe(1);
 	});
@@ -574,7 +645,7 @@ describe('SpaceStore — space.task.created event', () => {
 		const task = makeTask('other');
 
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-99', taskId: 'other', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', taskId: 'other', task });
 
 		expect(spaceStore.tasks.value).not.toContainEqual(task);
 	});
@@ -590,7 +661,7 @@ describe('SpaceStore — space.task.updated event', () => {
 
 		const updated = makeTask('t1', 'in_progress');
 		const handler = mockEventHandlers.get('space.task.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
 
 		expect(spaceStore.tasks.value[0].status).toBe('in_progress');
 	});
@@ -601,7 +672,7 @@ describe('SpaceStore — space.task.updated event', () => {
 
 		const task = makeTask('t2', 'in_progress');
 		const handler = mockEventHandlers.get('space.task.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't2', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't2', task });
 
 		expect(spaceStore.tasks.value).toContainEqual(task);
 	});
@@ -612,7 +683,7 @@ describe('SpaceStore — space.task.updated event', () => {
 
 		const updated = makeTask('t1', 'in_progress');
 		const handler = mockEventHandlers.get('space.task.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-99', taskId: 't1', task: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', taskId: 't1', task: updated });
 
 		expect(spaceStore.tasks.value[0].status).toBe('pending');
 	});
@@ -627,7 +698,7 @@ describe('SpaceStore — space.workflowRun.created event', () => {
 
 		const run = makeRun('run-1');
 		const handler = mockEventHandlers.get('space.workflowRun.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', runId: 'run-1', run });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', runId: 'run-1', run });
 
 		expect(spaceStore.workflowRuns.value).toContainEqual(run);
 	});
@@ -638,7 +709,7 @@ describe('SpaceStore — space.workflowRun.created event', () => {
 		spaceStore.workflowRuns.value = [run];
 
 		const handler = mockEventHandlers.get('space.workflowRun.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', runId: 'run-dup', run });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', runId: 'run-dup', run });
 
 		expect(spaceStore.workflowRuns.value.length).toBe(1);
 	});
@@ -648,7 +719,7 @@ describe('SpaceStore — space.workflowRun.created event', () => {
 		const run = makeRun('run-other');
 
 		const handler = mockEventHandlers.get('space.workflowRun.created');
-		handler!({ sessionId: 'global', spaceId: 'space-99', runId: 'run-other', run });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', runId: 'run-other', run });
 
 		expect(spaceStore.workflowRuns.value.length).toBe(0);
 	});
@@ -663,7 +734,7 @@ describe('SpaceStore — space.workflowRun.updated event', () => {
 		spaceStore.workflowRuns.value = [makeRun('run-1', 'pending')];
 
 		const handler = mockEventHandlers.get('space.workflowRun.updated');
-		handler!({
+		handler?.({
 			sessionId: 'global',
 			spaceId: 'space-1',
 			runId: 'run-1',
@@ -678,7 +749,7 @@ describe('SpaceStore — space.workflowRun.updated event', () => {
 		spaceStore.workflowRuns.value = [makeRun('run-1', 'pending')];
 
 		const handler = mockEventHandlers.get('space.workflowRun.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', runId: 'run-1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', runId: 'run-1' });
 
 		expect(spaceStore.workflowRuns.value[0].status).toBe('pending');
 	});
@@ -693,7 +764,7 @@ describe('SpaceStore — spaceAgent events', () => {
 		const agent = makeAgent('a1');
 
 		const handler = mockEventHandlers.get('spaceAgent.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', agent });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', agent });
 
 		expect(spaceStore.agents.value).toContainEqual(agent);
 	});
@@ -704,7 +775,7 @@ describe('SpaceStore — spaceAgent events', () => {
 
 		const updated = { ...makeAgent('a1'), name: 'New Name' };
 		const handler = mockEventHandlers.get('spaceAgent.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', agent: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', agent: updated });
 
 		expect(spaceStore.agents.value[0].name).toBe('New Name');
 	});
@@ -714,7 +785,7 @@ describe('SpaceStore — spaceAgent events', () => {
 		spaceStore.agents.value = [makeAgent('a1'), makeAgent('a2')];
 
 		const handler = mockEventHandlers.get('spaceAgent.deleted');
-		handler!({ sessionId: 'global', spaceId: 'space-1', agentId: 'a1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', agentId: 'a1' });
 
 		expect(spaceStore.agents.value.map((a) => a.id)).toEqual(['a2']);
 	});
@@ -722,7 +793,7 @@ describe('SpaceStore — spaceAgent events', () => {
 	it('ignores events for a different space', async () => {
 		await spaceStore.selectSpace('space-1');
 		const handler = mockEventHandlers.get('spaceAgent.created');
-		handler!({ sessionId: 'global', spaceId: 'space-99', agent: makeAgent('a1') });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', agent: makeAgent('a1') });
 
 		expect(spaceStore.agents.value.length).toBe(0);
 	});
@@ -737,7 +808,7 @@ describe('SpaceStore — spaceWorkflow events', () => {
 		const wf = makeWorkflow('wf1');
 
 		const handler = mockEventHandlers.get('spaceWorkflow.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', workflow: wf });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', workflow: wf });
 
 		expect(spaceStore.workflows.value).toContainEqual(
 			expect.objectContaining({ id: 'wf1', name: 'Workflow wf1' })
@@ -752,7 +823,7 @@ describe('SpaceStore — spaceWorkflow events', () => {
 		const updated = makeWorkflow('wf1');
 		updated.name = 'New';
 		const handler = mockEventHandlers.get('spaceWorkflow.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', workflow: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', workflow: updated });
 
 		expect(spaceStore.workflows.value[0].name).toBe('New');
 	});
@@ -762,7 +833,7 @@ describe('SpaceStore — spaceWorkflow events', () => {
 		spaceStore.workflows.value = [makeWorkflowSummary('wf1'), makeWorkflowSummary('wf2')];
 
 		const handler = mockEventHandlers.get('spaceWorkflow.deleted');
-		handler!({ sessionId: 'global', spaceId: 'space-1', workflowId: 'wf1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', workflowId: 'wf1' });
 
 		expect(spaceStore.workflows.value.map((w) => w.id)).toEqual(['wf2']);
 	});
@@ -772,7 +843,7 @@ describe('SpaceStore — spaceWorkflow events', () => {
 		const handler = mockEventHandlers.get('spaceWorkflow.deleted');
 		spaceStore.workflows.value = [makeWorkflowSummary('wf1')];
 
-		handler!({ sessionId: 'global', spaceId: 'space-99', workflowId: 'wf1' });
+		handler?.({ sessionId: 'global', spaceId: 'space-99', workflowId: 'wf1' });
 
 		expect(spaceStore.workflows.value.length).toBe(1);
 	});
@@ -853,7 +924,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const task = makeTask('t-new', 'open');
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't-new', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't-new', task });
 
 		expect(spaceStore.tasks.value).toHaveLength(1);
 		expect(spaceStore.tasks.value[0].id).toBe('t-new');
@@ -864,7 +935,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const task = makeTask('t-active', 'in_progress');
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't-active', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't-active', task });
 
 		expect(spaceStore.activeTasks.value).toHaveLength(1);
 		expect(spaceStore.activeTasks.value[0].id).toBe('t-active');
@@ -877,7 +948,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const updated = makeTask('t1', 'in_progress');
 		const handler = mockEventHandlers.get('space.task.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
 
 		expect(spaceStore.activeTasks.value).toHaveLength(1);
 		expect(spaceStore.activeTasks.value[0].status).toBe('in_progress');
@@ -888,7 +959,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const task = makeTask('t-wf', 'open', 'run-1');
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't-wf', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't-wf', task });
 
 		expect(spaceStore.tasksByRun.value.get('run-1')).toHaveLength(1);
 		expect(spaceStore.standaloneTasks.value).toHaveLength(0);
@@ -899,7 +970,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const task = makeTask('t-solo', 'open');
 		const handler = mockEventHandlers.get('space.task.created');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't-solo', task });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't-solo', task });
 
 		expect(spaceStore.standaloneTasks.value).toHaveLength(1);
 		expect(spaceStore.standaloneTasks.value[0].id).toBe('t-solo');
@@ -909,19 +980,19 @@ describe('SpaceStore — task visibility after real-time events', () => {
 		await spaceStore.selectSpace('space-1');
 		const handler = mockEventHandlers.get('space.task.created');
 
-		handler!({
+		handler?.({
 			sessionId: 'global',
 			spaceId: 'space-1',
 			taskId: 't1',
 			task: makeTask('t1', 'open'),
 		});
-		handler!({
+		handler?.({
 			sessionId: 'global',
 			spaceId: 'space-1',
 			taskId: 't2',
 			task: makeTask('t2', 'in_progress'),
 		});
-		handler!({
+		handler?.({
 			sessionId: 'global',
 			spaceId: 'space-1',
 			taskId: 't3',
@@ -939,7 +1010,7 @@ describe('SpaceStore — task visibility after real-time events', () => {
 
 		const updated = makeTask('t1', 'done');
 		const handler = mockEventHandlers.get('space.task.updated');
-		handler!({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
+		handler?.({ sessionId: 'global', spaceId: 'space-1', taskId: 't1', task: updated });
 
 		expect(spaceStore.activeTasks.value).toHaveLength(0);
 		expect(spaceStore.tasks.value[0].status).toBe('done');
@@ -1013,6 +1084,82 @@ describe('SpaceStore — CRUD methods', () => {
 			status: 'in_progress',
 		});
 		expect(task.status).toBe('in_progress');
+	});
+
+	it('listGoals calls spaceGoal.list RPC and updates goal state', async () => {
+		await spaceStore.selectSpace('space-1');
+		const goal = makeGoal({ id: 'goal-a', title: 'Alpha' });
+		mockHub.request.mockResolvedValueOnce({ goals: [goal] } as Awaited<
+			ReturnType<typeof mockHub.request>
+		>);
+
+		const goals = await spaceStore.listGoals({ includeArchived: true });
+
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.list', {
+			spaceId: 'space-1',
+			includeArchived: true,
+		});
+		expect(goals).toEqual([goal]);
+		expect(spaceStore.goals.value).toEqual([goal]);
+	});
+
+	it('createGoal and updateGoal call goal RPCs with current space', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		await spaceStore.createGoal({ title: 'New goal', labels: ['release'] });
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.create', {
+			spaceId: 'space-1',
+			title: 'New goal',
+			labels: ['release'],
+		});
+
+		await spaceStore.updateGoal('goal-1', { progress: 50, autoTriggerNext: true });
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.update', {
+			spaceId: 'space-1',
+			goalId: 'goal-1',
+			progress: 50,
+			autoTriggerNext: true,
+		});
+	});
+
+	it('goal actions update goals and immediate tasks in local state', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const paused = await spaceStore.pauseGoal('goal-1');
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.pause', {
+			spaceId: 'space-1',
+			goalId: 'goal-1',
+		});
+		expect(paused.status).toBe('paused');
+
+		const resumed = await spaceStore.resumeGoal('goal-1');
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.resume', {
+			spaceId: 'space-1',
+			goalId: 'goal-1',
+		});
+		expect(resumed.status).toBe('active');
+
+		const result = await spaceStore.createImmediateGoalTask('goal-1');
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.createImmediateTask', {
+			spaceId: 'space-1',
+			goalId: 'goal-1',
+		});
+		expect(result.queued).toBe(false);
+		expect(spaceStore.tasks.value.some((task) => task.id === 'goal-task')).toBe(true);
+	});
+
+	it('listGoalEvents stores events by goal id', async () => {
+		await spaceStore.selectSpace('space-1');
+
+		const events = await spaceStore.listGoalEvents('goal-1');
+
+		expect(mockHub.request).toHaveBeenLastCalledWith('spaceGoal.listEvents', {
+			spaceId: 'space-1',
+			goalId: 'goal-1',
+			limit: 20,
+		});
+		expect(events).toHaveLength(1);
+		expect(spaceStore.goalEvents.value.get('goal-1')).toEqual(events);
 	});
 
 	it('subscribeTaskActivity subscribes to LiveQuery and applies snapshots', async () => {

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -9,23 +9,23 @@
 import { batch } from '@preact/signals';
 import {
 	currentSessionIdSignal,
+	currentSpaceConfigureTabSignal,
 	currentSpaceIdSignal,
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
-	currentSpaceViewModeSignal,
-	currentSpaceConfigureTabSignal,
 	currentSpaceTasksFilterTabSignal,
 	currentSpaceTaskViewTabSignal,
+	currentSpaceViewModeSignal,
 	navSectionSignal,
-	settingsSectionSignal,
 	type SettingsSection,
-	spaceOverlaySessionIdSignal,
+	type SpaceOverlayTaskContext,
+	settingsSectionSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
-	type SpaceOverlayTaskContext,
-	spaceOverlayTaskContextSignal,
-	spaceOverlayPendingTaskIdSignal,
 	spaceOverlayPendingAgentNameSignal,
+	spaceOverlayPendingTaskIdSignal,
+	spaceOverlaySessionIdSignal,
+	spaceOverlayTaskContextSignal,
 } from './signals.ts';
 
 const SESSION_ROUTE_PATTERN = /^\/session\/([a-f0-9-]+)$/i;
@@ -36,6 +36,7 @@ const SPACE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)$/;
 const SPACE_CONFIGURE_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/configure$/;
 const SPACE_CONFIGURE_TAB_ROUTE_PATTERN =
 	/^\/space\/([a-z0-9-]+)\/configure\/(agents|workflows|settings)$/;
+const SPACE_GOALS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/goals$/;
 const SPACE_TASKS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks$/;
 const SPACE_TASKS_ARCHIVED_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks\/archived$/;
 const SPACE_TASKS_TAB_ROUTE_PATTERN =
@@ -86,6 +87,9 @@ export function getSpaceIdFromPath(path: string): string | null {
 	const tasksTabMatch = path.match(SPACE_TASKS_TAB_ROUTE_PATTERN);
 	if (tasksTabMatch) return tasksTabMatch[1];
 
+	const goalsMatch = path.match(SPACE_GOALS_ROUTE_PATTERN);
+	if (goalsMatch) return goalsMatch[1];
+
 	const tasksMatch = path.match(SPACE_TASKS_ROUTE_PATTERN);
 	if (tasksMatch) return tasksMatch[1];
 
@@ -124,6 +128,11 @@ export function getSpaceConfigureTabFromPath(
 	const match = path.match(SPACE_CONFIGURE_TAB_ROUTE_PATTERN);
 	if (!match) return null;
 	return { spaceId: match[1], tab: match[2] as 'agents' | 'workflows' | 'settings' };
+}
+
+export function getSpaceGoalsFromPath(path: string): string | null {
+	const match = path.match(SPACE_GOALS_ROUTE_PATTERN);
+	return match ? match[1] : null;
 }
 
 export function getSpaceTasksFromPath(path: string): string | null {
@@ -202,6 +211,10 @@ export function createSpacePath(spaceId: string): string {
 
 export function createSpaceConfigurePath(spaceId: string, tab?: string): string {
 	return tab ? `/space/${spaceId}/configure/${tab}` : `/space/${spaceId}/configure`;
+}
+
+export function createSpaceGoalsPath(spaceId: string): string {
+	return `/space/${spaceId}/goals`;
 }
 
 export function createSpaceTasksPath(spaceId: string, tab?: string): string {
@@ -410,6 +423,28 @@ export function navigateToSpaceConfigure(
 	navSectionSignal.value = 'spaces';
 }
 
+export function navigateToSpaceGoals(spaceId: string, replace = false): void {
+	if (routerState.isNavigating) return;
+
+	const targetPath = createSpaceGoalsPath(spaceId);
+	if (getCurrentPath() !== targetPath) {
+		routerState.isNavigating = true;
+		try {
+			pushPath(targetPath, { spaceId }, replace);
+		} finally {
+			finishNavigation();
+		}
+	}
+
+	currentSpaceIdSignal.value = spaceId;
+	currentSpaceViewModeSignal.value = 'goals';
+	currentSpaceSessionIdSignal.value = null;
+	currentSpaceTaskIdSignal.value = null;
+	currentSpaceTaskViewTabSignal.value = 'thread';
+	currentSessionIdSignal.value = null;
+	navSectionSignal.value = 'spaces';
+}
+
 export function navigateToSpaceTasks(
 	spaceId: string,
 	tab?: 'action' | 'active' | 'completed' | 'draft' | 'scheduled',
@@ -547,6 +582,7 @@ function applyPathToSignals(path: string, search = window.location.search): stri
 	const spaceConfigure = spaceConfigureTab
 		? spaceConfigureTab.spaceId
 		: getSpaceConfigureFromPath(path);
+	const spaceGoals = getSpaceGoalsFromPath(path);
 	const spaceTasksTab = getSpaceTasksTabFromPath(path);
 	const spaceTasks = spaceTasksTab ? spaceTasksTab.spaceId : getSpaceTasksFromPath(path);
 	const spaceTaskView = getSpaceTaskViewFromPath(path);
@@ -579,6 +615,14 @@ function applyPathToSignals(path: string, search = window.location.search): stri
 			currentSpaceIdSignal.value = spaceAgent;
 			currentSpaceViewModeSignal.value = 'overview';
 			currentSpaceSessionIdSignal.value = `space:chat:${spaceAgent}`;
+			currentSpaceTaskIdSignal.value = null;
+			currentSpaceTaskViewTabSignal.value = 'thread';
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceGoals) {
+			currentSpaceIdSignal.value = spaceGoals;
+			currentSpaceViewModeSignal.value = 'goals';
+			currentSpaceSessionIdSignal.value = null;
 			currentSpaceTaskIdSignal.value = null;
 			currentSpaceTaskViewTabSignal.value = 'thread';
 			currentSessionIdSignal.value = null;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -1,5 +1,5 @@
-import { signal } from '@preact/signals';
 import type { Session } from '@neokai/shared';
+import { signal } from '@preact/signals';
 
 // Shared signal for the current session ID - always starts as null
 // Refreshing the page will return to recent conversations view
@@ -27,7 +27,7 @@ export const navSectionSignal = signal<NavSection>('spaces');
 export const currentSpaceIdSignal = signal<string | null>(null);
 export const currentSpaceSessionIdSignal = signal<string | null>(null);
 export const currentSpaceTaskIdSignal = signal<string | null>(null);
-export type SpaceViewMode = 'overview' | 'tasks' | 'sessions' | 'configure';
+export type SpaceViewMode = 'overview' | 'goals' | 'tasks' | 'sessions' | 'configure';
 export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
 // Configure sub-tab (agents | workflows | settings) — driven by URL

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -25,6 +25,7 @@
 
 import type {
 	CreateSpaceAgentParams,
+	CreateSpaceGoalParams,
 	CreateSpaceTaskParams,
 	CreateSpaceWorkflowParams,
 	LiveQueryDeltaEvent,
@@ -36,17 +37,21 @@ import type {
 	Space,
 	SpaceAgent,
 	SpaceBlockReason,
+	SpaceGoal,
+	SpaceGoalEvent,
+	SpaceGoalListParams,
 	SpaceTask,
 	SpaceTaskActivityMember,
+	SpaceTaskPriority,
 	SpaceTaskStatus,
 	SpaceWorkflow,
-	SpaceWorkflowSummary,
 	SpaceWorkflowRun,
+	SpaceWorkflowSummary,
 	TaskSchedule,
 	TaskScheduleStatus,
 	TaskScheduleTriggerType,
-	SpaceTaskPriority,
 	UpdateSpaceAgentParams,
+	UpdateSpaceGoalParams,
 	UpdateSpaceParams,
 	UpdateSpaceTaskParams,
 	UpdateSpaceWorkflowParams,
@@ -142,6 +147,12 @@ class SpaceStore {
 
 	/** Task schedules for this space */
 	readonly schedules = signal<TaskSchedule[]>([]);
+
+	/** Space goals for this space */
+	readonly goals = signal<SpaceGoal[]>([]);
+
+	/** Goal events keyed by goal ID */
+	readonly goalEvents = signal<Map<string, SpaceGoalEvent[]>>(new Map());
 
 	/** Live task-agent activity rows keyed by task ID */
 	readonly taskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
@@ -329,39 +340,6 @@ class SpaceStore {
 				current.id !== task.id &&
 				(!task.workflowRunId || current.workflowRunId !== task.workflowRunId)
 		);
-	}
-
-	private collapseTasksOnePerRun(tasks: SpaceTask[], runs: SpaceWorkflowRun[]): SpaceTask[] {
-		if (tasks.length === 0) return [];
-		const runsById = new Map(runs.map((run) => [run.id, run]));
-		const groupedByRun = new Map<string, SpaceTask[]>();
-		const standalone: SpaceTask[] = [];
-
-		for (const task of tasks) {
-			if (!task.workflowRunId) {
-				standalone.push(task);
-				continue;
-			}
-			const existing = groupedByRun.get(task.workflowRunId) ?? [];
-			existing.push(task);
-			groupedByRun.set(task.workflowRunId, existing);
-		}
-
-		const canonicalWorkflowTasks = Array.from(groupedByRun.entries()).map(([runId, runTasks]) => {
-			const runTitle = runsById.get(runId)?.title?.trim().toLowerCase() ?? null;
-			const byRunTitle = runTitle
-				? runTasks.find((task) => task.title.trim().toLowerCase() === runTitle)
-				: undefined;
-			return (
-				byRunTitle ??
-				[...runTasks].sort((a, b) => {
-					if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
-					return a.taskNumber - b.taskNumber;
-				})[0]
-			);
-		});
-
-		return [...standalone, ...canonicalWorkflowTasks].sort((a, b) => b.updatedAt - a.updatedAt);
 	}
 
 	// ========================================
@@ -582,6 +560,8 @@ class SpaceStore {
 		this.nodeExecPromise = null;
 		this.sessions.value = [];
 		this.schedules.value = [];
+		this.goals.value = [];
+		this.goalEvents.value = new Map();
 		this.clearWorkflowDetailCache();
 		this.workflowVersions.value = new Map();
 		this.disposeSpaceSessionsSubscription();
@@ -917,6 +897,9 @@ class SpaceStore {
 		this.workflowRuns.value = overview.workflowRuns ?? [];
 		// Server already returns collapsed tasks via collapseToCanonicalTasks — use directly
 		this.tasks.value = overview.tasks ?? [];
+		this.listGoals({ includeArchived: false }).catch((err) => {
+			logger.warn('Failed to fetch space goals:', err);
+		});
 
 		return overview.space.id;
 	}
@@ -2119,6 +2102,157 @@ class SpaceStore {
 			{ id: workflowId, spaceId }
 		);
 		return workflow;
+	}
+
+	// ========================================
+	// Goal Methods
+	// ========================================
+
+	private upsertGoal(goal: SpaceGoal): void {
+		const existing = this.goals.value.filter((current) => current.id !== goal.id);
+		this.goals.value = [...existing, goal].sort((a, b) => b.updatedAt - a.updatedAt);
+	}
+
+	async listGoals(options: Omit<SpaceGoalListParams, 'spaceId'> = {}): Promise<SpaceGoal[]> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { goals } = await hub.request<{ goals: SpaceGoal[] }>('spaceGoal.list', {
+			...options,
+			spaceId,
+		});
+		if (this.spaceId.value === spaceId) {
+			this.goals.value = goals ?? [];
+		}
+		return goals ?? [];
+	}
+
+	async fetchGoal(goalId: string): Promise<SpaceGoal> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { goal } = await hub.request<{ goal: SpaceGoal }>('spaceGoal.get', { spaceId, goalId });
+		if (goal && this.spaceId.value === spaceId) this.upsertGoal(goal);
+		return goal;
+	}
+
+	async createGoal(params: Omit<CreateSpaceGoalParams, 'spaceId'>): Promise<SpaceGoal> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { goal } = await hub.request<{ goal: SpaceGoal }>('spaceGoal.create', {
+			...params,
+			spaceId,
+		});
+		if (goal && this.spaceId.value === spaceId) this.upsertGoal(goal);
+		return goal;
+	}
+
+	async updateGoal(
+		goalId: string,
+		params: Pick<
+			UpdateSpaceGoalParams,
+			| 'title'
+			| 'description'
+			| 'status'
+			| 'type'
+			| 'priority'
+			| 'labels'
+			| 'metrics'
+			| 'summary'
+			| 'progress'
+			| 'nextSteps'
+			| 'preferredWorkflowId'
+			| 'autoTriggerNext'
+		>
+	): Promise<SpaceGoal> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { goal } = await hub.request<{ goal: SpaceGoal }>('spaceGoal.update', {
+			...params,
+			spaceId,
+			goalId,
+		});
+		if (goal && this.spaceId.value === spaceId) this.upsertGoal(goal);
+		return goal;
+	}
+
+	async pauseGoal(goalId: string): Promise<SpaceGoal> {
+		return this.runGoalAction('spaceGoal.pause', goalId);
+	}
+
+	async resumeGoal(goalId: string): Promise<SpaceGoal> {
+		return this.runGoalAction('spaceGoal.resume', goalId);
+	}
+
+	async archiveGoal(goalId: string): Promise<SpaceGoal> {
+		return this.updateGoal(goalId, { status: 'archived' });
+	}
+
+	async createImmediateGoalTask(goalId: string): Promise<{
+		goal: SpaceGoal;
+		task: SpaceTask | null;
+		queued: boolean;
+	}> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const result = await hub.request<{
+			goal: SpaceGoal;
+			task: SpaceTask | null;
+			queued: boolean;
+		}>('spaceGoal.createImmediateTask', { spaceId, goalId });
+		if (result?.goal && this.spaceId.value === spaceId) this.upsertGoal(result.goal);
+		if (result?.task && this.spaceId.value === spaceId) {
+			this.tasks.value = this.upsertTaskOnePerRun(this.tasks.value, result.task);
+		}
+		return result;
+	}
+
+	async listGoalEvents(goalId: string): Promise<SpaceGoalEvent[]> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { events } = await hub.request<{ events: SpaceGoalEvent[] }>('spaceGoal.listEvents', {
+			spaceId,
+			goalId,
+			limit: 20,
+		});
+		if (this.spaceId.value === spaceId) {
+			this.goalEvents.value = new Map(this.goalEvents.value).set(goalId, events ?? []);
+		}
+		return events ?? [];
+	}
+
+	private async runGoalAction(method: 'spaceGoal.pause' | 'spaceGoal.resume', goalId: string) {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { goal } = await hub.request<{ goal: SpaceGoal }>(method, { spaceId, goalId });
+		if (goal && this.spaceId.value === spaceId) this.upsertGoal(goal);
+		return goal;
 	}
 
 	// ========================================

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2111,6 +2111,7 @@ class SpaceStore {
 	// ========================================
 
 	private upsertGoal(goal: SpaceGoal): void {
+		this.goalListRequestVersion += 1;
 		const existing = this.goals.value.filter((current) => current.id !== goal.id);
 		this.goals.value = [...existing, goal].sort((a, b) => b.updatedAt - a.updatedAt);
 	}

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -283,6 +283,9 @@ class SpaceStore {
 	/** Stale-event guard for node execution LiveQuery subscriptions */
 	private activeNodeExecSubscriptionIds = new Set<string>();
 
+	/** Monotonic counter so stale goal list responses cannot overwrite newer filters. */
+	private goalListRequestVersion = 0;
+
 	/** In-flight promise for ensureConfigData to prevent duplicate fetches */
 	private configDataPromise: Promise<void> | null = null;
 
@@ -2120,11 +2123,12 @@ class SpaceStore {
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
+		const requestVersion = ++this.goalListRequestVersion;
 		const { goals } = await hub.request<{ goals: SpaceGoal[] }>('spaceGoal.list', {
 			...options,
 			spaceId,
 		});
-		if (this.spaceId.value === spaceId) {
+		if (this.spaceId.value === spaceId && this.goalListRequestVersion === requestVersion) {
 			this.goals.value = goals ?? [];
 		}
 		return goals ?? [];

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -583,6 +583,9 @@ class SpaceStore {
 					if (resolvedId !== spaceIdOrSlug) {
 						this.spaceId.value = resolvedId;
 					}
+					this.listGoals({ includeArchived: false }).catch((err) => {
+						logger.warn('Failed to fetch space goals:', err);
+					});
 					await this.startSubscriptions(resolvedId);
 				}
 			} catch (err) {
@@ -900,10 +903,6 @@ class SpaceStore {
 		this.workflowRuns.value = overview.workflowRuns ?? [];
 		// Server already returns collapsed tasks via collapseToCanonicalTasks — use directly
 		this.tasks.value = overview.tasks ?? [];
-		this.listGoals({ includeArchived: false }).catch((err) => {
-			logger.warn('Failed to fetch space goals:', err);
-		});
-
 		return overview.space.id;
 	}
 


### PR DESCRIPTION
Adds minimal Space goals UI: sidebar route, goals list/detail surface, create/edit dialog, RPC-backed goal actions, and focused router/store/component coverage.

Checks:
- bun run --cwd ../.. check
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceGoals.test.tsx src/lib/__tests__/router.test.ts src/lib/__tests__/space-store.test.ts