### PR TITLE
fix: bump desktop npm package version to 0.27.0

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.26.0"
+version = "0.27.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Kai",
-	"version": "0.26.0",
+	"version": "0.27.0",
 	"identifier": "io.neokai.kai",
 	"build": {
 		"frontendDist": "loading",


### PR DESCRIPTION
packages/desktop/package.json was missed in the v0.27.0 release bump.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>