### PR TITLE
Fix worker session Space MCP reattach

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -366,7 +366,6 @@ export class QueryRunner {
 			);
 
 			queryOptions = await this.ensureSpaceChatMcpInvariant(queryOptions);
-			queryOptions = await this.ensureMemberSpaceMcpInvariant(queryOptions);
 			// P2-6 / P1-5: Self-heal — detect a missing required MCP server for
 			// workflow sub-sessions and recover via the registered callback.
 			// Required server:
@@ -464,6 +463,8 @@ export class QueryRunner {
 					);
 				}
 			}
+
+			queryOptions = await this.ensureMemberSpaceMcpInvariant(queryOptions);
 
 			// Apply provider env vars
 			{
@@ -1101,17 +1102,20 @@ export class QueryRunner {
 	 *   - space_chat sessions (handled by ensureSpaceChatMcpInvariant)
 	 *   - space_task_agent sessions (legacy, intentionally not provisioned by
 	 *     attachSpaceToolsToMemberSession)
-	 *   - workflow sub-sessions (handled by node-agent self-heal)
 	 *   - sessions without context.spaceId
+	 *
+	 * Workflow sub-sessions are included because they are also Space members;
+	 * TaskAgentManager provides the specialised self-heal callback for them.
 	 */
 	private async ensureMemberSpaceMcpInvariant(queryOptions: Options): Promise<Options> {
 		const { session, logger } = this.ctx;
 		// Only applies to member sessions that belong to a Space but are not the
-		// Space chat session itself, a legacy task-agent session, or a workflow sub-session.
+		// Space chat session itself or a legacy task-agent session. Workflow
+		// sub-sessions are still Space members, but TaskAgentManager wires their
+		// specialised space-agent-tools server and callback.
 		if (!session.context?.spaceId) return queryOptions;
 		if (session.type === 'space_chat') return queryOptions;
 		if (session.type === 'space_task_agent') return queryOptions;
-		if (session.id.includes(':task:') && session.id.includes(':exec:')) return queryOptions;
 
 		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
 		const missingServers = REQUIRED_MEMBER_SPACE_MCP_SERVERS.filter(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -892,9 +892,8 @@ export class TaskAgentManager {
 						// Re-merging with a fresh node-agent and restarting the query ensures the
 						// session's tool surface reflects the new node activation context.
 						//
-						// Re-inject node-agent and enforce the required-server invariant on
-						// the reused session. Node agents intentionally do not receive
-						// space-agent-tools; task creation is mirrored onto node-agent instead.
+						// Re-inject node-agent, attach specialised space-agent-tools, and enforce
+						// the required-server invariant on the reused session.
 						if (memberInfo.nodeId) {
 							const reuseWorkspacePath = this.taskWorktreePaths.get(taskId) ?? init.workspacePath;
 							const reuseCtx = {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -908,6 +908,7 @@ export class TaskAgentManager {
 							};
 							// Unconditionally rebuild node-agent (fresh node context).
 							await this.reinjectNodeAgentMcpServer(existing, reuseCtx);
+							await this.attachSpaceToolsToWorkflowSubSession(existing, reuseCtx, 'reuse');
 							await this.ensureRequiredMcpServersAttached(existing, {
 								...reuseCtx,
 								phase: 'spawn',
@@ -997,6 +998,25 @@ export class TaskAgentManager {
 			// replace-all setRuntimeMcpServers because it won't clobber servers injected
 			// by a concurrent subsystem before this path runs.
 			subSession.mergeRuntimeMcpServers(mergedSubSessionMcpServers);
+		}
+		const subSessionContext = subSession.session.context;
+		if (memberInfo?.nodeId && memberInfo.agentName && subSessionContext?.spaceId) {
+			const parentTask = this.config.taskRepo.getTask(taskId);
+			if (parentTask?.workflowRunId) {
+				await this.attachSpaceToolsToWorkflowSubSession(
+					subSession,
+					{
+						taskId,
+						subSessionId: sessionId,
+						agentName: memberInfo.agentName,
+						spaceId: subSessionContext.spaceId,
+						workflowRunId: parentTask.workflowRunId,
+						workspacePath: init.workspacePath,
+						workflowNodeId: memberInfo.nodeId,
+					},
+					'new'
+				);
+			}
 		}
 
 		// Determine node ID from session convention or task context.
@@ -2639,8 +2659,7 @@ export class TaskAgentManager {
 		// is safer than the deprecated replace-all setRuntimeMcpServers.
 		agentSession.mergeRuntimeMcpServers(mergedMcpServers);
 
-		// Defensive guarantee — see ensureNodeAgentAttached docs.
-		await this.ensureNodeAgentAttached(agentSession, {
+		const rehydrateCtx = {
 			taskId,
 			subSessionId,
 			agentName: execution.agentName,
@@ -2648,6 +2667,13 @@ export class TaskAgentManager {
 			workflowRunId,
 			workspacePath,
 			workflowNodeId: execution.workflowNodeId,
+		};
+
+		await this.attachSpaceToolsToWorkflowSubSession(agentSession, rehydrateCtx, 'rehydrate');
+
+		// Defensive guarantee — see ensureNodeAgentAttached docs.
+		await this.ensureNodeAgentAttached(agentSession, {
+			...rehydrateCtx,
 			phase: 'rehydrate',
 		});
 
@@ -3103,8 +3129,12 @@ export class TaskAgentManager {
 	 */
 	requiredWorkflowSubSessionMcpServers(): string[] {
 		return this.config.memoryRepo
-			? [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS, 'agent-memory']
-			: [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS];
+			? [
+					...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS,
+					'space-agent-tools',
+					'agent-memory',
+				]
+			: [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS, 'space-agent-tools'];
 	}
 
 	async ensureNodeAgentAttached(
@@ -3148,6 +3178,8 @@ export class TaskAgentManager {
 		for (const name of missing) {
 			if (name === 'node-agent') {
 				await this.reinjectNodeAgentMcpServer(session, ctx);
+			} else if (name === 'space-agent-tools') {
+				await this.attachSpaceToolsToWorkflowSubSession(session, ctx, ctx.phase);
 			} else if (name === 'agent-memory') {
 				await this.reinjectAgentMemoryMcpServer(session, ctx);
 			}
@@ -3368,6 +3400,35 @@ export class TaskAgentManager {
 		});
 
 		await session.restartQuery();
+	}
+
+	private async attachSpaceToolsToWorkflowSubSession(
+		session: AgentSession,
+		ctx: {
+			taskId: string;
+			subSessionId: string;
+			agentName: string;
+			spaceId: string;
+			workflowRunId: string;
+			workspacePath: string;
+			workflowNodeId: string;
+		},
+		phase: 'new' | 'reuse' | 'rehydrate' | 'spawn'
+	): Promise<void> {
+		try {
+			await this.reinjectSpaceAgentToolsMcpServer(session, ctx);
+			session.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
+				log.warn(
+					`Workflow sub-session ${ctx.subSessionId} missing Space MCP servers [${missing.join(', ')}]; re-attaching before query start`
+				);
+				await this.attachSpaceToolsToWorkflowSubSession(session, ctx, 'rehydrate');
+			};
+		} catch (err) {
+			log.error(
+				`Failed to attach space tools to ${phase} sub-session ${ctx.subSessionId} (space ${ctx.spaceId}):`,
+				err
+			);
+		}
 	}
 
 	/**

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -581,28 +581,54 @@ describe('QueryRunner', () => {
 			});
 		});
 
-		it('skips member Space MCP invariant for workflow sub-sessions', async () => {
+		it('self-heals missing member Space MCP for workflow sub-sessions', async () => {
 			await withAnthropicApiKey(async () => {
 				mockSession.id = 'space:s1:task:t1:exec:e1';
 				mockSession.workspacePath = tmpdir();
 				mockSession.type = 'worker';
 				mockSession.context = { spaceId: 's1', taskId: 't1' };
-				mockSession.config.mcpServers = {};
-				buildSpy.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} });
-				// Force early exit: make message generator throw so the query fails fast.
-				mockMessageQueue.messageGenerator = mock(async function* () {
-					throw new Error('generator abort for test');
-				});
+				const nodeAgentServer = {
+					type: 'sdk',
+					name: 'node-agent',
+					instance: {},
+				};
+				mockSession.config.mcpServers = {
+					'node-agent': nodeAgentServer,
+				} as unknown as Session['config']['mcpServers'];
 
-				const onMissingMemberSpaceMcpServers = mock(async () => {});
+				const repairedServers = {
+					'node-agent': nodeAgentServer,
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				buildSpy
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: { 'node-agent': nodeAgentServer },
+					})
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: repairedServers,
+					});
+				stopAfterRebuiltOptions();
+
+				const onMissingMemberSpaceMcpServers = mock(async () => {
+					mockSession.config.mcpServers =
+						repairedServers as unknown as Session['config']['mcpServers'];
+				});
 				const ctx = createContext({ onMissingMemberSpaceMcpServers });
 				runner = new QueryRunner(ctx);
 				runner.start();
 				await ctx.queryPromise?.catch(() => {});
 
-				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
-				expect(buildSpy).toHaveBeenCalledTimes(1);
-				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+				expect(onMissingMemberSpaceMcpServers).toHaveBeenCalledWith('space:s1:task:t1:exec:e1', [
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
 			});
 		});
 	});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 
@@ -29,6 +29,21 @@ function makeSession(mcpServers: Record<string, McpServerConfig>) {
 	};
 }
 
+function makeSpaceToolsManager(): TaskAgentManager {
+	return Object.create(TaskAgentManager.prototype, {
+		config: {
+			value: {},
+		},
+		reinjectSpaceAgentToolsMcpServer: {
+			value: mock(async (session) => {
+				session.mergeRuntimeMcpServers({
+					'space-agent-tools': { type: 'sdk' } as McpServerConfig,
+				});
+			}),
+		},
+	}) as TaskAgentManager;
+}
+
 describe('TaskAgentManager agent-memory MCP wiring', () => {
 	test('builds agent-memory server when memory repo is configured', () => {
 		const manager = makeManager({});
@@ -45,9 +60,13 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 	});
 
 	test('requires agent-memory only when memory repo is configured', () => {
-		expect(makeManager().requiredWorkflowSubSessionMcpServers()).toEqual(['node-agent']);
+		expect(makeManager().requiredWorkflowSubSessionMcpServers()).toEqual([
+			'node-agent',
+			'space-agent-tools',
+		]);
 		expect(makeManager({}).requiredWorkflowSubSessionMcpServers()).toEqual([
 			'node-agent',
+			'space-agent-tools',
 			'agent-memory',
 		]);
 	});
@@ -56,6 +75,7 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 		const manager = makeManager({});
 		const session = makeSession({
 			'node-agent': { type: 'sdk' } as McpServerConfig,
+			'space-agent-tools': { type: 'sdk' } as McpServerConfig,
 		});
 
 		await manager.ensureNodeAgentAttached(session as never, {
@@ -72,7 +92,32 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 		expect(Object.keys(session.session.config.mcpServers).sort()).toEqual([
 			'agent-memory',
 			'node-agent',
+			'space-agent-tools',
 		]);
 		expect(session.restartCount).toBe(1);
+	});
+
+	test('reattaches space-agent-tools and wires member self-heal callback', async () => {
+		const manager = makeSpaceToolsManager();
+		const session = makeSession({
+			'node-agent': { type: 'sdk' } as McpServerConfig,
+		});
+
+		await manager.ensureNodeAgentAttached(session as never, {
+			taskId: 'task-a',
+			subSessionId: 'session-a',
+			agentName: 'coder',
+			spaceId: 'space-a',
+			workflowRunId: 'run-a',
+			workspacePath: '/tmp/space-a',
+			workflowNodeId: 'node-a',
+			phase: 'rehydrate',
+		});
+
+		expect(Object.keys(session.session.config.mcpServers).sort()).toEqual([
+			'node-agent',
+			'space-agent-tools',
+		]);
+		expect(typeof session.onMissingMemberSpaceMcpServers).toBe('function');
 	});
 });


### PR DESCRIPTION
Fix worker sessions losing Space MCP tools after daemon restart.

- Attach specialised `space-agent-tools` during worker spawn, reuse, and rehydrate.
- Register member Space MCP self-heal for workflow sub-sessions.
- Cover workflow sub-session Space MCP recovery in unit tests.

Tested:
- `cd packages/daemon && bun test tests/unit/1-core/agent/query-runner.test.ts tests/unit/5-space/agent/task-agent-memory-mcp.test.ts`
- `bun run check`