### PR TITLE
chore(release): bump version to 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.27.1] - 2026-05-18
+
+### Fixed
+
+- Removed AppImage from Linux desktop release (unreliable linuxdeploy bundling); deb and rpm remain
+
 ## [0.27.0] - 2026-05-18
 
 A major release adding full-text message search, custom OpenAI-compatible endpoints, persistent agent memory, Space-native goals, and signed desktop release artifacts. 8 commits since v0.26.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/desktop",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"private": true,
 	"description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
 	"scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.27.0"
+version = "0.27.1"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Kai",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"identifier": "io.neokai.kai",
 	"build": {
 		"frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.27.0",
+	"version": "0.27.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Patch release to ship the AppImage removal fix.