### PR TITLE
Add Space actor registry adapter

### DIFF
--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -34,7 +34,7 @@ export class SpaceActorRegistryAdapter {
 		const actors = new Map<string, ActorRef>();
 		const sessions = this.repos.sessionRepo.getSessionsByIds(space.sessionIds);
 		for (const session of sessions.values()) {
-			if (!isHumanMemberSession(session, spaceId)) continue;
+			if (!isAdHocMemberSession(session)) continue;
 			this.add(actors, humanActorForSession(session, space));
 			const sessionActor = sessionActorForSession(session, spaceId);
 			if (sessionActor) this.add(actors, sessionActor);
@@ -57,8 +57,8 @@ export class SpaceActorRegistryAdapter {
 			}
 		}
 
-		for (const row of this.repos.pendingMessageRepo?.listAllPending() ?? []) {
-			if (row.spaceId !== spaceId || row.targetKind !== 'node_agent') continue;
+		for (const row of this.repos.pendingMessageRepo?.listPendingForSpace(spaceId) ?? []) {
+			if (row.targetKind !== 'node_agent') continue;
 			const run = this.repos.workflowRunRepo.getRun(row.workflowRunId);
 			const workflow = run
 				? (workflowById.get(run.workflowId) ?? this.repos.workflowRepo.getWorkflow(run.workflowId))
@@ -232,10 +232,6 @@ function encodeWorkerHandleSegment(value: string): string {
 function isSessionInSpace(session: Session, spaceId: string): boolean {
 	if (session.context?.spaceId === spaceId) return true;
 	return session.type === 'space_chat' && session.id === `space:chat:${spaceId}`;
-}
-
-function isHumanMemberSession(session: Session, spaceId: string): boolean {
-	return isSessionInSpace(session, spaceId) && isAdHocMemberSession(session);
 }
 
 function isAdHocMemberSession(session: Session): boolean {

--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -172,7 +172,7 @@ function agentActor(agent: SpaceAgent, handleCounts: Map<string, number>): Actor
 		kind: 'agent',
 		spaceId: agent.spaceId,
 		handle: `@${handleSlug}`,
-		roles: unique(['space-agent', slug]),
+		roles: unique(['space-agent', routableRole(slug)]),
 		status: 'active',
 	};
 }
@@ -183,7 +183,7 @@ function workerActorFromExecution(spaceId: string, execution: NodeExecution): Ac
 		kind: 'worker',
 		spaceId,
 		handle: workerHandle(execution.workflowRunId, execution.workflowNodeId, execution.agentName),
-		roles: unique([execution.agentName, execution.workflowNodeId]),
+		roles: unique([routableRole(execution.agentName), routableRole(execution.workflowNodeId)]),
 		status: statusFromNodeExecution(execution),
 	};
 }
@@ -204,7 +204,7 @@ function pendingWorkerActors(
 		kind: 'worker',
 		spaceId,
 		handle: workerHandle(workflowRunId, node.id, targetAgentName),
-		roles: unique([targetAgentName, node.id]),
+		roles: unique([routableRole(targetAgentName), routableRole(node.id)]),
 		status: 'inactive',
 	}));
 }
@@ -219,6 +219,20 @@ function workerHandle(workflowRunId: string, nodeId: string, agentName: string):
 
 function reservedHandles(): string[] {
 	return ['coordinator', ...SPACE_SYSTEM_ACTORS.map((actor) => actor.handle.slice(1))];
+}
+
+const RESERVED_ROLES = new Set([
+	'coordinator',
+	'member',
+	'member-session',
+	'runtime',
+	'workflow-runtime',
+	'messaging',
+	'space-agent',
+]);
+
+function routableRole(role: string): string {
+	return RESERVED_ROLES.has(role) ? `custom-${role}` : role;
 }
 
 function encodeActorIdComponent(value: string): string {
@@ -266,7 +280,7 @@ function strongerStatus(left: ActorStatus, right: ActorStatus): ActorStatus {
 	const rank: Record<ActorStatus, number> = {
 		active: 3,
 		inactive: 2,
-		archived: 1,
+		archived: 2,
 		deleted: 0,
 	};
 	return rank[right] > rank[left] ? right : left;

--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -172,7 +172,7 @@ function agentActor(agent: SpaceAgent, handleCounts: Map<string, number>): Actor
 		kind: 'agent',
 		spaceId: agent.spaceId,
 		handle: `@${handleSlug}`,
-		roles: unique(['space-agent', routableRole(slug)]),
+		roles: unique(['space-agent', routingRole(handleSlug)]),
 		status: 'active',
 	};
 }
@@ -183,7 +183,7 @@ function workerActorFromExecution(spaceId: string, execution: NodeExecution): Ac
 		kind: 'worker',
 		spaceId,
 		handle: workerHandle(execution.workflowRunId, execution.workflowNodeId, execution.agentName),
-		roles: unique([routableRole(execution.agentName), routableRole(execution.workflowNodeId)]),
+		roles: unique([routingRole(execution.agentName), routingRole(execution.workflowNodeId)]),
 		status: statusFromNodeExecution(execution),
 	};
 }
@@ -199,14 +199,17 @@ function pendingWorkerActors(
 		[];
 	if (nodes.length === 0) return [];
 
-	return nodes.map((node) => ({
-		actorId: workerActorId(workflowRunId, node.id, targetAgentName),
-		kind: 'worker',
-		spaceId,
-		handle: workerHandle(workflowRunId, node.id, targetAgentName),
-		roles: unique([routableRole(targetAgentName), routableRole(node.id)]),
-		status: 'inactive',
-	}));
+	const node = nodes[0];
+	return [
+		{
+			actorId: workerActorId(workflowRunId, node.id, targetAgentName),
+			kind: 'worker',
+			spaceId,
+			handle: workerHandle(workflowRunId, node.id, targetAgentName),
+			roles: unique([routingRole(targetAgentName), routingRole(node.id)]),
+			status: 'inactive',
+		},
+	];
 }
 
 function workerActorId(workflowRunId: string, nodeId: string, agentName: string): string {
@@ -221,18 +224,10 @@ function reservedHandles(): string[] {
 	return ['coordinator', ...SPACE_SYSTEM_ACTORS.map((actor) => actor.handle.slice(1))];
 }
 
-const RESERVED_ROLES = new Set([
-	'coordinator',
-	'member',
-	'member-session',
-	'runtime',
-	'workflow-runtime',
-	'messaging',
-	'space-agent',
-]);
+const ROUTING_ROLE_PREFIX = 'actor-role:';
 
-function routableRole(role: string): string {
-	return RESERVED_ROLES.has(role) ? `custom-${role}` : role;
+function routingRole(role: string): string {
+	return `${ROUTING_ROLE_PREFIX}${encodeURIComponent(role)}`;
 }
 
 function encodeActorIdComponent(value: string): string {

--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -94,13 +94,16 @@ export class SpaceActorRegistryAdapter {
 
 	private agentActors(spaceId: string): ActorRef[] {
 		const agents = this.repos.spaceAgentRepo.getBySpaceId(spaceId);
-		const slugCounts = new Map<string, number>();
+		const handleCounts = new Map<string, number>();
+		for (const handle of reservedHandles()) {
+			handleCounts.set(handle, 1);
+		}
 		for (const agent of agents) {
 			const slug = baseHandleSlug(agent.name, agent.id);
-			slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
+			handleCounts.set(slug, (handleCounts.get(slug) ?? 0) + 1);
 		}
 
-		return agents.map((agent) => agentActor(agent, slugCounts));
+		return agents.map((agent) => agentActor(agent, handleCounts));
 	}
 
 	private findCoordinatorSession(spaceId: string): Session | null {
@@ -131,7 +134,7 @@ function humanActorForSession(session: Session, space: Space): ActorRef {
 		actorId: `human:${session.id}`,
 		kind: 'human',
 		spaceId: space.id,
-		handle: session.id === `space:chat:${space.id}` ? '@human-coordinator' : undefined,
+		handle: undefined,
 		roles: ['member'],
 		status: statusFromSession(session),
 	};
@@ -161,11 +164,11 @@ function sessionActorForSession(session: Session, spaceId: string): ActorRef | n
 	};
 }
 
-function agentActor(agent: SpaceAgent, slugCounts: Map<string, number>): ActorRef {
+function agentActor(agent: SpaceAgent, handleCounts: Map<string, number>): ActorRef {
 	const slug = baseHandleSlug(agent.name, agent.id);
-	const handleSlug = slugCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
+	const handleSlug = handleCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
 	return {
-		actorId: `agent:${agent.id}`,
+		actorId: `agent:${encodeActorIdComponent(agent.id)}`,
 		kind: 'agent',
 		spaceId: agent.spaceId,
 		handle: `@${handleSlug}`,
@@ -207,11 +210,23 @@ function pendingWorkerActors(
 }
 
 function workerActorId(workflowRunId: string, nodeId: string, agentName: string): string {
-	return `worker:${workflowRunId}:${nodeId}:${agentName}`;
+	return `worker:${[workflowRunId, nodeId, agentName].map(encodeActorIdComponent).join(':')}`;
 }
 
 function workerHandle(workflowRunId: string, nodeId: string, agentName: string): string {
-	return `@worker:${workflowRunId}/${nodeId}/${agentName}`;
+	return `@worker:${encodeWorkerHandleSegment(workflowRunId)}/${encodeWorkerHandleSegment(nodeId)}/${encodeWorkerHandleSegment(agentName)}`;
+}
+
+function reservedHandles(): string[] {
+	return ['coordinator', ...SPACE_SYSTEM_ACTORS.map((actor) => actor.handle.slice(1))];
+}
+
+function encodeActorIdComponent(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function encodeWorkerHandleSegment(value: string): string {
+	return encodeURIComponent(value);
 }
 
 function isSessionInSpace(session: Session, spaceId: string): boolean {

--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -1,22 +1,24 @@
 import type { ActorRef, ActorStatus } from '../../../../messaging/src/types';
-import type { NodeExecution, Session, Space, SpaceAgent } from '@neokai/shared';
+import type { NodeExecution, Session, Space, SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import type { PendingAgentMessageRepository } from '../../storage/repositories/pending-agent-message-repository';
 import type { SessionRepository } from '../../storage/repositories/session-repository';
 import type { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import type { SpaceRepository } from '../../storage/repositories/space-repository';
+import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 
 export const SPACE_SYSTEM_ACTORS = [
-	{ actorId: 'system:runtime', handle: '@system:runtime', roles: ['runtime'] },
-	{ actorId: 'system:workflow', handle: '@system:workflow', roles: ['workflow-runtime'] },
-	{ actorId: 'system:messaging', handle: '@system:messaging', roles: ['messaging'] },
+	{ actorId: 'system:runtime', handle: '@system-runtime', roles: ['runtime'] },
+	{ actorId: 'system:workflow', handle: '@system-workflow', roles: ['workflow-runtime'] },
+	{ actorId: 'system:messaging', handle: '@system-messaging', roles: ['messaging'] },
 ] as const;
 
 export interface SpaceActorRegistryRepositories {
 	spaceRepo: SpaceRepository;
 	sessionRepo: SessionRepository;
 	spaceAgentRepo: SpaceAgentRepository;
+	workflowRepo: SpaceWorkflowRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	nodeExecutionRepo: NodeExecutionRepository;
 	pendingMessageRepo?: PendingAgentMessageRepository;
@@ -32,7 +34,7 @@ export class SpaceActorRegistryAdapter {
 		const actors = new Map<string, ActorRef>();
 		const sessions = this.repos.sessionRepo.getSessionsByIds(space.sessionIds);
 		for (const session of sessions.values()) {
-			if (!isSessionInSpace(session, spaceId)) continue;
+			if (!isHumanMemberSession(session, spaceId)) continue;
 			this.add(actors, humanActorForSession(session, space));
 			const sessionActor = sessionActorForSession(session, spaceId);
 			if (sessionActor) this.add(actors, sessionActor);
@@ -40,11 +42,16 @@ export class SpaceActorRegistryAdapter {
 
 		this.add(actors, coordinatorActor(space, this.findCoordinatorSession(spaceId)));
 
-		for (const agent of this.repos.spaceAgentRepo.getBySpaceId(spaceId)) {
-			this.add(actors, agentActor(agent));
+		for (const actor of this.agentActors(spaceId)) {
+			this.add(actors, actor);
 		}
 
+		const workflowById = new Map<string, SpaceWorkflow>();
 		for (const run of this.repos.workflowRunRepo.listBySpace(spaceId)) {
+			const workflow =
+				workflowById.get(run.workflowId) ?? this.repos.workflowRepo.getWorkflow(run.workflowId);
+			if (workflow) workflowById.set(workflow.id, workflow);
+
 			for (const execution of this.repos.nodeExecutionRepo.listByWorkflowRun(run.id)) {
 				this.add(actors, workerActorFromExecution(spaceId, execution));
 			}
@@ -52,15 +59,19 @@ export class SpaceActorRegistryAdapter {
 
 		for (const row of this.repos.pendingMessageRepo?.listAllPending() ?? []) {
 			if (row.spaceId !== spaceId || row.targetKind !== 'node_agent') continue;
-			const actorId = workerActorId(row.workflowRunId, row.targetAgentName, row.targetAgentName);
-			this.add(actors, {
-				actorId,
-				kind: 'worker',
+			const run = this.repos.workflowRunRepo.getRun(row.workflowRunId);
+			const workflow = run
+				? (workflowById.get(run.workflowId) ?? this.repos.workflowRepo.getWorkflow(run.workflowId))
+				: null;
+			if (workflow) workflowById.set(workflow.id, workflow);
+			for (const worker of pendingWorkerActors(
 				spaceId,
-				handle: workerHandle(row.workflowRunId, row.targetAgentName, row.targetAgentName),
-				roles: [row.targetAgentName],
-				status: 'inactive',
-			});
+				row.workflowRunId,
+				row.targetAgentName,
+				workflow
+			)) {
+				this.add(actors, worker);
+			}
 		}
 
 		for (const systemActor of SPACE_SYSTEM_ACTORS) {
@@ -79,6 +90,17 @@ export class SpaceActorRegistryAdapter {
 
 	getActor(spaceId: string, actorId: string): ActorRef | undefined {
 		return this.listActors(spaceId).find((actor) => actor.actorId === actorId);
+	}
+
+	private agentActors(spaceId: string): ActorRef[] {
+		const agents = this.repos.spaceAgentRepo.getBySpaceId(spaceId);
+		const slugCounts = new Map<string, number>();
+		for (const agent of agents) {
+			const slug = baseHandleSlug(agent.name, agent.id);
+			slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
+		}
+
+		return agents.map((agent) => agentActor(agent, slugCounts));
 	}
 
 	private findCoordinatorSession(spaceId: string): Session | null {
@@ -109,7 +131,7 @@ function humanActorForSession(session: Session, space: Space): ActorRef {
 		actorId: `human:${session.id}`,
 		kind: 'human',
 		spaceId: space.id,
-		handle: session.id === `space:chat:${space.id}` ? '@human:coordinator' : `@human:${session.id}`,
+		handle: session.id === `space:chat:${space.id}` ? '@human-coordinator' : undefined,
 		roles: ['member'],
 		status: statusFromSession(session),
 	};
@@ -139,13 +161,15 @@ function sessionActorForSession(session: Session, spaceId: string): ActorRef | n
 	};
 }
 
-function agentActor(agent: SpaceAgent): ActorRef {
+function agentActor(agent: SpaceAgent, slugCounts: Map<string, number>): ActorRef {
+	const slug = baseHandleSlug(agent.name, agent.id);
+	const handleSlug = slugCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
 	return {
 		actorId: `agent:${agent.id}`,
 		kind: 'agent',
 		spaceId: agent.spaceId,
-		handle: `@${handleSlug(agent.name)}`,
-		roles: unique(['space-agent', handleSlug(agent.name)]),
+		handle: `@${handleSlug}`,
+		roles: unique(['space-agent', slug]),
 		status: 'active',
 	};
 }
@@ -161,6 +185,27 @@ function workerActorFromExecution(spaceId: string, execution: NodeExecution): Ac
 	};
 }
 
+function pendingWorkerActors(
+	spaceId: string,
+	workflowRunId: string,
+	targetAgentName: string,
+	workflow: SpaceWorkflow | null
+): ActorRef[] {
+	const nodes =
+		workflow?.nodes.filter((node) => node.agents.some((agent) => agent.name === targetAgentName)) ??
+		[];
+	if (nodes.length === 0) return [];
+
+	return nodes.map((node) => ({
+		actorId: workerActorId(workflowRunId, node.id, targetAgentName),
+		kind: 'worker',
+		spaceId,
+		handle: workerHandle(workflowRunId, node.id, targetAgentName),
+		roles: unique([targetAgentName, node.id]),
+		status: 'inactive',
+	}));
+}
+
 function workerActorId(workflowRunId: string, nodeId: string, agentName: string): string {
 	return `worker:${workflowRunId}:${nodeId}:${agentName}`;
 }
@@ -172,6 +217,10 @@ function workerHandle(workflowRunId: string, nodeId: string, agentName: string):
 function isSessionInSpace(session: Session, spaceId: string): boolean {
 	if (session.context?.spaceId === spaceId) return true;
 	return session.type === 'space_chat' && session.id === `space:chat:${spaceId}`;
+}
+
+function isHumanMemberSession(session: Session, spaceId: string): boolean {
+	return isSessionInSpace(session, spaceId) && isAdHocMemberSession(session);
 }
 
 function isAdHocMemberSession(session: Session): boolean {
@@ -220,10 +269,15 @@ function unique(values: string[]): string[] {
 	return [...new Set(values)].sort();
 }
 
-function handleSlug(value: string): string {
-	return value
+function baseHandleSlug(name: string, id: string): string {
+	const slug = name
 		.trim()
 		.toLowerCase()
 		.replace(/[^a-z0-9_-]+/g, '-')
 		.replace(/^-+|-+$/g, '');
+	return slug || `agent-${shortId(id)}`;
+}
+
+function shortId(id: string): string {
+	return id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 8) || 'unknown';
 }

--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -1,0 +1,229 @@
+import type { ActorRef, ActorStatus } from '../../../../messaging/src/types';
+import type { NodeExecution, Session, Space, SpaceAgent } from '@neokai/shared';
+import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
+import type { PendingAgentMessageRepository } from '../../storage/repositories/pending-agent-message-repository';
+import type { SessionRepository } from '../../storage/repositories/session-repository';
+import type { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
+import type { SpaceRepository } from '../../storage/repositories/space-repository';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+
+export const SPACE_SYSTEM_ACTORS = [
+	{ actorId: 'system:runtime', handle: '@system:runtime', roles: ['runtime'] },
+	{ actorId: 'system:workflow', handle: '@system:workflow', roles: ['workflow-runtime'] },
+	{ actorId: 'system:messaging', handle: '@system:messaging', roles: ['messaging'] },
+] as const;
+
+export interface SpaceActorRegistryRepositories {
+	spaceRepo: SpaceRepository;
+	sessionRepo: SessionRepository;
+	spaceAgentRepo: SpaceAgentRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
+	pendingMessageRepo?: PendingAgentMessageRepository;
+}
+
+export class SpaceActorRegistryAdapter {
+	constructor(private readonly repos: SpaceActorRegistryRepositories) {}
+
+	listActors(spaceId: string): ActorRef[] {
+		const space = this.repos.spaceRepo.getSpace(spaceId);
+		if (!space) return [];
+
+		const actors = new Map<string, ActorRef>();
+		const sessions = this.repos.sessionRepo.getSessionsByIds(space.sessionIds);
+		for (const session of sessions.values()) {
+			if (!isSessionInSpace(session, spaceId)) continue;
+			this.add(actors, humanActorForSession(session, space));
+			const sessionActor = sessionActorForSession(session, spaceId);
+			if (sessionActor) this.add(actors, sessionActor);
+		}
+
+		this.add(actors, coordinatorActor(space, this.findCoordinatorSession(spaceId)));
+
+		for (const agent of this.repos.spaceAgentRepo.getBySpaceId(spaceId)) {
+			this.add(actors, agentActor(agent));
+		}
+
+		for (const run of this.repos.workflowRunRepo.listBySpace(spaceId)) {
+			for (const execution of this.repos.nodeExecutionRepo.listByWorkflowRun(run.id)) {
+				this.add(actors, workerActorFromExecution(spaceId, execution));
+			}
+		}
+
+		for (const row of this.repos.pendingMessageRepo?.listAllPending() ?? []) {
+			if (row.spaceId !== spaceId || row.targetKind !== 'node_agent') continue;
+			const actorId = workerActorId(row.workflowRunId, row.targetAgentName, row.targetAgentName);
+			this.add(actors, {
+				actorId,
+				kind: 'worker',
+				spaceId,
+				handle: workerHandle(row.workflowRunId, row.targetAgentName, row.targetAgentName),
+				roles: [row.targetAgentName],
+				status: 'inactive',
+			});
+		}
+
+		for (const systemActor of SPACE_SYSTEM_ACTORS) {
+			this.add(actors, {
+				actorId: systemActor.actorId,
+				kind: 'system',
+				spaceId,
+				handle: systemActor.handle,
+				roles: [...systemActor.roles],
+				status: 'active',
+			});
+		}
+
+		return [...actors.values()].sort(compareActors);
+	}
+
+	getActor(spaceId: string, actorId: string): ActorRef | undefined {
+		return this.listActors(spaceId).find((actor) => actor.actorId === actorId);
+	}
+
+	private findCoordinatorSession(spaceId: string): Session | null {
+		const canonicalId = `space:chat:${spaceId}`;
+		const canonical = this.repos.sessionRepo.getSession(canonicalId);
+		if (canonical && isSessionInSpace(canonical, spaceId)) return canonical;
+
+		return (
+			this.repos.sessionRepo
+				.listSessionsByType('space_chat')
+				.find((session) => isSessionInSpace(session, spaceId)) ?? null
+		);
+	}
+
+	private add(actors: Map<string, ActorRef>, actor: ActorRef): void {
+		const existing = actors.get(actor.actorId);
+		if (!existing) {
+			actors.set(actor.actorId, actor);
+			return;
+		}
+
+		actors.set(actor.actorId, mergeActorRefs(existing, actor));
+	}
+}
+
+function humanActorForSession(session: Session, space: Space): ActorRef {
+	return {
+		actorId: `human:${session.id}`,
+		kind: 'human',
+		spaceId: space.id,
+		handle: session.id === `space:chat:${space.id}` ? '@human:coordinator' : `@human:${session.id}`,
+		roles: ['member'],
+		status: statusFromSession(session),
+	};
+}
+
+function coordinatorActor(space: Space, session: Session | null): ActorRef {
+	return {
+		actorId: `agent:coordinator:${space.id}`,
+		kind: 'agent',
+		spaceId: space.id,
+		handle: '@coordinator',
+		roles: ['coordinator', 'space-agent'],
+		status: session ? statusFromSession(session) : 'inactive',
+	};
+}
+
+function sessionActorForSession(session: Session, spaceId: string): ActorRef | null {
+	if (!isAdHocMemberSession(session)) return null;
+
+	return {
+		actorId: `session:${session.id}`,
+		kind: 'session',
+		spaceId,
+		handle: `@session:${session.id}`,
+		roles: ['member-session'],
+		status: statusFromSession(session),
+	};
+}
+
+function agentActor(agent: SpaceAgent): ActorRef {
+	return {
+		actorId: `agent:${agent.id}`,
+		kind: 'agent',
+		spaceId: agent.spaceId,
+		handle: `@${handleSlug(agent.name)}`,
+		roles: unique(['space-agent', handleSlug(agent.name)]),
+		status: 'active',
+	};
+}
+
+function workerActorFromExecution(spaceId: string, execution: NodeExecution): ActorRef {
+	return {
+		actorId: workerActorId(execution.workflowRunId, execution.workflowNodeId, execution.agentName),
+		kind: 'worker',
+		spaceId,
+		handle: workerHandle(execution.workflowRunId, execution.workflowNodeId, execution.agentName),
+		roles: unique([execution.agentName, execution.workflowNodeId]),
+		status: statusFromNodeExecution(execution),
+	};
+}
+
+function workerActorId(workflowRunId: string, nodeId: string, agentName: string): string {
+	return `worker:${workflowRunId}:${nodeId}:${agentName}`;
+}
+
+function workerHandle(workflowRunId: string, nodeId: string, agentName: string): string {
+	return `@worker:${workflowRunId}/${nodeId}/${agentName}`;
+}
+
+function isSessionInSpace(session: Session, spaceId: string): boolean {
+	if (session.context?.spaceId === spaceId) return true;
+	return session.type === 'space_chat' && session.id === `space:chat:${spaceId}`;
+}
+
+function isAdHocMemberSession(session: Session): boolean {
+	if (session.type === 'space_chat' || session.type === 'space_task_agent') return false;
+	if (session.id.includes(':task:') && session.id.includes(':exec:')) return false;
+	if (session.metadata.promptProvenance?.workflowRunId) return false;
+	return true;
+}
+
+function statusFromSession(session: Session): ActorStatus {
+	if (session.status === 'archived') return 'archived';
+	if (session.status === 'active') return 'active';
+	return 'inactive';
+}
+
+function statusFromNodeExecution(execution: NodeExecution): ActorStatus {
+	if (execution.status === 'cancelled') return 'archived';
+	if (execution.status === 'in_progress' || execution.status === 'waiting_rebind') return 'active';
+	return 'inactive';
+}
+
+function mergeActorRefs(left: ActorRef, right: ActorRef): ActorRef {
+	return {
+		...left,
+		handle: left.handle ?? right.handle,
+		roles: unique([...(left.roles ?? []), ...(right.roles ?? [])]),
+		status: strongerStatus(left.status, right.status),
+	};
+}
+
+function strongerStatus(left: ActorStatus, right: ActorStatus): ActorStatus {
+	const rank: Record<ActorStatus, number> = {
+		active: 3,
+		inactive: 2,
+		archived: 1,
+		deleted: 0,
+	};
+	return rank[right] > rank[left] ? right : left;
+}
+
+function compareActors(left: ActorRef, right: ActorRef): number {
+	return left.kind.localeCompare(right.kind) || left.actorId.localeCompare(right.actorId);
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)].sort();
+}
+
+function handleSlug(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -37,6 +37,8 @@ export type { SpaceAgentNotificationServiceConfig } from './runtime/space-agent-
 export type { SessionFactory } from './runtime/types';
 export { TaskAgentManager } from './runtime/task-agent-manager';
 export type { TaskAgentManagerConfig } from './runtime/task-agent-manager';
+export { SpaceActorRegistryAdapter, SPACE_SYSTEM_ACTORS } from './actor-registry';
+export type { SpaceActorRegistryRepositories } from './actor-registry';
 
 export { selectWorkflow } from './runtime/workflow-selector';
 export type { WorkflowSelectionContext } from './runtime/workflow-selector';

--- a/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
@@ -217,6 +217,18 @@ export class PendingAgentMessageRepository {
 		return rows.map(rowToRecord);
 	}
 
+	/** List pending rows for a space, oldest first. Used by space-scoped actor registry lookups. */
+	listPendingForSpace(spaceId: string): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE space_id = ? AND status = 'pending'
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all(spaceId) as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+
 	/** List all pending rows across every run, oldest first. Used by the global sweeper. */
 	listAllPending(): PendingAgentMessageRecord[] {
 		const rows = this.db

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -635,6 +635,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 134: Add FTS5-backed message and Space task search.
 	runMigration134(db);
+
+	// Migration 135: Add space-scoped pending message lookup index for actor registry.
+	runMigration135(db);
 }
 
 /**
@@ -6630,10 +6633,6 @@ export function runMigration92(db: BunDatabase): void {
 			`ON pending_agent_messages(workflow_run_id, status, created_at)`
 	);
 	db.exec(
-		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_space_status ` +
-			`ON pending_agent_messages(space_id, status, created_at)`
-	);
-	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_target ` +
 			`ON pending_agent_messages(workflow_run_id, target_agent_name, status, created_at)`
 	);
@@ -9331,6 +9330,18 @@ function createAgentMemoryTables(db: BunDatabase): void {
 	if (shouldRebuildFts) {
 		db.exec(`INSERT INTO space_agent_memory_fts(space_agent_memory_fts) VALUES ('rebuild')`);
 	}
+}
+
+/**
+ * Migration 135: Add space-scoped pending message lookup index for actor registry.
+ */
+export function runMigration135(db: BunDatabase): void {
+	if (!tableExists(db, 'pending_agent_messages')) return;
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_space_status ` +
+			`ON pending_agent_messages(space_id, status, created_at)`
+	);
 }
 
 function migrateNeoMessageOrigins(db: BunDatabase): void {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -6630,6 +6630,10 @@ export function runMigration92(db: BunDatabase): void {
 			`ON pending_agent_messages(workflow_run_id, status, created_at)`
 	);
 	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_space_status ` +
+			`ON pending_agent_messages(space_id, status, created_at)`
+	);
+	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_target ` +
 			`ON pending_agent_messages(workflow_run_id, target_agent_name, status, created_at)`
 	);

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -108,6 +108,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			name: 'Project',
 		});
 		const member = makeSession('member-1', { context: { spaceId: space.id } });
+		const legacyMember = makeSession('legacy-member');
 		const coordinator = makeSession(`space:chat:${space.id}`, {
 			type: 'space_chat',
 			context: { spaceId: space.id },
@@ -132,11 +133,13 @@ describe('SpaceActorRegistryAdapter', () => {
 			},
 		});
 		sessionRepo.createSession(member);
+		sessionRepo.createSession(legacyMember);
 		sessionRepo.createSession(coordinator);
 		sessionRepo.createSession(taskAgent);
 		sessionRepo.createSession(workerSubSession);
 		sessionRepo.createSession(namedAgentSubSession);
 		spaceRepo.addSessionToSpace(space.id, member.id);
+		spaceRepo.addSessionToSpace(space.id, legacyMember.id);
 		spaceRepo.addSessionToSpace(space.id, coordinator.id);
 		spaceRepo.addSessionToSpace(space.id, taskAgent.id);
 		spaceRepo.addSessionToSpace(space.id, workerSubSession.id);
@@ -206,6 +209,22 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'session',
 			spaceId: space.id,
 			handle: `@session:${member.id}`,
+			roles: ['member-session'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `human:${legacyMember.id}`,
+			kind: 'human',
+			spaceId: space.id,
+			handle: undefined,
+			roles: ['member'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `session:${legacyMember.id}`,
+			kind: 'session',
+			spaceId: space.id,
+			handle: `@session:${legacyMember.id}`,
 			roles: ['member-session'],
 			status: 'active',
 		});

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -167,6 +167,11 @@ describe('SpaceActorRegistryAdapter', () => {
 					name: 'Review/QA',
 					agents: [{ agentId: agent.id, name: 'reviewer:lead' }],
 				},
+				{
+					id: 'coordinator',
+					name: 'Coordinator Worker',
+					agents: [{ agentId: agent.id, name: 'messaging' }],
+				},
 			],
 			transitions: [],
 			startNodeId: 'Coding',
@@ -186,12 +191,27 @@ describe('SpaceActorRegistryAdapter', () => {
 			agentSessionId: workerSubSession.id,
 			status: 'in_progress',
 		});
+		nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'coordinator',
+			agentName: 'messaging',
+			agentId: agent.id,
+			agentSessionId: null,
+			status: 'cancelled',
+		});
 		pendingMessageRepo.enqueue({
 			workflowRunId: run.id,
 			spaceId: space.id,
 			targetKind: 'node_agent',
 			targetAgentName: 'reviewer:lead',
 			message: 'review this',
+		});
+		pendingMessageRepo.enqueue({
+			workflowRunId: run.id,
+			spaceId: space.id,
+			targetKind: 'node_agent',
+			targetAgentName: 'messaging',
+			message: 'message cancelled worker',
 		});
 
 		const actors = registry.listActors(space.id);
@@ -249,7 +269,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'agent',
 			spaceId: space.id,
 			handle: `@coordinator-${reservedNameAgent.id.slice(0, 8)}`,
-			roles: ['coordinator', 'space-agent'],
+			roles: ['custom-coordinator', 'space-agent'],
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
@@ -267,6 +287,14 @@ describe('SpaceActorRegistryAdapter', () => {
 			handle: `@worker:${encodeURIComponent(run.id)}/Review%2FQA/reviewer%3Alead`,
 			roles: ['Review/QA', 'reviewer:lead'],
 			status: 'inactive',
+		});
+		expect(actors).toContainEqual({
+			actorId: `worker:${encodeURIComponent(run.id)}:coordinator:messaging`,
+			kind: 'worker',
+			spaceId: space.id,
+			handle: `@worker:${encodeURIComponent(run.id)}/coordinator/messaging`,
+			roles: ['custom-coordinator', 'custom-messaging'],
+			status: 'archived',
 		});
 		expect(actors.some((actor) => actor.actorId === `worker:${run.id}:reviewer:reviewer`)).toBe(
 			false

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
+import { parseAddress } from '../../../../messaging/src/address';
 import { SpaceActorRegistryAdapter } from '../../../src/lib/space/actor-registry';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
 import { PendingAgentMessageRepository } from '../../../src/storage/repositories/pending-agent-message-repository';
@@ -89,6 +90,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			spaceRepo,
 			sessionRepo,
 			spaceAgentRepo,
+			workflowRepo,
 			workflowRunRepo,
 			nodeExecutionRepo,
 			pendingMessageRepo,
@@ -133,7 +135,18 @@ describe('SpaceActorRegistryAdapter', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: space.id,
 			name: 'Coding Workflow',
-			nodes: [],
+			nodes: [
+				{
+					id: 'Coding',
+					name: 'Coding',
+					agents: [{ agentId: agent.id, name: 'coder' }],
+				},
+				{
+					id: 'Review',
+					name: 'Review',
+					agents: [{ agentId: agent.id, name: 'reviewer' }],
+				},
+			],
 			transitions: [],
 			startNodeId: 'Coding',
 			rules: [],
@@ -166,7 +179,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			actorId: `human:${member.id}`,
 			kind: 'human',
 			spaceId: space.id,
-			handle: `@human:${member.id}`,
+			handle: undefined,
 			roles: ['member'],
 			status: 'active',
 		});
@@ -203,24 +216,58 @@ describe('SpaceActorRegistryAdapter', () => {
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
-			actorId: `worker:${run.id}:reviewer:reviewer`,
+			actorId: `worker:${run.id}:Review:reviewer`,
 			kind: 'worker',
 			spaceId: space.id,
-			handle: `@worker:${run.id}/reviewer/reviewer`,
-			roles: ['reviewer'],
+			handle: `@worker:${run.id}/Review/reviewer`,
+			roles: ['Review', 'reviewer'],
 			status: 'inactive',
 		});
+		expect(actors.some((actor) => actor.actorId === `worker:${run.id}:reviewer:reviewer`)).toBe(
+			false
+		);
 		expect(actors).toContainEqual({
 			actorId: 'system:runtime',
 			kind: 'system',
 			spaceId: space.id,
-			handle: '@system:runtime',
+			handle: '@system-runtime',
 			roles: ['runtime'],
 			status: 'active',
 		});
 		expect(actors.some((actor) => actor.actorId === `session:${coordinator.id}`)).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `session:${taskAgent.id}`)).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `session:${workerSubSession.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `human:${taskAgent.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `human:${workerSubSession.id}`)).toBe(false);
+		for (const actor of actors) {
+			if (actor.handle) expect(() => parseAddress(actor.handle!)).not.toThrow();
+		}
+	});
+
+	it('uses fallback and collision-safe handles for slug-derived agent handles', () => {
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/project',
+			slug: 'project',
+			name: 'Project',
+		});
+		const first = spaceAgentRepo.create({ spaceId: space.id, name: 'A-B' });
+		const second = spaceAgentRepo.create({ spaceId: space.id, name: 'A B' });
+		const cjk = spaceAgentRepo.create({ spaceId: space.id, name: '助手' });
+
+		const actors = registry.listActors(space.id);
+
+		expect(registry.getActor(space.id, `agent:${first.id}`)?.handle).toBe(
+			`@a-b-${first.id.slice(0, 8)}`
+		);
+		expect(registry.getActor(space.id, `agent:${second.id}`)?.handle).toBe(
+			`@a-b-${second.id.slice(0, 8)}`
+		);
+		expect(registry.getActor(space.id, `agent:${cjk.id}`)?.handle).toBe(
+			`@agent-${cjk.id.slice(0, 8)}`
+		);
+		for (const actor of actors) {
+			if (actor.handle) expect(() => parseAddress(actor.handle!)).not.toThrow();
+		}
 	});
 
 	it('returns inactive coordinator when no space chat session exists', () => {

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -172,6 +172,11 @@ describe('SpaceActorRegistryAdapter', () => {
 					name: 'Coordinator Worker',
 					agents: [{ agentId: agent.id, name: 'messaging' }],
 				},
+				{
+					id: 'OtherReview',
+					name: 'Other Review',
+					agents: [{ agentId: agent.id, name: 'reviewer:lead' }],
+				},
 			],
 			transitions: [],
 			startNodeId: 'Coding',
@@ -261,7 +266,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'agent',
 			spaceId: space.id,
 			handle: '@long-term-agent',
-			roles: ['long-term-agent', 'space-agent'],
+			roles: ['actor-role:long-term-agent', 'space-agent'],
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
@@ -269,7 +274,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'agent',
 			spaceId: space.id,
 			handle: `@coordinator-${reservedNameAgent.id.slice(0, 8)}`,
-			roles: ['custom-coordinator', 'space-agent'],
+			roles: [`actor-role:coordinator-${reservedNameAgent.id.slice(0, 8)}`, 'space-agent'],
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
@@ -277,7 +282,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'worker',
 			spaceId: space.id,
 			handle: `@worker:${encodeURIComponent(run.id)}/Coding%3ANode/coder%2Flead`,
-			roles: ['Coding:Node', 'coder/lead'],
+			roles: ['actor-role:Coding%3ANode', 'actor-role:coder%2Flead'],
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
@@ -285,7 +290,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'worker',
 			spaceId: space.id,
 			handle: `@worker:${encodeURIComponent(run.id)}/Review%2FQA/reviewer%3Alead`,
-			roles: ['Review/QA', 'reviewer:lead'],
+			roles: ['actor-role:Review%2FQA', 'actor-role:reviewer%3Alead'],
 			status: 'inactive',
 		});
 		expect(actors).toContainEqual({
@@ -293,9 +298,15 @@ describe('SpaceActorRegistryAdapter', () => {
 			kind: 'worker',
 			spaceId: space.id,
 			handle: `@worker:${encodeURIComponent(run.id)}/coordinator/messaging`,
-			roles: ['custom-coordinator', 'custom-messaging'],
+			roles: ['actor-role:coordinator', 'actor-role:messaging'],
 			status: 'archived',
 		});
+		expect(
+			actors.some(
+				(actor) =>
+					actor.actorId === `worker:${encodeURIComponent(run.id)}:OtherReview:reviewer%3Alead`
+			)
+		).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `worker:${run.id}:reviewer:reviewer`)).toBe(
 			false
 		);
@@ -331,6 +342,7 @@ describe('SpaceActorRegistryAdapter', () => {
 		});
 		const first = spaceAgentRepo.create({ spaceId: space.id, name: 'A-B' });
 		const second = spaceAgentRepo.create({ spaceId: space.id, name: 'A B' });
+		const prefixed = spaceAgentRepo.create({ spaceId: space.id, name: 'custom-coordinator' });
 		const cjk = spaceAgentRepo.create({ spaceId: space.id, name: '助手' });
 
 		const actors = registry.listActors(space.id);
@@ -341,6 +353,18 @@ describe('SpaceActorRegistryAdapter', () => {
 		expect(registry.getActor(space.id, `agent:${second.id}`)?.handle).toBe(
 			`@a-b-${second.id.slice(0, 8)}`
 		);
+		expect(registry.getActor(space.id, `agent:${first.id}`)?.roles).toEqual([
+			`actor-role:a-b-${first.id.slice(0, 8)}`,
+			'space-agent',
+		]);
+		expect(registry.getActor(space.id, `agent:${second.id}`)?.roles).toEqual([
+			`actor-role:a-b-${second.id.slice(0, 8)}`,
+			'space-agent',
+		]);
+		expect(registry.getActor(space.id, `agent:${prefixed.id}`)?.roles).toEqual([
+			'actor-role:custom-coordinator',
+			'space-agent',
+		]);
 		expect(registry.getActor(space.id, `agent:${cjk.id}`)?.handle).toBe(
 			`@agent-${cjk.id.slice(0, 8)}`
 		);

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceActorRegistryAdapter } from '../../../src/lib/space/actor-registry';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
+import { PendingAgentMessageRepository } from '../../../src/storage/repositories/pending-agent-message-repository';
+import { SessionRepository } from '../../../src/storage/repositories/session-repository';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import type { Session } from '@neokai/shared';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+function alignTestSchema(db: Database): void {
+	db.exec('ALTER TABLE space_agents ADD COLUMN custom_prompt TEXT DEFAULT NULL');
+	db.exec('DROP TABLE sessions');
+	db.exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			workspace_path TEXT,
+			created_at TEXT NOT NULL,
+			last_active_at TEXT NOT NULL,
+			status TEXT NOT NULL CHECK(status IN ('active', 'paused', 'ended', 'archived', 'pending_worktree_choice')),
+			config TEXT NOT NULL,
+			metadata TEXT NOT NULL,
+			is_worktree INTEGER DEFAULT 0,
+			worktree_path TEXT,
+			main_repo_path TEXT,
+			worktree_branch TEXT,
+			git_branch TEXT,
+			sdk_session_id TEXT,
+			sdk_origin_path TEXT,
+			available_commands TEXT,
+			processing_state TEXT,
+			archived_at TEXT,
+			type TEXT DEFAULT 'worker',
+			session_context TEXT
+		)
+	`);
+}
+
+function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+	return {
+		id,
+		title: id,
+		workspacePath: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		lastActiveAt: '2026-01-01T00:00:00.000Z',
+		status: 'active',
+		config: {},
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+		},
+		type: 'worker',
+		context: undefined,
+		...overrides,
+	};
+}
+
+describe('SpaceActorRegistryAdapter', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let sessionRepo: SessionRepository;
+	let spaceAgentRepo: SpaceAgentRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let nodeExecutionRepo: NodeExecutionRepository;
+	let pendingMessageRepo: PendingAgentMessageRepository;
+	let registry: SpaceActorRegistryAdapter;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		alignTestSchema(db);
+		spaceRepo = new SpaceRepository(db);
+		sessionRepo = new SessionRepository(db);
+		spaceAgentRepo = new SpaceAgentRepository(db);
+		workflowRepo = new SpaceWorkflowRepository(db);
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+		pendingMessageRepo = new PendingAgentMessageRepository(db);
+		registry = new SpaceActorRegistryAdapter({
+			spaceRepo,
+			sessionRepo,
+			spaceAgentRepo,
+			workflowRunRepo,
+			nodeExecutionRepo,
+			pendingMessageRepo,
+		});
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('seeds humans, coordinator, ad-hoc sessions, agents, workers, pending workers, and systems', () => {
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/project',
+			slug: 'project',
+			name: 'Project',
+		});
+		const member = makeSession('member-1', { context: { spaceId: space.id } });
+		const coordinator = makeSession(`space:chat:${space.id}`, {
+			type: 'space_chat',
+			context: { spaceId: space.id },
+		});
+		const taskAgent = makeSession('task-agent-1', {
+			type: 'space_task_agent',
+			context: { spaceId: space.id },
+		});
+		const workerSubSession = makeSession('space:task:t1:exec:e1', {
+			context: { spaceId: space.id },
+		});
+		sessionRepo.createSession(member);
+		sessionRepo.createSession(coordinator);
+		sessionRepo.createSession(taskAgent);
+		sessionRepo.createSession(workerSubSession);
+		spaceRepo.addSessionToSpace(space.id, member.id);
+		spaceRepo.addSessionToSpace(space.id, coordinator.id);
+		spaceRepo.addSessionToSpace(space.id, taskAgent.id);
+		spaceRepo.addSessionToSpace(space.id, workerSubSession.id);
+
+		const agent = spaceAgentRepo.create({
+			spaceId: space.id,
+			name: 'Long Term Agent',
+		});
+		const workflow = workflowRepo.createWorkflow({
+			spaceId: space.id,
+			name: 'Coding Workflow',
+			nodes: [],
+			transitions: [],
+			startNodeId: 'Coding',
+			rules: [],
+			completionAutonomyLevel: 3,
+		});
+		const run = workflowRunRepo.createRun({
+			spaceId: space.id,
+			workflowId: workflow.id,
+			title: 'Run',
+		});
+		nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'Coding',
+			agentName: 'coder',
+			agentId: agent.id,
+			agentSessionId: workerSubSession.id,
+			status: 'in_progress',
+		});
+		pendingMessageRepo.enqueue({
+			workflowRunId: run.id,
+			spaceId: space.id,
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'review this',
+		});
+
+		const actors = registry.listActors(space.id);
+
+		expect(actors).toContainEqual({
+			actorId: `human:${member.id}`,
+			kind: 'human',
+			spaceId: space.id,
+			handle: `@human:${member.id}`,
+			roles: ['member'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `session:${member.id}`,
+			kind: 'session',
+			spaceId: space.id,
+			handle: `@session:${member.id}`,
+			roles: ['member-session'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `agent:coordinator:${space.id}`,
+			kind: 'agent',
+			spaceId: space.id,
+			handle: '@coordinator',
+			roles: ['coordinator', 'space-agent'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `agent:${agent.id}`,
+			kind: 'agent',
+			spaceId: space.id,
+			handle: '@long-term-agent',
+			roles: ['long-term-agent', 'space-agent'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `worker:${run.id}:Coding:coder`,
+			kind: 'worker',
+			spaceId: space.id,
+			handle: `@worker:${run.id}/Coding/coder`,
+			roles: ['Coding', 'coder'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `worker:${run.id}:reviewer:reviewer`,
+			kind: 'worker',
+			spaceId: space.id,
+			handle: `@worker:${run.id}/reviewer/reviewer`,
+			roles: ['reviewer'],
+			status: 'inactive',
+		});
+		expect(actors).toContainEqual({
+			actorId: 'system:runtime',
+			kind: 'system',
+			spaceId: space.id,
+			handle: '@system:runtime',
+			roles: ['runtime'],
+			status: 'active',
+		});
+		expect(actors.some((actor) => actor.actorId === `session:${coordinator.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `session:${taskAgent.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `session:${workerSubSession.id}`)).toBe(false);
+	});
+
+	it('returns inactive coordinator when no space chat session exists', () => {
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/project',
+			slug: 'project',
+			name: 'Project',
+		});
+
+		expect(registry.getActor(space.id, `agent:coordinator:${space.id}`)).toEqual({
+			actorId: `agent:coordinator:${space.id}`,
+			kind: 'agent',
+			spaceId: space.id,
+			handle: '@coordinator',
+			roles: ['coordinator', 'space-agent'],
+			status: 'inactive',
+		});
+	});
+});

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -119,18 +119,36 @@ describe('SpaceActorRegistryAdapter', () => {
 		const workerSubSession = makeSession('space:task:t1:exec:e1', {
 			context: { spaceId: space.id },
 		});
+		const namedAgentSubSession = makeSession('named-agent-session', {
+			context: { spaceId: space.id },
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+				promptProvenance: { workflowRunId: 'run-from-prompt' },
+			},
+		});
 		sessionRepo.createSession(member);
 		sessionRepo.createSession(coordinator);
 		sessionRepo.createSession(taskAgent);
 		sessionRepo.createSession(workerSubSession);
+		sessionRepo.createSession(namedAgentSubSession);
 		spaceRepo.addSessionToSpace(space.id, member.id);
 		spaceRepo.addSessionToSpace(space.id, coordinator.id);
 		spaceRepo.addSessionToSpace(space.id, taskAgent.id);
 		spaceRepo.addSessionToSpace(space.id, workerSubSession.id);
+		spaceRepo.addSessionToSpace(space.id, namedAgentSubSession.id);
 
 		const agent = spaceAgentRepo.create({
 			spaceId: space.id,
 			name: 'Long Term Agent',
+		});
+		const reservedNameAgent = spaceAgentRepo.create({
+			spaceId: space.id,
+			name: 'Coordinator',
 		});
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: space.id,
@@ -142,9 +160,9 @@ describe('SpaceActorRegistryAdapter', () => {
 					agents: [{ agentId: agent.id, name: 'coder' }],
 				},
 				{
-					id: 'Review',
-					name: 'Review',
-					agents: [{ agentId: agent.id, name: 'reviewer' }],
+					id: 'Review/QA',
+					name: 'Review/QA',
+					agents: [{ agentId: agent.id, name: 'reviewer:lead' }],
 				},
 			],
 			transitions: [],
@@ -159,8 +177,8 @@ describe('SpaceActorRegistryAdapter', () => {
 		});
 		nodeExecutionRepo.create({
 			workflowRunId: run.id,
-			workflowNodeId: 'Coding',
-			agentName: 'coder',
+			workflowNodeId: 'Coding:Node',
+			agentName: 'coder/lead',
 			agentId: agent.id,
 			agentSessionId: workerSubSession.id,
 			status: 'in_progress',
@@ -169,7 +187,7 @@ describe('SpaceActorRegistryAdapter', () => {
 			workflowRunId: run.id,
 			spaceId: space.id,
 			targetKind: 'node_agent',
-			targetAgentName: 'reviewer',
+			targetAgentName: 'reviewer:lead',
 			message: 'review this',
 		});
 
@@ -208,19 +226,27 @@ describe('SpaceActorRegistryAdapter', () => {
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
-			actorId: `worker:${run.id}:Coding:coder`,
-			kind: 'worker',
+			actorId: `agent:${reservedNameAgent.id}`,
+			kind: 'agent',
 			spaceId: space.id,
-			handle: `@worker:${run.id}/Coding/coder`,
-			roles: ['Coding', 'coder'],
+			handle: `@coordinator-${reservedNameAgent.id.slice(0, 8)}`,
+			roles: ['coordinator', 'space-agent'],
 			status: 'active',
 		});
 		expect(actors).toContainEqual({
-			actorId: `worker:${run.id}:Review:reviewer`,
+			actorId: `worker:${encodeURIComponent(run.id)}:Coding%3ANode:coder%2Flead`,
 			kind: 'worker',
 			spaceId: space.id,
-			handle: `@worker:${run.id}/Review/reviewer`,
-			roles: ['Review', 'reviewer'],
+			handle: `@worker:${encodeURIComponent(run.id)}/Coding%3ANode/coder%2Flead`,
+			roles: ['Coding:Node', 'coder/lead'],
+			status: 'active',
+		});
+		expect(actors).toContainEqual({
+			actorId: `worker:${encodeURIComponent(run.id)}:Review%2FQA:reviewer%3Alead`,
+			kind: 'worker',
+			spaceId: space.id,
+			handle: `@worker:${encodeURIComponent(run.id)}/Review%2FQA/reviewer%3Alead`,
+			roles: ['Review/QA', 'reviewer:lead'],
 			status: 'inactive',
 		});
 		expect(actors.some((actor) => actor.actorId === `worker:${run.id}:reviewer:reviewer`)).toBe(
@@ -237,8 +263,14 @@ describe('SpaceActorRegistryAdapter', () => {
 		expect(actors.some((actor) => actor.actorId === `session:${coordinator.id}`)).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `session:${taskAgent.id}`)).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `session:${workerSubSession.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `session:${namedAgentSubSession.id}`)).toBe(
+			false
+		);
 		expect(actors.some((actor) => actor.actorId === `human:${taskAgent.id}`)).toBe(false);
 		expect(actors.some((actor) => actor.actorId === `human:${workerSubSession.id}`)).toBe(false);
+		expect(actors.some((actor) => actor.actorId === `human:${namedAgentSubSession.id}`)).toBe(
+			false
+		);
 		for (const actor of actors) {
 			if (actor.handle) expect(() => parseAddress(actor.handle!)).not.toThrow();
 		}

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -368,6 +368,10 @@ export function createSpaceTables(db: BunDatabase): void {
 			`ON pending_agent_messages(workflow_run_id, status, created_at)`
 	);
 	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_space_status ` +
+			`ON pending_agent_messages(space_id, status, created_at)`
+	);
+	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_target ` +
 			`ON pending_agent_messages(workflow_run_id, target_agent_name, status, created_at)`
 	);


### PR DESCRIPTION
Seeds Space ActorRef entries for humans, coordinator, sessions, long-term agents, workflow workers, pending worker rows, and system subsystems.

Adds unit coverage for actor seeding and exclusion of space_chat, space_task_agent, and workflow sub-session session actors.

Tests:
- bun run check
- cd packages/daemon && bun test --preload=./tests/unit/setup.ts ./tests/unit/5-space/actor-registry.test.ts
- ./scripts/test-daemon.sh 5-space