### PR TITLE
Add space folder browse button

### DIFF
--- a/packages/web/src/components/space/SpaceCreateDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateDialog.tsx
@@ -13,6 +13,10 @@ import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { connectionManager } from '../../lib/connection-manager';
 import { navigateToSpace } from '../../lib/router';
+import {
+	hasNativeFolderPicker,
+	NATIVE_FOLDER_PICKER_TIMEOUT_MS,
+} from '../../lib/runtime-capabilities';
 import type { Space } from '@neokai/shared';
 
 interface SpaceCreateDialogProps {
@@ -36,12 +40,33 @@ export function SpaceCreateDialog({ isOpen, onClose }: SpaceCreateDialogProps) {
 	const [nameTouched, setNameTouched] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [nativeFolderPickerAvailable] = useState(() => hasNativeFolderPicker());
 
 	const handlePathInput = (value: string) => {
 		setWorkspacePath(value);
 		if (!nameTouched) {
 			const suggested = basenameFromPath(value);
 			setName(suggested);
+		}
+	};
+
+	const handleBrowse = async () => {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setError('Not connected to server. Please wait...');
+			return;
+		}
+
+		try {
+			const picked = await hub.request<{ path: string | null }>('dialog.pickFolder', undefined, {
+				timeout: NATIVE_FOLDER_PICKER_TIMEOUT_MS,
+			});
+			if (picked?.path) {
+				handlePathInput(picked.path);
+				setError(null);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to browse for folder');
 		}
 	};
 
@@ -109,15 +134,27 @@ export function SpaceCreateDialog({ isOpen, onClose }: SpaceCreateDialogProps) {
 					<p class="text-xs text-gray-500 mb-2">
 						Absolute path to the project directory this Space operates on.
 					</p>
-					<input
-						type="text"
-						value={workspacePath}
-						onInput={(e) => handlePathInput((e.target as HTMLInputElement).value)}
-						placeholder="/Users/you/projects/my-app"
-						class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-3 text-gray-100
-							placeholder-gray-600 focus:outline-none focus:border-blue-500 font-mono text-sm"
-						autoFocus
-					/>
+					<div class="flex gap-2">
+						<input
+							type="text"
+							value={workspacePath}
+							onInput={(e) => handlePathInput((e.target as HTMLInputElement).value)}
+							placeholder="/Users/you/projects/my-app"
+							class="flex-1 min-w-0 bg-dark-800 border border-dark-600 rounded-lg px-4 py-3 text-gray-100
+								placeholder-gray-600 focus:outline-none focus:border-blue-500 font-mono text-sm"
+							autoFocus
+						/>
+						{nativeFolderPickerAvailable && (
+							<button
+								type="button"
+								onClick={handleBrowse}
+								title="Browse on this computer"
+								class="px-4 py-3 rounded-lg bg-dark-700 hover:bg-dark-600 text-gray-300 hover:text-gray-100 border border-dark-600 transition-colors shrink-0 text-sm font-medium"
+							>
+								Browse
+							</button>
+						)}
+					</div>
 				</div>
 
 				{/* Name */}

--- a/packages/web/src/components/space/__tests__/SpaceCreateDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateDialog.test.tsx
@@ -39,6 +39,11 @@ vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }));
 
+vi.mock('../../../lib/runtime-capabilities', () => ({
+	hasNativeFolderPicker: vi.fn(() => false),
+	NATIVE_FOLDER_PICKER_TIMEOUT_MS: 605000,
+}));
+
 vi.mock('../../ui/Modal', () => ({
 	Modal: ({
 		isOpen,
@@ -83,6 +88,10 @@ vi.mock('../../ui/Button', () => ({
 	),
 }));
 
+import {
+	hasNativeFolderPicker,
+	NATIVE_FOLDER_PICKER_TIMEOUT_MS,
+} from '../../../lib/runtime-capabilities';
 import { SpaceCreateDialog } from '../SpaceCreateDialog';
 
 const SPACE_MOCK = {
@@ -106,6 +115,7 @@ describe('SpaceCreateDialog', () => {
 		mockRequest.mockReset();
 		mockGetHubIfConnected.mockReset();
 		mockNavigateToSpace.mockReset();
+		vi.mocked(hasNativeFolderPicker).mockReturnValue(false);
 	});
 
 	afterEach(() => {
@@ -129,6 +139,33 @@ describe('SpaceCreateDialog', () => {
 		expect(getByPlaceholderText('/Users/you/projects/my-app')).toBeTruthy();
 		expect(getByText('Workspace Path')).toBeTruthy();
 		expect(getByText('*')).toBeTruthy();
+	});
+
+	it('hides browse button when native folder picker is unavailable', () => {
+		const { queryByText } = render(<SpaceCreateDialog isOpen={true} onClose={onClose} />);
+		expect(queryByText('Browse')).toBeNull();
+	});
+
+	it('populates workspace path from browse selection', async () => {
+		vi.mocked(hasNativeFolderPicker).mockReturnValue(true);
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		mockRequest.mockResolvedValue({ path: '/projects/picked-app' });
+
+		const { getByPlaceholderText, getByText } = render(
+			<SpaceCreateDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.click(getByText('Browse'));
+
+		const pathInput = getByPlaceholderText('/Users/you/projects/my-app') as HTMLInputElement;
+		const nameInput = getByPlaceholderText('e.g., My App') as HTMLInputElement;
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('dialog.pickFolder', undefined, {
+				timeout: NATIVE_FOLDER_PICKER_TIMEOUT_MS,
+			});
+			expect(pathInput.value).toBe('/projects/picked-app');
+			expect(nameInput.value).toBe('picked-app');
+		});
 	});
 
 	it('auto-suggests name from workspace path', () => {


### PR DESCRIPTION
Adds a Browse button beside the Create Space workspace path input when native folder picking is available.

Tests:
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceCreateDialog.test.tsx
- bun run check