### PR TITLE
Add Space messaging resolver facade

### DIFF
--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -39,6 +39,17 @@ export { TaskAgentManager } from './runtime/task-agent-manager';
 export type { TaskAgentManagerConfig } from './runtime/task-agent-manager';
 export { SpaceActorRegistryAdapter, SPACE_SYSTEM_ACTORS } from './actor-registry';
 export type { SpaceActorRegistryRepositories } from './actor-registry';
+export {
+	SpaceMessageResolver,
+	SpaceDeliveryFacade,
+	pendingMessageToMessageRecord,
+	pendingMessageToDeliveryRecords,
+} from './messaging-adapter';
+export type {
+	SpaceMessageResolverConfig,
+	SpaceMessageResolverContext,
+	SpaceDeliveryFacadeConfig,
+} from './messaging-adapter';
 
 export { selectWorkflow } from './runtime/workflow-selector';
 export type { WorkflowSelectionContext } from './runtime/workflow-selector';

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -154,9 +154,10 @@ export class SpaceMessageResolver implements ActorResolver {
 		});
 		let routable = matches.filter(isRoutable);
 		if (!agentName && this.context.agentName) {
-			routable = routable.filter(
+			const contextMatches = routable.filter(
 				(actor) => parseWorkerActorId(actor.actorId)?.agentName === this.context.agentName
 			);
+			if (contextMatches.length > 0) routable = contextMatches;
 		}
 		if (routable.length === 0) {
 			return { actors: [], reason: `No routable worker actor found for ${targetRef}` };
@@ -240,19 +241,25 @@ export class SpaceDeliveryFacade {
 			deliveries.push(delivery);
 		}
 
+		const failedCounts = new Map<string, number>();
 		for (const target of result.unresolved) {
-			deliveries.push(createFailedDelivery(message, target.targetRef, target.reason));
+			const occurrence = failedCounts.get(target.targetRef) ?? 0;
+			failedCounts.set(target.targetRef, occurrence + 1);
+			deliveries.push(createFailedDelivery(message, target.targetRef, target.reason, occurrence));
 		}
 
 		return { message, deliveries };
 	}
 }
 
-export function pendingMessageToMessageRecord(row: PendingAgentMessageRecord): MessageRecord {
+export function pendingMessageToMessageRecord(
+	row: PendingAgentMessageRecord,
+	actors: ActorRef[] = []
+): MessageRecord {
 	return {
 		messageId: `msg_legacy_${row.id}`,
 		spaceId: row.spaceId,
-		senderActorId: legacySenderActorId(row.sourceAgentName, row.workflowRunId),
+		senderActorId: legacySenderActorId(row, actors),
 		targets: [row.targetAgentName],
 		body: row.message,
 		kind: 'message',
@@ -298,10 +305,12 @@ function createDeliveryFromActor(
 function createFailedDelivery(
 	message: MessageRecord,
 	targetRef: string,
-	lastError: string
+	lastError: string,
+	occurrence = 0
 ): DeliveryRecord {
+	const suffix = occurrence === 0 ? '' : `_${occurrence}`;
 	return {
-		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(targetRef)}_failed`,
+		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(targetRef)}_failed${suffix}`,
 		messageId: message.messageId,
 		targetRef,
 		state: 'failed',
@@ -344,8 +353,10 @@ function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]):
 		const parsed = parseWorkerActorId(actor.actorId);
 		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.targetAgentName;
 	});
-	if (row.status === 'pending') return stableActors(matches);
-	return stableActors(matches).slice(0, 1);
+	const sorted = stableActors(matches);
+	if (row.status === 'pending') return sorted;
+	if (sorted.length === 1) return sorted;
+	return [];
 }
 
 function pendingStatusToDeliveryState(status: PendingAgentMessageRecord['status']): DeliveryState {
@@ -361,16 +372,22 @@ function pendingStatusToDeliveryState(status: PendingAgentMessageRecord['status'
 	}
 }
 
-function legacySenderActorId(sourceAgentName: string, workflowRunId: string): string {
-	if (sourceAgentName === 'human') return 'human:legacy';
+function legacySenderActorId(row: PendingAgentMessageRecord, actors: ActorRef[]): string {
+	if (row.sourceAgentName === 'human') return 'human:legacy';
 	if (
-		sourceAgentName === 'coordinator' ||
-		sourceAgentName === 'space-agent' ||
-		sourceAgentName === 'task-agent'
+		row.sourceAgentName === 'coordinator' ||
+		row.sourceAgentName === 'space-agent' ||
+		row.sourceAgentName === 'task-agent'
 	) {
-		return 'agent:coordinator:legacy';
+		return `agent:coordinator:${row.spaceId}`;
 	}
-	return `worker:${encodeURIComponent(workflowRunId)}:unknown:${encodeURIComponent(sourceAgentName)}`;
+	const matches = actors.filter((actor) => {
+		if (actor.kind !== 'worker' || !isRoutable(actor)) return false;
+		const parsed = parseWorkerActorId(actor.actorId);
+		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.sourceAgentName;
+	});
+	if (matches.length === 1) return matches[0].actorId;
+	return `worker:${encodeURIComponent(row.workflowRunId)}:unresolved:${encodeURIComponent(row.sourceAgentName)}`;
 }
 
 function isRoutable(actor: ActorRef): boolean {

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -113,15 +113,10 @@ export class SpaceMessageResolver implements ActorResolver {
 			}
 			case 'role': {
 				const role = actorRole(address.role);
+				const workflowRunId = message.workflowRunId ?? this.context.workflowRunId;
 				const holders = this.permitRoleActors([
-					...actors.filter(
-						(actor) => actor.roles?.includes(address.role) || actor.roles?.includes(role)
-					),
-					...this.declaredRoleActors(
-						message.workflowRunId ?? this.context.workflowRunId,
-						address.role,
-						actors
-					),
+					...actors.filter((actor) => this.actorHasRole(actor, address.role, role, workflowRunId)),
+					...this.declaredRoleActors(workflowRunId, address.role, actors),
 				]);
 				const active = holders.filter((actor) => actor.status === 'active');
 				const inactive = holders.filter((actor) => actor.status === 'inactive');
@@ -227,6 +222,25 @@ export class SpaceMessageResolver implements ActorResolver {
 		return { actors: stableActors(permitted) };
 	}
 
+	private actorHasRole(
+		actor: ActorRef,
+		role: string,
+		encodedRole: string,
+		workflowRunId: string | undefined
+	): boolean {
+		if (actor.kind !== 'worker') {
+			return actor.roles?.includes(role) || actor.roles?.includes(encodedRole) || false;
+		}
+		const parsed = parseWorkerActorId(actor.actorId);
+		if (!parsed) return false;
+		if (workflowRunId && parsed.workflowRunId !== workflowRunId) return false;
+		return Boolean(
+			actor.roles?.includes(role) ||
+				actor.roles?.includes(encodedRole) ||
+				this.workerNodeMatchesRole(workflowRunId ?? parsed.workflowRunId, parsed.nodeId, role)
+		);
+	}
+
 	private permitRoleActors(actors: ActorRef[]): ActorRef[] {
 		if (!this.context.workflowRunId || !this.context.nodeId) return actors;
 		return actors.filter((actor) => {
@@ -275,6 +289,7 @@ export class SpaceMessageResolver implements ActorResolver {
 				.filter(
 					(agent) =>
 						agent.name === role ||
+						actorRole(agent.name) === role ||
 						node.id === role ||
 						node.name === role ||
 						actorRole(node.id) === role ||
@@ -286,6 +301,18 @@ export class SpaceMessageResolver implements ActorResolver {
 					return this.declaredWorkerActor(workflowRunId, node.id, agent.name);
 				})
 				.filter((actor): actor is ActorRef => Boolean(actor))
+		);
+	}
+
+	private workerNodeMatchesRole(workflowRunId: string, nodeId: string, role: string): boolean {
+		const workflow = this.workflowForRun(workflowRunId);
+		const node = workflow?.nodes.find((candidate) => candidate.id === nodeId);
+		return Boolean(
+			node &&
+				(node.id === role ||
+					node.name === role ||
+					actorRole(node.id) === role ||
+					actorRole(node.name) === role)
 		);
 	}
 

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -16,7 +16,7 @@ import type {
 import type { PendingAgentMessageRecord } from '../../storage/repositories/pending-agent-message-repository';
 import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
-import type { WorkflowChannel, WorkflowNode } from '@neokai/shared';
+import type { SpaceWorkflow, WorkflowChannel, WorkflowNode } from '@neokai/shared';
 import { ChannelResolver } from './runtime/channel-resolver';
 import type { SpaceActorRegistryAdapter } from './actor-registry';
 
@@ -113,11 +113,15 @@ export class SpaceMessageResolver implements ActorResolver {
 			}
 			case 'role': {
 				const role = actorRole(address.role);
-				const holders = this.permitRoleActors(
-					actors.filter(
+				const holders = this.permitRoleActors([
+					...actors.filter(
 						(actor) => actor.roles?.includes(address.role) || actor.roles?.includes(role)
-					)
-				);
+					),
+					...this.declaredRoleActors(
+						message.workflowRunId ?? this.context.workflowRunId,
+						address.role
+					),
+				]);
 				const active = holders.filter((actor) => actor.status === 'active');
 				const inactive = holders.filter((actor) => actor.status === 'inactive');
 				const routable = active.length > 0 ? active : inactive;
@@ -178,16 +182,20 @@ export class SpaceMessageResolver implements ActorResolver {
 			if (parsed.nodeId !== targetNodeId) return false;
 			return agentName ? parsed.agentName === agentName.value : true;
 		});
-		if (matches.length === 0) {
-			const declared = this.declaredWorkerActor(workflowRunId, targetNodeId, agentName?.value);
-			if (declared) matches.push(declared);
+		const declaredAgentName = this.declaredAgentName(workflow, targetNodeId, agentName?.value);
+		if (declaredAgentName) {
+			const declared = this.declaredWorkerActor(workflowRunId, targetNodeId, declaredAgentName);
+			const hasDeclared = matches.some((actor) => actor.actorId === declared?.actorId);
+			if (declared && !hasDeclared) matches.push(declared);
 		}
 		let routable = matches.filter(isRoutable);
 		if (!agentName && this.context.agentName) {
 			const contextMatches = routable.filter(
 				(actor) => parseWorkerActorId(actor.actorId)?.agentName === this.context.agentName
 			);
-			if (contextMatches.length > 0) routable = contextMatches;
+			if (contextMatches.length > 0 || declaredAgentName === this.context.agentName) {
+				routable = contextMatches;
+			}
 		}
 		if (routable.length === 0) {
 			return { actors: [], reason: `No routable worker actor found for ${targetRef}` };
@@ -246,6 +254,18 @@ export class SpaceMessageResolver implements ActorResolver {
 		);
 	}
 
+	private declaredRoleActors(workflowRunId: string | undefined, role: string): ActorRef[] {
+		if (!workflowRunId) return [];
+		const workflow = this.workflowForRun(workflowRunId);
+		if (!workflow) return [];
+		return workflow.nodes.flatMap((node) =>
+			node.agents
+				.filter((agent) => agent.name === role)
+				.map((agent) => this.declaredWorkerActor(workflowRunId, node.id, agent.name))
+				.filter((actor): actor is ActorRef => Boolean(actor))
+		);
+	}
+
 	private declaredWorkerActor(
 		workflowRunId: string,
 		nodeId: string,
@@ -263,6 +283,27 @@ export class SpaceMessageResolver implements ActorResolver {
 			roles: uniqueStrings([actorRole(agentName), actorRole(nodeId)]),
 			status: 'inactive',
 		};
+	}
+
+	private declaredAgentName(
+		workflow: SpaceWorkflow | null,
+		nodeId: string,
+		explicitAgentName: string | undefined
+	): string | undefined {
+		const node = workflow?.nodes.find((candidate) => candidate.id === nodeId);
+		if (!node) return explicitAgentName;
+		if (explicitAgentName) {
+			return node.agents.some((agent) => agent.name === explicitAgentName)
+				? explicitAgentName
+				: undefined;
+		}
+		if (
+			this.context.agentName &&
+			node.agents.some((agent) => agent.name === this.context.agentName)
+		) {
+			return this.context.agentName;
+		}
+		return node.agents.length === 1 ? node.agents[0].name : undefined;
 	}
 
 	private workflowForRun(workflowRunId: string) {
@@ -409,7 +450,10 @@ function createLegacyDelivery(
 
 function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]): ActorRef[] {
 	if (row.targetKind === 'space_agent') {
-		return actors.filter((actor) => actor.handle === '@coordinator' && isRoutable(actor));
+		return actors.filter(
+			(actor) =>
+				actor.handle === '@coordinator' && (row.status === 'pending' ? isRoutable(actor) : true)
+		);
 	}
 	const matches = actors.filter((actor) => {
 		if (actor.kind !== 'worker') return false;

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -1,0 +1,370 @@
+import { parseAddress } from '../../../../messaging/src/address';
+import type { ParsedAddress, WorkerAddress } from '../../../../messaging/src/address';
+import type {
+	ActorRef,
+	DeliveryRecord,
+	DeliveryState,
+	MessageRecord,
+} from '../../../../messaging/src/types';
+import type {
+	ActorResolver,
+	ResolvedTarget,
+	ResolveTargetsResult,
+	RouteMessageResult,
+	UnresolvedTarget,
+} from '../../../../messaging/src/contracts';
+import type { PendingAgentMessageRecord } from '../../storage/repositories/pending-agent-message-repository';
+import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import { ChannelResolver } from './runtime/channel-resolver';
+import type { SpaceActorRegistryAdapter } from './actor-registry';
+
+export interface SpaceMessageResolverContext {
+	spaceId: string;
+	workflowRunId?: string;
+	nodeId?: string;
+	agentName?: string;
+}
+
+export interface SpaceMessageResolverConfig {
+	actorRegistry: SpaceActorRegistryAdapter;
+	workflowRepo: SpaceWorkflowRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+}
+
+export class SpaceMessageResolver implements ActorResolver {
+	constructor(
+		private readonly config: SpaceMessageResolverConfig,
+		private readonly context: SpaceMessageResolverContext
+	) {}
+
+	async resolveTargets(message: MessageRecord): Promise<ResolveTargetsResult> {
+		const resolved: ResolvedTarget[] = [];
+		const unresolved: UnresolvedTarget[] = [];
+		const seen = new Set<string>();
+
+		for (const targetRef of message.targets) {
+			let address: ParsedAddress;
+			try {
+				address = parseAddress(targetRef);
+			} catch (error) {
+				unresolved.push({
+					targetRef,
+					reason: error instanceof Error ? error.message : String(error),
+				});
+				continue;
+			}
+
+			const result = this.resolveAddress(targetRef, address, message);
+			for (const actor of result.actors) {
+				const key = `${targetRef}\0${actor.actorId}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				resolved.push({ targetRef, address, actor });
+			}
+			if (result.reason) {
+				unresolved.push({ targetRef, address, reason: result.reason });
+			}
+		}
+
+		return { resolved, unresolved };
+	}
+
+	private resolveAddress(
+		targetRef: string,
+		address: ParsedAddress,
+		message: MessageRecord
+	): { actors: ActorRef[]; reason?: string } {
+		const spaceId = message.spaceId || this.context.spaceId;
+		const actors = this.config.actorRegistry.listActors(spaceId);
+
+		switch (address.kind) {
+			case 'handle': {
+				const handle = `@${address.handle}`;
+				const matches = actors.filter((actor) => actor.handle === handle && isRoutable(actor));
+				return matches.length > 0
+					? { actors: stableActors(matches) }
+					: { actors: [], reason: `No routable actor found for handle ${handle}` };
+			}
+			case 'role': {
+				const role = actorRole(address.role);
+				const holders = actors.filter(
+					(actor) => actor.roles?.includes(address.role) || actor.roles?.includes(role)
+				);
+				const active = holders.filter((actor) => actor.status === 'active');
+				const inactive = holders.filter((actor) => actor.status === 'inactive');
+				const routable = active.length > 0 ? active : inactive;
+				return routable.length > 0
+					? { actors: stableActors(routable) }
+					: { actors: [], reason: `No routable actor found for role ${address.role}` };
+			}
+			case 'session': {
+				const actorId = `session:${address.sessionId}`;
+				const actor = actors.find(
+					(candidate) => candidate.actorId === actorId && isRoutable(candidate)
+				);
+				return actor
+					? { actors: [actor] }
+					: { actors: [], reason: `No routable session actor found for ${address.sessionId}` };
+			}
+			case 'worker':
+				return this.resolveWorker(targetRef, address, message, actors);
+			case 'channel':
+				return {
+					actors: [],
+					reason: `Channel targets are not enabled in Space messaging v1: #${address.name}`,
+				};
+		}
+	}
+
+	private resolveWorker(
+		targetRef: string,
+		address: WorkerAddress,
+		message: MessageRecord,
+		actors: ActorRef[]
+	): { actors: ActorRef[]; reason?: string } {
+		const workflowRunId =
+			address.workflowRunId ?? message.workflowRunId ?? this.context.workflowRunId;
+		if (!workflowRunId) {
+			return {
+				actors: [],
+				reason: `Worker target ${targetRef} requires workflowRunId or @worker:<run>/<node>/<agent>`,
+			};
+		}
+
+		const nodeId = decodeURIComponent(address.nodeId);
+		const agentName = address.agentName ? decodeURIComponent(address.agentName) : undefined;
+		const workerActors = actors.filter(
+			(actor) =>
+				actor.kind === 'worker' &&
+				parseWorkerActorId(actor.actorId)?.workflowRunId === workflowRunId
+		);
+		const matches = workerActors.filter((actor) => {
+			const parsed = parseWorkerActorId(actor.actorId);
+			if (!parsed) return false;
+			if (parsed.nodeId !== nodeId) return false;
+			return agentName ? parsed.agentName === agentName : true;
+		});
+		const routable = matches.filter(isRoutable);
+		if (routable.length === 0) {
+			return { actors: [], reason: `No routable worker actor found for ${targetRef}` };
+		}
+		if (!agentName && routable.length > 1 && !this.context.agentName) {
+			return {
+				actors: [],
+				reason: `Worker target ${targetRef} is ambiguous; specify @worker:<node>/<agent>`,
+			};
+		}
+
+		const permitted = routable.filter((actor) => this.canSendToWorker(workflowRunId, actor));
+		if (permitted.length === 0) {
+			return {
+				actors: [],
+				reason: `Channel topology does not permit worker target ${targetRef}`,
+			};
+		}
+		return { actors: stableActors(permitted) };
+	}
+
+	private canSendToWorker(workflowRunId: string, actor: ActorRef): boolean {
+		const fromNode = this.context.nodeId;
+		if (!fromNode) return false;
+		const run = this.config.workflowRunRepo.getRun(workflowRunId);
+		if (!run) return false;
+		const workflow = this.config.workflowRepo.getWorkflow(run.workflowId);
+		if (!workflow?.channels || workflow.channels.length === 0) return false;
+		const parsed = parseWorkerActorId(actor.actorId);
+		if (!parsed) return false;
+		return new ChannelResolver(workflow.channels).canSend(fromNode, parsed.nodeId);
+	}
+}
+
+export interface SpaceDeliveryFacadeConfig {
+	resolver: ActorResolver;
+	deliverToSession?: (
+		actor: ActorRef,
+		message: MessageRecord
+	) => Promise<string | null | undefined>;
+}
+
+export class SpaceDeliveryFacade {
+	constructor(private readonly config: SpaceDeliveryFacadeConfig) {}
+
+	async routeMessage(message: MessageRecord): Promise<RouteMessageResult> {
+		const result = await this.config.resolver.resolveTargets(message);
+		const deliveries: DeliveryRecord[] = [];
+
+		for (const target of result.resolved) {
+			const delivery = createDeliveryFromActor(message, target.targetRef, target.actor);
+			if (target.actor.status === 'active' && this.config.deliverToSession) {
+				try {
+					const deliveredSessionId = await this.config.deliverToSession(target.actor, message);
+					delivery.state = 'delivered';
+					delivery.deliveredAt = Date.now();
+					if (deliveredSessionId) delivery.deliveredSessionId = deliveredSessionId;
+				} catch (error) {
+					delivery.state = 'failed';
+					delivery.attemptCount += 1;
+					delivery.lastError = error instanceof Error ? error.message : String(error);
+				}
+			}
+			deliveries.push(delivery);
+		}
+
+		for (const target of result.unresolved) {
+			deliveries.push(createFailedDelivery(message, target.targetRef, target.reason));
+		}
+
+		return { message, deliveries };
+	}
+}
+
+export function pendingMessageToMessageRecord(row: PendingAgentMessageRecord): MessageRecord {
+	return {
+		messageId: `msg_legacy_${row.id}`,
+		spaceId: row.spaceId,
+		senderActorId: legacySenderActorId(row.sourceAgentName, row.workflowRunId),
+		targets: [row.targetAgentName],
+		body: row.message,
+		kind: 'message',
+		workflowRunId: row.workflowRunId,
+		...(row.taskId ? { taskId: row.taskId } : {}),
+		...(row.idempotencyKey ? { idempotencyKey: row.idempotencyKey } : {}),
+		createdAt: row.createdAt,
+	};
+}
+
+export function pendingMessageToDeliveryRecords(
+	row: PendingAgentMessageRecord,
+	actors: ActorRef[]
+): DeliveryRecord[] {
+	const messageId = `msg_legacy_${row.id}`;
+	const state = pendingStatusToDeliveryState(row.status);
+	const targetActors = legacyTargetActors(row, actors);
+	if (targetActors.length === 0) {
+		return [createLegacyDelivery(row, messageId, state)];
+	}
+	return targetActors.map((actor, index) =>
+		createLegacyDelivery(row, messageId, state, actor, index === 0 ? undefined : index)
+	);
+}
+
+function createDeliveryFromActor(
+	message: MessageRecord,
+	targetRef: string,
+	actor: ActorRef
+): DeliveryRecord {
+	return {
+		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(actor.actorId)}`,
+		messageId: message.messageId,
+		targetActorId: actor.actorId,
+		targetRef,
+		state: actor.status === 'active' ? 'delivered' : 'queued',
+		attemptCount: 0,
+		maxAttempts: 5,
+		createdAt: Date.now(),
+	};
+}
+
+function createFailedDelivery(
+	message: MessageRecord,
+	targetRef: string,
+	lastError: string
+): DeliveryRecord {
+	return {
+		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(targetRef)}_failed`,
+		messageId: message.messageId,
+		targetRef,
+		state: 'failed',
+		attemptCount: 0,
+		maxAttempts: 0,
+		createdAt: Date.now(),
+		lastError,
+	};
+}
+
+function createLegacyDelivery(
+	row: PendingAgentMessageRecord,
+	messageId: string,
+	state: DeliveryState,
+	actor?: ActorRef,
+	fanoutIndex?: number
+): DeliveryRecord {
+	return {
+		deliveryId: `delivery_legacy_${row.id}${fanoutIndex === undefined ? '' : `_${fanoutIndex}`}`,
+		messageId,
+		targetActorId: actor?.actorId,
+		targetRef: row.targetAgentName,
+		state,
+		attemptCount: row.attempts,
+		maxAttempts: row.maxAttempts,
+		createdAt: row.createdAt,
+		expiresAt: row.expiresAt,
+		...(row.lastError ? { lastError: row.lastError } : {}),
+		...(row.deliveredSessionId ? { deliveredSessionId: row.deliveredSessionId } : {}),
+		...(row.deliveredAt ? { deliveredAt: row.deliveredAt } : {}),
+	};
+}
+
+function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]): ActorRef[] {
+	if (row.targetKind === 'space_agent') {
+		return actors.filter((actor) => actor.handle === '@coordinator' && isRoutable(actor));
+	}
+	const matches = actors.filter((actor) => {
+		if (actor.kind !== 'worker' || !isRoutable(actor)) return false;
+		const parsed = parseWorkerActorId(actor.actorId);
+		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.targetAgentName;
+	});
+	if (row.status === 'pending') return stableActors(matches);
+	return stableActors(matches).slice(0, 1);
+}
+
+function pendingStatusToDeliveryState(status: PendingAgentMessageRecord['status']): DeliveryState {
+	switch (status) {
+		case 'pending':
+			return 'queued';
+		case 'delivered':
+			return 'delivered';
+		case 'failed':
+			return 'failed';
+		case 'expired':
+			return 'expired';
+	}
+}
+
+function legacySenderActorId(sourceAgentName: string, workflowRunId: string): string {
+	if (sourceAgentName === 'human') return 'human:legacy';
+	if (
+		sourceAgentName === 'coordinator' ||
+		sourceAgentName === 'space-agent' ||
+		sourceAgentName === 'task-agent'
+	) {
+		return 'agent:coordinator:legacy';
+	}
+	return `worker:${encodeURIComponent(workflowRunId)}:unknown:${encodeURIComponent(sourceAgentName)}`;
+}
+
+function isRoutable(actor: ActorRef): boolean {
+	return actor.status === 'active' || actor.status === 'inactive';
+}
+
+function stableActors(actors: ActorRef[]): ActorRef[] {
+	return [...actors].sort((left, right) => left.actorId.localeCompare(right.actorId));
+}
+
+function actorRole(role: string): string {
+	return `actor-role:${encodeURIComponent(role)}`;
+}
+
+function parseWorkerActorId(
+	actorId: string
+): { workflowRunId: string; nodeId: string; agentName: string } | null {
+	if (!actorId.startsWith('worker:')) return null;
+	const parts = actorId.slice('worker:'.length).split(':');
+	if (parts.length !== 3) return null;
+	return {
+		workflowRunId: decodeURIComponent(parts[0]),
+		nodeId: decodeURIComponent(parts[1]),
+		agentName: decodeURIComponent(parts[2]),
+	};
+}

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -16,7 +16,7 @@ import type {
 import type { PendingAgentMessageRecord } from '../../storage/repositories/pending-agent-message-repository';
 import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
-import type { WorkflowNode } from '@neokai/shared';
+import type { WorkflowChannel, WorkflowNode } from '@neokai/shared';
 import { ChannelResolver } from './runtime/channel-resolver';
 import type { SpaceActorRegistryAdapter } from './actor-registry';
 
@@ -133,8 +133,14 @@ export class SpaceMessageResolver implements ActorResolver {
 			};
 		}
 
-		const nodeId = decodeURIComponent(address.nodeId);
-		const agentName = address.agentName ? decodeURIComponent(address.agentName) : undefined;
+		const workflow = this.workflowForRun(workflowRunId);
+		const nodeId = decodeAddressComponent(address.nodeId, targetRef);
+		if (!nodeId.ok) return { actors: [], reason: nodeId.reason };
+		const targetNodeId = workflowNodeId(workflow?.nodes ?? [], nodeId.value) ?? nodeId.value;
+		const agentName = address.agentName
+			? decodeAddressComponent(address.agentName, targetRef)
+			: undefined;
+		if (agentName && !agentName.ok) return { actors: [], reason: agentName.reason };
 		const workerActors = actors.filter(
 			(actor) =>
 				actor.kind === 'worker' &&
@@ -143,8 +149,8 @@ export class SpaceMessageResolver implements ActorResolver {
 		const matches = workerActors.filter((actor) => {
 			const parsed = parseWorkerActorId(actor.actorId);
 			if (!parsed) return false;
-			if (parsed.nodeId !== nodeId) return false;
-			return agentName ? parsed.agentName === agentName : true;
+			if (parsed.nodeId !== targetNodeId) return false;
+			return agentName ? parsed.agentName === agentName.value : true;
 		});
 		let routable = matches.filter(isRoutable);
 		if (!agentName && this.context.agentName) {
@@ -188,7 +194,17 @@ export class SpaceMessageResolver implements ActorResolver {
 		const targetNodeName = workflowNodeName(workflow.nodes, parsed.nodeId);
 		if (!fromNodeName || !targetNodeName) return false;
 		if (!workflow.channels || workflow.channels.length === 0) return false;
-		return new ChannelResolver(workflow.channels).canSend(fromNodeName, targetNodeName);
+		return canSendToWorkerTarget(
+			workflow.channels,
+			[fromNodeName, this.context.agentName],
+			[targetNodeName, parsed.agentName]
+		);
+	}
+
+	private workflowForRun(workflowRunId: string) {
+		const run = this.config.workflowRunRepo.getRun(workflowRunId);
+		if (!run || run.spaceId !== this.context.spaceId) return null;
+		return this.config.workflowRepo.getWorkflow(run.workflowId) ?? null;
 	}
 }
 
@@ -369,10 +385,47 @@ function actorRole(role: string): string {
 	return `actor-role:${encodeURIComponent(role)}`;
 }
 
+function workflowNodeId(nodes: WorkflowNode[], nodeRef: string): string | null {
+	const node = nodes.find((candidate) => candidate.id === nodeRef || candidate.name === nodeRef);
+	return node?.id ?? null;
+}
+
 function workflowNodeName(nodes: WorkflowNode[], nodeId: string | undefined): string | null {
 	if (!nodeId) return null;
 	const node = nodes.find((candidate) => candidate.id === nodeId || candidate.name === nodeId);
 	return node?.name ?? null;
+}
+
+function canSendToWorkerTarget(
+	channels: WorkflowChannel[],
+	fromRefs: Array<string | undefined>,
+	toRefs: Array<string | undefined>
+): boolean {
+	const resolver = new ChannelResolver(channels);
+	for (const from of uniqueStrings(fromRefs)) {
+		for (const to of uniqueStrings(toRefs)) {
+			if (resolver.canSend(from, to)) return true;
+		}
+	}
+	return false;
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+	return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+function decodeAddressComponent(
+	component: string,
+	targetRef: string
+): { ok: true; value: string } | { ok: false; reason: string } {
+	try {
+		return { ok: true, value: decodeURIComponent(component) };
+	} catch (error) {
+		if (error instanceof URIError) {
+			return { ok: false, reason: `Invalid worker target escape in ${targetRef}` };
+		}
+		throw error;
+	}
 }
 
 function parseWorkerActorId(

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -191,7 +191,7 @@ export class SpaceMessageResolver implements ActorResolver {
 			if (declared && !hasDeclared) matches.push(declared);
 		}
 		let routable = matches.filter(isRoutable);
-		if (!agentName && !this.context.agentName && declaredAgentNames.length > 1) {
+		if (!agentName && declaredAgentNames.length > 1 && !declaredAgentName) {
 			return {
 				actors: [],
 				reason: `Worker target ${targetRef} is ambiguous; specify @worker:<node>/<agent>`,
@@ -272,7 +272,14 @@ export class SpaceMessageResolver implements ActorResolver {
 		if (!workflow) return [];
 		return workflow.nodes.flatMap((node) =>
 			node.agents
-				.filter((agent) => agent.name === role)
+				.filter(
+					(agent) =>
+						agent.name === role ||
+						node.id === role ||
+						node.name === role ||
+						actorRole(node.id) === role ||
+						actorRole(node.name) === role
+				)
 				.map((agent) => {
 					const actorId = workerActorId(workflowRunId, node.id, agent.name);
 					if (actors.some((actor) => actor.actorId === actorId)) return null;
@@ -348,9 +355,11 @@ export class SpaceDeliveryFacade {
 			if (target.actor.status === 'active' && this.config.deliverToSession) {
 				try {
 					const deliveredSessionId = await this.config.deliverToSession(target.actor, message);
-					delivery.state = 'delivered';
-					delivery.deliveredAt = Date.now();
-					if (deliveredSessionId) delivery.deliveredSessionId = deliveredSessionId;
+					if (deliveredSessionId) {
+						delivery.state = 'delivered';
+						delivery.deliveredAt = Date.now();
+						delivery.deliveredSessionId = deliveredSessionId;
+					}
 				} catch (error) {
 					delivery.state = 'failed';
 					delivery.attemptCount += 1;

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -113,15 +113,16 @@ export class SpaceMessageResolver implements ActorResolver {
 			}
 			case 'role': {
 				const role = actorRole(address.role);
-				const holders = actors.filter(
-					(actor) => actor.roles?.includes(address.role) || actor.roles?.includes(role)
+				const holders = this.permitRoleActors(
+					actors.filter(
+						(actor) => actor.roles?.includes(address.role) || actor.roles?.includes(role)
+					)
 				);
 				const active = holders.filter((actor) => actor.status === 'active');
 				const inactive = holders.filter((actor) => actor.status === 'inactive');
 				const routable = active.length > 0 ? active : inactive;
-				const permitted = this.permitRoleActors(routable);
-				return permitted.length > 0
-					? { actors: stableActors(permitted) }
+				return routable.length > 0
+					? { actors: stableActors(routable) }
 					: { actors: [], reason: `No routable actor found for role ${address.role}` };
 			}
 			case 'session': {
@@ -177,6 +178,10 @@ export class SpaceMessageResolver implements ActorResolver {
 			if (parsed.nodeId !== targetNodeId) return false;
 			return agentName ? parsed.agentName === agentName.value : true;
 		});
+		if (matches.length === 0) {
+			const declared = this.declaredWorkerActor(workflowRunId, targetNodeId, agentName?.value);
+			if (declared) matches.push(declared);
+		}
 		let routable = matches.filter(isRoutable);
 		if (!agentName && this.context.agentName) {
 			const contextMatches = routable.filter(
@@ -239,6 +244,25 @@ export class SpaceMessageResolver implements ActorResolver {
 			[fromNodeName, this.context.agentName],
 			[targetNodeName, parsed.agentName]
 		);
+	}
+
+	private declaredWorkerActor(
+		workflowRunId: string,
+		nodeId: string,
+		agentName: string | undefined
+	): ActorRef | null {
+		if (!agentName) return null;
+		const workflow = this.workflowForRun(workflowRunId);
+		const node = workflow?.nodes.find((candidate) => candidate.id === nodeId);
+		if (!node?.agents.some((agent) => agent.name === agentName)) return null;
+		return {
+			actorId: workerActorId(workflowRunId, nodeId, agentName),
+			kind: 'worker',
+			spaceId: this.context.spaceId,
+			handle: workerHandle(workflowRunId, nodeId, agentName),
+			roles: uniqueStrings([actorRole(agentName), actorRole(nodeId)]),
+			status: 'inactive',
+		};
 	}
 
 	private workflowForRun(workflowRunId: string) {
@@ -388,7 +412,8 @@ function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]):
 		return actors.filter((actor) => actor.handle === '@coordinator' && isRoutable(actor));
 	}
 	const matches = actors.filter((actor) => {
-		if (actor.kind !== 'worker' || !isRoutable(actor)) return false;
+		if (actor.kind !== 'worker') return false;
+		if (row.status === 'pending' && !isRoutable(actor)) return false;
 		const parsed = parseWorkerActorId(actor.actorId);
 		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.targetAgentName;
 	});
@@ -421,7 +446,7 @@ function legacySenderActorId(row: PendingAgentMessageRecord, actors: ActorRef[])
 		return `agent:coordinator:${row.spaceId}`;
 	}
 	const matches = actors.filter((actor) => {
-		if (actor.kind !== 'worker' || !isRoutable(actor)) return false;
+		if (actor.kind !== 'worker') return false;
 		const parsed = parseWorkerActorId(actor.actorId);
 		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.sourceAgentName;
 	});
@@ -482,6 +507,14 @@ function decodeAddressComponent(
 		}
 		throw error;
 	}
+}
+
+function workerActorId(workflowRunId: string, nodeId: string, agentName: string): string {
+	return `worker:${[workflowRunId, nodeId, agentName].map(encodeURIComponent).join(':')}`;
+}
+
+function workerHandle(workflowRunId: string, nodeId: string, agentName: string): string {
+	return `@worker:${[workflowRunId, nodeId, agentName].map(encodeURIComponent).join('/')}`;
 }
 
 function parseWorkerActorId(

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -119,7 +119,8 @@ export class SpaceMessageResolver implements ActorResolver {
 					),
 					...this.declaredRoleActors(
 						message.workflowRunId ?? this.context.workflowRunId,
-						address.role
+						address.role,
+						actors
 					),
 				]);
 				const active = holders.filter((actor) => actor.status === 'active');
@@ -183,12 +184,19 @@ export class SpaceMessageResolver implements ActorResolver {
 			return agentName ? parsed.agentName === agentName.value : true;
 		});
 		const declaredAgentName = this.declaredAgentName(workflow, targetNodeId, agentName?.value);
+		const declaredAgentNames = this.declaredAgentNames(workflow, targetNodeId);
 		if (declaredAgentName) {
 			const declared = this.declaredWorkerActor(workflowRunId, targetNodeId, declaredAgentName);
 			const hasDeclared = matches.some((actor) => actor.actorId === declared?.actorId);
 			if (declared && !hasDeclared) matches.push(declared);
 		}
 		let routable = matches.filter(isRoutable);
+		if (!agentName && !this.context.agentName && declaredAgentNames.length > 1) {
+			return {
+				actors: [],
+				reason: `Worker target ${targetRef} is ambiguous; specify @worker:<node>/<agent>`,
+			};
+		}
 		if (!agentName && this.context.agentName) {
 			const contextMatches = routable.filter(
 				(actor) => parseWorkerActorId(actor.actorId)?.agentName === this.context.agentName
@@ -254,14 +262,22 @@ export class SpaceMessageResolver implements ActorResolver {
 		);
 	}
 
-	private declaredRoleActors(workflowRunId: string | undefined, role: string): ActorRef[] {
+	private declaredRoleActors(
+		workflowRunId: string | undefined,
+		role: string,
+		actors: ActorRef[]
+	): ActorRef[] {
 		if (!workflowRunId) return [];
 		const workflow = this.workflowForRun(workflowRunId);
 		if (!workflow) return [];
 		return workflow.nodes.flatMap((node) =>
 			node.agents
 				.filter((agent) => agent.name === role)
-				.map((agent) => this.declaredWorkerActor(workflowRunId, node.id, agent.name))
+				.map((agent) => {
+					const actorId = workerActorId(workflowRunId, node.id, agent.name);
+					if (actors.some((actor) => actor.actorId === actorId)) return null;
+					return this.declaredWorkerActor(workflowRunId, node.id, agent.name);
+				})
 				.filter((actor): actor is ActorRef => Boolean(actor))
 		);
 	}
@@ -290,20 +306,19 @@ export class SpaceMessageResolver implements ActorResolver {
 		nodeId: string,
 		explicitAgentName: string | undefined
 	): string | undefined {
-		const node = workflow?.nodes.find((candidate) => candidate.id === nodeId);
-		if (!node) return explicitAgentName;
-		if (explicitAgentName) {
-			return node.agents.some((agent) => agent.name === explicitAgentName)
-				? explicitAgentName
-				: undefined;
-		}
-		if (
-			this.context.agentName &&
-			node.agents.some((agent) => agent.name === this.context.agentName)
-		) {
+		const agentNames = this.declaredAgentNames(workflow, nodeId);
+		if (agentNames.length === 0) return explicitAgentName;
+		if (explicitAgentName)
+			return agentNames.includes(explicitAgentName) ? explicitAgentName : undefined;
+		if (this.context.agentName && agentNames.includes(this.context.agentName)) {
 			return this.context.agentName;
 		}
-		return node.agents.length === 1 ? node.agents[0].name : undefined;
+		return agentNames.length === 1 ? agentNames[0] : undefined;
+	}
+
+	private declaredAgentNames(workflow: SpaceWorkflow | null, nodeId: string): string[] {
+		const node = workflow?.nodes.find((candidate) => candidate.id === nodeId);
+		return node?.agents.map((agent) => agent.name) ?? [];
 	}
 
 	private workflowForRun(workflowRunId: string) {
@@ -376,11 +391,12 @@ export function pendingMessageToMessageRecord(
 
 export function pendingMessageToDeliveryRecords(
 	row: PendingAgentMessageRecord,
-	actors: ActorRef[]
+	actors: ActorRef[],
+	workflow?: SpaceWorkflow | null
 ): DeliveryRecord[] {
 	const messageId = `msg_legacy_${row.id}`;
 	const state = pendingStatusToDeliveryState(row.status);
-	const targetActors = legacyTargetActors(row, actors);
+	const targetActors = legacyTargetActors(row, actors, workflow);
 	if (targetActors.length === 0) {
 		return [createLegacyDelivery(row, messageId, state)];
 	}
@@ -448,7 +464,11 @@ function createLegacyDelivery(
 	};
 }
 
-function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]): ActorRef[] {
+function legacyTargetActors(
+	row: PendingAgentMessageRecord,
+	actors: ActorRef[],
+	workflow?: SpaceWorkflow | null
+): ActorRef[] {
 	if (row.targetKind === 'space_agent') {
 		return actors.filter(
 			(actor) =>
@@ -461,10 +481,37 @@ function legacyTargetActors(row: PendingAgentMessageRecord, actors: ActorRef[]):
 		const parsed = parseWorkerActorId(actor.actorId);
 		return parsed?.workflowRunId === row.workflowRunId && parsed.agentName === row.targetAgentName;
 	});
+	if (row.status === 'pending') {
+		return stableActors([...matches, ...declaredLegacyTargetActors(row, actors, workflow)]);
+	}
 	const sorted = stableActors(matches);
-	if (row.status === 'pending') return sorted;
 	if (sorted.length === 1) return sorted;
 	return [];
+}
+
+function declaredLegacyTargetActors(
+	row: PendingAgentMessageRecord,
+	actors: ActorRef[],
+	workflow?: SpaceWorkflow | null
+): ActorRef[] {
+	if (!workflow) return [];
+	return workflow.nodes.flatMap((node) =>
+		node.agents.flatMap((agent): ActorRef[] => {
+			if (agent.name !== row.targetAgentName) return [];
+			const actorId = workerActorId(row.workflowRunId, node.id, agent.name);
+			if (actors.some((actor) => actor.actorId === actorId)) return [];
+			return [
+				{
+					actorId,
+					kind: 'worker',
+					spaceId: row.spaceId,
+					handle: workerHandle(row.workflowRunId, node.id, agent.name),
+					roles: uniqueStrings([actorRole(agent.name), actorRole(node.id)]),
+					status: 'inactive',
+				},
+			];
+		})
+	);
 }
 
 function pendingStatusToDeliveryState(status: PendingAgentMessageRecord['status']): DeliveryState {

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -44,6 +44,30 @@ export class SpaceMessageResolver implements ActorResolver {
 		const unresolved: UnresolvedTarget[] = [];
 		const seen = new Set<string>();
 
+		if (message.spaceId !== this.context.spaceId) {
+			return {
+				resolved,
+				unresolved: message.targets.map((targetRef) => ({
+					targetRef,
+					reason: `Message space ${message.spaceId} does not match resolver space ${this.context.spaceId}`,
+				})),
+			};
+		}
+
+		if (
+			this.context.workflowRunId &&
+			message.workflowRunId &&
+			message.workflowRunId !== this.context.workflowRunId
+		) {
+			return {
+				resolved,
+				unresolved: message.targets.map((targetRef) => ({
+					targetRef,
+					reason: `Message workflowRunId ${message.workflowRunId} does not match resolver workflowRunId ${this.context.workflowRunId}`,
+				})),
+			};
+		}
+
 		for (const targetRef of message.targets) {
 			let address: ParsedAddress;
 			try {
@@ -95,8 +119,9 @@ export class SpaceMessageResolver implements ActorResolver {
 				const active = holders.filter((actor) => actor.status === 'active');
 				const inactive = holders.filter((actor) => actor.status === 'inactive');
 				const routable = active.length > 0 ? active : inactive;
-				return routable.length > 0
-					? { actors: stableActors(routable) }
+				const permitted = this.permitRoleActors(routable);
+				return permitted.length > 0
+					? { actors: stableActors(permitted) }
 					: { actors: [], reason: `No routable actor found for role ${address.role}` };
 			}
 			case 'session': {
@@ -181,7 +206,21 @@ export class SpaceMessageResolver implements ActorResolver {
 		return { actors: stableActors(permitted) };
 	}
 
-	private canSendToWorker(workflowRunId: string, actor: ActorRef, address: WorkerAddress): boolean {
+	private permitRoleActors(actors: ActorRef[]): ActorRef[] {
+		if (!this.context.workflowRunId || !this.context.nodeId) return actors;
+		return actors.filter((actor) => {
+			if (actor.kind !== 'worker') return true;
+			const parsed = parseWorkerActorId(actor.actorId);
+			if (!parsed || parsed.workflowRunId !== this.context.workflowRunId) return false;
+			return this.canSendToWorker(this.context.workflowRunId!, actor);
+		});
+	}
+
+	private canSendToWorker(
+		workflowRunId: string,
+		actor: ActorRef,
+		address?: WorkerAddress
+	): boolean {
 		const run = this.config.workflowRunRepo.getRun(workflowRunId);
 		if (!run || run.spaceId !== this.context.spaceId) return false;
 		const workflow = this.config.workflowRepo.getWorkflow(run.workflowId);
@@ -189,7 +228,7 @@ export class SpaceMessageResolver implements ActorResolver {
 		const parsed = parseWorkerActorId(actor.actorId);
 		if (!parsed) return false;
 
-		if (address.workflowRunId && !this.context.nodeId) return true;
+		if (address?.workflowRunId && !this.context.nodeId) return true;
 
 		const fromNodeName = workflowNodeName(workflow.nodes, this.context.nodeId);
 		const targetNodeName = workflowNodeName(workflow.nodes, parsed.nodeId);

--- a/packages/daemon/src/lib/space/messaging-adapter.ts
+++ b/packages/daemon/src/lib/space/messaging-adapter.ts
@@ -16,6 +16,7 @@ import type {
 import type { PendingAgentMessageRecord } from '../../storage/repositories/pending-agent-message-repository';
 import type { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type { WorkflowNode } from '@neokai/shared';
 import { ChannelResolver } from './runtime/channel-resolver';
 import type { SpaceActorRegistryAdapter } from './actor-registry';
 
@@ -145,18 +146,25 @@ export class SpaceMessageResolver implements ActorResolver {
 			if (parsed.nodeId !== nodeId) return false;
 			return agentName ? parsed.agentName === agentName : true;
 		});
-		const routable = matches.filter(isRoutable);
+		let routable = matches.filter(isRoutable);
+		if (!agentName && this.context.agentName) {
+			routable = routable.filter(
+				(actor) => parseWorkerActorId(actor.actorId)?.agentName === this.context.agentName
+			);
+		}
 		if (routable.length === 0) {
 			return { actors: [], reason: `No routable worker actor found for ${targetRef}` };
 		}
-		if (!agentName && routable.length > 1 && !this.context.agentName) {
+		if (!agentName && routable.length > 1) {
 			return {
 				actors: [],
 				reason: `Worker target ${targetRef} is ambiguous; specify @worker:<node>/<agent>`,
 			};
 		}
 
-		const permitted = routable.filter((actor) => this.canSendToWorker(workflowRunId, actor));
+		const permitted = routable.filter((actor) =>
+			this.canSendToWorker(workflowRunId, actor, address)
+		);
 		if (permitted.length === 0) {
 			return {
 				actors: [],
@@ -166,16 +174,21 @@ export class SpaceMessageResolver implements ActorResolver {
 		return { actors: stableActors(permitted) };
 	}
 
-	private canSendToWorker(workflowRunId: string, actor: ActorRef): boolean {
-		const fromNode = this.context.nodeId;
-		if (!fromNode) return false;
+	private canSendToWorker(workflowRunId: string, actor: ActorRef, address: WorkerAddress): boolean {
 		const run = this.config.workflowRunRepo.getRun(workflowRunId);
-		if (!run) return false;
+		if (!run || run.spaceId !== this.context.spaceId) return false;
 		const workflow = this.config.workflowRepo.getWorkflow(run.workflowId);
-		if (!workflow?.channels || workflow.channels.length === 0) return false;
+		if (!workflow) return false;
 		const parsed = parseWorkerActorId(actor.actorId);
 		if (!parsed) return false;
-		return new ChannelResolver(workflow.channels).canSend(fromNode, parsed.nodeId);
+
+		if (address.workflowRunId && !this.context.nodeId) return true;
+
+		const fromNodeName = workflowNodeName(workflow.nodes, this.context.nodeId);
+		const targetNodeName = workflowNodeName(workflow.nodes, parsed.nodeId);
+		if (!fromNodeName || !targetNodeName) return false;
+		if (!workflow.channels || workflow.channels.length === 0) return false;
+		return new ChannelResolver(workflow.channels).canSend(fromNodeName, targetNodeName);
 	}
 }
 
@@ -255,11 +268,11 @@ function createDeliveryFromActor(
 	actor: ActorRef
 ): DeliveryRecord {
 	return {
-		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(actor.actorId)}`,
+		deliveryId: `delivery_${message.messageId}_${encodeURIComponent(targetRef)}_${encodeURIComponent(actor.actorId)}`,
 		messageId: message.messageId,
 		targetActorId: actor.actorId,
 		targetRef,
-		state: actor.status === 'active' ? 'delivered' : 'queued',
+		state: 'queued',
 		attemptCount: 0,
 		maxAttempts: 5,
 		createdAt: Date.now(),
@@ -354,6 +367,12 @@ function stableActors(actors: ActorRef[]): ActorRef[] {
 
 function actorRole(role: string): string {
 	return `actor-role:${encodeURIComponent(role)}`;
+}
+
+function workflowNodeName(nodes: WorkflowNode[], nodeId: string | undefined): string | null {
+	if (!nodeId) return null;
+	const node = nodes.find((candidate) => candidate.id === nodeId || candidate.name === nodeId);
+	return node?.name ?? null;
 }
 
 function parseWorkerActorId(

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+	SpaceDeliveryFacade,
+	SpaceMessageResolver,
+	pendingMessageToDeliveryRecords,
+	pendingMessageToMessageRecord,
+} from '../../../src/lib/space/messaging-adapter';
+import { SpaceActorRegistryAdapter } from '../../../src/lib/space/actor-registry';
+import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
+import { PendingAgentMessageRepository } from '../../../src/storage/repositories/pending-agent-message-repository';
+import { SessionRepository } from '../../../src/storage/repositories/session-repository';
+import { SpaceAgentRepository } from '../../../src/storage/repositories/space-agent-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import type { MessageRecord } from '../../../../messaging/src/types';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+function alignTestSchema(db: Database): void {
+	db.exec('ALTER TABLE space_agents ADD COLUMN custom_prompt TEXT DEFAULT NULL');
+	db.exec('DROP TABLE sessions');
+	db.exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			workspace_path TEXT,
+			created_at TEXT NOT NULL,
+			last_active_at TEXT NOT NULL,
+			status TEXT NOT NULL CHECK(status IN ('active', 'paused', 'ended', 'archived', 'pending_worktree_choice')),
+			config TEXT NOT NULL,
+			metadata TEXT NOT NULL,
+			is_worktree INTEGER DEFAULT 0,
+			worktree_path TEXT,
+			main_repo_path TEXT,
+			worktree_branch TEXT,
+			git_branch TEXT,
+			sdk_session_id TEXT,
+			sdk_origin_path TEXT,
+			available_commands TEXT,
+			processing_state TEXT,
+			archived_at TEXT,
+			type TEXT DEFAULT 'worker',
+			session_context TEXT
+		)
+	`);
+}
+
+describe('Space messaging adapter', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let sessionRepo: SessionRepository;
+	let spaceAgentRepo: SpaceAgentRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let nodeExecutionRepo: NodeExecutionRepository;
+	let pendingMessageRepo: PendingAgentMessageRepository;
+	let registry: SpaceActorRegistryAdapter;
+	let spaceId: string;
+	let runId: string;
+	let message: MessageRecord;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		alignTestSchema(db);
+		spaceRepo = new SpaceRepository(db);
+		sessionRepo = new SessionRepository(db);
+		spaceAgentRepo = new SpaceAgentRepository(db);
+		workflowRepo = new SpaceWorkflowRepository(db);
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+		pendingMessageRepo = new PendingAgentMessageRepository(db);
+		registry = new SpaceActorRegistryAdapter({
+			spaceRepo,
+			sessionRepo,
+			spaceAgentRepo,
+			workflowRepo,
+			workflowRunRepo,
+			nodeExecutionRepo,
+			pendingMessageRepo,
+		});
+
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/project',
+			slug: 'project',
+			name: 'Project',
+		});
+		spaceId = space.id;
+		const agent = spaceAgentRepo.create({ spaceId, name: 'Worker Agent' });
+		const workflow = workflowRepo.createWorkflow({
+			spaceId,
+			name: 'Coding Workflow',
+			nodes: [
+				{ id: 'Coding', name: 'Coding', agents: [{ agentId: agent.id, name: 'coder' }] },
+				{ id: 'Review', name: 'Review', agents: [{ agentId: agent.id, name: 'reviewer' }] },
+				{ id: 'QA', name: 'QA', agents: [{ agentId: agent.id, name: 'reviewer' }] },
+			],
+			channels: [{ from: 'Coding', to: ['Review', 'QA'] }],
+			transitions: [],
+			startNodeId: 'Coding',
+			rules: [],
+			completionAutonomyLevel: 3,
+		});
+		const run = workflowRunRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Run' });
+		runId = run.id;
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'Coding',
+			agentName: 'coder',
+			agentId: agent.id,
+			agentSessionId: 'coding-session',
+			status: 'in_progress',
+		});
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'Review',
+			agentName: 'reviewer',
+			agentId: agent.id,
+			agentSessionId: 'review-session',
+			status: 'in_progress',
+		});
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'QA',
+			agentName: 'reviewer',
+			agentId: agent.id,
+			agentSessionId: null,
+			status: 'pending',
+		});
+		message = {
+			messageId: 'msg-1',
+			spaceId,
+			senderActorId: `worker:${encodeURIComponent(runId)}:Coding:coder`,
+			targets: [],
+			body: 'hello',
+			kind: 'message',
+			workflowRunId: runId,
+			createdAt: 1,
+		};
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('resolves handles, role fan-out, sessions, and workers deterministically', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'Coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@coordinator', '@role:reviewer', '@worker:Review/reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
+			`agent:coordinator:${spaceId}`,
+			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
+			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
+		]);
+	});
+
+	it('errors instead of falling back for stale handles and forbidden worker topology', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'Review', agentName: 'reviewer' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@coordiantor', '@worker:QA/reviewer'],
+		});
+
+		expect(result.resolved).toEqual([]);
+		expect(result.unresolved.map((target) => target.reason)).toEqual([
+			'No routable actor found for handle @coordiantor',
+			'Channel topology does not permit worker target @worker:QA/reviewer',
+		]);
+	});
+
+	it('writes queued deliveries for inactive actors and failed rows for unresolved targets', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'Coding', agentName: 'coder' }
+		);
+		const facade = new SpaceDeliveryFacade({ resolver });
+		const result = await facade.routeMessage({
+			...message,
+			targets: ['@worker:QA/reviewer', '@missing'],
+		});
+
+		expect(result.deliveries).toHaveLength(2);
+		expect(result.deliveries[0]).toMatchObject({
+			targetActorId: `worker:${encodeURIComponent(runId)}:QA:reviewer`,
+			targetRef: '@worker:QA/reviewer',
+			state: 'queued',
+		});
+		expect(result.deliveries[1]).toMatchObject({
+			targetRef: '@missing',
+			state: 'failed',
+			lastError: 'No routable actor found for handle @missing',
+		});
+	});
+
+	it('maps pending_agent_messages rows into message and delivery facade records', () => {
+		const pending = pendingMessageRepo.enqueue({
+			workflowRunId: runId,
+			spaceId,
+			taskId: 'task-1',
+			sourceAgentName: 'coder',
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'queued review',
+			idempotencyKey: 'idem-1',
+		}).record;
+
+		const mappedMessage = pendingMessageToMessageRecord(pending);
+		const deliveries = pendingMessageToDeliveryRecords(pending, registry.listActors(spaceId));
+
+		expect(mappedMessage).toMatchObject({
+			messageId: `msg_legacy_${pending.id}`,
+			spaceId,
+			targets: ['reviewer'],
+			body: 'queued review',
+			workflowRunId: runId,
+			taskId: 'task-1',
+			idempotencyKey: 'idem-1',
+		});
+		expect(deliveries.map((delivery) => delivery.targetActorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:QA:reviewer`,
+			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
+		]);
+		expect(deliveries.every((delivery) => delivery.state === 'queued')).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -491,6 +491,86 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('resolves spawned workers for node-name role targets', async () => {
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'node-deploy',
+			agentName: 'deployer',
+			agentId: spaceAgentRepo.getBySpaceId(spaceId)[0].id,
+			agentSessionId: 'deploy-session',
+			status: 'in_progress',
+		});
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:Deploy'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-deploy:deployer`,
+				status: 'active',
+			}),
+		]);
+	});
+
+	it('includes declared worker slots for encoded agent-role targets', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:actor-role:reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
+	it('scopes role worker candidates to the message workflow run', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+		expect(result.resolved.every((target) => target.actor.status === 'inactive')).toBe(true);
+	});
+
 	it('queues missing context-selected worker slots instead of unrelated spawned slots', async () => {
 		nodeExecutionRepo.delete(
 			nodeExecutionRepo

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -214,6 +214,40 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('falls back to permitted inactive role holders when active holders are rejected', async () => {
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'node-qa',
+			agentName: 'reviewer',
+			agentId: spaceAgentRepo.getBySpaceId(spaceId)[0].id,
+			agentSessionId: 'qa-session',
+			status: 'in_progress',
+		});
+		nodeExecutionRepo.updateStatus(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id,
+			'pending'
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+		expect(result.resolved[0].actor.status).toBe('inactive');
+	});
+
 	it('errors instead of falling back for stale handles and forbidden worker topology', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -332,6 +366,33 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('queues declared workflow workers that have not spawned yet', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@worker:Review/reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
 	it('returns unresolved deliveries for malformed worker escapes', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -396,6 +457,13 @@ describe('Space messaging adapter', () => {
 	});
 
 	it('maps legacy senders and terminal deliveries without inventing actors', () => {
+		const observerExecution = nodeExecutionRepo
+			.listByWorkflowRun(runId)
+			.find(
+				(execution) =>
+					execution.workflowNodeId === 'node-review' && execution.agentName === 'observer'
+			)!;
+		nodeExecutionRepo.updateStatus(observerExecution.id, 'cancelled');
 		const actors = registry.listActors(spaceId);
 		const queued = pendingMessageRepo.enqueue({
 			workflowRunId: runId,
@@ -406,6 +474,18 @@ describe('Space messaging adapter', () => {
 			targetAgentName: 'reviewer',
 			message: 'queued review',
 		}).record;
+		const archivedSender = pendingMessageToMessageRecord(
+			{
+				...queued,
+				sourceAgentName: 'observer',
+				targetAgentName: 'reviewer',
+			},
+			actors
+		);
+		expect(archivedSender.senderActorId).toBe(
+			`worker:${encodeURIComponent(runId)}:node-review:observer`
+		);
+
 		const mappedWorkerSender = pendingMessageToMessageRecord(queued, actors);
 		expect(mappedWorkerSender.senderActorId).toBe(
 			`worker:${encodeURIComponent(runId)}:node-coding:coder`
@@ -417,14 +497,28 @@ describe('Space messaging adapter', () => {
 		);
 		expect(coordinator.senderActorId).toBe(`agent:coordinator:${spaceId}`);
 
+		nodeExecutionRepo.updateStatus(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id,
+			'cancelled'
+		);
+		const actorsWithArchivedReviewer = registry.listActors(spaceId);
 		const delivered = {
 			...queued,
+			targetAgentName: 'observer',
 			status: 'delivered' as const,
-			deliveredSessionId: 'reviewer',
+			deliveredSessionId: 'observer',
 			deliveredAt: Date.now(),
 		};
-		expect(pendingMessageToDeliveryRecords(delivered, actors)).toEqual([
-			expect.objectContaining({ targetActorId: undefined, state: 'delivered' }),
+		expect(pendingMessageToDeliveryRecords(delivered, actorsWithArchivedReviewer)).toEqual([
+			expect.objectContaining({
+				targetActorId: `worker:${encodeURIComponent(runId)}:node-review:observer`,
+				state: 'delivered',
+			}),
 		]);
 
 		const failed = { ...queued, status: 'failed' as const };

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -282,10 +282,10 @@ describe('Space messaging adapter', () => {
 		const facade = new SpaceDeliveryFacade({ resolver });
 		const result = await facade.routeMessage({
 			...message,
-			targets: ['@worker:%/reviewer', '@worker:Review/reviewer'],
+			targets: ['@worker:%/reviewer', '@worker:Review/reviewer', '@worker:%/reviewer'],
 		});
 
-		expect(result.deliveries).toHaveLength(2);
+		expect(result.deliveries).toHaveLength(3);
 		expect(result.deliveries[0]).toMatchObject({
 			targetRef: '@worker:Review/reviewer',
 			state: 'queued',
@@ -295,6 +295,14 @@ describe('Space messaging adapter', () => {
 			state: 'failed',
 			lastError: 'Invalid worker target escape in @worker:%/reviewer',
 		});
+		expect(result.deliveries[2]).toMatchObject({
+			targetRef: '@worker:%/reviewer',
+			state: 'failed',
+			lastError: 'Invalid worker target escape in @worker:%/reviewer',
+		});
+		expect(new Set(result.deliveries.map((delivery) => delivery.deliveryId)).size).toBe(
+			result.deliveries.length
+		);
 	});
 
 	it('maps pending_agent_messages rows into message and delivery facade records', () => {
@@ -309,8 +317,9 @@ describe('Space messaging adapter', () => {
 			idempotencyKey: 'idem-1',
 		}).record;
 
-		const mappedMessage = pendingMessageToMessageRecord(pending);
-		const deliveries = pendingMessageToDeliveryRecords(pending, registry.listActors(spaceId));
+		const actors = registry.listActors(spaceId);
+		const mappedMessage = pendingMessageToMessageRecord(pending, actors);
+		const deliveries = pendingMessageToDeliveryRecords(pending, actors);
 
 		expect(mappedMessage).toMatchObject({
 			messageId: `msg_legacy_${pending.id}`,
@@ -326,5 +335,43 @@ describe('Space messaging adapter', () => {
 			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
 		]);
 		expect(deliveries.every((delivery) => delivery.state === 'queued')).toBe(true);
+	});
+
+	it('maps legacy senders and terminal deliveries without inventing actors', () => {
+		const actors = registry.listActors(spaceId);
+		const queued = pendingMessageRepo.enqueue({
+			workflowRunId: runId,
+			spaceId,
+			taskId: 'task-1',
+			sourceAgentName: 'coder',
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'queued review',
+		}).record;
+		const mappedWorkerSender = pendingMessageToMessageRecord(queued, actors);
+		expect(mappedWorkerSender.senderActorId).toBe(
+			`worker:${encodeURIComponent(runId)}:node-coding:coder`
+		);
+
+		const coordinator = pendingMessageToMessageRecord(
+			{ ...queued, sourceAgentName: 'coordinator' },
+			actors
+		);
+		expect(coordinator.senderActorId).toBe(`agent:coordinator:${spaceId}`);
+
+		const delivered = {
+			...queued,
+			status: 'delivered' as const,
+			deliveredSessionId: 'reviewer',
+			deliveredAt: Date.now(),
+		};
+		expect(pendingMessageToDeliveryRecords(delivered, actors)).toEqual([
+			expect.objectContaining({ targetActorId: undefined, state: 'delivered' }),
+		]);
+
+		const failed = { ...queued, status: 'failed' as const };
+		expect(pendingMessageToDeliveryRecords(failed, actors)).toEqual([
+			expect.objectContaining({ targetActorId: undefined, state: 'failed' }),
+		]);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -226,14 +226,14 @@ describe('Space messaging adapter', () => {
 		);
 	});
 
-	it('filters shorthand worker target by context agent and permits explicit run targets from space context', async () => {
+	it('resolves worker node names, context agent shorthand, and explicit run targets', async () => {
 		const shorthandResolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
 			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'reviewer' }
 		);
 		const shorthand = await shorthandResolver.resolveTargets({
 			...message,
-			targets: ['@worker:node-review'],
+			targets: ['@worker:Review'],
 		});
 		expect(shorthand.unresolved).toEqual([]);
 		expect(shorthand.resolved.map((target) => target.actor.actorId)).toEqual([
@@ -247,12 +247,54 @@ describe('Space messaging adapter', () => {
 		const explicit = await explicitResolver.resolveTargets({
 			...message,
 			workflowRunId: undefined,
-			targets: [`@worker:${runId}/node-review/reviewer`],
+			targets: [`@worker:${runId}/Review/reviewer`],
 		});
 		expect(explicit.unresolved).toEqual([]);
 		expect(explicit.resolved.map((target) => target.actor.actorId)).toEqual([
 			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
 		]);
+	});
+
+	it('permits worker routes declared with agent-name channel endpoints', async () => {
+		workflowRepo.updateWorkflow(workflowRunRepo.getRun(runId)!.workflowId, {
+			channels: [{ from: 'coder', to: 'reviewer' }],
+		});
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@worker:Review/reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+	});
+
+	it('returns unresolved deliveries for malformed worker escapes', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const facade = new SpaceDeliveryFacade({ resolver });
+		const result = await facade.routeMessage({
+			...message,
+			targets: ['@worker:%/reviewer', '@worker:Review/reviewer'],
+		});
+
+		expect(result.deliveries).toHaveLength(2);
+		expect(result.deliveries[0]).toMatchObject({
+			targetRef: '@worker:Review/reviewer',
+			state: 'queued',
+		});
+		expect(result.deliveries[1]).toMatchObject({
+			targetRef: '@worker:%/reviewer',
+			state: 'failed',
+			lastError: 'Invalid worker target escape in @worker:%/reviewer',
+		});
 	});
 
 	it('maps pending_agent_messages rows into message and delivery facade records', () => {

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -103,7 +103,7 @@ describe('Space messaging adapter', () => {
 				},
 				{ id: 'node-qa', name: 'QA', agents: [{ agentId: agent.id, name: 'reviewer' }] },
 			],
-			channels: [{ from: 'Coding', to: ['Review', 'QA'] }],
+			channels: [{ from: 'Coding', to: ['Review'] }],
 			transitions: [],
 			startNodeId: 'Coding',
 			rules: [],
@@ -111,6 +111,19 @@ describe('Space messaging adapter', () => {
 		});
 		const run = workflowRunRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Run' });
 		runId = run.id;
+		const otherRun = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Run 2',
+		});
+		nodeExecutionRepo.create({
+			workflowRunId: otherRun.id,
+			workflowNodeId: 'node-review',
+			agentName: 'reviewer',
+			agentId: agent.id,
+			agentSessionId: 'other-review-session',
+			status: 'in_progress',
+		});
 		nodeExecutionRepo.create({
 			workflowRunId: runId,
 			workflowNodeId: 'node-coding',
@@ -177,6 +190,30 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('filters role-resolved worker actors through channel topology', async () => {
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'node-qa',
+			agentName: 'reviewer',
+			agentId: spaceAgentRepo.getBySpaceId(spaceId)[0].id,
+			agentSessionId: 'qa-session',
+			status: 'in_progress',
+		});
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+	});
+
 	it('errors instead of falling back for stale handles and forbidden worker topology', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -194,6 +231,32 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('rejects message space and implicit workflow run mismatches', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const spaceMismatch = await resolver.resolveTargets({
+			...message,
+			spaceId: 'other-space',
+			targets: ['@coordinator'],
+		});
+		expect(spaceMismatch.resolved).toEqual([]);
+		expect(spaceMismatch.unresolved.map((target) => target.reason)).toEqual([
+			`Message space other-space does not match resolver space ${spaceId}`,
+		]);
+
+		const runMismatch = await resolver.resolveTargets({
+			...message,
+			workflowRunId: 'other-run',
+			targets: ['@worker:Review/reviewer'],
+		});
+		expect(runMismatch.resolved).toEqual([]);
+		expect(runMismatch.unresolved.map((target) => target.reason)).toEqual([
+			`Message workflowRunId other-run does not match resolver workflowRunId ${runId}`,
+		]);
+	});
+
 	it('writes queued deliveries for inactive actors and failed rows for unresolved targets', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -202,21 +265,16 @@ describe('Space messaging adapter', () => {
 		const facade = new SpaceDeliveryFacade({ resolver });
 		const result = await facade.routeMessage({
 			...message,
-			targets: ['@worker:node-review/reviewer', '@worker:node-qa/reviewer', '@missing'],
+			targets: ['@worker:node-review/reviewer', '@missing'],
 		});
 
-		expect(result.deliveries).toHaveLength(3);
+		expect(result.deliveries).toHaveLength(2);
 		expect(result.deliveries[0]).toMatchObject({
 			targetActorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
 			targetRef: '@worker:node-review/reviewer',
 			state: 'queued',
 		});
 		expect(result.deliveries[1]).toMatchObject({
-			targetActorId: `worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
-			targetRef: '@worker:node-qa/reviewer',
-			state: 'queued',
-		});
-		expect(result.deliveries[2]).toMatchObject({
 			targetRef: '@missing',
 			state: 'failed',
 			lastError: 'No routable actor found for handle @missing',

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -101,9 +101,10 @@ describe('Space messaging adapter', () => {
 						{ agentId: agent.id, name: 'observer' },
 					],
 				},
+				{ id: 'node-deploy', name: 'Deploy', agents: [{ agentId: agent.id, name: 'deployer' }] },
 				{ id: 'node-qa', name: 'QA', agents: [{ agentId: agent.id, name: 'reviewer' }] },
 			],
-			channels: [{ from: 'Coding', to: ['Review'] }],
+			channels: [{ from: 'Coding', to: ['Review', 'Deploy'] }],
 			transitions: [],
 			startNodeId: 'Coding',
 			rules: [],
@@ -393,6 +394,88 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('queues declared single-slot worker shorthand without a spawned execution', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@worker:Deploy'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-deploy:deployer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
+	it('includes declared worker slots in role resolution', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		nodeExecutionRepo.updateStatus(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-qa' && execution.agentName === 'reviewer'
+				)!.id,
+			'cancelled'
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:reviewer'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
+	it('queues missing context-selected worker slots instead of unrelated spawned slots', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'reviewer' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@worker:Review'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
 	it('returns unresolved deliveries for malformed worker escapes', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -524,6 +607,50 @@ describe('Space messaging adapter', () => {
 		const failed = { ...queued, status: 'failed' as const };
 		expect(pendingMessageToDeliveryRecords(failed, actors)).toEqual([
 			expect.objectContaining({ targetActorId: undefined, state: 'failed' }),
+		]);
+	});
+
+	it('preserves terminal coordinator delivery targets', () => {
+		sessionRepo.createSession({
+			id: `space:chat:${spaceId}`,
+			title: 'Space chat',
+			workspacePath: '/workspace/project',
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'archived',
+			config: {},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+			},
+			type: 'space_chat',
+			context: { spaceId },
+		});
+		const actors = registry.listActors(spaceId);
+		const queued = pendingMessageRepo.enqueue({
+			workflowRunId: runId,
+			spaceId,
+			sourceAgentName: 'coder',
+			targetKind: 'space_agent',
+			targetAgentName: 'coordinator',
+			message: 'terminal escalation',
+		}).record;
+		const delivered = {
+			...queued,
+			status: 'delivered' as const,
+			deliveredSessionId: `space:chat:${spaceId}`,
+			deliveredAt: Date.now(),
+		};
+
+		expect(pendingMessageToDeliveryRecords(delivered, actors)).toEqual([
+			expect.objectContaining({
+				targetActorId: `agent:coordinator:${spaceId}`,
+				state: 'delivered',
+			}),
 		]);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -92,9 +92,16 @@ describe('Space messaging adapter', () => {
 			spaceId,
 			name: 'Coding Workflow',
 			nodes: [
-				{ id: 'Coding', name: 'Coding', agents: [{ agentId: agent.id, name: 'coder' }] },
-				{ id: 'Review', name: 'Review', agents: [{ agentId: agent.id, name: 'reviewer' }] },
-				{ id: 'QA', name: 'QA', agents: [{ agentId: agent.id, name: 'reviewer' }] },
+				{ id: 'node-coding', name: 'Coding', agents: [{ agentId: agent.id, name: 'coder' }] },
+				{
+					id: 'node-review',
+					name: 'Review',
+					agents: [
+						{ agentId: agent.id, name: 'reviewer' },
+						{ agentId: agent.id, name: 'observer' },
+					],
+				},
+				{ id: 'node-qa', name: 'QA', agents: [{ agentId: agent.id, name: 'reviewer' }] },
 			],
 			channels: [{ from: 'Coding', to: ['Review', 'QA'] }],
 			transitions: [],
@@ -106,7 +113,7 @@ describe('Space messaging adapter', () => {
 		runId = run.id;
 		nodeExecutionRepo.create({
 			workflowRunId: runId,
-			workflowNodeId: 'Coding',
+			workflowNodeId: 'node-coding',
 			agentName: 'coder',
 			agentId: agent.id,
 			agentSessionId: 'coding-session',
@@ -114,7 +121,7 @@ describe('Space messaging adapter', () => {
 		});
 		nodeExecutionRepo.create({
 			workflowRunId: runId,
-			workflowNodeId: 'Review',
+			workflowNodeId: 'node-review',
 			agentName: 'reviewer',
 			agentId: agent.id,
 			agentSessionId: 'review-session',
@@ -122,7 +129,15 @@ describe('Space messaging adapter', () => {
 		});
 		nodeExecutionRepo.create({
 			workflowRunId: runId,
-			workflowNodeId: 'QA',
+			workflowNodeId: 'node-review',
+			agentName: 'observer',
+			agentId: agent.id,
+			agentSessionId: 'observer-session',
+			status: 'in_progress',
+		});
+		nodeExecutionRepo.create({
+			workflowRunId: runId,
+			workflowNodeId: 'node-qa',
 			agentName: 'reviewer',
 			agentId: agent.id,
 			agentSessionId: null,
@@ -131,7 +146,7 @@ describe('Space messaging adapter', () => {
 		message = {
 			messageId: 'msg-1',
 			spaceId,
-			senderActorId: `worker:${encodeURIComponent(runId)}:Coding:coder`,
+			senderActorId: `worker:${encodeURIComponent(runId)}:node-coding:coder`,
 			targets: [],
 			body: 'hello',
 			kind: 'message',
@@ -147,60 +162,97 @@ describe('Space messaging adapter', () => {
 	it('resolves handles, role fan-out, sessions, and workers deterministically', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
-			{ spaceId, workflowRunId: runId, nodeId: 'Coding', agentName: 'coder' }
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
 		);
 		const result = await resolver.resolveTargets({
 			...message,
-			targets: ['@coordinator', '@role:reviewer', '@worker:Review/reviewer'],
+			targets: ['@coordinator', '@role:reviewer', '@worker:node-review/reviewer'],
 		});
 
 		expect(result.unresolved).toEqual([]);
 		expect(result.resolved.map((target) => target.actor.actorId)).toEqual([
 			`agent:coordinator:${spaceId}`,
-			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
-			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
 		]);
 	});
 
 	it('errors instead of falling back for stale handles and forbidden worker topology', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
-			{ spaceId, workflowRunId: runId, nodeId: 'Review', agentName: 'reviewer' }
+			{ spaceId, workflowRunId: runId, nodeId: 'node-review', agentName: 'reviewer' }
 		);
 		const result = await resolver.resolveTargets({
 			...message,
-			targets: ['@coordiantor', '@worker:QA/reviewer'],
+			targets: ['@coordiantor', '@worker:node-qa/reviewer'],
 		});
 
 		expect(result.resolved).toEqual([]);
 		expect(result.unresolved.map((target) => target.reason)).toEqual([
 			'No routable actor found for handle @coordiantor',
-			'Channel topology does not permit worker target @worker:QA/reviewer',
+			'Channel topology does not permit worker target @worker:node-qa/reviewer',
 		]);
 	});
 
 	it('writes queued deliveries for inactive actors and failed rows for unresolved targets', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
-			{ spaceId, workflowRunId: runId, nodeId: 'Coding', agentName: 'coder' }
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
 		);
 		const facade = new SpaceDeliveryFacade({ resolver });
 		const result = await facade.routeMessage({
 			...message,
-			targets: ['@worker:QA/reviewer', '@missing'],
+			targets: ['@worker:node-review/reviewer', '@worker:node-qa/reviewer', '@missing'],
 		});
 
-		expect(result.deliveries).toHaveLength(2);
+		expect(result.deliveries).toHaveLength(3);
 		expect(result.deliveries[0]).toMatchObject({
-			targetActorId: `worker:${encodeURIComponent(runId)}:QA:reviewer`,
-			targetRef: '@worker:QA/reviewer',
+			targetActorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+			targetRef: '@worker:node-review/reviewer',
 			state: 'queued',
 		});
 		expect(result.deliveries[1]).toMatchObject({
+			targetActorId: `worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
+			targetRef: '@worker:node-qa/reviewer',
+			state: 'queued',
+		});
+		expect(result.deliveries[2]).toMatchObject({
 			targetRef: '@missing',
 			state: 'failed',
 			lastError: 'No routable actor found for handle @missing',
 		});
+		expect(new Set(result.deliveries.map((delivery) => delivery.deliveryId)).size).toBe(
+			result.deliveries.length
+		);
+	});
+
+	it('filters shorthand worker target by context agent and permits explicit run targets from space context', async () => {
+		const shorthandResolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'reviewer' }
+		);
+		const shorthand = await shorthandResolver.resolveTargets({
+			...message,
+			targets: ['@worker:node-review'],
+		});
+		expect(shorthand.unresolved).toEqual([]);
+		expect(shorthand.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+
+		const explicitResolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId }
+		);
+		const explicit = await explicitResolver.resolveTargets({
+			...message,
+			workflowRunId: undefined,
+			targets: [`@worker:${runId}/node-review/reviewer`],
+		});
+		expect(explicit.unresolved).toEqual([]);
+		expect(explicit.resolved.map((target) => target.actor.actorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
 	});
 
 	it('maps pending_agent_messages rows into message and delivery facade records', () => {
@@ -228,8 +280,8 @@ describe('Space messaging adapter', () => {
 			idempotencyKey: 'idem-1',
 		});
 		expect(deliveries.map((delivery) => delivery.targetActorId)).toEqual([
-			`worker:${encodeURIComponent(runId)}:QA:reviewer`,
-			`worker:${encodeURIComponent(runId)}:Review:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
 		]);
 		expect(deliveries.every((delivery) => delivery.state === 'queued')).toBe(true);
 	});

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -476,6 +476,56 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('rejects ambiguous worker node shorthand based on declared slots', async () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			workflowRunId: undefined,
+			targets: ['@worker:Review'],
+		});
+
+		expect(result.resolved).toEqual([]);
+		expect(result.unresolved.map((target) => target.reason)).toEqual([
+			'Worker target @worker:Review is ambiguous; specify @worker:<node>/<agent>',
+		]);
+	});
+
+	it('does not synthesize declared role workers over archived executions', async () => {
+		nodeExecutionRepo.updateStatus(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id,
+			'cancelled'
+		);
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:reviewer'],
+		});
+
+		expect(result.resolved).toEqual([]);
+		expect(result.unresolved.map((target) => target.reason)).toEqual([
+			'No routable actor found for role reviewer',
+		]);
+	});
+
 	it('returns unresolved deliveries for malformed worker escapes', async () => {
 		const resolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -532,6 +582,36 @@ describe('Space messaging adapter', () => {
 			taskId: 'task-1',
 			idempotencyKey: 'idem-1',
 		});
+		expect(deliveries.map((delivery) => delivery.targetActorId)).toEqual([
+			`worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
+			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+		]);
+		expect(deliveries.every((delivery) => delivery.state === 'queued')).toBe(true);
+	});
+
+	it('includes unspawned declared slots in pending legacy fan-out', () => {
+		nodeExecutionRepo.delete(
+			nodeExecutionRepo
+				.listByWorkflowRun(runId)
+				.find(
+					(execution) =>
+						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
+				)!.id
+		);
+		const pending = pendingMessageRepo.enqueue({
+			workflowRunId: runId,
+			spaceId,
+			taskId: 'task-1',
+			sourceAgentName: 'coder',
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'queued review',
+		}).record;
+
+		const actors = registry.listActors(spaceId);
+		const workflow = workflowRepo.getWorkflow(workflowRunRepo.getRun(runId)!.workflowId)!;
+		const deliveries = pendingMessageToDeliveryRecords(pending, actors, workflow);
+
 		expect(deliveries.map((delivery) => delivery.targetActorId)).toEqual([
 			`worker:${encodeURIComponent(runId)}:node-qa:reviewer`,
 			`worker:${encodeURIComponent(runId)}:node-review:reviewer`,

--- a/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
+++ b/packages/daemon/tests/unit/5-space/messaging-adapter.test.ts
@@ -319,6 +319,29 @@ describe('Space messaging adapter', () => {
 		);
 	});
 
+	it('keeps active actors queued when delivery callback returns no session id', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const facade = new SpaceDeliveryFacade({
+			resolver,
+			deliverToSession: async () => null,
+		});
+		const result = await facade.routeMessage({
+			...message,
+			targets: ['@worker:node-review/reviewer'],
+		});
+
+		expect(result.deliveries).toHaveLength(1);
+		expect(result.deliveries[0]).toMatchObject({
+			targetActorId: `worker:${encodeURIComponent(runId)}:node-review:reviewer`,
+			state: 'queued',
+		});
+		expect(result.deliveries[0].deliveredAt).toBeUndefined();
+		expect(result.deliveries[0].deliveredSessionId).toBeUndefined();
+	});
+
 	it('resolves worker node names, context agent shorthand, and explicit run targets', async () => {
 		const shorthandResolver = new SpaceMessageResolver(
 			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
@@ -449,6 +472,25 @@ describe('Space messaging adapter', () => {
 		]);
 	});
 
+	it('includes declared worker slots for node-role targets', async () => {
+		const resolver = new SpaceMessageResolver(
+			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+			{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName: 'coder' }
+		);
+		const result = await resolver.resolveTargets({
+			...message,
+			targets: ['@role:node-deploy'],
+		});
+
+		expect(result.unresolved).toEqual([]);
+		expect(result.resolved.map((target) => target.actor)).toEqual([
+			expect.objectContaining({
+				actorId: `worker:${encodeURIComponent(runId)}:node-deploy:deployer`,
+				status: 'inactive',
+			}),
+		]);
+	});
+
 	it('queues missing context-selected worker slots instead of unrelated spawned slots', async () => {
 		nodeExecutionRepo.delete(
 			nodeExecutionRepo
@@ -485,20 +527,22 @@ describe('Space messaging adapter', () => {
 						execution.workflowNodeId === 'node-review' && execution.agentName === 'reviewer'
 				)!.id
 		);
-		const resolver = new SpaceMessageResolver(
-			{ actorRegistry: registry, workflowRepo, workflowRunRepo },
-			{ spaceId, workflowRunId: runId, nodeId: 'node-coding' }
-		);
-		const result = await resolver.resolveTargets({
-			...message,
-			workflowRunId: undefined,
-			targets: ['@worker:Review'],
-		});
+		for (const agentName of [undefined, 'coder']) {
+			const resolver = new SpaceMessageResolver(
+				{ actorRegistry: registry, workflowRepo, workflowRunRepo },
+				{ spaceId, workflowRunId: runId, nodeId: 'node-coding', agentName }
+			);
+			const result = await resolver.resolveTargets({
+				...message,
+				workflowRunId: undefined,
+				targets: ['@worker:Review'],
+			});
 
-		expect(result.resolved).toEqual([]);
-		expect(result.unresolved.map((target) => target.reason)).toEqual([
-			'Worker target @worker:Review is ambiguous; specify @worker:<node>/<agent>',
-		]);
+			expect(result.resolved).toEqual([]);
+			expect(result.unresolved.map((target) => target.reason)).toEqual([
+				'Worker target @worker:Review is ambiguous; specify @worker:<node>/<agent>',
+			]);
+		}
 	});
 
 	it('does not synthesize declared role workers over archived executions', async () => {


### PR DESCRIPTION
Adds Space actor target resolution and delivery facade for actor-addressed messaging.

Covers deterministic handle/role/session/worker resolution, channel topology checks for worker targets, queued/inactive delivery rows, and pending_agent_messages compatibility mapping.

Tests: bun run check; cd packages/daemon && bun test tests/unit/5-space/messaging-adapter.test.ts