### PR TITLE
Cap agent slot event interests

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -102,6 +102,7 @@ import { selectWorkflow } from './workflow-selector';
 import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
 
 const log = new Logger('space-runtime');
+const MAX_AGENT_SLOT_EVENT_INTERESTS = 10;
 const PRIORITY_ORDER: Record<SpaceTaskPriority, number> = {
 	urgent: 0,
 	high: 1,
@@ -797,6 +798,18 @@ export class SpaceRuntime {
 					`${workflowRunId}/${nodeId}/${agentName}: ${validation.reason ?? 'invalid pattern'}`
 			);
 			return;
+		}
+		const existingInterests = this.topicTrie.count(
+			(target) =>
+				target.workflowRunId === workflowRunId &&
+				target.nodeId === nodeId &&
+				target.agentName === agentName
+		);
+		if (existingInterests >= MAX_AGENT_SLOT_EVENT_INTERESTS) {
+			throw new Error(
+				`Agent slot ${workflowRunId}/${nodeId}/${agentName} cannot register more than ` +
+					`${MAX_AGENT_SLOT_EVENT_INTERESTS} event interests`
+			);
 		}
 		this.topicTrie.insert(trimmed, { workflowRunId, taskId, nodeId, agentName });
 	}

--- a/packages/daemon/src/lib/space/runtime/topic-trie.ts
+++ b/packages/daemon/src/lib/space/runtime/topic-trie.ts
@@ -56,6 +56,24 @@ export class TopicTrie<T> {
 		return results;
 	}
 
+	count(predicate: (value: T) => boolean): number {
+		let total = 0;
+
+		const walk = (node: TrieNode<T>): void => {
+			if (node.values) {
+				for (const value of node.values) {
+					if (predicate(value)) total += 1;
+				}
+			}
+
+			for (const child of node.exactChildren.values()) walk(child);
+			for (const child of node.globChildren.values()) walk(child);
+		};
+
+		walk(this.root);
+		return total;
+	}
+
 	remove(predicate: (value: T) => boolean): void {
 		const clean = (node: TrieNode<T>): boolean => {
 			if (node.values) {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import type { SpaceWorkflow } from '@neokai/shared';
+import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import { ExternalEventService } from '../../../../src/lib/external-events/external-event-service';
 import { ExternalEventStore } from '../../../../src/lib/external-events/external-event-store';
 import type { ExternalEvent } from '../../../../src/lib/external-events/types';
@@ -262,6 +262,78 @@ describe('SpaceRuntime external event subscriptions', () => {
 		expect(injected).toHaveLength(0);
 		expect(eventStore.getById(event.id)?.state).toBe('ignored');
 		expect(eventStore.listDeliveries(event.id)).toHaveLength(0);
+	});
+
+	test('allows the first 10 event interests for an agent slot', async () => {
+		const workflow = createWorkflow();
+		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		const task = tasks[0]!;
+
+		for (let index = 0; index < 10; index += 1) {
+			expect(() =>
+				runtime.registerSubscription(
+					run.id,
+					task.id,
+					'code',
+					'coder',
+					`github/owner/repo/pull_request/${index}.opened`
+				)
+			).not.toThrow();
+		}
+	});
+
+	test('rejects the 11th event interest for an agent slot', async () => {
+		const workflow = createWorkflow();
+		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		const task = tasks[0]!;
+
+		for (let index = 0; index < 10; index += 1) {
+			runtime.registerSubscription(
+				run.id,
+				task.id,
+				'code',
+				'coder',
+				`github/owner/repo/pull_request/${index}.opened`
+			);
+		}
+
+		expect(() =>
+			runtime.registerSubscription(
+				run.id,
+				task.id,
+				'code',
+				'coder',
+				'github/owner/repo/pull_request/10.opened'
+			)
+		).toThrow('cannot register more than 10 event interests');
+	});
+
+	test('allows new event interests after an agent slot unsubscribes', async () => {
+		const workflow = createWorkflow();
+		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		const task = tasks[0]!;
+
+		for (let index = 0; index < 10; index += 1) {
+			runtime.registerSubscription(
+				run.id,
+				task.id,
+				'code',
+				'coder',
+				`github/owner/repo/pull_request/${index}.opened`
+			);
+		}
+
+		runtime.unregisterExecution(run.id, task.id, 'code', 'coder');
+
+		expect(() =>
+			runtime.registerSubscription(
+				run.id,
+				task.id,
+				'code',
+				'coder',
+				'github/owner/repo/pull_request/10.opened'
+			)
+		).not.toThrow();
 	});
 
 	test('drops stale queued deliveries when run interests are rebuilt', async () => {


### PR DESCRIPTION
Limit event-interest registration to 10 subscriptions per workflow agent slot.

Includes tests for the 10-interest success path, 11th-interest rejection, and unsubscribe allowing new registration.

Tests:
- cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-external-events.test.ts
- ./scripts/test-daemon.sh