### PR TITLE
chore(release): bump version to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.28.0] - 2026-05-20
+
+Space agent infrastructure, external event system, and semantic memory search. 19 commits since v0.27.1.
+
+### Added
+
+- **Space goals UI**: Frontend for Space-native goal tracking
+- **Dynamic external event subscriptions**: Agents subscribe to GitHub/webhook events at runtime via MCP tools
+- **External event source settings UI**: Configure event sources (GitHub repos, topics) in the Space settings panel
+- **External event backpressure**: Rate-limiting and queue depth controls for external event ingestion
+- **Hybrid semantic memory search**: Agents recall context via combined keyword + vector search
+- **Long-term Space agent inbox**: Persistent event queue for Space agents across sessions
+- **Space actor registry adapter**: Unified actor model for Space members and agents
+- **Space messaging resolver facade**: Actor-targeted message routing abstraction
+- **Space folder browse button**: Quick-access button to browse Space folders
+
+### Changed
+
+- Space messaging tools now wrap around actor targets instead of raw session IDs
+- Routine task events no longer pollute Space chat channels
+- Steer and queue controls polished for better usability
+- Legacy Space GitHub service removed (replaced by dynamic subscription system)
+
+### Fixed
+
+- GitHub external event topic format corrected
+- Worker session Space MCP reattach after disconnect
+- Agent slot event interest cap prevents unbounded subscription growth
+- Message search indexing constrained to prevent runaway index size
+- Transformers web backend loading failure
+
 ## [0.27.1] - 2026-05-18
 
 ### Fixed

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/desktop",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"private": true,
 	"description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
 	"scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.27.1"
+version = "0.28.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Kai",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"identifier": "io.neokai.kai",
 	"build": {
 		"frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.27.1",
+	"version": "0.28.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Release v0.28.0 — Space agent infrastructure, external event system, hybrid semantic memory search, and Space goals UI.