### PR TITLE
Add Forge evolution storage contracts

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -341,6 +341,72 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 		description:
 			'Persistent agent-written Space memories with keys, content, tags, and access metadata.',
 	},
+	{
+		tableName: 'evolution_scopes',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Forge evolution scopes that define bounded learning loops for a Space or Space goal.',
+	},
+	{
+		tableName: 'evolution_evidence',
+		scopeJoin: {
+			localColumn: 'scope_id',
+			joinTable: 'evolution_scopes',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description:
+			'Evidence references collected for Forge evolution scopes, such as tasks, runs, sessions, notes, and metric snapshots.',
+	},
+	{
+		tableName: 'evolution_episodes',
+		scopeJoin: {
+			localColumn: 'scope_id',
+			joinTable: 'evolution_scopes',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description:
+			'Forge learning episodes that summarize evidence, findings, and outcomes for a scope.',
+	},
+	{
+		tableName: 'evolution_lessons',
+		scopeJoin: {
+			localColumn: 'scope_id',
+			joinTable: 'evolution_scopes',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description:
+			'Candidate and active Forge lessons derived from evolution episodes for future scoped work.',
+	},
+	{
+		tableName: 'evolution_task_proposals',
+		scopeJoin: {
+			localColumn: 'scope_id',
+			joinTable: 'evolution_scopes',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description:
+			'Follow-up Space task proposals produced from Forge evolution findings and lessons.',
+	},
+	{
+		tableName: 'evolution_metric_snapshots',
+		scopeJoin: {
+			localColumn: 'scope_id',
+			joinTable: 'evolution_scopes',
+			joinPkColumn: 'id',
+			scopeColumn: 'space_id',
+		},
+		blacklistedColumns: [],
+		description: 'Metric snapshots captured for Forge evolution scopes over time.',
+	},
 	// ── Main-DB tables exposed with space-scoped filtering via session ID prefix ──
 	{
 		tableName: 'sessions',

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -43,6 +43,7 @@ import { SkillRepository } from './repositories/skill-repository';
 import { WorkspaceHistoryRepository } from './repositories/workspace-history-repository';
 import { TransformersAgentMemoryEmbedder } from './repositories/agent-memory-transformers';
 import { AgentMemoryRepository } from './repositories/agent-memory-repository';
+import { EvolutionRepository } from './repositories/evolution-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -74,6 +75,7 @@ export { McpEnablementRepository } from './repositories/mcp-enablement-repositor
 export { SkillRepository } from './repositories/skill-repository';
 export { WorkspaceHistoryRepository } from './repositories/workspace-history-repository';
 export { AgentMemoryRepository } from './repositories/agent-memory-repository';
+export { EvolutionRepository } from './repositories/evolution-repository';
 export type {
 	AgentMemoryEntry,
 	AgentMemorySearchResult,
@@ -101,6 +103,7 @@ export class Database {
 	private skillRepo!: SkillRepository;
 	private workspaceHistoryRepo!: WorkspaceHistoryRepository;
 	private agentMemoryRepo!: AgentMemoryRepository;
+	private evolutionRepo!: EvolutionRepository;
 	private shortIdAllocator!: ShortIdAllocator;
 
 	constructor(dbPath: string) {
@@ -135,6 +138,7 @@ export class Database {
 			reactiveDb,
 			new TransformersAgentMemoryEmbedder()
 		);
+		this.evolutionRepo = new EvolutionRepository(db);
 		this.agentMemoryRepo.backfillPendingEmbeddings();
 	}
 
@@ -557,6 +561,10 @@ export class Database {
 
 	get agentMemory(): AgentMemoryRepository {
 		return this.agentMemoryRepo;
+	}
+
+	get evolution(): EvolutionRepository {
+		return this.evolutionRepo;
 	}
 
 	close(): void {

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -1,0 +1,485 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	CreateEvidenceRefParams,
+	CreateEvolutionEpisodeParams,
+	CreateEvolutionLessonParams,
+	CreateEvolutionScopeParams,
+	CreateMetricSnapshotParams,
+	CreateTaskProposalParams,
+	EvidenceKind,
+	EvidenceRef,
+	EvolutionEpisode,
+	EvolutionEpisodeStatus,
+	EvolutionLesson,
+	EvolutionLessonStatus,
+	EvolutionPolicy,
+	EvolutionScope,
+	EvolutionScopeKind,
+	EvolutionScopeListParams,
+	MetricDefinition,
+	MetricSnapshot,
+	MetricSnapshotValues,
+	TaskProposal,
+	TaskProposalStatus,
+	UpdateEvolutionEpisodeParams,
+	UpdateEvolutionLessonParams,
+	UpdateEvolutionScopeParams,
+	UpdateTaskProposalParams,
+} from '@neokai/shared';
+import type { SQLiteValue } from '../types';
+
+export class EvolutionRepository {
+	constructor(private db: BunDatabase) {}
+
+	createScope(params: CreateEvolutionScopeParams): EvolutionScope {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO evolution_scopes (
+					id, space_id, space_goal_id, kind, name, objective, parent_scope_id,
+					metric_definitions_json, policy_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.spaceGoalId ?? null,
+				params.kind,
+				params.name,
+				params.objective,
+				params.parentScopeId ?? null,
+				JSON.stringify(params.metricDefinitions ?? []),
+				JSON.stringify(params.policy ?? {}),
+				now,
+				now
+			);
+		return this.getScope(id) as EvolutionScope;
+	}
+
+	getScope(id: string): EvolutionScope | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_scopes WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToScope(row) : null;
+	}
+
+	listScopes(params: EvolutionScopeListParams): EvolutionScope[] {
+		const values: SQLiteValue[] = [params.spaceId];
+		let where = `WHERE space_id = ?`;
+		if (params.spaceGoalId !== undefined) {
+			if (params.spaceGoalId === null) {
+				where += ` AND space_goal_id IS NULL`;
+			} else {
+				where += ` AND space_goal_id = ?`;
+				values.push(params.spaceGoalId);
+			}
+		}
+		if (params.kind) {
+			where += ` AND kind = ?`;
+			values.push(params.kind);
+		}
+		const rows = this.db
+			.prepare(`SELECT * FROM evolution_scopes ${where} ORDER BY updated_at DESC, id DESC`)
+			.all(...values) as Record<string, unknown>[];
+		return rows.map(rowToScope);
+	}
+
+	updateScope(id: string, params: UpdateEvolutionScopeParams): EvolutionScope | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+		if (params.spaceGoalId !== undefined) add('space_goal_id', params.spaceGoalId ?? null);
+		if (params.kind !== undefined) add('kind', params.kind);
+		if (params.name !== undefined) add('name', params.name);
+		if (params.objective !== undefined) add('objective', params.objective);
+		if (params.parentScopeId !== undefined) add('parent_scope_id', params.parentScopeId ?? null);
+		if (params.metricDefinitions !== undefined) {
+			add('metric_definitions_json', JSON.stringify(params.metricDefinitions));
+		}
+		if (params.policy !== undefined) add('policy_json', JSON.stringify(params.policy));
+		if (sets.length === 0) return this.getScope(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db.prepare(`UPDATE evolution_scopes SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		return this.getScope(id);
+	}
+
+	createEvidence(params: CreateEvidenceRefParams): EvidenceRef {
+		const id = generateUUID();
+		const createdAt = params.createdAt ?? Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO evolution_evidence (
+					id, scope_id, kind, summary, source_id, metadata_json, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.scopeId,
+				params.kind,
+				params.summary,
+				params.sourceId ?? null,
+				JSON.stringify(params.metadata ?? {}),
+				createdAt
+			);
+		return this.getEvidence(id) as EvidenceRef;
+	}
+
+	getEvidence(id: string): EvidenceRef | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_evidence WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToEvidence(row) : null;
+	}
+
+	listEvidence(scopeId: string): EvidenceRef[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM evolution_evidence WHERE scope_id = ? ORDER BY created_at DESC, id DESC`
+			)
+			.all(scopeId) as Record<string, unknown>[];
+		return rows.map(rowToEvidence);
+	}
+
+	createEpisode(params: CreateEvolutionEpisodeParams): EvolutionEpisode {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO evolution_episodes (
+					id, scope_id, status, title, time_window_json, evidence_ids_json,
+					outcome_summary, findings_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.scopeId,
+				params.status ?? 'draft',
+				params.title,
+				jsonOrNull(params.timeWindow ?? null),
+				JSON.stringify(params.evidenceIds ?? []),
+				params.outcomeSummary ?? '',
+				JSON.stringify(params.findings ?? []),
+				now,
+				now
+			);
+		return this.getEpisode(id) as EvolutionEpisode;
+	}
+
+	getEpisode(id: string): EvolutionEpisode | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_episodes WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToEpisode(row) : null;
+	}
+
+	listEpisodes(scopeId: string): EvolutionEpisode[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM evolution_episodes WHERE scope_id = ? ORDER BY created_at DESC, id DESC`
+			)
+			.all(scopeId) as Record<string, unknown>[];
+		return rows.map(rowToEpisode);
+	}
+
+	updateEpisode(id: string, params: UpdateEvolutionEpisodeParams): EvolutionEpisode | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+		if (params.status !== undefined) add('status', params.status);
+		if (params.title !== undefined) add('title', params.title);
+		if (params.timeWindow !== undefined) add('time_window_json', jsonOrNull(params.timeWindow));
+		if (params.evidenceIds !== undefined)
+			add('evidence_ids_json', JSON.stringify(params.evidenceIds));
+		if (params.outcomeSummary !== undefined) add('outcome_summary', params.outcomeSummary);
+		if (params.findings !== undefined) add('findings_json', JSON.stringify(params.findings));
+		if (sets.length === 0) return this.getEpisode(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db.prepare(`UPDATE evolution_episodes SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		return this.getEpisode(id);
+	}
+
+	createLesson(params: CreateEvolutionLessonParams): EvolutionLesson {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO evolution_lessons (
+					id, scope_id, status, applies_to_json, rule, why,
+					evidence_episode_ids_json, confidence, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.scopeId,
+				params.status ?? 'candidate',
+				JSON.stringify(params.appliesTo ?? []),
+				params.rule,
+				params.why,
+				JSON.stringify(params.evidenceEpisodeIds ?? []),
+				params.confidence ?? 0,
+				now,
+				now
+			);
+		return this.getLesson(id) as EvolutionLesson;
+	}
+
+	getLesson(id: string): EvolutionLesson | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_lessons WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToLesson(row) : null;
+	}
+
+	listLessons(scopeId: string, status?: EvolutionLessonStatus): EvolutionLesson[] {
+		const values: SQLiteValue[] = [scopeId];
+		let where = `WHERE scope_id = ?`;
+		if (status) {
+			where += ` AND status = ?`;
+			values.push(status);
+		}
+		const rows = this.db
+			.prepare(`SELECT * FROM evolution_lessons ${where} ORDER BY updated_at DESC, id DESC`)
+			.all(...values) as Record<string, unknown>[];
+		return rows.map(rowToLesson);
+	}
+
+	updateLesson(id: string, params: UpdateEvolutionLessonParams): EvolutionLesson | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+		if (params.status !== undefined) add('status', params.status);
+		if (params.appliesTo !== undefined) add('applies_to_json', JSON.stringify(params.appliesTo));
+		if (params.rule !== undefined) add('rule', params.rule);
+		if (params.why !== undefined) add('why', params.why);
+		if (params.evidenceEpisodeIds !== undefined) {
+			add('evidence_episode_ids_json', JSON.stringify(params.evidenceEpisodeIds));
+		}
+		if (params.confidence !== undefined) add('confidence', params.confidence);
+		if (sets.length === 0) return this.getLesson(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db.prepare(`UPDATE evolution_lessons SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		return this.getLesson(id);
+	}
+
+	createTaskProposal(params: CreateTaskProposalParams): TaskProposal {
+		const id = generateUUID();
+		const now = Date.now();
+		this.db
+			.prepare(
+				`INSERT INTO evolution_task_proposals (
+					id, scope_id, title, description, reason, priority, status,
+					evidence_episode_ids_json, created_task_id, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.scopeId,
+				params.title,
+				params.description,
+				params.reason,
+				params.priority ?? 'normal',
+				params.status ?? 'proposed',
+				JSON.stringify(params.evidenceEpisodeIds ?? []),
+				params.createdTaskId ?? null,
+				now,
+				now
+			);
+		return this.getTaskProposal(id) as TaskProposal;
+	}
+
+	getTaskProposal(id: string): TaskProposal | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_task_proposals WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToTaskProposal(row) : null;
+	}
+
+	listTaskProposals(scopeId: string, status?: TaskProposalStatus): TaskProposal[] {
+		const values: SQLiteValue[] = [scopeId];
+		let where = `WHERE scope_id = ?`;
+		if (status) {
+			where += ` AND status = ?`;
+			values.push(status);
+		}
+		const rows = this.db
+			.prepare(`SELECT * FROM evolution_task_proposals ${where} ORDER BY updated_at DESC, id DESC`)
+			.all(...values) as Record<string, unknown>[];
+		return rows.map(rowToTaskProposal);
+	}
+
+	updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {
+		const sets: string[] = [];
+		const values: SQLiteValue[] = [];
+		const add = (column: string, value: SQLiteValue) => {
+			sets.push(`${column} = ?`);
+			values.push(value);
+		};
+		if (params.title !== undefined) add('title', params.title);
+		if (params.description !== undefined) add('description', params.description);
+		if (params.reason !== undefined) add('reason', params.reason);
+		if (params.priority !== undefined) add('priority', params.priority);
+		if (params.status !== undefined) add('status', params.status);
+		if (params.evidenceEpisodeIds !== undefined) {
+			add('evidence_episode_ids_json', JSON.stringify(params.evidenceEpisodeIds));
+		}
+		if (params.createdTaskId !== undefined) add('created_task_id', params.createdTaskId ?? null);
+		if (sets.length === 0) return this.getTaskProposal(id);
+		add('updated_at', Date.now());
+		values.push(id);
+		this.db
+			.prepare(`UPDATE evolution_task_proposals SET ${sets.join(', ')} WHERE id = ?`)
+			.run(...values);
+		return this.getTaskProposal(id);
+	}
+
+	createMetricSnapshot(params: CreateMetricSnapshotParams): MetricSnapshot {
+		const id = generateUUID();
+		const now = Date.now();
+		const capturedAt = params.capturedAt ?? now;
+		this.db
+			.prepare(
+				`INSERT INTO evolution_metric_snapshots (
+					id, scope_id, captured_at, values_json, source, note, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.scopeId,
+				capturedAt,
+				JSON.stringify(params.values),
+				params.source,
+				params.note ?? null,
+				now
+			);
+		return this.getMetricSnapshot(id) as MetricSnapshot;
+	}
+
+	getMetricSnapshot(id: string): MetricSnapshot | null {
+		const row = this.db.prepare(`SELECT * FROM evolution_metric_snapshots WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? rowToMetricSnapshot(row) : null;
+	}
+
+	listMetricSnapshots(scopeId: string): MetricSnapshot[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM evolution_metric_snapshots WHERE scope_id = ? ORDER BY captured_at DESC, id DESC`
+			)
+			.all(scopeId) as Record<string, unknown>[];
+		return rows.map(rowToMetricSnapshot);
+	}
+}
+
+function rowToScope(row: Record<string, unknown>): EvolutionScope {
+	return {
+		id: row.id as string,
+		spaceId: row.space_id as string,
+		spaceGoalId: (row.space_goal_id as string | null) ?? null,
+		kind: row.kind as EvolutionScopeKind,
+		name: row.name as string,
+		objective: row.objective as string,
+		parentScopeId: (row.parent_scope_id as string | null) ?? null,
+		metricDefinitions: parseJson<MetricDefinition[]>(row.metric_definitions_json, []),
+		policy: parseJson<EvolutionPolicy>(row.policy_json, {}),
+		createdAt: row.created_at as number,
+		updatedAt: row.updated_at as number,
+	};
+}
+
+function rowToEvidence(row: Record<string, unknown>): EvidenceRef {
+	return {
+		id: row.id as string,
+		scopeId: row.scope_id as string,
+		kind: row.kind as EvidenceKind,
+		summary: row.summary as string,
+		sourceId: (row.source_id as string | null) ?? null,
+		metadata: parseJson<Record<string, unknown>>(row.metadata_json, {}),
+		createdAt: row.created_at as number,
+	};
+}
+
+function rowToEpisode(row: Record<string, unknown>): EvolutionEpisode {
+	return {
+		id: row.id as string,
+		scopeId: row.scope_id as string,
+		status: row.status as EvolutionEpisodeStatus,
+		title: row.title as string,
+		timeWindow: parseJson(row.time_window_json, null),
+		evidenceIds: parseJson<string[]>(row.evidence_ids_json, []),
+		outcomeSummary: (row.outcome_summary as string) ?? '',
+		findings: parseJson(row.findings_json, []),
+		createdAt: row.created_at as number,
+		updatedAt: row.updated_at as number,
+	};
+}
+
+function rowToLesson(row: Record<string, unknown>): EvolutionLesson {
+	return {
+		id: row.id as string,
+		scopeId: row.scope_id as string,
+		status: row.status as EvolutionLessonStatus,
+		appliesTo: parseJson<string[]>(row.applies_to_json, []),
+		rule: row.rule as string,
+		why: row.why as string,
+		evidenceEpisodeIds: parseJson<string[]>(row.evidence_episode_ids_json, []),
+		confidence: (row.confidence as number | null) ?? 0,
+		createdAt: row.created_at as number,
+		updatedAt: row.updated_at as number,
+	};
+}
+
+function rowToTaskProposal(row: Record<string, unknown>): TaskProposal {
+	return {
+		id: row.id as string,
+		scopeId: row.scope_id as string,
+		title: row.title as string,
+		description: row.description as string,
+		reason: row.reason as string,
+		priority: row.priority as TaskProposal['priority'],
+		status: row.status as TaskProposalStatus,
+		evidenceEpisodeIds: parseJson<string[]>(row.evidence_episode_ids_json, []),
+		createdTaskId: (row.created_task_id as string | null) ?? null,
+		createdAt: row.created_at as number,
+		updatedAt: row.updated_at as number,
+	};
+}
+
+function rowToMetricSnapshot(row: Record<string, unknown>): MetricSnapshot {
+	return {
+		id: row.id as string,
+		scopeId: row.scope_id as string,
+		capturedAt: row.captured_at as number,
+		values: parseJson<MetricSnapshotValues>(row.values_json, {}),
+		source: row.source as string,
+		note: (row.note as string | null) ?? null,
+		createdAt: row.created_at as number,
+	};
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+	if (typeof value !== 'string') return fallback;
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function jsonOrNull(value: unknown): string | null {
+	return value === null || value === undefined ? null : JSON.stringify(value);
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -127,8 +127,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, evolution_scope_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -143,6 +143,7 @@ export class SpaceTaskRepository {
 					params.preferredWorkflowId ?? null,
 					params.createdByTaskId ?? null,
 					params.goalId ?? null,
+					params.evolutionScopeId ?? null,
 					JSON.stringify(params.dependsOn ?? []),
 					params.taskAgentSessionId ?? null,
 					params.createdBy ?? null,
@@ -411,6 +412,10 @@ export class SpaceTaskRepository {
 		if (params.goalId !== undefined) {
 			fields.push('goal_id = ?');
 			values.push(params.goalId ?? null);
+		}
+		if (params.evolutionScopeId !== undefined) {
+			fields.push('evolution_scope_id = ?');
+			values.push(params.evolutionScopeId ?? null);
 		}
 		if (params.createdByTaskId !== undefined) {
 			fields.push('created_by_task_id = ?');
@@ -693,6 +698,7 @@ export class SpaceTaskRepository {
 			createdBySession: (row.created_by_session as string | null) ?? undefined,
 			createdByTaskScheduleId: (row.created_by_task_schedule_id as string | null) ?? undefined,
 			goalId: (row.goal_id as string | null) ?? undefined,
+			evolutionScopeId: (row.evolution_scope_id as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -1,0 +1,140 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+export function createEvolutionTables(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_scopes (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			space_goal_id TEXT,
+			kind TEXT NOT NULL
+				CHECK(kind IN ('mission', 'project', 'campaign', 'workflow', 'custom')),
+			name TEXT NOT NULL,
+			objective TEXT NOT NULL,
+			parent_scope_id TEXT,
+			metric_definitions_json TEXT NOT NULL DEFAULT '[]',
+			policy_json TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (space_goal_id) REFERENCES space_goals(id) ON DELETE SET NULL,
+			FOREIGN KEY (parent_scope_id) REFERENCES evolution_scopes(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_scopes_space ON evolution_scopes(space_id, updated_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_scopes_goal ON evolution_scopes(space_goal_id)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_scopes_parent ON evolution_scopes(parent_scope_id)`
+	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_evidence (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			kind TEXT NOT NULL
+				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot')),
+			summary TEXT NOT NULL,
+			source_id TEXT,
+			metadata_json TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_evidence_scope_created ON evolution_evidence(scope_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_evidence_source ON evolution_evidence(kind, source_id)`
+	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_episodes (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'draft'
+				CHECK(status IN ('draft', 'accepted', 'dismissed')),
+			title TEXT NOT NULL,
+			time_window_json TEXT,
+			evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+			outcome_summary TEXT NOT NULL DEFAULT '',
+			findings_json TEXT NOT NULL DEFAULT '[]',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_episodes_scope_created ON evolution_episodes(scope_id, created_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_episodes_scope_status ON evolution_episodes(scope_id, status, updated_at DESC)`
+	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_lessons (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'candidate'
+				CHECK(status IN ('candidate', 'active', 'dismissed')),
+			applies_to_json TEXT NOT NULL DEFAULT '[]',
+			rule TEXT NOT NULL,
+			why TEXT NOT NULL,
+			evidence_episode_ids_json TEXT NOT NULL DEFAULT '[]',
+			confidence REAL NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_lessons_scope_status ON evolution_lessons(scope_id, status, updated_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_lessons_scope_confidence ON evolution_lessons(scope_id, confidence DESC)`
+	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_task_proposals (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			status TEXT NOT NULL DEFAULT 'proposed'
+				CHECK(status IN ('proposed', 'accepted', 'dismissed', 'created')),
+			evidence_episode_ids_json TEXT NOT NULL DEFAULT '[]',
+			created_task_id TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE,
+			FOREIGN KEY (created_task_id) REFERENCES space_tasks(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_task_proposals_scope_status ON evolution_task_proposals(scope_id, status, updated_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_task_proposals_created_task ON evolution_task_proposals(created_task_id)`
+	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS evolution_metric_snapshots (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			captured_at INTEGER NOT NULL,
+			values_json TEXT NOT NULL DEFAULT '{}',
+			source TEXT NOT NULL,
+			note TEXT,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_evolution_metric_snapshots_scope_captured ON evolution_metric_snapshots(scope_id, captured_at DESC)`
+	);
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
+import { createEvolutionTables } from './evolution';
 import { DEFAULT_GLOBAL_TOOLS_CONFIG, DEFAULT_GLOBAL_SETTINGS } from '@neokai/shared';
 
 // Re-export migrations
@@ -695,6 +696,7 @@ export function createTables(db: BunDatabase): void {
 
 	createSpaceAgentInboxTables(db);
 	createAgentMemoryTables(db);
+	createEvolutionTables(db);
 
 	// Create indexes
 	createIndexes(db);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -13,6 +13,7 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import { runMigration94 as runMigration94External } from './m94-backfill-workflow-templates';
 import { runMigration106 as runMigration106External } from './m106-backfill-agent-templates';
 import { slugify, validateSlug } from '../../lib/space/slug';
+import { createEvolutionTables } from './evolution';
 
 /**
  * Run all database migrations
@@ -647,6 +648,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 138: Add durable inbox for long-term Space agents.
 	runMigration138(db);
+
+	// Migration 139: Add Forge MVP evolution storage.
+	runMigration139(db);
 }
 
 /**
@@ -9541,6 +9545,18 @@ export function runMigration135(db: BunDatabase): void {
  * agents are space-scoped and can receive DMs from ad-hoc sessions or workers,
  * so they need a separate inbox that can wake/replay their stable session.
  */
+export function runMigration139(db: BunDatabase): void {
+	createEvolutionTables(db);
+	if (tableExists(db, 'space_tasks') && !tableHasColumn(db, 'space_tasks', 'evolution_scope_id')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN evolution_scope_id TEXT DEFAULT NULL`);
+	}
+	if (tableExists(db, 'space_tasks')) {
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_tasks_evolution_scope_id ON space_tasks(evolution_scope_id)`
+		);
+	}
+}
+
 export function runMigration138(db: BunDatabase): void {
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_agent_inbox_messages (

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -73,13 +73,19 @@ describe('scope-config', () => {
 				'mcp_audit_log',
 				'task_schedules',
 				'space_agent_memory',
+				'evolution_scopes',
+				'evolution_evidence',
+				'evolution_episodes',
+				'evolution_lessons',
+				'evolution_task_proposals',
+				'evolution_metric_snapshots',
 				// Main-DB tables exposed with space-scoped filtering via session ID prefix:
 				'sessions',
 				'sdk_messages',
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(19);
+			expect(names).toHaveLength(25);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { EvolutionRepository } from '../../../../src/storage/repositories/evolution-repository';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+describe('EvolutionRepository', () => {
+	let db: Database;
+	let repo: EvolutionRepository;
+	let spaceTaskRepo: SpaceTaskRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const spaceRepo = new SpaceRepository(db as never);
+		repo = new EvolutionRepository(db as never);
+		spaceTaskRepo = new SpaceTaskRepository(db as never);
+
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/forge-test',
+			slug: 'forge-test',
+			name: 'Forge Test',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('creates, lists, and updates scopes linked to SpaceGoal IDs', () => {
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO space_goals (id, space_id, title, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+		).run('goal-1', spaceId, 'Recurring Forge goal', now, now);
+
+		const scope = repo.createScope({
+			spaceId,
+			spaceGoalId: 'goal-1',
+			kind: 'mission',
+			name: 'Improve coding workflow',
+			objective: 'Reduce review churn',
+			metricDefinitions: [
+				{
+					key: 'review_comments',
+					label: 'Review comments',
+					direction: 'decrease',
+					targetValue: 3,
+				},
+			],
+			policy: { maxActiveLessons: 3 },
+		});
+
+		expect(scope.spaceId).toBe(spaceId);
+		expect(scope.spaceGoalId).toBe('goal-1');
+		expect(scope.metricDefinitions[0]?.key).toBe('review_comments');
+		expect(scope.policy.maxActiveLessons).toBe(3);
+		expect(repo.listScopes({ spaceId, spaceGoalId: 'goal-1' })).toHaveLength(1);
+		expect(repo.listScopes({ spaceId, kind: 'mission' })[0]?.id).toBe(scope.id);
+
+		const updated = repo.updateScope(scope.id, {
+			spaceGoalId: null,
+			objective: 'Reduce review churn and retries',
+		});
+
+		expect(updated?.spaceGoalId).toBeNull();
+		expect(updated?.objective).toBe('Reduce review churn and retries');
+		expect(repo.listScopes({ spaceId, spaceGoalId: null })[0]?.id).toBe(scope.id);
+	});
+
+	it('stores evidence, episodes, lessons, proposals, and metric snapshots for a scope', () => {
+		const scope = repo.createScope({
+			spaceId,
+			kind: 'workflow',
+			name: 'Coding loop',
+			objective: 'Learn from scoped tasks',
+		});
+
+		const task = spaceTaskRepo.createTask({
+			spaceId,
+			title: 'Implement Forge storage',
+			description: 'Add storage contracts',
+			evolutionScopeId: scope.id,
+		});
+		expect(task.evolutionScopeId).toBe(scope.id);
+
+		const evidence = repo.createEvidence({
+			scopeId: scope.id,
+			kind: 'task',
+			sourceId: task.id,
+			summary: 'Task completed with reviewer feedback',
+			metadata: { taskNumber: task.taskNumber },
+			createdAt: 100,
+		});
+
+		const episode = repo.createEpisode({
+			scopeId: scope.id,
+			title: 'Storage foundation',
+			timeWindow: { start: 100, end: 200 },
+			evidenceIds: [evidence.id],
+			outcomeSummary: 'Repository contract landed',
+			findings: [
+				{
+					domain: 'workflow',
+					kind: 'optimization',
+					impact: 'medium',
+					confidence: 0.8,
+					evidence: [evidence.id],
+					proposedAction: 'Keep storage tests focused',
+				},
+			],
+		});
+
+		const lesson = repo.createLesson({
+			scopeId: scope.id,
+			status: 'active',
+			appliesTo: ['storage'],
+			rule: 'Add repository tests with every storage contract',
+			why: 'Catches schema drift',
+			evidenceEpisodeIds: [episode.id],
+			confidence: 0.75,
+		});
+
+		const proposal = repo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Inject active lessons',
+			description: 'Use active lessons in future task messages',
+			reason: 'Close scoped learning loop',
+			priority: 'high',
+			evidenceEpisodeIds: [episode.id],
+		});
+
+		const snapshot = repo.createMetricSnapshot({
+			scopeId: scope.id,
+			capturedAt: 150,
+			values: { reviewComments: 2, accepted: true },
+			source: 'manual',
+			note: 'Baseline after first MVP slice',
+		});
+
+		expect(repo.listEvidence(scope.id)[0]).toMatchObject({ id: evidence.id, sourceId: task.id });
+		expect(repo.listEpisodes(scope.id)[0]).toMatchObject({
+			id: episode.id,
+			evidenceIds: [evidence.id],
+		});
+		expect(repo.listLessons(scope.id, 'active')[0]).toMatchObject({
+			id: lesson.id,
+			appliesTo: ['storage'],
+		});
+		expect(repo.listTaskProposals(scope.id, 'proposed')[0]).toMatchObject({
+			id: proposal.id,
+			priority: 'high',
+		});
+		expect(repo.listMetricSnapshots(scope.id)[0]).toMatchObject({
+			id: snapshot.id,
+			values: { reviewComments: 2, accepted: true },
+		});
+	});
+
+	it('updates episode, lesson, and proposal lifecycle state', () => {
+		const scope = repo.createScope({
+			spaceId,
+			kind: 'campaign',
+			name: 'Scoped learning',
+			objective: 'Track lessons',
+		});
+		const episode = repo.createEpisode({ scopeId: scope.id, title: 'Draft episode' });
+		const lesson = repo.createLesson({ scopeId: scope.id, rule: 'Do X', why: 'Because Y' });
+		const proposal = repo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Follow-up task',
+			description: 'Do follow-up work',
+			reason: 'Episode found gap',
+		});
+
+		expect(repo.updateEpisode(episode.id, { status: 'accepted' })?.status).toBe('accepted');
+		expect(repo.updateLesson(lesson.id, { status: 'dismissed', confidence: 0.2 })?.status).toBe(
+			'dismissed'
+		);
+		const createdTask = spaceTaskRepo.createTask({
+			spaceId,
+			title: 'Created follow-up task',
+			description: 'Task materialized from proposal',
+		});
+		expect(
+			repo.updateTaskProposal(proposal.id, { status: 'created', createdTaskId: createdTask.id })
+				?.createdTaskId
+		).toBe(createdTask.id);
+	});
+});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -296,6 +296,9 @@ export function createSpaceTables(db: BunDatabase): void {
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
 
 	createEvolutionTables(db);
 

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
+import { createEvolutionTables } from '../../../src/storage/schema/evolution';
 
 export function createSpaceTables(db: BunDatabase): void {
 	db.exec('PRAGMA foreign_keys = ON');
@@ -219,6 +220,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			preferred_workflow_id TEXT,
 			created_by_task_id TEXT,
 			goal_id TEXT DEFAULT NULL,
+			evolution_scope_id TEXT DEFAULT NULL,
 			result TEXT,
 			depends_on TEXT NOT NULL DEFAULT '[]',
 			active_session TEXT
@@ -257,8 +259,45 @@ export function createSpaceTables(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_space_id ON space_tasks(space_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
 	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_tasks_evolution_scope_id ON space_tasks(evolution_scope_id)`
+	);
+	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_tasks_workflow_run_id ON space_tasks(workflow_run_id)`
 	);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_goals (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
+			type TEXT NOT NULL DEFAULT 'one_shot'
+				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			metrics TEXT NOT NULL DEFAULT '{}',
+			summary TEXT NOT NULL DEFAULT '',
+			progress INTEGER NOT NULL DEFAULT 0,
+			next_steps TEXT NOT NULL DEFAULT '[]',
+			preferred_workflow_id TEXT,
+			task_schedule_id TEXT,
+			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
+			pending_next_run INTEGER NOT NULL DEFAULT 0,
+			active_task_id TEXT,
+			last_task_id TEXT,
+			last_check_in_at INTEGER,
+			next_check_in_at INTEGER,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completed_at INTEGER,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	createEvolutionTables(db);
 
 	// Minimal `sessions` table — used by tests that need to seed
 	// `session_context.taskId` so the SDKMessageRepository can derive the

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with the fully-migrated production schema (after M86).
+ * Keep in sync with the fully-migrated production schema (after all migrations).
  *
  * IMPORTANT: The schema defined here must exactly match the fully-migrated production
  * schema (i.e. after all migrations have run). Never add columns or constraints here
@@ -605,40 +605,6 @@ export function createSpaceTables(db: BunDatabase): void {
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_task_schedules_goal ON task_schedules(goal_id)`);
 
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS space_goals (
-			id TEXT PRIMARY KEY,
-			space_id TEXT NOT NULL,
-			title TEXT NOT NULL,
-			description TEXT NOT NULL DEFAULT '',
-			status TEXT NOT NULL DEFAULT 'active'
-				CHECK(status IN ('active', 'paused', 'completed', 'archived')),
-			type TEXT NOT NULL DEFAULT 'one_shot'
-				CHECK(type IN ('one_shot', 'measurable', 'recurring')),
-			priority TEXT NOT NULL DEFAULT 'normal'
-				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
-			labels TEXT NOT NULL DEFAULT '[]',
-			metrics TEXT NOT NULL DEFAULT '{}',
-			summary TEXT NOT NULL DEFAULT '',
-			progress INTEGER NOT NULL DEFAULT 0,
-			next_steps TEXT NOT NULL DEFAULT '[]',
-			preferred_workflow_id TEXT,
-			task_schedule_id TEXT,
-			auto_trigger_next INTEGER NOT NULL DEFAULT 0,
-			pending_next_run INTEGER NOT NULL DEFAULT 0,
-			active_task_id TEXT,
-			last_task_id TEXT,
-			last_check_in_at INTEGER,
-			next_check_in_at INTEGER,
-			created_at INTEGER NOT NULL,
-			updated_at INTEGER NOT NULL,
-			completed_at INTEGER,
-			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
-		)
-	`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_space ON space_goals(space_id, status)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_schedule ON space_goals(task_schedule_id)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_space_goals_active_task ON space_goals(active_task_id)`);
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS space_goal_events (
 			id TEXT PRIMARY KEY,

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -32,6 +32,25 @@ import type {
 	UpdateAppMcpServerRequest,
 } from './types/app-mcp-server.ts';
 import type { AppSkill, CreateSkillParams, UpdateSkillParams } from './types/skills.ts';
+import type {
+	CreateEvidenceRefParams,
+	CreateEvolutionEpisodeParams,
+	CreateEvolutionLessonParams,
+	CreateEvolutionScopeParams,
+	CreateMetricSnapshotParams,
+	CreateTaskProposalParams,
+	EvidenceRef,
+	EvolutionEpisode,
+	EvolutionLesson,
+	EvolutionScope,
+	EvolutionScopeListParams,
+	MetricSnapshot,
+	TaskProposal,
+	UpdateEvolutionEpisodeParams,
+	UpdateEvolutionLessonParams,
+	UpdateEvolutionScopeParams,
+	UpdateTaskProposalParams,
+} from './types/evolution.ts';
 
 // Request types
 export interface CreateSessionRequest {
@@ -579,6 +598,148 @@ export interface SpaceMcpClearOverrideRequest {
 
 export interface SpaceMcpClearOverrideResponse {
 	ok: boolean;
+}
+
+// --- Forge evolution storage (Forge MVP 1) ---
+
+export interface EvolutionScopeCreateRequest {
+	params: CreateEvolutionScopeParams;
+}
+
+export interface EvolutionScopeCreateResponse {
+	scope: EvolutionScope;
+}
+
+export interface EvolutionScopeGetRequest {
+	id: string;
+}
+
+export interface EvolutionScopeGetResponse {
+	scope: EvolutionScope | null;
+}
+
+export interface EvolutionScopeListRequest extends EvolutionScopeListParams {}
+
+export interface EvolutionScopeListResponse {
+	scopes: EvolutionScope[];
+}
+
+export interface EvolutionScopeUpdateRequest {
+	id: string;
+	params: UpdateEvolutionScopeParams;
+}
+
+export interface EvolutionScopeUpdateResponse {
+	scope: EvolutionScope | null;
+}
+
+export interface EvolutionEvidenceCreateRequest {
+	params: CreateEvidenceRefParams;
+}
+
+export interface EvolutionEvidenceCreateResponse {
+	evidence: EvidenceRef;
+}
+
+export interface EvolutionEvidenceListRequest {
+	scopeId: string;
+}
+
+export interface EvolutionEvidenceListResponse {
+	evidence: EvidenceRef[];
+}
+
+export interface EvolutionEpisodeCreateRequest {
+	params: CreateEvolutionEpisodeParams;
+}
+
+export interface EvolutionEpisodeCreateResponse {
+	episode: EvolutionEpisode;
+}
+
+export interface EvolutionEpisodeUpdateRequest {
+	id: string;
+	params: UpdateEvolutionEpisodeParams;
+}
+
+export interface EvolutionEpisodeUpdateResponse {
+	episode: EvolutionEpisode | null;
+}
+
+export interface EvolutionEpisodeListRequest {
+	scopeId: string;
+}
+
+export interface EvolutionEpisodeListResponse {
+	episodes: EvolutionEpisode[];
+}
+
+export interface EvolutionLessonCreateRequest {
+	params: CreateEvolutionLessonParams;
+}
+
+export interface EvolutionLessonCreateResponse {
+	lesson: EvolutionLesson;
+}
+
+export interface EvolutionLessonUpdateRequest {
+	id: string;
+	params: UpdateEvolutionLessonParams;
+}
+
+export interface EvolutionLessonUpdateResponse {
+	lesson: EvolutionLesson | null;
+}
+
+export interface EvolutionLessonListRequest {
+	scopeId: string;
+	status?: EvolutionLesson['status'];
+}
+
+export interface EvolutionLessonListResponse {
+	lessons: EvolutionLesson[];
+}
+
+export interface EvolutionTaskProposalCreateRequest {
+	params: CreateTaskProposalParams;
+}
+
+export interface EvolutionTaskProposalCreateResponse {
+	proposal: TaskProposal;
+}
+
+export interface EvolutionTaskProposalUpdateRequest {
+	id: string;
+	params: UpdateTaskProposalParams;
+}
+
+export interface EvolutionTaskProposalUpdateResponse {
+	proposal: TaskProposal | null;
+}
+
+export interface EvolutionTaskProposalListRequest {
+	scopeId: string;
+	status?: TaskProposal['status'];
+}
+
+export interface EvolutionTaskProposalListResponse {
+	proposals: TaskProposal[];
+}
+
+export interface EvolutionMetricSnapshotCreateRequest {
+	params: CreateMetricSnapshotParams;
+}
+
+export interface EvolutionMetricSnapshotCreateResponse {
+	snapshot: MetricSnapshot;
+}
+
+export interface EvolutionMetricSnapshotListRequest {
+	scopeId: string;
+}
+
+export interface EvolutionMetricSnapshotListResponse {
+	snapshots: MetricSnapshot[];
 }
 
 // --- MCP Imports (explicit refresh trigger for .mcp.json discovery) ---

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -19,6 +19,7 @@ export * from './types/custom-endpoint.ts';
 export * from './types/rewind.ts';
 export * from './types/github.ts';
 export * from './types/space.ts';
+export * from './types/evolution.ts';
 export * from './types/space-utils.ts';
 export * from './space/workflow-autonomy.ts';
 export * from './types/tools.ts';

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -1,0 +1,218 @@
+import type { SpaceTaskPriority } from './space.ts';
+
+export type EvolutionScopeKind = 'mission' | 'project' | 'campaign' | 'workflow' | 'custom';
+export type EvidenceKind = 'task' | 'workflow_run' | 'session' | 'manual_note' | 'metric_snapshot';
+export type EvolutionEpisodeStatus = 'draft' | 'accepted' | 'dismissed';
+export type EvolutionLessonStatus = 'candidate' | 'active' | 'dismissed';
+export type TaskProposalStatus = 'proposed' | 'accepted' | 'dismissed' | 'created';
+export type MetricDirection = 'increase' | 'decrease' | 'target' | 'maintain';
+export type EvolutionFindingDomain = 'workflow' | 'target_artifact' | 'neokai_product';
+export type EvolutionFindingKind =
+	| 'friction'
+	| 'bug'
+	| 'optimization'
+	| 'missing_capability'
+	| 'new_opportunity';
+export type EvolutionImpact = 'low' | 'medium' | 'high';
+export type EvolutionPolicy = Record<string, unknown>;
+export type MetricSnapshotValues = Record<string, string | number | boolean | null>;
+
+export interface MetricDefinition {
+	key: string;
+	label: string;
+	description?: string;
+	direction: MetricDirection;
+	targetValue?: number | string | boolean | null;
+	unit?: string;
+}
+
+export interface EvolutionScope {
+	id: string;
+	spaceId: string;
+	spaceGoalId: string | null;
+	kind: EvolutionScopeKind;
+	name: string;
+	objective: string;
+	parentScopeId: string | null;
+	metricDefinitions: MetricDefinition[];
+	policy: EvolutionPolicy;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface CreateEvolutionScopeParams {
+	spaceId: string;
+	spaceGoalId?: string | null;
+	kind: EvolutionScopeKind;
+	name: string;
+	objective: string;
+	parentScopeId?: string | null;
+	metricDefinitions?: MetricDefinition[];
+	policy?: EvolutionPolicy;
+}
+
+export interface UpdateEvolutionScopeParams {
+	spaceGoalId?: string | null;
+	kind?: EvolutionScopeKind;
+	name?: string;
+	objective?: string;
+	parentScopeId?: string | null;
+	metricDefinitions?: MetricDefinition[];
+	policy?: EvolutionPolicy;
+}
+
+export interface EvidenceRef {
+	id: string;
+	scopeId: string;
+	kind: EvidenceKind;
+	summary: string;
+	sourceId: string | null;
+	metadata: Record<string, unknown>;
+	createdAt: number;
+}
+
+export interface CreateEvidenceRefParams {
+	scopeId: string;
+	kind: EvidenceKind;
+	summary: string;
+	sourceId?: string | null;
+	metadata?: Record<string, unknown>;
+	createdAt?: number;
+}
+
+export interface EvolutionFinding {
+	domain: EvolutionFindingDomain;
+	kind: EvolutionFindingKind;
+	impact: EvolutionImpact;
+	confidence: number;
+	evidence: string[];
+	proposedAction: string;
+}
+
+export interface EvolutionEpisodeTimeWindow {
+	start: number;
+	end: number;
+}
+
+export interface EvolutionEpisode {
+	id: string;
+	scopeId: string;
+	status: EvolutionEpisodeStatus;
+	title: string;
+	timeWindow: EvolutionEpisodeTimeWindow | null;
+	evidenceIds: string[];
+	outcomeSummary: string;
+	findings: EvolutionFinding[];
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface CreateEvolutionEpisodeParams {
+	scopeId: string;
+	status?: EvolutionEpisodeStatus;
+	title: string;
+	timeWindow?: EvolutionEpisodeTimeWindow | null;
+	evidenceIds?: string[];
+	outcomeSummary?: string;
+	findings?: EvolutionFinding[];
+}
+
+export interface UpdateEvolutionEpisodeParams {
+	status?: EvolutionEpisodeStatus;
+	title?: string;
+	timeWindow?: EvolutionEpisodeTimeWindow | null;
+	evidenceIds?: string[];
+	outcomeSummary?: string;
+	findings?: EvolutionFinding[];
+}
+
+export interface EvolutionLesson {
+	id: string;
+	scopeId: string;
+	status: EvolutionLessonStatus;
+	appliesTo: string[];
+	rule: string;
+	why: string;
+	evidenceEpisodeIds: string[];
+	confidence: number;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface CreateEvolutionLessonParams {
+	scopeId: string;
+	status?: EvolutionLessonStatus;
+	appliesTo?: string[];
+	rule: string;
+	why: string;
+	evidenceEpisodeIds?: string[];
+	confidence?: number;
+}
+
+export interface UpdateEvolutionLessonParams {
+	status?: EvolutionLessonStatus;
+	appliesTo?: string[];
+	rule?: string;
+	why?: string;
+	evidenceEpisodeIds?: string[];
+	confidence?: number;
+}
+
+export interface TaskProposal {
+	id: string;
+	scopeId: string;
+	title: string;
+	description: string;
+	reason: string;
+	priority: SpaceTaskPriority;
+	status: TaskProposalStatus;
+	evidenceEpisodeIds: string[];
+	createdTaskId: string | null;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface CreateTaskProposalParams {
+	scopeId: string;
+	title: string;
+	description: string;
+	reason: string;
+	priority?: SpaceTaskPriority;
+	status?: TaskProposalStatus;
+	evidenceEpisodeIds?: string[];
+	createdTaskId?: string | null;
+}
+
+export interface UpdateTaskProposalParams {
+	title?: string;
+	description?: string;
+	reason?: string;
+	priority?: SpaceTaskPriority;
+	status?: TaskProposalStatus;
+	evidenceEpisodeIds?: string[];
+	createdTaskId?: string | null;
+}
+
+export interface MetricSnapshot {
+	id: string;
+	scopeId: string;
+	capturedAt: number;
+	values: MetricSnapshotValues;
+	source: string;
+	note: string | null;
+	createdAt: number;
+}
+
+export interface CreateMetricSnapshotParams {
+	scopeId: string;
+	capturedAt?: number;
+	values: MetricSnapshotValues;
+	source: string;
+	note?: string | null;
+}
+
+export interface EvolutionScopeListParams {
+	spaceId: string;
+	spaceGoalId?: string | null;
+	kind?: EvolutionScopeKind;
+}

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -555,6 +555,8 @@ export interface SpaceTask {
 	createdByTaskScheduleId?: string | null;
 	/** ID of the SpaceGoal this task is executing toward. */
 	goalId?: string | null;
+	/** ID of the EvolutionScope this task explicitly contributes evidence to. */
+	evolutionScopeId?: string | null;
 	/**
 	 * Which agent session is currently active (generating output).
 	 * Cleared when the session reaches a terminal state.
@@ -764,6 +766,8 @@ export interface CreateSpaceTaskParams {
 export interface InternalCreateSpaceTaskParams extends CreateSpaceTaskParams {
 	/** ID of the SpaceGoal this task should be linked to. */
 	goalId?: string | null;
+	/** ID of the EvolutionScope this task explicitly contributes evidence to. */
+	evolutionScopeId?: string | null;
 }
 
 /**
@@ -846,6 +850,8 @@ export interface UpdateSpaceTaskParams {
 export interface InternalUpdateSpaceTaskParams extends UpdateSpaceTaskParams {
 	/** ID of the SpaceGoal this task is linked to; null to clear. */
 	goalId?: string | null;
+	/** ID of the EvolutionScope this task explicitly contributes evidence to; null to clear. */
+	evolutionScopeId?: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
Adds Forge MVP storage foundation: shared evolution contracts, SQLite tables/migration, repositories, and focused repository tests.

Validation:
- cd packages/daemon && bun test tests/unit/4-space-storage/storage/evolution-repository.test.ts
- bun run check