### PR TITLE
Add actor messaging UI projections

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -627,11 +627,20 @@ ORDER BY createdAt ASC, id ASC
 `.trim();
 
 const ACTOR_MESSAGES_BY_WORKFLOW_RUN_SQL = `
-WITH node_rows AS (
+WITH node_status_events AS (
+  SELECT 'in_progress' AS status, 'handoff' AS eventKind, 'Node handoff' AS title, 0 AS rank
+  UNION ALL SELECT 'idle', 'status', 'Node completed', 1
+  UNION ALL SELECT 'done', 'status', 'Node completed', 1
+  UNION ALL SELECT 'blocked', 'status', 'Node status', 1
+  UNION ALL SELECT 'cancelled', 'status', 'Node status', 1
+  UNION ALL SELECT 'waiting_rebind', 'retry', 'Node status', 1
+  UNION ALL SELECT 'pending', 'status', 'Node status', 0
+),
+node_rows AS (
   SELECT
-    'node:' || ne.id || ':' || ne.status AS id,
+    'node:' || ne.id || ':' || nse.status AS id,
     'workflow_log' AS scope,
-    CASE WHEN ne.status = 'in_progress' THEN 'handoff' ELSE 'status' END AS eventKind,
+    nse.eventKind AS eventKind,
     (SELECT st.id FROM space_tasks st WHERE st.workflow_run_id = ne.workflow_run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskId,
     (SELECT st.title FROM space_tasks st WHERE st.workflow_run_id = ne.workflow_run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskTitle,
     ne.workflow_run_id AS workflowRunId,
@@ -641,12 +650,15 @@ WITH node_rows AS (
     json_object('kind', 'worker', 'label', COALESCE(sa.name, ne.agent_name), 'role', ne.agent_name, 'sessionId', ne.agent_session_id, 'nodeExecutionId', ne.id) AS targetActor,
     'system' AS targetResolution,
     NULL AS deliveryState,
-    CASE WHEN ne.status = 'in_progress' THEN 'Node handoff' WHEN ne.status = 'done' THEN 'Node completed' ELSE 'Node status' END AS title,
-    ne.agent_name || ' is ' || ne.status AS summary,
-    ne.result AS details,
-    CASE WHEN ne.status IN ('blocked', 'cancelled') THEN 'warning' WHEN ne.status = 'done' THEN 'success' ELSE 'info' END AS severity,
-    COALESCE(ne.updated_at, ne.created_at) AS createdAt
+    nse.title AS title,
+    ne.agent_name || ' is ' || nse.status AS summary,
+    CASE WHEN nse.status = ne.status THEN ne.result ELSE NULL END AS details,
+    CASE WHEN nse.status IN ('blocked', 'cancelled') THEN 'warning' WHEN nse.status IN ('idle', 'done') THEN 'success' ELSE 'info' END AS severity,
+    CASE WHEN nse.status IN ('idle', 'done', 'blocked', 'cancelled') THEN COALESCE(ne.completed_at, ne.updated_at, ne.created_at) ELSE COALESCE(ne.started_at, ne.created_at) END AS createdAt
   FROM node_executions ne
+  JOIN node_status_events nse
+    ON nse.status = ne.status
+    OR (nse.status = 'in_progress' AND ne.status IN ('idle', 'done', 'blocked', 'cancelled', 'waiting_rebind'))
   LEFT JOIN space_agents sa ON sa.id = ne.agent_id
   WHERE ne.workflow_run_id = ?
 ),
@@ -2237,6 +2249,60 @@ function buildTaskScopeFilter(
 // writes are infrequent compared to `sdk_messages`, so re-evaluating
 // `sessions.list` on every session write is cheap and correct.
 
+function buildWorkflowRunScopeFilter(
+	params: ReadonlyArray<unknown>,
+	db: BunDatabase
+): (scope: TableChangeScope) => boolean {
+	const workflowRunId = params[0] as string;
+	const taskIds = new Set<string>();
+	const sessionIds = new Set<string>();
+	const loadScope = () => {
+		taskIds.clear();
+		sessionIds.clear();
+		try {
+			const tasks = db
+				.prepare('SELECT id, task_agent_session_id FROM space_tasks WHERE workflow_run_id = ?')
+				.all(workflowRunId) as Array<{ id: string; task_agent_session_id: string | null }>;
+			for (const row of tasks) {
+				taskIds.add(row.id);
+				if (row.task_agent_session_id) sessionIds.add(row.task_agent_session_id);
+			}
+		} catch {
+			// space_tasks may not exist in minimal test schemas
+		}
+		try {
+			const executions = db
+				.prepare('SELECT agent_session_id FROM node_executions WHERE workflow_run_id = ?')
+				.all(workflowRunId) as Array<{ agent_session_id: string | null }>;
+			for (const row of executions) {
+				if (row.agent_session_id) sessionIds.add(row.agent_session_id);
+			}
+		} catch {
+			// node_executions may not exist in minimal test schemas
+		}
+		try {
+			const messages = db
+				.prepare(
+					'SELECT DISTINCT session_id FROM sdk_messages WHERE task_id IN (SELECT id FROM space_tasks WHERE workflow_run_id = ?)'
+				)
+				.all(workflowRunId) as Array<{ session_id: string | null }>;
+			for (const row of messages) {
+				if (row.session_id) sessionIds.add(row.session_id);
+			}
+		} catch {
+			// sdk_messages may not exist in minimal test schemas
+		}
+	};
+	loadScope();
+	return (scope) => {
+		if (scope.taskId) return taskIds.has(scope.taskId);
+		if (!scope.sessionId) return true;
+		if (sessionIds.has(scope.sessionId)) return true;
+		loadScope();
+		return sessionIds.has(scope.sessionId);
+	};
+}
+
 function buildSpaceSessionsScopeFilter(
 	params: ReadonlyArray<unknown>,
 	db: BunDatabase
@@ -2390,6 +2456,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 3,
 			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapActorMessageProjectionRow,
+			buildScopeFilter: buildWorkflowRunScopeFilter,
 		},
 	],
 	[
@@ -2571,7 +2638,8 @@ export function setupLiveQueryHandlers(
 			queryName === 'spaceTaskActivity.byTask' ||
 			queryName === 'spaceTaskMessages.byTask' ||
 			queryName === 'spaceTaskMessages.byTask.compact' ||
-			queryName === 'spaceTaskActiveTurn.byTask'
+			queryName === 'spaceTaskActiveTurn.byTask' ||
+			queryName === 'actorMessages.byTask'
 		) {
 			const taskId = params[0] as string;
 			let spaceTask: { space_id: string } | null = null;
@@ -2584,6 +2652,21 @@ export function setupLiveQueryHandlers(
 			}
 			if (!spaceTask) {
 				throw new Error(`Unauthorized: space task "${taskId}" not found`);
+			}
+		} else if (queryName === 'actorMessages.byWorkflowRun') {
+			const workflowRunId = params[0] as string;
+			let workflowRun: { id: string } | null = null;
+			try {
+				workflowRun = db
+					.prepare('SELECT id FROM space_workflow_runs WHERE id = ?')
+					.get(workflowRunId) as {
+					id: string;
+				} | null;
+			} catch {
+				workflowRun = null;
+			}
+			if (!workflowRun) {
+				throw new Error(`Unauthorized: workflow run "${workflowRunId}" not found`);
 			}
 		} else if (queryName === 'spaceSessions.bySpace' || queryName === 'mcpEnablement.bySpace') {
 			const spaceId = params[0] as string;

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -192,8 +192,7 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	const turnUserMessageId =
 		typeof row.turnUserMessageId === 'string' ? row.turnUserMessageId : null;
 	const origin = typeof row.origin === 'string' ? row.origin : null;
-	const deliveryState =
-		messageType === 'user' ? (row.deliveryState === 'failed' ? 'failed' : 'delivered') : null;
+	const deliveryState = messageType === 'user' && row.deliveryState === 'failed' ? 'failed' : null;
 	// Optional backward-compat field from older compact-query variants.
 	// Current compact SQL no longer emits this, but keep tolerant parsing so
 	// historical rows/tests and alternate query variants remain safe.
@@ -568,7 +567,7 @@ pending_rows AS (
     pm.message AS summary,
     pm.last_error AS details,
     CASE WHEN pm.status IN ('failed', 'expired') THEN 'error' WHEN pm.status = 'delivered' THEN 'success' ELSE 'info' END AS severity,
-    pm.created_at AS createdAt
+    COALESCE(pm.last_attempt_at, pm.delivered_at, pm.created_at) AS createdAt
   FROM target_task tt
   JOIN pending_agent_messages pm ON pm.task_id = tt.id
 ),
@@ -607,8 +606,8 @@ WITH node_rows AS (
     'node:' || ne.id || ':' || ne.status AS id,
     'workflow_log' AS scope,
     CASE WHEN ne.status = 'in_progress' THEN 'handoff' ELSE 'status' END AS eventKind,
-    st.id AS taskId,
-    st.title AS taskTitle,
+    (SELECT st.id FROM space_tasks st WHERE st.workflow_run_id = ne.workflow_run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskId,
+    (SELECT st.title FROM space_tasks st WHERE st.workflow_run_id = ne.workflow_run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskTitle,
     ne.workflow_run_id AS workflowRunId,
     NULL AS messageId,
     ne.id AS eventRef,
@@ -623,7 +622,6 @@ WITH node_rows AS (
     COALESCE(ne.updated_at, ne.created_at) AS createdAt
   FROM node_executions ne
   LEFT JOIN space_agents sa ON sa.id = ne.agent_id
-  LEFT JOIN space_tasks st ON st.workflow_run_id = ne.workflow_run_id
   WHERE ne.workflow_run_id = ?
 ),
 delivery_rows AS (
@@ -654,8 +652,8 @@ artifact_rows AS (
     'artifact:' || wra.id AS id,
     'workflow_log' AS scope,
     'artifact' AS eventKind,
-    st.id AS taskId,
-    st.title AS taskTitle,
+    (SELECT st.id FROM space_tasks st WHERE st.workflow_run_id = wra.run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskId,
+    (SELECT st.title FROM space_tasks st WHERE st.workflow_run_id = wra.run_id ORDER BY st.created_at ASC, st.id ASC LIMIT 1) AS taskTitle,
     wra.run_id AS workflowRunId,
     NULL AS messageId,
     wra.id AS eventRef,
@@ -669,7 +667,6 @@ artifact_rows AS (
     'success' AS severity,
     wra.created_at AS createdAt
   FROM workflow_run_artifacts wra
-  LEFT JOIN space_tasks st ON st.workflow_run_id = wra.run_id
   WHERE wra.run_id = ?
 )
 SELECT * FROM node_rows

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -485,6 +485,31 @@ const ACTOR_MESSAGES_BY_TASK_SQL = `
 WITH target_task AS (
   SELECT * FROM space_tasks WHERE id = ?
 ),
+session_node_exec AS (
+  SELECT
+    ne.id,
+    ne.workflow_run_id,
+    ne.agent_session_id,
+    ne.agent_id,
+    ne.agent_name,
+    ROW_NUMBER() OVER (
+      PARTITION BY ne.workflow_run_id, ne.agent_session_id
+      ORDER BY
+        CASE ne.status
+          WHEN 'in_progress' THEN 0
+          WHEN 'waiting_rebind' THEN 1
+          WHEN 'blocked' THEN 2
+          WHEN 'pending' THEN 3
+          ELSE 4
+        END,
+        ne.updated_at DESC,
+        ne.created_at DESC,
+        ne.id DESC
+    ) AS rn
+  FROM node_executions ne
+  JOIN target_task tt ON tt.workflow_run_id = ne.workflow_run_id
+  WHERE ne.agent_session_id IS NOT NULL
+),
 sdk_rows AS (
   SELECT
     'msg:' || sm.id AS id,
@@ -543,9 +568,10 @@ sdk_rows AS (
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt
   FROM target_task tt
   JOIN sdk_messages sm ON sm.task_id = tt.id
-  LEFT JOIN node_executions ne
+  LEFT JOIN session_node_exec ne
     ON ne.workflow_run_id = tt.workflow_run_id
    AND ne.agent_session_id = sm.session_id
+   AND ne.rn = 1
   LEFT JOIN space_agents sa ON sa.id = ne.agent_id
   WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 ),

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -559,6 +559,8 @@ sdk_rows AS (
     CASE
       WHEN sm.message_type = 'result' THEN 'Agent turn finished'
       WHEN sm.message_type = 'assistant' THEN 'Agent response recorded'
+      WHEN sm.message_type = 'user' AND sm.send_status = 'failed' AND sm.origin = 'human' THEN 'Human message failed'
+      WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'Actor message failed'
       WHEN sm.message_type = 'user' AND sm.origin = 'human' THEN 'Human message delivered'
       WHEN sm.message_type = 'user' THEN 'Actor message delivered'
       ELSE sm.message_type
@@ -610,7 +612,7 @@ github_rows AS (
     json_object('kind', 'github', 'label', ge.actor, 'role', ge.actor_type) AS fromActor,
     json_object('kind', 'system', 'label', 'Task timeline', 'role', 'task') AS targetActor,
     'external' AS targetResolution,
-    'delivered' AS deliveryState,
+    CASE WHEN ge.state = 'failed' THEN 'failed' ELSE 'delivered' END AS deliveryState,
     'GitHub activity' AS title,
     ge.summary AS summary,
     ge.external_url AS details,
@@ -654,7 +656,11 @@ node_rows AS (
     ne.agent_name || ' is ' || nse.status AS summary,
     CASE WHEN nse.status = ne.status THEN ne.result ELSE NULL END AS details,
     CASE WHEN nse.status IN ('blocked', 'cancelled') THEN 'warning' WHEN nse.status IN ('idle', 'done') THEN 'success' ELSE 'info' END AS severity,
-    CASE WHEN nse.status IN ('idle', 'done', 'blocked', 'cancelled') THEN COALESCE(ne.completed_at, ne.updated_at, ne.created_at) ELSE COALESCE(ne.started_at, ne.created_at) END AS createdAt
+    CASE
+      WHEN nse.status IN ('idle', 'done', 'blocked', 'cancelled') THEN COALESCE(ne.completed_at, ne.updated_at, ne.created_at)
+      WHEN nse.status IN ('waiting_rebind', 'pending') THEN COALESCE(ne.updated_at, ne.started_at, ne.created_at)
+      ELSE COALESCE(ne.started_at, ne.created_at)
+    END AS createdAt
   FROM node_executions ne
   JOIN node_status_events nse
     ON nse.status = ne.status

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -143,6 +143,39 @@ function mapSessionGroupMessageRow(row: Record<string, unknown>): Record<string,
  * Map a raw SQLite row from `spaceTaskMessages.byTask` into a web-friendly
  * message envelope that preserves agent/task attribution.
  */
+function parseProjectionRef(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== 'string' || value.length === 0) return null;
+	try {
+		const parsed = JSON.parse(value) as Record<string, unknown>;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function mapActorMessageProjectionRow(row: Record<string, unknown>): Record<string, unknown> {
+	const createdAt = Number(row.createdAt ?? Date.now());
+	return {
+		id: String(row.id ?? `projection-${createdAt}`),
+		scope: row.scope === 'workflow_log' ? 'workflow_log' : 'task_timeline',
+		eventKind: String(row.eventKind ?? 'system'),
+		taskId: typeof row.taskId === 'string' ? row.taskId : null,
+		taskTitle: typeof row.taskTitle === 'string' ? row.taskTitle : null,
+		workflowRunId: typeof row.workflowRunId === 'string' ? row.workflowRunId : null,
+		messageId: typeof row.messageId === 'string' ? row.messageId : null,
+		eventRef: typeof row.eventRef === 'string' ? row.eventRef : null,
+		from: parseProjectionRef(row.fromActor) ?? { kind: 'system', label: 'System' },
+		target: parseProjectionRef(row.targetActor),
+		targetResolution: typeof row.targetResolution === 'string' ? row.targetResolution : null,
+		deliveryState: typeof row.deliveryState === 'string' ? row.deliveryState : null,
+		title: String(row.title ?? 'Event'),
+		summary: String(row.summary ?? ''),
+		details: typeof row.details === 'string' ? row.details : null,
+		severity: typeof row.severity === 'string' ? row.severity : null,
+		createdAt,
+	};
+}
+
 function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, unknown> {
 	const sessionId = typeof row.sessionId === 'string' ? row.sessionId : null;
 	const role = String(row.role ?? 'system');
@@ -159,6 +192,8 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	const turnUserMessageId =
 		typeof row.turnUserMessageId === 'string' ? row.turnUserMessageId : null;
 	const origin = typeof row.origin === 'string' ? row.origin : null;
+	const deliveryState =
+		messageType === 'user' ? (row.deliveryState === 'failed' ? 'failed' : 'delivered') : null;
 	// Optional backward-compat field from older compact-query variants.
 	// Current compact SQL no longer emits this, but keep tolerant parsing so
 	// historical rows/tests and alternate query variants remain safe.
@@ -214,6 +249,7 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 		content,
 		createdAt,
 		origin,
+		deliveryState,
 		parentToolUseId,
 	};
 	if (sessionMessageCount !== undefined) {
@@ -444,6 +480,202 @@ SELECT
 FROM workflow_run_artifacts
 WHERE run_id = ?
 ORDER BY created_at ASC, id ASC
+`.trim();
+
+const ACTOR_MESSAGES_BY_TASK_SQL = `
+WITH target_task AS (
+  SELECT * FROM space_tasks WHERE id = ?
+),
+sdk_rows AS (
+  SELECT
+    'msg:' || sm.id AS id,
+    'task_timeline' AS scope,
+    CASE
+      WHEN sm.message_type = 'user' AND sm.origin = 'human' THEN 'question'
+      WHEN sm.message_type = 'user' THEN 'handoff'
+      WHEN sm.message_type = 'result' THEN 'status'
+      WHEN sm.message_type = 'assistant' THEN 'answer'
+      ELSE 'system'
+    END AS eventKind,
+    tt.id AS taskId,
+    tt.title AS taskTitle,
+    tt.workflow_run_id AS workflowRunId,
+    sm.id AS messageId,
+    NULL AS eventRef,
+    json_object(
+      'kind', CASE WHEN sm.origin = 'human' THEN 'human' WHEN sm.origin = 'system' THEN 'system' ELSE 'worker' END,
+      'label', CASE WHEN sm.origin = 'human' THEN 'Human' WHEN sm.origin = 'system' THEN 'System' ELSE COALESCE(sa.name, ne.agent_name, 'Agent') END,
+      'role', CASE WHEN sm.origin = 'human' THEN 'human' WHEN sm.origin = 'system' THEN 'system' ELSE COALESCE(ne.agent_name, 'agent') END,
+      'sessionId', sm.session_id,
+      'nodeExecutionId', ne.id
+    ) AS fromActor,
+    CASE
+      WHEN sm.message_type = 'user' THEN json_object(
+        'kind', 'worker',
+        'label', COALESCE(sa.name, ne.agent_name, 'Agent'),
+        'role', COALESCE(ne.agent_name, 'agent'),
+        'sessionId', sm.session_id,
+        'nodeExecutionId', ne.id
+      )
+      ELSE NULL
+    END AS targetActor,
+    CASE WHEN sm.message_type = 'user' THEN 'inferred' ELSE NULL END AS targetResolution,
+    CASE
+      WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'failed'
+      WHEN sm.message_type = 'user' THEN 'delivered'
+      ELSE NULL
+    END AS deliveryState,
+    CASE
+      WHEN sm.message_type = 'user' AND sm.origin = 'human' THEN 'Question'
+      WHEN sm.message_type = 'user' THEN 'Handoff'
+      WHEN sm.message_type = 'result' THEN 'Status'
+      WHEN sm.message_type = 'assistant' THEN 'Answer'
+      ELSE 'System event'
+    END AS title,
+    CASE
+      WHEN sm.message_type = 'result' THEN 'Agent turn finished'
+      WHEN sm.message_type = 'assistant' THEN 'Agent response recorded'
+      WHEN sm.message_type = 'user' AND sm.origin = 'human' THEN 'Human message delivered'
+      WHEN sm.message_type = 'user' THEN 'Actor message delivered'
+      ELSE sm.message_type
+    END AS summary,
+    NULL AS details,
+    CASE WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'error' ELSE 'info' END AS severity,
+    CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt
+  FROM target_task tt
+  JOIN sdk_messages sm ON sm.task_id = tt.id
+  LEFT JOIN node_executions ne
+    ON ne.workflow_run_id = tt.workflow_run_id
+   AND ne.agent_session_id = sm.session_id
+  LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+  WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+),
+pending_rows AS (
+  SELECT
+    'delivery:' || pm.id AS id,
+    'task_timeline' AS scope,
+    'handoff' AS eventKind,
+    tt.id AS taskId,
+    tt.title AS taskTitle,
+    pm.workflow_run_id AS workflowRunId,
+    NULL AS messageId,
+    pm.id AS eventRef,
+    json_object('kind', 'worker', 'label', pm.source_agent_name, 'role', pm.source_agent_name) AS fromActor,
+    json_object('kind', CASE WHEN pm.target_kind = 'space_agent' THEN 'agent' ELSE 'worker' END, 'label', pm.target_agent_name, 'role', pm.target_agent_name, 'sessionId', pm.delivered_session_id) AS targetActor,
+    CASE WHEN pm.status = 'pending' THEN 'queued' ELSE 'direct' END AS targetResolution,
+    CASE WHEN pm.status = 'pending' THEN 'queued' ELSE pm.status END AS deliveryState,
+    CASE WHEN pm.status = 'pending' THEN 'Queued delivery' WHEN pm.status = 'delivered' THEN 'Delivered message' WHEN pm.status = 'expired' THEN 'Expired delivery' ELSE 'Failed delivery' END AS title,
+    pm.message AS summary,
+    pm.last_error AS details,
+    CASE WHEN pm.status IN ('failed', 'expired') THEN 'error' WHEN pm.status = 'delivered' THEN 'success' ELSE 'info' END AS severity,
+    pm.created_at AS createdAt
+  FROM target_task tt
+  JOIN pending_agent_messages pm ON pm.task_id = tt.id
+),
+github_rows AS (
+  SELECT
+    'github:' || ge.id AS id,
+    'task_timeline' AS scope,
+    'github' AS eventKind,
+    tt.id AS taskId,
+    tt.title AS taskTitle,
+    tt.workflow_run_id AS workflowRunId,
+    NULL AS messageId,
+    ge.id AS eventRef,
+    json_object('kind', 'github', 'label', ge.actor, 'role', ge.actor_type) AS fromActor,
+    json_object('kind', 'system', 'label', 'Task timeline', 'role', 'task') AS targetActor,
+    'external' AS targetResolution,
+    'delivered' AS deliveryState,
+    'GitHub activity' AS title,
+    ge.summary AS summary,
+    ge.external_url AS details,
+    CASE WHEN ge.state = 'failed' THEN 'error' ELSE 'info' END AS severity,
+    ge.occurred_at AS createdAt
+  FROM target_task tt
+  JOIN space_github_events ge ON ge.task_id = tt.id
+  WHERE ge.state IN ('routed', 'delivered', 'failed')
+)
+SELECT * FROM sdk_rows
+UNION ALL SELECT * FROM pending_rows
+UNION ALL SELECT * FROM github_rows
+ORDER BY createdAt ASC, id ASC
+`.trim();
+
+const ACTOR_MESSAGES_BY_WORKFLOW_RUN_SQL = `
+WITH node_rows AS (
+  SELECT
+    'node:' || ne.id || ':' || ne.status AS id,
+    'workflow_log' AS scope,
+    CASE WHEN ne.status = 'in_progress' THEN 'handoff' ELSE 'status' END AS eventKind,
+    st.id AS taskId,
+    st.title AS taskTitle,
+    ne.workflow_run_id AS workflowRunId,
+    NULL AS messageId,
+    ne.id AS eventRef,
+    json_object('kind', 'system', 'label', 'Workflow runtime', 'role', 'runtime') AS fromActor,
+    json_object('kind', 'worker', 'label', COALESCE(sa.name, ne.agent_name), 'role', ne.agent_name, 'sessionId', ne.agent_session_id, 'nodeExecutionId', ne.id) AS targetActor,
+    'system' AS targetResolution,
+    NULL AS deliveryState,
+    CASE WHEN ne.status = 'in_progress' THEN 'Node handoff' WHEN ne.status = 'done' THEN 'Node completed' ELSE 'Node status' END AS title,
+    ne.agent_name || ' is ' || ne.status AS summary,
+    ne.result AS details,
+    CASE WHEN ne.status IN ('blocked', 'cancelled') THEN 'warning' WHEN ne.status = 'done' THEN 'success' ELSE 'info' END AS severity,
+    COALESCE(ne.updated_at, ne.created_at) AS createdAt
+  FROM node_executions ne
+  LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+  LEFT JOIN space_tasks st ON st.workflow_run_id = ne.workflow_run_id
+  WHERE ne.workflow_run_id = ?
+),
+delivery_rows AS (
+  SELECT
+    'delivery:' || pm.id AS id,
+    'workflow_log' AS scope,
+    CASE WHEN pm.attempts > 0 AND pm.status = 'pending' THEN 'retry' ELSE 'handoff' END AS eventKind,
+    pm.task_id AS taskId,
+    st.title AS taskTitle,
+    pm.workflow_run_id AS workflowRunId,
+    NULL AS messageId,
+    pm.id AS eventRef,
+    json_object('kind', 'worker', 'label', pm.source_agent_name, 'role', pm.source_agent_name) AS fromActor,
+    json_object('kind', CASE WHEN pm.target_kind = 'space_agent' THEN 'agent' ELSE 'worker' END, 'label', pm.target_agent_name, 'role', pm.target_agent_name, 'sessionId', pm.delivered_session_id) AS targetActor,
+    CASE WHEN pm.status = 'pending' THEN 'queued' ELSE 'direct' END AS targetResolution,
+    CASE WHEN pm.status = 'pending' THEN 'queued' ELSE pm.status END AS deliveryState,
+    CASE WHEN pm.status = 'pending' THEN 'Queued delivery' WHEN pm.status = 'delivered' THEN 'Delivered message' WHEN pm.status = 'expired' THEN 'Expired delivery' ELSE 'Failed delivery' END AS title,
+    pm.message AS summary,
+    pm.last_error AS details,
+    CASE WHEN pm.status IN ('failed', 'expired') THEN 'error' WHEN pm.status = 'delivered' THEN 'success' ELSE 'info' END AS severity,
+    COALESCE(pm.last_attempt_at, pm.delivered_at, pm.created_at) AS createdAt
+  FROM pending_agent_messages pm
+  LEFT JOIN space_tasks st ON st.id = pm.task_id
+  WHERE pm.workflow_run_id = ?
+),
+artifact_rows AS (
+  SELECT
+    'artifact:' || wra.id AS id,
+    'workflow_log' AS scope,
+    'artifact' AS eventKind,
+    st.id AS taskId,
+    st.title AS taskTitle,
+    wra.run_id AS workflowRunId,
+    NULL AS messageId,
+    wra.id AS eventRef,
+    json_object('kind', 'worker', 'label', wra.node_id, 'role', wra.node_id) AS fromActor,
+    json_object('kind', 'system', 'label', 'Artifact store', 'role', 'artifact') AS targetActor,
+    'system' AS targetResolution,
+    'delivered' AS deliveryState,
+    'Artifact saved' AS title,
+    wra.artifact_type || CASE WHEN wra.artifact_key = '' THEN '' ELSE ':' || wra.artifact_key END AS summary,
+    wra.data AS details,
+    'success' AS severity,
+    wra.created_at AS createdAt
+  FROM workflow_run_artifacts wra
+  LEFT JOIN space_tasks st ON st.workflow_run_id = wra.run_id
+  WHERE wra.run_id = ?
+)
+SELECT * FROM node_rows
+UNION ALL SELECT * FROM delivery_rows
+UNION ALL SELECT * FROM artifact_rows
+ORDER BY createdAt ASC, id ASC
 `.trim();
 
 function mapArtifactRow(row: Record<string, unknown>): Record<string, unknown> {
@@ -789,6 +1021,7 @@ github_events AS (
       )
     ) AS content,
     'system' AS origin,
+    'delivered' AS deliveryState,
     ge.occurred_at AS createdAt,
     NULL AS parentToolUseId,
     1 AS isRenderable,
@@ -853,6 +1086,7 @@ sdk_rows_raw AS (
     sm.message_type AS messageType,
     sm.sdk_message AS content,
     sm.origin AS origin,
+    CASE WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'failed' WHEN sm.message_type = 'user' THEN 'delivered' ELSE NULL END AS deliveryState,
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
     sm.parent_tool_use_id AS parentToolUseId,
     sm.is_renderable AS isRenderable,
@@ -923,6 +1157,7 @@ sdk_rows AS (
     t.messageType,
     t.content,
     t.origin,
+    t.deliveryState,
     t.createdAt,
     t.parentToolUseId,
     t.isRenderable,
@@ -948,6 +1183,7 @@ joined AS (
     messageType,
     content,
     origin,
+    deliveryState,
     createdAt,
     parentToolUseId,
     isRenderable,
@@ -975,6 +1211,7 @@ SELECT
   messageType,
   content,
   origin,
+  deliveryState,
   createdAt,
   turnUserMessageId,
   parentToolUseId
@@ -1107,6 +1344,7 @@ SELECT
   messageType,
   content,
   origin,
+  deliveryState,
   createdAt,
   turnIndex,
   CASE
@@ -2110,6 +2348,25 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			sql: MCP_ENABLEMENT_BY_SPACE_SQL,
 			paramCount: 1,
 			mapRow: mapMcpEnablementBySpaceRow,
+		},
+	],
+	[
+		'actorMessages.byTask',
+		{
+			sql: ACTOR_MESSAGES_BY_TASK_SQL,
+			paramCount: 1,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
+			mapRow: mapActorMessageProjectionRow,
+			buildScopeFilter: buildTaskScopeFilter,
+		},
+	],
+	[
+		'actorMessages.byWorkflowRun',
+		{
+			sql: ACTOR_MESSAGES_BY_WORKFLOW_RUN_SQL,
+			paramCount: 3,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
+			mapRow: mapActorMessageProjectionRow,
 		},
 	],
 	[

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2655,6 +2655,11 @@ export function setupLiveQueryHandlers(
 			}
 		} else if (queryName === 'actorMessages.byWorkflowRun') {
 			const workflowRunId = params[0] as string;
+			if (params.some((param) => param !== workflowRunId)) {
+				throw new Error(
+					'Unauthorized: actorMessages.byWorkflowRun requires matching workflow run ids'
+				);
+			}
 			let workflowRun: { id: string } | null = null;
 			try {
 				workflowRun = db

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -57,6 +57,8 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask.compact')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskActiveTurn.byTask')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('actorMessages.byTask')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('actorMessages.byWorkflowRun')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(false);
 	});
 
@@ -66,6 +68,8 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskActiveTurn.byTask')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('actorMessages.byWorkflowRun')!.paramCount).toBe(3);
 	});
 
 	test('retired Room-scoped query names are not active contracts', () => {
@@ -205,6 +209,50 @@ describe('NAMED_QUERY_REGISTRY', () => {
 					id TEXT PRIMARY KEY,
 					space_id TEXT NOT NULL,
 					name TEXT NOT NULL
+				);
+				CREATE TABLE IF NOT EXISTS space_workflow_runs (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					workflow_id TEXT NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					current_step_index INTEGER NOT NULL DEFAULT 0,
+					current_step_id TEXT,
+					status TEXT NOT NULL DEFAULT 'pending',
+					config TEXT,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					completed_at INTEGER
+				);
+				CREATE TABLE IF NOT EXISTS pending_agent_messages (
+					id TEXT PRIMARY KEY,
+					workflow_run_id TEXT NOT NULL,
+					space_id TEXT NOT NULL,
+					task_id TEXT,
+					source_agent_name TEXT NOT NULL DEFAULT 'task-agent',
+					target_kind TEXT NOT NULL,
+					target_agent_name TEXT NOT NULL,
+					message TEXT NOT NULL,
+					idempotency_key TEXT,
+					attempts INTEGER NOT NULL DEFAULT 0,
+					max_attempts INTEGER NOT NULL DEFAULT 5,
+					last_attempt_at INTEGER,
+					last_error TEXT,
+					status TEXT NOT NULL DEFAULT 'pending',
+					delivered_at INTEGER,
+					delivered_session_id TEXT,
+					expires_at INTEGER NOT NULL,
+					created_at INTEGER NOT NULL
+				);
+				CREATE TABLE IF NOT EXISTS workflow_run_artifacts (
+					id TEXT PRIMARY KEY NOT NULL,
+					run_id TEXT NOT NULL,
+					node_id TEXT NOT NULL,
+					artifact_type TEXT NOT NULL,
+					artifact_key TEXT NOT NULL DEFAULT '',
+					data TEXT NOT NULL DEFAULT '{}',
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL
 				);
 				CREATE TABLE IF NOT EXISTS space_tasks (
 					id TEXT PRIMARY KEY,
@@ -517,6 +565,99 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			expect(node!.messageCount).toBe(0);
 			expect(node!.label).toBe('Coder');
 			expect(node!.role).toBe('coder');
+		});
+
+		function insertPendingAgentMessage(overrides: Record<string, unknown>): void {
+			db.exec(`
+				INSERT INTO pending_agent_messages (
+					id, workflow_run_id, space_id, task_id, source_agent_name, target_kind,
+					target_agent_name, message, attempts, last_attempt_at, last_error, status,
+					delivered_at, delivered_session_id, expires_at, created_at
+				) VALUES (
+					'${String(overrides.id)}', '${String(overrides.workflowRunId)}', '${spaceId}',
+					${overrides.taskId ? `'${String(overrides.taskId)}'` : 'NULL'},
+					'${String(overrides.sourceAgentName ?? 'coder')}',
+					'${String(overrides.targetKind ?? 'node_agent')}',
+					'${String(overrides.targetAgentName ?? 'reviewer')}',
+					'${String(overrides.message ?? 'please review').replace(/'/g, "''")}',
+					${Number(overrides.attempts ?? 1)},
+					${overrides.lastAttemptAt === null ? 'NULL' : Number(overrides.lastAttemptAt ?? now + 5000)},
+					${overrides.lastError ? `'${String(overrides.lastError).replace(/'/g, "''")}'` : 'NULL'},
+					'${String(overrides.status ?? 'delivered')}',
+					${overrides.deliveredAt === null ? 'NULL' : Number(overrides.deliveredAt ?? now + 7000)},
+					${overrides.deliveredSessionId ? `'${String(overrides.deliveredSessionId)}'` : 'NULL'},
+					${Number(overrides.expiresAt ?? now + 60000)},
+					${Number(overrides.createdAt ?? now)}
+				)
+			`);
+		}
+
+		function insertWorkflowRun(id: string): void {
+			db.exec(`
+				INSERT INTO space_workflow_runs (
+					id, space_id, workflow_id, title, description, current_step_index,
+					current_step_id, status, config, created_at, updated_at, completed_at
+				) VALUES (
+					'${id}', '${spaceId}', 'workflow-test', 'Workflow test', '', 0,
+					NULL, 'in_progress', '{}', ${now}, ${now}, NULL
+				)
+			`);
+		}
+
+		test('actorMessages.byTask timestamps delivery outcomes by attempt time', () => {
+			const workflowRunId = 'wr-actor-task';
+			const taskId = insertSpaceTask({ id: 'actor-task', workflowRunId, status: 'in_progress' });
+			insertPendingAgentMessage({
+				id: 'pm-delivered',
+				workflowRunId,
+				taskId,
+				status: 'delivered',
+				createdAt: now + 1000,
+				lastAttemptAt: now + 9000,
+				deliveredAt: now + 7000,
+			});
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!;
+			const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped).toHaveLength(1);
+			expect(mapped[0].id).toBe('delivery:pm-delivered');
+			expect(mapped[0].createdAt).toBe(now + 9000);
+		});
+
+		test('actorMessages.byWorkflowRun does not fan out node or artifact rows across tasks', () => {
+			const workflowRunId = 'wr-actor-run';
+			insertWorkflowRun(workflowRunId);
+			insertSpaceTask({ id: 'actor-run-task-a', workflowRunId, status: 'in_progress' });
+			insertSpaceTask({ id: 'actor-run-task-b', workflowRunId, status: 'in_progress' });
+			insertNodeExecution({
+				id: 'actor-node',
+				workflowRunId,
+				workflowNodeId: 'node-coder',
+				agentName: 'coder',
+				status: 'in_progress',
+			});
+			db.exec(`
+				INSERT INTO workflow_run_artifacts (
+					id, run_id, node_id, artifact_type, artifact_key, data, created_at, updated_at
+				) VALUES (
+					'artifact-actor', '${workflowRunId}', 'node-coder', 'result', '', '{}', ${now + 2000}, ${now + 2000}
+				)
+			`);
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byWorkflowRun')!;
+			const rows = db.prepare(entry.sql).all(workflowRunId, workflowRunId, workflowRunId) as Record<
+				string,
+				unknown
+			>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped.map((row) => row.id)).toEqual([
+				'node:actor-node:in_progress',
+				'artifact:artifact-actor',
+			]);
+			expect(new Set(mapped.map((row) => row.id)).size).toBe(2);
 		});
 
 		test('classifies by session type, not current task_agent_session_id pointer', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -604,6 +604,26 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			`);
 		}
 
+		function insertSdkMessageAt(
+			id: string,
+			sessionIdValue: string,
+			timestampMs: number,
+			messageType = 'assistant'
+		): void {
+			const iso = new Date(timestampMs).toISOString();
+			const taskIdForSession = sessionTaskIds.get(sessionIdValue) ?? null;
+			db.exec(`
+				INSERT INTO sdk_messages (
+					id, session_id, message_type, message_subtype, sdk_message, timestamp,
+					send_status, origin, task_id
+				) VALUES (
+					'${id}', '${sessionIdValue}', '${messageType}', NULL,
+					'{"type":"${messageType}","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}',
+					'${iso}', 'consumed', 'system', ${taskIdForSession ? `'${taskIdForSession}'` : 'NULL'}
+				)
+			`);
+		}
+
 		test('actorMessages.byTask timestamps delivery outcomes by attempt time', () => {
 			const workflowRunId = 'wr-actor-task';
 			const taskId = insertSpaceTask({ id: 'actor-task', workflowRunId, status: 'in_progress' });
@@ -624,6 +644,43 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			expect(mapped).toHaveLength(1);
 			expect(mapped[0].id).toBe('delivery:pm-delivered');
 			expect(mapped[0].createdAt).toBe(now + 9000);
+		});
+
+		test('actorMessages.byTask does not fan out SDK rows across node execution history', () => {
+			const workflowRunId = 'wr-actor-sdk';
+			const nodeSessionId = 'node-agent-actor-sdk';
+			const taskId = insertSpaceTask({
+				id: 'actor-sdk-task',
+				workflowRunId,
+				status: 'in_progress',
+			});
+			insertSession(nodeSessionId, 'worker', '{"status":"processing"}');
+			sessionTaskIds.set(nodeSessionId, taskId);
+			insertNodeExecution({
+				id: 'actor-sdk-old',
+				workflowRunId,
+				workflowNodeId: 'node-coder-old',
+				agentName: 'coder-old',
+				agentSessionId: nodeSessionId,
+				status: 'done',
+			});
+			insertNodeExecution({
+				id: 'actor-sdk-current',
+				workflowRunId,
+				workflowNodeId: 'node-coder-current',
+				agentName: 'coder-current',
+				agentSessionId: nodeSessionId,
+				status: 'in_progress',
+			});
+			insertSdkMessageAt('sdk-actor-one', nodeSessionId, now + 1000);
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!;
+			const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped).toHaveLength(1);
+			expect(mapped[0].id).toBe('msg:sdk-actor-one');
+			expect((mapped[0].from as Record<string, unknown>).nodeExecutionId).toBe('actor-sdk-current');
 		});
 
 		test('actorMessages.byWorkflowRun does not fan out node or artifact rows across tasks', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { createTables, runMigration74, runMigrations } from '../../../../src/storage/schema';
+import { createTables, runMigration74 } from '../../../../src/storage/schema';
 import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
 import {
 	computeIsRenderable,
@@ -353,6 +353,10 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			agentId?: string | null;
 			agentSessionId?: string | null;
 			status?: string;
+			createdAt?: number;
+			startedAt?: number;
+			updatedAt?: number;
+			completedAt?: number | null;
 		}): void {
 			const {
 				id,
@@ -362,6 +366,10 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				agentId = null,
 				agentSessionId = null,
 				status = 'in_progress',
+				createdAt = now,
+				startedAt = now,
+				updatedAt = now,
+				completedAt = null,
 			} = params;
 			db.exec(`
 				INSERT INTO node_executions (
@@ -372,7 +380,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 					'${id}', '${workflowRunId}', '${workflowNodeId}', '${agentName}',
 					${agentId ? `'${agentId}'` : 'NULL'},
 					${agentSessionId ? `'${agentSessionId}'` : 'NULL'},
-					'${status}', NULL, ${now}, ${now}, NULL, ${now}
+					'${status}', NULL, ${createdAt}, ${startedAt}, ${completedAt ?? 'NULL'}, ${updatedAt}
 				)
 			`);
 			if (agentSessionId) {
@@ -608,7 +616,9 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			id: string,
 			sessionIdValue: string,
 			timestampMs: number,
-			messageType = 'assistant'
+			messageType = 'assistant',
+			sendStatus = 'consumed',
+			origin = 'system'
 		): void {
 			const iso = new Date(timestampMs).toISOString();
 			const taskIdForSession = sessionTaskIds.get(sessionIdValue) ?? null;
@@ -619,7 +629,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				) VALUES (
 					'${id}', '${sessionIdValue}', '${messageType}', NULL,
 					'{"type":"${messageType}","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}',
-					'${iso}', 'consumed', 'system', ${taskIdForSession ? `'${taskIdForSession}'` : 'NULL'}
+					'${iso}', '${sendStatus}', '${origin}', ${taskIdForSession ? `'${taskIdForSession}'` : 'NULL'}
 				)
 			`);
 		}
@@ -644,6 +654,68 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			expect(mapped).toHaveLength(1);
 			expect(mapped[0].id).toBe('delivery:pm-delivered');
 			expect(mapped[0].createdAt).toBe(now + 9000);
+		});
+
+		test('actorMessages.byTask describes failed user sends as failures', () => {
+			const workflowRunId = 'wr-failed-user-send';
+			const sessionIdValue = 'session-failed-user-send';
+			const taskId = insertSpaceTask({
+				id: 'task-failed-user-send',
+				workflowRunId,
+				status: 'in_progress',
+			});
+			sessionTaskIds.set(sessionIdValue, taskId);
+			insertSdkMessageAt(
+				'sdk-failed-user-send',
+				sessionIdValue,
+				now + 1000,
+				'user',
+				'failed',
+				'human'
+			);
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!;
+			const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped).toHaveLength(1);
+			expect(mapped[0].id).toBe('msg:sdk-failed-user-send');
+			expect(mapped[0].deliveryState).toBe('failed');
+			expect(mapped[0].severity).toBe('error');
+			expect(mapped[0].summary).toBe('Human message failed');
+		});
+
+		test('actorMessages.byTask marks failed GitHub events as failed deliveries', () => {
+			const workflowRunId = 'wr-failed-github-event';
+			const taskId = insertSpaceTask({
+				id: 'task-failed-github-event',
+				workflowRunId,
+				status: 'in_progress',
+			});
+			db.exec(`
+				INSERT INTO space_github_events (
+					id, space_id, task_id, source, delivery_id, event_type, action,
+					repo_owner, repo_name, pr_number, pr_url, actor, actor_type,
+					body, summary, external_url, external_id, occurred_at, dedupe_key,
+					raw_payload, state, created_at, updated_at
+				) VALUES (
+					'github-failed-event', '${spaceId}', '${taskId}', 'webhook', 'delivery-1',
+					'pull_request_review_comment', 'created', 'lsm', 'neokai', 1965,
+					'https://github.com/lsm/neokai/pull/1965', 'reviewer', 'User', '',
+					'GitHub route failed', 'https://github.com/lsm/neokai/pull/1965#discussion',
+					'comment-1', ${now + 1000}, 'github-failed-event', '{}', 'failed',
+					${now + 1000}, ${now + 1000}
+				)
+			`);
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!;
+			const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped).toHaveLength(1);
+			expect(mapped[0].id).toBe('github:github-failed-event');
+			expect(mapped[0].deliveryState).toBe('failed');
+			expect(mapped[0].severity).toBe('error');
 		});
 
 		test('actorMessages.byTask does not fan out SDK rows across node execution history', () => {
@@ -743,6 +815,46 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			expect(new Set(mapped.map((row) => row.title))).toEqual(
 				new Set(['Node handoff', 'Node completed'])
 			);
+		});
+
+		test('actorMessages.byWorkflowRun timestamps retry node states by update time', () => {
+			const workflowRunId = 'wr-node-retry-timing';
+			insertWorkflowRun(workflowRunId);
+			insertSpaceTask({ id: 'actor-retry-task', workflowRunId, status: 'in_progress' });
+			insertNodeExecution({
+				id: 'actor-node-pending',
+				workflowRunId,
+				workflowNodeId: 'node-coder-pending',
+				agentName: 'reviewer',
+				status: 'pending',
+				createdAt: now + 3000,
+				startedAt: now + 4000,
+				updatedAt: now + 11000,
+			});
+			db.exec(`
+				PRAGMA ignore_check_constraints = ON;
+				INSERT INTO node_executions (
+					id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+					agent_session_id, status, result, created_at, started_at,
+					completed_at, updated_at
+				) VALUES (
+					'actor-node-waiting', '${workflowRunId}', 'node-coder-waiting', 'coder',
+					NULL, NULL, 'waiting_rebind', NULL, ${now + 1000}, ${now + 2000},
+					NULL, ${now + 9000}
+				);
+				PRAGMA ignore_check_constraints = OFF;
+			`);
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byWorkflowRun')!;
+			const rows = db.prepare(entry.sql).all(workflowRunId, workflowRunId, workflowRunId) as Record<
+				string,
+				unknown
+			>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+			const byId = new Map(mapped.map((row) => [row.id, row]));
+
+			expect(byId.get('node:actor-node-waiting:waiting_rebind')?.createdAt).toBe(now + 9000);
+			expect(byId.get('node:actor-node-pending:pending')?.createdAt).toBe(now + 11000);
 		});
 
 		test('classifies by session type, not current task_agent_session_id pointer', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -717,6 +717,34 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			expect(new Set(mapped.map((row) => row.id)).size).toBe(2);
 		});
 
+		test('actorMessages.byWorkflowRun preserves node handoff event for completed nodes', () => {
+			const workflowRunId = 'wr-node-history';
+			insertWorkflowRun(workflowRunId);
+			insertSpaceTask({ id: 'actor-history-task', workflowRunId, status: 'in_progress' });
+			insertNodeExecution({
+				id: 'actor-node-history',
+				workflowRunId,
+				workflowNodeId: 'node-coder',
+				agentName: 'coder',
+				status: 'done',
+			});
+
+			const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byWorkflowRun')!;
+			const rows = db.prepare(entry.sql).all(workflowRunId, workflowRunId, workflowRunId) as Record<
+				string,
+				unknown
+			>[];
+			const mapped = entry.mapRow ? rows.map(entry.mapRow) : rows;
+
+			expect(mapped.map((row) => row.id).sort()).toEqual([
+				'node:actor-node-history:done',
+				'node:actor-node-history:in_progress',
+			]);
+			expect(new Set(mapped.map((row) => row.title))).toEqual(
+				new Set(['Node handoff', 'Node completed'])
+			);
+		});
+
 		test('classifies by session type, not current task_agent_session_id pointer', () => {
 			// Simulate a scenario where the orchestration session was replaced
 			// (rehydrate self-heal) but historical messages still exist. The
@@ -2090,6 +2118,66 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				// Any scope filter here would be unsound — keep it absent.
 				const entry = NAMED_QUERY_REGISTRY.get('sessions.list')!;
 				expect(entry.buildScopeFilter).toBeUndefined();
+			});
+		});
+
+		describe('actor message queries', () => {
+			let scopedDb: BunDatabase;
+
+			beforeEach(() => {
+				scopedDb = new BunDatabase(':memory:');
+				scopedDb.exec(`
+					CREATE TABLE space_tasks (
+						id TEXT PRIMARY KEY,
+						workflow_run_id TEXT,
+						task_agent_session_id TEXT
+					);
+					CREATE TABLE node_executions (
+						id TEXT PRIMARY KEY,
+						workflow_run_id TEXT NOT NULL,
+						agent_session_id TEXT
+					);
+					CREATE TABLE sdk_messages (
+						id TEXT PRIMARY KEY,
+						session_id TEXT NOT NULL,
+						task_id TEXT
+					);
+				`);
+				scopedDb.exec(`
+					INSERT INTO space_tasks (id, workflow_run_id, task_agent_session_id)
+					VALUES ('task-a', 'run-a', 'task-session-a');
+					INSERT INTO node_executions (id, workflow_run_id, agent_session_id)
+					VALUES ('node-a', 'run-a', 'node-session-a');
+					INSERT INTO sdk_messages (id, session_id, task_id)
+					VALUES ('msg-a', 'message-session-a', 'task-a');
+				`);
+			});
+
+			afterEach(() => {
+				scopedDb.close();
+			});
+
+			test('task timeline uses the shared task scope filter', () => {
+				const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byTask')!;
+				expect(entry.buildScopeFilter).toBeDefined();
+				const filter = entry.buildScopeFilter!(['task-a'], scopedDb)!;
+
+				expect(filter({ taskId: 'task-a' })).toBe(true);
+				expect(filter({ taskId: 'task-b' })).toBe(false);
+			});
+
+			test('workflow log filters out unrelated task and session writes', () => {
+				const entry = NAMED_QUERY_REGISTRY.get('actorMessages.byWorkflowRun')!;
+				expect(entry.buildScopeFilter).toBeDefined();
+				const filter = entry.buildScopeFilter!(['run-a', 'run-a', 'run-a'], scopedDb)!;
+
+				expect(filter({ taskId: 'task-a' })).toBe(true);
+				expect(filter({ taskId: 'task-b' })).toBe(false);
+				expect(filter({ sessionId: 'task-session-a' })).toBe(true);
+				expect(filter({ sessionId: 'node-session-a' })).toBe(true);
+				expect(filter({ sessionId: 'message-session-a' })).toBe(true);
+				expect(filter({ sessionId: 'other-session' })).toBe(false);
+				expect(filter({})).toBe(true);
 			});
 		});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
@@ -112,6 +112,17 @@ function createDb() {
 			name TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			workflow_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT,
+			status TEXT NOT NULL,
+			config TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
 		)
 	`);
 	return db;
@@ -150,6 +161,17 @@ function insertMcpServer(db: BunDatabase, id: string, name: string, enabled = tr
 	db.exec(
 		`INSERT INTO app_mcp_servers (id, name, source_type, enabled, source, created_at, updated_at)
 		 VALUES ('${id}', '${name}', 'stdio', ${enabled ? 1 : 0}, 'user', ${now}, ${now})`
+	);
+}
+
+function insertWorkflowRun(db: BunDatabase, runId: string) {
+	const now = Date.now();
+	db.exec(
+		`INSERT OR IGNORE INTO space_workflow_runs (
+			id, space_id, workflow_id, title, description, status, config, created_at, updated_at
+		) VALUES (
+			'${runId}', 'space-test-1', 'workflow-test-1', 'Test Run', '', 'in_progress', '{}', ${now}, ${now}
+		)`
 	);
 }
 
@@ -250,6 +272,27 @@ describe('setupLiveQueryHandlers', () => {
 				queryName: 'spaceTaskMessages.byTask.compact',
 				params: ['space-task-does-not-exist'],
 				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
+	test('subscribe actorMessages.byWorkflowRun: mismatched run params rejected', async () => {
+		insertWorkflowRun(db, 'workflow-run-valid');
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'actorMessages.byWorkflowRun',
+				params: ['workflow-run-valid', 'workflow-run-other', 'workflow-run-valid'],
+				subscriptionId: 'sub-actor-run',
+			})
+		).rejects.toThrow('requires matching workflow run ids');
+	});
+
+	test('subscribe actorMessages.byWorkflowRun: nonexistent run rejected', async () => {
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'actorMessages.byWorkflowRun',
+				params: ['workflow-run-missing', 'workflow-run-missing', 'workflow-run-missing'],
+				subscriptionId: 'sub-actor-run-missing',
 			})
 		).rejects.toThrow('Unauthorized');
 	});

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -19,6 +19,7 @@ export * from './types/custom-endpoint.ts';
 export * from './types/rewind.ts';
 export * from './types/github.ts';
 export * from './types/space.ts';
+export * from './types/actor-message-projection.ts';
 export * from './types/evolution.ts';
 export * from './types/space-utils.ts';
 export * from './space/workflow-autonomy.ts';

--- a/packages/shared/src/types/actor-message-projection.ts
+++ b/packages/shared/src/types/actor-message-projection.ts
@@ -1,0 +1,47 @@
+export type ActorProjectionKind = 'human' | 'agent' | 'worker' | 'system' | 'github';
+
+export type ActorMessageDeliveryState = 'queued' | 'delivered' | 'failed' | 'expired' | 'skipped';
+
+export type ActorMessageProjectionScope = 'task_timeline' | 'workflow_log';
+
+export type ActorMessageProjectionEventKind =
+	| 'message'
+	| 'decision'
+	| 'question'
+	| 'answer'
+	| 'artifact'
+	| 'status'
+	| 'handoff'
+	| 'gate'
+	| 'retry'
+	| 'ci'
+	| 'system'
+	| 'github';
+
+export interface ActorProjectionRef {
+	kind: ActorProjectionKind;
+	label: string;
+	role?: string | null;
+	sessionId?: string | null;
+	nodeExecutionId?: string | null;
+}
+
+export interface ActorMessageProjectionRow {
+	id: string;
+	scope: ActorMessageProjectionScope;
+	eventKind: ActorMessageProjectionEventKind;
+	taskId?: string | null;
+	taskTitle?: string | null;
+	workflowRunId?: string | null;
+	messageId?: string | null;
+	eventRef?: string | null;
+	from: ActorProjectionRef;
+	target?: ActorProjectionRef | null;
+	targetResolution?: 'direct' | 'inferred' | 'queued' | 'external' | 'system' | null;
+	deliveryState?: ActorMessageDeliveryState | null;
+	title: string;
+	summary: string;
+	details?: string | null;
+	severity?: 'info' | 'success' | 'warning' | 'error' | null;
+	createdAt: number;
+}

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -28,6 +28,7 @@ import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import { SpaceTaskThreadMessageActions } from '../space/thread/SpaceTaskThreadMessageActions.tsx';
+import { DeliveryStateBadge } from '../ui/DeliveryStateBadge.tsx';
 
 type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }>;
 
@@ -87,24 +88,6 @@ function extractCopyText(content: string | Array<Record<string, unknown>>): stri
 		.map((block) => (block.type === 'text' ? (block.text as string) : ''))
 		.filter(Boolean)
 		.join('\n');
-}
-
-function DeliveryStateBadge({ state }: { state?: ActorMessageDeliveryState | null }) {
-	if (!state) return null;
-	const className =
-		state === 'failed' || state === 'expired'
-			? 'border-red-500/40 bg-red-500/10 text-red-200'
-			: state === 'queued'
-				? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
-				: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
-	return (
-		<span
-			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${className}`}
-			data-testid="synthetic-delivery-state"
-		>
-			{state}
-		</span>
-	);
 }
 
 export function SyntheticMessageBlock({
@@ -212,7 +195,7 @@ export function SyntheticMessageBlock({
 								</span>
 							</>
 						)}
-						<DeliveryStateBadge state={deliveryState} />
+						<DeliveryStateBadge state={deliveryState} test-id="synthetic-delivery-state" />
 					</div>
 
 					{/* Body — capped preview + gradient fade + show more / less. */}

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -23,6 +23,7 @@
  *   placement as the human bubble for visual consistency).
  */
 
+import type { ActorMessageDeliveryState } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
@@ -50,6 +51,8 @@ interface Props {
 	fromShort?: string;
 	/** Optional shorter label for the TO badge (defaults to `toAgent`). */
 	toShort?: string;
+	/** Optional delivery state for synthetic actor messages. */
+	deliveryState?: ActorMessageDeliveryState | null;
 	/** When provided, an "open in session" icon appears in the actions row. */
 	onOpenSession?: () => void;
 	/** When provided, a session-info dropdown appears in the actions row,
@@ -86,6 +89,24 @@ function extractCopyText(content: string | Array<Record<string, unknown>>): stri
 		.join('\n');
 }
 
+function DeliveryStateBadge({ state }: { state?: ActorMessageDeliveryState | null }) {
+	if (!state) return null;
+	const className =
+		state === 'failed' || state === 'expired'
+			? 'border-red-500/40 bg-red-500/10 text-red-200'
+			: state === 'queued'
+				? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
+				: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+	return (
+		<span
+			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${className}`}
+			data-testid="synthetic-delivery-state"
+		>
+			{state}
+		</span>
+	);
+}
+
 export function SyntheticMessageBlock({
 	content,
 	timestamp,
@@ -96,6 +117,7 @@ export function SyntheticMessageBlock({
 	toColor,
 	fromShort,
 	toShort,
+	deliveryState,
 	onOpenSession,
 	sessionInit,
 	renderAsPlainText = false,
@@ -190,6 +212,7 @@ export function SyntheticMessageBlock({
 								</span>
 							</>
 						)}
+						<DeliveryStateBadge state={deliveryState} />
 					</div>
 
 					{/* Body — capped preview + gradient fade + show more / less. */}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -29,6 +29,8 @@ import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
+import { TaskTimelineFeed } from './TaskTimelineFeed';
+import { WorkflowExecutionLogFeed } from './WorkflowExecutionLogFeed';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { TaskSessionChatComposer } from './TaskSessionChatComposer';
 import { getTransitionActions } from './TaskStatusActions';
@@ -949,6 +951,36 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						>
 							Thread
 						</button>
+						<button
+							type="button"
+							onClick={() => navigateToSpaceTask(navigationSpaceId, taskId, 'timeline')}
+							class={cn(
+								'px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap',
+								activeView === 'timeline'
+									? 'text-gray-100 bg-dark-700/70 shadow-sm'
+									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+							)}
+							data-testid="timeline-toggle"
+							aria-pressed={activeView === 'timeline'}
+						>
+							Timeline
+						</button>
+						{task.workflowRunId && (
+							<button
+								type="button"
+								onClick={() => navigateToSpaceTask(navigationSpaceId, taskId, 'log')}
+								class={cn(
+									'px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors whitespace-nowrap',
+									activeView === 'log'
+										? 'text-gray-100 bg-dark-700/70 shadow-sm'
+										: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+								)}
+								data-testid="execution-log-toggle"
+								aria-pressed={activeView === 'log'}
+							>
+								Log
+							</button>
+						)}
 						{canShowCanvasTab && (
 							<button
 								type="button"
@@ -994,7 +1026,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						)}
 					</div>
 				</div>
-				{activeView === 'canvas' && task.workflowRunId && canvasWorkflowId ? (
+				{activeView === 'timeline' ? (
+					<TaskTimelineFeed taskId={task.id} bottomInsetPx={taskComposerPaddingPx} />
+				) : activeView === 'log' && task.workflowRunId ? (
+					<WorkflowExecutionLogFeed
+						workflowRunId={task.workflowRunId}
+						bottomInsetPx={taskComposerPaddingPx}
+					/>
+				) : activeView === 'canvas' && task.workflowRunId && canvasWorkflowId ? (
 					<div class="h-full" data-testid="canvas-view">
 						<ReadOnlyWorkflowCanvas
 							workflowId={canvasWorkflowId}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -204,6 +204,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const activeView = currentSpaceTaskViewTabSignal.value;
 
 	useEffect(() => {
+		if (activeView === 'log' && task && !task.workflowRunId) {
+			navigateToSpaceTask(spaceId ?? currentSpaceIdSignal.value ?? task.spaceId, task.id, 'thread');
+		}
+	}, [activeView, task, spaceId]);
+
+	useEffect(() => {
 		setThreadSendError(null);
 		setSelectedTargetId(null);
 		setTargetLocked(false);

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -205,7 +205,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	useEffect(() => {
 		if (activeView === 'log' && task && !task.workflowRunId) {
-			navigateToSpaceTask(spaceId ?? currentSpaceIdSignal.value ?? task.spaceId, task.id, 'thread');
+			navigateToSpaceTask(
+				spaceId ?? currentSpaceIdSignal.value ?? task.spaceId,
+				task.id,
+				'thread',
+				true
+			);
 		}
 	}, [activeView, task, spaceId]);
 

--- a/packages/web/src/components/space/TaskTimelineFeed.tsx
+++ b/packages/web/src/components/space/TaskTimelineFeed.tsx
@@ -1,0 +1,19 @@
+import { ActorMessageProjectionFeed } from './actor-messages/ActorMessageProjectionFeed';
+
+interface TaskTimelineFeedProps {
+	taskId: string;
+	bottomInsetPx?: number;
+}
+
+export function TaskTimelineFeed({ taskId, bottomInsetPx }: TaskTimelineFeedProps) {
+	return (
+		<ActorMessageProjectionFeed
+			scope="task_timeline"
+			taskId={taskId}
+			bottomInsetPx={bottomInsetPx}
+			emptyLabel="No task timeline events yet."
+			loadingLabel="Loading task timeline…"
+			reconnectingLabel="Reconnecting task timeline…"
+		/>
+	);
+}

--- a/packages/web/src/components/space/WorkflowExecutionLogFeed.tsx
+++ b/packages/web/src/components/space/WorkflowExecutionLogFeed.tsx
@@ -1,0 +1,22 @@
+import { ActorMessageProjectionFeed } from './actor-messages/ActorMessageProjectionFeed';
+
+interface WorkflowExecutionLogFeedProps {
+	workflowRunId: string;
+	bottomInsetPx?: number;
+}
+
+export function WorkflowExecutionLogFeed({
+	workflowRunId,
+	bottomInsetPx,
+}: WorkflowExecutionLogFeedProps) {
+	return (
+		<ActorMessageProjectionFeed
+			scope="workflow_log"
+			workflowRunId={workflowRunId}
+			bottomInsetPx={bottomInsetPx}
+			emptyLabel="No workflow execution events yet."
+			loadingLabel="Loading workflow execution log…"
+			reconnectingLabel="Reconnecting workflow execution log…"
+		/>
+	);
+}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -375,7 +375,7 @@ describe('SpaceTaskPane', () => {
 		render(<SpaceTaskPane taskId="task-1" />);
 
 		await waitFor(() => {
-			expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'thread');
+			expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'thread', true);
 		});
 		expect(mockCurrentSpaceTaskViewTabSignal.value).toBe('thread');
 	});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -368,6 +368,18 @@ describe('SpaceTaskPane', () => {
 		expect(getByTestId('space-task-unified-thread')).toBeTruthy();
 	});
 
+	it('redirects log view to thread when task has no workflow run', async () => {
+		mockCurrentSpaceTaskViewTabSignal.value = 'log';
+		mockTasks.value = [makeTask({ workflowRunId: null })];
+
+		render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() => {
+			expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'thread');
+		});
+		expect(mockCurrentSpaceTaskViewTabSignal.value).toBe('thread');
+	});
+
 	it('shows unavailable-thread copy when no task session exists', () => {
 		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: null })];
 		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);

--- a/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.test.tsx
+++ b/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/preact';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockUseActorMessageProjections = vi.fn();
+
+vi.mock('../../../hooks/useActorMessageProjections', () => ({
+	useActorMessageProjections: (args: unknown) => mockUseActorMessageProjections(args),
+}));
+
+import { ActorMessageProjectionFeed } from './ActorMessageProjectionFeed';
+
+describe('ActorMessageProjectionFeed', () => {
+	it('renders actor labels, target badges, and delivery states', () => {
+		mockUseActorMessageProjections.mockReturnValue({
+			rows: [
+				{
+					id: 'row-1',
+					scope: 'task_timeline',
+					eventKind: 'handoff',
+					from: { kind: 'worker', label: 'Coder' },
+					target: { kind: 'worker', label: 'Review' },
+					targetResolution: 'queued',
+					deliveryState: 'queued',
+					title: 'Queued delivery',
+					summary: 'Please review this PR.',
+					severity: 'info',
+					createdAt: 1700000000000,
+				},
+			],
+			isLoading: false,
+			isReconnecting: false,
+		});
+
+		render(
+			<ActorMessageProjectionFeed
+				scope="task_timeline"
+				taskId="task-1"
+				emptyLabel="Empty"
+				loadingLabel="Loading"
+				reconnectingLabel="Reconnecting"
+			/>
+		);
+
+		expect(screen.getByText('Coder')).toBeTruthy();
+		expect(screen.getByTestId('actor-target-badge').textContent).toContain('Review');
+		expect(screen.getByTestId('delivery-state-badge').textContent).toBe('queued');
+		expect(screen.getByText('Queued delivery')).toBeTruthy();
+	});
+
+	it('renders empty label when projection has no rows', () => {
+		mockUseActorMessageProjections.mockReturnValue({
+			rows: [],
+			isLoading: false,
+			isReconnecting: false,
+		});
+
+		render(
+			<ActorMessageProjectionFeed
+				scope="workflow_log"
+				workflowRunId="run-1"
+				emptyLabel="No events"
+				loadingLabel="Loading"
+				reconnectingLabel="Reconnecting"
+			/>
+		);
+
+		expect(screen.getByText('No events')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.tsx
+++ b/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.tsx
@@ -1,5 +1,6 @@
-import type { ActorMessageDeliveryState, ActorMessageProjectionRow } from '@neokai/shared';
+import type { ActorMessageProjectionRow } from '@neokai/shared';
 import { useActorMessageProjections } from '../../../hooks/useActorMessageProjections';
+import { DeliveryStateBadge } from '../../ui/DeliveryStateBadge';
 
 const EVENT_LABELS: Record<string, string> = {
 	message: 'Message',
@@ -14,14 +15,6 @@ const EVENT_LABELS: Record<string, string> = {
 	ci: 'CI',
 	system: 'System',
 	github: 'GitHub',
-};
-
-const DELIVERY_CLASSES: Record<ActorMessageDeliveryState, string> = {
-	queued: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
-	delivered: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
-	failed: 'border-red-500/45 bg-red-500/10 text-red-200',
-	expired: 'border-red-500/45 bg-red-500/10 text-red-200',
-	skipped: 'border-gray-500/40 bg-gray-500/10 text-gray-300',
 };
 
 const SEVERITY_DOT: Record<string, string> = {
@@ -64,18 +57,6 @@ function TargetBadge({ row }: { row: ActorMessageProjectionRow }) {
 	);
 }
 
-function DeliveryBadge({ state }: { state?: ActorMessageDeliveryState | null }) {
-	if (!state) return null;
-	return (
-		<span
-			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${DELIVERY_CLASSES[state]}`}
-			data-testid="delivery-state-badge"
-		>
-			{state}
-		</span>
-	);
-}
-
 function ProjectionRow({ row }: { row: ActorMessageProjectionRow }) {
 	const eventLabel = EVENT_LABELS[row.eventKind] ?? row.eventKind;
 	const dotClass = SEVERITY_DOT[row.severity ?? 'info'] ?? SEVERITY_DOT.info;
@@ -89,7 +70,7 @@ function ProjectionRow({ row }: { row: ActorMessageProjectionRow }) {
 					</span>
 					<ActorLabel row={row} />
 					<TargetBadge row={row} />
-					<DeliveryBadge state={row.deliveryState} />
+					<DeliveryStateBadge state={row.deliveryState} class="text-[11px]" />
 					<span class="ml-auto text-[11px] text-gray-500">{formatClock(row.createdAt)}</span>
 				</div>
 				<div class="mt-2 text-sm font-medium text-gray-100">{row.title}</div>

--- a/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.tsx
+++ b/packages/web/src/components/space/actor-messages/ActorMessageProjectionFeed.tsx
@@ -1,0 +1,165 @@
+import type { ActorMessageDeliveryState, ActorMessageProjectionRow } from '@neokai/shared';
+import { useActorMessageProjections } from '../../../hooks/useActorMessageProjections';
+
+const EVENT_LABELS: Record<string, string> = {
+	message: 'Message',
+	decision: 'Decision',
+	question: 'Question',
+	answer: 'Answer',
+	artifact: 'Artifact',
+	status: 'Status',
+	handoff: 'Handoff',
+	gate: 'Gate',
+	retry: 'Retry',
+	ci: 'CI',
+	system: 'System',
+	github: 'GitHub',
+};
+
+const DELIVERY_CLASSES: Record<ActorMessageDeliveryState, string> = {
+	queued: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+	delivered: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+	failed: 'border-red-500/45 bg-red-500/10 text-red-200',
+	expired: 'border-red-500/45 bg-red-500/10 text-red-200',
+	skipped: 'border-gray-500/40 bg-gray-500/10 text-gray-300',
+};
+
+const SEVERITY_DOT: Record<string, string> = {
+	info: 'bg-blue-400',
+	success: 'bg-emerald-400',
+	warning: 'bg-amber-400',
+	error: 'bg-red-400',
+};
+
+function formatClock(timestamp: number): string {
+	return new Date(timestamp).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function shorten(value: string | null | undefined, max = 220): string {
+	const collapsed = (value ?? '').replace(/\s+/g, ' ').trim();
+	if (collapsed.length <= max) return collapsed;
+	return `${collapsed.slice(0, max - 1)}…`;
+}
+
+function ActorLabel({ row }: { row: ActorMessageProjectionRow }) {
+	return (
+		<span class="inline-flex items-center gap-1.5 rounded-md border border-dark-700 bg-dark-800/70 px-2 py-0.5 text-[11px] font-medium text-gray-200">
+			<span class="uppercase tracking-wide text-gray-500">{row.from.kind}</span>
+			<span>{row.from.label}</span>
+		</span>
+	);
+}
+
+function TargetBadge({ row }: { row: ActorMessageProjectionRow }) {
+	if (!row.target) return null;
+	return (
+		<span
+			class="inline-flex items-center gap-1 rounded-md border border-dark-700 bg-dark-900/70 px-2 py-0.5 text-[11px] font-medium text-gray-300"
+			data-testid="actor-target-badge"
+		>
+			<span class="text-gray-600">→</span>
+			<span>{row.target.label}</span>
+			{row.targetResolution ? <span class="text-gray-500">({row.targetResolution})</span> : null}
+		</span>
+	);
+}
+
+function DeliveryBadge({ state }: { state?: ActorMessageDeliveryState | null }) {
+	if (!state) return null;
+	return (
+		<span
+			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${DELIVERY_CLASSES[state]}`}
+			data-testid="delivery-state-badge"
+		>
+			{state}
+		</span>
+	);
+}
+
+function ProjectionRow({ row }: { row: ActorMessageProjectionRow }) {
+	const eventLabel = EVENT_LABELS[row.eventKind] ?? row.eventKind;
+	const dotClass = SEVERITY_DOT[row.severity ?? 'info'] ?? SEVERITY_DOT.info;
+	return (
+		<li class="relative pl-7" data-testid="actor-message-projection-row">
+			<span class={`absolute left-0 top-2 h-2.5 w-2.5 rounded-full ${dotClass}`} />
+			<div class="rounded-lg border border-dark-700 bg-dark-850/70 px-3 py-2.5 shadow-sm shadow-black/10">
+				<div class="flex flex-wrap items-center gap-2">
+					<span class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+						{eventLabel}
+					</span>
+					<ActorLabel row={row} />
+					<TargetBadge row={row} />
+					<DeliveryBadge state={row.deliveryState} />
+					<span class="ml-auto text-[11px] text-gray-500">{formatClock(row.createdAt)}</span>
+				</div>
+				<div class="mt-2 text-sm font-medium text-gray-100">{row.title}</div>
+				{row.summary ? (
+					<p class="mt-1 text-sm leading-relaxed text-gray-300">{shorten(row.summary)}</p>
+				) : null}
+				{row.details ? (
+					<p class="mt-1 text-xs leading-relaxed text-gray-500">{shorten(row.details, 160)}</p>
+				) : null}
+			</div>
+		</li>
+	);
+}
+
+interface ActorMessageProjectionFeedProps {
+	scope: 'task_timeline' | 'workflow_log';
+	taskId?: string | null;
+	workflowRunId?: string | null;
+	topInsetClass?: string;
+	bottomInsetPx?: number;
+	emptyLabel: string;
+	loadingLabel: string;
+	reconnectingLabel: string;
+}
+
+export function ActorMessageProjectionFeed({
+	scope,
+	taskId,
+	workflowRunId,
+	topInsetClass = 'pt-12',
+	bottomInsetPx = 0,
+	emptyLabel,
+	loadingLabel,
+	reconnectingLabel,
+}: ActorMessageProjectionFeedProps) {
+	const { rows, isLoading, isReconnecting } = useActorMessageProjections({
+		scope,
+		taskId,
+		workflowRunId,
+	});
+
+	const paddingStyle = bottomInsetPx > 0 ? { paddingBottom: `${bottomInsetPx}px` } : undefined;
+
+	if (isReconnecting || isLoading) {
+		return (
+			<div class="h-full overflow-y-auto">
+				<div class="min-h-[calc(100%+1px)] flex items-center justify-center px-6 text-center text-sm text-gray-500">
+					{isReconnecting ? reconnectingLabel : loadingLabel}
+				</div>
+			</div>
+		);
+	}
+
+	if (rows.length === 0) {
+		return (
+			<div class="h-full overflow-y-auto">
+				<div class="min-h-[calc(100%+1px)] flex items-center justify-center px-6 text-center text-sm text-gray-500">
+					{emptyLabel}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div class={`h-full overflow-y-auto ${topInsetClass}`} style={paddingStyle}>
+			<ol class="min-h-[calc(100%+1px)] space-y-3 px-4 py-4">
+				{rows.map((row) => (
+					<ProjectionRow key={row.id} row={row} />
+				))}
+			</ol>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -23,7 +23,7 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import type { ActiveTurnSummary, ActivityEntry } from '@neokai/shared';
+import type { ActiveTurnSummary, ActivityEntry, ActorMessageDeliveryState } from '@neokai/shared';
 import {
 	isSDKAssistantMessage,
 	isSDKResultMessage,
@@ -219,6 +219,8 @@ interface MessageFeedTurn {
 	isSynthetic: boolean;
 	/** Recipient session id — same role as `CompletedFeedTurn.sessionId`. */
 	sessionId: string | null;
+	/** User-message delivery state, shown as a small send-state badge. */
+	deliveryState?: ActorMessageDeliveryState | null;
 	/** SDK message UUID, used to deep-link the slide-over. */
 	highlightMessageUuid?: string;
 	/**
@@ -636,6 +638,7 @@ function buildMessageTurn(
 		bodyIsFallback: fallback,
 		createdAt: row.createdAt,
 		isSynthetic,
+		deliveryState: row.deliveryState ?? null,
 		sessionId: row.sessionId,
 		highlightMessageUuid: highlightUuid,
 		sessionInit,
@@ -828,6 +831,24 @@ function StatusPill({ color, status }: { color: string; status: string }) {
 		<span class="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider font-medium">
 			<PulseDot color={color} />
 			<span style={{ color }}>{status}</span>
+		</span>
+	);
+}
+
+function DeliveryStatePill({ state }: { state?: ActorMessageDeliveryState | null }) {
+	if (!state) return null;
+	const className =
+		state === 'failed' || state === 'expired'
+			? 'border-red-500/40 bg-red-500/10 text-red-200'
+			: state === 'queued'
+				? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
+				: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+	return (
+		<span
+			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${className}`}
+			data-testid="minimal-thread-delivery-state"
+		>
+			{state}
 		</span>
 	);
 }
@@ -1212,6 +1233,9 @@ function HumanMessageTurn({ turn }: { turn: MessageFeedTurn }) {
 				    session-init dropdown + copy. Replaces the bare
 				    timestamp so the human bubble has parity with synthetic
 				    messages and agent reply bubbles. */}
+				<div class="mt-1 flex justify-end">
+					<DeliveryStatePill state={turn.deliveryState} />
+				</div>
 				<SpaceTaskThreadMessageActions
 					timestamp={turn.createdAt}
 					copyText={turn.body}
@@ -1256,6 +1280,7 @@ function SyntheticMessageTurn({
 			data-to-label={turn.toLabel}
 		>
 			<SyntheticMessageBlock
+				deliveryState={turn.deliveryState}
 				content={turn.body ?? ''}
 				timestamp={turn.createdAt}
 				uuid={turn.highlightMessageUuid}

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -42,6 +42,7 @@ import {
 	normalizeAgentKey,
 } from '../space-task-thread-turns';
 import { SyntheticMessageBlock } from '../../../sdk/SyntheticMessageBlock';
+import { DeliveryStateBadge } from '../../../ui/DeliveryStateBadge';
 import { SpaceTaskThreadMessageActions } from '../SpaceTaskThreadMessageActions';
 import { getAgentColor } from '../space-task-thread-agent-colors';
 import type { ParsedThreadRow } from '../space-task-thread-events';
@@ -835,24 +836,6 @@ function StatusPill({ color, status }: { color: string; status: string }) {
 	);
 }
 
-function DeliveryStatePill({ state }: { state?: ActorMessageDeliveryState | null }) {
-	if (!state) return null;
-	const className =
-		state === 'failed' || state === 'expired'
-			? 'border-red-500/40 bg-red-500/10 text-red-200'
-			: state === 'queued'
-				? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
-				: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
-	return (
-		<span
-			class={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${className}`}
-			data-testid="minimal-thread-delivery-state"
-		>
-			{state}
-		</span>
-	);
-}
-
 function rosterToolLabel(toolName: string): string {
 	if (toolName.startsWith('mcp__')) {
 		const parts = toolName.split('__');
@@ -1233,9 +1216,14 @@ function HumanMessageTurn({ turn }: { turn: MessageFeedTurn }) {
 				    session-init dropdown + copy. Replaces the bare
 				    timestamp so the human bubble has parity with synthetic
 				    messages and agent reply bubbles. */}
-				<div class="mt-1 flex justify-end">
-					<DeliveryStatePill state={turn.deliveryState} />
-				</div>
+				{turn.deliveryState && turn.deliveryState !== 'delivered' ? (
+					<div class="mt-1 flex justify-end">
+						<DeliveryStateBadge
+							state={turn.deliveryState}
+							test-id="minimal-thread-delivery-state"
+						/>
+					</div>
+				) : null}
 				<SpaceTaskThreadMessageActions
 					timestamp={turn.createdAt}
 					copyText={turn.body}

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -38,6 +38,7 @@ export interface ParsedThreadRow {
 	createdAt: number;
 	turnIndex?: number;
 	turnHiddenMessageCount?: number;
+	deliveryState?: 'delivered' | 'failed' | null;
 	message: SDKMessage | null;
 	fallbackText: string | null;
 }
@@ -356,6 +357,7 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 			createdAt: row.createdAt,
 			turnIndex: row.turnIndex,
 			turnHiddenMessageCount: row.turnHiddenMessageCount,
+			deliveryState: row.deliveryState ?? null,
 			message: withTimestamp,
 			fallbackText: null,
 		};
@@ -372,6 +374,7 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 			createdAt: row.createdAt,
 			turnIndex: row.turnIndex,
 			turnHiddenMessageCount: row.turnHiddenMessageCount,
+			deliveryState: row.deliveryState ?? null,
 			message: null,
 			fallbackText: row.content,
 		};

--- a/packages/web/src/components/ui/DeliveryStateBadge.tsx
+++ b/packages/web/src/components/ui/DeliveryStateBadge.tsx
@@ -1,0 +1,36 @@
+import type { ActorMessageDeliveryState } from '@neokai/shared';
+import { cn } from '../../lib/utils';
+
+const DELIVERY_STATE_CLASSES: Record<ActorMessageDeliveryState, string> = {
+	queued: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+	delivered: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+	failed: 'border-red-500/45 bg-red-500/10 text-red-200',
+	expired: 'border-red-500/45 bg-red-500/10 text-red-200',
+	skipped: 'border-gray-500/40 bg-gray-500/10 text-gray-300',
+};
+
+interface DeliveryStateBadgeProps {
+	state?: ActorMessageDeliveryState | null;
+	class?: string;
+	'test-id'?: string;
+}
+
+export function DeliveryStateBadge({
+	state,
+	class: className = '',
+	'test-id': testId = 'delivery-state-badge',
+}: DeliveryStateBadgeProps) {
+	if (!state) return null;
+	return (
+		<span
+			class={cn(
+				'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+				DELIVERY_STATE_CLASSES[state],
+				className
+			)}
+			data-testid={testId}
+		>
+			{state}
+		</span>
+	);
+}

--- a/packages/web/src/hooks/__tests__/useActorMessageProjections.test.ts
+++ b/packages/web/src/hooks/__tests__/useActorMessageProjections.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from '@testing-library/preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequest, mockOnEvent, mockGetHub, mockIsConnected } = vi.hoisted(() => ({
+	mockRequest: vi.fn().mockResolvedValue(undefined),
+	mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
+		() => () => {}
+	),
+	mockGetHub: vi.fn(),
+	mockIsConnected: { value: true },
+}));
+
+vi.mock('../useMessageHub', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		getHub: mockGetHub,
+		get isConnected() {
+			return mockIsConnected.value;
+		},
+	}),
+}));
+
+type EventHandler = (event: unknown) => void;
+let eventHandlers: Record<string, EventHandler[]> = {};
+
+function fireEvent(method: string, payload: unknown): void {
+	(eventHandlers[method] ?? []).forEach((handler) => handler(payload));
+}
+
+function subscribeCalls() {
+	return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+}
+
+import { useActorMessageProjections } from '../useActorMessageProjections';
+
+describe('useActorMessageProjections', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockGetHub.mockReset();
+		mockRequest.mockResolvedValue(undefined);
+		mockGetHub.mockReturnValue({ request: mockRequest, onConnection: vi.fn(() => () => {}) });
+		mockIsConnected.value = true;
+		eventHandlers = {};
+		mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
+			if (!eventHandlers[method]) eventHandlers[method] = [];
+			eventHandlers[method].push(handler);
+			return () => {
+				eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
+			};
+		});
+	});
+
+	it('subscribes to task timeline projection', () => {
+		renderHook(() => useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' }));
+
+		expect(subscribeCalls()).toHaveLength(1);
+		expect(subscribeCalls()[0][1]).toMatchObject({
+			queryName: 'actorMessages.byTask',
+			params: ['task-1'],
+		});
+	});
+
+	it('subscribes to workflow log projection with each SQL parameter', () => {
+		renderHook(() => useActorMessageProjections({ scope: 'workflow_log', workflowRunId: 'run-1' }));
+
+		expect(subscribeCalls()).toHaveLength(1);
+		expect(subscribeCalls()[0][1]).toMatchObject({
+			queryName: 'actorMessages.byWorkflowRun',
+			params: ['run-1', 'run-1', 'run-1'],
+		});
+	});
+
+	it('merges delta rows and keeps chronological order', () => {
+		const { result } = renderHook(() =>
+			useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+		);
+		const subId = subscribeCalls()[0][1].subscriptionId;
+
+		act(() => {
+			fireEvent('liveQuery.snapshot', {
+				subscriptionId: subId,
+				rows: [
+					{
+						id: 'b',
+						scope: 'task_timeline',
+						eventKind: 'answer',
+						from: { kind: 'worker', label: 'Coder' },
+						title: 'Answer',
+						summary: 'Done',
+						createdAt: 20,
+					},
+				],
+				version: 1,
+			});
+			fireEvent('liveQuery.delta', {
+				subscriptionId: subId,
+				added: [
+					{
+						id: 'a',
+						scope: 'task_timeline',
+						eventKind: 'question',
+						from: { kind: 'human', label: 'Human' },
+						title: 'Question',
+						summary: 'Start?',
+						createdAt: 10,
+					},
+				],
+			});
+		});
+
+		expect(result.current.rows.map((row) => row.id)).toEqual(['a', 'b']);
+		expect(result.current.isLoading).toBe(false);
+	});
+});

--- a/packages/web/src/hooks/useActorMessageProjections.ts
+++ b/packages/web/src/hooks/useActorMessageProjections.ts
@@ -1,0 +1,147 @@
+import type {
+	ActorMessageProjectionRow,
+	LiveQueryDeltaEvent,
+	LiveQuerySnapshotEvent,
+} from '@neokai/shared';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useMessageHub } from './useMessageHub';
+
+type ProjectionScope = 'task_timeline' | 'workflow_log';
+
+interface UseActorMessageProjectionsOptions {
+	scope: ProjectionScope;
+	taskId?: string | null;
+	workflowRunId?: string | null;
+}
+
+export interface UseActorMessageProjectionsResult {
+	rows: ActorMessageProjectionRow[];
+	isLoading: boolean;
+	isReconnecting: boolean;
+}
+
+let _actorProjectionSubCounter = 0;
+
+function nextProjectionSubId(scope: ProjectionScope, id: string): string {
+	_actorProjectionSubCounter += 1;
+	return `actor-message-projections-${scope}-${id}-${_actorProjectionSubCounter}`;
+}
+
+function sortRows(rows: ActorMessageProjectionRow[]): ActorMessageProjectionRow[] {
+	return [...rows].sort((a, b) => {
+		if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+		return a.id.localeCompare(b.id);
+	});
+}
+
+function applyDelta(
+	currentRows: ActorMessageProjectionRow[],
+	event: LiveQueryDeltaEvent
+): ActorMessageProjectionRow[] {
+	const next = new Map(currentRows.map((row) => [row.id, row]));
+	for (const row of (event.removed ?? []) as ActorMessageProjectionRow[]) {
+		next.delete(row.id);
+	}
+	for (const row of (event.updated ?? []) as ActorMessageProjectionRow[]) {
+		next.set(row.id, row);
+	}
+	for (const row of (event.added ?? []) as ActorMessageProjectionRow[]) {
+		next.set(row.id, row);
+	}
+	return sortRows(Array.from(next.values()));
+}
+
+export function useActorMessageProjections({
+	scope,
+	taskId,
+	workflowRunId,
+}: UseActorMessageProjectionsOptions): UseActorMessageProjectionsResult {
+	const { request, onEvent, getHub, isConnected } = useMessageHub();
+	const [rows, setRows] = useState<ActorMessageProjectionRow[]>([]);
+	const [loadedForKey, setLoadedForKey] = useState<string | null>(null);
+	const activeSubIdRef = useRef<string | null>(null);
+
+	const query = useMemo(() => {
+		if (scope === 'task_timeline') {
+			if (!taskId) return null;
+			return {
+				key: `${scope}:${taskId}`,
+				queryName: 'actorMessages.byTask',
+				params: [taskId],
+			};
+		}
+		if (!workflowRunId) return null;
+		return {
+			key: `${scope}:${workflowRunId}`,
+			queryName: 'actorMessages.byWorkflowRun',
+			params: [workflowRunId, workflowRunId, workflowRunId],
+		};
+	}, [scope, taskId, workflowRunId]);
+
+	useEffect(() => {
+		if (!query || !isConnected) {
+			setRows([]);
+			setLoadedForKey(null);
+			activeSubIdRef.current = null;
+			return;
+		}
+
+		const subscriptionId = nextProjectionSubId(scope, query.key);
+		activeSubIdRef.current = subscriptionId;
+		setRows([]);
+		setLoadedForKey(null);
+
+		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+			if (event.subscriptionId !== activeSubIdRef.current) return;
+			setRows(sortRows((event.rows as ActorMessageProjectionRow[]) ?? []));
+			setLoadedForKey(query.key);
+		});
+
+		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			if (event.subscriptionId !== activeSubIdRef.current) return;
+			setRows((prev) => applyDelta(prev, event));
+		});
+
+		const subscribe = () => {
+			const hub = getHub();
+			if (!hub) return;
+			hub
+				.request('liveQuery.subscribe', {
+					queryName: query.queryName,
+					params: query.params,
+					subscriptionId,
+				})
+				.catch(() => {
+					if (activeSubIdRef.current === subscriptionId) {
+						setLoadedForKey(query.key);
+					}
+				});
+		};
+
+		const unsubReconnect = getHub()?.onConnection((state) => {
+			if (state !== 'connected') return;
+			if (activeSubIdRef.current !== subscriptionId) return;
+			setLoadedForKey(null);
+			subscribe();
+		});
+
+		subscribe();
+
+		return () => {
+			unsubSnapshot();
+			unsubDelta();
+			unsubReconnect?.();
+			activeSubIdRef.current = null;
+			Promise.resolve(request('liveQuery.unsubscribe', { subscriptionId })).catch(() => {});
+		};
+	}, [getHub, isConnected, onEvent, query, request, scope]);
+
+	const sortedRows = useMemo(() => sortRows(rows), [rows]);
+	const activeKey = query?.key ?? null;
+
+	return {
+		rows: sortedRows,
+		isLoading: activeKey !== null && isConnected && loadedForKey !== activeKey,
+		isReconnecting: !isConnected && activeKey !== null,
+	};
+}

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -21,6 +21,8 @@ export interface SpaceTaskThreadMessageRow {
 	createdAt: number;
 	/** Message origin from the DB (human, system). Used to classify sender in the thread UI. */
 	origin?: string | null;
+	/** User-message delivery state from sdk_messages.send_status, normalized for UI badges. */
+	deliveryState?: 'delivered' | 'failed' | null;
 	parentToolUseId?: string | null;
 	/**
 	 * Server-computed turn index (per session) for compact thread grouping.

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -140,6 +140,16 @@ describe('router', () => {
 			taskId: TASK_ID,
 			view: 'canvas',
 		});
+		expect(getSpaceTaskViewFromPath(`/space/${SPACE_ID}/task/${TASK_ID}/timeline`)).toEqual({
+			spaceId: SPACE_ID,
+			taskId: TASK_ID,
+			view: 'timeline',
+		});
+		expect(getSpaceTaskViewFromPath(`/space/${SPACE_ID}/task/${TASK_ID}/log`)).toEqual({
+			spaceId: SPACE_ID,
+			taskId: TASK_ID,
+			view: 'log',
+		});
 	});
 
 	it('initializes space configure and task list tabs', () => {

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -19,6 +19,7 @@ import {
 	navSectionSignal,
 	type SettingsSection,
 	type SpaceOverlayTaskContext,
+	type SpaceTaskViewTab,
 	settingsSectionSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
@@ -176,13 +177,13 @@ export function getSpaceTaskIdFromPath(path: string): { spaceId: string; taskId:
 
 export function getSpaceTaskViewFromPath(
 	path: string
-): { spaceId: string; taskId: string; view: 'thread' | 'canvas' | 'artifacts' } | null {
+): { spaceId: string; taskId: string; view: SpaceTaskViewTab } | null {
 	const match = path.match(SPACE_TASK_VIEW_ROUTE_PATTERN);
 	if (!match) return null;
 	return {
 		spaceId: match[1],
 		taskId: match[2],
-		view: match[3] as 'thread' | 'canvas' | 'artifacts',
+		view: match[3] as SpaceTaskViewTab,
 	};
 }
 

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -45,7 +45,7 @@ const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-fA-F0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)$/;
 const SPACE_TASK_VIEW_ROUTE_PATTERN =
-	/^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)\/(thread|canvas|artifacts)$/;
+	/^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)\/(thread|timeline|log|canvas|artifacts)$/;
 const SPACE_SESSIONS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/sessions$/;
 const SETTINGS_SECTIONS = new Set<SettingsSection>([
 	'general',
@@ -519,7 +519,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 export function navigateToSpaceTask(
 	spaceId: string,
 	taskId: string,
-	view?: 'thread' | 'canvas' | 'artifacts',
+	view?: 'thread' | 'timeline' | 'log' | 'canvas' | 'artifacts',
 	replace = false
 ): void {
 	if (routerState.isNavigating) return;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -38,8 +38,8 @@ export const currentSpaceConfigureTabSignal = signal<SpaceConfigureTab>('agents'
 export type SpaceTasksFilterTab = 'action' | 'active' | 'completed' | 'draft' | 'scheduled';
 export const currentSpaceTasksFilterTabSignal = signal<SpaceTasksFilterTab>('active');
 
-// Task detail sub-view (thread | canvas | artifacts) — driven by URL
-export type SpaceTaskViewTab = 'thread' | 'canvas' | 'artifacts';
+// Task detail sub-view (thread | timeline | log | canvas | artifacts) — driven by URL
+export type SpaceTaskViewTab = 'thread' | 'timeline' | 'log' | 'canvas' | 'artifacts';
 export const currentSpaceTaskViewTabSignal = signal<SpaceTaskViewTab>('thread');
 
 // Overlay signals — session shown in slide-over panel on top of the current view


### PR DESCRIPTION
Adds read-only actor messaging projections for Space tasks:
- task timeline and workflow execution log tabs
- actor labels, target badges, and delivery-state indicators
- LiveQuery-backed projection rows with focused web tests

Tests:
- bun run check
- cd packages/web && bunx vitest run src/hooks/__tests__/useActorMessageProjections.test.ts src/components/space/actor-messages/ActorMessageProjectionFeed.test.tsx
- ./scripts/test-daemon.sh 2-handlers