### PR TITLE
Centralize Space MCP session policy

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,6 +25,12 @@ import type { ProcessingStateManager } from './processing-state-manager';
 import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from './transient-error-patterns';
+import {
+	missingMcpServers,
+	resolveSpaceMcpSessionPolicy,
+	SPACE_COORDINATOR_REQUIRED_MCP_SERVERS,
+	SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS,
+} from '../space/runtime/space-mcp-session-policy';
 import type { OriginalEnvVars } from '../provider-service';
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
@@ -86,7 +92,7 @@ function getStartupTimeoutMs(): number {
 // in user-facing error messages reflect these module-load-time snapshots.
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
 
-const REQUIRED_SPACE_CHAT_MCP_SERVERS = ['space-agent-tools'] as const;
+const REQUIRED_SPACE_CHAT_MCP_SERVERS = SPACE_COORDINATOR_REQUIRED_MCP_SERVERS;
 const REQUIRED_SPACE_CHAT_COORDINATION_TOOLS = [
 	'create_standalone_task',
 	'get_task_detail',
@@ -97,8 +103,6 @@ const REQUIRED_SPACE_CHAT_COORDINATION_TOOLS = [
 	'suggest_workflow',
 	'get_workflow_detail',
 ] as const;
-const REQUIRED_MEMBER_SPACE_MCP_SERVERS = ['space-agent-tools'] as const;
-
 /**
  * Context interface - what QueryRunner needs from AgentSession
  * Handlers take AgentSession instance directly via this context pattern
@@ -161,10 +165,10 @@ export interface QueryRunnerContext {
 	onMissingSpaceChatMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
 	/**
-	 * Self-heal hook for Space member sessions (ad-hoc worker sessions with
-	 * `context.spaceId`) missing their `space-agent-tools` MCP server.
-	 * SpaceRuntimeService wires this in `attachSpaceToolsToMemberSession()` so
-	 * cache eviction / DB reload cannot silently start a degraded turn.
+	 * Self-heal hook for SpaceRuntime-owned member sessions missing their
+	 * `space-agent-tools` MCP server. SpaceRuntimeService wires this in
+	 * `attachSpaceToolsToMemberSession()` so cache eviction / DB reload cannot
+	 * silently start a degraded turn.
 	 */
 	onMissingMemberSpaceMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
@@ -337,23 +341,19 @@ export class QueryRunner {
 			// (joinable by sessionId/taskId/workflowRunId) so monitoring can detect
 			// regressions without grepping prose log lines.
 			const mcpServerNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
-			const isWorkflowSubSession = !!(
-				session.context?.spaceId &&
-				session.id.includes(':task:') &&
-				session.id.includes(':exec:')
-			);
-			// Best-effort taskId / workflowRunId extraction from sub-session ids.
-			// Sub-session id shape: "space:<spaceId>:task:<taskId>:exec:<execId>".
-			// The fields are diagnostic only — never used to drive behavior.
-			const subSessionTaskId = isWorkflowSubSession
-				? session.id.split(':task:')[1]?.split(':')[0]
-				: undefined;
-			const sessionTaskId = (session.context?.taskId as string | undefined) ?? subSessionTaskId;
+			const spacePolicy = resolveSpaceMcpSessionPolicy(session, {
+				nodeExecutionRepo: this.ctx.db.getNodeExecutionRepo(),
+				taskRepo: this.ctx.db.getSpaceTaskRepo(),
+			});
+			const isWorkflowSubSession = spacePolicy.isWorkflowWorker;
+			const sessionTaskId = session.context?.taskId as string | undefined;
 			const snapshotPayload = {
 				event: 'query.mcp.snapshot',
 				sessionId: session.id,
 				sessionType: session.type,
-				...(session.context?.spaceId ? { spaceId: session.context.spaceId } : {}),
+				role: spacePolicy.role,
+				owner: spacePolicy.owner,
+				...(spacePolicy.spaceId ? { spaceId: spacePolicy.spaceId } : {}),
 				...(sessionTaskId ? { taskId: sessionTaskId } : {}),
 				...(isWorkflowSubSession ? { workflowSubSession: true } : {}),
 				mcpServers: mcpServerNames,
@@ -377,15 +377,20 @@ export class QueryRunner {
 			// No health check on healthy starts — the outer condition is strictly
 			// `missingServers.length > 0` to avoid false-positive throws.
 			if (isWorkflowSubSession) {
-				const requiredServers = ['node-agent'] as const;
-				const missingServers = requiredServers.filter((name) => !mcpServerNames.includes(name));
+				const requiredServers = SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS;
+				const missingServers = missingMcpServers(
+					queryOptions.mcpServers as Record<string, unknown> | undefined,
+					requiredServers
+				);
 
 				if (missingServers.length > 0) {
 					const diagnosticPayload = {
 						event: 'workflow.mcp.missing',
 						sessionId: session.id,
-						spaceId: session.context?.spaceId,
+						spaceId: spacePolicy.spaceId,
 						sessionType: session.type,
+						role: spacePolicy.role,
+						owner: spacePolicy.owner,
 						requiredServers,
 						missingServers,
 						presentServers: mcpServerNames,
@@ -1087,48 +1092,37 @@ export class QueryRunner {
 	}
 
 	/**
-	 * Ensure Space member sessions (ad-hoc worker sessions with `context.spaceId`)
-	 * have their required `space-agent-tools` MCP server attached before the SDK
-	 * query starts.
+	 * Ensure sessions owned by SpaceRuntimeService have their role-specific
+	 * `space-agent-tools` MCP server attached before the SDK query starts.
 	 *
-	 * This is the member-session counterpart to `ensureSpaceChatMcpInvariant`.
-	 * Space chat sessions get their tools + system prompt from
-	 * `setupSpaceAgentSession`; member sessions get only the MCP tools from
-	 * `attachSpaceToolsToMemberSession`. Both paths are vulnerable to losing
-	 * runtime-only MCP config after cache eviction / DB reload, so both need a
-	 * deterministic pre-query guard.
-	 *
-	 * Skipped for:
-	 *   - space_chat sessions (handled by ensureSpaceChatMcpInvariant)
-	 *   - space_task_agent sessions (legacy, intentionally not provisioned by
-	 *     attachSpaceToolsToMemberSession)
-	 *   - sessions without context.spaceId
-	 *
-	 * Workflow sub-sessions are included because they are also Space members;
-	 * TaskAgentManager provides the specialised self-heal callback for them.
+	 * This guard follows the central Space MCP session policy instead of inferring
+	 * ownership from broad Space context or session ID shape. Workflow workers are
+	 * guarded separately above because TaskAgentManager owns their node-agent and
+	 * workflow-scoped space-agent-tools attachment.
 	 */
 	private async ensureMemberSpaceMcpInvariant(queryOptions: Options): Promise<Options> {
 		const { session, logger } = this.ctx;
-		// Only applies to member sessions that belong to a Space but are not the
-		// Space chat session itself or a legacy task-agent session. Workflow
-		// sub-sessions are still Space members, but TaskAgentManager wires their
-		// specialised space-agent-tools server and callback.
-		if (!session.context?.spaceId) return queryOptions;
-		if (session.type === 'space_chat') return queryOptions;
-		if (session.type === 'space_task_agent') return queryOptions;
+		const policy = resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: this.ctx.db.getNodeExecutionRepo(),
+			taskRepo: this.ctx.db.getSpaceTaskRepo(),
+		});
+		if (!policy.attachGenericSpaceTools) return queryOptions;
 
 		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
-		const missingServers = REQUIRED_MEMBER_SPACE_MCP_SERVERS.filter(
-			(name) => !serverNames.includes(name)
+		const missingServers = missingMcpServers(
+			queryOptions.mcpServers as Record<string, unknown> | undefined,
+			policy.requiredServers
 		);
 		if (missingServers.length === 0) return queryOptions;
 
 		const payload = {
 			event: 'member_space.mcp.missing',
 			sessionId: session.id,
-			spaceId: session.context.spaceId,
+			spaceId: policy.spaceId,
 			sessionType: session.type,
-			requiredServers: REQUIRED_MEMBER_SPACE_MCP_SERVERS,
+			role: policy.role,
+			owner: policy.owner,
+			requiredServers: policy.requiredServers,
 			missingServers,
 			presentServers: serverNames,
 			liveSdkServers: this.getLiveSdkMcpServerNames(queryOptions),
@@ -1145,9 +1139,9 @@ export class QueryRunner {
 			await this.ctx.onMissingMemberSpaceMcpServers(session.id, missingServers);
 			const rebuilt = await this.ctx.optionsBuilder.build();
 			const repairedOptions = this.ctx.optionsBuilder.addSessionStateOptions(rebuilt);
-			const repairedServerNames = Object.keys(repairedOptions.mcpServers ?? {});
-			const stillMissing = REQUIRED_MEMBER_SPACE_MCP_SERVERS.filter(
-				(name) => !repairedServerNames.includes(name)
+			const stillMissing = missingMcpServers(
+				repairedOptions.mcpServers as Record<string, unknown> | undefined,
+				policy.requiredServers
 			);
 			if (stillMissing.length > 0) {
 				throw new Error(

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -1106,7 +1106,7 @@ export class QueryRunner {
 			nodeExecutionRepo: this.ctx.db.getNodeExecutionRepo(),
 			taskRepo: this.ctx.db.getSpaceTaskRepo(),
 		});
-		if (!policy.attachGenericSpaceTools) return queryOptions;
+		if (!policy.attachGenericSpaceTools && !policy.attachLongTermAgentTools) return queryOptions;
 
 		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
 		const missingServers = missingMcpServers(

--- a/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
+++ b/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
@@ -1,0 +1,135 @@
+import type { Session } from '@neokai/shared';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import { longTermAgentSessionId } from '../long-term-agent-session';
+
+export type SpaceMcpSessionRole =
+	| 'coordinator'
+	| 'ad_hoc_member'
+	| 'workflow_worker'
+	| 'long_term_agent'
+	| 'legacy_task_agent'
+	| 'outside_space';
+
+export interface SpaceMcpSessionPolicyContext {
+	readonly nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId'>;
+	readonly taskRepo?: Pick<SpaceTaskRepository, 'getTask'>;
+}
+
+export interface SpaceMcpSessionPolicy {
+	readonly role: SpaceMcpSessionRole;
+	readonly spaceId?: string;
+	readonly owner: 'space-runtime' | 'task-agent-manager' | 'none';
+	readonly requiredServers: readonly string[];
+	readonly attachGenericSpaceTools: boolean;
+	readonly attachCoordinatorTools: boolean;
+	readonly attachLongTermAgentTools: boolean;
+	readonly isWorkflowWorker: boolean;
+}
+
+export const SPACE_COORDINATOR_REQUIRED_MCP_SERVERS = ['space-agent-tools'] as const;
+export const SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS = ['space-agent-tools'] as const;
+export const SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS = [
+	'node-agent',
+	'space-agent-tools',
+] as const;
+
+export function resolveSpaceMcpSessionPolicy(
+	session: Session,
+	context: SpaceMcpSessionPolicyContext = {}
+): SpaceMcpSessionPolicy {
+	const spaceId = session.context?.spaceId;
+
+	if (session.type === 'space_task_agent') {
+		return {
+			role: 'legacy_task_agent',
+			spaceId,
+			owner: 'none',
+			requiredServers: [],
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			attachLongTermAgentTools: false,
+			isWorkflowWorker: false,
+		};
+	}
+
+	if (session.type === 'space_chat' && spaceId) {
+		return {
+			role: 'coordinator',
+			spaceId,
+			owner: 'space-runtime',
+			requiredServers: SPACE_COORDINATOR_REQUIRED_MCP_SERVERS,
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: true,
+			attachLongTermAgentTools: false,
+			isWorkflowWorker: false,
+		};
+	}
+
+	const workflowExecution = context.nodeExecutionRepo?.getByAgentSessionId(session.id) ?? null;
+	if (workflowExecution) {
+		const taskId = session.context?.taskId;
+		const task = taskId ? (context.taskRepo?.getTask(taskId) ?? null) : null;
+		const resolvedSpaceId = spaceId ?? task?.spaceId;
+		return {
+			role: 'workflow_worker',
+			spaceId: resolvedSpaceId,
+			owner: 'task-agent-manager',
+			requiredServers: SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS,
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			attachLongTermAgentTools: false,
+			isWorkflowWorker: true,
+		};
+	}
+
+	if (!spaceId) {
+		return {
+			role: 'outside_space',
+			owner: 'none',
+			requiredServers: [],
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			attachLongTermAgentTools: false,
+			isWorkflowWorker: false,
+		};
+	}
+
+	if (isLongTermAgentSession(session, spaceId)) {
+		return {
+			role: 'long_term_agent',
+			spaceId,
+			owner: 'space-runtime',
+			requiredServers: ['space-agent-tools'],
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			attachLongTermAgentTools: true,
+			isWorkflowWorker: false,
+		};
+	}
+
+	return {
+		role: 'ad_hoc_member',
+		spaceId,
+		owner: 'space-runtime',
+		requiredServers: SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS,
+		attachGenericSpaceTools: true,
+		attachCoordinatorTools: false,
+		attachLongTermAgentTools: false,
+		isWorkflowWorker: false,
+	};
+}
+
+function isLongTermAgentSession(session: Session, spaceId: string): boolean {
+	const agentId = session.metadata.promptProvenance?.agentId;
+	if (!agentId) return false;
+	return session.id === longTermAgentSessionId(spaceId, agentId);
+}
+
+export function missingMcpServers(
+	mcpServers: Record<string, unknown> | undefined,
+	requiredServers: readonly string[]
+): string[] {
+	const serverNames = Object.keys(mcpServers ?? {});
+	return requiredServers.filter((name) => !serverNames.includes(name));
+}

--- a/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
+++ b/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
@@ -12,7 +12,7 @@ export type SpaceMcpSessionRole =
 	| 'outside_space';
 
 export interface SpaceMcpSessionPolicyContext {
-	readonly nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId'>;
+	readonly nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId' | 'getById'>;
 	readonly taskRepo?: Pick<SpaceTaskRepository, 'getTask'>;
 }
 
@@ -66,7 +66,7 @@ export function resolveSpaceMcpSessionPolicy(
 		};
 	}
 
-	const workflowExecution = context.nodeExecutionRepo?.getByAgentSessionId(session.id) ?? null;
+	const workflowExecution = resolveWorkflowExecution(session, context.nodeExecutionRepo);
 	if (workflowExecution) {
 		const taskId = session.context?.taskId;
 		const task = taskId ? (context.taskRepo?.getTask(taskId) ?? null) : null;
@@ -118,6 +118,28 @@ export function resolveSpaceMcpSessionPolicy(
 		attachLongTermAgentTools: false,
 		isWorkflowWorker: false,
 	};
+}
+
+function resolveWorkflowExecution(
+	session: Session,
+	nodeExecutionRepo: SpaceMcpSessionPolicyContext['nodeExecutionRepo']
+) {
+	const bySessionId = nodeExecutionRepo?.getByAgentSessionId(session.id) ?? null;
+	if (bySessionId) return bySessionId;
+
+	const executionId = parseExecutionIdFromSubSessionId(session.id);
+	if (!executionId) return null;
+
+	const byEmbeddedId = nodeExecutionRepo?.getById(executionId) ?? null;
+	return byEmbeddedId?.agentSessionId ? null : byEmbeddedId;
+}
+
+function parseExecutionIdFromSubSessionId(sessionId: string): string | null {
+	const marker = ':exec:';
+	const markerIndex = sessionId.indexOf(marker);
+	if (markerIndex === -1) return null;
+	const executionId = sessionId.slice(markerIndex + marker.length).split(':')[0];
+	return executionId || null;
 }
 
 function isLongTermAgentSession(session: Session, spaceId: string): boolean {

--- a/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
+++ b/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
@@ -130,8 +130,7 @@ function resolveWorkflowExecution(
 	const executionId = parseExecutionIdFromSubSessionId(session.id);
 	if (!executionId) return null;
 
-	const byEmbeddedId = nodeExecutionRepo?.getById(executionId) ?? null;
-	return byEmbeddedId?.agentSessionId ? null : byEmbeddedId;
+	return nodeExecutionRepo?.getById(executionId) ?? null;
 }
 
 function parseExecutionIdFromSubSessionId(sessionId: string): string | null {

--- a/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
+++ b/packages/daemon/src/lib/space/runtime/space-mcp-session-policy.ts
@@ -29,10 +29,7 @@ export interface SpaceMcpSessionPolicy {
 
 export const SPACE_COORDINATOR_REQUIRED_MCP_SERVERS = ['space-agent-tools'] as const;
 export const SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS = ['space-agent-tools'] as const;
-export const SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS = [
-	'node-agent',
-	'space-agent-tools',
-] as const;
+export const SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS = ['node-agent'] as const;
 
 export function resolveSpaceMcpSessionPolicy(
 	session: Session,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -203,6 +203,8 @@ export class SpaceRuntimeService {
 	 * when the daemon stops, mirroring `spaceDbQueryServers` for space-chat sessions.
 	 */
 	private readonly memberSessionDbQueryServers = new Map<string, DbQueryMcpServer>();
+	/** Stores db-query server instances attached to long-term Space agent sessions. */
+	private readonly longTermAgentDbQueryServers = new Map<string, DbQueryMcpServer>();
 	/**
 	 * Per-space SpaceAgentNotificationService unsubscribe handles.
 	 * Created when a space's chat session is provisioned; cleaned up on stop.
@@ -457,6 +459,7 @@ export class SpaceRuntimeService {
 		if (!space) return null;
 		const sessionId = longTermAgentSessionId(actor.spaceId, agentId);
 		let session = await sessionManager.getSessionAsync(sessionId);
+		const created = !session;
 		if (!session) {
 			const resolvedPrompt = resolveCustomAgentPrompt(agent, {
 				resolutionContext: { agentId: agent.id, agentName: agent.name },
@@ -523,7 +526,9 @@ export class SpaceRuntimeService {
 				},
 			});
 		}
-		this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId);
+		if (created || this.missingLongTermAgentMcpServers(session)) {
+			this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId);
+		}
 		return session;
 	}
 
@@ -593,13 +598,32 @@ export class SpaceRuntimeService {
 			}) as unknown as McpServerConfig;
 		}
 		if (this.config.dbPath) {
-			mcpServers['db-query'] = createDbQueryMcpServer({
+			this.releaseLongTermAgentDbQuery(sessionId);
+			const dbQueryServer = createDbQueryMcpServer({
 				dbPath: this.config.dbPath,
 				scopeType: 'space',
 				scopeValue: space.id,
-			}) as unknown as McpServerConfig;
+			});
+			this.longTermAgentDbQueryServers.set(sessionId, dbQueryServer);
+			mcpServers['db-query'] = dbQueryServer as unknown as McpServerConfig;
 		}
 		session.mergeRuntimeMcpServers(mcpServers);
+	}
+
+	private missingLongTermAgentMcpServers(session: { getSessionData(): Session }): boolean {
+		const current = session.getSessionData().config?.mcpServers;
+		return !current?.['space-agent-tools'];
+	}
+
+	private releaseLongTermAgentDbQuery(sessionId: string): void {
+		const server = this.longTermAgentDbQueryServers.get(sessionId);
+		if (!server) return;
+		try {
+			server.close();
+		} catch (err) {
+			log.warn(`Failed to close db-query server for long-term agent session ${sessionId}:`, err);
+		}
+		this.longTermAgentDbQueryServers.delete(sessionId);
 	}
 
 	private buildLongTermAgentMcpServer(space: Space, agentName: string, sessionId: string) {
@@ -858,6 +882,18 @@ export class SpaceRuntimeService {
 		}
 		this.memberSessionDbQueryServers.clear();
 
+		for (const [sessionId, server] of this.longTermAgentDbQueryServers) {
+			try {
+				server.close();
+			} catch (error) {
+				log.warn(
+					`Failed to close db-query server for long-term agent session ${sessionId}:`,
+					error
+				);
+			}
+		}
+		this.longTermAgentDbQueryServers.clear();
+
 		// Tear down per-space SpaceAgentNotificationService subscriptions.
 		for (const [spaceId, unsub] of this.spaceAgentNotificationUnsubs) {
 			try {
@@ -949,6 +985,7 @@ export class SpaceRuntimeService {
 			'session.deleted',
 			(event) => {
 				this.releaseMemberSessionDbQuery(event.sessionId);
+				this.releaseLongTermAgentDbQuery(event.sessionId);
 			},
 			{ subscriberName: 'SpaceRuntimeService.sessionDeleted' }
 		);

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -522,9 +522,50 @@ export class SpaceRuntimeService {
 					},
 				},
 			});
-			this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId);
 		}
+		this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId);
 		return session;
+	}
+
+	private async attachLongTermAgentMcpServersForSession(
+		session: Session,
+		options: { replayPendingMessages?: boolean } = {}
+	): Promise<void> {
+		const { sessionManager } = this.config;
+		if (!sessionManager) return;
+		const policy = this.resolveMcpSessionPolicy(session);
+		if (!policy.attachLongTermAgentTools || !policy.spaceId) return;
+		const agentId = session.metadata.promptProvenance?.agentId;
+		const agentName = session.metadata.promptProvenance?.agentName;
+		if (!agentId || !agentName) return;
+		const [space, agentSession] = await Promise.all([
+			this.config.spaceManager.getSpace(policy.spaceId),
+			sessionManager.getSessionAsync(session.id),
+		]);
+		if (!space) {
+			log.warn(
+				`attachLongTermAgentMcpServersForSession: space "${policy.spaceId}" not found (session ${session.id})`
+			);
+			return;
+		}
+		if (!agentSession) {
+			log.warn(
+				`attachLongTermAgentMcpServersForSession: agent session not found for ${session.id}`
+			);
+			return;
+		}
+		this.attachLongTermAgentMcpServers(agentSession, space, agentName, session.id);
+		agentSession.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
+			log.warn(
+				`Long-term Space agent session ${session.id} missing MCP servers [${missing.join(', ')}]; re-attaching space-agent-tools before query start`
+			);
+			await this.attachLongTermAgentMcpServersForSession(session, {
+				replayPendingMessages: false,
+			});
+		};
+		if (options.replayPendingMessages !== false) {
+			await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
+		}
 	}
 
 	private attachLongTermAgentMcpServers(
@@ -882,7 +923,11 @@ export class SpaceRuntimeService {
 		const unsubSessionCreated = internalEventBus.subscribe(
 			'session.created',
 			(event) => {
-				void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
+				const policy = this.resolveMcpSessionPolicy(event.session);
+				const attachPromise = policy.attachLongTermAgentTools
+					? this.attachLongTermAgentMcpServersForSession(event.session)
+					: this.attachSpaceToolsToMemberSession(event.session);
+				void attachPromise.catch((err) => {
 					log.error(
 						`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
 						err
@@ -995,6 +1040,10 @@ export class SpaceRuntimeService {
 		}
 
 		const policy = this.resolveMcpSessionPolicy(session);
+		if (policy.attachLongTermAgentTools) {
+			await this.attachLongTermAgentMcpServersForSession(session, options);
+			return;
+		}
 		if (policy.attachGenericSpaceTools) {
 			await this.attachSpaceToolsToMemberSession(session, options);
 		}
@@ -1091,9 +1140,13 @@ export class SpaceRuntimeService {
 			const all = sessionManager.listSessions({ includeArchived: false });
 			for (const session of all) {
 				const policy = this.resolveMcpSessionPolicy(session);
-				if (policy.owner !== 'space-runtime' || !policy.attachGenericSpaceTools) continue;
+				if (policy.owner !== 'space-runtime') continue;
 				try {
-					await this.attachSpaceToolsToMemberSession(session);
+					if (policy.attachLongTermAgentTools) {
+						await this.attachLongTermAgentMcpServersForSession(session);
+					} else if (policy.attachGenericSpaceTools) {
+						await this.attachSpaceToolsToMemberSession(session);
+					}
 				} catch (err) {
 					log.error(
 						`Failed to attach space tools to existing session ${session.id} (space ${policy.spaceId ?? '?'}, role ${policy.role}):`,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -48,6 +48,10 @@ import { Logger } from '../../logger';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { createAgentMemoryMcpServer } from '../tools/agent-memory-tools';
 import {
+	resolveSpaceMcpSessionPolicy,
+	type SpaceMcpSessionPolicy,
+} from './space-mcp-session-policy';
+import {
 	SpaceAgentNotificationService,
 	type SpaceAgentNotificationServiceConfig,
 } from './space-agent-notification-service';
@@ -120,9 +124,8 @@ export interface SpaceRuntimeServiceConfig {
 	pendingMessageRepo?: PendingAgentMessageRepository;
 	channelCycleRepo?: ChannelCycleRepository;
 	/**
-	 * Optional SessionManager for provisioning space:chat:${spaceId} sessions.
-	 * When provided, setupSpaceAgentSession() attaches MCP tools and system prompts
-	 * to space chat sessions on startup and on space.created events.
+	 * Optional SessionManager for provisioning Space-owned sessions.
+	 * When provided, role-specific MCP tools attach on startup and session events.
 	 */
 	sessionManager?: SessionManager;
 	/**
@@ -195,10 +198,9 @@ export class SpaceRuntimeService {
 	/** Stores db-query server instances per space for cleanup on stop. */
 	private readonly spaceDbQueryServers = new Map<string, DbQueryMcpServer>();
 	/**
-	 * Stores db-query server instances attached to member sessions of a space
-	 * (non-space-chat sessions with `context.spaceId`). Keyed by `sessionId`.
-	 * Each entry holds the server instance so it can be closed when the daemon
-	 * stops, mirroring `spaceDbQueryServers` for the space-chat session.
+	 * Stores db-query server instances attached to SpaceRuntime-owned member sessions.
+	 * Keyed by `sessionId`. Each entry holds the server instance so it can be closed
+	 * when the daemon stops, mirroring `spaceDbQueryServers` for space-chat sessions.
 	 */
 	private readonly memberSessionDbQueryServers = new Map<string, DbQueryMcpServer>();
 	/**
@@ -211,9 +213,8 @@ export class SpaceRuntimeService {
 	 * Resolves when startup-time session provisioning has completed:
 	 *   - every existing space's space:chat session has had MCP tools +
 	 *     system prompt re-attached (via `setupSpaceAgentSession`), and
-	 *   - every existing member session (non-space-chat session with
-	 *     `context.spaceId`) has had `space-agent-tools` (and, when configured,
-	 *     `db-query`) re-attached (via `attachSpaceToolsToMemberSession`).
+	 *   - every existing session owned by the Space runtime policy has had its
+	 *     role-specific MCP servers re-attached.
 	 *
 	 * Set by `start()` to the provisioning promise returned by
 	 * `provisionExistingSpaces()`. `null` before `start()` is called.
@@ -273,6 +274,13 @@ export class SpaceRuntimeService {
 					run,
 				});
 			},
+		});
+	}
+
+	private resolveMcpSessionPolicy(session: Session): SpaceMcpSessionPolicy {
+		return resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: this.nodeExecutionRepo,
+			taskRepo: this.config.taskRepo,
 		});
 	}
 
@@ -825,10 +833,9 @@ export class SpaceRuntimeService {
 
 	/**
 	 * Subscribe to space.created and session.created events so newly created
-	 * spaces get their chat sessions provisioned with MCP tools + system
-	 * prompt, and every new session with a `context.spaceId` gets
-	 * `space-agent-tools` (and `db-query`) attached so it can coordinate with
-	 * the rest of the Space.
+	 * spaces get their chat sessions provisioned with MCP tools + system prompt,
+	 * and every new SpaceRuntime-owned member session gets `space-agent-tools`
+	 * (and `db-query`) attached so it can coordinate with the rest of the Space.
 	 *
 	 * Called once during start(). No-op when sessionManager or internalEventBus are absent.
 	 */
@@ -863,14 +870,10 @@ export class SpaceRuntimeService {
 		);
 		this.unsubscribers.push(unsubWorkflowUpdated);
 
-		// When any new session is created with `context.spaceId`, attach the
-		// shared Space coordination tools. The space-chat session itself is
-		// handled by `setupSpaceAgentSession` (it also sets the system prompt);
-		// space_chat sessions are handled by `setupSpaceAgentSession`
-		// (which merges `space-agent-tools` into its MCP set). This subscription
-		// covers the remaining cases: worker sessions
-		// that live inside a Space and need to send/receive messages via
-		// `send_message_to_agent`, inspect tasks, etc.
+		// New sessions are routed through the explicit Space MCP policy. Coordinator
+		// sessions are handled by `setupSpaceAgentSession`; ad-hoc Space member
+		// sessions get the generic Space tools here; workflow workers are owned by
+		// TaskAgentManager and skipped by policy.
 		//
 		// NOTE: no `{ sessionId: 'global', subscriberName: 'SpaceRuntimeService.global' }` filter here — `session.created` is
 		// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
@@ -991,7 +994,10 @@ export class SpaceRuntimeService {
 			return;
 		}
 
-		await this.attachSpaceToolsToMemberSession(session, options);
+		const policy = this.resolveMcpSessionPolicy(session);
+		if (policy.attachGenericSpaceTools) {
+			await this.attachSpaceToolsToMemberSession(session, options);
+		}
 	}
 
 	/**
@@ -1027,21 +1033,16 @@ export class SpaceRuntimeService {
 	}
 
 	/**
-	 * Provision space:chat:${spaceId} sessions for all existing spaces, and
-	 * attach `space-agent-tools` to every other existing session whose
-	 * `context.spaceId` is set.
+	 * Provision existing Space sessions after daemon restart.
 	 *
-	 * Called during start() to re-attach MCP tools and system prompts to existing
-	 * space chat sessions after a daemon restart. The sessions already exist in DB;
-	 * only the runtime configuration (MCP server, system prompt) needs re-attaching.
+	 * Space chat sessions are provisioned from the spaces table because they are
+	 * guaranteed one-per-space. All other persisted sessions are routed through the
+	 * explicit Space MCP session policy: SpaceRuntime owns ad-hoc members and skips
+	 * workflow workers because TaskAgentManager owns their node wrapper.
 	 *
 	 * Returns a promise that resolves only after **both** sweeps complete so the
 	 * daemon bootstrap can `await spaceRuntimeService.ready()` before accepting
-	 * queries. Previously this was fire-and-forget, which left a race window in
-	 * which a session's RPC query could run before `space-agent-tools` had been
-	 * re-attached and execute with `mcpServers: undefined` (strictMcpConfig is on
-	 * globally), producing "No such tool available" errors — the root cause of
-	 * task #83.
+	 * queries.
 	 *
 	 * No-op when sessionManager is absent.
 	 */
@@ -1068,26 +1069,19 @@ export class SpaceRuntimeService {
 				log.error('Failed to list spaces for session provisioning:', err);
 			});
 
-		// Member sessions: `space-agent-tools` (and, if configured, `db-query`)
-		// attached to every non-space-chat session whose `context.spaceId` is set.
-		// Awaited together with the chat sweep so neither can race past startup.
+		// Space-owned session sweep: ad-hoc member sessions get generic Space tools;
+		// workflow workers are skipped because TaskAgentManager owns node-specific tools.
 		const memberSweep = this.reattachSpaceToolsToExistingSessions();
 
 		await Promise.all([chatSweep, memberSweep]);
 	}
 
 	/**
-	 * Re-attach `space-agent-tools` (and, if configured, `db-query`) to every
-	 * non-space-chat session whose `context.spaceId` is set. Runs sequentially
-	 * rather than in parallel because each attach performs a space lookup and a
-	 * session lookup (both SQLite reads); a daemon restarting with many member
-	 * sessions would otherwise issue a thundering herd of reads. Sequential is
-	 * fast enough — the work is small per session and happens once at startup —
-	 * and avoids the burst.
+	 * Re-attach SpaceRuntime-owned MCP tools to existing sessions.
 	 *
-	 * Must be `await`ed by the startup path so that no incoming query can reach a
-	 * member session before its tools are attached; the previous fire-and-forget
-	 * variant was the root cause of task #83.
+	 * Runs sequentially because each policy decision can read node-execution state
+	 * and each attach performs SQLite-backed session/space lookups. Sequential is
+	 * fast enough for daemon startup and avoids a thundering herd.
 	 */
 	private async reattachSpaceToolsToExistingSessions(): Promise<void> {
 		const { sessionManager } = this.config;
@@ -1096,12 +1090,13 @@ export class SpaceRuntimeService {
 		try {
 			const all = sessionManager.listSessions({ includeArchived: false });
 			for (const session of all) {
-				if (!session.context?.spaceId) continue;
+				const policy = this.resolveMcpSessionPolicy(session);
+				if (policy.owner !== 'space-runtime' || !policy.attachGenericSpaceTools) continue;
 				try {
 					await this.attachSpaceToolsToMemberSession(session);
 				} catch (err) {
 					log.error(
-						`Failed to attach space tools to existing session ${session.id} (space ${session.context?.spaceId}):`,
+						`Failed to attach space tools to existing session ${session.id} (space ${policy.spaceId ?? '?'}, role ${policy.role}):`,
 						err
 					);
 				}
@@ -1112,24 +1107,12 @@ export class SpaceRuntimeService {
 	}
 
 	/**
-	 * Attach the shared `space-agent-tools` MCP server (and, when configured,
-	 * a space-scoped `db-query` server) to a session that lives inside a Space
-	 * but is not the Space-chat session itself.
+	 * Attach generic Space MCP servers to an ad-hoc Space member session.
 	 *
-	 * This widens the tool surface from "space chat session only" to "every
-	 * session in the space", so worker sessions
-	 * spawned inside a Space can coordinate with the rest of the Space
-	 * (e.g., `send_message_to_agent`, `list_task_members`). Permission gating
-	 * inside each tool handler (autonomyLevel checks, writer checks, etc.)
-	 * ensures widening the surface does not bypass access control.
-	 *
-	 * Explicitly skipped for:
-	 *   - `space_chat` sessions — handled by `setupSpaceAgentSession`, which
-	 *     also sets the system prompt.
-	 *
-	 * Uses `mergeRuntimeMcpServers` so any previously-attached MCP servers on
-	 * the session (e.g., room tools) are preserved. The session's system
-	 * prompt is **not** touched.
+	 * Role selection is centralised in `resolveSpaceMcpSessionPolicy`; this method
+	 * only serves sessions whose policy says SpaceRuntime owns generic member tools.
+	 * Workflow workers are skipped because TaskAgentManager attaches node-scoped
+	 * `node-agent` plus specialised `space-agent-tools`.
 	 */
 	async attachSpaceToolsToMemberSession(
 		session: Session,
@@ -1137,25 +1120,9 @@ export class SpaceRuntimeService {
 	): Promise<void> {
 		const { sessionManager } = this.config;
 		if (!sessionManager) return;
-		const spaceId = session.context?.spaceId;
-		if (!spaceId) return;
-
-		// Skip sessions that other owners already manage.
-		if (session.type === 'space_chat') return;
-		// Legacy task-agent sessions (no longer created) must not receive the
-		// generic member-server — they lack myAgentName and would misattribute
-		// outbound messages as "space-agent".
-		if (session.type === 'space_task_agent') return;
-
-		// Skip workflow node-agent sub-sessions (session ID contains `:task:…:exec:`).
-		// These are owned by TaskAgentManager, which builds a SUB-SESSION-SPECIFIC
-		// `space-agent-tools` server via `buildSpaceAgentToolsMcpServerForSubSession`.
-		// That server carries `myAgentName` / `myNodeId` context required for gate
-		// writer authorization — context the generic member-session server lacks.
-		// Merging the generic server here would silently overwrite the specialised
-		// one (mergeRuntimeMcpServers overwrites on key collision), breaking
-		// `write_gate` / `read_gate` / `approve_gate` for the sub-session.
-		if (session.id.includes(':task:') && session.id.includes(':exec:')) return;
+		const policy = this.resolveMcpSessionPolicy(session);
+		if (!policy.attachGenericSpaceTools || !policy.spaceId) return;
+		const spaceId = policy.spaceId;
 
 		const space = await this.config.spaceManager.getSpace(spaceId);
 		if (!space) {
@@ -1248,7 +1215,7 @@ export class SpaceRuntimeService {
 		}
 
 		log.info(
-			`Attached space-agent-tools to member session ${session.id} (space ${space.id}, type ${session.type ?? 'worker'})`
+			`Attached space-agent-tools to member session ${session.id} (space ${space.id}, role ${policy.role}, type ${session.type ?? 'worker'})`
 		);
 	}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -536,11 +536,11 @@ export class SpaceRuntimeService {
 		const policy = this.resolveMcpSessionPolicy(session);
 		if (!policy.attachLongTermAgentTools || !policy.spaceId) return;
 		const agentId = session.metadata.promptProvenance?.agentId;
-		const agentName = session.metadata.promptProvenance?.agentName;
-		if (!agentId || !agentName) return;
-		const [space, agentSession] = await Promise.all([
+		if (!agentId) return;
+		const [space, agentSession, persistedAgent] = await Promise.all([
 			this.config.spaceManager.getSpace(policy.spaceId),
 			sessionManager.getSessionAsync(session.id),
+			this.config.actorRegistryRepos?.spaceAgentRepo.getById(agentId) ?? null,
 		]);
 		if (!space) {
 			log.warn(
@@ -554,6 +554,8 @@ export class SpaceRuntimeService {
 			);
 			return;
 		}
+		const agentName =
+			session.metadata.promptProvenance?.agentName ?? persistedAgent?.name ?? 'Space Agent';
 		this.attachLongTermAgentMcpServers(agentSession, space, agentName, session.id);
 		agentSession.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
 			log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -74,6 +74,7 @@ import type { ActorRef, MessageRecord } from '../../../../../messaging/src/types
 import type { ActorResolver } from '../../../../../messaging/src/contracts';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
+import { SpaceTaskManager } from '../managers/space-task-manager';
 /** Agent identity metadata for sub-session creation. */
 export interface SubSessionMemberInfo {
 	/** ID of the SpaceAgent config this sub-session uses */
@@ -85,7 +86,6 @@ export interface SubSessionMemberInfo {
 }
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { createEndNodeHandlers, createMarkCompleteHandler } from '../tools/end-node-handlers';
-import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { jsonResult } from '../tools/tool-result';
 import {
 	assertExecutionValidAgainstWorkflow,
@@ -111,7 +111,6 @@ import {
 } from '../agents/custom-agent';
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import { Logger } from '../../logger';
-import { SpaceTaskManager } from '../managers/space-task-manager';
 import {
 	formatAgentMessage,
 	extractReplyToSessionId,
@@ -915,8 +914,7 @@ export class TaskAgentManager {
 						// Re-merging with a fresh node-agent and restarting the query ensures the
 						// session's tool surface reflects the new node activation context.
 						//
-						// Re-inject node-agent, attach specialised space-agent-tools, and enforce
-						// the required-server invariant on the reused session.
+						// Re-inject node-agent and enforce the required-server invariant on the reused session.
 						if (memberInfo.nodeId) {
 							const reuseWorkspacePath = this.taskWorktreePaths.get(taskId) ?? init.workspacePath;
 							const reuseCtx = {
@@ -930,7 +928,6 @@ export class TaskAgentManager {
 							};
 							// Unconditionally rebuild node-agent (fresh node context).
 							await this.reinjectNodeAgentMcpServer(existing, reuseCtx);
-							await this.attachSpaceToolsToWorkflowSubSession(existing, reuseCtx, 'reuse');
 							await this.ensureRequiredMcpServersAttached(existing, {
 								...reuseCtx,
 								phase: 'spawn',
@@ -1020,25 +1017,6 @@ export class TaskAgentManager {
 			// replace-all setRuntimeMcpServers because it won't clobber servers injected
 			// by a concurrent subsystem before this path runs.
 			subSession.mergeRuntimeMcpServers(mergedSubSessionMcpServers);
-		}
-		const subSessionContext = subSession.session.context;
-		if (memberInfo?.nodeId && memberInfo.agentName && subSessionContext?.spaceId) {
-			const parentTask = this.config.taskRepo.getTask(taskId);
-			if (parentTask?.workflowRunId) {
-				await this.attachSpaceToolsToWorkflowSubSession(
-					subSession,
-					{
-						taskId,
-						subSessionId: sessionId,
-						agentName: memberInfo.agentName,
-						spaceId: subSessionContext.spaceId,
-						workflowRunId: parentTask.workflowRunId,
-						workspacePath: init.workspacePath,
-						workflowNodeId: memberInfo.nodeId,
-					},
-					'new'
-				);
-			}
 		}
 
 		// Determine node ID from session convention or task context.
@@ -2476,7 +2454,7 @@ export class TaskAgentManager {
 
 	/**
 	 * Eagerly rehydrate every workflow sub-session attached to a workflow run,
-	 * so the in-process `node-agent` and `space-agent-tools` MCP servers are
+	 * so the in-process `node-agent` MCP server is
 	 * re-attached to each sub-session before any external consumer
 	 * (UI overlay, peer message, gate write) reaches them.
 	 *
@@ -2706,8 +2684,6 @@ export class TaskAgentManager {
 			workspacePath,
 			workflowNodeId: execution.workflowNodeId,
 		};
-
-		await this.attachSpaceToolsToWorkflowSubSession(agentSession, rehydrateCtx, 'rehydrate');
 
 		// Defensive guarantee — see ensureNodeAgentAttached docs.
 		await this.ensureNodeAgentAttached(agentSession, {
@@ -3167,12 +3143,8 @@ export class TaskAgentManager {
 	 */
 	requiredWorkflowSubSessionMcpServers(): string[] {
 		return this.config.memoryRepo
-			? [
-					...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS,
-					'space-agent-tools',
-					'agent-memory',
-				]
-			: [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS, 'space-agent-tools'];
+			? [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS, 'agent-memory']
+			: [...TaskAgentManager.REQUIRED_WORKFLOW_SUBSESSION_MCP_SERVERS];
 	}
 
 	async ensureNodeAgentAttached(
@@ -3216,8 +3188,6 @@ export class TaskAgentManager {
 		for (const name of missing) {
 			if (name === 'node-agent') {
 				await this.reinjectNodeAgentMcpServer(session, ctx);
-			} else if (name === 'space-agent-tools') {
-				await this.attachSpaceToolsToWorkflowSubSession(session, ctx, ctx.phase);
 			} else if (name === 'agent-memory') {
 				await this.reinjectAgentMemoryMcpServer(session, ctx);
 			}
@@ -3317,8 +3287,7 @@ export class TaskAgentManager {
 	 * Preferred alias for `ensureNodeAgentAttached`. See that method for behaviour.
 	 *
 	 * The original name remains for backwards compatibility with existing callers,
-	 * but is misleading now that the check covers both `node-agent` and
-	 * `space-agent-tools`. New code should prefer this alias.
+	 * but is misleading now that the check covers `node-agent` and optional `agent-memory`. New code should prefer this alias.
 	 */
 	async ensureRequiredMcpServersAttached(
 		session: AgentSession,
@@ -3375,7 +3344,7 @@ export class TaskAgentManager {
 			ctx.workflowNodeId
 		);
 
-		// Use merge semantics so other runtime servers (space-agent-tools, db-query, etc.)
+		// Use merge semantics so other runtime servers (agent-memory, db-query, etc.)
 		// are preserved. The deprecated setRuntimeMcpServers would clobber them.
 		session.mergeRuntimeMcpServers({
 			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
@@ -3395,164 +3364,6 @@ export class TaskAgentManager {
 		if (Object.keys(mcpServers).length === 0) return;
 		session.mergeRuntimeMcpServers(mcpServers);
 		await session.restartQuery();
-	}
-
-	/**
-	 * Build (or re-build) the per-session `space-agent-tools` MCP server and merge
-	 * it into the session's runtime MCP map, preserving any other MCP servers
-	 * already present.
-	 *
-	 * Symmetric to `reinjectNodeAgentMcpServer`. Used by the defensive self-heal
-	 * path in `ensureNodeAgentAttached` / `ensureRequiredMcpServersAttached` when
-	 * a workflow sub-session is missing `space-agent-tools` (e.g. because a
-	 * `createSubSession` reuse path reused a session whose in-memory MCP map had
-	 * been trimmed, or a rehydrate path raced with `attachSpaceToolsToMemberSession`).
-	 *
-	 * Without `space-agent-tools` a workflow node cannot call `write_gate`,
-	 * `read_gate`, `approve_gate`, or `list_tasks`, and the workflow stalls at its
-	 * first gate boundary (Task #99 failure mode).
-	 *
-	 * The re-attached server wires `onRestoreNodeAgent` into a closure that calls
-	 * back into this manager's `reinjectNodeAgentMcpServer` — mirroring the
-	 * rehydrate-time wiring in `rehydrateSubSession` — so the combined self-heal
-	 * remains complete even across subsequent node-agent losses.
-	 *
-	 * Calls `restartQuery()` after merge so the SDK mounts the fresh tool surface.
-	 */
-	async reinjectSpaceAgentToolsMcpServer(
-		session: AgentSession,
-		ctx: {
-			taskId: string;
-			subSessionId: string;
-			agentName: string;
-			spaceId: string;
-			workflowRunId: string;
-			workspacePath: string;
-			workflowNodeId: string;
-		}
-	): Promise<void> {
-		const spaceAgentToolsServer = this.buildSpaceAgentToolsMcpServerForSubSession(ctx);
-
-		session.mergeRuntimeMcpServers({
-			'space-agent-tools': spaceAgentToolsServer as unknown as McpServerConfig,
-		});
-
-		await session.restartQuery();
-	}
-
-	private async attachSpaceToolsToWorkflowSubSession(
-		session: AgentSession,
-		ctx: {
-			taskId: string;
-			subSessionId: string;
-			agentName: string;
-			spaceId: string;
-			workflowRunId: string;
-			workspacePath: string;
-			workflowNodeId: string;
-		},
-		phase: 'new' | 'reuse' | 'rehydrate' | 'spawn'
-	): Promise<void> {
-		try {
-			await this.reinjectSpaceAgentToolsMcpServer(session, ctx);
-			session.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
-				log.warn(
-					`Workflow sub-session ${ctx.subSessionId} missing Space MCP servers [${missing.join(', ')}]; re-attaching before query start`
-				);
-				await this.attachSpaceToolsToWorkflowSubSession(session, ctx, 'rehydrate');
-			};
-		} catch (err) {
-			log.error(
-				`Failed to attach space tools to ${phase} sub-session ${ctx.subSessionId} (space ${ctx.spaceId}):`,
-				err
-			);
-		}
-	}
-
-	/**
-	 * Build the `space-agent-tools` MCP server for a specific workflow sub-session.
-	 *
-	 * Centralises the `createSpaceAgentMcpServer({ … })` construction that was
-	 * previously inlined in four spawn/rehydrate paths
-	 * (`spawnWorkflowNodeAgentForExecution`, `eagerlySpawnWorkflowNodeAgents`,
-	 * `rehydrateSubSession`, and the reuse branch of `createSubSession`). Keeping
-	 * the builder in one place means a future change to the server wiring (e.g.
-	 * new config field, new callback) is applied uniformly, preventing drift
-	 * between spawn and self-heal paths.
-	 *
-	 * The returned server includes an `onRestoreNodeAgent` callback that
-	 * re-injects `node-agent` on the live sub-session, so the Space UI's
-	 * "restore node-agent" affordance keeps working even when this server was
-	 * attached via the self-heal path.
-	 */
-	private buildSpaceAgentToolsMcpServerForSubSession(ctx: {
-		taskId: string;
-		subSessionId: string;
-		agentName: string;
-		spaceId: string;
-		workflowRunId: string;
-		workspacePath: string;
-		workflowNodeId: string;
-	}) {
-		const subSessionTaskManager = new SpaceTaskManager(
-			this.config.db.getDatabase(),
-			ctx.spaceId,
-			this.config.reactiveDb
-		);
-		return createSpaceAgentMcpServer({
-			spaceId: ctx.spaceId,
-			runtime: this.config.spaceRuntimeService.getSharedRuntime(),
-			workflowManager: this.config.spaceWorkflowManager,
-			spaceManager: this.config.spaceManager,
-			taskRepo: this.config.taskRepo,
-			nodeExecutionRepo: this.config.nodeExecutionRepo,
-			workflowRunRepo: this.config.workflowRunRepo,
-			taskManager: subSessionTaskManager,
-			spaceAgentManager: this.config.spaceAgentManager,
-			taskAgentManager: this,
-			gateDataRepo: this.config.gateDataRepo,
-			internalEventBus: this.config.internalEventBus,
-			onGateChanged: (runId, gateId) => {
-				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
-			},
-			pendingMessageQueue: this.config.pendingMessageRepo,
-			getSpaceAutonomyLevel: async (sid) => {
-				const s = await this.config.spaceManager.getSpace(sid);
-				return s?.autonomyLevel ?? 1;
-			},
-			myAgentName: ctx.agentName,
-			mySessionId: ctx.subSessionId,
-			auditLogRepo: this.auditLogRepo,
-			scheduleService: this.config.scheduleService,
-			// Wire restore_node_agent so it is callable even when node-agent is
-			// missing. The closure captures the rebuild-time values of taskId,
-			// subSessionId, agentName, etc. which are stable for this session.
-			onRestoreNodeAgent: async (_args) => {
-				const liveSession = this.getSubSession(ctx.subSessionId);
-				if (!liveSession) {
-					log.warn(
-						`space-agent-tools.restore_node_agent: no live session found for sub-session ${ctx.subSessionId}`
-					);
-					return;
-				}
-				await this.reinjectNodeAgentMcpServer(liveSession, {
-					taskId: ctx.taskId,
-					subSessionId: ctx.subSessionId,
-					agentName: ctx.agentName,
-					spaceId: ctx.spaceId,
-					workflowRunId: ctx.workflowRunId,
-					workspacePath: ctx.workspacePath,
-					workflowNodeId: ctx.workflowNodeId,
-				});
-			},
-			replyRoutingRegistry: this.config.replyRoutingRegistry,
-			messageResolver: this.config.messageResolverFactory?.(ctx.spaceId, {
-				workflowRunId: ctx.workflowRunId,
-				nodeId: ctx.workflowNodeId,
-				agentName: ctx.agentName,
-			}),
-			longTermAgentDelivery: this.config.longTermAgentDelivery,
-		});
 	}
 
 	/**

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -38,6 +38,8 @@ import {
 import { JobQueueRepository } from './repositories/job-queue-repository';
 import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 import { TaskRepository } from './repositories/task-repository';
+import { SpaceTaskRepository } from './repositories/space-task-repository';
+import { NodeExecutionRepository } from './repositories/node-execution-repository';
 import { McpEnablementRepository } from './repositories/mcp-enablement-repository';
 import { SkillRepository } from './repositories/skill-repository';
 import { WorkspaceHistoryRepository } from './repositories/workspace-history-repository';
@@ -99,6 +101,8 @@ export class Database {
 	private jobQueueRepo!: JobQueueRepository;
 	private appMcpServerRepo!: AppMcpServerRepository;
 	private taskRepo!: TaskRepository;
+	private spaceTaskRepo!: SpaceTaskRepository;
+	private nodeExecutionRepo!: NodeExecutionRepository;
 	private mcpEnablementRepo!: McpEnablementRepository;
 	private skillRepo!: SkillRepository;
 	private workspaceHistoryRepo!: WorkspaceHistoryRepository;
@@ -128,6 +132,8 @@ export class Database {
 		this.inboxItemRepo = new InboxItemRepository(db);
 		this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
 		this.taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
+		this.spaceTaskRepo = new SpaceTaskRepository(db, reactiveDb);
+		this.nodeExecutionRepo = new NodeExecutionRepository(db);
 		this.jobQueueRepo = new JobQueueRepository(db);
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 		this.mcpEnablementRepo = new McpEnablementRepository(db, reactiveDb);
@@ -511,6 +517,22 @@ export class Database {
 	 */
 	getTaskRepo(): TaskRepository {
 		return this.taskRepo;
+	}
+
+	/**
+	 * Get the Space task repository
+	 * Used for Space workflow session-role policy checks
+	 */
+	getSpaceTaskRepo(): SpaceTaskRepository {
+		return this.spaceTaskRepo;
+	}
+
+	/**
+	 * Get the Space node execution repository
+	 * Used for workflow worker session-role policy checks
+	 */
+	getNodeExecutionRepo(): NodeExecutionRepository {
+		return this.nodeExecutionRepo;
 	}
 
 	/**

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { QueryRunner, type QueryRunnerContext } from '../../../../src/lib/agent/query-runner';
+import { longTermAgentSessionId } from '../../../../src/lib/space/long-term-agent-session';
 import type { Session, MessageHub } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
@@ -592,6 +593,52 @@ describe('QueryRunner', () => {
 				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
 				expect(buildSpy).toHaveBeenCalledTimes(1);
 				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		it('self-heals missing MCP servers for long-term Space agent sessions', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = longTermAgentSessionId('s1', 'agent-1');
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.metadata.promptProvenance = {
+					source: 'test',
+					hash: 'hash',
+					agentId: 'agent-1',
+					agentName: 'Long Term',
+				};
+				mockSession.config.mcpServers = {};
+
+				const repairedServers = {
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				buildSpy
+					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: repairedServers,
+					});
+				stopAfterRebuiltOptions();
+				const onMissingMemberSpaceMcpServers = mock(async () => {
+					mockSession.config.mcpServers =
+						repairedServers as unknown as Session['config']['mcpServers'];
+				});
+
+				const ctx = createContext({ onMissingMemberSpaceMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingMemberSpaceMcpServers).toHaveBeenCalledWith(mockSession.id, [
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
 			});
 		});
 

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -315,11 +315,6 @@ describe('QueryRunner', () => {
 						name: 'node-agent',
 						instance: {},
 					},
-					'space-agent-tools': {
-						type: 'sdk',
-						name: 'space-agent-tools',
-						instance: {},
-					},
 				};
 				buildSpy
 					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
@@ -340,7 +335,6 @@ describe('QueryRunner', () => {
 
 				expect(onMissingWorkflowMcpServers).toHaveBeenCalledWith('space:s1:task:t1:exec:e1', [
 					'node-agent',
-					'space-agent-tools',
 				]);
 				expect(buildSpy).toHaveBeenCalledTimes(2);
 				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -105,6 +105,14 @@ describe('QueryRunner', () => {
 			getMessagesByStatus: getMessagesByStatusSpy,
 			getSDKMessages: getSDKMessagesSpy,
 			updateMessageStatus: updateMessageStatusSpy,
+			getNodeExecutionRepo: mock(() => ({
+				getByAgentSessionId: (sessionId: string) =>
+					sessionId === 'space:s1:task:t1:exec:e1' ? { id: 'exec-1' } : null,
+			})),
+			getSpaceTaskRepo: mock(() => ({
+				getTask: (taskId: string) =>
+					taskId === 't1' ? { id: 't1', spaceId: 's1', workflowRunId: 'run-1' } : null,
+			})),
 		} as unknown as Database;
 
 		// MessageHub spies
@@ -306,6 +314,11 @@ describe('QueryRunner', () => {
 						name: 'node-agent',
 						instance: {},
 					},
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
 				};
 				buildSpy
 					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
@@ -326,6 +339,7 @@ describe('QueryRunner', () => {
 
 				expect(onMissingWorkflowMcpServers).toHaveBeenCalledWith('space:s1:task:t1:exec:e1', [
 					'node-agent',
+					'space-agent-tools',
 				]);
 				expect(buildSpy).toHaveBeenCalledTimes(2);
 				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
@@ -581,7 +595,7 @@ describe('QueryRunner', () => {
 			});
 		});
 
-		it('self-heals missing member Space MCP for workflow sub-sessions', async () => {
+		it('skips member Space MCP invariant for workflow sub-sessions', async () => {
 			await withAnthropicApiKey(async () => {
 				mockSession.id = 'space:s1:task:t1:exec:e1';
 				mockSession.workspacePath = tmpdir();
@@ -624,11 +638,9 @@ describe('QueryRunner', () => {
 				runner.start();
 				await ctx.queryPromise?.catch(() => {});
 
-				expect(onMissingMemberSpaceMcpServers).toHaveBeenCalledWith('space:s1:task:t1:exec:e1', [
-					'space-agent-tools',
-				]);
-				expect(buildSpy).toHaveBeenCalledTimes(2);
-				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
+				expect(onMissingMemberSpaceMcpServers).not.toHaveBeenCalled();
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { parseAddress } from '../../../../messaging/src/address';
 import { SpaceActorRegistryAdapter } from '../../../src/lib/space/actor-registry';
+import { longTermAgentSessionId } from '../../../src/lib/space/long-term-agent-session';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
 import { PendingAgentMessageRepository } from '../../../src/storage/repositories/pending-agent-message-repository';
 import { SessionRepository } from '../../../src/storage/repositories/session-repository';
@@ -149,10 +150,48 @@ describe('SpaceActorRegistryAdapter', () => {
 			spaceId: space.id,
 			name: 'Long Term Agent',
 		});
+		sessionRepo.createSession(
+			makeSession(longTermAgentSessionId(space.id, agent.id), {
+				context: { spaceId: space.id },
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: agent.id,
+						agentName: agent.name,
+					},
+				},
+			})
+		);
 		const reservedNameAgent = spaceAgentRepo.create({
 			spaceId: space.id,
 			name: 'Coordinator',
 		});
+		sessionRepo.createSession(
+			makeSession(longTermAgentSessionId(space.id, reservedNameAgent.id), {
+				context: { spaceId: space.id },
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: reservedNameAgent.id,
+						agentName: reservedNameAgent.name,
+					},
+				},
+			})
+		);
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: space.id,
 			name: 'Coding Workflow',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-memory-mcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import type { McpServerConfig } from '@neokai/shared';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 
@@ -29,21 +29,6 @@ function makeSession(mcpServers: Record<string, McpServerConfig>) {
 	};
 }
 
-function makeSpaceToolsManager(): TaskAgentManager {
-	return Object.create(TaskAgentManager.prototype, {
-		config: {
-			value: {},
-		},
-		reinjectSpaceAgentToolsMcpServer: {
-			value: mock(async (session) => {
-				session.mergeRuntimeMcpServers({
-					'space-agent-tools': { type: 'sdk' } as McpServerConfig,
-				});
-			}),
-		},
-	}) as TaskAgentManager;
-}
-
 describe('TaskAgentManager agent-memory MCP wiring', () => {
 	test('builds agent-memory server when memory repo is configured', () => {
 		const manager = makeManager({});
@@ -60,13 +45,9 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 	});
 
 	test('requires agent-memory only when memory repo is configured', () => {
-		expect(makeManager().requiredWorkflowSubSessionMcpServers()).toEqual([
-			'node-agent',
-			'space-agent-tools',
-		]);
+		expect(makeManager().requiredWorkflowSubSessionMcpServers()).toEqual(['node-agent']);
 		expect(makeManager({}).requiredWorkflowSubSessionMcpServers()).toEqual([
 			'node-agent',
-			'space-agent-tools',
 			'agent-memory',
 		]);
 	});
@@ -75,7 +56,6 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 		const manager = makeManager({});
 		const session = makeSession({
 			'node-agent': { type: 'sdk' } as McpServerConfig,
-			'space-agent-tools': { type: 'sdk' } as McpServerConfig,
 		});
 
 		await manager.ensureNodeAgentAttached(session as never, {
@@ -92,32 +72,7 @@ describe('TaskAgentManager agent-memory MCP wiring', () => {
 		expect(Object.keys(session.session.config.mcpServers).sort()).toEqual([
 			'agent-memory',
 			'node-agent',
-			'space-agent-tools',
 		]);
 		expect(session.restartCount).toBe(1);
-	});
-
-	test('reattaches space-agent-tools and wires member self-heal callback', async () => {
-		const manager = makeSpaceToolsManager();
-		const session = makeSession({
-			'node-agent': { type: 'sdk' } as McpServerConfig,
-		});
-
-		await manager.ensureNodeAgentAttached(session as never, {
-			taskId: 'task-a',
-			subSessionId: 'session-a',
-			agentName: 'coder',
-			spaceId: 'space-a',
-			workflowRunId: 'run-a',
-			workspacePath: '/tmp/space-a',
-			workflowNodeId: 'node-a',
-			phase: 'rehydrate',
-		});
-
-		expect(Object.keys(session.session.config.mcpServers).sort()).toEqual([
-			'node-agent',
-			'space-agent-tools',
-		]);
-		expect(typeof session.onMissingMemberSpaceMcpServers).toBe('function');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from 'bun:test';
+import type { NodeExecution, Session, SpaceTask } from '@neokai/shared';
+import {
+	missingMcpServers,
+	resolveSpaceMcpSessionPolicy,
+	SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS,
+	SPACE_COORDINATOR_REQUIRED_MCP_SERVERS,
+	SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS,
+} from '../../../../src/lib/space/runtime/space-mcp-session-policy.ts';
+import { longTermAgentSessionId } from '../../../../src/lib/space/long-term-agent-session.ts';
+
+const now = Date.now();
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: 'session-1',
+		title: 'Session',
+		workspacePath: '/tmp/ws',
+		createdAt: new Date(now).toISOString(),
+		lastActiveAt: new Date(now).toISOString(),
+		status: 'active',
+		config: { tools: {} },
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+		},
+		type: 'worker',
+		...overrides,
+	} as Session;
+}
+
+function makeNodeExecution(overrides: Partial<NodeExecution> = {}): NodeExecution {
+	return {
+		id: 'exec-1',
+		workflowRunId: 'run-1',
+		workflowNodeId: 'node-1',
+		agentName: 'coder',
+		agentId: null,
+		agentSessionId: 'worker-session',
+		status: 'in_progress',
+		result: null,
+		data: null,
+		createdAt: now,
+		startedAt: now,
+		completedAt: null,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-from-task',
+		taskNumber: 1,
+		title: 'Task',
+		description: 'Task description',
+		status: 'in_progress',
+		priority: 'normal',
+		labels: [],
+		dependsOn: [],
+		result: null,
+		workflowRunId: null,
+		preferredWorkflowId: null,
+		createdByTaskId: null,
+		createdBy: 'user',
+		createdBySession: null,
+		createdByTaskScheduleId: null,
+		goalId: null,
+		evolutionScopeId: null,
+		activeSession: null,
+		taskAgentSessionId: null,
+		createdAt: now,
+		startedAt: now,
+		completedAt: null,
+		archivedAt: null,
+		blockReason: null,
+		approvalSource: null,
+		approvalReason: null,
+		approvedAt: null,
+		pendingCheckpointType: null,
+		pendingCompletionSubmittedByNodeId: null,
+		pendingCompletionSubmittedAt: null,
+		pendingCompletionReason: null,
+		reportedStatus: null,
+		reportedSummary: null,
+		postApprovalSessionId: null,
+		postApprovalStartedAt: null,
+		postApprovalBlockedReason: null,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+describe('resolveSpaceMcpSessionPolicy', () => {
+	test('routes space_chat sessions to SpaceRuntime coordinator tools', () => {
+		const policy = resolveSpaceMcpSessionPolicy(
+			makeSession({ id: 'space:chat:space-1', type: 'space_chat', context: { spaceId: 'space-1' } })
+		);
+
+		expect(policy).toMatchObject({
+			role: 'coordinator',
+			spaceId: 'space-1',
+			owner: 'space-runtime',
+			attachCoordinatorTools: true,
+			attachGenericSpaceTools: false,
+			isWorkflowWorker: false,
+		});
+		expect(policy.requiredServers).toBe(SPACE_COORDINATOR_REQUIRED_MCP_SERVERS);
+	});
+
+	test('routes ad-hoc Space sessions to SpaceRuntime generic member tools', () => {
+		const policy = resolveSpaceMcpSessionPolicy(
+			makeSession({ id: 'ad-hoc-1', type: 'worker', context: { spaceId: 'space-1' } })
+		);
+
+		expect(policy).toMatchObject({
+			role: 'ad_hoc_member',
+			spaceId: 'space-1',
+			owner: 'space-runtime',
+			attachGenericSpaceTools: true,
+			attachCoordinatorTools: false,
+			isWorkflowWorker: false,
+		});
+		expect(policy.requiredServers).toBe(SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS);
+	});
+
+	test('routes workflow workers by node execution ownership, not session ID shape', () => {
+		const session = makeSession({
+			id: 'opaque-worker-session',
+			type: 'worker',
+			context: { spaceId: 'space-1', taskId: 'task-1' },
+		});
+		const policy = resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: {
+				getByAgentSessionId: (sessionId) =>
+					sessionId === session.id ? makeNodeExecution({ agentSessionId: session.id }) : null,
+			},
+			taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-1' }) },
+		});
+
+		expect(policy).toMatchObject({
+			role: 'workflow_worker',
+			spaceId: 'space-1',
+			owner: 'task-agent-manager',
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			isWorkflowWorker: true,
+		});
+		expect(policy.requiredServers).toBe(SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS);
+	});
+
+	test('resolves workflow worker space from task when session context lacks spaceId', () => {
+		const session = makeSession({ id: 'opaque-worker-session', context: { taskId: 'task-1' } });
+		const policy = resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: { getByAgentSessionId: () => makeNodeExecution() },
+			taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-from-task' }) },
+		});
+
+		expect(policy.role).toBe('workflow_worker');
+		expect(policy.spaceId).toBe('space-from-task');
+	});
+
+	test('routes long-term agents using canonical session identity and prompt provenance', () => {
+		const session = makeSession({
+			id: longTermAgentSessionId('space-1', 'agent-1'),
+			context: { spaceId: 'space-1' },
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+				promptProvenance: { source: 'custom_agent', hash: 'hash', agentId: 'agent-1' },
+			},
+		});
+		const policy = resolveSpaceMcpSessionPolicy(session);
+
+		expect(policy).toMatchObject({
+			role: 'long_term_agent',
+			spaceId: 'space-1',
+			owner: 'space-runtime',
+			attachLongTermAgentTools: true,
+			attachGenericSpaceTools: false,
+			isWorkflowWorker: false,
+		});
+	});
+
+	test('leaves legacy space_task_agent sessions unowned', () => {
+		const policy = resolveSpaceMcpSessionPolicy(
+			makeSession({ type: 'space_task_agent', context: { spaceId: 'space-1' } })
+		);
+
+		expect(policy).toMatchObject({
+			role: 'legacy_task_agent',
+			owner: 'none',
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			isWorkflowWorker: false,
+		});
+		expect(policy.requiredServers).toEqual([]);
+	});
+
+	test('leaves non-Space sessions unowned', () => {
+		const policy = resolveSpaceMcpSessionPolicy(makeSession({ context: undefined }));
+
+		expect(policy).toMatchObject({
+			role: 'outside_space',
+			owner: 'none',
+			attachGenericSpaceTools: false,
+			attachCoordinatorTools: false,
+			isWorkflowWorker: false,
+		});
+		expect(policy.requiredServers).toEqual([]);
+	});
+});
+
+describe('missingMcpServers', () => {
+	test('returns only required servers missing from the MCP map', () => {
+		expect(
+			missingMcpServers(
+				{ 'node-agent': {}, 'other-server': {} },
+				SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS
+			)
+		).toEqual(['space-agent-tools']);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
@@ -192,6 +192,31 @@ describe('resolveSpaceMcpSessionPolicy', () => {
 		expect(policy.requiredServers).toBe(SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS);
 	});
 
+	test('routes suffixed workflow workers by embedded execution id even when another session owns the row', () => {
+		const session = makeSession({
+			id: 'space:space-1:task:task-1:exec:exec-1:1',
+			type: 'worker',
+			context: { spaceId: 'space-1', taskId: 'task-1' },
+		});
+		const policy = resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: {
+				getByAgentSessionId: () => null,
+				getById: (id) =>
+					id === 'exec-1' ? makeNodeExecution({ id, agentSessionId: 'older-session' }) : null,
+			},
+			taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-1' }) },
+		});
+
+		expect(policy).toMatchObject({
+			role: 'workflow_worker',
+			spaceId: 'space-1',
+			owner: 'task-agent-manager',
+			attachGenericSpaceTools: false,
+			isWorkflowWorker: true,
+		});
+		expect(policy.requiredServers).toBe(SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS);
+	});
+
 	test('routes long-term agents using canonical session identity and prompt provenance', () => {
 		const session = makeSession({
 			id: longTermAgentSessionId('space-1', 'agent-1'),

--- a/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
@@ -157,12 +157,39 @@ describe('resolveSpaceMcpSessionPolicy', () => {
 	test('resolves workflow worker space from task when session context lacks spaceId', () => {
 		const session = makeSession({ id: 'opaque-worker-session', context: { taskId: 'task-1' } });
 		const policy = resolveSpaceMcpSessionPolicy(session, {
-			nodeExecutionRepo: { getByAgentSessionId: () => makeNodeExecution() },
+			nodeExecutionRepo: {
+				getByAgentSessionId: () => makeNodeExecution(),
+				getById: () => null,
+			},
 			taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-from-task' }) },
 		});
 
 		expect(policy.role).toBe('workflow_worker');
 		expect(policy.spaceId).toBe('space-from-task');
+	});
+
+	test('routes workflow workers by embedded execution id when session id backfill is missing', () => {
+		const session = makeSession({
+			id: 'space:space-1:task:task-1:exec:exec-1',
+			type: 'worker',
+			context: { spaceId: 'space-1', taskId: 'task-1' },
+		});
+		const policy = resolveSpaceMcpSessionPolicy(session, {
+			nodeExecutionRepo: {
+				getByAgentSessionId: () => null,
+				getById: (id) => (id === 'exec-1' ? makeNodeExecution({ id, agentSessionId: null }) : null),
+			},
+			taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-1' }) },
+		});
+
+		expect(policy).toMatchObject({
+			role: 'workflow_worker',
+			spaceId: 'space-1',
+			owner: 'task-agent-manager',
+			attachGenericSpaceTools: false,
+			isWorkflowWorker: true,
+		});
+		expect(policy.requiredServers).toBe(SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS);
 	});
 
 	test('routes long-term agents using canonical session identity and prompt provenance', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
@@ -275,10 +275,7 @@ describe('resolveSpaceMcpSessionPolicy', () => {
 describe('missingMcpServers', () => {
 	test('returns only required servers missing from the MCP map', () => {
 		expect(
-			missingMcpServers(
-				{ 'node-agent': {}, 'other-server': {} },
-				SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS
-			)
-		).toEqual(['space-agent-tools']);
+			missingMcpServers({ 'other-server': {} }, SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS)
+		).toEqual(['node-agent']);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -83,6 +83,7 @@ function buildConfig(
 function makeNoopNodeExecutionRepo(): NodeExecutionRepository {
 	return {
 		getByAgentSessionId: mock(() => null),
+		getById: mock(() => null),
 	} as unknown as NodeExecutionRepository;
 }
 
@@ -757,7 +758,8 @@ describe('SpaceRuntimeService', () => {
 			sessionManager: SessionManager;
 			listSessionsResult?: Session[];
 			dbPath?: string;
-			nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId'>;
+			nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId' | 'getById'>;
+			actorRegistryRepos?: SpaceRuntimeServiceConfig['actorRegistryRepos'];
 		}): SpaceRuntimeServiceConfig {
 			if (opts.listSessionsResult) {
 				(opts.sessionManager as unknown as { listSessions: Mock<() => Session[]> }).listSessions =
@@ -780,6 +782,7 @@ describe('SpaceRuntimeService', () => {
 				nodeExecutionRepo:
 					(opts.nodeExecutionRepo as NodeExecutionRepository | undefined) ??
 					makeNoopNodeExecutionRepo(),
+				actorRegistryRepos: opts.actorRegistryRepos,
 			};
 		}
 
@@ -924,6 +927,48 @@ describe('SpaceRuntimeService', () => {
 			// session is filtered out before getSessionAsync is consulted.
 			expect(mergeMock).toHaveBeenCalledTimes(3);
 			expect(mergeMock.mock.calls[2][0]).toHaveProperty('space-agent-tools');
+
+			await svc.stop();
+		});
+
+		test('start() derives long-term agent names from repository when metadata lacks agentName', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const longTermSession = makeMemberSession({
+				id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+					},
+				},
+			});
+			const svc = new SpaceRuntimeService(
+				buildMemberConfig({
+					sessionManager,
+					listSessionsResult: [longTermSession],
+					actorRegistryRepos: {
+						spaceRepo: {} as SpaceRuntimeServiceConfig['actorRegistryRepos']['spaceRepo'],
+						sessionRepo: {} as SpaceRuntimeServiceConfig['actorRegistryRepos']['sessionRepo'],
+						spaceAgentRepo: {
+							getById: mock(() => ({ id: 'agent-1', spaceId: mockSpace.id, name: 'Repo Agent' })),
+						} as unknown as SpaceRuntimeServiceConfig['actorRegistryRepos']['spaceAgentRepo'],
+						workflowRepo: {} as SpaceRuntimeServiceConfig['actorRegistryRepos']['workflowRepo'],
+						workflowRunRepo:
+							{} as SpaceRuntimeServiceConfig['actorRegistryRepos']['workflowRunRepo'],
+						nodeExecutionRepo: makeNoopNodeExecutionRepo(),
+					},
+				})
+			);
+
+			svc.start();
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			const [mcpArg] = (agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>)
+				.mock.calls[0];
+			expect(mcpArg).toHaveProperty('space-agent-tools');
 
 			await svc.stop();
 		});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -24,6 +24,7 @@ import type { SpaceTaskRepository } from '../../../../src/storage/repositories/s
 import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import type { SessionManager } from '../../../../src/lib/session-manager.ts';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import type { McpServerConfig, Session, Space } from '@neokai/shared';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -73,8 +74,15 @@ function buildConfig(
 		spaceWorkflowManager: {} as SpaceWorkflowManager,
 		workflowRunRepo: {} as SpaceWorkflowRunRepository,
 		taskRepo: {} as SpaceTaskRepository,
+		nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 		tickIntervalMs,
 	};
+}
+
+function makeNoopNodeExecutionRepo(): NodeExecutionRepository {
+	return {
+		getByAgentSessionId: mock(() => null),
+	} as unknown as NodeExecutionRepository;
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -436,6 +444,7 @@ describe('SpaceRuntimeService', () => {
 				spaceWorkflowManager: makeWorkflowManager(),
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
@@ -662,11 +671,10 @@ describe('SpaceRuntimeService', () => {
 
 	// ─── attachSpaceToolsToMemberSession ─────────────────────────────────────
 	//
-	// These tests cover the wider scope introduced for Task #31 Part B:
-	// every session whose `context.spaceId` is set (other than space_chat,
-	// which has its own full-prompt setup, and space_task_agent, which is
-	// managed by TaskAgentManager) should get `space-agent-tools` merged
-	// into its runtime MCP map — without touching its system prompt.
+	// These tests cover the role policy used for SpaceRuntime-owned sessions:
+	// ad-hoc Space members get `space-agent-tools` merged into their runtime MCP
+	// map without touching their system prompt; coordinator and workflow-worker
+	// sessions are owned by other paths and skipped here.
 
 	describe('attachSpaceToolsToMemberSession()', () => {
 		function makeMemberAgentSession() {
@@ -688,6 +696,7 @@ describe('SpaceRuntimeService', () => {
 			sessionManager: SessionManager;
 			listSessionsResult?: Session[];
 			dbPath?: string;
+			nodeExecutionRepo?: Pick<NodeExecutionRepository, 'getByAgentSessionId'>;
 		}): SpaceRuntimeServiceConfig {
 			if (opts.listSessionsResult) {
 				(opts.sessionManager as unknown as { listSessions: Mock<() => Session[]> }).listSessions =
@@ -707,6 +716,9 @@ describe('SpaceRuntimeService', () => {
 				taskRepo: {} as SpaceTaskRepository,
 				tickIntervalMs: 60_000,
 				sessionManager: opts.sessionManager,
+				nodeExecutionRepo:
+					(opts.nodeExecutionRepo as NodeExecutionRepository | undefined) ??
+					makeNoopNodeExecutionRepo(),
 			};
 		}
 
@@ -726,7 +738,7 @@ describe('SpaceRuntimeService', () => {
 			} as unknown as Session;
 		}
 
-		test('attaches space-agent-tools to a worker session with context.spaceId', async () => {
+		test('attaches space-agent-tools to an ad-hoc Space member session', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = makeSessionManager(agent);
 			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
@@ -776,7 +788,7 @@ describe('SpaceRuntimeService', () => {
 			}
 		});
 
-		test('skips sessions without context.spaceId', async () => {
+		test('skips sessions outside Space policy', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = makeSessionManager(agent);
 			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
@@ -800,19 +812,20 @@ describe('SpaceRuntimeService', () => {
 			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
 		});
 
-		test('skips workflow node-agent sub-sessions (session ID contains :task:…:exec:)', async () => {
+		test('skips workflow workers identified by node execution ownership', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = makeSessionManager(agent);
-			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+			const workflowSession = makeMemberSession({ id: 'opaque-workflow-worker' });
+			const nodeExecutionRepo = {
+				getByAgentSessionId: mock((sessionId: string) =>
+					sessionId === workflowSession.id ? { id: 'exec-1' } : null
+				),
+			};
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager, nodeExecutionRepo }));
 
-			// Simulate a workflow sub-session ID: space:<spaceId>:task:<taskId>:exec:<execId>
-			await svc.attachSpaceToolsToMemberSession(
-				makeMemberSession({
-					type: 'worker',
-					id: `space:${mockSpace.id}:task:task-1:exec:exec-a`,
-				})
-			);
+			await svc.attachSpaceToolsToMemberSession(workflowSession);
 
+			expect(nodeExecutionRepo.getByAgentSessionId).toHaveBeenCalledWith(workflowSession.id);
 			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
 		});
 
@@ -931,6 +944,7 @@ describe('SpaceRuntimeService', () => {
 				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
@@ -955,7 +969,7 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
-		test('does NOT attach for sessions without context.spaceId (non-space sessions)', async () => {
+		test('does NOT attach for sessions outside Space policy', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = {
 				getSessionAsync: mock(async () => agent),
@@ -970,6 +984,7 @@ describe('SpaceRuntimeService', () => {
 				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
@@ -1003,6 +1018,7 @@ describe('SpaceRuntimeService', () => {
 				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
@@ -1024,13 +1040,21 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
-		test('does NOT attach for workflow node-agent sub-sessions (session ID contains :task:…:exec:)', async () => {
+		test('does NOT attach for workflow workers identified by node execution ownership', async () => {
+			const agent = makeMemberAgentSession();
 			const sessionManager = {
-				getSessionAsync: mock(async () => null),
+				getSessionAsync: mock(async () => agent),
 				listSessions: mock(() => [] as Session[]),
 			} as unknown as SessionManager;
-			const internalEventBus = await createTestInternalEventBus('space-rts-test-sub-session-guard');
-			const agent = makeMemberAgentSession();
+			const internalEventBus = await createTestInternalEventBus(
+				'space-rts-test-sub-session-policy'
+			);
+			const subSession = makeMemberSession({ id: 'opaque-workflow-worker' });
+			const nodeExecutionRepo = {
+				getByAgentSessionId: mock((sessionId: string) =>
+					sessionId === subSession.id ? { id: 'exec-1' } : null
+				),
+			};
 			const svc = new SpaceRuntimeService({
 				db: {} as BunDatabase,
 				spaceManager: createMockSpaceManager(mockSpace),
@@ -1041,22 +1065,18 @@ describe('SpaceRuntimeService', () => {
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
-				getSessionAsync: mock(async () => agent),
+				nodeExecutionRepo: nodeExecutionRepo as unknown as NodeExecutionRepository,
 			});
 
 			svc.start();
 
-			// Simulate a workflow sub-session ID: space:<spaceId>:task:<taskId>:exec:<execId>
-			const subSession = makeMemberSession({
-				type: 'worker',
-				id: `space:${mockSpace.id}:task:task-1:exec:exec-a`,
-			});
 			await internalEventBus.publish('session.created', {
 				sessionId: subSession.id,
 				session: subSession,
 			});
 			await new Promise<void>((resolve) => setTimeout(resolve, 10));
 
+			expect(nodeExecutionRepo.getByAgentSessionId).toHaveBeenCalledWith(subSession.id);
 			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
 
 			await svc.stop();
@@ -1079,6 +1099,7 @@ describe('SpaceRuntimeService', () => {
 				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 				internalEventBus,
@@ -1198,6 +1219,7 @@ describe('SpaceRuntimeService', () => {
 					getActiveRuns: mock(() => []),
 				} as unknown as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 			});
@@ -1265,6 +1287,7 @@ describe('SpaceRuntimeService', () => {
 				} as unknown as SpaceWorkflowManager,
 				workflowRunRepo: {} as SpaceWorkflowRunRepository,
 				taskRepo: {} as SpaceTaskRepository,
+				nodeExecutionRepo: makeNoopNodeExecutionRepo(),
 				tickIntervalMs: 60_000,
 				sessionManager,
 			});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntimeServiceConfig } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
+import { longTermAgentSessionId } from '../../../../src/lib/space/long-term-agent-session.ts';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
 import type { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import type { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -641,6 +642,66 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
+		test('session.reset re-provisions reset long-term Space agents before query replay', async () => {
+			const agentSession = makeSession();
+			const sessionManager = makeSessionManager(agentSession);
+			let resetHandler:
+				| ((event: { sessionId: string; session: Session; restartQuery: boolean }) => Promise<void>)
+				| undefined;
+			const sessionManagerWithSubscriber = {
+				...sessionManager,
+				registerSessionResetSubscriber: mock((handler: typeof resetHandler) => {
+					resetHandler = handler;
+					return () => {};
+				}),
+			} as unknown as SessionManager;
+			const internalEventBus = {
+				subscribe: mock(() => () => {}),
+				publish: mock(async () => ({ delivered: 0, failures: [] })),
+				publishAsync: mock(() => {}),
+			} as unknown as SpaceRuntimeServiceConfig['internalEventBus'];
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfigWithSession(
+					sessionManagerWithSubscriber,
+					createMockSpaceManager(),
+					internalEventBus
+				),
+			};
+			const svc = new SpaceRuntimeService(config);
+			const longTermSessionId = longTermAgentSessionId(mockSpace.id, 'agent-1');
+
+			svc.start();
+			expect(resetHandler).toBeDefined();
+
+			await resetHandler?.({
+				sessionId: longTermSessionId,
+				session: {
+					id: longTermSessionId,
+					type: 'worker',
+					context: { spaceId: mockSpace.id },
+					metadata: {
+						promptProvenance: {
+							source: 'test',
+							hash: 'hash',
+							agentId: 'agent-1',
+							agentName: 'Long Term',
+						},
+					},
+				} as Session,
+				restartQuery: true,
+			});
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith(longTermSessionId);
+			expect(agentSession.mergeRuntimeMcpServers).toHaveBeenCalled();
+			const [mcpArg] = (
+				agentSession.mergeRuntimeMcpServers as Mock<typeof agentSession.mergeRuntimeMcpServers>
+			).mock.calls.at(-1)!;
+			expect(mcpArg).toHaveProperty('space-agent-tools');
+			expect(typeof agentSession.onMissingMemberSpaceMcpServers).toBe('function');
+
+			await svc.stop();
+		});
+
 		test('stop() unsubscribes from space.created events', async () => {
 			const unsubFn = mock(() => {});
 			const session = makeSession();
@@ -829,12 +890,24 @@ describe('SpaceRuntimeService', () => {
 			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
 		});
 
-		test('start() attaches tools to existing member sessions listed by sessionManager', async () => {
+		test('start() attaches tools to existing member and long-term agent sessions listed by sessionManager', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = makeSessionManager(agent);
+			const longTermSession = makeMemberSession({
+				id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+						agentName: 'Long Term',
+					},
+				},
+			});
 			const listed: Session[] = [
 				makeMemberSession({ id: 'member-1' }),
 				makeMemberSession({ id: 'member-2' }),
+				longTermSession,
 				// A session without spaceId — should be skipped.
 				makeMemberSession({ id: 'no-space', context: {} }),
 			];
@@ -847,9 +920,10 @@ describe('SpaceRuntimeService', () => {
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 			const mergeMock = agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>;
-			// Exactly 2 attaches (one per member-N session). The no-space session
-			// is filtered out before getSessionAsync is consulted.
-			expect(mergeMock).toHaveBeenCalledTimes(2);
+			// Two ad-hoc members plus one long-term agent are reprovisioned. The no-space
+			// session is filtered out before getSessionAsync is consulted.
+			expect(mergeMock).toHaveBeenCalledTimes(3);
+			expect(mergeMock.mock.calls[2][0]).toHaveProperty('space-agent-tools');
 
 			await svc.stop();
 		});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -739,11 +739,18 @@ describe('SpaceRuntimeService', () => {
 	// sessions are owned by other paths and skipped here.
 
 	describe('attachSpaceToolsToMemberSession()', () => {
-		function makeMemberAgentSession() {
+		function makeMemberAgentSession(overrides: Partial<Session> = {}) {
+			const sessionData = makeMemberSession(overrides);
 			return {
-				mergeRuntimeMcpServers: mock((_: Record<string, McpServerConfig>) => {}),
+				mergeRuntimeMcpServers: mock((additional: Record<string, McpServerConfig>) => {
+					sessionData.config.mcpServers = {
+						...(sessionData.config.mcpServers ?? {}),
+						...additional,
+					};
+				}),
 				setRuntimeMcpServers: mock(() => {}),
 				setRuntimeSystemPrompt: mock(() => {}),
+				getSessionData: mock(() => sessionData),
 			} as unknown as AgentSession;
 		}
 
@@ -927,6 +934,43 @@ describe('SpaceRuntimeService', () => {
 			// session is filtered out before getSessionAsync is consulted.
 			expect(mergeMock).toHaveBeenCalledTimes(3);
 			expect(mergeMock.mock.calls[2][0]).toHaveProperty('space-agent-tools');
+
+			await svc.stop();
+		});
+
+		test('start() does not reattach already-provisioned long-term agent sessions', async () => {
+			const agent = makeMemberAgentSession({
+				config: {
+					tools: {},
+					mcpServers: {
+						'space-agent-tools': {} as McpServerConfig,
+					},
+				},
+			});
+			const sessionManager = makeSessionManager(agent);
+			const longTermSession = makeMemberSession({
+				id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+						agentName: 'Long Term',
+					},
+				},
+			});
+			const svc = new SpaceRuntimeService(
+				buildMemberConfig({
+					sessionManager,
+					listSessionsResult: [longTermSession],
+					dbPath: '/tmp/test.db',
+				})
+			);
+
+			svc.start();
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
 
 			await svc.stop();
 		});


### PR DESCRIPTION
Centralizes Space MCP ownership in one session-role policy and routes SpaceRuntimeService/QueryRunner through it.

Covers coordinator, ad-hoc member, workflow worker, long-term agent, legacy task agent, and outside-space roles with targeted unit tests.

Tests:
- bun test tests/unit/5-space/runtime/space-mcp-session-policy.test.ts tests/unit/5-space/runtime/space-runtime-service.test.ts tests/unit/1-core/agent/query-runner.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/untangle-space-mcp-ownership-by-session-role check