### PR TITLE
Fix review approval gate writer

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -24,6 +24,7 @@ import type {
 	DeclarativeToolGuard,
 	GatePoll,
 	GateScript,
+	Gate,
 	SpaceWorkflow,
 	WorkflowNode,
 } from '@neokai/shared';
@@ -1513,6 +1514,30 @@ function mergeNodeStructuralFieldsFromTemplate(
 	});
 }
 
+function mergeGateStructuralFieldsFromTemplate(
+	existingGates: Gate[] | undefined,
+	templateGates: Gate[] | undefined
+): Gate[] | undefined {
+	if (!existingGates || !templateGates) return existingGates;
+
+	const templateGatesById = new Map(templateGates.map((gate) => [gate.id, gate]));
+	return existingGates.map((gate) => {
+		const templateGate = templateGatesById.get(gate.id);
+		if (!templateGate) return gate;
+
+		const templateFieldsByName = new Map(
+			(templateGate.fields ?? []).map((field) => [field.name, field])
+		);
+		const fields = (gate.fields ?? []).map((field) => {
+			const templateField = templateFieldsByName.get(field.name);
+			if (!templateField) return field;
+			return { ...field, writers: templateField.writers };
+		});
+
+		return { ...gate, fields };
+	});
+}
+
 /**
  * Fields that the built-in seeder re-stamps when it detects template drift
  * on an already-seeded row.
@@ -1525,7 +1550,10 @@ function mergeNodeStructuralFieldsFromTemplate(
  *   agent name) so structural enforcement metadata stays in sync with the
  *   template when node + agent names still match. Other node fields
  *   (customPrompt, model, disabledSkillIds, etc.) are preserved.
- * - Channels, gates, layout, and node rows are NOT re-stamped. Workflow IDs,
+ * - Gate field `writers` are merged onto matching gate fields (by gate id +
+ *   field name) so structural authorization changes land on pre-existing spaces.
+ *   Checks, scripts, and gate topology remain untouched.
+ * - Channels, layout, and node rows are NOT re-stamped. Workflow IDs,
  *   node IDs, and persisted node-agent slots are stable identifiers for
  *   in-flight runs, so template drift must never replace node rows. Agent
  *   `toolGuards` are updated in-place on existing node configs instead.
@@ -1535,6 +1563,7 @@ const RESTAMP_FIELDS = [
 	'completionAutonomyLevel',
 	'templateHash',
 	'nodes(postApproval + toolGuards in-place)',
+	'gates(field writers in-place)',
 ] as const;
 
 /**
@@ -1596,16 +1625,17 @@ export function seedBuiltInWorkflows(
 			if (row.templateHash === expectedHash) continue;
 
 			try {
-				// Targeted merge of toolGuards from template onto existing agent slots.
-				// Unlike prompts (user-configurable), toolGuards are structural enforcement
-				// metadata that must stay in sync with the template.
+				// Targeted merge of structural template fields that must stay in sync while
+				// preserving user-configurable prompts and workflow topology.
 				const mergedNodes = mergeNodeStructuralFieldsFromTemplate(row.nodes, template.nodes);
+				const mergedGates = mergeGateStructuralFieldsFromTemplate(row.gates, template.gates);
 
 				workflowManager.updateWorkflow(row.id, {
 					completionAutonomyLevel: template.completionAutonomyLevel,
 					// Built-ins now store routes on terminal nodes. Clear any legacy
 					// workflow-level value while the node updater writes node routes.
 					postApproval: null,
+					gates: mergedGates,
 					templateHash: expectedHash,
 				});
 				workflowManager.updateWorkflowNodeToolGuards(row.id, mergedNodes);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1364,7 +1364,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: [],
+					writers: ['reviewer'],
 					check: { op: '==', value: true },
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -141,6 +141,7 @@ export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFinge
 					.map((f) => ({
 						name: f.name,
 						type: f.type,
+						writers: [...f.writers].sort(),
 						check: serializeCheck(f.check),
 					})),
 				script: g.script ? g.script.source : null,

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1460,6 +1460,65 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 		expect(data.gateWrite).toBeUndefined();
 	});
 
+	test('gate-write authorizes fields whose writers reference current agent name', async () => {
+		const gate: Gate = {
+			id: 'gate-agent-writer',
+			fields: [
+				{
+					name: 'approved',
+					type: 'boolean',
+					writers: ['reviewer'],
+					check: { op: '==', value: true },
+				},
+			],
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGatedChannel(gate);
+		workflow.nodes.push({
+			id: 'node-qa',
+			name: 'QA',
+			agents: [{ agentId: 'agent-qa', name: 'qa' }],
+		});
+		workflow.channels = [{ id: 'ch-review-qa', from: 'Review', to: 'QA', gateId: gate.id }];
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		const config = makeConfig(ctx, {
+			mySessionId: ctx.reviewerSessionId,
+			myAgentName: 'reviewer',
+			workflow,
+			workflowNodeId: 'node-review',
+			gateDataRepo,
+			agentMessageRouter: new AgentMessageRouter({
+				nodeExecutionRepo: ctx.nodeExecutionRepo,
+				workflowRunId: ctx.workflowRunId,
+				workflowChannels: workflow.channels,
+				nodeGroups: { Review: ['reviewer'], QA: ['qa'] },
+				messageInjector: async () => {},
+			}),
+		});
+		seedSpaceTask(
+			ctx.db,
+			ctx.spaceId,
+			ctx.workflowRunId,
+			'node-qa',
+			'qa',
+			'in_progress',
+			null,
+			'session-qa'
+		);
+		const handlers = createNodeAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'QA',
+			message: 'approved',
+			data: { approved: true },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.gateWrite.gateOpen).toBe(true);
+		expect(gateDataRepo.get(ctx.workflowRunId, 'gate-agent-writer')?.data.approved).toBe(true);
+	});
+
 	test('only authorized fields are merged into gate', async () => {
 		const gate: Gate = {
 			id: 'gate-auth',

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1856,6 +1856,38 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
 	});
 
+	test('re-stamp updates gate field writers in place', () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const workflow = manager
+			.listWorkflows(SPACE_ID)
+			.find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
+		const gateWithStaleWriters = workflow.gates!.map((gate) =>
+			gate.id !== 'review-approval-gate'
+				? gate
+				: {
+						...gate,
+						fields: gate.fields!.map((field) =>
+							field.name === 'approved' ? { ...field, writers: [] } : field
+						),
+					}
+		);
+
+		manager.updateWorkflow(workflow.id, { gates: gateWithStaleWriters });
+		db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+			'pre-review-gate-writers-hash',
+			workflow.id
+		);
+
+		const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
+
+		const after = manager.getWorkflow(workflow.id)!;
+		const gate = after.gates!.find((g) => g.id === 'review-approval-gate')!;
+		const approvedField = gate.fields!.find((f) => f.name === 'approved')!;
+		expect(approvedField.writers).toEqual(['reviewer']);
+		expect(approvedField.check).toEqual({ op: '==', value: true });
+	});
+
 	test('re-stamp preserves node rows, layout, and updates toolGuards in place', () => {
 		// The narrow re-stamp explicitly does NOT regenerate node UUIDs because
 		// live workflow_run rows reference them. It also must not delete/reinsert

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2961,6 +2961,15 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
 		expect(prompt).toMatch(/same approval semantic/i);
 	});
 
+	test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate lets reviewer approve', () => {
+		const gate = FULLSTACK_QA_LOOP_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
+		const approvalField = gate.fields!.find((f) => f.name === 'approved')!;
+
+		expect(approvalField.type).toBe('boolean');
+		expect(approvalField.writers).toEqual(['reviewer']);
+		expect(approvalField.check).toEqual({ op: '==', value: true });
+	});
+
 	test('FULLSTACK_QA_LOOP_WORKFLOW Review node forbids gate-write while findings are open', () => {
 		const reviewNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const prompt = reviewNode.agents[0].customPrompt!.value;

--- a/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
@@ -374,22 +374,26 @@ describe('buildWorkflowFingerprint', () => {
 		expect(parsed.poll.script).toHaveLength(100);
 	});
 
-	it('excludes writers from gate field serialization', () => {
+	it('includes sorted writers in gate field serialization', () => {
 		const wf = makeWorkflow({
 			gates: [
 				{
 					id: 'gate-1',
 					resetOnCycle: false,
 					fields: [
-						{ name: 'approved', type: 'boolean', writers: ['Coder'], check: { op: 'exists' } },
+						{
+							name: 'approved',
+							type: 'boolean',
+							writers: ['Reviewer', 'Coder'],
+							check: { op: 'exists' },
+						},
 					],
 				},
 			],
 		});
 		const fp = buildWorkflowFingerprint(wf);
 		const parsed = JSON.parse(fp.gates[0]);
-		// writers are not included in the fingerprint (agent-specific)
-		expect(parsed.fields[0].writers).toBeUndefined();
+		expect(parsed.fields[0].writers).toEqual(['Coder', 'Reviewer']);
 		expect(parsed.fields[0].name).toBe('approved');
 	});
 
@@ -640,6 +644,30 @@ describe('computeWorkflowHash', () => {
 					id: 'gate-1',
 					resetOnCycle: false,
 					fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when gate field writers change', () => {
+		const wf1 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
+				},
+			],
+		});
+		const wf2 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [
+						{ name: 'approved', type: 'boolean', writers: ['reviewer'], check: { op: 'exists' } },
+					],
 				},
 			],
 		});

--- a/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
+++ b/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
@@ -241,7 +241,7 @@ export function makeBuiltInTemplateWorkflows(
 						{
 							name: 'approved',
 							type: 'boolean',
-							writers: [],
+							writers: ['reviewer'],
 							check: { op: '==', value: true },
 						},
 					],


### PR DESCRIPTION
Fixes the QA workflow review-approval-gate so the reviewer agent can write the approval that advances the workflow.

Adds regression coverage for reviewer-authorized gate writes and the built-in workflow gate config.

Tested:
- ../../scripts/test-daemon.sh
- bun run check