### PR TITLE
Optimize message search FTS writes

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -493,6 +493,7 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	// read MCP state through the resolver rather than hitting the table directly.
 	'mcp_enablement',
 	// Message search FTS projection and FTS5 shadow tables — queried through message.search RPC.
+	'message_search_content',
 	'message_search_fts',
 	'message_search_fts_config',
 	'message_search_fts_content',

--- a/packages/daemon/src/storage/database-core.ts
+++ b/packages/daemon/src/storage/database-core.ts
@@ -13,13 +13,14 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { dirname, join } from 'node:path';
 import { mkdirSync, existsSync, copyFileSync, readdirSync, unlinkSync, statSync } from 'node:fs';
 import { Logger } from '../lib/logger';
-import { createTables, runMigrations } from './schema';
+import { configureMessageSearchFts, createTables, runMigrations } from './schema';
 import { DatabaseLock } from './database-lock';
 
 export class DatabaseCore {
 	private db: BunDatabase;
 	private logger = new Logger('Database');
 	private lock: DatabaseLock;
+	private messageSearchMergeTimer: Timer | null = null;
 
 	constructor(private dbPath: string) {
 		// Initialize as null until initialize() is called
@@ -73,6 +74,25 @@ export class DatabaseCore {
 
 		// Create any missing tables (will be no-ops if migrations already created them)
 		createTables(this.db);
+
+		configureMessageSearchFts(this.db);
+		this.startMessageSearchMergeTimer();
+	}
+
+	private startMessageSearchMergeTimer(): void {
+		if (this.messageSearchMergeTimer) return;
+		this.messageSearchMergeTimer = setInterval(() => {
+			try {
+				this.db.exec(
+					`INSERT INTO message_search_fts(message_search_fts, rank) VALUES('merge', 4096)`
+				);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (!/no such table/i.test(message)) {
+					this.logger.warn('message_search_fts background merge failed:', err);
+				}
+			}
+		}, 30_000);
 	}
 
 	/**
@@ -100,6 +120,10 @@ export class DatabaseCore {
 	 * were not yet checkpointed.
 	 */
 	close(): void {
+		if (this.messageSearchMergeTimer) {
+			clearInterval(this.messageSearchMergeTimer);
+			this.messageSearchMergeTimer = null;
+		}
 		try {
 			this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
 		} catch {

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -106,7 +106,7 @@ export class SDKMessageRepository {
 	constructor(private db: BunDatabase) {}
 
 	private hasMessageSearchIndex(): boolean {
-		return this.tableExists('message_search_fts');
+		return this.tableExists('message_search_content');
 	}
 
 	private tableExists(tableName: string): boolean {
@@ -198,7 +198,7 @@ export class SDKMessageRepository {
 		}
 		const body = extractVisibleSearchText(parsed);
 		this.db
-			.prepare(`DELETE FROM message_search_fts WHERE kind = 'message' AND source_id = ?`)
+			.prepare(`DELETE FROM message_search_content WHERE kind = 'message' AND source_id = ?`)
 			.run(row.id);
 		if (!SEARCHABLE_MESSAGE_TYPES.has(row.message_type)) return;
 		if (!this.isMessageSearchIndexEligible(row)) return;
@@ -208,7 +208,7 @@ export class SDKMessageRepository {
 		}
 		this.db
 			.prepare(
-				`INSERT INTO message_search_fts (
+				`INSERT INTO message_search_content (
 					kind, source_id, message_id, session_id, task_id, space_id, task_number,
 					message_type, title, body, timestamp
 				) VALUES ('message', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -279,7 +279,7 @@ export class SDKMessageRepository {
 	private deleteMessageSearchRow(rowId: string): void {
 		if (!this.hasMessageSearchIndex()) return;
 		this.db
-			.prepare(`DELETE FROM message_search_fts WHERE kind = 'message' AND source_id = ?`)
+			.prepare(`DELETE FROM message_search_content WHERE kind = 'message' AND source_id = ?`)
 			.run(rowId);
 	}
 
@@ -1259,12 +1259,8 @@ export class SDKMessageRepository {
 		const broadQuery = isBroadMessageSearchQuery(params.query);
 		const hasSessions = this.tableExists('sessions');
 		const hasSpaceTasks = this.tableExists('space_tasks');
-		const sessionJoin = hasSessions
-			? 'LEFT JOIN sessions s ON s.id = message_search_fts.session_id'
-			: '';
-		const taskJoin = hasSpaceTasks
-			? 'LEFT JOIN space_tasks st ON st.id = message_search_fts.task_id'
-			: '';
+		const sessionJoin = hasSessions ? 'LEFT JOIN sessions s ON s.id = msc.session_id' : '';
+		const taskJoin = hasSpaceTasks ? 'LEFT JOIN space_tasks st ON st.id = msc.task_id' : '';
 		const sessionPolicy = hasSessions
 			? `AND COALESCE(s.status, '') != 'archived'
 				AND NOT (
@@ -1281,16 +1277,17 @@ export class SDKMessageRepository {
 			: '';
 		let candidateSql = `
 			SELECT
-				message_search_fts.rowid,
+				msc.rowid,
 				${broadQuery ? '0' : 'bm25(message_search_fts)'} AS rank,
-				message_search_fts.timestamp,
-				message_search_fts.source_id
+				msc.timestamp,
+				msc.source_id
 			FROM message_search_fts
+			JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid
 			${sessionJoin}
 			${taskJoin}
 			WHERE message_search_fts MATCH ?
 			  AND (
-				message_search_fts.kind != 'message'
+				msc.kind != 'message'
 				OR (
 					1 = 1
 					${sessionPolicy}
@@ -1300,25 +1297,25 @@ export class SDKMessageRepository {
 		const values: SQLiteValue[] = [ftsQuery];
 
 		if (params.sessionId) {
-			candidateSql += ` AND session_id = ?`;
+			candidateSql += ` AND msc.session_id = ?`;
 			values.push(params.sessionId);
 		}
 		if (params.messageType) {
-			candidateSql += ` AND message_type = ?`;
+			candidateSql += ` AND msc.message_type = ?`;
 			values.push(params.messageType);
 		}
 		if (params.from !== undefined) {
-			candidateSql += ` AND timestamp >= ?`;
+			candidateSql += ` AND msc.timestamp >= ?`;
 			values.push(params.from);
 		}
 		if (params.to !== undefined) {
-			candidateSql += ` AND timestamp <= ?`;
+			candidateSql += ` AND msc.timestamp <= ?`;
 			values.push(params.to);
 		}
 
 		candidateSql += broadQuery
-			? ` ORDER BY timestamp DESC, source_id ASC LIMIT ? OFFSET ?`
-			: ` ORDER BY rank ASC, timestamp DESC, source_id ASC LIMIT ? OFFSET ?`;
+			? ` ORDER BY msc.timestamp DESC, msc.source_id ASC LIMIT ? OFFSET ?`
+			: ` ORDER BY rank ASC, msc.timestamp DESC, msc.source_id ASC LIMIT ? OFFSET ?`;
 		values.push(limit, offset);
 
 		const candidates = this.db.prepare(candidateSql).all(...values) as Array<{
@@ -1334,12 +1331,13 @@ export class SDKMessageRepository {
 			.prepare(
 				`
 				SELECT
-					rowid, kind, source_id, message_id, session_id, task_id, space_id, task_number,
-					message_type, title,
-					snippet(message_search_fts, 9, '<mark>', '</mark>', '…', 16) AS snippet,
-					timestamp
+					msc.rowid, msc.kind, msc.source_id, msc.message_id, msc.session_id, msc.task_id,
+					msc.space_id, msc.task_number, msc.message_type, msc.title,
+					snippet(message_search_fts, 1, '<mark>', '</mark>', '…', 16) AS snippet,
+					msc.timestamp
 				FROM message_search_fts
-				WHERE rowid IN (${placeholders})
+				JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid
+				WHERE message_search_fts.rowid IN (${placeholders})
 				  AND message_search_fts MATCH ?`
 			)
 			.all(...candidates.map((row) => row.rowid), ftsQuery) as Array<{

--- a/packages/daemon/src/storage/repositories/session-repository.ts
+++ b/packages/daemon/src/storage/repositories/session-repository.ts
@@ -240,21 +240,23 @@ export class SessionRepository {
 	}
 
 	private updateMessageSearchSessionTitle(sessionId: string, title: string): void {
-		if (!this.tableExists('message_search_fts')) return;
+		if (!this.tableExists('message_search_content')) return;
 		this.db
-			.prepare(`UPDATE message_search_fts SET title = ? WHERE kind = 'message' AND session_id = ?`)
+			.prepare(
+				`UPDATE message_search_content SET title = ? WHERE kind = 'message' AND session_id = ?`
+			)
 			.run(title, sessionId);
 	}
 
 	private deleteMessageSearchRows(sessionId: string): void {
-		if (!this.tableExists('message_search_fts')) return;
+		if (!this.tableExists('message_search_content')) return;
 		this.db
-			.prepare(`DELETE FROM message_search_fts WHERE kind = 'message' AND session_id = ?`)
+			.prepare(`DELETE FROM message_search_content WHERE kind = 'message' AND session_id = ?`)
 			.run(sessionId);
 	}
 
 	private rebuildMessageSearchRows(sessionId: string): void {
-		if (!this.tableExists('message_search_fts') || !this.tableExists('sdk_messages')) return;
+		if (!this.tableExists('message_search_content') || !this.tableExists('sdk_messages')) return;
 		const hasSpaceTasks = this.tableExists('space_tasks');
 		const spaceTaskColumns = hasSpaceTasks
 			? 'st.space_id, st.task_number'
@@ -270,7 +272,7 @@ export class SessionRepository {
 		this.deleteMessageSearchRows(sessionId);
 		this.db
 			.prepare(
-				`INSERT INTO message_search_fts (
+				`INSERT INTO message_search_content (
 					kind, source_id, message_id, session_id, task_id, space_id, task_number,
 					message_type, title, body, timestamp
 				)
@@ -333,8 +335,10 @@ export class SessionRepository {
 		const deleteOverrides = this.db.prepare(
 			`DELETE FROM mcp_enablement WHERE scope_type = 'session' AND scope_id = ?`
 		);
-		const deleteSearchRows = this.tableExists('message_search_fts')
-			? this.db.prepare(`DELETE FROM message_search_fts WHERE kind = 'message' AND session_id = ?`)
+		const deleteSearchRows = this.tableExists('message_search_content')
+			? this.db.prepare(
+					`DELETE FROM message_search_content WHERE kind = 'message' AND session_id = ?`
+				)
 			: null;
 		const deleteSession = this.db.prepare(`DELETE FROM sessions WHERE id = ?`);
 		const tx = this.db.transaction((sessionId: string) => {

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -300,8 +300,8 @@ export class SpaceRepository {
 	 * Delete a space by ID
 	 */
 	deleteSpace(id: string): boolean {
-		const deleteSearchRows = this.tableExists('message_search_fts')
-			? this.db.prepare(`DELETE FROM message_search_fts WHERE space_id = ?`)
+		const deleteSearchRows = this.tableExists('message_search_content')
+			? this.db.prepare(`DELETE FROM message_search_content WHERE space_id = ?`)
 			: null;
 		const deleteSpace = this.db.prepare(`DELETE FROM spaces WHERE id = ?`);
 		const tx = this.db.transaction((spaceId: string) => {

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -25,7 +25,7 @@ export class SpaceTaskRepository {
 	private hasMessageSearchIndex(): boolean {
 		try {
 			const row = this.db
-				.prepare(`SELECT name FROM sqlite_master WHERE name = 'message_search_fts'`)
+				.prepare(`SELECT name FROM sqlite_master WHERE name = 'message_search_content'`)
 				.get();
 			return !!row;
 		} catch {
@@ -56,7 +56,7 @@ export class SpaceTaskRepository {
 		if (!body) return;
 		this.db
 			.prepare(
-				`INSERT INTO message_search_fts (
+				`INSERT INTO message_search_content (
 					kind, source_id, task_id, space_id, task_number, title, body, timestamp
 				) VALUES ('task', ?, ?, ?, ?, ?, ?, ?)`
 			)
@@ -66,7 +66,7 @@ export class SpaceTaskRepository {
 	private deleteTaskSearchRow(taskId: string): void {
 		if (!this.hasMessageSearchIndex()) return;
 		this.db
-			.prepare(`DELETE FROM message_search_fts WHERE kind = 'task' AND source_id = ?`)
+			.prepare(`DELETE FROM message_search_content WHERE kind = 'task' AND source_id = ?`)
 			.run(taskId);
 	}
 
@@ -77,13 +77,13 @@ export class SpaceTaskRepository {
 	 */
 	private deleteTaskMessageSearchRows(taskId: string): void {
 		if (!this.hasMessageSearchIndex()) return;
-		this.db.prepare(`DELETE FROM message_search_fts WHERE task_id = ?`).run(taskId);
+		this.db.prepare(`DELETE FROM message_search_content WHERE task_id = ?`).run(taskId);
 	}
 
 	private deleteTaskMessageRows(taskId: string): void {
 		if (!this.hasMessageSearchIndex()) return;
 		this.db
-			.prepare(`DELETE FROM message_search_fts WHERE kind = 'message' AND task_id = ?`)
+			.prepare(`DELETE FROM message_search_content WHERE kind = 'message' AND task_id = ?`)
 			.run(taskId);
 	}
 
@@ -91,13 +91,13 @@ export class SpaceTaskRepository {
 		if (!this.hasMessageSearchIndex()) return;
 		this.db
 			.prepare(
-				`DELETE FROM message_search_fts
+				`DELETE FROM message_search_content
 				 WHERE kind = 'message'
 				   AND task_id = ?
 				   AND EXISTS (
 					 SELECT 1
 					 FROM space_tasks st
-					 WHERE st.id = message_search_fts.task_id
+					 WHERE st.id = message_search_content.task_id
 					   AND st.status IN ('done', 'cancelled', 'completed')
 					   AND COALESCE(st.completed_at, st.updated_at, 0) < unixepoch('now', '-30 days') * 1000
 				   )`

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -109,11 +109,11 @@ export { runMigration133 } from './migrations';
 // knip-ignore-next-line
 export { runMigration134 } from './migrations';
 // knip-ignore-next-line
-export { configureMessageSearchFts, runMigration141 } from './migrations';
-// knip-ignore-next-line
 export { runMigration137 } from './migrations';
 // knip-ignore-next-line
 export { runMigration138 } from './migrations';
+// knip-ignore-next-line
+export { configureMessageSearchFts, runMigration141 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -109,6 +109,8 @@ export { runMigration133 } from './migrations';
 // knip-ignore-next-line
 export { runMigration134 } from './migrations';
 // knip-ignore-next-line
+export { configureMessageSearchFts, runMigration141 } from './migrations';
+// knip-ignore-next-line
 export { runMigration137 } from './migrations';
 // knip-ignore-next-line
 export { runMigration138 } from './migrations';

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -654,6 +654,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 140: Add Space agent core memory table for consolidation.
 	runMigration140(db);
+
+	// Migration 141: Rebuild message search FTS with detail=column and external content.
+	runMigration141(db);
 }
 
 /**
@@ -9027,10 +9030,6 @@ export function runMigration131(db: BunDatabase): void {
 
 /**
  * Migration 134: Add FTS5-backed message and Space task search.
- *
- * `message_search_fts` is a denormalized projection rather than an external-content table because
- * searched text is derived from SDK JSON. Repository writes maintain rows for new messages; this
- * migration backfills existing messages and task titles/descriptions.
  */
 export function runMigration136(db: BunDatabase): void {
 	if (!tableExists(db, 'space_agent_memory')) return;
@@ -9121,10 +9120,13 @@ function recreateMemoryVectorsWithNamedParentKey(db: BunDatabase): void {
 
 export function runMigration134(db: BunDatabase): void {
 	const existed = tableExists(db, 'message_search_fts');
+	createMessageSearchContentTable(db);
 	createMessageSearchFtsTable(db);
+	createMessageSearchSyncTriggers(db);
 	if (!existed || isMessageSearchFtsEmpty(db)) {
 		backfillMessageSearchFts(db);
 	}
+	configureMessageSearchFts(db, { automerge: 16 });
 }
 
 export function runMigration137(db: BunDatabase): void {
@@ -9140,7 +9142,7 @@ export function runMigration137(db: BunDatabase): void {
 	recordPrune(
 		db
 			.prepare(
-				`DELETE FROM message_search_fts
+				`DELETE FROM message_search_content
 				 WHERE kind = 'message'
 				   AND COALESCE(message_type, '') NOT IN ('system', 'user', 'assistant')`
 			)
@@ -9148,7 +9150,7 @@ export function runMigration137(db: BunDatabase): void {
 	);
 
 	const deleteRoomNamespacedRows = db.prepare(`
-		DELETE FROM message_search_fts
+		DELETE FROM message_search_content
 		WHERE kind = 'message'
 		  AND (
 			session_id LIKE 'room:chat:%'
@@ -9172,7 +9174,7 @@ export function runMigration137(db: BunDatabase): void {
 			db
 				.prepare(
 					`
-					DELETE FROM message_search_fts
+					DELETE FROM message_search_content
 					WHERE kind = 'message'
 					  AND session_id IN (
 						SELECT id
@@ -9200,7 +9202,7 @@ export function runMigration137(db: BunDatabase): void {
 			db
 				.prepare(
 					`
-					DELETE FROM message_search_fts
+					DELETE FROM message_search_content
 					WHERE kind = 'message'
 					  AND task_id IN (
 						SELECT id
@@ -9227,27 +9229,77 @@ function isMessageSearchFtsEmpty(db: BunDatabase): boolean {
 	return !row;
 }
 
+function createMessageSearchContentTable(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS message_search_content (
+			kind TEXT NOT NULL CHECK(kind IN ('message', 'task')),
+			source_id TEXT NOT NULL,
+			message_id TEXT,
+			session_id TEXT,
+			task_id TEXT,
+			space_id TEXT,
+			task_number INTEGER,
+			message_type TEXT,
+			title TEXT,
+			body TEXT,
+			timestamp INTEGER,
+			PRIMARY KEY (kind, source_id)
+		)
+	`);
+}
+
 function createMessageSearchFtsTable(db: BunDatabase): void {
 	db.exec(`
 		CREATE VIRTUAL TABLE IF NOT EXISTS message_search_fts USING fts5(
-			kind UNINDEXED,
-			source_id UNINDEXED,
-			message_id UNINDEXED,
-			session_id UNINDEXED,
-			task_id UNINDEXED,
-			space_id UNINDEXED,
-			task_number UNINDEXED,
-			message_type UNINDEXED,
 			title,
 			body,
-			timestamp UNINDEXED,
+			content='message_search_content',
+			content_rowid='rowid',
+			detail=column,
 			tokenize = 'unicode61'
 		)
 	`);
 }
 
+function createMessageSearchSyncTriggers(db: BunDatabase): void {
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS message_search_content_ai
+		AFTER INSERT ON message_search_content BEGIN
+			INSERT INTO message_search_fts(rowid, title, body)
+			VALUES (new.rowid, new.title, new.body);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS message_search_content_ad
+		AFTER DELETE ON message_search_content BEGIN
+			INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+			VALUES ('delete', old.rowid, old.title, old.body);
+		END
+	`);
+	db.exec(`
+		CREATE TRIGGER IF NOT EXISTS message_search_content_au
+		AFTER UPDATE OF title, body ON message_search_content BEGIN
+			INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+			VALUES ('delete', old.rowid, old.title, old.body);
+			INSERT INTO message_search_fts(rowid, title, body)
+			VALUES (new.rowid, new.title, new.body);
+		END
+	`);
+}
+
+export function configureMessageSearchFts(
+	db: BunDatabase,
+	options: { automerge?: 0 | 16 } = {}
+): void {
+	if (!tableExists(db, 'message_search_fts')) return;
+	db.exec(
+		`INSERT INTO message_search_fts(message_search_fts, rank) VALUES('automerge', ${options.automerge ?? 0})`
+	);
+	db.exec(`INSERT INTO message_search_fts(message_search_fts, rank) VALUES('crisismerge', 64)`);
+}
+
 function backfillMessageSearchFts(db: BunDatabase): void {
-	db.exec(`DELETE FROM message_search_fts`);
+	db.exec(`DELETE FROM message_search_content`);
 
 	if (tableExists(db, 'sdk_messages')) {
 		const sessionTitleSelect = tableExists(db, 'sessions')
@@ -9263,7 +9315,7 @@ function backfillMessageSearchFts(db: BunDatabase): void {
 			? 'LEFT JOIN space_tasks st ON st.id = sm.task_id'
 			: '';
 		db.exec(`
-			INSERT INTO message_search_fts (
+			INSERT INTO message_search_content (
 				kind, source_id, message_id, session_id, task_id, space_id, task_number,
 				message_type, title, body, timestamp
 			)
@@ -9334,7 +9386,7 @@ function backfillMessageSearchFts(db: BunDatabase): void {
 
 	if (tableExists(db, 'space_tasks')) {
 		db.exec(`
-			INSERT INTO message_search_fts (
+			INSERT INTO message_search_content (
 				kind, source_id, task_id, space_id, task_number, title, body, timestamp
 			)
 			SELECT
@@ -9421,6 +9473,34 @@ function migrateNeoSessions(db: BunDatabase): void {
  * Stores lifecycle and state-change events for Space goals so agents and
  * humans can inspect why the current rolling goal state changed.
  */
+
+export function runMigration141(db: BunDatabase): void {
+	dropMessageSearchTriggers(db);
+	db.exec(`DROP TABLE IF EXISTS message_search_fts`);
+	createMessageSearchContentTable(db);
+	if (isMessageSearchContentEmpty(db)) {
+		backfillMessageSearchFts(db);
+	}
+	createMessageSearchFtsTable(db);
+	createMessageSearchSyncTriggers(db);
+	db.exec(`INSERT INTO message_search_fts(message_search_fts) VALUES('rebuild')`);
+	configureMessageSearchFts(db);
+}
+
+function dropMessageSearchTriggers(db: BunDatabase): void {
+	db.exec(`DROP TRIGGER IF EXISTS message_search_content_ai`);
+	db.exec(`DROP TRIGGER IF EXISTS message_search_content_ad`);
+	db.exec(`DROP TRIGGER IF EXISTS message_search_content_au`);
+}
+
+function isMessageSearchContentEmpty(db: BunDatabase): boolean {
+	if (!tableExists(db, 'message_search_content')) return true;
+	const row = db.prepare(`SELECT 1 AS present FROM message_search_content LIMIT 1`).get() as
+		| { present: number }
+		| undefined;
+	return !row;
+}
+
 export function runMigration133(db: BunDatabase): void {
 	if (!tableExists(db, 'space_goals')) return;
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9130,8 +9130,15 @@ export function runMigration134(db: BunDatabase): void {
 }
 
 export function runMigration137(db: BunDatabase): void {
-	if (!tableExists(db, 'message_search_fts')) return;
+	if (!tableExists(db, 'message_search_content')) return;
+	const prunedRows = pruneMessageSearchFts(db);
 
+	if (prunedRows > 0 && tableExists(db, 'message_search_fts')) {
+		db.exec(`INSERT INTO message_search_fts(message_search_fts) VALUES('optimize')`);
+	}
+}
+
+function pruneMessageSearchFts(db: BunDatabase): number {
 	let prunedRows = 0;
 	const recordPrune = (result: { changes?: number }): void => {
 		prunedRows += result.changes ?? 0;
@@ -9217,9 +9224,7 @@ export function runMigration137(db: BunDatabase): void {
 		);
 	}
 
-	if (prunedRows > 0) {
-		db.exec(`INSERT INTO message_search_fts(message_search_fts) VALUES('optimize')`);
-	}
+	return prunedRows;
 }
 
 function isMessageSearchFtsEmpty(db: BunDatabase): boolean {
@@ -9475,15 +9480,19 @@ function migrateNeoSessions(db: BunDatabase): void {
  */
 
 export function runMigration141(db: BunDatabase): void {
-	dropMessageSearchTriggers(db);
-	db.exec(`DROP TABLE IF EXISTS message_search_fts`);
+	const ftsSql = tableCreateSql(db, 'message_search_fts');
+	const hasOptimizedFts =
+		ftsSql?.includes("content='message_search_content'") && ftsSql.includes('detail=column');
 	createMessageSearchContentTable(db);
-	if (isMessageSearchContentEmpty(db)) {
+	if (!hasOptimizedFts) {
+		dropMessageSearchTriggers(db);
+		db.exec(`DROP TABLE IF EXISTS message_search_fts`);
 		backfillMessageSearchFts(db);
+		pruneMessageSearchFts(db);
+		createMessageSearchFtsTable(db);
+		createMessageSearchSyncTriggers(db);
+		db.exec(`INSERT INTO message_search_fts(message_search_fts) VALUES('rebuild')`);
 	}
-	createMessageSearchFtsTable(db);
-	createMessageSearchSyncTriggers(db);
-	db.exec(`INSERT INTO message_search_fts(message_search_fts) VALUES('rebuild')`);
 	configureMessageSearchFts(db);
 }
 
@@ -9491,14 +9500,6 @@ function dropMessageSearchTriggers(db: BunDatabase): void {
 	db.exec(`DROP TRIGGER IF EXISTS message_search_content_ai`);
 	db.exec(`DROP TRIGGER IF EXISTS message_search_content_ad`);
 	db.exec(`DROP TRIGGER IF EXISTS message_search_content_au`);
-}
-
-function isMessageSearchContentEmpty(db: BunDatabase): boolean {
-	if (!tableExists(db, 'message_search_content')) return true;
-	const row = db.prepare(`SELECT 1 AS present FROM message_search_content LIMIT 1`).get() as
-		| { present: number }
-		| undefined;
-	return !row;
 }
 
 export function runMigration133(db: BunDatabase): void {

--- a/packages/daemon/tests/unit/2-handlers/rpc/message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/message-handlers.test.ts
@@ -655,24 +655,36 @@ describe('Message RPC Handlers', () => {
 					parent_tool_use_id TEXT,
 					task_id TEXT
 				);
+				CREATE TABLE message_search_content (
+					kind TEXT,
+					source_id TEXT,
+					message_id TEXT,
+					session_id TEXT,
+					task_id TEXT,
+					space_id TEXT,
+					task_number INTEGER,
+					message_type TEXT,
+					title TEXT,
+					body TEXT,
+					timestamp INTEGER
+				);
 				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
 					title,
 					body,
-					timestamp UNINDEXED,
+					content='message_search_content',
+					content_rowid='rowid',
+					detail=column,
 					tokenize = 'unicode61'
 				);
+				CREATE TRIGGER message_search_content_ai
+				AFTER INSERT ON message_search_content BEGIN
+					INSERT INTO message_search_fts(rowid, title, body)
+					VALUES (new.rowid, new.title, new.body);
+				END;
 			`);
 			sqlite
 				.prepare(
-					`INSERT INTO message_search_fts (kind, source_id, session_id, message_type, title, body, timestamp)
+					`INSERT INTO message_search_content (kind, source_id, session_id, message_type, title, body, timestamp)
 					 VALUES ('message', 'msg-1', 'session-1', 'user', 'In Memory', 'inmemory needle marker', ?)`
 				)
 				.run(Date.now());

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-search-worker-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-search-worker-service.test.ts
@@ -10,23 +10,14 @@ function createSearchDb(): string {
 	const path = join(tmpDir, `message-search-worker-${Date.now()}.db`);
 	const db = new BunDatabase(path);
 	db.exec(`
-		CREATE VIRTUAL TABLE message_search_fts USING fts5(
-			kind UNINDEXED,
-			source_id UNINDEXED,
-			message_id UNINDEXED,
-			session_id UNINDEXED,
-			task_id UNINDEXED,
-			space_id UNINDEXED,
-			task_number UNINDEXED,
-			message_type UNINDEXED,
-			title,
-			body,
-			timestamp UNINDEXED,
-			tokenize = 'unicode61'
-		)
+		CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 	`);
 	db.prepare(
-		`INSERT INTO message_search_fts (kind, source_id, session_id, message_type, title, body, timestamp)
+		`INSERT INTO message_search_content (kind, source_id, session_id, message_type, title, body, timestamp)
 		 VALUES ('message', 'msg-1', 'session-1', 'user', 'Worker Smoke', 'worker smoke marker', ?)`
 	).run(Date.now());
 	db.close();

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-134-message-search.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-134-message-search.test.ts
@@ -194,4 +194,51 @@ describe('Migration 134: message search FTS', () => {
 			'task:task-1',
 		]);
 	});
+
+	test('migration 141 prunes policy-excluded rows after legacy FTS upgrade', () => {
+		runMigration134(db);
+		db.prepare(`INSERT INTO sessions (id, title) VALUES (?, ?)`).run('coder:old', 'Coder');
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run(
+			'msg-coder',
+			'coder:old',
+			'user',
+			JSON.stringify({
+				type: 'user',
+				uuid: 'uuid-coder',
+				message: { content: [{ type: 'text', text: 'excluded coder marker' }] },
+			}),
+			new Date().toISOString(),
+			'consumed'
+		);
+
+		runMigration141(db);
+
+		const rows = db
+			.prepare(`SELECT source_id FROM message_search_content WHERE source_id = ?`)
+			.all('msg-coder') as Array<{ source_id: string }>;
+		expect(rows).toEqual([]);
+	});
+
+	test('migration 141 skips rebuild once optimized FTS schema exists', () => {
+		seedSearchFixtures(db);
+		runMigration134(db);
+		runMigration141(db);
+		db.prepare(`INSERT INTO message_search_content (kind, source_id, title, body, timestamp)
+			 VALUES ('task', 'manual-row', 'Manual', 'manual marker', ?)`).run(Date.now());
+
+		runMigration141(db);
+
+		const rows = db
+			.prepare(
+				`SELECT msc.source_id
+				 FROM message_search_fts
+				 JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid
+				 WHERE message_search_fts MATCH ?`
+			)
+			.all('manual') as Array<{ source_id: string }>;
+		expect(rows.map((row) => row.source_id)).toEqual(['manual-row']);
+	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-134-message-search.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-134-message-search.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigration134 } from '../../../../../src/storage/schema/index.ts';
+import { runMigration134, runMigration141 } from '../../../../../src/storage/schema/index.ts';
 
 function tableExists(db: BunDatabase, table: string): boolean {
 	const row = db
@@ -81,7 +81,9 @@ describe('Migration 134: message search FTS', () => {
 
 		expect(tableExists(db, 'message_search_fts')).toBe(true);
 		const rows = db
-			.prepare(`SELECT kind, source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+			.prepare(
+				`SELECT msc.kind, msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+			)
 			.all('needle') as Array<{ kind: string; source_id: string }>;
 		expect(rows.map((row) => `${row.kind}:${row.source_id}`).sort()).toEqual([
 			'message:msg-1',
@@ -98,7 +100,7 @@ describe('Migration 134: message search FTS', () => {
 	test('does not backfill again when FTS table already contains rows', () => {
 		runMigration134(db);
 		db.prepare(
-			`INSERT INTO message_search_fts (kind, source_id, title, body, timestamp)
+			`INSERT INTO message_search_content (kind, source_id, title, body, timestamp)
 			 VALUES ('task', 'sentinel', 'sentinel', 'sentinel body', ?)`
 		).run(Date.now());
 		db.prepare(`DELETE FROM sdk_messages`).run();
@@ -106,7 +108,9 @@ describe('Migration 134: message search FTS', () => {
 		runMigration134(db);
 
 		const rows = db
-			.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+			.prepare(
+				`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+			)
 			.all('sentinel') as Array<{ source_id: string }>;
 		expect(rows.map((row) => row.source_id)).toEqual(['sentinel']);
 	});
@@ -114,12 +118,14 @@ describe('Migration 134: message search FTS', () => {
 	test('backfills when FTS table exists but is empty', () => {
 		seedSearchFixtures(db);
 		runMigration134(db);
-		db.prepare(`DELETE FROM message_search_fts`).run();
+		db.prepare(`DELETE FROM message_search_content`).run();
 
 		runMigration134(db);
 
 		const rows = db
-			.prepare(`SELECT kind, source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+			.prepare(
+				`SELECT msc.kind, msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+			)
 			.all('needle') as Array<{ kind: string; source_id: string }>;
 		expect(rows.map((row) => `${row.kind}:${row.source_id}`).sort()).toEqual([
 			'message:msg-1',
@@ -130,7 +136,7 @@ describe('Migration 134: message search FTS', () => {
 	test('does not backfill populated FTS table when source rows lack searchable text', () => {
 		runMigration134(db);
 		db.prepare(
-			`INSERT INTO message_search_fts (kind, source_id, title, body, timestamp)
+			`INSERT INTO message_search_content (kind, source_id, title, body, timestamp)
 			 VALUES ('task', 'sentinel', 'sentinel', 'sentinel body', ?)`
 		).run(Date.now());
 		db.prepare(
@@ -147,8 +153,45 @@ describe('Migration 134: message search FTS', () => {
 		runMigration134(db);
 
 		const rows = db
-			.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+			.prepare(
+				`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+			)
 			.all('sentinel') as Array<{ source_id: string }>;
 		expect(rows.map((row) => row.source_id)).toEqual(['sentinel']);
+	});
+	test('creates external-content FTS with detail column tuning', () => {
+		seedSearchFixtures(db);
+
+		runMigration134(db);
+		runMigration141(db);
+
+		const createSql = db
+			.prepare(`SELECT sql FROM sqlite_master WHERE name = 'message_search_fts'`)
+			.get() as { sql: string };
+		expect(createSql.sql).toContain("content='message_search_content'");
+		expect(createSql.sql).toContain('detail=column');
+		expect(
+			db.prepare(`SELECT v FROM message_search_fts_config WHERE k = 'automerge'`).get()
+		).toEqual({
+			v: 0,
+		});
+		expect(
+			db.prepare(`SELECT v FROM message_search_fts_config WHERE k = 'crisismerge'`).get()
+		).toEqual({
+			v: 64,
+		});
+
+		const rows = db
+			.prepare(
+				`SELECT msc.kind, msc.source_id
+				 FROM message_search_fts
+				 JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid
+				 WHERE message_search_fts MATCH ?`
+			)
+			.all('needle') as Array<{ kind: string; source_id: string }>;
+		expect(rows.map((row) => `${row.kind}:${row.source_id}`).sort()).toEqual([
+			'message:msg-1',
+			'task:task-1',
+		]);
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-137-message-search-policy.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-137-message-search-policy.test.ts
@@ -6,7 +6,7 @@ import { runMigration137 } from '../../../../../src/storage/schema/index.ts';
 
 function indexedSourceIds(db: BunDatabase): string[] {
 	return (
-		db.prepare(`SELECT source_id FROM message_search_fts ORDER BY source_id`).all() as Array<{
+		db.prepare(`SELECT source_id FROM message_search_content ORDER BY source_id`).all() as Array<{
 			source_id: string;
 		}>
 	).map((row) => row.source_id);
@@ -37,20 +37,11 @@ describe('Migration 137: message search indexing policy', () => {
 				completed_at INTEGER,
 				updated_at INTEGER NOT NULL
 			);
-			CREATE VIRTUAL TABLE message_search_fts USING fts5(
-				kind UNINDEXED,
-				source_id UNINDEXED,
-				message_id UNINDEXED,
-				session_id UNINDEXED,
-				task_id UNINDEXED,
-				space_id UNINDEXED,
-				task_number UNINDEXED,
-				message_type UNINDEXED,
-				title,
-				body,
-				timestamp UNINDEXED,
-				tokenize = 'unicode61'
-			);
+			CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
 		`);
 	}, 10_000);
 
@@ -73,7 +64,7 @@ describe('Migration 137: message search indexing policy', () => {
 		messageType = 'user'
 	): void {
 		db.prepare(
-			`INSERT INTO message_search_fts (kind, source_id, session_id, task_id, message_type, title, body, timestamp)
+			`INSERT INTO message_search_content (kind, source_id, session_id, task_id, message_type, title, body, timestamp)
 			 VALUES ('message', ?, ?, ?, ?, ?, ?, ?)`
 		).run(id, sessionId, taskId, messageType, id, 'searchable policy marker', Date.now());
 	}

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -87,20 +87,43 @@ describe('SDKMessageRepository', () => {
 
 	function createSearchIndex(): void {
 		db.exec(`
+			CREATE TABLE message_search_content (
+				kind TEXT NOT NULL,
+				source_id TEXT NOT NULL,
+				message_id TEXT,
+				session_id TEXT,
+				task_id TEXT,
+				space_id TEXT,
+				task_number INTEGER,
+				message_type TEXT,
+				title TEXT,
+				body TEXT,
+				timestamp INTEGER,
+				PRIMARY KEY (kind, source_id)
+			);
 			CREATE VIRTUAL TABLE message_search_fts USING fts5(
-				kind UNINDEXED,
-				source_id UNINDEXED,
-				message_id UNINDEXED,
-				session_id UNINDEXED,
-				task_id UNINDEXED,
-				space_id UNINDEXED,
-				task_number UNINDEXED,
-				message_type UNINDEXED,
 				title,
 				body,
-				timestamp UNINDEXED,
+				content='message_search_content',
+				content_rowid='rowid',
+				detail=column,
 				tokenize = 'unicode61'
-			)
+			);
+			CREATE TRIGGER message_search_content_ai
+			AFTER INSERT ON message_search_content BEGIN
+				INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+			END;
+			CREATE TRIGGER message_search_content_ad
+			AFTER DELETE ON message_search_content BEGIN
+				INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+				VALUES ('delete', old.rowid, old.title, old.body);
+			END;
+			CREATE TRIGGER message_search_content_au
+			AFTER UPDATE OF title, body ON message_search_content BEGIN
+				INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+				VALUES ('delete', old.rowid, old.title, old.body);
+				INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+			END;
 		`);
 	}
 
@@ -1161,7 +1184,7 @@ describe('SDKMessageRepository', () => {
 		it('returns task search rows from indexed titles and descriptions', () => {
 			createSearchIndex();
 			db.prepare(
-				`INSERT INTO message_search_fts (
+				`INSERT INTO message_search_content (
 					kind, source_id, task_id, space_id, task_number, title, body, timestamp
 				) VALUES ('task', ?, ?, ?, ?, ?, ?, ?)`
 			).run('task-1', 'task-1', 'space-1', 12, 'Orion title', 'Task description', Date.now());

--- a/packages/daemon/tests/unit/4-space-storage/storage/session-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/session-repository.test.ts
@@ -264,31 +264,22 @@ describe('SessionRepository', () => {
 
 		it('updates message search row titles when title changes', () => {
 			db.exec(`
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			repository.createSession(createDefaultSession({ title: 'Old Title' }));
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, title, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?, ?)`
 			).run('msg-1', 'uuid-1', 'session-1', 'Old Title', 'body text', Date.now());
 
 			repository.updateSession('session-1', { title: 'New Title' });
 
 			const row = db
-				.prepare(`SELECT title FROM message_search_fts WHERE source_id = ?`)
+				.prepare(`SELECT title FROM message_search_content WHERE source_id = ?`)
 				.get('msg-1') as { title: string };
 			expect(row.title).toBe('New Title');
 		});
@@ -313,20 +304,11 @@ describe('SessionRepository', () => {
 					completed_at INTEGER,
 					updated_at INTEGER NOT NULL
 				);
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			repository.createSession(createDefaultSession({ status: 'archived' }));
 			db.prepare(
@@ -349,7 +331,7 @@ describe('SessionRepository', () => {
 
 			const rows = db
 				.prepare(
-					`SELECT source_id, title, timestamp FROM message_search_fts WHERE message_search_fts MATCH ?`
+					`SELECT msc.source_id, msc.title, msc.timestamp FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
 				)
 				.all('restored') as Array<{ source_id: string; title: string; timestamp: number }>;
 			expect(rows).toEqual([
@@ -373,20 +355,11 @@ describe('SessionRepository', () => {
 					send_status TEXT,
 					task_id TEXT
 				);
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			repository.createSession(createDefaultSession());
 			db.prepare(
@@ -407,21 +380,27 @@ describe('SessionRepository', () => {
 			repository.updateSession('session-1', { context: { roomId: 'room-1' } });
 			expect(
 				db
-					.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+					.prepare(
+						`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+					)
 					.all('context')
 			).toEqual([]);
 
 			repository.updateSession('session-1', { context: undefined });
 			expect(
 				db
-					.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+					.prepare(
+						`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+					)
 					.all('context')
 			).toEqual([{ source_id: 'msg-1' }]);
 
 			repository.updateSession('session-1', { type: 'lobby' });
 			expect(
 				db
-					.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+					.prepare(
+						`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+					)
 					.all('context')
 			).toEqual([]);
 		});
@@ -438,20 +417,11 @@ describe('SessionRepository', () => {
 					send_status TEXT,
 					task_id TEXT
 				);
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			repository.createSession(createDefaultSession({ status: 'archived' }));
 			db.prepare(
@@ -478,7 +448,9 @@ describe('SessionRepository', () => {
 
 			expect(
 				db
-					.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+					.prepare(
+						`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+					)
 					.all('valid')
 			).toEqual([{ source_id: 'good-json' }]);
 		});
@@ -806,36 +778,29 @@ describe('SessionRepository', () => {
 
 		it('deletes message search rows before sdk_messages cascade', () => {
 			db.exec(`
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			repository.createSession(createDefaultSession({ id: 'session-1' }));
 			repository.createSession(createDefaultSession({ id: 'session-2' }));
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?)`
 			).run('msg-1', 'uuid-1', 'session-1', 'deleted needle', Date.now());
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?)`
 			).run('msg-2', 'uuid-2', 'session-2', 'kept needle', Date.now());
 
 			repository.deleteSession('session-1');
 
 			const rows = db
-				.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+				.prepare(
+					`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+				)
 				.all('needle') as Array<{ source_id: string }>;
 			expect(rows.map((row) => row.source_id)).toEqual(['msg-2']);
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-repository.test.ts
@@ -468,36 +468,29 @@ describe('SpaceRepository', () => {
 
 		it('deletes task search rows before task rows cascade', () => {
 			db.exec(`
-				CREATE VIRTUAL TABLE message_search_fts USING fts5(
-					kind UNINDEXED,
-					source_id UNINDEXED,
-					message_id UNINDEXED,
-					session_id UNINDEXED,
-					task_id UNINDEXED,
-					space_id UNINDEXED,
-					task_number UNINDEXED,
-					message_type UNINDEXED,
-					title,
-					body,
-					timestamp UNINDEXED,
-					tokenize = 'unicode61'
-				)
+				CREATE TABLE message_search_content (kind TEXT, source_id TEXT, message_id TEXT, session_id TEXT, task_id TEXT, space_id TEXT, task_number INTEGER, message_type TEXT, title TEXT, body TEXT, timestamp INTEGER);
+					CREATE VIRTUAL TABLE message_search_fts USING fts5(title, body, content='message_search_content', content_rowid='rowid', detail=column, tokenize = 'unicode61');
+					CREATE TRIGGER message_search_content_ai AFTER INSERT ON message_search_content BEGIN INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END;
+					CREATE TRIGGER message_search_content_ad AFTER DELETE ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); END;
+					CREATE TRIGGER message_search_content_au AFTER UPDATE OF title, body ON message_search_content BEGIN INSERT INTO message_search_fts(message_search_fts, rowid, title, body) VALUES ('delete', old.rowid, old.title, old.body); INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body); END
 			`);
 			const deleted = repo.createSpace({ workspacePath: '/workspace/a', slug: 'a', name: 'A' });
 			const kept = repo.createSpace({ workspacePath: '/workspace/b', slug: 'b', name: 'B' });
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, task_id, space_id, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, task_id, space_id, title, body, timestamp)
 				 VALUES ('task', ?, ?, ?, ?, ?, ?)`
 			).run('task-1', 'task-1', deleted.id, 'Deleted', 'needle deleted', Date.now());
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, task_id, space_id, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, task_id, space_id, title, body, timestamp)
 				 VALUES ('task', ?, ?, ?, ?, ?, ?)`
 			).run('task-2', 'task-2', kept.id, 'Kept', 'needle kept', Date.now());
 
 			repo.deleteSpace(deleted.id);
 
 			const rows = db
-				.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+				.prepare(
+					`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+				)
 				.all('needle') as Array<{ source_id: string }>;
 			expect(rows.map((row) => row.source_id)).toEqual(['task-2']);
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -53,27 +53,52 @@ describe('SpaceTaskRepository', () => {
 
 	function createSearchIndex(): void {
 		db.exec(`
+			CREATE TABLE message_search_content (
+				kind TEXT NOT NULL,
+				source_id TEXT NOT NULL,
+				message_id TEXT,
+				session_id TEXT,
+				task_id TEXT,
+				space_id TEXT,
+				task_number INTEGER,
+				message_type TEXT,
+				title TEXT,
+				body TEXT,
+				timestamp INTEGER,
+				PRIMARY KEY (kind, source_id)
+			);
 			CREATE VIRTUAL TABLE message_search_fts USING fts5(
-				kind UNINDEXED,
-				source_id UNINDEXED,
-				message_id UNINDEXED,
-				session_id UNINDEXED,
-				task_id UNINDEXED,
-				space_id UNINDEXED,
-				task_number UNINDEXED,
-				message_type UNINDEXED,
 				title,
 				body,
-				timestamp UNINDEXED,
+				content='message_search_content',
+				content_rowid='rowid',
+				detail=column,
 				tokenize = 'unicode61'
-			)
+			);
+			CREATE TRIGGER message_search_content_ai
+			AFTER INSERT ON message_search_content BEGIN
+				INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+			END;
+			CREATE TRIGGER message_search_content_ad
+			AFTER DELETE ON message_search_content BEGIN
+				INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+				VALUES ('delete', old.rowid, old.title, old.body);
+			END;
+			CREATE TRIGGER message_search_content_au
+			AFTER UPDATE OF title, body ON message_search_content BEGIN
+				INSERT INTO message_search_fts(message_search_fts, rowid, title, body)
+				VALUES ('delete', old.rowid, old.title, old.body);
+				INSERT INTO message_search_fts(rowid, title, body) VALUES (new.rowid, new.title, new.body);
+			END;
 		`);
 	}
 
 	function searchIndexedTaskIds(query: string): string[] {
 		return (
 			(db as any)
-				.prepare(`SELECT source_id FROM message_search_fts WHERE message_search_fts MATCH ?`)
+				.prepare(
+					`SELECT msc.source_id FROM message_search_fts JOIN message_search_content msc ON msc.rowid = message_search_fts.rowid WHERE message_search_fts MATCH ?`
+				)
 				.all(query) as Array<{ source_id: string }>
 		).map((row) => row.source_id);
 	}
@@ -571,7 +596,7 @@ describe('SpaceTaskRepository', () => {
 				status: 'in_progress',
 			});
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			).run(
 				'msg-1',
@@ -601,7 +626,7 @@ describe('SpaceTaskRepository', () => {
 				status: 'in_progress',
 			});
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			).run(
 				'msg-old',
@@ -634,7 +659,7 @@ describe('SpaceTaskRepository', () => {
 				status: 'in_progress',
 			});
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			).run(
 				'msg-1',
@@ -665,7 +690,7 @@ describe('SpaceTaskRepository', () => {
 				status: 'in_progress',
 			});
 			db.prepare(
-				`INSERT INTO message_search_fts (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
+				`INSERT INTO message_search_content (kind, source_id, message_id, session_id, task_id, space_id, task_number, message_type, title, body, timestamp)
 				 VALUES ('message', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			).run(
 				'msg-2',


### PR DESCRIPTION
## Summary
- Rebuild `message_search_fts` with `detail=column` and external content backed by `message_search_content`.
- Disable FTS automerge on DB open and run background merge work every 30s.
- Update message search repositories/tests for external-content joins.

## Test plan
- `bun run check`
- `./scripts/test-daemon.sh 4-space-storage`