### PR TITLE
Add Forge episode judge

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
@@ -1,8 +1,20 @@
 import type {
+	EvolutionEpisodeCreateFromEvidenceRequest,
+	EvolutionEpisodeCreateRequest,
+	EvolutionEpisodeCreateResponse,
+	EvolutionEpisodeListRequest,
+	EvolutionEpisodeListResponse,
+	EvolutionEpisodeReviewBundleResponse,
+	EvolutionEpisodeUpdateRequest,
+	EvolutionEpisodeUpdateResponse,
 	EvolutionEvidenceCreateRequest,
 	EvolutionEvidenceCreateResponse,
 	EvolutionEvidenceListRequest,
 	EvolutionEvidenceListResponse,
+	EvolutionLessonListRequest,
+	EvolutionLessonListResponse,
+	EvolutionLessonUpdateRequest,
+	EvolutionLessonUpdateResponse,
 	EvolutionMetricSnapshotCreateRequest,
 	EvolutionMetricSnapshotCreateResponse,
 	EvolutionMetricSnapshotListRequest,
@@ -15,8 +27,13 @@ import type {
 	EvolutionScopeListResponse,
 	EvolutionScopeUpdateRequest,
 	EvolutionScopeUpdateResponse,
+	EvolutionTaskProposalListRequest,
+	EvolutionTaskProposalListResponse,
+	EvolutionTaskProposalUpdateRequest,
+	EvolutionTaskProposalUpdateResponse,
 	MessageHub,
 } from '@neokai/shared';
+import type { EvolutionEpisodeService } from '../space/evolution-episode-service';
 import type {
 	AddManualNoteEvidenceParams,
 	AddMetricSnapshotEvidenceParams,
@@ -33,7 +50,8 @@ interface RecordPayload {
 
 export function setupEvolutionHandlers(
 	messageHub: MessageHub,
-	service: EvolutionScopeService
+	service: EvolutionScopeService,
+	episodeService?: EvolutionEpisodeService
 ): void {
 	messageHub.onRequest<EvolutionScopeCreateRequest, EvolutionScopeCreateResponse>(
 		'evolution.scope.create',
@@ -160,6 +178,83 @@ export function setupEvolutionHandlers(
 		async (data) => ({
 			snapshots: service.listMetricSnapshots(readRequiredString(data, 'scopeId')),
 		})
+	);
+
+	if (!episodeService) return;
+
+	messageHub.onRequest<EvolutionEpisodeCreateRequest, EvolutionEpisodeCreateResponse>(
+		'evolution.episode.create',
+		async (data) => {
+			const payload = readRecord(data);
+			const params = readRecord(
+				payload.params
+			) as unknown as EvolutionEpisodeCreateRequest['params'];
+			return { episode: episodeService.createEpisode(params) };
+		}
+	);
+
+	messageHub.onRequest<EvolutionEpisodeCreateFromEvidenceRequest, EvolutionEpisodeCreateResponse>(
+		'evolution.episode.createFromEvidence',
+		async (data) => {
+			const payload = readRecord(data) as unknown as EvolutionEpisodeCreateFromEvidenceRequest;
+			return episodeService.createFromEvidence(payload);
+		}
+	);
+
+	messageHub.onRequest<EvolutionEpisodeListRequest, EvolutionEpisodeListResponse>(
+		'evolution.episode.list',
+		async (data) => ({ episodes: episodeService.listEpisodes(readRequiredString(data, 'scopeId')) })
+	);
+
+	messageHub.onRequest<EvolutionEpisodeListRequest, EvolutionEpisodeReviewBundleResponse>(
+		'evolution.review.get',
+		async (data) => episodeService.listReviewBundle(readRequiredString(data, 'scopeId'))
+	);
+
+	messageHub.onRequest<EvolutionEpisodeUpdateRequest, EvolutionEpisodeUpdateResponse>(
+		'evolution.episode.update',
+		async (data) => {
+			const payload = readRecord(data);
+			const id = readRequiredString(payload, 'id');
+			const params = readRecord(payload.params) as EvolutionEpisodeUpdateRequest['params'];
+			return { episode: episodeService.updateEpisode(id, params) };
+		}
+	);
+
+	messageHub.onRequest<EvolutionLessonListRequest, EvolutionLessonListResponse>(
+		'evolution.lesson.list',
+		async (data) => {
+			const payload = readRecord(data) as unknown as EvolutionLessonListRequest;
+			return { lessons: episodeService.listLessons(payload.scopeId, payload.status) };
+		}
+	);
+
+	messageHub.onRequest<EvolutionLessonUpdateRequest, EvolutionLessonUpdateResponse>(
+		'evolution.lesson.update',
+		async (data) => {
+			const payload = readRecord(data);
+			const id = readRequiredString(payload, 'id');
+			const params = readRecord(payload.params) as EvolutionLessonUpdateRequest['params'];
+			return { lesson: episodeService.updateLesson(id, params) };
+		}
+	);
+
+	messageHub.onRequest<EvolutionTaskProposalListRequest, EvolutionTaskProposalListResponse>(
+		'evolution.taskProposal.list',
+		async (data) => {
+			const payload = readRecord(data) as unknown as EvolutionTaskProposalListRequest;
+			return { proposals: episodeService.listTaskProposals(payload.scopeId, payload.status) };
+		}
+	);
+
+	messageHub.onRequest<EvolutionTaskProposalUpdateRequest, EvolutionTaskProposalUpdateResponse>(
+		'evolution.taskProposal.update',
+		async (data) => {
+			const payload = readRecord(data);
+			const id = readRequiredString(payload, 'id');
+			const params = readRecord(payload.params) as EvolutionTaskProposalUpdateRequest['params'];
+			return { proposal: episodeService.updateTaskProposal(id, params) };
+		}
 	);
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -99,6 +99,7 @@ import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { setupAgentMemoryHandlers } from './agent-memory-handlers';
 import { setupSpaceGoalHandlers } from './space-goal-handlers';
 import { setupEvolutionHandlers } from './evolution-handlers';
+import { EvolutionEpisodeService } from '../space/evolution-episode-service';
 import { EvolutionScopeService } from '../space/evolution-scope-service';
 import { ScheduleService } from '../space/schedule/schedule-service';
 import { SpaceGoalEventRepository } from '../../storage/repositories/space-goal-event-repository';
@@ -538,7 +539,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 	});
-	setupEvolutionHandlers(deps.messageHub, evolutionScopeService);
+	const evolutionEpisodeService = new EvolutionEpisodeService({
+		evolutionRepo: deps.db.evolution,
+		taskRepo: spaceTaskRepo,
+		workflowRunRepo: spaceWorkflowRunRepo,
+		artifactRepo,
+	});
+	setupEvolutionHandlers(deps.messageHub, evolutionScopeService, evolutionEpisodeService);
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -1,0 +1,512 @@
+import type {
+	CreateEvolutionEpisodeParams,
+	CreateEvolutionLessonParams,
+	CreateTaskProposalParams,
+	EvidenceRef,
+	EvolutionEpisode,
+	EvolutionFinding,
+	EvolutionFindingDomain,
+	EvolutionFindingKind,
+	EvolutionImpact,
+	EvolutionLesson,
+	EvolutionLessonStatus,
+	EvolutionScope,
+	SpaceTaskPriority,
+	MetricSnapshot,
+	SpaceTask,
+	TaskProposal,
+	TaskProposalStatus,
+	UpdateEvolutionEpisodeParams,
+	UpdateEvolutionLessonParams,
+	UpdateTaskProposalParams,
+} from '@neokai/shared';
+import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
+import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type {
+	WorkflowRunArtifactRecord,
+	WorkflowRunArtifactRepository,
+} from '../../storage/repositories/workflow-run-artifact-repository';
+import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
+import { Logger } from '../logger';
+import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+
+const log = new Logger('evolution-episode-service');
+
+const FINDING_DOMAINS: EvolutionFindingDomain[] = ['workflow', 'target_artifact', 'neokai_product'];
+const FINDING_KINDS: EvolutionFindingKind[] = [
+	'friction',
+	'bug',
+	'optimization',
+	'missing_capability',
+	'new_opportunity',
+];
+const IMPACTS: EvolutionImpact[] = ['low', 'medium', 'high'];
+const LESSON_STATUSES: EvolutionLessonStatus[] = ['candidate', 'active', 'dismissed'];
+const PROPOSAL_STATUSES: TaskProposalStatus[] = ['proposed', 'accepted', 'dismissed', 'created'];
+const PRIORITIES: SpaceTaskPriority[] = ['low', 'normal', 'high', 'urgent'];
+const MAX_TEXT = 1200;
+const MAX_ARTIFACTS_PER_RUN = 8;
+
+export interface CreateEpisodeFromEvidenceParams {
+	scopeId: string;
+	evidenceIds: string[];
+	timeWindow?: CreateEvolutionEpisodeParams['timeWindow'];
+}
+
+export interface CreateEpisodeFromEvidenceResult {
+	episode: EvolutionEpisode;
+	lessons: EvolutionLesson[];
+	proposals: TaskProposal[];
+}
+
+export interface EpisodeReviewBundle {
+	episodes: EvolutionEpisode[];
+	lessons: EvolutionLesson[];
+	proposals: TaskProposal[];
+}
+
+export interface EvolutionEpisodeServiceDeps {
+	evolutionRepo: EvolutionRepository;
+	taskRepo: SpaceTaskRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	artifactRepo: WorkflowRunArtifactRepository;
+	judgeEpisode?: (input: EpisodeJudgePromptInput) => Promise<EpisodeJudgeOutput>;
+}
+
+export interface EpisodeJudgePromptInput {
+	scope: EvolutionScope;
+	evidence: EvidenceRef[];
+	metricSnapshots: MetricSnapshot[];
+	tasks: EpisodeTaskContext[];
+	workflowRuns: EpisodeWorkflowRunContext[];
+	timeWindow: CreateEvolutionEpisodeParams['timeWindow'];
+}
+
+export interface EpisodeTaskContext {
+	evidenceId: string;
+	task: SpaceTask;
+}
+
+export interface EpisodeWorkflowRunContext {
+	evidenceId: string;
+	run: NonNullable<ReturnType<SpaceWorkflowRunRepository['getRun']>>;
+	tasks: SpaceTask[];
+	artifacts: WorkflowRunArtifactRecord[];
+}
+
+export interface EpisodeJudgeOutput {
+	title: string;
+	outcomeSummary: string;
+	findings: EvolutionFinding[];
+	candidateLessons?: Array<Omit<CreateEvolutionLessonParams, 'scopeId' | 'evidenceEpisodeIds'>>;
+	proposals?: Array<Omit<CreateTaskProposalParams, 'scopeId' | 'evidenceEpisodeIds'>>;
+}
+
+export class EvolutionEpisodeService {
+	constructor(private deps: EvolutionEpisodeServiceDeps) {}
+
+	async createFromEvidence(
+		params: CreateEpisodeFromEvidenceParams
+	): Promise<CreateEpisodeFromEvidenceResult> {
+		const input = this.buildEpisodeInput(params);
+		const judged = this.deps.judgeEpisode
+			? await this.deps.judgeEpisode(input)
+			: await judgeEpisodeWithModel(input);
+		const episode = this.deps.evolutionRepo.createEpisode({
+			scopeId: input.scope.id,
+			status: 'draft',
+			title: judged.title,
+			timeWindow: input.timeWindow,
+			evidenceIds: input.evidence.map((item) => item.id),
+			outcomeSummary: judged.outcomeSummary,
+			findings: judged.findings,
+		});
+		const lessons = (judged.candidateLessons ?? []).map((lesson) =>
+			this.deps.evolutionRepo.createLesson({
+				...lesson,
+				scopeId: input.scope.id,
+				status: lesson.status ?? 'candidate',
+				evidenceEpisodeIds: [episode.id],
+			})
+		);
+		const proposals = (judged.proposals ?? []).map((proposal) =>
+			this.deps.evolutionRepo.createTaskProposal({
+				...proposal,
+				scopeId: input.scope.id,
+				status: proposal.status ?? 'proposed',
+				evidenceEpisodeIds: [episode.id],
+			})
+		);
+		return { episode, lessons, proposals };
+	}
+
+	buildEpisodeInput(params: CreateEpisodeFromEvidenceParams): EpisodeJudgePromptInput {
+		const scope = this.requireScope(params.scopeId);
+		const requestedIds = new Set(params.evidenceIds);
+		if (requestedIds.size === 0) throw new Error('evidenceIds is required');
+		const evidence = this.deps.evolutionRepo
+			.listEvidence(params.scopeId)
+			.filter((item) => requestedIds.has(item.id));
+		if (evidence.length !== requestedIds.size) {
+			throw new Error('All evidenceIds must belong to the scope');
+		}
+		const tasks = this.collectTasks(scope, evidence);
+		const workflowRuns = this.collectWorkflowRuns(scope, evidence);
+		return {
+			scope,
+			evidence,
+			metricSnapshots: this.deps.evolutionRepo.listMetricSnapshots(scope.id),
+			tasks,
+			workflowRuns,
+			timeWindow: params.timeWindow ?? deriveTimeWindow(evidence),
+		};
+	}
+
+	listEpisodes(scopeId: string): EvolutionEpisode[] {
+		this.requireScope(scopeId);
+		return this.deps.evolutionRepo.listEpisodes(scopeId);
+	}
+
+	getEpisode(id: string): EvolutionEpisode | null {
+		return this.deps.evolutionRepo.getEpisode(id);
+	}
+
+	createEpisode(params: CreateEvolutionEpisodeParams): EvolutionEpisode {
+		this.requireScope(params.scopeId);
+		return this.deps.evolutionRepo.createEpisode(params);
+	}
+
+	updateEpisode(id: string, params: UpdateEvolutionEpisodeParams): EvolutionEpisode | null {
+		return this.deps.evolutionRepo.updateEpisode(id, params);
+	}
+
+	listReviewBundle(scopeId: string): EpisodeReviewBundle {
+		this.requireScope(scopeId);
+		return {
+			episodes: this.deps.evolutionRepo.listEpisodes(scopeId),
+			lessons: this.deps.evolutionRepo.listLessons(scopeId),
+			proposals: this.deps.evolutionRepo.listTaskProposals(scopeId),
+		};
+	}
+
+	listLessons(scopeId: string, status?: EvolutionLessonStatus): EvolutionLesson[] {
+		this.requireScope(scopeId);
+		return this.deps.evolutionRepo.listLessons(scopeId, status);
+	}
+
+	updateLesson(id: string, params: UpdateEvolutionLessonParams): EvolutionLesson | null {
+		return this.deps.evolutionRepo.updateLesson(id, params);
+	}
+
+	listTaskProposals(scopeId: string, status?: TaskProposalStatus): TaskProposal[] {
+		this.requireScope(scopeId);
+		return this.deps.evolutionRepo.listTaskProposals(scopeId, status);
+	}
+
+	updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {
+		return this.deps.evolutionRepo.updateTaskProposal(id, params);
+	}
+
+	private collectTasks(scope: EvolutionScope, evidence: EvidenceRef[]): EpisodeTaskContext[] {
+		return evidence.flatMap((item) => {
+			if (item.kind !== 'task' || !item.sourceId) return [];
+			const task = this.deps.taskRepo.getTask(item.sourceId);
+			if (!task) return [];
+			if (task.spaceId !== scope.spaceId) {
+				throw new Error(`Task and scope must belong to the same space: ${task.id}`);
+			}
+			return [{ evidenceId: item.id, task }];
+		});
+	}
+
+	private collectWorkflowRuns(
+		scope: EvolutionScope,
+		evidence: EvidenceRef[]
+	): EpisodeWorkflowRunContext[] {
+		return evidence.flatMap((item) => {
+			if (item.kind !== 'workflow_run' || !item.sourceId) return [];
+			const run = this.deps.workflowRunRepo.getRun(item.sourceId);
+			if (!run) return [];
+			if (run.spaceId !== scope.spaceId) {
+				throw new Error(`Workflow run and scope must belong to the same space: ${run.id}`);
+			}
+			return [
+				{
+					evidenceId: item.id,
+					run,
+					tasks: this.deps.taskRepo.listByWorkflowRunIncludingArchived(run.id),
+					artifacts: this.deps.artifactRepo.listByRun(run.id).slice(0, MAX_ARTIFACTS_PER_RUN),
+				},
+			];
+		});
+	}
+
+	private requireScope(scopeId: string): EvolutionScope {
+		if (!scopeId) throw new Error('scopeId is required');
+		const scope = this.deps.evolutionRepo.getScope(scopeId);
+		if (!scope) throw new Error(`EvolutionScope not found: ${scopeId}`);
+		return scope;
+	}
+}
+
+export function buildEpisodeJudgePrompt(input: EpisodeJudgePromptInput): string {
+	return `You are Forge Episode Judge for NeoKai.
+
+Build a structured draft episode from scoped evidence. Focus on factual outcomes, product/workflow findings, candidate lessons, and follow-up proposals. Do not mutate anything.
+
+Return ONLY valid JSON with this shape:
+{
+  "title": "short episode title",
+  "outcomeSummary": "what happened and why it matters",
+  "findings": [
+    { "domain": "workflow|target_artifact|neokai_product", "kind": "friction|bug|optimization|missing_capability|new_opportunity", "impact": "low|medium|high", "confidence": 0.0, "evidence": ["evidence id or summary"], "proposedAction": "specific action" }
+  ],
+  "candidateLessons": [
+    { "appliesTo": ["workflow|prompt|tool|ui"], "rule": "lesson candidate", "why": "supporting reason", "confidence": 0.0 }
+  ],
+  "proposals": [
+    { "title": "task title", "description": "task body", "reason": "why now", "priority": "low|normal|high|urgent" }
+  ]
+}
+
+Scope:
+${JSON.stringify({ id: input.scope.id, name: input.scope.name, objective: input.scope.objective, metrics: input.scope.metricDefinitions, policy: input.scope.policy }, null, 2)}
+
+Time window:
+${JSON.stringify(input.timeWindow)}
+
+Selected evidence:
+${JSON.stringify(
+	input.evidence.map((item) => ({
+		id: item.id,
+		kind: item.kind,
+		summary: item.summary,
+		sourceId: item.sourceId,
+		metadata: item.metadata,
+		createdAt: item.createdAt,
+	})),
+	null,
+	2
+)}
+
+Task results and summaries:
+${JSON.stringify(
+	input.tasks.map(({ evidenceId, task }) => ({
+		evidenceId,
+		id: task.id,
+		number: task.taskNumber,
+		title: task.title,
+		status: task.status,
+		reportedStatus: task.reportedStatus,
+		reportedSummary: truncate(task.reportedSummary ?? '', MAX_TEXT),
+		result: truncate(task.result ?? '', MAX_TEXT),
+	})),
+	null,
+	2
+)}
+
+Workflow run artifacts:
+${JSON.stringify(
+	input.workflowRuns.map(({ evidenceId, run, tasks, artifacts }) => ({
+		evidenceId,
+		run: {
+			id: run.id,
+			title: run.title,
+			status: run.status,
+			failureReason: run.failureReason ?? null,
+		},
+		tasks: tasks.map((task) => ({
+			id: task.id,
+			title: task.title,
+			status: task.status,
+			reportedSummary: truncate(task.reportedSummary ?? '', 500),
+			result: truncate(task.result ?? '', 500),
+		})),
+		artifacts: artifacts.map((artifact) => ({
+			nodeId: artifact.nodeId,
+			type: artifact.artifactType,
+			key: artifact.artifactKey,
+			data: truncate(JSON.stringify(artifact.data), MAX_TEXT),
+		})),
+	})),
+	null,
+	2
+)}
+
+Metric snapshots and manual notes:
+${JSON.stringify({ metricSnapshots: input.metricSnapshots, manualNotes: input.evidence.filter((item) => item.kind === 'manual_note').map((item) => ({ id: item.id, summary: item.summary, metadata: item.metadata, createdAt: item.createdAt })) }, null, 2)}`;
+}
+
+export function parseEpisodeJudgeJson(raw: string): EpisodeJudgeOutput {
+	let text = raw.trim();
+	const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+	if (fenced?.[1]) {
+		text = fenced[1].trim();
+	} else {
+		const start = text.indexOf('{');
+		const end = text.lastIndexOf('}');
+		if (start >= 0 && end > start) text = text.slice(start, end + 1);
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		throw new Error(
+			`Episode judge returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`
+		);
+	}
+	return normalizeJudgeOutput(parsed);
+}
+
+async function judgeEpisodeWithModel(input: EpisodeJudgePromptInput): Promise<EpisodeJudgeOutput> {
+	const providerService = getProviderService();
+	const provider = await providerService.getDefaultProvider();
+	const cfg = await providerService.getTitleGenerationConfig(provider);
+	const modelId = cfg.modelId;
+	const prompt = buildEpisodeJudgePrompt(input);
+	const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+	try {
+		const { query } = await import('@anthropic-ai/claude-agent-sdk');
+		const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
+		const agentQuery = query({
+			prompt,
+			options: {
+				model: provider === 'glm' ? 'haiku' : modelId,
+				maxTurns: 1,
+				permissionMode: 'acceptEdits',
+				allowDangerouslySkipPermissions: false,
+				mcpServers: {},
+				settingSources: [],
+				tools: [],
+				pathToClaudeCodeExecutable: resolveSDKCliPath(),
+				executable: isRunningUnderBun() ? 'bun' : undefined,
+				env: mergeProviderEnvVars(
+					providerService.getEnvVarsForModel(modelId, provider) as Record<
+						string,
+						string | undefined
+					>
+				),
+				thinking: { type: 'disabled' },
+			},
+		});
+		let raw = '';
+		for await (const message of agentQuery) {
+			if (isSDKAssistantMessage(message)) {
+				const textBlocks = message.message.content.filter(
+					(block: { type: string }) => block.type === 'text'
+				) as Array<{ text?: string }>;
+				raw = textBlocks
+					.map((block) => block.text ?? '')
+					.join('\n')
+					.trim();
+				if (raw) break;
+			}
+		}
+		if (!raw) throw new Error('Episode judge returned no text');
+		return parseEpisodeJudgeJson(raw);
+	} catch (err) {
+		log.warn('Episode judge model call failed:', err);
+		throw err;
+	} finally {
+		providerService.restoreEnvVars(originalEnv);
+	}
+}
+
+function normalizeJudgeOutput(value: unknown): EpisodeJudgeOutput {
+	const record = requireRecord(value, 'episode judge output');
+	const title = requireString(record.title, 'title');
+	const outcomeSummary = requireString(record.outcomeSummary, 'outcomeSummary');
+	const findingsValue = Array.isArray(record.findings) ? record.findings : [];
+	const findings = findingsValue.map(normalizeFinding);
+	const candidateLessons = Array.isArray(record.candidateLessons)
+		? record.candidateLessons.map(normalizeLesson)
+		: [];
+	const proposals = Array.isArray(record.proposals) ? record.proposals.map(normalizeProposal) : [];
+	return { title, outcomeSummary, findings, candidateLessons, proposals };
+}
+
+function normalizeFinding(value: unknown): EvolutionFinding {
+	const record = requireRecord(value, 'finding');
+	return {
+		domain: enumValue(record.domain, FINDING_DOMAINS, 'finding.domain'),
+		kind: enumValue(record.kind, FINDING_KINDS, 'finding.kind'),
+		impact: enumValue(record.impact, IMPACTS, 'finding.impact'),
+		confidence: clampConfidence(record.confidence),
+		evidence: stringArray(record.evidence),
+		proposedAction: requireString(record.proposedAction, 'finding.proposedAction'),
+	};
+}
+
+function normalizeLesson(
+	value: unknown
+): Omit<CreateEvolutionLessonParams, 'scopeId' | 'evidenceEpisodeIds'> {
+	const record = requireRecord(value, 'candidate lesson');
+	return {
+		status:
+			record.status === undefined
+				? 'candidate'
+				: enumValue(record.status, LESSON_STATUSES, 'lesson.status'),
+		appliesTo: stringArray(record.appliesTo),
+		rule: requireString(record.rule, 'lesson.rule'),
+		why: requireString(record.why, 'lesson.why'),
+		confidence: clampConfidence(record.confidence),
+	};
+}
+
+function normalizeProposal(
+	value: unknown
+): Omit<CreateTaskProposalParams, 'scopeId' | 'evidenceEpisodeIds'> {
+	const record = requireRecord(value, 'proposal');
+	return {
+		title: requireString(record.title, 'proposal.title'),
+		description: requireString(record.description, 'proposal.description'),
+		reason: requireString(record.reason, 'proposal.reason'),
+		priority: enumValue(record.priority ?? 'normal', PRIORITIES, 'proposal.priority'),
+		status:
+			record.status === undefined
+				? 'proposed'
+				: enumValue(record.status, PROPOSAL_STATUSES, 'proposal.status'),
+	};
+}
+
+function deriveTimeWindow(evidence: EvidenceRef[]): CreateEvolutionEpisodeParams['timeWindow'] {
+	if (evidence.length === 0) return null;
+	const times = evidence.map((item) => item.createdAt);
+	return { start: Math.min(...times), end: Math.max(...times) };
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error(`${label} must be an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new Error(`${label} is required`);
+	}
+	return value.trim();
+}
+
+function enumValue<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+	if (typeof value !== 'string' || !allowed.includes(value as T)) {
+		throw new Error(`${label} must be one of: ${allowed.join(', ')}`);
+	}
+	return value as T;
+}
+
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function clampConfidence(value: unknown): number {
+	const numeric = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+	return Math.max(0, Math.min(1, numeric));
+}
+
+function truncate(value: string, max: number): string {
+	return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+	buildEpisodeJudgePrompt,
+	EvolutionEpisodeService,
+	parseEpisodeJudgeJson,
+} from '../../../src/lib/space/evolution-episode-service';
+import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
+import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import { WorkflowRunArtifactRepository } from '../../../src/storage/repositories/workflow-run-artifact-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('EvolutionEpisodeService', () => {
+	let db: Database;
+	let evolutionRepo: EvolutionRepository;
+	let taskRepo: SpaceTaskRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let artifactRepo: WorkflowRunArtifactRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const spaceRepo = new SpaceRepository(db as never);
+		evolutionRepo = new EvolutionRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+		workflowRunRepo = new SpaceWorkflowRunRepository(
+			db as never,
+			new GateOpenStateRepository(db as never)
+		);
+		artifactRepo = new WorkflowRunArtifactRepository(db as never);
+		workflowRepo = new SpaceWorkflowRepository(db as never);
+		spaceId = spaceRepo.createSpace({
+			workspacePath: '/workspace/episode-service-test',
+			slug: 'episode-service-test',
+			name: 'Episode Service Test',
+		}).id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it('builds episode input with task results, workflow artifacts, metrics, and notes', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Review loop',
+			objective: 'Reduce review churn',
+			metricDefinitions: [{ key: 'comments', label: 'Comments', direction: 'decrease' }],
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Fix review feedback',
+			description: 'Address comments',
+			evolutionScopeId: scope.id,
+		});
+		taskRepo.updateTask(task.id, {
+			result: 'PR updated and tests pass',
+			reportedSummary: 'Resolved reviewer comments',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Code workflow' });
+		const run = workflowRunRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Run one' });
+		artifactRepo.upsert({
+			id: 'artifact-1',
+			runId: run.id,
+			nodeId: 'coder',
+			artifactType: 'result',
+			artifactKey: 'final',
+			data: { summary: 'Implementation ready' },
+		});
+		const taskEvidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'task',
+			sourceId: task.id,
+			summary: 'Task completed',
+			createdAt: 100,
+		});
+		const runEvidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'workflow_run',
+			sourceId: run.id,
+			summary: 'Workflow completed',
+			createdAt: 200,
+		});
+		const note = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'manual_note',
+			summary: 'Reviewer saw repeated confusion',
+			createdAt: 150,
+		});
+		evolutionRepo.createMetricSnapshot({
+			scopeId: scope.id,
+			values: { comments: 2 },
+			source: 'manual',
+			note: 'After review',
+			capturedAt: 125,
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		const input = service.buildEpisodeInput({
+			scopeId: scope.id,
+			evidenceIds: [taskEvidence.id, runEvidence.id, note.id],
+		});
+		const prompt = buildEpisodeJudgePrompt(input);
+
+		expect(input.timeWindow).toEqual({ start: 100, end: 200 });
+		expect(prompt).toContain('Reduce review churn');
+		expect(prompt).toContain('Resolved reviewer comments');
+		expect(prompt).toContain('PR updated and tests pass');
+		expect(prompt).toContain('Implementation ready');
+		expect(prompt).toContain('Reviewer saw repeated confusion');
+		expect(prompt).toContain('comments');
+	});
+
+	it('parses fenced judge JSON and clamps confidence', () => {
+		const output = parseEpisodeJudgeJson(`\n\`\`\`json\n{
+			"title": "Review churn reduced",
+			"outcomeSummary": "Task landed with fewer comments.",
+			"findings": [{
+				"domain": "workflow",
+				"kind": "optimization",
+				"impact": "medium",
+				"confidence": 1.4,
+				"evidence": ["ev-1"],
+				"proposedAction": "Keep reviewer checklist"
+			}],
+			"candidateLessons": [{
+				"appliesTo": ["workflow"],
+				"rule": "Use checklist before PR",
+				"why": "It reduced comments",
+				"confidence": 0.8
+			}],
+			"proposals": [{
+				"title": "Add checklist template",
+				"description": "Create review checklist",
+				"reason": "Avoid repeat misses",
+				"priority": "normal"
+			}]
+		}\n\`\`\``);
+
+		expect(output.title).toBe('Review churn reduced');
+		expect(output.findings[0]?.confidence).toBe(1);
+		expect(output.candidateLessons?.[0]?.rule).toBe('Use checklist before PR');
+		expect(output.proposals?.[0]?.title).toBe('Add checklist template');
+	});
+
+	it('rejects malformed judge JSON and invalid enum values', () => {
+		expect(() => parseEpisodeJudgeJson('{ nope')).toThrow('Episode judge returned invalid JSON');
+		expect(() =>
+			parseEpisodeJudgeJson(
+				JSON.stringify({
+					title: 'Bad domain',
+					outcomeSummary: 'Bad domain',
+					findings: [
+						{
+							domain: 'bad',
+							kind: 'friction',
+							impact: 'low',
+							confidence: 0.5,
+							evidence: [],
+							proposedAction: 'Fix it',
+						},
+					],
+				})
+			)
+		).toThrow('finding.domain must be one of');
+	});
+
+	it('persists draft episode, candidate lessons, and proposals from judge output', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Draft scope',
+			objective: 'Create draft',
+		});
+		const evidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'manual_note',
+			summary: 'Manual observation',
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+			judgeEpisode: async () => ({
+				title: 'Manual episode',
+				outcomeSummary: 'Observation summarized',
+				findings: [
+					{
+						domain: 'neokai_product',
+						kind: 'friction',
+						impact: 'high',
+						confidence: 0.9,
+						evidence: [evidence.id],
+						proposedAction: 'Reduce UI friction',
+					},
+				],
+				candidateLessons: [
+					{
+						appliesTo: ['ui'],
+						rule: 'Surface next step',
+						why: 'User got stuck',
+						confidence: 0.7,
+					},
+				],
+				proposals: [
+					{
+						title: 'Improve review UI',
+						description: 'Add clearer actions',
+						reason: 'Reduce friction',
+						priority: 'high',
+					},
+				],
+			}),
+		});
+
+		const result = await service.createFromEvidence({
+			scopeId: scope.id,
+			evidenceIds: [evidence.id],
+		});
+
+		expect(result.episode).toMatchObject({
+			status: 'draft',
+			title: 'Manual episode',
+			evidenceIds: [evidence.id],
+		});
+		expect(result.lessons[0]).toMatchObject({
+			status: 'candidate',
+			rule: 'Surface next step',
+			evidenceEpisodeIds: [result.episode.id],
+		});
+		expect(result.proposals[0]).toMatchObject({
+			status: 'proposed',
+			title: 'Improve review UI',
+			evidenceEpisodeIds: [result.episode.id],
+		});
+	});
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -653,8 +653,22 @@ export interface EvolutionEpisodeCreateRequest {
 	params: CreateEvolutionEpisodeParams;
 }
 
+export interface EvolutionEpisodeCreateFromEvidenceRequest {
+	scopeId: string;
+	evidenceIds: string[];
+	timeWindow?: EvolutionEpisode['timeWindow'];
+}
+
 export interface EvolutionEpisodeCreateResponse {
 	episode: EvolutionEpisode;
+	lessons?: EvolutionLesson[];
+	proposals?: TaskProposal[];
+}
+
+export interface EvolutionEpisodeReviewBundleResponse {
+	episodes: EvolutionEpisode[];
+	lessons: EvolutionLesson[];
+	proposals: TaskProposal[];
 }
 
 export interface EvolutionEpisodeUpdateRequest {

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -1,4 +1,10 @@
 import type {
+	EvolutionEpisode,
+	EvolutionEpisodeCreateResponse,
+	EvolutionEpisodeReviewBundleResponse,
+	EvolutionFinding,
+	EvolutionFindingDomain,
+	EvolutionLesson,
 	EvolutionScope,
 	EvolutionScopeCreateResponse,
 	EvolutionScopeKind,
@@ -12,7 +18,9 @@ import type {
 	MetricSnapshot,
 	MetricSnapshotValues,
 	SpaceGoal,
+	TaskProposal,
 } from '@neokai/shared';
+import type { ComponentChild } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useMessageHub } from '../../hooks/useMessageHub';
 import { spaceStore } from '../../lib/space-store';
@@ -20,10 +28,13 @@ import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 
-type ScopeTab = 'overview' | 'evidence' | 'metrics';
+type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'episodes';
+
+type ReviewActionKind = 'episode' | 'lesson' | 'proposal';
 
 const SCOPE_KINDS: EvolutionScopeKind[] = ['mission', 'project', 'campaign', 'workflow', 'custom'];
 const METRIC_DIRECTIONS: MetricDirection[] = ['increase', 'decrease', 'target', 'maintain'];
+const EPISODE_JUDGE_TIMEOUT_MS = 120000;
 
 interface SpaceForgeProps {
 	spaceId: string;
@@ -464,6 +475,381 @@ function EvidenceTab({ scope }: { scope: EvolutionScope }) {
 	);
 }
 
+function EpisodesTab({ scope }: { scope: EvolutionScope }) {
+	const { request } = useMessageHub();
+	const [episodes, setEpisodes] = useState<EvolutionEpisode[]>([]);
+	const [lessons, setLessons] = useState<EvolutionLesson[]>([]);
+	const [proposals, setProposals] = useState<TaskProposal[]>([]);
+	const [evidence, setEvidence] = useState<EvidenceRef[]>([]);
+	const [selectedEvidenceIds, setSelectedEvidenceIds] = useState<string[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const requestVersion = useRef(0);
+
+	const loadReview = useCallback(async () => {
+		const version = ++requestVersion.current;
+		setLoading(true);
+		setError(null);
+		try {
+			const [reviewResponse, evidenceResponse] = await Promise.all([
+				request<EvolutionEpisodeReviewBundleResponse>('evolution.review.get', {
+					scopeId: scope.id,
+				}),
+				request<EvolutionEvidenceListResponse>('evolution.evidence.list', { scopeId: scope.id }),
+			]);
+			if (requestVersion.current !== version) return;
+			setEpisodes(reviewResponse.episodes ?? []);
+			setLessons(reviewResponse.lessons ?? []);
+			setProposals(reviewResponse.proposals ?? []);
+			setEvidence(evidenceResponse.evidence ?? []);
+			setSelectedEvidenceIds((current) =>
+				current.filter((id) => evidenceResponse.evidence.some((item) => item.id === id))
+			);
+		} catch (err) {
+			if (requestVersion.current === version) {
+				setError(err instanceof Error ? err.message : 'Failed to load episode review');
+			}
+		} finally {
+			if (requestVersion.current === version) setLoading(false);
+		}
+	}, [request, scope.id]);
+
+	useEffect(() => {
+		setSelectedEvidenceIds([]);
+		loadReview().catch(() => undefined);
+	}, [loadReview]);
+
+	const latestEpisode = episodes[0] ?? null;
+	const groupedFindings = useMemo(
+		() => groupFindingsByDomain(latestEpisode?.findings ?? []),
+		[latestEpisode]
+	);
+	const frictionFindings = (latestEpisode?.findings ?? []).filter(
+		(finding) => finding.kind === 'friction'
+	);
+	const candidateLessons = lessons.filter((lesson) => lesson.status === 'candidate');
+	const proposedTasks = proposals.filter((proposal) => proposal.status === 'proposed');
+
+	const toggleEvidence = (id: string) => {
+		setSelectedEvidenceIds((current) =>
+			current.includes(id) ? current.filter((item) => item !== id) : [...current, id]
+		);
+	};
+
+	const handleCreateEpisode = async () => {
+		if (selectedEvidenceIds.length === 0) {
+			setError('Select at least one evidence item');
+			return;
+		}
+		try {
+			setSubmitting(true);
+			setError(null);
+			const response = await request<EvolutionEpisodeCreateResponse>(
+				'evolution.episode.createFromEvidence',
+				{
+					scopeId: scope.id,
+					evidenceIds: selectedEvidenceIds,
+				},
+				{ timeout: EPISODE_JUDGE_TIMEOUT_MS }
+			);
+			setEpisodes((current) => [response.episode, ...current]);
+			setLessons((current) => [...(response.lessons ?? []), ...current]);
+			setProposals((current) => [...(response.proposals ?? []), ...current]);
+			setSelectedEvidenceIds([]);
+			toast.success(`Episode "${response.episode.title}" drafted`);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to create episode');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const updateReviewItem = async (kind: ReviewActionKind, id: string, status: string) => {
+		try {
+			setError(null);
+			if (kind === 'episode') {
+				const response = await request<{ episode: EvolutionEpisode | null }>(
+					'evolution.episode.update',
+					{
+						id,
+						params: { status },
+					}
+				);
+				if (response.episode) {
+					setEpisodes((current) =>
+						current.map((item) => (item.id === response.episode?.id ? response.episode : item))
+					);
+				}
+			} else if (kind === 'lesson') {
+				const response = await request<{ lesson: EvolutionLesson | null }>(
+					'evolution.lesson.update',
+					{
+						id,
+						params: { status },
+					}
+				);
+				if (response.lesson) {
+					setLessons((current) =>
+						current.map((item) => (item.id === response.lesson?.id ? response.lesson : item))
+					);
+				}
+			} else {
+				const response = await request<{ proposal: TaskProposal | null }>(
+					'evolution.taskProposal.update',
+					{
+						id,
+						params: { status },
+					}
+				);
+				if (response.proposal) {
+					setProposals((current) =>
+						current.map((item) => (item.id === response.proposal?.id ? response.proposal : item))
+					);
+				}
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to update review item');
+		}
+	};
+
+	return (
+		<div class="space-y-4">
+			<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+				<div class="mb-3 flex items-start justify-between gap-3">
+					<div>
+						<h3 class="text-sm font-medium text-gray-100">Generate episode draft</h3>
+						<p class="mt-1 text-xs text-gray-500">
+							Select scoped evidence. Judge creates draft only; lessons and proposals remain
+							candidates.
+						</p>
+					</div>
+					<Button
+						type="button"
+						size="sm"
+						onClick={handleCreateEpisode}
+						disabled={submitting || selectedEvidenceIds.length === 0}
+					>
+						{submitting ? 'Judging…' : 'Create episode'}
+					</Button>
+				</div>
+				{evidence.length === 0 ? (
+					<p class="text-sm text-gray-500">No evidence available.</p>
+				) : (
+					<div class="grid gap-2 md:grid-cols-2">
+						{evidence.map((item) => (
+							<label
+								key={item.id}
+								class="flex gap-3 rounded-lg border border-white/10 bg-dark-900/60 p-3 text-sm text-gray-300"
+							>
+								<input
+									type="checkbox"
+									checked={selectedEvidenceIds.includes(item.id)}
+									onChange={() => toggleEvidence(item.id)}
+									class="mt-1"
+								/>
+								<span>
+									<span class="mb-1 block text-xs text-cyan-300">{formatKind(item.kind)}</span>
+									{item.summary}
+								</span>
+							</label>
+						))}
+					</div>
+				)}
+			</section>
+
+			{error && (
+				<div class="rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-400">
+					{error}
+				</div>
+			)}
+
+			{loading ? (
+				<p class="text-sm text-gray-500">Loading review…</p>
+			) : !latestEpisode ? (
+				<div class="rounded-xl border border-white/10 bg-white/[0.02] p-4 text-sm text-gray-500">
+					No episode drafts yet.
+				</div>
+			) : (
+				<div class="space-y-4">
+					<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+						<div class="flex items-start justify-between gap-3">
+							<div>
+								<p class="text-xs uppercase tracking-wide text-gray-500">Outcome summary</p>
+								<h3 class="mt-1 text-base font-semibold text-gray-100">{latestEpisode.title}</h3>
+							</div>
+							<span class="rounded-full bg-white/5 px-2 py-1 text-xs text-gray-300">
+								{latestEpisode.status}
+							</span>
+						</div>
+						<p class="mt-3 text-sm text-gray-300">{latestEpisode.outcomeSummary}</p>
+						<div class="mt-4 flex gap-2">
+							<Button
+								size="sm"
+								onClick={() => updateReviewItem('episode', latestEpisode.id, 'accepted')}
+							>
+								Accept
+							</Button>
+							<Button
+								size="sm"
+								variant="secondary"
+								onClick={() => updateReviewItem('episode', latestEpisode.id, 'dismissed')}
+							>
+								Dismiss
+							</Button>
+						</div>
+					</section>
+
+					<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+						<h3 class="mb-3 text-sm font-medium text-gray-100">Findings by domain</h3>
+						<div class="space-y-3">
+							{Object.entries(groupedFindings).map(([domain, findings]) => (
+								<div key={domain} class="rounded-lg border border-white/10 bg-dark-900/60 p-3">
+									<h4 class="mb-2 text-sm font-medium text-cyan-200">{formatKind(domain)}</h4>
+									<div class="space-y-2">
+										{findings.map((finding, index) => (
+											<FindingCard key={`${domain}-${index}`} finding={finding} />
+										))}
+									</div>
+								</div>
+							))}
+						</div>
+					</section>
+
+					<section class="rounded-xl border border-orange-500/20 bg-orange-500/5 p-4">
+						<h3 class="mb-3 text-sm font-medium text-orange-100">NeoKai friction findings</h3>
+						{frictionFindings.length === 0 ? (
+							<p class="text-sm text-orange-200/70">No friction findings in latest episode.</p>
+						) : (
+							<div class="space-y-2">
+								{frictionFindings.map((finding, index) => (
+									<FindingCard key={`friction-${index}`} finding={finding} />
+								))}
+							</div>
+						)}
+					</section>
+
+					<div class="grid gap-4 lg:grid-cols-2">
+						<ReviewList
+							title="Candidate lessons"
+							empty="No candidate lessons."
+							items={candidateLessons}
+							render={(lesson) => (
+								<div key={lesson.id} class="rounded-lg border border-white/10 bg-dark-900/60 p-3">
+									<p class="text-sm text-gray-100">{lesson.rule}</p>
+									<p class="mt-1 text-xs text-gray-500">{lesson.why}</p>
+									<div class="mt-3 flex gap-2">
+										<Button
+											size="sm"
+											onClick={() => updateReviewItem('lesson', lesson.id, 'active')}
+										>
+											Activate
+										</Button>
+										<Button
+											size="sm"
+											variant="secondary"
+											onClick={() => updateReviewItem('lesson', lesson.id, 'dismissed')}
+										>
+											Dismiss
+										</Button>
+									</div>
+								</div>
+							)}
+						/>
+						<ReviewList
+							title="Next action proposals"
+							empty="No proposed actions."
+							items={proposedTasks}
+							render={(proposal) => (
+								<div key={proposal.id} class="rounded-lg border border-white/10 bg-dark-900/60 p-3">
+									<div class="flex items-start justify-between gap-2">
+										<p class="text-sm font-medium text-gray-100">{proposal.title}</p>
+										<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-400">
+											{proposal.priority}
+										</span>
+									</div>
+									<p class="mt-1 text-xs text-gray-400">{proposal.description}</p>
+									<p class="mt-2 text-xs text-gray-500">Reason: {proposal.reason}</p>
+									<div class="mt-3 flex gap-2">
+										<Button
+											size="sm"
+											onClick={() => updateReviewItem('proposal', proposal.id, 'accepted')}
+										>
+											Accept
+										</Button>
+										<Button
+											size="sm"
+											variant="secondary"
+											onClick={() => updateReviewItem('proposal', proposal.id, 'dismissed')}
+										>
+											Dismiss
+										</Button>
+									</div>
+								</div>
+							)}
+						/>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function FindingCard({ finding }: { finding: EvolutionFinding }) {
+	return (
+		<div class="rounded-md border border-white/10 bg-black/20 p-3">
+			<div class="mb-2 flex flex-wrap gap-2">
+				<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-300">
+					{formatKind(finding.kind)}
+				</span>
+				<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-300">
+					{finding.impact} impact
+				</span>
+				<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-300">
+					{Math.round(finding.confidence * 100)}% confidence
+				</span>
+			</div>
+			<p class="text-sm text-gray-200">{finding.proposedAction}</p>
+			{finding.evidence.length > 0 && (
+				<p class="mt-2 text-xs text-gray-500">Evidence: {finding.evidence.join(', ')}</p>
+			)}
+		</div>
+	);
+}
+
+function ReviewList<T>({
+	title,
+	empty,
+	items,
+	render,
+}: {
+	title: string;
+	empty: string;
+	items: T[];
+	render: (item: T) => ComponentChild;
+}) {
+	return (
+		<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+			<h3 class="mb-3 text-sm font-medium text-gray-100">{title}</h3>
+			{items.length === 0 ? (
+				<p class="text-sm text-gray-500">{empty}</p>
+			) : (
+				<div class="space-y-3">{items.map(render)}</div>
+			)}
+		</section>
+	);
+}
+
+function groupFindingsByDomain(
+	findings: EvolutionFinding[]
+): Record<EvolutionFindingDomain, EvolutionFinding[]> {
+	return {
+		workflow: findings.filter((finding) => finding.domain === 'workflow'),
+		target_artifact: findings.filter((finding) => finding.domain === 'target_artifact'),
+		neokai_product: findings.filter((finding) => finding.domain === 'neokai_product'),
+	};
+}
+
 function MetricsTab({ scope }: { scope: EvolutionScope }) {
 	const { request } = useMessageHub();
 	const [snapshots, setSnapshots] = useState<MetricSnapshot[]>([]);
@@ -663,7 +1049,7 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 				<p class="mt-1 text-sm text-gray-400">{scope.objective}</p>
 			</div>
 			<div class="flex gap-2 border-b border-white/10 px-5 py-3">
-				{(['overview', 'evidence', 'metrics'] as const).map((item) => (
+				{(['overview', 'evidence', 'metrics', 'episodes'] as const).map((item) => (
 					<button
 						key={item}
 						type="button"
@@ -700,6 +1086,7 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 				)}
 				{tab === 'evidence' && <EvidenceTab scope={scope} />}
 				{tab === 'metrics' && <MetricsTab scope={scope} />}
+				{tab === 'episodes' && <EpisodesTab scope={scope} />}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -19,6 +19,7 @@ import type {
 	MetricSnapshotValues,
 	SpaceGoal,
 	TaskProposal,
+	TaskProposalStatus,
 } from '@neokai/shared';
 import type { ComponentChild } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
@@ -30,7 +31,10 @@ import { Modal } from '../ui/Modal';
 
 type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'episodes';
 
-type ReviewActionKind = 'episode' | 'lesson' | 'proposal';
+type ReviewAction =
+	| { kind: 'episode'; id: string; status: EvolutionEpisode['status'] }
+	| { kind: 'lesson'; id: string; status: EvolutionLesson['status'] }
+	| { kind: 'proposal'; id: string; status: TaskProposalStatus };
 
 const SCOPE_KINDS: EvolutionScopeKind[] = ['mission', 'project', 'campaign', 'workflow', 'custom'];
 const METRIC_DIRECTIONS: MetricDirection[] = ['increase', 'decrease', 'target', 'maintain'];
@@ -520,6 +524,7 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 		loadReview().catch(() => undefined);
 	}, [loadReview]);
 
+	// MVP review focuses on the newest draft; deeper episode history/selection can layer on later.
 	const latestEpisode = episodes[0] ?? null;
 	const groupedFindings = useMemo(
 		() => groupFindingsByDomain(latestEpisode?.findings ?? []),
@@ -565,15 +570,15 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 		}
 	};
 
-	const updateReviewItem = async (kind: ReviewActionKind, id: string, status: string) => {
+	const updateReviewItem = async (action: ReviewAction) => {
 		try {
 			setError(null);
-			if (kind === 'episode') {
+			if (action.kind === 'episode') {
 				const response = await request<{ episode: EvolutionEpisode | null }>(
 					'evolution.episode.update',
 					{
-						id,
-						params: { status },
+						id: action.id,
+						params: { status: action.status },
 					}
 				);
 				if (response.episode) {
@@ -581,12 +586,12 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 						current.map((item) => (item.id === response.episode?.id ? response.episode : item))
 					);
 				}
-			} else if (kind === 'lesson') {
+			} else if (action.kind === 'lesson') {
 				const response = await request<{ lesson: EvolutionLesson | null }>(
 					'evolution.lesson.update',
 					{
-						id,
-						params: { status },
+						id: action.id,
+						params: { status: action.status },
 					}
 				);
 				if (response.lesson) {
@@ -598,8 +603,8 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 				const response = await request<{ proposal: TaskProposal | null }>(
 					'evolution.taskProposal.update',
 					{
-						id,
-						params: { status },
+						id: action.id,
+						params: { status: action.status },
 					}
 				);
 				if (response.proposal) {
@@ -686,14 +691,18 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 						<div class="mt-4 flex gap-2">
 							<Button
 								size="sm"
-								onClick={() => updateReviewItem('episode', latestEpisode.id, 'accepted')}
+								onClick={() =>
+									updateReviewItem({ kind: 'episode', id: latestEpisode.id, status: 'accepted' })
+								}
 							>
 								Accept
 							</Button>
 							<Button
 								size="sm"
 								variant="secondary"
-								onClick={() => updateReviewItem('episode', latestEpisode.id, 'dismissed')}
+								onClick={() =>
+									updateReviewItem({ kind: 'episode', id: latestEpisode.id, status: 'dismissed' })
+								}
 							>
 								Dismiss
 							</Button>
@@ -741,14 +750,18 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 									<div class="mt-3 flex gap-2">
 										<Button
 											size="sm"
-											onClick={() => updateReviewItem('lesson', lesson.id, 'active')}
+											onClick={() =>
+												updateReviewItem({ kind: 'lesson', id: lesson.id, status: 'active' })
+											}
 										>
 											Activate
 										</Button>
 										<Button
 											size="sm"
 											variant="secondary"
-											onClick={() => updateReviewItem('lesson', lesson.id, 'dismissed')}
+											onClick={() =>
+												updateReviewItem({ kind: 'lesson', id: lesson.id, status: 'dismissed' })
+											}
 										>
 											Dismiss
 										</Button>
@@ -773,14 +786,18 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 									<div class="mt-3 flex gap-2">
 										<Button
 											size="sm"
-											onClick={() => updateReviewItem('proposal', proposal.id, 'accepted')}
+											onClick={() =>
+												updateReviewItem({ kind: 'proposal', id: proposal.id, status: 'accepted' })
+											}
 										>
 											Accept
 										</Button>
 										<Button
 											size="sm"
 											variant="secondary"
-											onClick={() => updateReviewItem('proposal', proposal.id, 'dismissed')}
+											onClick={() =>
+												updateReviewItem({ kind: 'proposal', id: proposal.id, status: 'dismissed' })
+											}
 										>
 											Dismiss
 										</Button>

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -1,4 +1,12 @@
-import type { EvolutionScope, EvidenceRef, MetricSnapshot, SpaceGoal } from '@neokai/shared';
+import type {
+	EvolutionEpisode,
+	EvolutionLesson,
+	EvolutionScope,
+	EvidenceRef,
+	MetricSnapshot,
+	SpaceGoal,
+	TaskProposal,
+} from '@neokai/shared';
 import type { Signal } from '@preact/signals';
 import { signal } from '@preact/signals';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
@@ -110,13 +118,106 @@ function makeSnapshot(overrides: Partial<MetricSnapshot> = {}): MetricSnapshot {
 	};
 }
 
+function makeEpisode(overrides: Partial<EvolutionEpisode> = {}): EvolutionEpisode {
+	const now = Date.now();
+	return {
+		id: 'episode-1',
+		scopeId: 'scope-1',
+		status: 'draft',
+		title: 'Review loop episode',
+		timeWindow: { start: now - 1000, end: now },
+		evidenceIds: ['evidence-1'],
+		outcomeSummary: 'Reviewer feedback identified recurring friction.',
+		findings: [
+			{
+				domain: 'workflow',
+				kind: 'optimization',
+				impact: 'medium',
+				confidence: 0.8,
+				evidence: ['evidence-1'],
+				proposedAction: 'Keep checklist before review',
+			},
+			{
+				domain: 'neokai_product',
+				kind: 'friction',
+				impact: 'high',
+				confidence: 0.9,
+				evidence: ['evidence-1'],
+				proposedAction: 'Make review actions clearer',
+			},
+		],
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function makeLesson(overrides: Partial<EvolutionLesson> = {}): EvolutionLesson {
+	const now = Date.now();
+	return {
+		id: 'lesson-1',
+		scopeId: 'scope-1',
+		status: 'candidate',
+		appliesTo: ['workflow'],
+		rule: 'Use checklist before PR',
+		why: 'Checklist reduced comments',
+		evidenceEpisodeIds: ['episode-1'],
+		confidence: 0.7,
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+function makeProposal(overrides: Partial<TaskProposal> = {}): TaskProposal {
+	const now = Date.now();
+	return {
+		id: 'proposal-1',
+		scopeId: 'scope-1',
+		title: 'Improve review UI',
+		description: 'Make accept/dismiss actions clearer',
+		reason: 'Reduce NeoKai friction',
+		priority: 'high',
+		status: 'proposed',
+		evidenceEpisodeIds: ['episode-1'],
+		createdTaskId: null,
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
 function setupRequests(scope = makeScope()) {
 	const evidence = [makeEvidence()];
 	const snapshot = makeSnapshot();
+	const episode = makeEpisode();
+	const lesson = makeLesson();
+	const proposal = makeProposal();
 	mockRequest.mockImplementation(async (method: string, data?: unknown) => {
 		if (method === 'evolution.scope.list') return { scopes: [scope] };
 		if (method === 'evolution.evidence.list') return { evidence };
 		if (method === 'evolution.metricSnapshot.list') return { snapshots: [snapshot] };
+		if (method === 'evolution.review.get') {
+			return { episodes: [episode], lessons: [lesson], proposals: [proposal] };
+		}
+		if (method === 'evolution.episode.createFromEvidence') {
+			expect(data).toEqual({ scopeId: scope.id, evidenceIds: ['evidence-1'] });
+			return {
+				episode: makeEpisode({ id: 'episode-2', title: 'Generated episode' }),
+				lessons: [makeLesson({ id: 'lesson-2', rule: 'Generated lesson' })],
+				proposals: [makeProposal({ id: 'proposal-2', title: 'Generated proposal' })],
+			};
+		}
+		if (method === 'evolution.episode.update') {
+			expect(data).toEqual({ id: 'episode-1', params: { status: 'accepted' } });
+			return { episode: makeEpisode({ status: 'accepted' }) };
+		}
+		if (method === 'evolution.lesson.update') {
+			return { lesson: makeLesson({ status: 'active' }) };
+		}
+		if (method === 'evolution.taskProposal.update') {
+			return { proposal: makeProposal({ status: 'accepted' }) };
+		}
 		if (method === 'evolution.evidence.addManualNote') {
 			expect(data).toEqual({ scopeId: scope.id, summary: 'Manual proof' });
 			return { evidence: makeEvidence({ id: 'evidence-2', summary: 'Manual proof' }) };
@@ -206,6 +307,51 @@ describe('SpaceForge', () => {
 				note: 'Improved',
 			},
 		});
+	});
+
+	it('renders episode review and generates episode from selected evidence', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+
+		expect(
+			await screen.findByText('Reviewer feedback identified recurring friction.')
+		).toBeTruthy();
+		expect(screen.getByText('Findings by domain')).toBeTruthy();
+		expect(screen.getByText('NeoKai friction findings')).toBeTruthy();
+		expect(screen.getByText('Use checklist before PR')).toBeTruthy();
+		expect(screen.getByText('Improve review UI')).toBeTruthy();
+
+		fireEvent.click(screen.getByLabelText(/Reviewer found regression before merge/));
+		fireEvent.click(screen.getByRole('button', { name: 'Create episode' }));
+
+		await waitFor(() =>
+			expect(mockToastSuccess).toHaveBeenCalledWith('Episode "Generated episode" drafted')
+		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			'evolution.episode.createFromEvidence',
+			{
+				scopeId: 'scope-1',
+				evidenceIds: ['evidence-1'],
+			},
+			{ timeout: 120000 }
+		);
+	});
+
+	it('accepts latest episode draft from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.click((await screen.findAllByRole('button', { name: 'Accept' }))[0]);
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.episode.update', {
+				id: 'episode-1',
+				params: { status: 'accepted' },
+			})
+		);
 	});
 
 	it('creates scope with linked recurring goal and metrics', async () => {

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -213,9 +213,11 @@ function setupRequests(scope = makeScope()) {
 			return { episode: makeEpisode({ status: 'accepted' }) };
 		}
 		if (method === 'evolution.lesson.update') {
+			expect(data).toEqual({ id: 'lesson-1', params: { status: 'active' } });
 			return { lesson: makeLesson({ status: 'active' }) };
 		}
 		if (method === 'evolution.taskProposal.update') {
+			expect(data).toEqual({ id: 'proposal-1', params: { status: 'accepted' } });
 			return { proposal: makeProposal({ status: 'accepted' }) };
 		}
 		if (method === 'evolution.evidence.addManualNote') {
@@ -349,6 +351,36 @@ describe('SpaceForge', () => {
 		await waitFor(() =>
 			expect(mockRequest).toHaveBeenCalledWith('evolution.episode.update', {
 				id: 'episode-1',
+				params: { status: 'accepted' },
+			})
+		);
+	});
+
+	it('activates candidate lesson from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.click(await screen.findByRole('button', { name: 'Activate' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.lesson.update', {
+				id: 'lesson-1',
+				params: { status: 'active' },
+			})
+		);
+	});
+
+	it('accepts task proposal from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.click((await screen.findAllByRole('button', { name: 'Accept' }))[1]);
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.taskProposal.update', {
+				id: 'proposal-1',
 				params: { status: 'accepted' },
 			})
 		);


### PR DESCRIPTION
Adds Forge episode draft generation from selected scope evidence, including prompt construction from task results, workflow artifacts, metric snapshots, and manual notes.

Adds episode review UI for outcome summaries, domain-grouped findings, candidate lessons, next action proposals, and NeoKai friction findings.

Validation:
- cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx
- bun run check