### PR TITLE
Inject scoped Forge lessons

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
@@ -27,6 +27,8 @@ import type {
 	EvolutionScopeListResponse,
 	EvolutionScopeUpdateRequest,
 	EvolutionScopeUpdateResponse,
+	EvolutionTaskLessonSelectRequest,
+	EvolutionTaskLessonSelectResponse,
 	EvolutionTaskProposalListRequest,
 	EvolutionTaskProposalListResponse,
 	EvolutionTaskProposalUpdateRequest,
@@ -178,6 +180,14 @@ export function setupEvolutionHandlers(
 		async (data) => ({
 			snapshots: service.listMetricSnapshots(readRequiredString(data, 'scopeId')),
 		})
+	);
+
+	messageHub.onRequest<EvolutionTaskLessonSelectRequest, EvolutionTaskLessonSelectResponse>(
+		'evolution.task.lessons.select',
+		async (data) => {
+			const payload = readRecord(data) as unknown as EvolutionTaskLessonSelectRequest;
+			return { lessons: service.selectActiveLessonsForTask(payload) };
+		}
 	);
 
 	if (!episodeService) return;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -640,6 +640,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		replyRoutingRegistry,
 		memoryRepo: deps.db.agentMemory,
 		goalService: spaceGoalService,
+		evolutionScopeService,
 	});
 
 	deps.commandBus.register('agent.message.inject', async (command) => {

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -326,7 +326,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		sections.push(...roleLines);
 	}
 
-	// 4. Previous work summaries.
+	// 6. Previous work summaries.
 	if (previousTaskSummaries && previousTaskSummaries.length > 0) {
 		sections.push('');
 		sections.push('## Previous Work on This Goal');
@@ -336,7 +336,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		}
 	}
 
-	// 5. Core memories are space-scoped and selected by background consolidation.
+	// 7. Core memories are space-scoped and selected by background consolidation.
 	const coreMemoryLines = buildCoreMemoryLines(coreMemories);
 	if (coreMemoryLines.length > 0) {
 		sections.push('');
@@ -345,7 +345,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		sections.push(...coreMemoryLines);
 	}
 
-	// 6. Relevant persistent memories.
+	// 8. Relevant persistent memories.
 	if (relevantMemories && relevantMemories.length > 0) {
 		sections.push('');
 		sections.push('## Relevant Memories');
@@ -358,7 +358,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		}
 	}
 
-	// 6. Project context from the Space.
+	// 9. Project context from the Space.
 	if (space.backgroundContext) {
 		sections.push('');
 		sections.push('## Project Context');

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -11,6 +11,7 @@ import type {
 	AgentDefinition,
 	DeclarativeToolGuard,
 	McpServerConfig,
+	EvolutionLesson,
 	Space,
 	SpaceAgent,
 	SpaceGoal,
@@ -142,6 +143,8 @@ export interface CustomAgentConfig {
 	workspacePath: string;
 	/** Linked long-horizon goal for this task, when present. */
 	goal?: SpaceGoal | null;
+	/** Active scope lessons selected for this task, newest first. */
+	relevantScopeLessons?: EvolutionLesson[];
 	/** Summaries of previously completed tasks for context */
 	previousTaskSummaries?: string[];
 	/** Optional per-slot workflow overrides */
@@ -232,11 +235,12 @@ function hashPrompt(prompt: string): string {
  * Section order (top → bottom), action-first:
  *   1. `## Your Task` — title, description, priority
  *   2. `## Runtime Location` — worktree path, derived PR URL
- *   3. `## Your Role in This Workflow` — current node, peers, outbound channels,
+ *   3. `## Relevant Scope Lessons` — accepted lessons from task scope
+ *   4. `## Your Role in This Workflow` — current node, peers, outbound channels,
  *      writable gates (omitted outside a workflow)
- *   4. `## Previous Work on This Goal` — bulleted summaries
- *   5. `## Project Context` — space.backgroundContext
- *   6. `## Standing Instructions` — space.instructions + workflow.instructions
+ *   5. `## Previous Work on This Goal` — bulleted summaries
+ *   6. `## Project Context` — space.backgroundContext
+ *   7. `## Standing Instructions` — space.instructions + workflow.instructions
  *
  * Node UUIDs are intentionally dropped — they are not useful to the LLM and add
  * noise. The previous "Workflow Context" + "Workflow Structure" sections are
@@ -250,6 +254,7 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		space,
 		workspacePath,
 		goal,
+		relevantScopeLessons,
 		previousTaskSummaries,
 		nodeId,
 		agentSlotName,
@@ -300,7 +305,19 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		);
 	}
 
-	// 4. Your Role in This Workflow — scoped to the current node when known.
+	// 4. Relevant scope lessons — accepted lessons from this task's evolution scope.
+	if (relevantScopeLessons && relevantScopeLessons.length > 0) {
+		sections.push('');
+		sections.push('## Relevant Scope Lessons');
+		sections.push('');
+		for (const lesson of relevantScopeLessons) {
+			const appliesTo = lesson.appliesTo.length > 0 ? ` [${lesson.appliesTo.join(', ')}]` : '';
+			sections.push(`- ${lesson.rule}${appliesTo}`);
+			if (lesson.why) sections.push(`  Why: ${lesson.why}`);
+		}
+	}
+
+	// 5. Your Role in This Workflow — scoped to the current node when known.
 	const roleLines = buildRoleSection(workflow, nodeId, agentSlotName);
 	if (roleLines.length > 0) {
 		sections.push('');

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -3,6 +3,7 @@ import type {
 	CreateEvolutionScopeParams,
 	CreateMetricSnapshotParams,
 	EvidenceRef,
+	EvolutionLesson,
 	EvolutionScope,
 	EvolutionScopeListParams,
 	MetricSnapshot,
@@ -63,6 +64,15 @@ export interface AddMetricSnapshotEvidenceParams {
 	capturedAt?: number;
 	summary?: string;
 	metadata?: Record<string, unknown>;
+}
+
+export interface ResolveScopeForTaskParams {
+	taskId: string;
+}
+
+export interface SelectTaskLessonsParams {
+	taskId: string;
+	limit?: number;
 }
 
 export interface ScopeTimeline {
@@ -127,6 +137,20 @@ export class EvolutionScopeService {
 		return (
 			this.deps.evolutionRepo.listScopes({ spaceId: goal.spaceId, spaceGoalId: goal.id })[0] ?? null
 		);
+	}
+
+	resolveScopeForTask(params: ResolveScopeForTaskParams): EvolutionScope | null {
+		const task = this.deps.taskRepo.getTask(params.taskId);
+		if (!task) throw new Error(`Task not found: ${params.taskId}`);
+		return this.findScopeForTask(task.evolutionScopeId ?? null, task.goalId ?? null);
+	}
+
+	selectActiveLessonsForTask(params: SelectTaskLessonsParams): EvolutionLesson[] {
+		const scope = this.resolveScopeForTask({ taskId: params.taskId });
+		if (!scope) return [];
+		const limit = Math.max(0, params.limit ?? 3);
+		if (limit === 0) return [];
+		return this.deps.evolutionRepo.listLessons(scope.id, 'active').slice(0, limit);
 	}
 
 	createEvidence(params: CreateEvidenceRefParams): EvidenceRef {
@@ -264,16 +288,24 @@ export class EvolutionScopeService {
 		return scope;
 	}
 
+	private findScopeForTask(
+		evolutionScopeId: string | null,
+		goalId: string | null
+	): EvolutionScope | null {
+		if (evolutionScopeId) return this.requireScope(evolutionScopeId);
+		if (!goalId) return null;
+		return this.resolveScopeForGoal({ spaceGoalId: goalId });
+	}
+
 	private requireScopeForTask(
 		taskId: string,
 		evolutionScopeId: string | null,
 		goalId: string | null
 	): EvolutionScope {
-		if (evolutionScopeId) return this.requireScope(evolutionScopeId);
+		const scope = this.findScopeForTask(evolutionScopeId, goalId);
+		if (scope) return scope;
 		if (!goalId) throw new Error(`Task is not linked to an EvolutionScope or SpaceGoal: ${taskId}`);
-		const scope = this.resolveScopeForGoal({ spaceGoalId: goalId });
-		if (!scope) throw new Error(`EvolutionScope not found for SpaceGoal: ${goalId}`);
-		return scope;
+		throw new Error(`EvolutionScope not found for SpaceGoal: ${goalId}`);
 	}
 
 	private requireScopeForWorkflowRun(workflowRunId: string): EvolutionScope {

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -292,7 +292,7 @@ export class EvolutionScopeService {
 		evolutionScopeId: string | null,
 		goalId: string | null
 	): EvolutionScope | null {
-		if (evolutionScopeId) return this.requireScope(evolutionScopeId);
+		if (evolutionScopeId) return this.deps.evolutionRepo.getScope(evolutionScopeId) ?? null;
 		if (!goalId) return null;
 		return this.resolveScopeForGoal({ spaceGoalId: goalId });
 	}
@@ -304,6 +304,7 @@ export class EvolutionScopeService {
 	): EvolutionScope {
 		const scope = this.findScopeForTask(evolutionScopeId, goalId);
 		if (scope) return scope;
+		if (evolutionScopeId) throw new Error(`EvolutionScope not found: ${evolutionScopeId}`);
 		if (!goalId) throw new Error(`Task is not linked to an EvolutionScope or SpaceGoal: ${taskId}`);
 		throw new Error(`EvolutionScope not found for SpaceGoal: ${goalId}`);
 	}

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -296,7 +296,11 @@ export class EvolutionScopeService {
 	): EvolutionScope | null {
 		if (evolutionScopeId) return this.deps.evolutionRepo.getScope(evolutionScopeId) ?? null;
 		if (!goalId) return null;
-		return this.resolveScopeForGoal({ spaceGoalId: goalId });
+		const goal = this.deps.goalRepo.getById(goalId);
+		if (!goal) return null;
+		return (
+			this.deps.evolutionRepo.listScopes({ spaceId: goal.spaceId, spaceGoalId: goal.id })[0] ?? null
+		);
 	}
 
 	private requireScopeForTask(

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -142,7 +142,9 @@ export class EvolutionScopeService {
 	resolveScopeForTask(params: ResolveScopeForTaskParams): EvolutionScope | null {
 		const task = this.deps.taskRepo.getTask(params.taskId);
 		if (!task) throw new Error(`Task not found: ${params.taskId}`);
-		return this.findScopeForTask(task.evolutionScopeId ?? null, task.goalId ?? null);
+		const scope = this.findScopeForTask(task.evolutionScopeId ?? null, task.goalId ?? null);
+		if (!scope || scope.spaceId !== task.spaceId) return null;
+		return scope;
 	}
 
 	selectActiveLessonsForTask(params: SelectTaskLessonsParams): EvolutionLesson[] {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -99,6 +99,7 @@ import { ChannelRouter } from './channel-router';
 import { AgentMessageRouter } from './agent-message-router';
 import type { ReplyRoutingRegistry } from './reply-routing-registry';
 import type { AgentMemoryRepository } from '../../../storage/repositories/agent-memory-repository';
+import type { EvolutionScopeService } from '../evolution-scope-service';
 import { createAgentMemoryMcpServer } from '../tools/agent-memory-tools';
 import { RUNTIME_ESCALATION_REASONS } from './escalation-reasons';
 import { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
@@ -281,6 +282,8 @@ export interface TaskAgentManagerConfig {
 	};
 	/** Goal service for terminal goal-task side effects. */
 	goalService?: import('../goals/goal-service').SpaceGoalService;
+	/** Evolution scope service for scoped lesson injection. */
+	evolutionScopeService?: EvolutionScopeService;
 }
 
 // ---------------------------------------------------------------------------
@@ -746,6 +749,12 @@ export class TaskAgentManager {
 				const relevantMemories = this.config.memoryRepo
 					? await this.config.memoryRepo.search(space.id, memoryQuery, 5)
 					: [];
+				const relevantScopeLessons = this.config.evolutionScopeService
+					? this.config.evolutionScopeService.selectActiveLessonsForTask({
+							taskId: task.id,
+							limit: 3,
+						})
+					: [];
 				const initialMessage = buildCustomAgentTaskMessage({
 					customAgent: customAgent!,
 					task,
@@ -755,6 +764,7 @@ export class TaskAgentManager {
 					sessionId: actualSessionId,
 					workspacePath,
 					goal: linkedGoal,
+					relevantScopeLessons,
 					slotOverrides,
 					nodeId: execution.workflowNodeId,
 					agentSlotName: execution.agentName,

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -248,7 +248,9 @@ export class EvolutionRepository {
 			values.push(status);
 		}
 		const rows = this.db
-			.prepare(`SELECT * FROM evolution_lessons ${where} ORDER BY updated_at DESC, id DESC`)
+			.prepare(
+				`SELECT * FROM evolution_lessons ${where} ORDER BY updated_at DESC, created_at DESC, id DESC`
+			)
 			.all(...values) as Record<string, unknown>[];
 		return rows.map(rowToLesson);
 	}

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/evolution-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/evolution-handlers.test.ts
@@ -76,6 +76,10 @@ describe('evolution RPC handlers', () => {
 					calls.push(['listMetricSnapshots', scopeId]);
 					return [{ id: 'snapshot-listed' }];
 				},
+				selectActiveLessonsForTask: (params: unknown) => {
+					calls.push(['selectActiveLessonsForTask', params]);
+					return [{ id: 'lesson-selected' }];
+				},
 			} as never
 		);
 
@@ -143,10 +147,14 @@ describe('evolution RPC handlers', () => {
 		expect(await handlers.get('evolution.metricSnapshot.list')?.({ scopeId: 'scope-1' })).toEqual({
 			snapshots: [{ id: 'snapshot-listed' }],
 		});
+		expect(
+			await handlers.get('evolution.task.lessons.select')?.({ taskId: 'task-1', limit: 3 })
+		).toEqual({ lessons: [{ id: 'lesson-selected' }] });
 
 		expect(calls).toContainEqual(['createScopeFromGoal', { spaceGoalId: 'goal-1' }]);
 		expect(calls).toContainEqual(['updateScope', { id: 'scope-1', params: { name: 'New' } }]);
 		expect(calls).toContainEqual(['listMetricSnapshots', 'scope-1']);
+		expect(calls).toContainEqual(['selectActiveLessonsForTask', { taskId: 'task-1', limit: 3 }]);
 	});
 
 	test('rejects non-object payloads', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test';
 import type {
+	EvolutionLesson,
 	Space,
 	SpaceAgent,
 	SpaceGoal,
@@ -88,6 +89,22 @@ function makeGoal(overrides?: Partial<SpaceGoal>): SpaceGoal {
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeLesson(overrides?: Partial<EvolutionLesson>): EvolutionLesson {
+	return {
+		id: 'lesson-1',
+		scopeId: 'scope-1',
+		status: 'active',
+		appliesTo: ['review'],
+		rule: 'Run focused review before broad refactor',
+		why: 'Focused reviews caught regressions faster',
+		evidenceEpisodeIds: ['episode-1'],
+		confidence: 0.8,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
 		...overrides,
 	};
 }
@@ -313,6 +330,28 @@ describe('buildCustomAgentTaskMessage', () => {
 		expect(message).toContain('**Metrics:** {"activated":10}');
 		expect(message).toContain('- Audit current flow');
 		expect(message).toContain('mark_complete goal_update');
+	});
+
+	it('renders active scope lessons in task message', () => {
+		const message = buildCustomAgentTaskMessage(
+			makeConfig({
+				relevantScopeLessons: [
+					makeLesson(),
+					makeLesson({
+						id: 'lesson-2',
+						appliesTo: [],
+						rule: 'Keep changes surgical',
+						why: 'Smaller diffs review faster',
+					}),
+				],
+			})
+		);
+
+		expect(message).toContain('## Relevant Scope Lessons');
+		expect(message).toContain('- Run focused review before broad refactor [review]');
+		expect(message).toContain('  Why: Focused reviews caught regressions faster');
+		expect(message).toContain('- Keep changes surgical');
+		expect(message).toContain('  Why: Smaller diffs review faster');
 	});
 
 	it('renders PR URL from gate data when present', () => {

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -441,6 +441,7 @@ describe('buildCustomAgentTaskMessage', () => {
 			})
 		);
 
+		expect(message).not.toContain('## Relevant Scope Lessons');
 		expect(message).not.toContain('## Previous Work on This Goal');
 		expect(message).not.toContain('## Project Context');
 		expect(message).not.toContain('## Standing Instructions');

--- a/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
@@ -149,6 +149,32 @@ describe('EvolutionScopeService', () => {
 		).toBe(true);
 	});
 
+	it('returns no active lessons for unscoped tasks', () => {
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Unscoped task',
+			description: 'No goal or explicit scope',
+		});
+
+		expect(service.resolveScopeForTask({ taskId: task.id })).toBeNull();
+		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toEqual([]);
+	});
+
+	it('returns no active lessons for tasks with stale evolutionScopeId', () => {
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Stale scoped task',
+			description: 'References missing scope',
+			evolutionScopeId: 'missing-scope',
+		});
+
+		expect(service.resolveScopeForTask({ taskId: task.id })).toBeNull();
+		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toEqual([]);
+		expect(() => service.attachTaskEvidence({ taskId: task.id })).toThrow(
+			'EvolutionScope not found: missing-scope'
+		);
+	});
+
 	it('attaches workflow-run evidence through explicit evolutionScopeId parent task', () => {
 		const scope = service.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
@@ -160,6 +160,21 @@ describe('EvolutionScopeService', () => {
 		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toEqual([]);
 	});
 
+	it('returns no active lessons for tasks with stale goalId', () => {
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Stale goal task',
+			description: 'References missing goal',
+			goalId: 'missing-goal',
+		});
+
+		expect(service.resolveScopeForTask({ taskId: task.id })).toBeNull();
+		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toEqual([]);
+		expect(() => service.attachTaskEvidence({ taskId: task.id })).toThrow(
+			'EvolutionScope not found for SpaceGoal: missing-goal'
+		);
+	});
+
 	it('returns no active lessons for tasks with stale evolutionScopeId', () => {
 		const task = taskRepo.createTask({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
@@ -121,6 +121,34 @@ describe('EvolutionScopeService', () => {
 		});
 	});
 
+	it('resolves task scope through linked goal and selects top 3 active lessons', () => {
+		const goal = goalRepo.create({ spaceId, title: 'Weekly check-in', type: 'recurring' });
+		const scope = service.createScopeFromGoal({ spaceGoalId: goal.id });
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Scheduled check-in task',
+			description: 'Review goal progress',
+			goalId: goal.id,
+		});
+		for (let index = 1; index <= 5; index++) {
+			const lesson = evolutionRepo.createLesson({
+				scopeId: scope.id,
+				status: index === 5 ? 'candidate' : 'active',
+				rule: `Lesson ${index}`,
+				why: `Why ${index}`,
+			});
+			evolutionRepo.updateLesson(lesson.id, { confidence: index / 10 });
+		}
+
+		expect(service.resolveScopeForTask({ taskId: task.id })?.id).toBe(scope.id);
+		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toHaveLength(3);
+		expect(
+			service
+				.selectActiveLessonsForTask({ taskId: task.id })
+				.every((lesson) => lesson.status === 'active')
+		).toBe(true);
+	});
+
 	it('attaches workflow-run evidence through explicit evolutionScopeId parent task', () => {
 		const scope = service.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-scope-service.test.ts
@@ -175,6 +175,38 @@ describe('EvolutionScopeService', () => {
 		);
 	});
 
+	it('returns no active lessons for tasks with cross-space evolutionScopeId', () => {
+		const otherSpaceId = spaceRepo.createSpace({
+			workspacePath: '/workspace/other-forge-service-test',
+			slug: 'other-forge-service-test',
+			name: 'Other Forge Service Test',
+		}).id;
+		const otherScope = service.createScope({
+			spaceId: otherSpaceId,
+			kind: 'custom',
+			name: 'Other scope',
+			objective: 'Own unrelated lessons',
+		});
+		evolutionRepo.createLesson({
+			scopeId: otherScope.id,
+			status: 'active',
+			rule: 'Unrelated lesson',
+			why: 'Different space',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Cross-space scoped task',
+			description: 'References another space scope',
+			evolutionScopeId: otherScope.id,
+		});
+
+		expect(service.resolveScopeForTask({ taskId: task.id })).toBeNull();
+		expect(service.selectActiveLessonsForTask({ taskId: task.id })).toEqual([]);
+		expect(() => service.attachTaskEvidence({ taskId: task.id })).toThrow(
+			'Task and scope must belong to the same space'
+		);
+	});
+
 	it('attaches workflow-run evidence through explicit evolutionScopeId parent task', () => {
 		const scope = service.createScope({
 			spaceId,

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -714,6 +714,15 @@ export interface EvolutionLessonListResponse {
 	lessons: EvolutionLesson[];
 }
 
+export interface EvolutionTaskLessonSelectRequest {
+	taskId: string;
+	limit?: number;
+}
+
+export interface EvolutionTaskLessonSelectResponse {
+	lessons: EvolutionLesson[];
+}
+
 export interface EvolutionTaskProposalCreateRequest {
 	params: CreateTaskProposalParams;
 }

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -29,7 +29,7 @@ import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 
-type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'episodes';
+type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'lessons' | 'episodes';
 
 type ReviewAction =
 	| { kind: 'episode'; id: string; status: EvolutionEpisode['status'] }
@@ -812,6 +812,95 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 	);
 }
 
+function ActiveLessonsTab({ scope }: { scope: EvolutionScope }) {
+	const { request } = useMessageHub();
+	const [lessons, setLessons] = useState<EvolutionLesson[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const requestVersion = useRef(0);
+
+	const loadLessons = useCallback(async () => {
+		const version = ++requestVersion.current;
+		setLoading(true);
+		setError(null);
+		try {
+			const response = await request<{ lessons: EvolutionLesson[] }>('evolution.lesson.list', {
+				scopeId: scope.id,
+				status: 'active',
+			});
+			if (requestVersion.current === version) setLessons(response.lessons ?? []);
+		} catch (err) {
+			if (requestVersion.current === version) {
+				setError(err instanceof Error ? err.message : 'Failed to load active lessons');
+			}
+		} finally {
+			if (requestVersion.current === version) setLoading(false);
+		}
+	}, [request, scope.id]);
+
+	useEffect(() => {
+		loadLessons().catch(() => undefined);
+	}, [loadLessons]);
+
+	const dismissLesson = async (lessonId: string) => {
+		try {
+			setError(null);
+			const response = await request<{ lesson: EvolutionLesson | null }>(
+				'evolution.lesson.update',
+				{
+					id: lessonId,
+					params: { status: 'dismissed' },
+				}
+			);
+			if (response.lesson) setLessons((current) => current.filter((item) => item.id !== lessonId));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to dismiss lesson');
+		}
+	};
+
+	return (
+		<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+			<div class="mb-3">
+				<h3 class="text-sm font-medium text-gray-100">Active lessons</h3>
+				<p class="mt-1 text-xs text-gray-500">
+					Top active lessons from this scope are injected into future scoped task-agent messages.
+				</p>
+			</div>
+			{error && (
+				<div class="mb-3 rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-400">
+					{error}
+				</div>
+			)}
+			{loading ? (
+				<p class="text-sm text-gray-500">Loading active lessons…</p>
+			) : lessons.length === 0 ? (
+				<p class="text-sm text-gray-500">No active lessons yet.</p>
+			) : (
+				<div class="space-y-3">
+					{lessons.map((lesson) => (
+						<div key={lesson.id} class="rounded-lg border border-white/10 bg-dark-900/60 p-3">
+							<div class="flex items-start justify-between gap-3">
+								<div>
+									<p class="text-sm text-gray-100">{lesson.rule}</p>
+									<p class="mt-1 text-xs text-gray-500">{lesson.why}</p>
+									{lesson.appliesTo.length > 0 && (
+										<p class="mt-2 text-xs text-cyan-300">
+											Applies to: {lesson.appliesTo.join(', ')}
+										</p>
+									)}
+								</div>
+								<Button size="sm" variant="secondary" onClick={() => dismissLesson(lesson.id)}>
+									Dismiss
+								</Button>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}
+
 function FindingCard({ finding }: { finding: EvolutionFinding }) {
 	return (
 		<div class="rounded-md border border-white/10 bg-black/20 p-3">
@@ -1066,7 +1155,7 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 				<p class="mt-1 text-sm text-gray-400">{scope.objective}</p>
 			</div>
 			<div class="flex gap-2 border-b border-white/10 px-5 py-3">
-				{(['overview', 'evidence', 'metrics', 'episodes'] as const).map((item) => (
+				{(['overview', 'evidence', 'metrics', 'lessons', 'episodes'] as const).map((item) => (
 					<button
 						key={item}
 						type="button"
@@ -1103,6 +1192,7 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 				)}
 				{tab === 'evidence' && <EvidenceTab scope={scope} />}
 				{tab === 'metrics' && <MetricsTab scope={scope} />}
+				{tab === 'lessons' && <ActiveLessonsTab scope={scope} />}
 				{tab === 'episodes' && <EpisodesTab scope={scope} />}
 			</div>
 		</div>

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -200,6 +200,10 @@ function setupRequests(scope = makeScope()) {
 		if (method === 'evolution.review.get') {
 			return { episodes: [episode], lessons: [lesson], proposals: [proposal] };
 		}
+		if (method === 'evolution.lesson.list') {
+			expect(data).toEqual({ scopeId: scope.id, status: 'active' });
+			return { lessons: [makeLesson({ status: 'active' })] };
+		}
 		if (method === 'evolution.episode.createFromEvidence') {
 			expect(data).toEqual({ scopeId: scope.id, evidenceIds: ['evidence-1'] });
 			return {
@@ -213,8 +217,10 @@ function setupRequests(scope = makeScope()) {
 			return { episode: makeEpisode({ status: 'accepted' }) };
 		}
 		if (method === 'evolution.lesson.update') {
-			expect(data).toEqual({ id: 'lesson-1', params: { status: 'active' } });
-			return { lesson: makeLesson({ status: 'active' }) };
+			const payload = data as { id: string; params: { status: EvolutionLesson['status'] } };
+			expect(payload.id).toBe('lesson-1');
+			expect(['active', 'dismissed']).toContain(payload.params.status);
+			return { lesson: makeLesson({ status: payload.params.status }) };
 		}
 		if (method === 'evolution.taskProposal.update') {
 			expect(data).toEqual({ id: 'proposal-1', params: { status: 'accepted' } });
@@ -367,6 +373,23 @@ describe('SpaceForge', () => {
 			expect(mockRequest).toHaveBeenCalledWith('evolution.lesson.update', {
 				id: 'lesson-1',
 				params: { status: 'active' },
+			})
+		);
+	});
+
+	it('manages active lessons from scope detail', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'lessons' }));
+
+		expect(await screen.findByText('Use checklist before PR')).toBeTruthy();
+		fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.lesson.update', {
+				id: 'lesson-1',
+				params: { status: 'dismissed' },
 			})
 		);
 	});


### PR DESCRIPTION
## Summary
- Accept/dismiss Forge lessons and manage active scope lessons in the Forge UI.
- Resolve task scopes from explicit scope IDs or goal-linked scopes.
- Inject up to three active scope lessons into future task-agent messages.

## Tests
- cd packages/daemon && bun test tests/unit/5-space/evolution-scope-service.test.ts tests/unit/5-space/agent/custom-agent.test.ts tests/unit/2-handlers/rpc-handlers/evolution-handlers.test.ts
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx
- bun run check