### PR TITLE
Add Forge proposal task creation

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/evolution-handlers.ts
@@ -29,10 +29,14 @@ import type {
 	EvolutionScopeUpdateResponse,
 	EvolutionTaskLessonSelectRequest,
 	EvolutionTaskLessonSelectResponse,
+	EvolutionTaskProposalCreateTaskRequest,
+	EvolutionTaskProposalCreateTaskResponse,
 	EvolutionTaskProposalListRequest,
 	EvolutionTaskProposalListResponse,
 	EvolutionTaskProposalUpdateRequest,
 	EvolutionTaskProposalUpdateResponse,
+	EvolutionRollupApplyRequest,
+	EvolutionRollupApplyResponse,
 	MessageHub,
 } from '@neokai/shared';
 import type { EvolutionEpisodeService } from '../space/evolution-episode-service';
@@ -264,6 +268,27 @@ export function setupEvolutionHandlers(
 			const id = readRequiredString(payload, 'id');
 			const params = readRecord(payload.params) as EvolutionTaskProposalUpdateRequest['params'];
 			return { proposal: episodeService.updateTaskProposal(id, params) };
+		}
+	);
+
+	messageHub.onRequest<
+		EvolutionTaskProposalCreateTaskRequest,
+		EvolutionTaskProposalCreateTaskResponse
+	>('evolution.taskProposal.createTask', async (data) => {
+		const payload = readRecord(data);
+		const id = readRequiredString(payload, 'id');
+		const params = payload.params === undefined ? {} : readRecord(payload.params);
+		return episodeService.createTaskFromProposal(
+			id,
+			params as EvolutionTaskProposalCreateTaskRequest['params']
+		);
+	});
+
+	messageHub.onRequest<EvolutionRollupApplyRequest, EvolutionRollupApplyResponse>(
+		'evolution.rollup.apply',
+		async (data) => {
+			const payload = readRecord(data) as unknown as EvolutionRollupApplyRequest;
+			return episodeService.applyRollupGoalUpdate(payload);
 		}
 	);
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -544,6 +544,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		artifactRepo,
+		goalService: spaceGoalService,
 	});
 	setupEvolutionHandlers(deps.messageHub, evolutionScopeService, evolutionEpisodeService);
 

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -13,6 +13,7 @@ import type {
 	EvolutionScope,
 	SpaceTaskPriority,
 	MetricSnapshot,
+	SpaceGoal,
 	SpaceTask,
 	TaskProposal,
 	TaskProposalStatus,
@@ -27,6 +28,7 @@ import type {
 	WorkflowRunArtifactRecord,
 	WorkflowRunArtifactRepository,
 } from '../../storage/repositories/workflow-run-artifact-repository';
+import type { SpaceGoalService } from './goals/goal-service';
 import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
 import { Logger } from '../logger';
 import { getProviderService, mergeProviderEnvVars } from '../provider-service';
@@ -66,11 +68,39 @@ export interface EpisodeReviewBundle {
 	proposals: TaskProposal[];
 }
 
+export interface CreateTaskFromProposalParams {
+	title?: string;
+	description?: string;
+	reason?: string;
+	priority?: SpaceTaskPriority;
+}
+
+export interface CreateTaskFromProposalResult {
+	proposal: TaskProposal;
+	task: SpaceTask;
+}
+
+export interface ApplyRollupGoalUpdateParams {
+	episodeId: string;
+	goalUpdate: {
+		summary?: string;
+		progress?: number;
+		nextSteps?: string[];
+		metrics?: Record<string, string | number | boolean | null>;
+	};
+}
+
+export interface ApplyRollupGoalUpdateResult {
+	episode: EvolutionEpisode;
+	goal: SpaceGoal;
+}
+
 export interface EvolutionEpisodeServiceDeps {
 	evolutionRepo: EvolutionRepository;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo: WorkflowRunArtifactRepository;
+	goalService?: Pick<SpaceGoalService, 'updateGoal'>;
 	judgeEpisode?: (input: EpisodeJudgePromptInput) => Promise<EpisodeJudgeOutput>;
 }
 
@@ -206,6 +236,59 @@ export class EvolutionEpisodeService {
 
 	updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {
 		return this.deps.evolutionRepo.updateTaskProposal(id, params);
+	}
+
+	createTaskFromProposal(
+		id: string,
+		params: CreateTaskFromProposalParams = {}
+	): CreateTaskFromProposalResult {
+		const existing = this.deps.evolutionRepo.getTaskProposal(id);
+		if (!existing) throw new Error(`TaskProposal not found: ${id}`);
+		if (existing.status === 'created' && existing.createdTaskId) {
+			const existingTask = this.deps.taskRepo.getTask(existing.createdTaskId);
+			if (existingTask) return { proposal: existing, task: existingTask };
+		}
+		if (existing.status === 'dismissed') throw new Error('Dismissed proposal cannot create a task');
+
+		const scope = this.requireScope(existing.scopeId);
+		const title = params.title?.trim() || existing.title;
+		const description = params.description?.trim() || existing.description;
+		const reason = params.reason?.trim() || existing.reason;
+		const priority = params.priority ?? existing.priority;
+		if (!title.trim()) throw new Error('title is required');
+		const task = this.deps.taskRepo.createTask({
+			spaceId: scope.spaceId,
+			title,
+			description: buildProposalTaskDescription(description, reason, existing.evidenceEpisodeIds),
+			priority,
+			goalId: scope.spaceGoalId,
+			evolutionScopeId: scope.id,
+		});
+		const proposal = this.deps.evolutionRepo.updateTaskProposal(existing.id, {
+			title,
+			description,
+			reason,
+			priority,
+			status: 'created',
+			createdTaskId: task.id,
+		});
+		if (!proposal) throw new Error(`TaskProposal not found: ${id}`);
+		return { proposal, task };
+	}
+
+	applyRollupGoalUpdate(params: ApplyRollupGoalUpdateParams): ApplyRollupGoalUpdateResult {
+		if (!this.deps.goalService) throw new Error('SpaceGoalService is required');
+		const episode = this.deps.evolutionRepo.getEpisode(params.episodeId);
+		if (!episode) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
+		const scope = this.requireScope(episode.scopeId);
+		if (!scope.spaceGoalId) throw new Error('Episode scope is not linked to a recurring goal');
+		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, { status: 'accepted' });
+		if (!accepted) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
+		const goal = this.deps.goalService.updateGoal(scope.spaceGoalId, params.goalUpdate, {
+			source: 'rpc',
+			note: `Forge rollup accepted: ${accepted.title}`,
+		});
+		return { episode: accepted, goal };
 	}
 
 	private collectTasks(scope: EvolutionScope, evidence: EvidenceRef[]): EpisodeTaskContext[] {
@@ -474,6 +557,19 @@ function deriveTimeWindow(evidence: EvidenceRef[]): CreateEvolutionEpisodeParams
 	if (evidence.length === 0) return null;
 	const times = evidence.map((item) => item.createdAt);
 	return { start: Math.min(...times), end: Math.max(...times) };
+}
+
+function buildProposalTaskDescription(
+	description: string,
+	reason: string,
+	evidenceEpisodeIds: string[]
+): string {
+	const parts = [description.trim()];
+	if (reason.trim()) parts.push(`Proposal reason:\n${reason.trim()}`);
+	if (evidenceEpisodeIds.length > 0) {
+		parts.push(`Forge evidence episodes:\n${evidenceEpisodeIds.map((id) => `- ${id}`).join('\n')}`);
+	}
+	return parts.filter(Boolean).join('\n\n');
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -280,6 +280,8 @@ export class EvolutionEpisodeService {
 		if (!this.deps.goalService) throw new Error('SpaceGoalService is required');
 		const episode = this.deps.evolutionRepo.getEpisode(params.episodeId);
 		if (!episode) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
+		if (episode.status === 'accepted') throw new Error('Episode already accepted');
+		if (episode.status === 'dismissed') throw new Error('Dismissed episode cannot accept rollup');
 		const scope = this.requireScope(episode.scopeId);
 		if (!scope.spaceGoalId) throw new Error('Episode scope is not linked to a recurring goal');
 		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, { status: 'accepted' });

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -234,6 +234,16 @@ describe('EvolutionEpisodeService', () => {
 		expect(result.task.description).toContain(episode.id);
 	});
 
+	function createGoalService(): SpaceGoalService {
+		return new SpaceGoalService({
+			goalRepo,
+			goalEventRepo: new SpaceGoalEventRepository(db as never),
+			taskRepo,
+			spaceRepo,
+			scheduleService: {} as never,
+		});
+	}
+
 	it('applies accepted rollup fields to the linked recurring goal', () => {
 		const goal = goalRepo.create({
 			spaceId,
@@ -255,19 +265,12 @@ describe('EvolutionEpisodeService', () => {
 			title: 'Weekly rollup',
 			outcomeSummary: 'Progress improved',
 		});
-		const goalService = new SpaceGoalService({
-			goalRepo,
-			goalEventRepo: new SpaceGoalEventRepository(db as never),
-			taskRepo,
-			spaceRepo,
-			scheduleService: {} as never,
-		});
 		const service = new EvolutionEpisodeService({
 			evolutionRepo,
 			taskRepo,
 			workflowRunRepo,
 			artifactRepo,
-			goalService,
+			goalService: createGoalService(),
 		});
 
 		const result = service.applyRollupGoalUpdate({
@@ -287,6 +290,106 @@ describe('EvolutionEpisodeService', () => {
 			nextSteps: ['Create follow-up task'],
 			metrics: { latency: 3 },
 		});
+	});
+
+	it('rejects invalid proposal-to-task requests', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Review scope',
+			objective: 'Track review health',
+		});
+		const dismissed = evolutionRepo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Dismissed task',
+			description: 'Do not create',
+			reason: 'Rejected',
+			status: 'dismissed',
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		expect(() => service.createTaskFromProposal(dismissed.id)).toThrow(
+			'Dismissed proposal cannot create a task'
+		);
+		expect(() => service.createTaskFromProposal('missing-proposal')).toThrow(
+			'TaskProposal not found: missing-proposal'
+		);
+	});
+
+	it('rejects invalid rollup writeback requests', () => {
+		const goal = goalRepo.create({ spaceId, title: 'Recurring review goal', type: 'recurring' });
+		const linkedScope = evolutionRepo.createScope({
+			spaceId,
+			spaceGoalId: goal.id,
+			kind: 'mission',
+			name: 'Linked scope',
+			objective: 'Track review health',
+		});
+		const unlinkedScope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Unlinked scope',
+			objective: 'Track review health',
+		});
+		const draftEpisode = evolutionRepo.createEpisode({
+			scopeId: linkedScope.id,
+			title: 'Draft rollup',
+		});
+		const unlinkedEpisode = evolutionRepo.createEpisode({
+			scopeId: unlinkedScope.id,
+			title: 'Unlinked rollup',
+		});
+		const acceptedEpisode = evolutionRepo.createEpisode({
+			scopeId: linkedScope.id,
+			title: 'Accepted rollup',
+			status: 'accepted',
+		});
+		const dismissedEpisode = evolutionRepo.createEpisode({
+			scopeId: linkedScope.id,
+			title: 'Dismissed rollup',
+			status: 'dismissed',
+		});
+		const serviceWithoutGoalService = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+			goalService: createGoalService(),
+		});
+		const request = { episodeId: draftEpisode.id, goalUpdate: { summary: 'Rollup' } };
+
+		expect(() => serviceWithoutGoalService.applyRollupGoalUpdate(request)).toThrow(
+			'SpaceGoalService is required'
+		);
+		expect(() =>
+			service.applyRollupGoalUpdate({
+				episodeId: unlinkedEpisode.id,
+				goalUpdate: { summary: 'Rollup' },
+			})
+		).toThrow('Episode scope is not linked to a recurring goal');
+		expect(() =>
+			service.applyRollupGoalUpdate({
+				episodeId: acceptedEpisode.id,
+				goalUpdate: { summary: 'Rollup' },
+			})
+		).toThrow('Episode already accepted');
+		expect(() =>
+			service.applyRollupGoalUpdate({
+				episodeId: dismissedEpisode.id,
+				goalUpdate: { summary: 'Rollup' },
+			})
+		).toThrow('Dismissed episode cannot accept rollup');
 	});
 
 	it('persists draft episode, candidate lessons, and proposals from judge output', async () => {

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -7,11 +7,14 @@ import {
 } from '../../../src/lib/space/evolution-episode-service';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
 import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
+import { SpaceGoalEventRepository } from '../../../src/storage/repositories/space-goal-event-repository';
+import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
 import { WorkflowRunArtifactRepository } from '../../../src/storage/repositories/workflow-run-artifact-repository';
 import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceGoalService } from '../../../src/lib/space/goals/goal-service';
 import { createSpaceTables } from '../helpers/space-test-db';
 
 describe('EvolutionEpisodeService', () => {
@@ -21,14 +24,17 @@ describe('EvolutionEpisodeService', () => {
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let artifactRepo: WorkflowRunArtifactRepository;
 	let workflowRepo: SpaceWorkflowRepository;
+	let goalRepo: SpaceGoalRepository;
+	let spaceRepo: SpaceRepository;
 	let spaceId: string;
 
 	beforeEach(() => {
 		db = new Database(':memory:');
 		createSpaceTables(db);
-		const spaceRepo = new SpaceRepository(db as never);
+		spaceRepo = new SpaceRepository(db as never);
 		evolutionRepo = new EvolutionRepository(db as never);
 		taskRepo = new SpaceTaskRepository(db as never);
+		goalRepo = new SpaceGoalRepository(db as never);
 		workflowRunRepo = new SpaceWorkflowRunRepository(
 			db as never,
 			new GateOpenStateRepository(db as never)
@@ -175,6 +181,112 @@ describe('EvolutionEpisodeService', () => {
 				})
 			)
 		).toThrow('finding.domain must be one of');
+	});
+
+	it('creates a scoped SpaceTask from a proposal and records evidence context', async () => {
+		const goal = goalRepo.create({
+			spaceId,
+			title: 'Improve review loop',
+			type: 'recurring',
+		});
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			spaceGoalId: goal.id,
+			kind: 'mission',
+			name: 'Review scope',
+			objective: 'Track review health',
+		});
+		const episode = evolutionRepo.createEpisode({
+			scopeId: scope.id,
+			title: 'Manual rollup',
+			outcomeSummary: 'Review friction found',
+		});
+		const proposal = evolutionRepo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Improve review UI',
+			description: 'Make actions clearer',
+			reason: 'Users miss next steps',
+			priority: 'high',
+			evidenceEpisodeIds: [episode.id],
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		const result = service.createTaskFromProposal(proposal.id);
+
+		expect(result.proposal).toMatchObject({
+			status: 'created',
+			createdTaskId: result.task.id,
+		});
+		expect(result.task).toMatchObject({
+			spaceId,
+			goalId: goal.id,
+			evolutionScopeId: scope.id,
+			title: 'Improve review UI',
+			priority: 'high',
+		});
+		expect(result.task.description).toContain('Make actions clearer');
+		expect(result.task.description).toContain('Proposal reason:\nUsers miss next steps');
+		expect(result.task.description).toContain(episode.id);
+	});
+
+	it('applies accepted rollup fields to the linked recurring goal', () => {
+		const goal = goalRepo.create({
+			spaceId,
+			title: 'Recurring review goal',
+			type: 'recurring',
+			summary: 'Old summary',
+			progress: 20,
+			nextSteps: ['Old step'],
+		});
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			spaceGoalId: goal.id,
+			kind: 'mission',
+			name: 'Review scope',
+			objective: 'Track review health',
+		});
+		const episode = evolutionRepo.createEpisode({
+			scopeId: scope.id,
+			title: 'Weekly rollup',
+			outcomeSummary: 'Progress improved',
+		});
+		const goalService = new SpaceGoalService({
+			goalRepo,
+			goalEventRepo: new SpaceGoalEventRepository(db as never),
+			taskRepo,
+			spaceRepo,
+			scheduleService: {} as never,
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+			goalService,
+		});
+
+		const result = service.applyRollupGoalUpdate({
+			episodeId: episode.id,
+			goalUpdate: {
+				summary: 'New rollup summary',
+				progress: 75,
+				nextSteps: ['Create follow-up task'],
+				metrics: { latency: 3 },
+			},
+		});
+
+		expect(result.episode.status).toBe('accepted');
+		expect(result.goal).toMatchObject({
+			summary: 'New rollup summary',
+			progress: 75,
+			nextSteps: ['Create follow-up task'],
+			metrics: { latency: 3 },
+		});
 	});
 
 	it('persists draft episode, candidate lessons, and proposals from judge output', async () => {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -51,6 +51,7 @@ import type {
 	UpdateEvolutionScopeParams,
 	UpdateTaskProposalParams,
 } from './types/evolution.ts';
+import type { SpaceGoal, SpaceTask, UpdateSpaceGoalParams } from './types/space.ts';
 
 // Request types
 export interface CreateSessionRequest {
@@ -747,6 +748,26 @@ export interface EvolutionTaskProposalListRequest {
 
 export interface EvolutionTaskProposalListResponse {
 	proposals: TaskProposal[];
+}
+
+export interface EvolutionTaskProposalCreateTaskRequest {
+	id: string;
+	params?: Partial<Pick<TaskProposal, 'title' | 'description' | 'reason' | 'priority'>>;
+}
+
+export interface EvolutionTaskProposalCreateTaskResponse {
+	proposal: TaskProposal;
+	task: SpaceTask;
+}
+
+export interface EvolutionRollupApplyRequest {
+	episodeId: string;
+	goalUpdate: Pick<UpdateSpaceGoalParams, 'summary' | 'progress' | 'nextSteps' | 'metrics'>;
+}
+
+export interface EvolutionRollupApplyResponse {
+	episode: EvolutionEpisode;
+	goal: SpaceGoal;
 }
 
 export interface EvolutionMetricSnapshotCreateRequest {

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -820,7 +820,7 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 						</div>
 					</section>
 
-					{goal && latestEpisode.status !== 'dismissed' && (
+					{goal && latestEpisode.status === 'draft' && (
 						<section class="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
 							<p class="text-sm font-medium text-blue-100">Manual rollup writeback</p>
 							<p class="mt-1 text-xs text-blue-200/70">

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -5,6 +5,8 @@ import type {
 	EvolutionFinding,
 	EvolutionFindingDomain,
 	EvolutionLesson,
+	EvolutionRollupApplyResponse,
+	EvolutionTaskProposalCreateTaskResponse,
 	EvolutionScope,
 	EvolutionScopeCreateResponse,
 	EvolutionScopeKind,
@@ -65,6 +67,19 @@ interface SnapshotValueDraft {
 	value: string;
 }
 
+interface ProposalEditDraft {
+	title: string;
+	description: string;
+	reason: string;
+	priority: TaskProposal['priority'];
+}
+
+interface RollupDraft {
+	summary: string;
+	progress: string;
+	nextSteps: string;
+}
+
 function formatDate(value: number): string {
 	return new Date(value).toLocaleString();
 }
@@ -92,6 +107,22 @@ function buildMetricDefinitions(drafts: MetricDefinitionDraft[]): MetricDefiniti
 			targetValue: draft.targetValue.trim() ? parseMetricValue(draft.targetValue) : undefined,
 		}))
 		.filter((metric) => metric.key && metric.label);
+}
+
+function createProposalDraft(proposal: TaskProposal): ProposalEditDraft {
+	return {
+		title: proposal.title,
+		description: proposal.description,
+		reason: proposal.reason,
+		priority: proposal.priority,
+	};
+}
+
+function nextStepsFromText(value: string): string[] {
+	return value
+		.split('\n')
+		.map((step) => step.trim())
+		.filter(Boolean);
 }
 
 function getGoal(scope: EvolutionScope | null, goals: SpaceGoal[]): SpaceGoal | null {
@@ -479,7 +510,7 @@ function EvidenceTab({ scope }: { scope: EvolutionScope }) {
 	);
 }
 
-function EpisodesTab({ scope }: { scope: EvolutionScope }) {
+function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal | null }) {
 	const { request } = useMessageHub();
 	const [episodes, setEpisodes] = useState<EvolutionEpisode[]>([]);
 	const [lessons, setLessons] = useState<EvolutionLesson[]>([]);
@@ -489,6 +520,13 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 	const [loading, setLoading] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [editingProposalId, setEditingProposalId] = useState<string | null>(null);
+	const [proposalDraft, setProposalDraft] = useState<ProposalEditDraft | null>(null);
+	const [rollupDraft, setRollupDraft] = useState<RollupDraft>({
+		summary: goal?.summary ?? '',
+		progress: String(goal?.progress ?? 0),
+		nextSteps: goal?.nextSteps.join('\n') ?? '',
+	});
 	const requestVersion = useRef(0);
 
 	const loadReview = useCallback(async () => {
@@ -523,6 +561,14 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 		setSelectedEvidenceIds([]);
 		loadReview().catch(() => undefined);
 	}, [loadReview]);
+
+	useEffect(() => {
+		setRollupDraft({
+			summary: goal?.summary ?? '',
+			progress: String(goal?.progress ?? 0),
+			nextSteps: goal?.nextSteps.join('\n') ?? '',
+		});
+	}, [goal]);
 
 	// MVP review focuses on the newest draft; deeper episode history/selection can layer on later.
 	const latestEpisode = episodes[0] ?? null;
@@ -618,6 +664,71 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 		}
 	};
 
+	const createTaskFromProposal = async (proposal: TaskProposal, draft?: ProposalEditDraft) => {
+		try {
+			setSubmitting(true);
+			setError(null);
+			const response = await request<EvolutionTaskProposalCreateTaskResponse>(
+				'evolution.taskProposal.createTask',
+				{
+					id: proposal.id,
+					params: draft
+						? {
+								title: draft.title,
+								description: draft.description,
+								reason: draft.reason,
+								priority: draft.priority,
+							}
+						: undefined,
+				}
+			);
+			setProposals((current) =>
+				current.map((item) => (item.id === response.proposal.id ? response.proposal : item))
+			);
+			setEditingProposalId(null);
+			setProposalDraft(null);
+			toast.success(`Task #${response.task.taskNumber} created`);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to create task from proposal');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const beginEditProposal = (proposal: TaskProposal) => {
+		setEditingProposalId(proposal.id);
+		setProposalDraft(createProposalDraft(proposal));
+	};
+
+	const applyRollup = async () => {
+		if (!latestEpisode || !goal) return;
+		const progress = Number(rollupDraft.progress);
+		if (!Number.isFinite(progress)) {
+			setError('Progress must be a number');
+			return;
+		}
+		try {
+			setSubmitting(true);
+			setError(null);
+			const response = await request<EvolutionRollupApplyResponse>('evolution.rollup.apply', {
+				episodeId: latestEpisode.id,
+				goalUpdate: {
+					summary: rollupDraft.summary.trim(),
+					progress,
+					nextSteps: nextStepsFromText(rollupDraft.nextSteps),
+				},
+			});
+			setEpisodes((current) =>
+				current.map((item) => (item.id === response.episode.id ? response.episode : item))
+			);
+			toast.success(`Rollup applied to "${response.goal.title}"`);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to apply rollup');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
 	return (
 		<div class="space-y-4">
 			<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
@@ -709,6 +820,60 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 						</div>
 					</section>
 
+					{goal && latestEpisode.status !== 'dismissed' && (
+						<section class="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
+							<p class="text-sm font-medium text-blue-100">Manual rollup writeback</p>
+							<p class="mt-1 text-xs text-blue-200/70">
+								Apply accepted episode state to linked recurring goal.
+							</p>
+							<div class="mt-3 grid gap-3 md:grid-cols-[1fr_110px]">
+								<textarea
+									aria-label="Rollup summary"
+									value={rollupDraft.summary}
+									onInput={(event) =>
+										setRollupDraft((current) => ({
+											...current,
+											summary: (event.target as HTMLTextAreaElement).value,
+										}))
+									}
+									placeholder="Goal summary after this rollup"
+									rows={3}
+									class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:border-blue-500 focus:outline-none"
+								/>
+								<input
+									aria-label="Rollup progress"
+									value={rollupDraft.progress}
+									onInput={(event) =>
+										setRollupDraft((current) => ({
+											...current,
+											progress: (event.target as HTMLInputElement).value,
+										}))
+									}
+									placeholder="0-100"
+									class="rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:border-blue-500 focus:outline-none"
+								/>
+							</div>
+							<textarea
+								aria-label="Rollup next steps"
+								value={rollupDraft.nextSteps}
+								onInput={(event) =>
+									setRollupDraft((current) => ({
+										...current,
+										nextSteps: (event.target as HTMLTextAreaElement).value,
+									}))
+								}
+								placeholder="One next step per line"
+								rows={2}
+								class="mt-3 w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:border-blue-500 focus:outline-none"
+							/>
+							<div class="mt-3 flex justify-end">
+								<Button size="sm" onClick={applyRollup} disabled={submitting}>
+									Apply rollup
+								</Button>
+							</div>
+						</section>
+					)}
+
 					<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
 						<h3 class="mb-3 text-sm font-medium text-gray-100">Findings by domain</h3>
 						<div class="space-y-3">
@@ -773,37 +938,136 @@ function EpisodesTab({ scope }: { scope: EvolutionScope }) {
 							title="Next action proposals"
 							empty="No proposed actions."
 							items={proposedTasks}
-							render={(proposal) => (
-								<div key={proposal.id} class="rounded-lg border border-white/10 bg-dark-900/60 p-3">
-									<div class="flex items-start justify-between gap-2">
-										<p class="text-sm font-medium text-gray-100">{proposal.title}</p>
-										<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-400">
-											{proposal.priority}
-										</span>
+							render={(proposal) => {
+								const editing = editingProposalId === proposal.id && proposalDraft;
+								return (
+									<div
+										key={proposal.id}
+										class="rounded-lg border border-white/10 bg-dark-900/60 p-3"
+									>
+										{editing ? (
+											<div class="space-y-2">
+												<input
+													aria-label="Proposal title"
+													value={proposalDraft.title}
+													onInput={(event) =>
+														setProposalDraft((current) =>
+															current
+																? { ...current, title: (event.target as HTMLInputElement).value }
+																: current
+														)
+													}
+													class="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+												/>
+												<textarea
+													aria-label="Proposal description"
+													value={proposalDraft.description}
+													onInput={(event) =>
+														setProposalDraft((current) =>
+															current
+																? {
+																		...current,
+																		description: (event.target as HTMLTextAreaElement).value,
+																	}
+																: current
+														)
+													}
+													rows={2}
+													class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+												/>
+												<textarea
+													aria-label="Proposal reason"
+													value={proposalDraft.reason}
+													onInput={(event) =>
+														setProposalDraft((current) =>
+															current
+																? {
+																		...current,
+																		reason: (event.target as HTMLTextAreaElement).value,
+																	}
+																: current
+														)
+													}
+													rows={2}
+													class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+												/>
+												<select
+													aria-label="Proposal priority"
+													value={proposalDraft.priority}
+													onChange={(event) =>
+														setProposalDraft((current) =>
+															current
+																? {
+																		...current,
+																		priority: (event.target as HTMLSelectElement)
+																			.value as TaskProposal['priority'],
+																	}
+																: current
+														)
+													}
+													class="rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+												>
+													{(['low', 'normal', 'high', 'urgent'] as const).map((priority) => (
+														<option key={priority} value={priority}>
+															{priority}
+														</option>
+													))}
+												</select>
+											</div>
+										) : (
+											<>
+												<div class="flex items-start justify-between gap-2">
+													<p class="text-sm font-medium text-gray-100">{proposal.title}</p>
+													<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-gray-400">
+														{proposal.priority}
+													</span>
+												</div>
+												<p class="mt-1 text-xs text-gray-400">{proposal.description}</p>
+												<p class="mt-2 text-xs text-gray-500">Reason: {proposal.reason}</p>
+											</>
+										)}
+										<div class="mt-3 flex flex-wrap gap-2">
+											<Button
+												size="sm"
+												onClick={() => createTaskFromProposal(proposal)}
+												disabled={submitting}
+											>
+												Create Task
+											</Button>
+											{editing ? (
+												<Button
+													size="sm"
+													onClick={() => createTaskFromProposal(proposal, proposalDraft)}
+													disabled={submitting || !proposalDraft.title.trim()}
+												>
+													Save & Create
+												</Button>
+											) : (
+												<Button
+													size="sm"
+													variant="secondary"
+													onClick={() => beginEditProposal(proposal)}
+												>
+													Edit & Create
+												</Button>
+											)}
+											<Button
+												size="sm"
+												variant="secondary"
+												onClick={() =>
+													updateReviewItem({
+														kind: 'proposal',
+														id: proposal.id,
+														status: 'dismissed',
+													})
+												}
+											>
+												Dismiss
+											</Button>
+										</div>
 									</div>
-									<p class="mt-1 text-xs text-gray-400">{proposal.description}</p>
-									<p class="mt-2 text-xs text-gray-500">Reason: {proposal.reason}</p>
-									<div class="mt-3 flex gap-2">
-										<Button
-											size="sm"
-											onClick={() =>
-												updateReviewItem({ kind: 'proposal', id: proposal.id, status: 'accepted' })
-											}
-										>
-											Accept
-										</Button>
-										<Button
-											size="sm"
-											variant="secondary"
-											onClick={() =>
-												updateReviewItem({ kind: 'proposal', id: proposal.id, status: 'dismissed' })
-											}
-										>
-											Dismiss
-										</Button>
-									</div>
-								</div>
-							)}
+								);
+							}}
 						/>
 					</div>
 				</div>
@@ -1193,7 +1457,7 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 				{tab === 'evidence' && <EvidenceTab scope={scope} />}
 				{tab === 'metrics' && <MetricsTab scope={scope} />}
 				{tab === 'lessons' && <ActiveLessonsTab scope={scope} />}
-				{tab === 'episodes' && <EpisodesTab scope={scope} />}
+				{tab === 'episodes' && <EpisodesTab scope={scope} goal={goal} />}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -223,8 +223,28 @@ function setupRequests(scope = makeScope()) {
 			return { lesson: makeLesson({ status: payload.params.status }) };
 		}
 		if (method === 'evolution.taskProposal.update') {
-			expect(data).toEqual({ id: 'proposal-1', params: { status: 'accepted' } });
-			return { proposal: makeProposal({ status: 'accepted' }) };
+			const payload = data as { id: string; params: { status: TaskProposal['status'] } };
+			expect(payload.id).toBe('proposal-1');
+			expect(['accepted', 'dismissed']).toContain(payload.params.status);
+			return { proposal: makeProposal({ status: payload.params.status }) };
+		}
+		if (method === 'evolution.taskProposal.createTask') {
+			const payload = data as { id: string; params?: Partial<TaskProposal> };
+			expect(payload.id).toBe('proposal-1');
+			return {
+				proposal: makeProposal({ status: 'created', createdTaskId: 'task-1' }),
+				task: {
+					id: 'task-1',
+					taskNumber: 7,
+					title: payload.params?.title ?? 'Improve review UI',
+				},
+			};
+		}
+		if (method === 'evolution.rollup.apply') {
+			return {
+				episode: makeEpisode({ status: 'accepted' }),
+				goal: makeGoal({ title: 'Improve review loop' }),
+			};
 		}
 		if (method === 'evolution.evidence.addManualNote') {
 			expect(data).toEqual({ scopeId: scope.id, summary: 'Manual proof' });
@@ -394,17 +414,81 @@ describe('SpaceForge', () => {
 		);
 	});
 
-	it('accepts task proposal from review UI', async () => {
+	it('creates task from proposal from review UI', async () => {
 		render(<SpaceForge spaceId="space-1" />);
 
 		await screen.findByRole('heading', { name: 'Review quality scope' });
 		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
-		fireEvent.click((await screen.findAllByRole('button', { name: 'Accept' }))[1]);
+		fireEvent.click(await screen.findByRole('button', { name: 'Create Task' }));
+
+		await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledWith('Task #7 created'));
+		expect(mockRequest).toHaveBeenCalledWith('evolution.taskProposal.createTask', {
+			id: 'proposal-1',
+			params: undefined,
+		});
+	});
+
+	it('edits and creates task from proposal from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.click(await screen.findByRole('button', { name: 'Edit & Create' }));
+		fireEvent.input(screen.getByLabelText('Proposal title'), {
+			target: { value: 'Edited review UI task' },
+		});
+		fireEvent.click(await screen.findByRole('button', { name: 'Save & Create' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.taskProposal.createTask', {
+				id: 'proposal-1',
+				params: {
+					title: 'Edited review UI task',
+					description: 'Make accept/dismiss actions clearer',
+					reason: 'Reduce NeoKai friction',
+					priority: 'high',
+				},
+			})
+		);
+	});
+
+	it('dismisses task proposal from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.click((await screen.findAllByRole('button', { name: 'Dismiss' }))[2]);
 
 		await waitFor(() =>
 			expect(mockRequest).toHaveBeenCalledWith('evolution.taskProposal.update', {
 				id: 'proposal-1',
-				params: { status: 'accepted' },
+				params: { status: 'dismissed' },
+			})
+		);
+	});
+
+	it('applies manual rollup to linked recurring goal from review UI', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.input(await screen.findByLabelText('Rollup summary'), {
+			target: { value: 'Rollup summary' },
+		});
+		fireEvent.input(screen.getByLabelText('Rollup progress'), { target: { value: '80' } });
+		fireEvent.input(screen.getByLabelText('Rollup next steps'), {
+			target: { value: 'Create follow-up\nMeasure again' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: 'Apply rollup' }));
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.rollup.apply', {
+				episodeId: 'episode-1',
+				goalUpdate: {
+					summary: 'Rollup summary',
+					progress: 80,
+					nextSteps: ['Create follow-up', 'Measure again'],
+				},
 			})
 		);
 	});


### PR DESCRIPTION
Adds Forge episode review actions to create SpaceTasks from next-action proposals, including edit-and-create and dismiss controls.

Adds manual rollup writeback so accepted scoped rollups can update linked recurring goal summary, progress, and next steps.

Validation:
- cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx
- bun run check