### PR TITLE
Harden Forge review follow-ups

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -545,6 +545,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		workflowRunRepo: spaceWorkflowRunRepo,
 		artifactRepo,
 		goalService: spaceGoalService,
+		db: deps.db.getDatabase(),
+		taskCreatedEventHub: {
+			publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
+		},
 	});
 	setupEvolutionHandlers(deps.messageHub, evolutionScopeService, evolutionEpisodeService);
 

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -1,3 +1,4 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
 	CreateEvolutionEpisodeParams,
 	CreateEvolutionLessonParams,
@@ -100,7 +101,11 @@ export interface EvolutionEpisodeServiceDeps {
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo: WorkflowRunArtifactRepository;
-	goalService?: Pick<SpaceGoalService, 'updateGoal'>;
+	goalService?: Pick<SpaceGoalService, 'getGoal' | 'updateGoal'>;
+	db?: BunDatabase;
+	taskCreatedEventHub?: {
+		publish: (event: string, data: Record<string, unknown>) => Promise<unknown>;
+	};
 	judgeEpisode?: (input: EpisodeJudgePromptInput) => Promise<EpisodeJudgeOutput>;
 }
 
@@ -242,38 +247,58 @@ export class EvolutionEpisodeService {
 		id: string,
 		params: CreateTaskFromProposalParams = {}
 	): CreateTaskFromProposalResult {
-		const existing = this.deps.evolutionRepo.getTaskProposal(id);
-		if (!existing) throw new Error(`TaskProposal not found: ${id}`);
-		if (existing.status === 'created' && existing.createdTaskId) {
-			const existingTask = this.deps.taskRepo.getTask(existing.createdTaskId);
-			if (existingTask) return { proposal: existing, task: existingTask };
-		}
-		if (existing.status === 'dismissed') throw new Error('Dismissed proposal cannot create a task');
+		const result = this.runAtomic(() => {
+			const existing = this.deps.evolutionRepo.getTaskProposal(id);
+			if (!existing) throw new Error(`TaskProposal not found: ${id}`);
+			if (existing.status === 'created' && existing.createdTaskId) {
+				const existingTask = this.deps.taskRepo.getTask(existing.createdTaskId);
+				if (existingTask) return { proposal: existing, task: existingTask, created: false };
+				throw new Error('Created proposal references a missing task');
+			}
+			if (existing.status === 'dismissed')
+				throw new Error('Dismissed proposal cannot create a task');
 
-		const scope = this.requireScope(existing.scopeId);
-		const title = params.title?.trim() || existing.title;
-		const description = params.description?.trim() || existing.description;
-		const reason = params.reason?.trim() || existing.reason;
-		const priority = params.priority ?? existing.priority;
-		if (!title.trim()) throw new Error('title is required');
-		const task = this.deps.taskRepo.createTask({
-			spaceId: scope.spaceId,
-			title,
-			description: buildProposalTaskDescription(description, reason, existing.evidenceEpisodeIds),
-			priority,
-			goalId: scope.spaceGoalId,
-			evolutionScopeId: scope.id,
+			const claimed = this.deps.evolutionRepo.updateTaskProposalIfStatus(
+				existing.id,
+				['proposed', 'accepted'],
+				{ status: 'accepted' }
+			);
+			if (!claimed) {
+				const current = this.deps.evolutionRepo.getTaskProposal(id);
+				if (current?.status === 'created' && current.createdTaskId) {
+					const currentTask = this.deps.taskRepo.getTask(current.createdTaskId);
+					if (currentTask) return { proposal: current, task: currentTask, created: false };
+				}
+				throw new Error('Task proposal is already being created');
+			}
+
+			const scope = this.requireScope(existing.scopeId);
+			const title = params.title?.trim() || existing.title;
+			const description = params.description?.trim() || existing.description;
+			const reason = params.reason?.trim() || existing.reason;
+			const priority = params.priority ?? existing.priority;
+			if (!title.trim()) throw new Error('title is required');
+			const task = this.deps.taskRepo.createTask({
+				spaceId: scope.spaceId,
+				title,
+				description: buildProposalTaskDescription(description, reason, existing.evidenceEpisodeIds),
+				priority,
+				goalId: scope.spaceGoalId,
+				evolutionScopeId: scope.id,
+			});
+			const proposal = this.deps.evolutionRepo.updateTaskProposal(existing.id, {
+				title,
+				description,
+				reason,
+				priority,
+				status: 'created',
+				createdTaskId: task.id,
+			});
+			if (!proposal) throw new Error(`TaskProposal not found: ${id}`);
+			return { proposal, task, created: true };
 		});
-		const proposal = this.deps.evolutionRepo.updateTaskProposal(existing.id, {
-			title,
-			description,
-			reason,
-			priority,
-			status: 'created',
-			createdTaskId: task.id,
-		});
-		if (!proposal) throw new Error(`TaskProposal not found: ${id}`);
-		return { proposal, task };
+		if (result.created) this.emitTaskCreated(result.task);
+		return { proposal: result.proposal, task: result.task };
 	}
 
 	applyRollupGoalUpdate(params: ApplyRollupGoalUpdateParams): ApplyRollupGoalUpdateResult {
@@ -284,12 +309,20 @@ export class EvolutionEpisodeService {
 		if (episode.status === 'dismissed') throw new Error('Dismissed episode cannot accept rollup');
 		const scope = this.requireScope(episode.scopeId);
 		if (!scope.spaceGoalId) throw new Error('Episode scope is not linked to a recurring goal');
-		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, { status: 'accepted' });
-		if (!accepted) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
+		const existingGoal = this.deps.goalService.getGoal(scope.spaceGoalId);
+		if (
+			!existingGoal ||
+			existingGoal.spaceId !== scope.spaceId ||
+			existingGoal.type !== 'recurring'
+		) {
+			throw new Error('Episode scope is not linked to a recurring goal');
+		}
 		const goal = this.deps.goalService.updateGoal(scope.spaceGoalId, params.goalUpdate, {
 			source: 'rpc',
-			note: `Forge rollup accepted: ${accepted.title}`,
+			note: `Forge rollup accepted: ${episode.title}`,
 		});
+		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, { status: 'accepted' });
+		if (!accepted) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
 		return { episode: accepted, goal };
 	}
 
@@ -332,6 +365,25 @@ export class EvolutionEpisodeService {
 		const scope = this.deps.evolutionRepo.getScope(scopeId);
 		if (!scope) throw new Error(`EvolutionScope not found: ${scopeId}`);
 		return scope;
+	}
+
+	private runAtomic<T>(fn: () => T): T {
+		if (!this.deps.db) return fn();
+		return this.deps.db.transaction(fn)();
+	}
+
+	private emitTaskCreated(task: SpaceTask): void {
+		if (!this.deps.taskCreatedEventHub) return;
+		this.deps.taskCreatedEventHub
+			.publish('space.task.created', {
+				sessionId: 'global',
+				spaceId: task.spaceId,
+				taskId: task.id,
+				task,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.task.created:', err);
+			});
 	}
 }
 

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -324,6 +324,23 @@ export class EvolutionRepository {
 	}
 
 	updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {
+		return this.updateTaskProposalWhere(id, params);
+	}
+
+	updateTaskProposalIfStatus(
+		id: string,
+		statuses: TaskProposalStatus[],
+		params: UpdateTaskProposalParams
+	): TaskProposal | null {
+		if (statuses.length === 0) return null;
+		return this.updateTaskProposalWhere(id, params, statuses);
+	}
+
+	private updateTaskProposalWhere(
+		id: string,
+		params: UpdateTaskProposalParams,
+		statuses?: TaskProposalStatus[]
+	): TaskProposal | null {
 		const sets: string[] = [];
 		const values: SQLiteValue[] = [];
 		const add = (column: string, value: SQLiteValue) => {
@@ -341,11 +358,16 @@ export class EvolutionRepository {
 		if (params.createdTaskId !== undefined) add('created_task_id', params.createdTaskId ?? null);
 		if (sets.length === 0) return this.getTaskProposal(id);
 		add('updated_at', Date.now());
+		let where = `id = ?`;
 		values.push(id);
-		this.db
-			.prepare(`UPDATE evolution_task_proposals SET ${sets.join(', ')} WHERE id = ?`)
+		if (statuses) {
+			where += ` AND status IN (${statuses.map(() => '?').join(', ')})`;
+			values.push(...statuses);
+		}
+		const result = this.db
+			.prepare(`UPDATE evolution_task_proposals SET ${sets.join(', ')} WHERE ${where}`)
 			.run(...values);
-		return this.getTaskProposal(id);
+		return result.changes > 0 ? this.getTaskProposal(id) : null;
 	}
 
 	createMetricSnapshot(params: CreateMetricSnapshotParams): MetricSnapshot {

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -209,15 +209,32 @@ describe('EvolutionEpisodeService', () => {
 			priority: 'high',
 			evidenceEpisodeIds: [episode.id],
 		});
+		const publishedEvents: Array<{ event: string; data: Record<string, unknown> }> = [];
 		const service = new EvolutionEpisodeService({
 			evolutionRepo,
 			taskRepo,
 			workflowRunRepo,
 			artifactRepo,
+			db,
+			taskCreatedEventHub: {
+				publish: async (event, data) => {
+					publishedEvents.push({ event, data });
+				},
+			},
 		});
 
 		const result = service.createTaskFromProposal(proposal.id);
+		const duplicate = service.createTaskFromProposal(proposal.id);
 
+		expect(duplicate.task.id).toBe(result.task.id);
+		expect(
+			taskRepo.listBySpace(spaceId).filter((item) => item.title === 'Improve review UI')
+		).toHaveLength(1);
+		expect(publishedEvents).toHaveLength(1);
+		expect(publishedEvents[0]).toMatchObject({
+			event: 'space.task.created',
+			data: { spaceId, taskId: result.task.id, task: result.task },
+		});
 		expect(result.proposal).toMatchObject({
 			status: 'created',
 			createdTaskId: result.task.id,
@@ -323,6 +340,7 @@ describe('EvolutionEpisodeService', () => {
 
 	it('rejects invalid rollup writeback requests', () => {
 		const goal = goalRepo.create({ spaceId, title: 'Recurring review goal', type: 'recurring' });
+		const oneShotGoal = goalRepo.create({ spaceId, title: 'One-shot goal', type: 'one_shot' });
 		const linkedScope = evolutionRepo.createScope({
 			spaceId,
 			spaceGoalId: goal.id,
@@ -336,6 +354,13 @@ describe('EvolutionEpisodeService', () => {
 			name: 'Unlinked scope',
 			objective: 'Track review health',
 		});
+		const oneShotScope = evolutionRepo.createScope({
+			spaceId,
+			spaceGoalId: oneShotGoal.id,
+			kind: 'mission',
+			name: 'One-shot scope',
+			objective: 'Track review health',
+		});
 		const draftEpisode = evolutionRepo.createEpisode({
 			scopeId: linkedScope.id,
 			title: 'Draft rollup',
@@ -343,6 +368,10 @@ describe('EvolutionEpisodeService', () => {
 		const unlinkedEpisode = evolutionRepo.createEpisode({
 			scopeId: unlinkedScope.id,
 			title: 'Unlinked rollup',
+		});
+		const oneShotEpisode = evolutionRepo.createEpisode({
+			scopeId: oneShotScope.id,
+			title: 'One-shot rollup',
 		});
 		const acceptedEpisode = evolutionRepo.createEpisode({
 			scopeId: linkedScope.id,
@@ -368,13 +397,34 @@ describe('EvolutionEpisodeService', () => {
 			goalService: createGoalService(),
 		});
 		const request = { episodeId: draftEpisode.id, goalUpdate: { summary: 'Rollup' } };
+		const failingGoalService = {
+			getGoal: (goalId: string) => goalRepo.getById(goalId),
+			updateGoal: () => {
+				throw new Error('goal update failed');
+			},
+		};
+		const failingService = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+			goalService: failingGoalService,
+		});
 
+		expect(() => failingService.applyRollupGoalUpdate(request)).toThrow('goal update failed');
+		expect(evolutionRepo.getEpisode(draftEpisode.id)?.status).toBe('draft');
 		expect(() => serviceWithoutGoalService.applyRollupGoalUpdate(request)).toThrow(
 			'SpaceGoalService is required'
 		);
 		expect(() =>
 			service.applyRollupGoalUpdate({
 				episodeId: unlinkedEpisode.id,
+				goalUpdate: { summary: 'Rollup' },
+			})
+		).toThrow('Episode scope is not linked to a recurring goal');
+		expect(() =>
+			service.applyRollupGoalUpdate({
+				episodeId: oneShotEpisode.id,
 				goalUpdate: { summary: 'Rollup' },
 			})
 		).toThrow('Episode scope is not linked to a recurring goal');

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -721,7 +721,9 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 			setEpisodes((current) =>
 				current.map((item) => (item.id === response.episode.id ? response.episode : item))
 			);
-			spaceStore.upsertGoal(response.goal);
+			if (spaceStore.spaceId.value === response.goal.spaceId) {
+				spaceStore.upsertGoal(response.goal);
+			}
 			toast.success(`Rollup applied to "${response.goal.title}"`);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to apply rollup');

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -721,6 +721,7 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 			setEpisodes((current) =>
 				current.map((item) => (item.id === response.episode.id ? response.episode : item))
 			);
+			spaceStore.upsertGoal(response.goal);
 			toast.success(`Rollup applied to "${response.goal.title}"`);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to apply rollup');

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -501,6 +501,24 @@ describe('SpaceForge', () => {
 		);
 	});
 
+	it('skips rollup goal cache update after switching spaces', async () => {
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		fireEvent.input(await screen.findByLabelText('Rollup summary'), {
+			target: { value: 'Rollup summary' },
+		});
+		fireEvent.input(screen.getByLabelText('Rollup progress'), { target: { value: '80' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Apply rollup' }));
+		mockSpaceId.value = 'space-2';
+
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('evolution.rollup.apply', expect.anything())
+		);
+		expect(mockUpsertGoal).not.toHaveBeenCalled();
+	});
+
 	it('creates scope with linked recurring goal and metrics', async () => {
 		render(<SpaceForge spaceId="space-1" />);
 

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -31,15 +31,20 @@ import { SpaceForge } from '../SpaceForge';
 const mockSpaceId = signal<string | null>('space-1');
 const mockGoals = signal<SpaceGoal[]>([]);
 const mockListGoals = vi.fn(async () => [] as SpaceGoal[]);
+const mockUpsertGoal = vi.fn((goal: SpaceGoal) => {
+	mockGoals.value = [goal, ...mockGoals.value.filter((current) => current.id !== goal.id)];
+});
 
 const mutableSpaceStore = spaceStore as unknown as {
 	spaceId: Signal<string | null>;
 	goals: Signal<SpaceGoal[]>;
 	listGoals: typeof mockListGoals;
+	upsertGoal: typeof mockUpsertGoal;
 };
 mutableSpaceStore.spaceId = mockSpaceId;
 mutableSpaceStore.goals = mockGoals;
 mutableSpaceStore.listGoals = mockListGoals;
+mutableSpaceStore.upsertGoal = mockUpsertGoal;
 
 function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
 	const now = Date.now();
@@ -243,7 +248,7 @@ function setupRequests(scope = makeScope()) {
 		if (method === 'evolution.rollup.apply') {
 			return {
 				episode: makeEpisode({ status: 'accepted' }),
-				goal: makeGoal({ title: 'Improve review loop' }),
+				goal: makeGoal({ title: 'Improve review loop', summary: 'Rollup summary', progress: 80 }),
 			};
 		}
 		if (method === 'evolution.evidence.addManualNote') {
@@ -490,6 +495,9 @@ describe('SpaceForge', () => {
 					nextSteps: ['Create follow-up', 'Measure again'],
 				},
 			})
+		);
+		expect(mockUpsertGoal).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'goal-1', summary: 'Rollup summary', progress: 80 })
 		);
 	});
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2110,7 +2110,7 @@ class SpaceStore {
 	// Goal Methods
 	// ========================================
 
-	private upsertGoal(goal: SpaceGoal): void {
+	upsertGoal(goal: SpaceGoal): void {
 		this.goalListRequestVersion += 1;
 		const existing = this.goals.value.filter((current) => current.id !== goal.id);
 		this.goals.value = [...existing, goal].sort((a, b) => b.updatedAt - a.updatedAt);


### PR DESCRIPTION
Follow-up to #1974 for unresolved review comments.

- Emit task-created events for Forge proposal-created tasks and guard duplicate creation.
- Validate recurring goal rollups and update goals before accepting episodes.
- Keep Forge goal state fresh after rollup apply.

Tested:
- cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx
- bun run check