### PR TITLE
Add Forge judge model selector

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -541,6 +541,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	});
 	const evolutionEpisodeService = new EvolutionEpisodeService({
 		evolutionRepo: deps.db.evolution,
+		spaceRepo,
 		taskRepo: spaceTaskRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		artifactRepo,

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -22,6 +22,7 @@ import type {
 	UpdateTaskProposalParams,
 } from '@neokai/shared';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
+import type { SpaceRepository } from '../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import type {
@@ -32,6 +33,7 @@ import type { SpaceGoalService } from './goals/goal-service';
 import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
 import { Logger } from '../logger';
 import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+import { inferProviderForModel } from '../providers/registry';
 
 const log = new Logger('evolution-episode-service');
 
@@ -97,6 +99,7 @@ export interface ApplyRollupGoalUpdateResult {
 
 export interface EvolutionEpisodeServiceDeps {
 	evolutionRepo: EvolutionRepository;
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo: WorkflowRunArtifactRepository;
@@ -142,7 +145,7 @@ export class EvolutionEpisodeService {
 		const input = this.buildEpisodeInput(params);
 		const judged = this.deps.judgeEpisode
 			? await this.deps.judgeEpisode(input)
-			: await judgeEpisodeWithModel(input);
+			: await judgeEpisodeWithModel(input, this.deps.spaceRepo);
 		const episode = this.deps.evolutionRepo.createEpisode({
 			scopeId: input.scope.id,
 			status: 'draft',
@@ -431,7 +434,10 @@ export function parseEpisodeJudgeJson(raw: string): EpisodeJudgeOutput {
 	} else {
 		const start = text.indexOf('{');
 		const end = text.lastIndexOf('}');
-		if (start >= 0 && end > start) text = text.slice(start, end + 1);
+		if (start < 0) {
+			throw new Error(`Episode judge returned non-JSON text: ${truncate(text, 300)}`);
+		}
+		if (end > start) text = text.slice(start, end + 1);
 	}
 	let parsed: unknown;
 	try {
@@ -444,11 +450,35 @@ export function parseEpisodeJudgeJson(raw: string): EpisodeJudgeOutput {
 	return normalizeJudgeOutput(parsed);
 }
 
-async function judgeEpisodeWithModel(input: EpisodeJudgePromptInput): Promise<EpisodeJudgeOutput> {
+export async function resolveEpisodeJudgeModel(
+	input: EpisodeJudgePromptInput,
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>
+): Promise<{ provider: string; modelId: string }> {
+	const scopeModel = readEpisodeJudgeModel(input.scope);
+	const spaceModel = scopeModel
+		? undefined
+		: spaceRepo?.getSpace(input.scope.spaceId)?.defaultModel;
+	const selectedModel = scopeModel ?? spaceModel?.trim();
+	if (selectedModel) {
+		return { provider: inferProviderForModel(selectedModel), modelId: selectedModel };
+	}
 	const providerService = getProviderService();
 	const provider = await providerService.getDefaultProvider();
 	const cfg = await providerService.getTitleGenerationConfig(provider);
-	const modelId = cfg.modelId;
+	return { provider, modelId: cfg.modelId };
+}
+
+function readEpisodeJudgeModel(scope: EvolutionScope): string | undefined {
+	const value = scope.policy.episodeJudgeModel;
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+async function judgeEpisodeWithModel(
+	input: EpisodeJudgePromptInput,
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>
+): Promise<EpisodeJudgeOutput> {
+	const providerService = getProviderService();
+	const { provider, modelId } = await resolveEpisodeJudgeModel(input, spaceRepo);
 	const prompt = buildEpisodeJudgePrompt(input);
 	const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
 	try {

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -4,6 +4,7 @@ import {
 	buildEpisodeJudgePrompt,
 	EvolutionEpisodeService,
 	parseEpisodeJudgeJson,
+	resolveEpisodeJudgeModel,
 } from '../../../src/lib/space/evolution-episode-service';
 import { EvolutionScopeService } from '../../../src/lib/space/evolution-scope-service';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
@@ -60,6 +61,7 @@ describe('EvolutionEpisodeService', () => {
 			name: 'Review loop',
 			objective: 'Reduce review churn',
 			metricDefinitions: [{ key: 'comments', label: 'Comments', direction: 'decrease' }],
+			policy: { episodeJudgeModel: 'claude-sonnet-4-6' },
 		});
 		const task = taskRepo.createTask({
 			spaceId,
@@ -128,6 +130,56 @@ describe('EvolutionEpisodeService', () => {
 		expect(prompt).toContain('Implementation ready');
 		expect(prompt).toContain('Reviewer saw repeated confusion');
 		expect(prompt).toContain('comments');
+		expect(prompt).toContain('claude-sonnet-4-6');
+	});
+
+	it('resolves judge model from scope policy before Space default', async () => {
+		const scopedInput = {
+			scope: evolutionRepo.createScope({
+				spaceId,
+				kind: 'custom',
+				name: 'Scoped model',
+				objective: 'Use scope override',
+				policy: { episodeJudgeModel: 'claude-opus-4-7' },
+			}),
+			evidence: [],
+			metricSnapshots: [],
+			tasks: [],
+			workflowRuns: [],
+			timeWindow: undefined,
+		};
+
+		expect(await resolveEpisodeJudgeModel(scopedInput, spaceRepo)).toEqual({
+			provider: 'anthropic',
+			modelId: 'claude-opus-4-7',
+		});
+	});
+
+	it('falls back to Space default model when scope has no judge model', async () => {
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/episode-service-default-model',
+			slug: 'episode-service-default-model',
+			name: 'Episode Service Default Model',
+			defaultModel: 'claude-sonnet-4-6',
+		});
+		const input = {
+			scope: evolutionRepo.createScope({
+				spaceId: space.id,
+				kind: 'custom',
+				name: 'Space model',
+				objective: 'Use space default',
+			}),
+			evidence: [],
+			metricSnapshots: [],
+			tasks: [],
+			workflowRuns: [],
+			timeWindow: undefined,
+		};
+
+		expect(await resolveEpisodeJudgeModel(input, spaceRepo)).toEqual({
+			provider: 'anthropic',
+			modelId: 'claude-sonnet-4-6',
+		});
 	});
 
 	it('parses fenced judge JSON and clamps confidence', () => {
@@ -163,6 +215,9 @@ describe('EvolutionEpisodeService', () => {
 	});
 
 	it('rejects malformed judge JSON and invalid enum values', () => {
+		expect(() => parseEpisodeJudgeJson('Failed to authenticate')).toThrow(
+			'Episode judge returned non-JSON text: Failed to authenticate'
+		);
 		expect(() => parseEpisodeJudgeJson('{ nope')).toThrow('Episode judge returned invalid JSON');
 		expect(() =>
 			parseEpisodeJudgeJson(

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -14,7 +14,9 @@ export type EvolutionFindingKind =
 	| 'missing_capability'
 	| 'new_opportunity';
 export type EvolutionImpact = 'low' | 'medium' | 'high';
-export type EvolutionPolicy = Record<string, unknown>;
+export interface EvolutionPolicy extends Record<string, unknown> {
+	episodeJudgeModel?: string;
+}
 export type MetricSnapshotValues = Record<string, string | number | boolean | null>;
 
 export interface MetricDefinition {

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -30,6 +30,7 @@ import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
+import { WorkflowModelSelect } from './visual-editor/WorkflowModelSelect';
 
 type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'lessons' | 'episodes';
 
@@ -136,6 +137,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 	const [objective, setObjective] = useState('');
 	const [kind, setKind] = useState<EvolutionScopeKind>('project');
 	const [spaceGoalId, setSpaceGoalId] = useState('');
+	const [episodeJudgeModel, setEpisodeJudgeModel] = useState<string | undefined>(undefined);
 	const [metrics, setMetrics] = useState<MetricDefinitionDraft[]>([]);
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -149,6 +151,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 		setObjective('');
 		setKind('project');
 		setSpaceGoalId('');
+		setEpisodeJudgeModel(undefined);
 		setMetrics([]);
 		setError(null);
 	};
@@ -205,6 +208,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 					objective: objective.trim(),
 					spaceGoalId: spaceGoalId || null,
 					metricDefinitions,
+					...(episodeJudgeModel ? { policy: { episodeJudgeModel } } : {}),
 				},
 			});
 			toast.success(`Scope "${response.scope.name}" created`);
@@ -283,6 +287,19 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 						rows={3}
 						class="w-full resize-none rounded-lg border border-dark-700 bg-dark-800 px-4 py-2.5 text-sm text-gray-100 placeholder-gray-600 focus:border-blue-500 focus:outline-none"
 					/>
+				</div>
+
+				<div>
+					<label class="mb-1.5 block text-sm font-medium text-gray-300">Episode judge model</label>
+					<WorkflowModelSelect
+						value={episodeJudgeModel}
+						onChange={setEpisodeJudgeModel}
+						testId="forge-scope-model-select"
+						className="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+					/>
+					<p class="mt-1 text-xs text-gray-500">
+						Optional. Falls back to this Space&apos;s default model when unset.
+					</p>
 				</div>
 
 				<div class="space-y-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -25,6 +25,27 @@ vi.mock('../../../lib/toast', () => ({
 	toast: { success: mockToastSuccess },
 }));
 
+vi.mock('../visual-editor/WorkflowModelSelect', () => ({
+	WorkflowModelSelect: ({
+		value,
+		onChange,
+		testId,
+	}: {
+		value?: string;
+		onChange: (value: string | undefined) => void;
+		testId?: string;
+	}) => (
+		<select
+			data-testid={testId}
+			value={value ?? ''}
+			onInput={(event) => onChange(event.currentTarget.value || undefined)}
+		>
+			<option value="">No override</option>
+			<option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+		</select>
+	),
+}));
+
 import { spaceStore } from '../../../lib/space-store';
 import { SpaceForge } from '../SpaceForge';
 
@@ -506,6 +527,9 @@ describe('SpaceForge', () => {
 		fireEvent.input(screen.getByLabelText('Linked recurring goal'), {
 			target: { value: 'goal-1' },
 		});
+		fireEvent.input(screen.getByTestId('forge-scope-model-select'), {
+			target: { value: 'claude-sonnet-4-6' },
+		});
 		fireEvent.click(screen.getByRole('button', { name: 'Add metric' }));
 		fireEvent.input(screen.getByPlaceholderText('key'), { target: { value: 'quality' } });
 		fireEvent.input(screen.getByPlaceholderText('Label'), { target: { value: 'Review quality' } });
@@ -528,6 +552,7 @@ describe('SpaceForge', () => {
 						targetValue: undefined,
 					},
 				],
+				policy: { episodeJudgeModel: 'claude-sonnet-4-6' },
 			},
 		});
 	});


### PR DESCRIPTION
## Summary
- Add per-scope Forge episode judge model selection in the Create Scope dialog.
- Resolve judge model from scope policy, then Space default model, then existing global fallback.
- Surface non-JSON judge failures more clearly and cover model resolution in tests.

## Test plan
- bun run check
- cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts
- cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx