### PR TITLE
Include Forge evidence metadata in episode prompts

### DIFF
--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -475,7 +475,7 @@ ${JSON.stringify(
 )}
 
 Metric snapshots and manual notes:
-${JSON.stringify({ metricSnapshots: input.metricSnapshots, manualNotes: input.evidence.filter((item) => item.kind === 'manual_note').map((item) => ({ id: item.id, summary: item.summary, metadata: item.metadata, createdAt: item.createdAt })) }, null, 2)}`;
+${JSON.stringify({ metricSnapshots: input.metricSnapshots, manualNotes: input.evidence.filter((item) => item.kind === 'manual_note').map((item) => ({ id: item.id, summary: item.summary, metadata: truncate(JSON.stringify(item.metadata), MAX_TEXT), createdAt: item.createdAt })) }, null, 2)}`;
 }
 
 export function parseEpisodeJudgeJson(raw: string): EpisodeJudgeOutput {

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -423,7 +423,7 @@ ${JSON.stringify(
 		kind: item.kind,
 		summary: item.summary,
 		sourceId: item.sourceId,
-		metadata: item.metadata,
+		metadata: truncate(JSON.stringify(item.metadata), MAX_TEXT),
 		createdAt: item.createdAt,
 	})),
 	null,

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -182,6 +182,49 @@ describe('EvolutionEpisodeService', () => {
 		});
 	});
 
+	it('includes evidence metadata so backfilled task artifacts reach the judge', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Forge dogfood',
+			objective: 'Generate useful episodes from completed task evidence',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Implement Forge storage',
+			description: 'Add storage and shared contracts',
+			evolutionScopeId: scope.id,
+		});
+		const evidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'task',
+			sourceId: task.id,
+			summary: 'Task completed; workflow artifacts contain review and QA results.',
+			metadata: {
+				artifacts: [
+					{
+						type: 'result',
+						summary: 'Requested changes: missing review-path tests',
+						prUrl: 'https://github.com/lsm/neokai/pull/1963',
+					},
+				],
+			},
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		const prompt = buildEpisodeJudgePrompt(
+			service.buildEpisodeInput({ scopeId: scope.id, evidenceIds: [evidence.id] })
+		);
+
+		expect(prompt).toContain('Requested changes: missing review-path tests');
+		expect(prompt).toContain('https://github.com/lsm/neokai/pull/1963');
+	});
+
 	it('parses fenced judge JSON and clamps confidence', () => {
 		const output = parseEpisodeJudgeJson(`\n\`\`\`json\n{
 			"title": "Review churn reduced",

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -225,6 +225,34 @@ describe('EvolutionEpisodeService', () => {
 		expect(prompt).toContain('https://github.com/lsm/neokai/pull/1963');
 	});
 
+	it('truncates manual note metadata in every prompt section', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Manual note metadata',
+			objective: 'Keep prompt metadata bounded',
+		});
+		const note = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'manual_note',
+			summary: 'Manual note with oversized metadata',
+			metadata: { marker: 'metadata-marker', payload: 'x'.repeat(1500) },
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		const prompt = buildEpisodeJudgePrompt(
+			service.buildEpisodeInput({ scopeId: scope.id, evidenceIds: [note.id] })
+		);
+
+		expect(prompt).toContain('metadata-marker');
+		expect(prompt).not.toContain('x'.repeat(1300));
+	});
+
 	it('parses fenced judge JSON and clamps confidence', () => {
 		const output = parseEpisodeJudgeJson(`\n\`\`\`json\n{
 			"title": "Review churn reduced",


### PR DESCRIPTION
Include evidence metadata in Forge episode judge prompts so backfilled task artifacts reach the model.

Generated the Forge MVP pass-1 episode from backfilled evidence in the live Forge scope:
- evidence: 7 task records, 1 metric snapshot, 1 manual note
- episode: 6e16b705-9092-4a44-9bb7-3792568aa0cd
- outputs: 5 findings, 3 candidate lessons, 3 proposals

Validation:
- bun test tests/unit/5-space/evolution-episode-service.test.ts
- bun run --cwd ../.. check