### PR TITLE
Backfill Forge MVP evidence

### DIFF
--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -346,6 +346,7 @@ export class EvolutionEpisodeService {
 		scope: EvolutionScope,
 		evidence: EvidenceRef[]
 	): EpisodeWorkflowRunContext[] {
+		const seenRunIds = new Set<string>();
 		return evidence.flatMap((item) => {
 			if (item.kind !== 'workflow_run' && item.kind !== 'artifact' && item.kind !== 'error')
 				return [];
@@ -355,6 +356,8 @@ export class EvolutionEpisodeService {
 			if (run.spaceId !== scope.spaceId) {
 				throw new Error(`Workflow run and scope must belong to the same space: ${run.id}`);
 			}
+			if (seenRunIds.has(run.id)) return [];
+			seenRunIds.add(run.id);
 			return [
 				{
 					evidenceId: item.id,

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -331,7 +331,8 @@ export class EvolutionEpisodeService {
 
 	private collectTasks(scope: EvolutionScope, evidence: EvidenceRef[]): EpisodeTaskContext[] {
 		return evidence.flatMap((item) => {
-			if (item.kind !== 'task' || !item.sourceId) return [];
+			if (item.kind !== 'task' && item.kind !== 'task_result') return [];
+			if (!item.sourceId) return [];
 			const task = this.deps.taskRepo.getTask(item.sourceId);
 			if (!task) return [];
 			if (task.spaceId !== scope.spaceId) {
@@ -346,7 +347,9 @@ export class EvolutionEpisodeService {
 		evidence: EvidenceRef[]
 	): EpisodeWorkflowRunContext[] {
 		return evidence.flatMap((item) => {
-			if (item.kind !== 'workflow_run' || !item.sourceId) return [];
+			if (item.kind !== 'workflow_run' && item.kind !== 'artifact' && item.kind !== 'error')
+				return [];
+			if (!item.sourceId) return [];
 			const run = this.deps.workflowRunRepo.getRun(item.sourceId);
 			if (!run) return [];
 			if (run.spaceId !== scope.spaceId) {

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -35,7 +35,7 @@ export function createEvolutionTables(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			scope_id TEXT NOT NULL,
 			kind TEXT NOT NULL
-				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot')),
+				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error')),
 			summary TEXT NOT NULL,
 			source_id TEXT,
 			metadata_json TEXT NOT NULL DEFAULT '{}',

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -114,6 +114,8 @@ export { runMigration137 } from './migrations';
 export { runMigration138 } from './migrations';
 // knip-ignore-next-line
 export { configureMessageSearchFts, runMigration141 } from './migrations';
+// knip-ignore-next-line
+export { runMigration142 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -657,6 +657,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 141: Rebuild message search FTS with detail=column and external content.
 	runMigration141(db);
+
+	// Migration 142: Expand Forge evidence kinds and backfill MVP task evidence.
+	runMigration142(db);
 }
 
 /**
@@ -9478,6 +9481,294 @@ function migrateNeoSessions(db: BunDatabase): void {
  * Stores lifecycle and state-change events for Space goals so agents and
  * humans can inspect why the current rolling goal state changed.
  */
+
+export function runMigration142(db: BunDatabase): void {
+	widenEvolutionEvidenceKinds(db);
+	backfillForgeMvpEvidence(db);
+}
+
+function widenEvolutionEvidenceKinds(db: BunDatabase): void {
+	if (!tableExists(db, 'evolution_evidence')) return;
+	const sql = tableCreateSql(db, 'evolution_evidence');
+	if (sql?.includes("'task_result'") && sql.includes("'artifact'") && sql.includes("'error'")) {
+		return;
+	}
+
+	db.exec('PRAGMA foreign_keys = OFF');
+	try {
+		db.exec(`DROP TABLE IF EXISTS evolution_evidence_new`);
+		db.exec(`
+			CREATE TABLE evolution_evidence_new (
+				id TEXT PRIMARY KEY,
+				scope_id TEXT NOT NULL,
+				kind TEXT NOT NULL
+					CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error')),
+				summary TEXT NOT NULL,
+				source_id TEXT,
+				metadata_json TEXT NOT NULL DEFAULT '{}',
+				created_at INTEGER NOT NULL,
+				FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(`
+			INSERT INTO evolution_evidence_new (
+				id, scope_id, kind, summary, source_id, metadata_json, created_at
+			)
+			SELECT id, scope_id, kind, summary, source_id, metadata_json, created_at
+			FROM evolution_evidence
+		`);
+		db.exec(`DROP TABLE evolution_evidence`);
+		db.exec(`ALTER TABLE evolution_evidence_new RENAME TO evolution_evidence`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_evolution_evidence_scope_created ON evolution_evidence(scope_id, created_at DESC)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_evolution_evidence_source ON evolution_evidence(kind, source_id)`
+		);
+	} finally {
+		db.exec('PRAGMA foreign_keys = ON');
+	}
+}
+
+function backfillForgeMvpEvidence(db: BunDatabase): void {
+	if (!tableExists(db, 'evolution_scopes') || !tableExists(db, 'evolution_evidence')) return;
+	if (!tableExists(db, 'space_tasks') || !tableExists(db, 'space_workflow_runs')) return;
+	if (!tableExists(db, 'workflow_run_artifacts')) return;
+
+	const scope = db
+		.prepare(
+			`SELECT id FROM evolution_scopes
+			 WHERE id = ?
+			    OR (space_goal_id = ? AND name = ?)
+			 ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END
+			 LIMIT 1`
+		)
+		.get(
+			'b2ff245a-98ef-4429-954a-3e7b96366cfa',
+			'10612c8d-e412-4169-8429-b48fa4d3e234',
+			'Build and harden NeoKai Forge',
+			'b2ff245a-98ef-4429-954a-3e7b96366cfa'
+		) as { id: string } | undefined;
+	if (!scope) return;
+
+	const tasks = [425, 426, 427, 428, 429, 430, 431];
+	for (const taskNumber of tasks) {
+		const task = db
+			.prepare(
+				`SELECT id, task_number, title, description, status, priority, workflow_run_id,
+				        reported_status, reported_summary, result, completed_at, updated_at
+				 FROM space_tasks WHERE task_number = ?`
+			)
+			.get(taskNumber) as ForgeMvpTaskRow | undefined;
+		if (!task?.workflow_run_id) continue;
+		const run = db
+			.prepare(
+				`SELECT id, title, status, failure_reason, completed_at, updated_at
+				 FROM space_workflow_runs WHERE id = ?`
+			)
+			.get(task.workflow_run_id) as ForgeMvpRunRow | undefined;
+		const artifacts = db
+			.prepare(
+				`SELECT id, node_id, artifact_type, artifact_key, data, created_at, updated_at
+				 FROM workflow_run_artifacts WHERE run_id = ? ORDER BY created_at, id`
+			)
+			.all(task.workflow_run_id) as ForgeMvpArtifactRow[];
+		const parsedArtifacts = artifacts.map((artifact) => ({
+			id: artifact.id,
+			nodeId: artifact.node_id,
+			type: artifact.artifact_type,
+			key: artifact.artifact_key,
+			data: parseMigrationJson(artifact.data),
+			createdAt: artifact.created_at,
+			updatedAt: artifact.updated_at,
+		}));
+		const artifactSummaries = parsedArtifacts
+			.map((artifact) => extractArtifactSummary(artifact.data))
+			.filter((summary): summary is string => Boolean(summary));
+		const prUrls = uniqueStrings(
+			parsedArtifacts.flatMap((artifact) => extractArtifactUrls(artifact.data))
+		);
+		const errors = collectForgeMvpErrors(run, parsedArtifacts);
+		const createdAt = task.completed_at ?? task.updated_at;
+
+		upsertForgeEvidence(db, {
+			id: `forge-mvp-${taskNumber}-task-result`,
+			scopeId: scope.id,
+			kind: 'task_result',
+			summary: `Task #${taskNumber} completed: ${task.title}. Workflow run ${run?.status ?? task.status}; PRs: ${prUrls.join(', ') || 'none recorded'}.`,
+			sourceId: task.id,
+			metadata: {
+				task: {
+					id: task.id,
+					number: task.task_number,
+					title: task.title,
+					status: task.status,
+					priority: task.priority,
+					reportedStatus: task.reported_status,
+					reportedSummary: task.reported_summary,
+					result: task.result,
+					completedAt: task.completed_at,
+				},
+				workflowRun: run,
+				prUrls,
+				artifactCount: artifacts.length,
+			},
+			createdAt,
+		});
+
+		upsertForgeEvidence(db, {
+			id: `forge-mvp-${taskNumber}-artifact`,
+			scopeId: scope.id,
+			kind: 'artifact',
+			summary: `Task #${taskNumber} artifacts: ${artifactSummaries.join(' | ') || `${artifacts.length} workflow artifacts captured`}.`,
+			sourceId: task.workflow_run_id,
+			metadata: { taskNumber, workflowRunId: task.workflow_run_id, artifacts: parsedArtifacts },
+			createdAt,
+		});
+
+		if (errors.length > 0) {
+			upsertForgeEvidence(db, {
+				id: `forge-mvp-${taskNumber}-error`,
+				scopeId: scope.id,
+				kind: 'error',
+				summary: `Task #${taskNumber} error/rework signals: ${errors.map((error) => error.summary).join(' | ')}.`,
+				sourceId: task.workflow_run_id,
+				metadata: { taskNumber, workflowRunId: task.workflow_run_id, errors },
+				createdAt,
+			});
+		}
+	}
+}
+
+interface ForgeMvpTaskRow {
+	id: string;
+	task_number: number;
+	title: string;
+	description: string;
+	status: string;
+	priority: string;
+	workflow_run_id: string | null;
+	reported_status: string | null;
+	reported_summary: string | null;
+	result: string | null;
+	completed_at: number | null;
+	updated_at: number;
+}
+
+interface ForgeMvpRunRow {
+	id: string;
+	title: string;
+	status: string;
+	failure_reason: string | null;
+	completed_at: number | null;
+	updated_at: number;
+}
+
+interface ForgeMvpArtifactRow {
+	id: string;
+	node_id: string;
+	artifact_type: string;
+	artifact_key: string;
+	data: string;
+	created_at: number;
+	updated_at: number;
+}
+
+interface ForgeEvidenceUpsert {
+	id: string;
+	scopeId: string;
+	kind: 'task_result' | 'artifact' | 'error';
+	summary: string;
+	sourceId: string | null;
+	metadata: Record<string, unknown>;
+	createdAt: number;
+}
+
+function upsertForgeEvidence(db: BunDatabase, evidence: ForgeEvidenceUpsert): void {
+	db.prepare(
+		`INSERT INTO evolution_evidence (
+			id, scope_id, kind, summary, source_id, metadata_json, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			scope_id = excluded.scope_id,
+			kind = excluded.kind,
+			summary = excluded.summary,
+			source_id = excluded.source_id,
+			metadata_json = excluded.metadata_json,
+			created_at = excluded.created_at`
+	).run(
+		evidence.id,
+		evidence.scopeId,
+		evidence.kind,
+		evidence.summary,
+		evidence.sourceId,
+		JSON.stringify(evidence.metadata),
+		evidence.createdAt
+	);
+}
+
+function collectForgeMvpErrors(
+	run: ForgeMvpRunRow | undefined,
+	artifacts: Array<{ data: Record<string, unknown> }>
+): Array<{ summary: string; data: Record<string, unknown> }> {
+	const errors: Array<{ summary: string; data: Record<string, unknown> }> = [];
+	if (run?.failure_reason) {
+		errors.push({ summary: run.failure_reason, data: { source: 'workflow_run', runId: run.id } });
+	}
+	for (const artifact of artifacts) {
+		const summary = extractArtifactSummary(artifact.data);
+		const verdict = stringValue(artifact.data.verdict);
+		const gateBlocker = stringValue(artifact.data.gateBlocker ?? artifact.data.gate_reason);
+		const gateIssue = stringValue(artifact.data.gateIssue);
+		const blockingIssues = Array.isArray(artifact.data.blocking_issues)
+			? artifact.data.blocking_issues
+			: [];
+		const testOutput = stringValue(artifact.data.test_output);
+		const hasRequestChanges = verdict === 'REQUEST_CHANGES';
+		const hasGateBlocker = Boolean(gateBlocker || gateIssue);
+		const hasBlockingIssues = blockingIssues.length > 0;
+		const hasPreexistingFailure = /pre-existing/i.test(`${summary ?? ''} ${testOutput ?? ''}`);
+		if (!hasRequestChanges && !hasGateBlocker && !hasBlockingIssues && !hasPreexistingFailure)
+			continue;
+		errors.push({
+			summary: summary ?? gateBlocker ?? gateIssue ?? 'Error signal captured in workflow artifact',
+			data: artifact.data,
+		});
+	}
+	return errors;
+}
+
+function parseMigrationJson(value: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
+function extractArtifactSummary(data: Record<string, unknown>): string | null {
+	return stringValue(data.summary) ?? stringValue(data.test_output) ?? null;
+}
+
+function extractArtifactUrls(data: Record<string, unknown>): string[] {
+	const urls: string[] = [];
+	for (const key of ['pr_url', 'merged_pr_url', 'review_url', 'reviewUrl', 'url']) {
+		const value = stringValue(data[key]);
+		if (value) urls.push(value);
+	}
+	return urls;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function uniqueStrings(values: string[]): string[] {
+	return Array.from(new Set(values));
+}
 
 export function runMigration141(db: BunDatabase): void {
 	const ftsSql = tableCreateSql(db, 'message_search_fts');

--- a/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
@@ -88,7 +88,7 @@ describe('EvolutionRepository', () => {
 
 		const evidence = repo.createEvidence({
 			scopeId: scope.id,
-			kind: 'task',
+			kind: 'task_result',
 			sourceId: task.id,
 			summary: 'Task completed with reviewer feedback',
 			metadata: { taskNumber: task.taskNumber },

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration142 } from '../../../../../src/storage/schema/index.ts';
+
+const SCOPE_ID = 'b2ff245a-98ef-4429-954a-3e7b96366cfa';
+const GOAL_ID = '10612c8d-e412-4169-8429-b48fa4d3e234';
+
+function createMigration142Tables(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE evolution_scopes (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			space_goal_id TEXT,
+			kind TEXT NOT NULL,
+			name TEXT NOT NULL,
+			objective TEXT NOT NULL,
+			parent_scope_id TEXT,
+			metric_definitions_json TEXT NOT NULL DEFAULT '[]',
+			policy_json TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE evolution_evidence (
+			id TEXT PRIMARY KEY,
+			scope_id TEXT NOT NULL,
+			kind TEXT NOT NULL
+				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot')),
+			summary TEXT NOT NULL,
+			source_id TEXT,
+			metadata_json TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL
+		);
+		CREATE TABLE space_tasks (
+			id TEXT PRIMARY KEY,
+			task_number INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL,
+			priority TEXT NOT NULL,
+			workflow_run_id TEXT,
+			reported_status TEXT,
+			reported_summary TEXT,
+			result TEXT,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL,
+			failure_reason TEXT,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE workflow_run_artifacts (
+			id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL,
+			node_id TEXT NOT NULL,
+			artifact_type TEXT NOT NULL,
+			artifact_key TEXT NOT NULL DEFAULT '',
+			data TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+	`);
+}
+
+function seedForgeMvpTask(db: BunDatabase): void {
+	db.prepare(
+		`INSERT INTO evolution_scopes (
+			id, space_id, space_goal_id, kind, name, objective, parent_scope_id,
+			metric_definitions_json, policy_json, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		SCOPE_ID,
+		'space-1',
+		GOAL_ID,
+		'mission',
+		'Build and harden NeoKai Forge',
+		'Improve Forge',
+		null,
+		'[]',
+		'{}',
+		1,
+		1
+	);
+	db.prepare(
+		`INSERT INTO space_tasks (
+			id, task_number, title, description, status, priority, workflow_run_id,
+			reported_status, reported_summary, result, completed_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		'task-425',
+		425,
+		'Forge MVP 1: storage and shared contracts',
+		'Add storage',
+		'done',
+		'high',
+		'run-425',
+		null,
+		null,
+		null,
+		100,
+		100
+	);
+	db.prepare(
+		`INSERT INTO space_workflow_runs (
+			id, title, status, failure_reason, completed_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)`
+	).run('run-425', 'Forge MVP 1', 'done', null, 101, 101);
+	db.prepare(
+		`INSERT INTO workflow_run_artifacts (
+			id, run_id, node_id, artifact_type, artifact_key, data, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		'artifact-425-review',
+		'run-425',
+		'review',
+		'result',
+		'review-round-1',
+		JSON.stringify({
+			summary: 'Requested changes: duplicate helper table.',
+			verdict: 'REQUEST_CHANGES',
+			pr_url: 'https://github.com/lsm/neokai/pull/1963',
+		}),
+		50,
+		50
+	);
+	db.prepare(
+		`INSERT INTO workflow_run_artifacts (
+			id, run_id, node_id, artifact_type, artifact_key, data, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		'artifact-425-merge',
+		'run-425',
+		'review',
+		'result',
+		'merged',
+		JSON.stringify({
+			summary: 'PR #1963 merged (squash) to dev.',
+			merged_pr_url: 'https://github.com/lsm/neokai/pull/1963',
+		}),
+		75,
+		75
+	);
+}
+
+describe('Migration 142: Forge MVP evidence backfill', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-142', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		createMigration142Tables(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test('widens evidence kinds and backfills task result, artifact, and error records', () => {
+		seedForgeMvpTask(db);
+
+		runMigration142(db);
+
+		const rows = db
+			.prepare(
+				`SELECT id, kind, source_id, summary, metadata_json
+				 FROM evolution_evidence
+				 WHERE id LIKE 'forge-mvp-425-%'
+				 ORDER BY id`
+			)
+			.all() as Array<{
+			id: string;
+			kind: string;
+			source_id: string;
+			summary: string;
+			metadata_json: string;
+		}>;
+
+		expect(rows.map((row) => `${row.id}:${row.kind}`)).toEqual([
+			'forge-mvp-425-artifact:artifact',
+			'forge-mvp-425-error:error',
+			'forge-mvp-425-task-result:task_result',
+		]);
+		expect(rows[0].source_id).toBe('run-425');
+		expect(rows[1].summary).toContain('Requested changes');
+		expect(rows[2].source_id).toBe('task-425');
+		expect(JSON.parse(rows[0].metadata_json).artifacts).toHaveLength(2);
+
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO evolution_evidence (
+						id, scope_id, kind, summary, source_id, metadata_json, created_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run('manual-artifact', SCOPE_ID, 'artifact', 'Manual artifact', 'run-425', '{}', 200)
+		).not.toThrow();
+	});
+
+	test('is idempotent', () => {
+		seedForgeMvpTask(db);
+
+		runMigration142(db);
+		runMigration142(db);
+
+		const rows = db
+			.prepare(`SELECT COUNT(*) count FROM evolution_evidence WHERE id LIKE 'forge-mvp-425-%'`)
+			.get() as { count: number };
+		expect(rows.count).toBe(3);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -97,6 +97,13 @@ describe('EvolutionEpisodeService', () => {
 			summary: 'Workflow completed',
 			createdAt: 200,
 		});
+		const errorEvidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'error',
+			sourceId: run.id,
+			summary: 'Same workflow run had rework',
+			createdAt: 225,
+		});
 		const note = evolutionRepo.createEvidence({
 			scopeId: scope.id,
 			kind: 'manual_note',
@@ -119,11 +126,13 @@ describe('EvolutionEpisodeService', () => {
 
 		const input = service.buildEpisodeInput({
 			scopeId: scope.id,
-			evidenceIds: [taskEvidence.id, runEvidence.id, note.id],
+			evidenceIds: [taskEvidence.id, runEvidence.id, errorEvidence.id, note.id],
 		});
 		const prompt = buildEpisodeJudgePrompt(input);
 
-		expect(input.timeWindow).toEqual({ start: 100, end: 200 });
+		expect(input.timeWindow).toEqual({ start: 100, end: 225 });
+		expect(input.workflowRuns).toHaveLength(1);
+		expect(input.workflowRuns[0]?.run.id).toBe(run.id);
 		expect(prompt).toContain('Reduce review churn');
 		expect(prompt).toContain('Resolved reviewer comments');
 		expect(prompt).toContain('PR updated and tests pass');

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -85,14 +85,14 @@ describe('EvolutionEpisodeService', () => {
 		});
 		const taskEvidence = evolutionRepo.createEvidence({
 			scopeId: scope.id,
-			kind: 'task',
+			kind: 'task_result',
 			sourceId: task.id,
 			summary: 'Task completed',
 			createdAt: 100,
 		});
 		const runEvidence = evolutionRepo.createEvidence({
 			scopeId: scope.id,
-			kind: 'workflow_run',
+			kind: 'artifact',
 			sourceId: run.id,
 			summary: 'Workflow completed',
 			createdAt: 200,

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -1,7 +1,15 @@
 import type { SpaceTaskPriority } from './space.ts';
 
 export type EvolutionScopeKind = 'mission' | 'project' | 'campaign' | 'workflow' | 'custom';
-export type EvidenceKind = 'task' | 'workflow_run' | 'session' | 'manual_note' | 'metric_snapshot';
+export type EvidenceKind =
+	| 'task'
+	| 'workflow_run'
+	| 'session'
+	| 'manual_note'
+	| 'metric_snapshot'
+	| 'task_result'
+	| 'artifact'
+	| 'error';
 export type EvolutionEpisodeStatus = 'draft' | 'accepted' | 'dismissed';
 export type EvolutionLessonStatus = 'candidate' | 'active' | 'dismissed';
 export type TaskProposalStatus = 'proposed' | 'accepted' | 'dismissed' | 'created';


### PR DESCRIPTION
Backfills Forge MVP tasks #425-#431 into structured evidence records from actual task/run artifacts.

Includes typed `task_result`, `artifact`, and `error` evidence kinds, migration-backed seed records, and episode input support for those kinds.

Tests:
- `bun test tests/unit/4-space-storage/storage/evolution-repository.test.ts tests/unit/5-space/evolution-episode-service.test.ts`
- `bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/backfill-forge-mvp-tasks-425-431-as-structured-evidence check`