### PR TITLE
Add Forge space agent tools

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -460,6 +460,22 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// and task-agent-tools / node-agent-tools (lookup).
 	const replyRoutingRegistry = new ReplyRoutingRegistry();
 
+	const evolutionScopeService = new EvolutionScopeService({
+		evolutionRepo: deps.db.evolution,
+		spaceRepo,
+		goalRepo: spaceGoalRepo,
+		taskRepo: spaceTaskRepo,
+		workflowRunRepo: spaceWorkflowRunRepo,
+	});
+	const evolutionEpisodeService = new EvolutionEpisodeService({
+		evolutionRepo: deps.db.evolution,
+		taskRepo: spaceTaskRepo,
+		workflowRunRepo: spaceWorkflowRunRepo,
+		artifactRepo,
+		goalService: spaceGoalService,
+	});
+	setupEvolutionHandlers(deps.messageHub, evolutionScopeService, evolutionEpisodeService);
+
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		dbPath: deps.db.getDatabasePath(),
@@ -494,6 +510,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		replyRoutingRegistry,
 		memoryRepo: deps.db.agentMemory,
 		goalService: spaceGoalService,
+		evolutionScopeService,
+		evolutionEpisodeService,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -531,22 +549,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		goalService: spaceGoalService,
 		spaceManager: deps.spaceManager,
 	});
-
-	const evolutionScopeService = new EvolutionScopeService({
-		evolutionRepo: deps.db.evolution,
-		spaceRepo,
-		goalRepo: spaceGoalRepo,
-		taskRepo: spaceTaskRepo,
-		workflowRunRepo: spaceWorkflowRunRepo,
-	});
-	const evolutionEpisodeService = new EvolutionEpisodeService({
-		evolutionRepo: deps.db.evolution,
-		taskRepo: spaceTaskRepo,
-		workflowRunRepo: spaceWorkflowRunRepo,
-		artifactRepo,
-		goalService: spaceGoalService,
-	});
-	setupEvolutionHandlers(deps.messageHub, evolutionScopeService, evolutionEpisodeService);
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -225,6 +225,10 @@ export class EvolutionEpisodeService {
 		return this.deps.evolutionRepo.listLessons(scopeId, status);
 	}
 
+	getLesson(id: string): EvolutionLesson | null {
+		return this.deps.evolutionRepo.getLesson(id);
+	}
+
 	updateLesson(id: string, params: UpdateEvolutionLessonParams): EvolutionLesson | null {
 		return this.deps.evolutionRepo.updateLesson(id, params);
 	}
@@ -232,6 +236,15 @@ export class EvolutionEpisodeService {
 	listTaskProposals(scopeId: string, status?: TaskProposalStatus): TaskProposal[] {
 		this.requireScope(scopeId);
 		return this.deps.evolutionRepo.listTaskProposals(scopeId, status);
+	}
+
+	getTaskProposal(id: string): TaskProposal | null {
+		return this.deps.evolutionRepo.getTaskProposal(id);
+	}
+
+	createTaskProposal(params: CreateTaskProposalParams): TaskProposal {
+		this.requireScope(params.scopeId);
+		return this.deps.evolutionRepo.createTaskProposal(params);
 	}
 
 	updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -179,8 +179,12 @@ export interface SpaceRuntimeServiceConfig {
 	};
 	/** Durable inbox for inactive long-term Space agents. */
 	spaceAgentInboxRepo?: SpaceAgentInboxRepository;
-	/** Optional goal service for processing terminal goal-task side effects. */
-	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
+	/** Optional goal service for processing terminal goal-task side effects and MCP goal tools. */
+	goalService?: import('../goals/goal-service').SpaceGoalService;
+	/** Optional Forge scope service for MCP Forge tools. */
+	evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
+	/** Optional Forge episode service for MCP Forge tools. */
+	evolutionEpisodeService?: import('../evolution-episode-service').EvolutionEpisodeService;
 }
 
 export class SpaceRuntimeService {
@@ -652,6 +656,9 @@ export class SpaceRuntimeService {
 			mySessionId: sessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			goalService: this.config.goalService,
+			evolutionScopeService: this.config.evolutionScopeService,
+			evolutionEpisodeService: this.config.evolutionEpisodeService,
 			replyRoutingRegistry: this.config.replyRoutingRegistry,
 			messageResolver: this.createMessageResolver(space.id),
 			longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
@@ -1260,6 +1267,9 @@ export class SpaceRuntimeService {
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			goalService: this.config.goalService,
+			evolutionScopeService: this.config.evolutionScopeService,
+			evolutionEpisodeService: this.config.evolutionEpisodeService,
 			replyRoutingRegistry: this.config.replyRoutingRegistry,
 			messageResolver: this.createMessageResolver(space.id),
 			longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
@@ -1374,6 +1384,9 @@ export class SpaceRuntimeService {
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,
+			goalService: this.config.goalService,
+			evolutionScopeService: this.config.evolutionScopeService,
+			evolutionEpisodeService: this.config.evolutionEpisodeService,
 			replyRoutingRegistry: this.config.replyRoutingRegistry,
 			messageResolver: this.createMessageResolver(space.id),
 			longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -23,12 +23,20 @@
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type {
+	CreateEvolutionEpisodeParams,
+	EvolutionEpisodeStatus,
+	EvolutionLessonStatus,
+	EvolutionPolicy,
+	EvolutionScopeKind,
+	MetricDefinition,
+	MetricSnapshotValues,
 	NodeExecution,
 	SpaceGoalStatus,
 	SpaceGoalType,
 	SpaceTask,
 	SpaceTaskPriority,
 	SpaceTaskStatus,
+	TaskProposalStatus,
 	TaskScheduleStatus,
 	TaskScheduleTriggerType,
 } from '@neokai/shared';
@@ -254,8 +262,12 @@ export interface SpaceAgentToolsConfig {
 	 * session instead of the canonical space:chat: session.
 	 */
 	replyRoutingRegistry?: ReplyRoutingRegistry;
-	/** Goal service for terminal goal-task side effects. */
+	/** Goal service for terminal goal-task side effects and goal MCP tools. */
 	goalService?: import('../goals/goal-service').SpaceGoalService;
+	/** Forge scope/evidence service for EvolutionScope MCP tools. */
+	evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
+	/** Forge episode/review service for lesson, proposal, and rollup MCP tools. */
+	evolutionEpisodeService?: import('../evolution-episode-service').EvolutionEpisodeService;
 	/** Generic Space actor resolver for @handle/@role DMs. */
 	messageResolver?: ActorResolver;
 	/** Deliver to or activate long-term Space agents. */
@@ -324,6 +336,44 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		const goal = requireGoalService().getGoal(goalId);
 		if (!goal || goal.spaceId !== spaceId) throw new Error(`Goal not found: ${goalId}`);
 		return goal;
+	}
+
+	function requireEvolutionScopeService() {
+		if (!config.evolutionScopeService) throw new Error('Forge scope management not available');
+		return config.evolutionScopeService;
+	}
+
+	function requireEvolutionEpisodeService() {
+		if (!config.evolutionEpisodeService) throw new Error('Forge episode management not available');
+		return config.evolutionEpisodeService;
+	}
+
+	function requireEvolutionScopeInSpace(scopeId: string) {
+		const scope = requireEvolutionScopeService().getScope(scopeId);
+		if (!scope || scope.spaceId !== spaceId)
+			throw new Error(`EvolutionScope not found: ${scopeId}`);
+		return scope;
+	}
+
+	function requireEvolutionEpisodeInSpace(episodeId: string) {
+		const episode = requireEvolutionEpisodeService().getEpisode(episodeId);
+		if (!episode) throw new Error(`EvolutionEpisode not found: ${episodeId}`);
+		requireEvolutionScopeInSpace(episode.scopeId);
+		return episode;
+	}
+
+	function requireEvolutionLessonInSpace(lessonId: string) {
+		const lesson = requireEvolutionEpisodeService().getLesson(lessonId);
+		if (!lesson) throw new Error(`EvolutionLesson not found: ${lessonId}`);
+		requireEvolutionScopeInSpace(lesson.scopeId);
+		return lesson;
+	}
+
+	function requireTaskProposalInSpace(proposalId: string) {
+		const proposal = requireEvolutionEpisodeService().getTaskProposal(proposalId);
+		if (!proposal) throw new Error(`TaskProposal not found: ${proposalId}`);
+		requireEvolutionScopeInSpace(proposal.scopeId);
+		return proposal;
 	}
 
 	const goalToolContext = {
@@ -1752,6 +1802,455 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 		},
 
+		async create_forge_scope(args: {
+			goal_id?: string | null;
+			kind: EvolutionScopeKind;
+			name: string;
+			objective: string;
+			parent_scope_id?: string | null;
+			metric_definitions?: MetricDefinition[];
+			policy?: EvolutionPolicy;
+		}): Promise<ToolResult> {
+			try {
+				if (args.goal_id) requireGoalInSpace(args.goal_id);
+				if (args.parent_scope_id) requireEvolutionScopeInSpace(args.parent_scope_id);
+				const scope = requireEvolutionScopeService().createScope({
+					spaceId,
+					spaceGoalId: args.goal_id ?? null,
+					kind: args.kind,
+					name: args.name,
+					objective: args.objective,
+					parentScopeId: args.parent_scope_id ?? null,
+					metricDefinitions: args.metric_definitions,
+					policy: args.policy,
+				});
+				logAudit('create_forge_scope', { name: args.name, kind: args.kind, goal_id: args.goal_id });
+				return jsonResult({ success: true, scope });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async create_forge_scope_from_goal(args: {
+			goal_id: string;
+			name?: string;
+			objective?: string;
+			metric_definitions?: MetricDefinition[];
+			policy?: EvolutionPolicy;
+		}): Promise<ToolResult> {
+			try {
+				requireGoalInSpace(args.goal_id);
+				const scope = requireEvolutionScopeService().createScopeFromGoal({
+					spaceGoalId: args.goal_id,
+					name: args.name,
+					objective: args.objective,
+					metricDefinitions: args.metric_definitions,
+					policy: args.policy,
+				});
+				logAudit('create_forge_scope_from_goal', { goal_id: args.goal_id, name: args.name });
+				return jsonResult({ success: true, scope });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_forge_scopes(
+			args: { goal_id?: string | null; kind?: EvolutionScopeKind } = {}
+		): Promise<ToolResult> {
+			try {
+				if (args.goal_id) requireGoalInSpace(args.goal_id);
+				const scopes = requireEvolutionScopeService().listScopes({
+					spaceId,
+					spaceGoalId: args.goal_id,
+					kind: args.kind,
+				});
+				return jsonResult({ success: true, scopes });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async get_forge_scope(args: { scope_id: string }): Promise<ToolResult> {
+			try {
+				const scope = requireEvolutionScopeInSpace(args.scope_id);
+				return jsonResult({ success: true, scope });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async update_forge_scope(args: {
+			scope_id: string;
+			goal_id?: string | null;
+			kind?: EvolutionScopeKind;
+			name?: string;
+			objective?: string;
+			parent_scope_id?: string | null;
+			metric_definitions?: MetricDefinition[];
+			policy?: EvolutionPolicy;
+			episode_judge_model?: string | null;
+		}): Promise<ToolResult> {
+			try {
+				const existing = requireEvolutionScopeInSpace(args.scope_id);
+				if (args.goal_id) requireGoalInSpace(args.goal_id);
+				if (args.parent_scope_id) requireEvolutionScopeInSpace(args.parent_scope_id);
+				const policy =
+					args.episode_judge_model !== undefined
+						? { ...(args.policy ?? existing.policy), episodeJudgeModel: args.episode_judge_model }
+						: args.policy;
+				const scope = requireEvolutionScopeService().updateScope(args.scope_id, {
+					spaceGoalId: args.goal_id,
+					kind: args.kind,
+					name: args.name,
+					objective: args.objective,
+					parentScopeId: args.parent_scope_id,
+					metricDefinitions: args.metric_definitions,
+					policy,
+				});
+				logAudit('update_forge_scope', { scope_id: args.scope_id });
+				return jsonResult({ success: true, scope });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async get_forge_timeline(args: { scope_id: string }): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const timeline = requireEvolutionScopeService().listTimeline(args.scope_id);
+				return jsonResult({ success: true, ...timeline });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async add_forge_manual_note(args: {
+			scope_id: string;
+			summary: string;
+			metadata?: Record<string, unknown>;
+			created_at?: number;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const evidence = requireEvolutionScopeService().addManualNoteEvidence({
+					scopeId: args.scope_id,
+					summary: args.summary,
+					metadata: args.metadata,
+					createdAt: args.created_at,
+				});
+				logAudit('add_forge_manual_note', { scope_id: args.scope_id });
+				return jsonResult({ success: true, evidence });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async attach_forge_task_evidence(args: {
+			task_id: string;
+			scope_id?: string;
+			summary?: string;
+			metadata?: Record<string, unknown>;
+		}): Promise<ToolResult> {
+			try {
+				const task = taskRepo.getTask(args.task_id);
+				if (!task || task.spaceId !== spaceId) throw new Error(`Task not found: ${args.task_id}`);
+				if (args.scope_id) requireEvolutionScopeInSpace(args.scope_id);
+				const evidence = requireEvolutionScopeService().attachTaskEvidence({
+					taskId: args.task_id,
+					scopeId: args.scope_id,
+					summary: args.summary,
+					metadata: args.metadata,
+				});
+				requireEvolutionScopeInSpace(evidence.scopeId);
+				logAudit('attach_forge_task_evidence', {
+					scope_id: evidence.scopeId,
+					task_id: args.task_id,
+				});
+				return jsonResult({ success: true, evidence });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async attach_forge_workflow_run_evidence(args: {
+			workflow_run_id: string;
+			scope_id?: string;
+			summary?: string;
+			metadata?: Record<string, unknown>;
+		}): Promise<ToolResult> {
+			try {
+				const run = workflowRunRepo.getRun(args.workflow_run_id);
+				if (!run || run.spaceId !== spaceId) {
+					throw new Error(`Workflow run not found: ${args.workflow_run_id}`);
+				}
+				if (args.scope_id) requireEvolutionScopeInSpace(args.scope_id);
+				const evidence = requireEvolutionScopeService().attachWorkflowRunEvidence({
+					workflowRunId: args.workflow_run_id,
+					scopeId: args.scope_id,
+					summary: args.summary,
+					metadata: args.metadata,
+				});
+				requireEvolutionScopeInSpace(evidence.scopeId);
+				logAudit('attach_forge_workflow_run_evidence', {
+					scope_id: evidence.scopeId,
+					workflow_run_id: args.workflow_run_id,
+				});
+				return jsonResult({ success: true, evidence });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async add_forge_metric_snapshot(args: {
+			scope_id: string;
+			values: MetricSnapshotValues;
+			source: string;
+			note?: string | null;
+			captured_at?: number;
+			summary?: string;
+			metadata?: Record<string, unknown>;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const result = requireEvolutionScopeService().addMetricSnapshotEvidence({
+					scopeId: args.scope_id,
+					values: args.values,
+					source: args.source,
+					note: args.note,
+					capturedAt: args.captured_at,
+					summary: args.summary,
+					metadata: args.metadata,
+				});
+				logAudit('add_forge_metric_snapshot', { scope_id: args.scope_id, source: args.source });
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_forge_evidence(args: { scope_id: string }): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const evidence = requireEvolutionScopeService().listEvidence(args.scope_id);
+				return jsonResult({ success: true, evidence });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_forge_metric_snapshots(args: { scope_id: string }): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const snapshots = requireEvolutionScopeService().listMetricSnapshots(args.scope_id);
+				return jsonResult({ success: true, snapshots });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async create_forge_episode(args: {
+			scope_id: string;
+			evidence_ids: string[];
+			time_window?: CreateEvolutionEpisodeParams['timeWindow'];
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const result = await requireEvolutionEpisodeService().createFromEvidence({
+					scopeId: args.scope_id,
+					evidenceIds: args.evidence_ids,
+					timeWindow: args.time_window,
+				});
+				logAudit('create_forge_episode', {
+					scope_id: args.scope_id,
+					evidence_count: args.evidence_ids.length,
+				});
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_forge_review_bundle(args: { scope_id: string }): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const bundle = requireEvolutionEpisodeService().listReviewBundle(args.scope_id);
+				return jsonResult({ success: true, ...bundle });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async update_forge_episode(args: {
+			episode_id: string;
+			status?: EvolutionEpisodeStatus;
+			title?: string;
+			outcome_summary?: string;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionEpisodeInSpace(args.episode_id);
+				const episode = requireEvolutionEpisodeService().updateEpisode(args.episode_id, {
+					status: args.status,
+					title: args.title,
+					outcomeSummary: args.outcome_summary,
+				});
+				logAudit('update_forge_episode', { episode_id: args.episode_id, status: args.status });
+				return jsonResult({ success: true, episode });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async update_forge_lesson(args: {
+			lesson_id: string;
+			status?: EvolutionLessonStatus;
+			applies_to?: string[];
+			rule?: string;
+			why?: string;
+			confidence?: number;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionLessonInSpace(args.lesson_id);
+				const lesson = requireEvolutionEpisodeService().updateLesson(args.lesson_id, {
+					status: args.status,
+					appliesTo: args.applies_to,
+					rule: args.rule,
+					why: args.why,
+					confidence: args.confidence,
+				});
+				logAudit('update_forge_lesson', { lesson_id: args.lesson_id, status: args.status });
+				return jsonResult({ success: true, lesson });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async create_forge_task_proposal(args: {
+			scope_id: string;
+			title: string;
+			description: string;
+			reason: string;
+			priority?: SpaceTaskPriority;
+			evidence_episode_ids?: string[];
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				for (const episodeId of args.evidence_episode_ids ?? [])
+					requireEvolutionEpisodeInSpace(episodeId);
+				const proposal = requireEvolutionEpisodeService().createTaskProposal({
+					scopeId: args.scope_id,
+					title: args.title,
+					description: args.description,
+					reason: args.reason,
+					priority: args.priority,
+					evidenceEpisodeIds: args.evidence_episode_ids,
+				});
+				logAudit('create_forge_task_proposal', { scope_id: args.scope_id, title: args.title });
+				return jsonResult({ success: true, proposal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async update_forge_task_proposal(args: {
+			proposal_id: string;
+			title?: string;
+			description?: string;
+			reason?: string;
+			priority?: SpaceTaskPriority;
+			status?: TaskProposalStatus;
+		}): Promise<ToolResult> {
+			try {
+				requireTaskProposalInSpace(args.proposal_id);
+				const proposal = requireEvolutionEpisodeService().updateTaskProposal(args.proposal_id, {
+					title: args.title,
+					description: args.description,
+					reason: args.reason,
+					priority: args.priority,
+					status: args.status,
+				});
+				logAudit('update_forge_task_proposal', {
+					proposal_id: args.proposal_id,
+					status: args.status,
+				});
+				return jsonResult({ success: true, proposal });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async create_task_from_forge_proposal(args: {
+			proposal_id: string;
+			title?: string;
+			description?: string;
+			reason?: string;
+			priority?: SpaceTaskPriority;
+		}): Promise<ToolResult> {
+			try {
+				requireTaskProposalInSpace(args.proposal_id);
+				const result = requireEvolutionEpisodeService().createTaskFromProposal(args.proposal_id, {
+					title: args.title,
+					description: args.description,
+					reason: args.reason,
+					priority: args.priority,
+				});
+				logAudit(
+					'create_task_from_forge_proposal',
+					{ proposal_id: args.proposal_id },
+					result.task.id
+				);
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async apply_forge_rollup(args: {
+			episode_id: string;
+			goal_update: {
+				summary?: string;
+				progress?: number;
+				next_steps?: string[];
+				metrics?: Record<string, string | number | boolean | null>;
+			};
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionEpisodeInSpace(args.episode_id);
+				const result = requireEvolutionEpisodeService().applyRollupGoalUpdate({
+					episodeId: args.episode_id,
+					goalUpdate: {
+						summary: args.goal_update.summary,
+						progress: args.goal_update.progress,
+						nextSteps: args.goal_update.next_steps,
+						metrics: args.goal_update.metrics,
+					},
+				});
+				logAudit('apply_forge_rollup', { episode_id: args.episode_id });
+				return jsonResult({ success: true, ...result });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
 		/**
 		 * Create a recurring (cron) or one-shot (at) scheduled task.
 		 */
@@ -2220,14 +2719,15 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 	];
 
+	const goalStatusSchema = z.enum(['active', 'paused', 'completed', 'archived']);
+	const goalTypeSchema = z.enum(['one_shot', 'measurable', 'recurring']);
+	const goalMetricsSchema = z.record(
+		z.string(),
+		z.union([z.string(), z.number(), z.boolean(), z.null()])
+	);
+
 	// Goal management tools — only registered when goalService is provided.
 	if (config.goalService) {
-		const goalStatusSchema = z.enum(['active', 'paused', 'completed', 'archived']);
-		const goalTypeSchema = z.enum(['one_shot', 'measurable', 'recurring']);
-		const goalMetricsSchema = z.record(
-			z.string(),
-			z.union([z.string(), z.number(), z.boolean(), z.null()])
-		);
 		const goalUpdateShape = {
 			title: z.string().min(1).optional().describe('New goal title'),
 			description: z.string().optional().describe('New goal description'),
@@ -2361,6 +2861,260 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 						.describe('Cursor event ID for same-timestamp pagination'),
 				},
 				(args) => handlers.list_goal_events(args)
+			)
+		);
+	}
+
+	// Forge management tools — only registered when Forge services are provided.
+	if (config.evolutionScopeService && config.evolutionEpisodeService) {
+		const forgeScopeKindSchema = z.enum(['mission', 'project', 'campaign', 'workflow', 'custom']);
+		const forgePolicySchema = z.record(z.string(), z.unknown());
+		const metricDefinitionSchema = z.object({
+			key: z.string().min(1).describe('Stable metric key'),
+			label: z.string().min(1).describe('Human-readable metric label'),
+			description: z.string().optional().describe('What this metric measures'),
+			direction: z.enum(['increase', 'decrease', 'target', 'maintain']),
+			targetValue: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+			unit: z.string().optional(),
+		});
+		const metricValuesSchema = z.record(
+			z.string(),
+			z.union([z.string(), z.number(), z.boolean(), z.null()])
+		);
+		const metadataSchema = z.record(z.string(), z.unknown());
+		const episodeStatusSchema = z.enum(['draft', 'accepted', 'dismissed']);
+		const lessonStatusSchema = z.enum(['candidate', 'active', 'dismissed']);
+		const proposalStatusSchema = z.enum(['proposed', 'accepted', 'dismissed', 'created']);
+		const prioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
+
+		tools.push(
+			tool(
+				'create_forge_scope',
+				'Create a Forge EvolutionScope in this space. Use goal_id to link it to a recurring goal; policy can include episodeJudgeModel and other judge guidance.',
+				{
+					goal_id: z.string().nullable().optional().describe('Optional linked SpaceGoal ID'),
+					kind: forgeScopeKindSchema.describe('Scope kind'),
+					name: z.string().min(1).describe('Scope name'),
+					objective: z.string().min(1).describe('Scope objective'),
+					parent_scope_id: z.string().nullable().optional().describe('Optional parent scope ID'),
+					metric_definitions: z
+						.array(metricDefinitionSchema)
+						.optional()
+						.describe('Metric definitions tracked by this scope'),
+					policy: forgePolicySchema.optional().describe('Scope policy JSON for judge guidance'),
+				},
+				(args) => handlers.create_forge_scope(args)
+			),
+			tool(
+				'create_forge_scope_from_goal',
+				'Create a mission Forge scope linked to an existing SpaceGoal, defaulting name/objective from the goal.',
+				{
+					goal_id: z.string().describe('SpaceGoal ID in this space'),
+					name: z.string().optional().describe('Override scope name'),
+					objective: z.string().optional().describe('Override scope objective'),
+					metric_definitions: z.array(metricDefinitionSchema).optional(),
+					policy: forgePolicySchema.optional(),
+				},
+				(args) => handlers.create_forge_scope_from_goal(args)
+			),
+			tool(
+				'list_forge_scopes',
+				'List Forge scopes in this space, optionally filtered by linked goal or kind.',
+				{
+					goal_id: z
+						.string()
+						.nullable()
+						.optional()
+						.describe('Filter by linked goal ID; null means unlinked scopes'),
+					kind: forgeScopeKindSchema.optional().describe('Filter by scope kind'),
+				},
+				(args) => handlers.list_forge_scopes(args)
+			),
+			tool(
+				'get_forge_scope',
+				'Get one Forge scope in this space, including linked goal, metric definitions, and policy.',
+				{ scope_id: z.string().describe('EvolutionScope ID') },
+				(args) => handlers.get_forge_scope(args)
+			),
+			tool(
+				'update_forge_scope',
+				'Update a Forge scope. Use goal_id to link/unlink a goal, policy to replace policy JSON, or episode_judge_model to update policy.episodeJudgeModel.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					goal_id: z.string().nullable().optional().describe('Linked SpaceGoal ID; null unlinks'),
+					kind: forgeScopeKindSchema.optional(),
+					name: z.string().min(1).optional(),
+					objective: z.string().min(1).optional(),
+					parent_scope_id: z.string().nullable().optional(),
+					metric_definitions: z.array(metricDefinitionSchema).optional(),
+					policy: forgePolicySchema.optional().describe('Replacement policy JSON'),
+					episode_judge_model: z
+						.string()
+						.nullable()
+						.optional()
+						.describe('Convenience setter for policy.episodeJudgeModel'),
+				},
+				(args) => handlers.update_forge_scope(args)
+			),
+			tool(
+				'get_forge_timeline',
+				'Get scope overview/timeline: scope, evidence, and metric snapshots.',
+				{ scope_id: z.string().describe('EvolutionScope ID') },
+				(args) => handlers.get_forge_timeline(args)
+			),
+			tool(
+				'add_forge_manual_note',
+				'Attach manual note evidence to a Forge scope.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					summary: z.string().min(1).describe('Evidence note text'),
+					metadata: metadataSchema.optional(),
+					created_at: z.number().int().optional().describe('Optional timestamp ms'),
+				},
+				(args) => handlers.add_forge_manual_note(args)
+			),
+			tool(
+				'attach_forge_task_evidence',
+				'Attach a completed or relevant SpaceTask as Forge evidence. If scope_id omitted, resolves from task.evolutionScopeId or task.goalId.',
+				{
+					task_id: z.string().describe('SpaceTask ID'),
+					scope_id: z.string().optional().describe('Optional explicit EvolutionScope ID'),
+					summary: z.string().optional(),
+					metadata: metadataSchema.optional(),
+				},
+				(args) => handlers.attach_forge_task_evidence(args)
+			),
+			tool(
+				'attach_forge_workflow_run_evidence',
+				'Attach a workflow run as Forge evidence. If scope_id omitted, resolves via first task in the run.',
+				{
+					workflow_run_id: z.string().describe('Workflow run ID'),
+					scope_id: z.string().optional().describe('Optional explicit EvolutionScope ID'),
+					summary: z.string().optional(),
+					metadata: metadataSchema.optional(),
+				},
+				(args) => handlers.attach_forge_workflow_run_evidence(args)
+			),
+			tool(
+				'add_forge_metric_snapshot',
+				'Add metric snapshot evidence to a Forge scope.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					values: metricValuesSchema.describe('Metric values keyed by metric name'),
+					source: z.string().min(1).describe('Source label, e.g. manual, CI, analytics'),
+					note: z.string().nullable().optional(),
+					captured_at: z.number().int().optional().describe('Optional timestamp ms'),
+					summary: z.string().optional().describe('Optional evidence summary'),
+					metadata: metadataSchema.optional(),
+				},
+				(args) => handlers.add_forge_metric_snapshot(args)
+			),
+			tool(
+				'list_forge_evidence',
+				'List evidence refs for a Forge scope.',
+				{ scope_id: z.string().describe('EvolutionScope ID') },
+				(args) => handlers.list_forge_evidence(args)
+			),
+			tool(
+				'list_forge_metric_snapshots',
+				'List metric snapshots for a Forge scope.',
+				{ scope_id: z.string().describe('EvolutionScope ID') },
+				(args) => handlers.list_forge_metric_snapshots(args)
+			),
+			tool(
+				'create_forge_episode',
+				'Generate a draft Forge episode from selected evidence. Calls the episode judge; LLM/model/auth errors are surfaced clearly.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					evidence_ids: z.array(z.string()).min(1).describe('Evidence IDs from this scope'),
+					time_window: z
+						.object({ start: z.number().int(), end: z.number().int() })
+						.nullable()
+						.optional(),
+				},
+				(args) => handlers.create_forge_episode(args)
+			),
+			tool(
+				'list_forge_review_bundle',
+				'List episodes, lessons, and task proposals for reviewing a Forge scope.',
+				{ scope_id: z.string().describe('EvolutionScope ID') },
+				(args) => handlers.list_forge_review_bundle(args)
+			),
+			tool(
+				'update_forge_episode',
+				'Accept, dismiss, or edit a Forge episode draft. Use status accepted/dismissed only after explicit decision.',
+				{
+					episode_id: z.string().describe('EvolutionEpisode ID'),
+					status: episodeStatusSchema.optional(),
+					title: z.string().min(1).optional(),
+					outcome_summary: z.string().optional(),
+				},
+				(args) => handlers.update_forge_episode(args)
+			),
+			tool(
+				'update_forge_lesson',
+				'Activate, dismiss, or edit a candidate lesson. Activation requires explicit tool call.',
+				{
+					lesson_id: z.string().describe('EvolutionLesson ID'),
+					status: lessonStatusSchema.optional(),
+					applies_to: z.array(z.string()).optional(),
+					rule: z.string().min(1).optional(),
+					why: z.string().optional(),
+					confidence: z.number().min(0).max(1).optional(),
+				},
+				(args) => handlers.update_forge_lesson(args)
+			),
+			tool(
+				'create_forge_task_proposal',
+				'Create a Forge task proposal manually for this scope. Later use create_task_from_forge_proposal to make a real SpaceTask.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					title: z.string().min(1),
+					description: z.string(),
+					reason: z.string(),
+					priority: prioritySchema.optional(),
+					evidence_episode_ids: z.array(z.string()).optional(),
+				},
+				(args) => handlers.create_forge_task_proposal(args)
+			),
+			tool(
+				'update_forge_task_proposal',
+				'Edit, accept, or dismiss a Forge task proposal. Creating a SpaceTask is separate and explicit.',
+				{
+					proposal_id: z.string().describe('TaskProposal ID'),
+					title: z.string().min(1).optional(),
+					description: z.string().optional(),
+					reason: z.string().optional(),
+					priority: prioritySchema.optional(),
+					status: proposalStatusSchema.optional(),
+				},
+				(args) => handlers.update_forge_task_proposal(args)
+			),
+			tool(
+				'create_task_from_forge_proposal',
+				'Create a real SpaceTask from a Forge proposal, preserving linked goalId and evolutionScopeId. Idempotent when task already exists.',
+				{
+					proposal_id: z.string().describe('TaskProposal ID'),
+					title: z.string().optional().describe('Optional edited task title'),
+					description: z.string().optional().describe('Optional edited task description'),
+					reason: z.string().optional().describe('Optional edited proposal reason'),
+					priority: prioritySchema.optional(),
+				},
+				(args) => handlers.create_task_from_forge_proposal(args)
+			),
+			tool(
+				'apply_forge_rollup',
+				'Accept a Forge episode and roll summary/progress/metrics/next steps into its linked recurring goal.',
+				{
+					episode_id: z.string().describe('EvolutionEpisode ID'),
+					goal_update: z.object({
+						summary: z.string().optional(),
+						progress: z.number().int().min(0).max(100).optional(),
+						next_steps: z.array(z.string()).optional(),
+						metrics: goalMetricsSchema.optional(),
+					}),
+				},
+				(args) => handlers.apply_forge_rollup(args)
 			)
 		);
 	}

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2165,7 +2165,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			outcome_summary?: string;
 		}): Promise<ToolResult> {
 			try {
-				requireEvolutionEpisodeInSpace(args.episode_id);
+				const existing = requireEvolutionEpisodeInSpace(args.episode_id);
+				if (existing.status !== 'draft' && args.status && args.status !== existing.status) {
+					throw new Error('Terminal Forge episodes cannot be reopened');
+				}
 				const episode = requireEvolutionEpisodeService().updateEpisode(args.episode_id, {
 					status: args.status,
 					title: args.title,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2097,6 +2097,67 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 		},
 
+		async list_forge_lessons(args: {
+			scope_id: string;
+			status?: EvolutionLessonStatus;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const lessons = requireEvolutionEpisodeService().listLessons(args.scope_id, args.status);
+				logAudit('list_forge_lessons', { scope_id: args.scope_id, status: args.status });
+				return jsonResult({ success: true, lessons });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_forge_proposals(args: {
+			scope_id: string;
+			status?: TaskProposalStatus;
+		}): Promise<ToolResult> {
+			try {
+				requireEvolutionScopeInSpace(args.scope_id);
+				const proposals = requireEvolutionEpisodeService().listTaskProposals(
+					args.scope_id,
+					args.status
+				);
+				logAudit('list_forge_proposals', { scope_id: args.scope_id, status: args.status });
+				return jsonResult({ success: true, proposals });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async resolve_forge_scope(args: { goal_id?: string; task_id?: string }): Promise<ToolResult> {
+			try {
+				let scope;
+				if (args.goal_id) {
+					requireGoalInSpace(args.goal_id);
+					scope = requireEvolutionScopeService().resolveScopeForGoal({
+						spaceGoalId: args.goal_id,
+					});
+				} else if (args.task_id) {
+					const task = taskRepo.getTask(args.task_id);
+					if (!task || task.spaceId !== spaceId) throw new Error(`Task not found: ${args.task_id}`);
+					scope = requireEvolutionScopeService().resolveScopeForTask({ taskId: args.task_id });
+				} else {
+					throw new Error('Provide goal_id or task_id');
+				}
+				if (!scope) return jsonResult({ success: false, error: 'No scope found' });
+				logAudit('resolve_forge_scope', {
+					goal_id: args.goal_id,
+					task_id: args.task_id,
+					scope_id: scope.id,
+				});
+				return jsonResult({ success: true, scope });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
 		async update_forge_episode(args: {
 			episode_id: string;
 			status?: EvolutionEpisodeStatus;
@@ -2897,7 +2958,8 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		const metadataSchema = z.record(z.string(), z.unknown());
 		const episodeStatusSchema = z.enum(['draft', 'accepted', 'dismissed']);
 		const lessonStatusSchema = z.enum(['candidate', 'active', 'dismissed']);
-		const proposalStatusSchema = z.enum(['proposed', 'accepted', 'dismissed']);
+		const proposalUpdateStatusSchema = z.enum(['proposed', 'accepted', 'dismissed']);
+		const proposalStatusSchema = z.enum(['proposed', 'accepted', 'dismissed', 'created']);
 		const prioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
 
 		tools.push(
@@ -3054,6 +3116,33 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 				(args) => handlers.list_forge_review_bundle(args)
 			),
 			tool(
+				'list_forge_lessons',
+				'List Forge lessons for a scope, optionally filtered by status.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					status: lessonStatusSchema.optional(),
+				},
+				(args) => handlers.list_forge_lessons(args)
+			),
+			tool(
+				'list_forge_proposals',
+				'List Forge task proposals for a scope, optionally filtered by status.',
+				{
+					scope_id: z.string().describe('EvolutionScope ID'),
+					status: proposalStatusSchema.optional(),
+				},
+				(args) => handlers.list_forge_proposals(args)
+			),
+			tool(
+				'resolve_forge_scope',
+				'Resolve a Forge scope from a linked goal_id or task_id when scope_id is unknown.',
+				{
+					goal_id: z.string().optional(),
+					task_id: z.string().optional(),
+				},
+				(args) => handlers.resolve_forge_scope(args)
+			),
+			tool(
 				'update_forge_episode',
 				'Accept, dismiss, or edit a Forge episode draft. Use status accepted/dismissed only after explicit decision.',
 				{
@@ -3099,7 +3188,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					description: z.string().optional(),
 					reason: z.string().optional(),
 					priority: prioritySchema.optional(),
-					status: proposalStatusSchema.optional(),
+					status: proposalUpdateStatusSchema.optional(),
 				},
 				(args) => handlers.update_forge_task_proposal(args)
 			),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -434,7 +434,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 */
 		async get_workflow_run(args: { run_id: string }): Promise<ToolResult> {
 			const run = workflowRunRepo.getRun(args.run_id);
-			if (!run) {
+			if (!run || run.spaceId !== spaceId) {
 				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
 			}
 
@@ -459,7 +459,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			workflow_handle?: string;
 		}): Promise<ToolResult> {
 			const run = workflowRunRepo.getRun(args.run_id);
-			if (!run) {
+			if (!run || run.spaceId !== spaceId) {
 				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
 			}
 
@@ -660,6 +660,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		}): Promise<ToolResult> {
 			let tasks: SpaceTask[];
 			if (args.workflow_run_id) {
+				const run = workflowRunRepo.getRun(args.workflow_run_id);
+				if (!run || run.spaceId !== spaceId) {
+					return jsonResult({
+						success: false,
+						error: `Workflow run not found: ${args.workflow_run_id}`,
+					});
+				}
 				tasks = taskRepo.listByWorkflowRun(args.workflow_run_id);
 				if (args.status) {
 					tasks = tasks.filter((t) => t.status === args.status);
@@ -1389,7 +1396,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			}
 
 			const run = workflowRunRepo.getRun(args.run_id);
-			if (!run) {
+			if (!run || run.spaceId !== spaceId) {
 				return jsonResult({ success: false, error: `Workflow run not found: ${args.run_id}` });
 			}
 			if (run.status === 'done' || run.status === 'cancelled' || run.status === 'pending') {
@@ -2191,7 +2198,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			confidence?: number;
 		}): Promise<ToolResult> {
 			try {
-				requireEvolutionLessonInSpace(args.lesson_id);
+				const existing = requireEvolutionLessonInSpace(args.lesson_id);
+				if (existing.status === 'dismissed' && args.status && args.status !== 'dismissed') {
+					throw new Error('Dismissed lessons cannot be reactivated');
+				}
 				const lesson = requireEvolutionEpisodeService().updateLesson(args.lesson_id, {
 					status: args.status,
 					appliesTo: args.applies_to,
@@ -2254,6 +2264,9 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				}
 				if (existing.status === 'created' && args.status) {
 					throw new Error('Created task proposals cannot be reopened');
+				}
+				if (existing.status === 'dismissed' && args.status && args.status !== 'dismissed') {
+					throw new Error('Dismissed proposals cannot be reopened');
 				}
 				const proposal = requireEvolutionEpisodeService().updateTaskProposal(args.proposal_id, {
 					title: args.title,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2153,8 +2153,12 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		}): Promise<ToolResult> {
 			try {
 				requireEvolutionScopeInSpace(args.scope_id);
-				for (const episodeId of args.evidence_episode_ids ?? [])
-					requireEvolutionEpisodeInSpace(episodeId);
+				for (const episodeId of args.evidence_episode_ids ?? []) {
+					const episode = requireEvolutionEpisodeInSpace(episodeId);
+					if (episode.scopeId !== args.scope_id) {
+						throw new Error(`EvolutionEpisode not found in scope: ${episodeId}`);
+					}
+				}
 				const proposal = requireEvolutionEpisodeService().createTaskProposal({
 					scopeId: args.scope_id,
 					title: args.title,
@@ -2180,7 +2184,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			status?: TaskProposalStatus;
 		}): Promise<ToolResult> {
 			try {
-				requireTaskProposalInSpace(args.proposal_id);
+				const existing = requireTaskProposalInSpace(args.proposal_id);
+				if (args.status === 'created') {
+					throw new Error('Use create_task_from_forge_proposal to create tasks from proposals');
+				}
+				if (existing.status === 'created' && args.status) {
+					throw new Error('Created task proposals cannot be reopened');
+				}
 				const proposal = requireEvolutionEpisodeService().updateTaskProposal(args.proposal_id, {
 					title: args.title,
 					description: args.description,
@@ -2887,7 +2897,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		const metadataSchema = z.record(z.string(), z.unknown());
 		const episodeStatusSchema = z.enum(['draft', 'accepted', 'dismissed']);
 		const lessonStatusSchema = z.enum(['candidate', 'active', 'dismissed']);
-		const proposalStatusSchema = z.enum(['proposed', 'accepted', 'dismissed', 'created']);
+		const proposalStatusSchema = z.enum(['proposed', 'accepted', 'dismissed']);
 		const prioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
 
 		tools.push(

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -360,6 +360,9 @@ describe('createSpaceAgentMcpServer — tool registration', () => {
 		expect(names).toContain('create_forge_scope');
 		expect(names).toContain('add_forge_manual_note');
 		expect(names).toContain('create_forge_episode');
+		expect(names).toContain('list_forge_lessons');
+		expect(names).toContain('list_forge_proposals');
+		expect(names).toContain('resolve_forge_scope');
 		expect(names).toContain('update_forge_lesson');
 		expect(names).toContain('create_task_from_forge_proposal');
 	});
@@ -603,6 +606,155 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(rollup.episode.status).toBe('accepted');
 		expect(rollup.goal.summary).toBe('Dogfood path complete');
 		expect(rollup.goal.progress).toBe(42);
+	});
+
+	test('lists Forge lessons with optional status filter', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Lesson scope',
+					objective: 'List lessons',
+				})
+			).content[0].text
+		).scope;
+		const evidence = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: scope.id,
+					summary: 'Lesson evidence',
+				})
+			).content[0].text
+		).evidence;
+		const episodeResult = JSON.parse(
+			(
+				await handlers.create_forge_episode({
+					scope_id: scope.id,
+					evidence_ids: [evidence.id],
+				})
+			).content[0].text
+		);
+
+		const candidateLessons = JSON.parse(
+			(await handlers.list_forge_lessons({ scope_id: scope.id })).content[0].text
+		);
+		expect(candidateLessons.success).toBe(true);
+		expect(candidateLessons.lessons).toHaveLength(1);
+		expect(candidateLessons.lessons[0].status).toBe('candidate');
+
+		await handlers.update_forge_lesson({
+			lesson_id: episodeResult.lessons[0].id,
+			status: 'active',
+		});
+		const activeLessons = JSON.parse(
+			(await handlers.list_forge_lessons({ scope_id: scope.id, status: 'active' })).content[0].text
+		);
+		expect(activeLessons.success).toBe(true);
+		expect(activeLessons.lessons).toHaveLength(1);
+		expect(activeLessons.lessons[0].id).toBe(episodeResult.lessons[0].id);
+
+		const remainingCandidates = JSON.parse(
+			(await handlers.list_forge_lessons({ scope_id: scope.id, status: 'candidate' })).content[0]
+				.text
+		);
+		expect(remainingCandidates.lessons).toHaveLength(0);
+	});
+
+	test('lists Forge proposals with optional status filter', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Proposal list scope',
+					objective: 'List proposals',
+				})
+			).content[0].text
+		).scope;
+		const proposal = JSON.parse(
+			(
+				await handlers.create_forge_task_proposal({
+					scope_id: scope.id,
+					title: 'Manual proposal',
+					description: 'Do thing',
+					reason: 'Need thing',
+				})
+			).content[0].text
+		).proposal;
+
+		const proposals = JSON.parse(
+			(await handlers.list_forge_proposals({ scope_id: scope.id })).content[0].text
+		);
+		expect(proposals.success).toBe(true);
+		expect(proposals.proposals).toHaveLength(1);
+		expect(proposals.proposals[0].id).toBe(proposal.id);
+
+		const proposed = JSON.parse(
+			(await handlers.list_forge_proposals({ scope_id: scope.id, status: 'proposed' })).content[0]
+				.text
+		);
+		expect(proposed.success).toBe(true);
+		expect(proposed.proposals).toHaveLength(1);
+		expect(proposed.proposals[0].status).toBe('proposed');
+
+		const accepted = JSON.parse(
+			(await handlers.list_forge_proposals({ scope_id: scope.id, status: 'accepted' })).content[0]
+				.text
+		);
+		expect(accepted.proposals).toHaveLength(0);
+	});
+
+	test('resolves Forge scope by goal or task', async () => {
+		const handlers = makeHandlers(ctx);
+		const goal = JSON.parse(
+			(
+				await handlers.create_goal({
+					title: 'Resolve goal',
+					type: 'recurring',
+				})
+			).content[0].text
+		).goal;
+		const scope = JSON.parse(
+			(await handlers.create_forge_scope_from_goal({ goal_id: goal.id })).content[0].text
+		).scope;
+
+		const byGoal = JSON.parse(
+			(await handlers.resolve_forge_scope({ goal_id: goal.id })).content[0].text
+		);
+		expect(byGoal.success).toBe(true);
+		expect(byGoal.scope.id).toBe(scope.id);
+
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Scoped task',
+			description: 'Has scope',
+			goalId: goal.id,
+			evolutionScopeId: scope.id,
+		});
+		const byTask = JSON.parse(
+			(await handlers.resolve_forge_scope({ task_id: task.id })).content[0].text
+		);
+		expect(byTask.success).toBe(true);
+		expect(byTask.scope.id).toBe(scope.id);
+
+		const unlinkedGoal = JSON.parse(
+			(
+				await handlers.create_goal({
+					title: 'Unlinked goal',
+					type: 'recurring',
+				})
+			).content[0].text
+		).goal;
+		const missing = JSON.parse(
+			(await handlers.resolve_forge_scope({ goal_id: unlinkedGoal.id })).content[0].text
+		);
+		expect(missing.success).toBe(false);
+		expect(missing.error).toBe('No scope found');
+
+		const noArgs = JSON.parse((await handlers.resolve_forge_scope({})).content[0].text);
+		expect(noArgs.success).toBe(false);
+		expect(noArgs.error).toContain('Provide goal_id or task_id');
 	});
 
 	test('rejects mismatched proposal evidence episodes', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -19,6 +19,8 @@ import { SpaceGoalEventRepository } from '../../../../src/storage/repositories/s
 import { SpaceGoalRepository } from '../../../../src/storage/repositories/space-goal-repository.ts';
 import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
 import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository.ts';
+import { EvolutionRepository } from '../../../../src/storage/repositories/evolution-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
@@ -29,6 +31,8 @@ import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.t
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import { ScheduleService } from '../../../../src/lib/space/schedule/schedule-service.ts';
 import { SpaceGoalService } from '../../../../src/lib/space/goals/goal-service.ts';
+import { EvolutionScopeService } from '../../../../src/lib/space/evolution-scope-service.ts';
+import { EvolutionEpisodeService } from '../../../../src/lib/space/evolution-episode-service.ts';
 import {
 	createSpaceAgentMcpServer,
 	createSpaceAgentToolHandlers,
@@ -128,6 +132,9 @@ interface TestCtx {
 	nodeExecutionRepo: NodeExecutionRepository;
 	spaceManager: SpaceManager;
 	goalService: SpaceGoalService;
+	evolutionRepo: EvolutionRepository;
+	evolutionScopeService: EvolutionScopeService;
+	evolutionEpisodeService: EvolutionEpisodeService;
 }
 
 function makeCtx(): TestCtx {
@@ -170,13 +177,59 @@ function makeCtx(): TestCtx {
 		jobQueue: new JobQueueRepository(db),
 		spaceRepo,
 	});
+	const goalRepo = new SpaceGoalRepository(db);
 	const goalService = new SpaceGoalService({
-		goalRepo: new SpaceGoalRepository(db),
+		goalRepo,
 		goalEventRepo: new SpaceGoalEventRepository(db),
 		taskRepo,
 		spaceRepo,
 		scheduleService,
 		db,
+	});
+	const evolutionRepo = new EvolutionRepository(db);
+	const evolutionScopeService = new EvolutionScopeService({
+		evolutionRepo,
+		spaceRepo,
+		goalRepo,
+		taskRepo,
+		workflowRunRepo,
+	});
+	const evolutionEpisodeService = new EvolutionEpisodeService({
+		evolutionRepo,
+		taskRepo,
+		workflowRunRepo,
+		artifactRepo: new WorkflowRunArtifactRepository(db),
+		goalService,
+		judgeEpisode: async () => ({
+			title: 'Dogfood episode',
+			outcomeSummary: 'Scoped evidence reviewed',
+			findings: [
+				{
+					domain: 'workflow',
+					kind: 'optimization',
+					impact: 'medium',
+					confidence: 0.8,
+					evidence: ['manual note'],
+					proposedAction: 'Add follow-up task',
+				},
+			],
+			candidateLessons: [
+				{
+					appliesTo: ['workflow'],
+					rule: 'Keep evidence scoped',
+					why: 'Reduces drift',
+					confidence: 0.9,
+				},
+			],
+			proposals: [
+				{
+					title: 'Improve Forge MCP dogfood',
+					description: 'Use MCP tools for Forge path',
+					reason: 'Judge found next step',
+					priority: 'high',
+				},
+			],
+		}),
 	});
 
 	return {
@@ -192,6 +245,9 @@ function makeCtx(): TestCtx {
 		nodeExecutionRepo,
 		spaceManager,
 		goalService,
+		evolutionRepo,
+		evolutionScopeService,
+		evolutionEpisodeService,
 	};
 }
 
@@ -207,6 +263,8 @@ function makeHandlers(ctx: TestCtx) {
 		nodeExecutionRepo: ctx.nodeExecutionRepo,
 		spaceManager: ctx.spaceManager,
 		goalService: ctx.goalService,
+		evolutionScopeService: ctx.evolutionScopeService,
+		evolutionEpisodeService: ctx.evolutionEpisodeService,
 	});
 }
 
@@ -281,6 +339,29 @@ describe('createSpaceAgentMcpServer — tool registration', () => {
 		expect(names).toContain('trigger_goal_task');
 		expect(names).toContain('list_goal_tasks');
 		expect(names).toContain('list_goal_events');
+	});
+
+	test('registers Forge tools when evolution services are configured', () => {
+		const server = createSpaceAgentMcpServer({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			goalService: ctx.goalService,
+			evolutionScopeService: ctx.evolutionScopeService,
+			evolutionEpisodeService: ctx.evolutionEpisodeService,
+		});
+
+		const names = getRegisteredToolNames(server);
+		expect(names).toContain('create_forge_scope');
+		expect(names).toContain('add_forge_manual_note');
+		expect(names).toContain('create_forge_episode');
+		expect(names).toContain('update_forge_lesson');
+		expect(names).toContain('create_task_from_forge_proposal');
 	});
 });
 
@@ -404,6 +485,158 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
 		const events = JSON.parse(eventsOut.content[0].text);
 		expect(events.success).toBe(false);
 		expect(events.error).toContain('Goal not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Forge tools
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — Forge tools', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('runs dogfood path with scope, evidence, episode, lesson, proposal task, and rollup', async () => {
+		const handlers = makeHandlers(ctx);
+		const goal = JSON.parse(
+			(
+				await handlers.create_goal({
+					title: 'Forge dogfood',
+					type: 'recurring',
+					progress: 5,
+					next_steps: ['Collect evidence'],
+				})
+			).content[0].text
+		).goal;
+
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope_from_goal({
+					goal_id: goal.id,
+					policy: { cadence: 'weekly', episodeJudgeModel: 'claude-sonnet-4-5' },
+				})
+			).content[0].text
+		).scope;
+		expect(scope.spaceGoalId).toBe(goal.id);
+
+		const updatedScope = JSON.parse(
+			(
+				await handlers.update_forge_scope({
+					scope_id: scope.id,
+					episode_judge_model: 'claude-opus-4-5',
+				})
+			).content[0].text
+		).scope;
+		expect(updatedScope.policy.episodeJudgeModel).toBe('claude-opus-4-5');
+
+		const note = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: scope.id,
+					summary: 'Manual dogfood note',
+					metadata: { source: 'test' },
+				})
+			).content[0].text
+		).evidence;
+		const snapshot = JSON.parse(
+			(
+				await handlers.add_forge_metric_snapshot({
+					scope_id: scope.id,
+					values: { friction: 2 },
+					source: 'manual',
+					note: 'Less friction',
+				})
+			).content[0].text
+		);
+		expect(snapshot.evidence.kind).toBe('metric_snapshot');
+
+		const episodeResult = JSON.parse(
+			(
+				await handlers.create_forge_episode({
+					scope_id: scope.id,
+					evidence_ids: [note.id, snapshot.evidence.id],
+				})
+			).content[0].text
+		);
+		expect(episodeResult.success).toBe(true);
+		expect(episodeResult.lessons).toHaveLength(1);
+		expect(episodeResult.proposals).toHaveLength(1);
+
+		const lesson = JSON.parse(
+			(
+				await handlers.update_forge_lesson({
+					lesson_id: episodeResult.lessons[0].id,
+					status: 'active',
+				})
+			).content[0].text
+		).lesson;
+		expect(lesson.status).toBe('active');
+
+		const taskResult = JSON.parse(
+			(
+				await handlers.create_task_from_forge_proposal({
+					proposal_id: episodeResult.proposals[0].id,
+				})
+			).content[0].text
+		);
+		expect(taskResult.task.goalId).toBe(goal.id);
+		expect(taskResult.task.evolutionScopeId).toBe(scope.id);
+
+		const rollup = JSON.parse(
+			(
+				await handlers.apply_forge_rollup({
+					episode_id: episodeResult.episode.id,
+					goal_update: {
+						summary: 'Dogfood path complete',
+						progress: 42,
+						next_steps: ['Use proposal task'],
+						metrics: { friction: 2 },
+					},
+				})
+			).content[0].text
+		);
+		expect(rollup.episode.status).toBe('accepted');
+		expect(rollup.goal.summary).toBe('Dogfood path complete');
+		expect(rollup.goal.progress).toBe(42);
+	});
+
+	test('rejects cross-space scope and task evidence access', async () => {
+		const otherSpaceId = 'other-forge-space';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-forge');
+		const otherScope = ctx.evolutionScopeService.createScope({
+			spaceId: otherSpaceId,
+			kind: 'custom',
+			name: 'Other scope',
+			objective: 'Other objective',
+		});
+		const otherTask = ctx.taskRepo.createTask({
+			spaceId: otherSpaceId,
+			title: 'Other task',
+			description: 'Outside this space',
+		});
+		const handlers = makeHandlers(ctx);
+
+		const scopeOut = JSON.parse(
+			(await handlers.get_forge_scope({ scope_id: otherScope.id })).content[0].text
+		);
+		expect(scopeOut.success).toBe(false);
+		expect(scopeOut.error).toContain('EvolutionScope not found');
+
+		const evidenceOut = JSON.parse(
+			(
+				await handlers.attach_forge_task_evidence({
+					scope_id: otherScope.id,
+					task_id: otherTask.id,
+				})
+			).content[0].text
+		);
+		expect(evidenceOut.success).toBe(false);
+		expect(evidenceOut.error).toContain('Task not found');
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -608,6 +608,62 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(rollup.goal.progress).toBe(42);
 	});
 
+	test('rejects reopening terminal Forge episodes', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Terminal episode scope',
+					objective: 'Guard episode status',
+				})
+			).content[0].text
+		).scope;
+		const evidence = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: scope.id,
+					summary: 'Terminal episode evidence',
+				})
+			).content[0].text
+		).evidence;
+		const episode = JSON.parse(
+			(
+				await handlers.create_forge_episode({
+					scope_id: scope.id,
+					evidence_ids: [evidence.id],
+				})
+			).content[0].text
+		).episode;
+
+		const accepted = JSON.parse(
+			(
+				await handlers.update_forge_episode({
+					episode_id: episode.id,
+					status: 'accepted',
+				})
+			).content[0].text
+		);
+		expect(accepted.success).toBe(true);
+		expect(accepted.episode.status).toBe('accepted');
+
+		const reopen = JSON.parse(
+			(
+				await handlers.update_forge_episode({
+					episode_id: episode.id,
+					status: 'draft',
+				})
+			).content[0].text
+		);
+		expect(reopen.success).toBe(false);
+		expect(reopen.error).toContain('Terminal Forge episodes cannot be reopened');
+
+		const afterReopenAttempt = JSON.parse(
+			(await handlers.list_forge_review_bundle({ scope_id: scope.id })).content[0].text
+		).episodes[0];
+		expect(afterReopenAttempt.status).toBe('accepted');
+	});
+
 	test('lists Forge lessons with optional status filter', async () => {
 		const handlers = makeHandlers(ctx);
 		const scope = JSON.parse(

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -23,6 +23,7 @@ import { EvolutionRepository } from '../../../../src/storage/repositories/evolut
 import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -608,6 +609,113 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(rollup.goal.progress).toBe(42);
 	});
 
+	test('covers untested Forge read tools', async () => {
+		const handlers = makeHandlers(ctx);
+		const created = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Read tools scope',
+					objective: 'Exercise read tools',
+				})
+			).content[0].text
+		).scope;
+		const note = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: created.id,
+					summary: 'Read note',
+				})
+			).content[0].text
+		).evidence;
+		const snapshot = JSON.parse(
+			(
+				await handlers.add_forge_metric_snapshot({
+					scope_id: created.id,
+					values: { quality: 7 },
+					source: 'manual',
+					note: 'Quality snapshot',
+				})
+			).content[0].text
+		);
+
+		const listed = JSON.parse((await handlers.list_forge_scopes({})).content[0].text);
+		expect(listed.success).toBe(true);
+		expect(listed.scopes.some((scope: { id: string }) => scope.id === created.id)).toBe(true);
+
+		const fetched = JSON.parse(
+			(await handlers.get_forge_scope({ scope_id: created.id })).content[0].text
+		);
+		expect(fetched.success).toBe(true);
+		expect(fetched.scope.id).toBe(created.id);
+
+		const timeline = JSON.parse(
+			(await handlers.get_forge_timeline({ scope_id: created.id })).content[0].text
+		);
+		expect(timeline.success).toBe(true);
+		expect(timeline.scope.id).toBe(created.id);
+		expect(timeline.evidence).toHaveLength(2);
+		expect(timeline.metricSnapshots).toHaveLength(1);
+
+		const evidence = JSON.parse(
+			(await handlers.list_forge_evidence({ scope_id: created.id })).content[0].text
+		);
+		expect(evidence.success).toBe(true);
+		expect(evidence.evidence.map((item: { id: string }) => item.id)).toContain(note.id);
+		expect(evidence.evidence.map((item: { id: string }) => item.id)).toContain(
+			snapshot.evidence.id
+		);
+
+		const snapshots = JSON.parse(
+			(await handlers.list_forge_metric_snapshots({ scope_id: created.id })).content[0].text
+		);
+		expect(snapshots.success).toBe(true);
+		expect(snapshots.snapshots).toHaveLength(1);
+		expect(snapshots.snapshots[0].values.quality).toBe(7);
+	});
+
+	test('attaches workflow run evidence', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Workflow evidence scope',
+					objective: 'Attach workflow evidence',
+				})
+			).content[0].text
+		).scope;
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Forge workflow evidence'
+		);
+		const run = ctx.workflowRunRepo.createRun({
+			spaceId: ctx.spaceId,
+			workflowId: wf.id,
+			title: 'Evidence run',
+		});
+
+		const attached = JSON.parse(
+			(
+				await handlers.attach_forge_workflow_run_evidence({
+					scope_id: scope.id,
+					workflow_run_id: run.id,
+					summary: 'Workflow run evidence',
+				})
+			).content[0].text
+		);
+		expect(attached.success).toBe(true);
+		expect(attached.evidence.sourceId).toBe(run.id);
+
+		const evidence = JSON.parse(
+			(await handlers.list_forge_evidence({ scope_id: scope.id })).content[0].text
+		);
+		expect(evidence.success).toBe(true);
+		expect(evidence.evidence[0].id).toBe(attached.evidence.id);
+	});
+
 	test('rejects reopening terminal Forge episodes', async () => {
 		const handlers = makeHandlers(ctx);
 		const scope = JSON.parse(
@@ -865,6 +973,56 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(result.error).toContain('EvolutionEpisode not found in scope');
 	});
 
+	test('rejects reactivating dismissed lessons', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Dismissed lesson scope',
+					objective: 'Guard lesson status',
+				})
+			).content[0].text
+		).scope;
+		const evidence = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: scope.id,
+					summary: 'Lesson status evidence',
+				})
+			).content[0].text
+		).evidence;
+		const episodeResult = JSON.parse(
+			(
+				await handlers.create_forge_episode({
+					scope_id: scope.id,
+					evidence_ids: [evidence.id],
+				})
+			).content[0].text
+		);
+
+		const dismissed = JSON.parse(
+			(
+				await handlers.update_forge_lesson({
+					lesson_id: episodeResult.lessons[0].id,
+					status: 'dismissed',
+				})
+			).content[0].text
+		);
+		expect(dismissed.success).toBe(true);
+
+		const reactivated = JSON.parse(
+			(
+				await handlers.update_forge_lesson({
+					lesson_id: episodeResult.lessons[0].id,
+					status: 'active',
+				})
+			).content[0].text
+		);
+		expect(reactivated.success).toBe(false);
+		expect(reactivated.error).toContain('Dismissed lessons cannot be reactivated');
+	});
+
 	test('rejects unsafe proposal status updates', async () => {
 		const handlers = makeHandlers(ctx);
 		const scope = JSON.parse(
@@ -919,6 +1077,50 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		);
 		expect(idempotent.success).toBe(true);
 		expect(idempotent.task.id).toBe(taskResult.task.id);
+	});
+
+	test('rejects reopening dismissed proposals', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Dismissed proposal scope',
+					objective: 'Guard proposal status',
+				})
+			).content[0].text
+		).scope;
+		const proposal = JSON.parse(
+			(
+				await handlers.create_forge_task_proposal({
+					scope_id: scope.id,
+					title: 'Dismissible proposal',
+					description: 'Can dismiss',
+					reason: 'Test guard',
+				})
+			).content[0].text
+		).proposal;
+
+		const dismissed = JSON.parse(
+			(
+				await handlers.update_forge_task_proposal({
+					proposal_id: proposal.id,
+					status: 'dismissed',
+				})
+			).content[0].text
+		);
+		expect(dismissed.success).toBe(true);
+
+		const accepted = JSON.parse(
+			(
+				await handlers.update_forge_task_proposal({
+					proposal_id: proposal.id,
+					status: 'accepted',
+				})
+			).content[0].text
+		);
+		expect(accepted.success).toBe(false);
+		expect(accepted.error).toContain('Dismissed proposals cannot be reopened');
 	});
 
 	test('rejects cross-space scope and task evidence access', async () => {
@@ -1027,6 +1229,27 @@ describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
 		expect(parsed.error).toContain('run-missing');
 	});
 
+	test('rejects cross-space workflow run access', async () => {
+		const otherSpaceId = 'other-run-space';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-run-space');
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Other Run WF'
+		);
+		const rawRun = ctx.workflowRunRepo.createRun({
+			spaceId: otherSpaceId,
+			workflowId: wf.id,
+			title: 'other-space run',
+		});
+
+		const result = await makeHandlers(ctx).get_workflow_run({ run_id: rawRun.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(rawRun.id);
+	});
+
 	test('returns run with empty tasks when no tasks have been created', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'NoStep WF');
 		const rawRun = ctx.workflowRunRepo.createRun({
@@ -1102,6 +1325,30 @@ describe('createSpaceAgentToolHandlers — change_plan', () => {
 		const result = await makeHandlers(ctx).change_plan({ run_id: 'run-missing' });
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
+	});
+
+	test('rejects cross-space workflow run plan changes', async () => {
+		const otherSpaceId = 'other-plan-space';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-plan-space');
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Other Plan WF'
+		);
+		const rawRun = ctx.workflowRunRepo.createRun({
+			spaceId: otherSpaceId,
+			workflowId: wf.id,
+			title: 'other-space plan',
+		});
+
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: rawRun.id,
+			description: 'should not update',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(rawRun.id);
 	});
 
 	test('returns error when trying to change plan on completed run', async () => {
@@ -1384,6 +1631,52 @@ describe('createSpaceAgentToolHandlers — change_plan', () => {
 	});
 });
 
+describe('createSpaceAgentToolHandlers — approve_gate', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('rejects cross-space workflow runs', async () => {
+		const otherSpaceId = 'other-gate-space';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-gate-space');
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Other Gate WF'
+		);
+		const rawRun = ctx.workflowRunRepo.createRun({
+			spaceId: otherSpaceId,
+			workflowId: wf.id,
+			title: 'other-space gate',
+		});
+
+		const handlers = createSpaceAgentToolHandlers({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			gateDataRepo: new GateDataRepository(ctx.db),
+		});
+		const result = await handlers.approve_gate({
+			run_id: rawRun.id,
+			gate_id: 'gate-1',
+			approved: true,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(rawRun.id);
+	});
+});
+
 // ---------------------------------------------------------------------------
 // list_tasks
 // ---------------------------------------------------------------------------
@@ -1421,6 +1714,27 @@ describe('createSpaceAgentToolHandlers — list_tasks', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.tasks).toHaveLength(1);
 		expect(parsed.tasks[0].workflowRunId).toBe(runId);
+	});
+
+	test('rejects cross-space workflow_run_id task filter', async () => {
+		const otherSpaceId = 'other-task-filter-space';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-task-filter-space');
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Other Task WF'
+		);
+		const rawRun = ctx.workflowRunRepo.createRun({
+			spaceId: otherSpaceId,
+			workflowId: wf.id,
+			title: 'other-space task filter',
+		});
+
+		const result = await makeHandlers(ctx).list_tasks({ workflow_run_id: rawRun.id });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(rawRun.id);
 	});
 
 	test('filters tasks by status', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -605,6 +605,114 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(rollup.goal.progress).toBe(42);
 	});
 
+	test('rejects mismatched proposal evidence episodes', async () => {
+		const handlers = makeHandlers(ctx);
+		const scopeA = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Scope A',
+					objective: 'First scope',
+				})
+			).content[0].text
+		).scope;
+		const scopeB = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Scope B',
+					objective: 'Second scope',
+				})
+			).content[0].text
+		).scope;
+		const evidenceB = JSON.parse(
+			(
+				await handlers.add_forge_manual_note({
+					scope_id: scopeB.id,
+					summary: 'Scope B evidence',
+				})
+			).content[0].text
+		).evidence;
+		const episodeB = JSON.parse(
+			(
+				await handlers.create_forge_episode({
+					scope_id: scopeB.id,
+					evidence_ids: [evidenceB.id],
+				})
+			).content[0].text
+		).episode;
+
+		const result = JSON.parse(
+			(
+				await handlers.create_forge_task_proposal({
+					scope_id: scopeA.id,
+					title: 'Wrong scope proposal',
+					description: 'Should fail',
+					reason: 'Episode belongs elsewhere',
+					evidence_episode_ids: [episodeB.id],
+				})
+			).content[0].text
+		);
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('EvolutionEpisode not found in scope');
+	});
+
+	test('rejects unsafe proposal status updates', async () => {
+		const handlers = makeHandlers(ctx);
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Proposal scope',
+					objective: 'Guard proposal status',
+				})
+			).content[0].text
+		).scope;
+		const proposal = JSON.parse(
+			(
+				await handlers.create_forge_task_proposal({
+					scope_id: scope.id,
+					title: 'Proposal',
+					description: 'Create task later',
+					reason: 'Need task',
+				})
+			).content[0].text
+		).proposal;
+
+		const manualCreated = JSON.parse(
+			(
+				await handlers.update_forge_task_proposal({
+					proposal_id: proposal.id,
+					status: 'created',
+				})
+			).content[0].text
+		);
+		expect(manualCreated.success).toBe(false);
+		expect(manualCreated.error).toContain('create_task_from_forge_proposal');
+
+		const taskResult = JSON.parse(
+			(await handlers.create_task_from_forge_proposal({ proposal_id: proposal.id })).content[0].text
+		);
+		expect(taskResult.success).toBe(true);
+
+		const reopen = JSON.parse(
+			(
+				await handlers.update_forge_task_proposal({
+					proposal_id: proposal.id,
+					status: 'accepted',
+				})
+			).content[0].text
+		);
+		expect(reopen.success).toBe(false);
+		expect(reopen.error).toContain('cannot be reopened');
+
+		const idempotent = JSON.parse(
+			(await handlers.create_task_from_forge_proposal({ proposal_id: proposal.id })).content[0].text
+		);
+		expect(idempotent.success).toBe(true);
+		expect(idempotent.task.id).toBe(taskResult.task.id);
+	});
+
 	test('rejects cross-space scope and task evidence access', async () => {
 		const otherSpaceId = 'other-forge-space';
 		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-forge');


### PR DESCRIPTION
Adds Space Agent MCP tools for recurring goals and Forge dogfood flows: scope CRUD/linking, evidence, metric snapshots, episode review, lessons, proposals, proposal task creation, and rollups.

Reuses existing goal/Forge services and adds daemon unit coverage for same-space validation plus end-to-end MCP-only dogfood path.

Tests:
- bun test tests/unit/5-space/runtime/space-agent-tools.test.ts
- bun run check