### PR TITLE
Fix Forge rollup after episode acceptance

### DIFF
--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -280,16 +280,19 @@ export class EvolutionEpisodeService {
 		if (!this.deps.goalService) throw new Error('SpaceGoalService is required');
 		const episode = this.deps.evolutionRepo.getEpisode(params.episodeId);
 		if (!episode) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
-		if (episode.status === 'accepted') throw new Error('Episode already accepted');
+		if (episode.rollupAppliedAt !== null) throw new Error('Episode rollup already applied');
 		if (episode.status === 'dismissed') throw new Error('Dismissed episode cannot accept rollup');
 		const scope = this.requireScope(episode.scopeId);
 		if (!scope.spaceGoalId) throw new Error('Episode scope is not linked to a recurring goal');
-		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, { status: 'accepted' });
-		if (!accepted) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
 		const goal = this.deps.goalService.updateGoal(scope.spaceGoalId, params.goalUpdate, {
 			source: 'rpc',
-			note: `Forge rollup accepted: ${accepted.title}`,
+			note: `Forge rollup accepted: ${episode.title}`,
 		});
+		const accepted = this.deps.evolutionRepo.updateEpisode(episode.id, {
+			status: 'accepted',
+			rollupAppliedAt: Date.now(),
+		});
+		if (!accepted) throw new Error(`EvolutionEpisode not found: ${params.episodeId}`);
 		return { episode: accepted, goal };
 	}
 

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -216,7 +216,8 @@ export class EvolutionEpisodeService {
 	}
 
 	updateEpisode(id: string, params: UpdateEvolutionEpisodeParams): EvolutionEpisode | null {
-		return this.deps.evolutionRepo.updateEpisode(id, params);
+		const { rollupAppliedAt: _rollupAppliedAt, ...safeParams } = params;
+		return this.deps.evolutionRepo.updateEpisode(id, safeParams);
 	}
 
 	listReviewBundle(scopeId: string): EpisodeReviewBundle {

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -152,14 +152,15 @@ export class EvolutionRepository {
 		this.db
 			.prepare(
 				`INSERT INTO evolution_episodes (
-					id, scope_id, status, title, time_window_json, evidence_ids_json,
+					id, scope_id, status, rollup_applied_at, title, time_window_json, evidence_ids_json,
 					outcome_summary, findings_json, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				id,
 				params.scopeId,
 				params.status ?? 'draft',
+				null,
 				params.title,
 				jsonOrNull(params.timeWindow ?? null),
 				JSON.stringify(params.evidenceIds ?? []),
@@ -195,6 +196,7 @@ export class EvolutionRepository {
 			values.push(value);
 		};
 		if (params.status !== undefined) add('status', params.status);
+		if (params.rollupAppliedAt !== undefined) add('rollup_applied_at', params.rollupAppliedAt);
 		if (params.title !== undefined) add('title', params.title);
 		if (params.timeWindow !== undefined) add('time_window_json', jsonOrNull(params.timeWindow));
 		if (params.evidenceIds !== undefined)
@@ -420,6 +422,7 @@ function rowToEpisode(row: Record<string, unknown>): EvolutionEpisode {
 		id: row.id as string,
 		scopeId: row.scope_id as string,
 		status: row.status as EvolutionEpisodeStatus,
+		rollupAppliedAt: (row.rollup_applied_at as number | null) ?? null,
 		title: row.title as string,
 		timeWindow: parseJson(row.time_window_json, null),
 		evidenceIds: parseJson<string[]>(row.evidence_ids_json, []),

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -56,6 +56,7 @@ export function createEvolutionTables(db: BunDatabase): void {
 			scope_id TEXT NOT NULL,
 			status TEXT NOT NULL DEFAULT 'draft'
 				CHECK(status IN ('draft', 'accepted', 'dismissed')),
+			rollup_applied_at INTEGER,
 			title TEXT NOT NULL,
 			time_window_json TEXT,
 			evidence_ids_json TEXT NOT NULL DEFAULT '[]',
@@ -66,6 +67,9 @@ export function createEvolutionTables(db: BunDatabase): void {
 			FOREIGN KEY (scope_id) REFERENCES evolution_scopes(id) ON DELETE CASCADE
 		)
 	`);
+	if (!hasColumn(db, 'evolution_episodes', 'rollup_applied_at')) {
+		db.exec(`ALTER TABLE evolution_episodes ADD COLUMN rollup_applied_at INTEGER`);
+	}
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_evolution_episodes_scope_created ON evolution_episodes(scope_id, created_at DESC)`
 	);
@@ -137,4 +141,10 @@ export function createEvolutionTables(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_evolution_metric_snapshots_scope_captured ON evolution_metric_snapshots(scope_id, captured_at DESC)`
 	);
+}
+
+function hasColumn(db: BunDatabase, tableName: string, columnName: string): boolean {
+	return !!db
+		.prepare(`SELECT name FROM pragma_table_info(?) WHERE name = ?`)
+		.get(tableName, columnName);
 }

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -285,6 +285,7 @@ describe('EvolutionEpisodeService', () => {
 		});
 
 		expect(result.episode.status).toBe('accepted');
+		expect(result.episode.rollupAppliedAt).toBeNumber();
 		expect(result.goal).toMatchObject({
 			summary: 'New rollup summary',
 			progress: 75,
@@ -345,11 +346,6 @@ describe('EvolutionEpisodeService', () => {
 			scopeId: unlinkedScope.id,
 			title: 'Unlinked rollup',
 		});
-		const acceptedEpisode = evolutionRepo.createEpisode({
-			scopeId: linkedScope.id,
-			title: 'Accepted rollup',
-			status: 'accepted',
-		});
 		const dismissedEpisode = evolutionRepo.createEpisode({
 			scopeId: linkedScope.id,
 			title: 'Dismissed rollup',
@@ -368,8 +364,24 @@ describe('EvolutionEpisodeService', () => {
 			artifactRepo,
 			goalService: createGoalService(),
 		});
-		const request = { episodeId: draftEpisode.id, goalUpdate: { summary: 'Rollup' } };
+		const serviceOnlyEpisode = evolutionRepo.createEpisode({
+			scopeId: linkedScope.id,
+			title: 'Service-only rollup',
+		});
+		const request = { episodeId: serviceOnlyEpisode.id, goalUpdate: { summary: 'Rollup' } };
+		const applied = service.applyRollupGoalUpdate({
+			episodeId: draftEpisode.id,
+			goalUpdate: { summary: 'Applied once' },
+		});
 
+		expect(applied.episode.status).toBe('accepted');
+		expect(applied.episode.rollupAppliedAt).toBeNumber();
+		expect(() =>
+			service.applyRollupGoalUpdate({
+				episodeId: draftEpisode.id,
+				goalUpdate: { summary: 'Rollup' },
+			})
+		).toThrow('Episode rollup already applied');
 		expect(() => serviceWithoutGoalService.applyRollupGoalUpdate(request)).toThrow(
 			'SpaceGoalService is required'
 		);
@@ -379,12 +391,6 @@ describe('EvolutionEpisodeService', () => {
 				goalUpdate: { summary: 'Rollup' },
 			})
 		).toThrow('Episode scope is not linked to a recurring goal');
-		expect(() =>
-			service.applyRollupGoalUpdate({
-				episodeId: acceptedEpisode.id,
-				goalUpdate: { summary: 'Rollup' },
-			})
-		).toThrow('Episode already accepted');
 		expect(() =>
 			service.applyRollupGoalUpdate({
 				episodeId: dismissedEpisode.id,
@@ -545,6 +551,7 @@ describe('EvolutionEpisodeService', () => {
 			},
 		]);
 		expect(rollup.episode.status).toBe('accepted');
+		expect(rollup.episode.rollupAppliedAt).toBeNumber();
 		expect(rollup.goal).toMatchObject({
 			summary: 'Forge MVP dogfood loop completed once.',
 			progress: 80,

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -355,9 +355,11 @@ describe('EvolutionEpisodeService', () => {
 				metrics: { latency: 3 },
 			},
 		});
+		const updated = service.updateEpisode(episode.id, { rollupAppliedAt: null });
 
 		expect(result.episode.status).toBe('accepted');
 		expect(result.episode.rollupAppliedAt).toBeNumber();
+		expect(updated?.rollupAppliedAt).toBe(result.episode.rollupAppliedAt);
 		expect(result.goal).toMatchObject({
 			summary: 'New rollup summary',
 			progress: 75,

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -98,6 +98,7 @@ export interface EvolutionEpisode {
 	id: string;
 	scopeId: string;
 	status: EvolutionEpisodeStatus;
+	rollupAppliedAt: number | null;
 	title: string;
 	timeWindow: EvolutionEpisodeTimeWindow | null;
 	evidenceIds: string[];
@@ -119,6 +120,7 @@ export interface CreateEvolutionEpisodeParams {
 
 export interface UpdateEvolutionEpisodeParams {
 	status?: EvolutionEpisodeStatus;
+	rollupAppliedAt?: number | null;
 	title?: string;
 	timeWindow?: EvolutionEpisodeTimeWindow | null;
 	evidenceIds?: string[];

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -586,6 +586,11 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 	);
 	const candidateLessons = lessons.filter((lesson) => lesson.status === 'candidate');
 	const proposedTasks = proposals.filter((proposal) => proposal.status === 'proposed');
+	const canApplyRollup =
+		!!goal &&
+		!!latestEpisode &&
+		latestEpisode.status !== 'dismissed' &&
+		latestEpisode.rollupAppliedAt === null;
 
 	const toggleEvidence = (id: string) => {
 		setSelectedEvidenceIds((current) =>
@@ -726,6 +731,12 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 			setEpisodes((current) =>
 				current.map((item) => (item.id === response.episode.id ? response.episode : item))
 			);
+			if (spaceStore.spaceId.value === response.goal.spaceId) {
+				spaceStore.goals.value = [
+					...spaceStore.goals.value.filter((current) => current.id !== response.goal.id),
+					response.goal,
+				].sort((a, b) => b.updatedAt - a.updatedAt);
+			}
 			toast.success(`Rollup applied to "${response.goal.title}"`);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to apply rollup');
@@ -833,7 +844,7 @@ function EpisodesTab({ scope, goal }: { scope: EvolutionScope; goal: SpaceGoal |
 						</div>
 					</section>
 
-					{goal && latestEpisode.status === 'draft' && (
+					{canApplyRollup && (
 						<section class="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
 							<p class="text-sm font-medium text-blue-100">Manual rollup writeback</p>
 							<p class="mt-1 text-xs text-blue-200/70">

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -124,6 +124,7 @@ function makeEpisode(overrides: Partial<EvolutionEpisode> = {}): EvolutionEpisod
 		id: 'episode-1',
 		scopeId: 'scope-1',
 		status: 'draft',
+		rollupAppliedAt: null,
 		title: 'Review loop episode',
 		timeWindow: { start: now - 1000, end: now },
 		evidenceIds: ['evidence-1'],
@@ -242,7 +243,7 @@ function setupRequests(scope = makeScope()) {
 		}
 		if (method === 'evolution.rollup.apply') {
 			return {
-				episode: makeEpisode({ status: 'accepted' }),
+				episode: makeEpisode({ status: 'accepted', rollupAppliedAt: Date.now() }),
 				goal: makeGoal({ title: 'Improve review loop' }),
 			};
 		}
@@ -367,11 +368,12 @@ describe('SpaceForge', () => {
 		);
 	});
 
-	it('accepts latest episode draft from review UI', async () => {
+	it('accepts latest episode draft from review UI without hiding rollup controls', async () => {
 		render(<SpaceForge spaceId="space-1" />);
 
 		await screen.findByRole('heading', { name: 'Review quality scope' });
 		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+		expect(await screen.findByText('Manual rollup writeback')).toBeTruthy();
 		fireEvent.click((await screen.findAllByRole('button', { name: 'Accept' }))[0]);
 
 		await waitFor(() =>
@@ -380,6 +382,77 @@ describe('SpaceForge', () => {
 				params: { status: 'accepted' },
 			})
 		);
+		expect(screen.getByText('Manual rollup writeback')).toBeTruthy();
+	});
+
+	it('shows rollup controls for accepted episodes until rollup is applied', async () => {
+		const acceptedEpisode = makeEpisode({ status: 'accepted' });
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'evolution.scope.list') return { scopes: [makeScope()] };
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.review.get') {
+				return {
+					episodes: [acceptedEpisode],
+					lessons: [makeLesson()],
+					proposals: [makeProposal()],
+				};
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+
+		expect(await screen.findByText('Manual rollup writeback')).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Apply rollup' })).toBeTruthy();
+	});
+
+	it('hides rollup controls for dismissed episodes', async () => {
+		const dismissedEpisode = makeEpisode({ status: 'dismissed' });
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'evolution.scope.list') return { scopes: [makeScope()] };
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.review.get') {
+				return {
+					episodes: [dismissedEpisode],
+					lessons: [makeLesson()],
+					proposals: [makeProposal()],
+				};
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+
+		await screen.findByText('Reviewer feedback identified recurring friction.');
+		expect(screen.queryByText('Manual rollup writeback')).toBeNull();
+		expect(screen.queryByRole('button', { name: 'Apply rollup' })).toBeNull();
+	});
+
+	it('hides rollup controls once rollup is applied', async () => {
+		const appliedEpisode = makeEpisode({ status: 'accepted', rollupAppliedAt: Date.now() });
+		mockRequest.mockImplementation(async (method: string) => {
+			if (method === 'evolution.scope.list') return { scopes: [makeScope()] };
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.review.get') {
+				return { episodes: [appliedEpisode], lessons: [makeLesson()], proposals: [makeProposal()] };
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.click(screen.getByRole('button', { name: 'episodes' }));
+
+		await screen.findByText('Reviewer feedback identified recurring friction.');
+		expect(screen.queryByText('Manual rollup writeback')).toBeNull();
+		expect(screen.queryByRole('button', { name: 'Apply rollup' })).toBeNull();
 	});
 
 	it('activates candidate lesson from review UI', async () => {


### PR DESCRIPTION
Fixes Forge episode review so accepting an episode no longer hides manual rollup writeback.

- Track rollup application separately with `rollupAppliedAt`
- Keep rollup controls visible for accepted, not-yet-rolled-up episodes
- Mark rollup applied after linked recurring goal update succeeds
- Cover draft, accepted, dismissed, and applied states in tests

Tests:
- `cd packages/web && bunx vitest run src/components/space/__tests__/SpaceForge.test.tsx`
- `cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts`
- `bun run check`
- Browser validation on `make dev DB_PATH=/tmp/beokai-8383 PORT=8383`