### PR TITLE
Edit Forge judge model on scopes

### DIFF
--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -354,6 +354,7 @@ export class ProviderService {
 		return provider.ownsModel(model);
 	}
 
+
 	/**
 	 * Get environment variables for SDK subprocess based on explicit (modelId, providerId) pair.
 	 *

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -354,7 +354,6 @@ export class ProviderService {
 		return provider.ownsModel(model);
 	}
 
-
 	/**
 	 * Get environment variables for SDK subprocess based on explicit (modelId, providerId) pair.
 	 *

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -34,6 +34,7 @@ import type { SpaceGoalService } from './goals/goal-service';
 import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
 import { Logger } from '../logger';
 import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+import { getAvailableModels } from '../model-service';
 import { inferProviderForModel } from '../providers/registry';
 
 const log = new Logger('evolution-episode-service');
@@ -522,7 +523,11 @@ export async function resolveEpisodeJudgeModel(
 		: spaceRepo?.getSpace(input.scope.spaceId)?.defaultModel;
 	const selectedModel = scopeModel ?? spaceModel?.trim();
 	if (selectedModel) {
-		return { provider: inferProviderForModel(selectedModel), modelId: selectedModel };
+		const cachedModel = findCachedModel(selectedModel);
+		return {
+			provider: cachedModel?.provider ?? inferProviderForModel(selectedModel),
+			modelId: cachedModel?.id ?? selectedModel,
+		};
 	}
 	const providerService = getProviderService();
 	const provider = await providerService.getDefaultProvider();
@@ -533,6 +538,12 @@ export async function resolveEpisodeJudgeModel(
 function readEpisodeJudgeModel(scope: EvolutionScope): string | undefined {
 	const value = scope.policy.episodeJudgeModel;
 	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function findCachedModel(modelId: string): { id: string; provider: string } | undefined {
+	return getAvailableModels('global').find(
+		(model) => model.id === modelId || model.alias === modelId
+	);
 }
 
 async function judgeEpisodeWithModel(

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -518,14 +518,15 @@ export async function resolveEpisodeJudgeModel(
 	spaceRepo?: Pick<SpaceRepository, 'getSpace'>
 ): Promise<{ provider: string; modelId: string }> {
 	const scopeModel = readEpisodeJudgeModel(input.scope);
+	const scopeProvider = scopeModel ? readEpisodeJudgeProvider(input.scope) : undefined;
 	const spaceModel = scopeModel
 		? undefined
 		: spaceRepo?.getSpace(input.scope.spaceId)?.defaultModel;
 	const selectedModel = scopeModel ?? spaceModel?.trim();
 	if (selectedModel) {
-		const cachedModel = findCachedModel(selectedModel);
+		const cachedModel = findCachedModel(selectedModel, scopeProvider);
 		return {
-			provider: cachedModel?.provider ?? inferProviderForModel(selectedModel),
+			provider: scopeProvider ?? cachedModel?.provider ?? inferProviderForModel(selectedModel),
 			modelId: cachedModel?.id ?? selectedModel,
 		};
 	}
@@ -540,9 +541,20 @@ function readEpisodeJudgeModel(scope: EvolutionScope): string | undefined {
 	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-function findCachedModel(modelId: string): { id: string; provider: string } | undefined {
-	return getAvailableModels('global').find(
-		(model) => model.id === modelId || model.alias === modelId
+function readEpisodeJudgeProvider(scope: EvolutionScope): string | undefined {
+	const value = scope.policy.episodeJudgeProvider;
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function findCachedModel(
+	modelId: string,
+	provider?: string
+): { id: string; provider: string } | undefined {
+	const models = getAvailableModels('global');
+	const providerMatches = provider ? models.filter((model) => model.provider === provider) : models;
+	return (
+		providerMatches.find((model) => model.id === modelId) ??
+		providerMatches.find((model) => model.alias === modelId)
 	);
 }
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/evolution-repository.test.ts
@@ -63,10 +63,15 @@ describe('EvolutionRepository', () => {
 		const updated = repo.updateScope(scope.id, {
 			spaceGoalId: null,
 			objective: 'Reduce review churn and retries',
+			policy: { ...scope.policy, episodeJudgeModel: 'claude-sonnet-4-5' },
 		});
 
 		expect(updated?.spaceGoalId).toBeNull();
 		expect(updated?.objective).toBe('Reduce review churn and retries');
+		expect(updated?.policy).toMatchObject({
+			episodeJudgeModel: 'claude-sonnet-4-5',
+			maxActiveLessons: 3,
+		});
 		expect(repo.listScopes({ spaceId, spaceGoalId: null })[0]?.id).toBe(scope.id);
 	});
 

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -133,6 +133,110 @@ describe('EvolutionEpisodeService', () => {
 		).resolves.toEqual({ provider: 'openrouter', modelId: 'shared-model' });
 	});
 
+	it('resolves exact cached model IDs before alias fallback', async () => {
+		setModelsCache(
+			new Map([
+				[
+					'global',
+					[
+						{
+							id: 'sonnet',
+							name: 'Claude Sonnet',
+							alias: 'default',
+							family: 'sonnet',
+							provider: 'anthropic',
+							contextWindow: 200000,
+							description: 'Fallback sonnet',
+							releaseDate: '2026-01-01',
+							available: true,
+						},
+						{
+							id: 'default',
+							name: 'Custom default',
+							alias: 'custom-default',
+							family: 'sonnet',
+							provider: 'openrouter',
+							contextWindow: 200000,
+							description: 'Custom endpoint default model',
+							releaseDate: '2026-01-01',
+							available: true,
+						},
+					],
+				],
+			])
+		);
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Judge scope',
+			objective: 'Select judge model',
+			policy: { episodeJudgeModel: 'default' },
+		});
+
+		await expect(
+			resolveEpisodeJudgeModel({
+				scope,
+				evidence: [],
+				metricSnapshots: [],
+				tasks: [],
+				workflowRuns: [],
+				timeWindow: null,
+			})
+		).resolves.toEqual({ provider: 'openrouter', modelId: 'default' });
+	});
+
+	it('resolves scope judge model with stored provider identity', async () => {
+		setModelsCache(
+			new Map([
+				[
+					'global',
+					[
+						{
+							id: 'shared-model',
+							name: 'Anthropic shared',
+							alias: 'shared',
+							family: 'sonnet',
+							provider: 'anthropic',
+							contextWindow: 200000,
+							description: 'Anthropic shared model',
+							releaseDate: '2026-01-01',
+							available: true,
+						},
+						{
+							id: 'shared-model',
+							name: 'OpenRouter shared',
+							alias: 'shared',
+							family: 'sonnet',
+							provider: 'openrouter',
+							contextWindow: 200000,
+							description: 'OpenRouter shared model',
+							releaseDate: '2026-01-01',
+							available: true,
+						},
+					],
+				],
+			])
+		);
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Judge scope',
+			objective: 'Select judge model',
+			policy: { episodeJudgeModel: 'shared-model', episodeJudgeProvider: 'openrouter' },
+		});
+
+		await expect(
+			resolveEpisodeJudgeModel({
+				scope,
+				evidence: [],
+				metricSnapshots: [],
+				tasks: [],
+				workflowRuns: [],
+				timeWindow: null,
+			})
+		).resolves.toEqual({ provider: 'openrouter', modelId: 'shared-model' });
+	});
+
 	it('builds episode input with task results, workflow artifacts, metrics, and notes', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -7,6 +7,7 @@ import {
 	resolveEpisodeJudgeModel,
 } from '../../../src/lib/space/evolution-episode-service';
 import { EvolutionScopeService } from '../../../src/lib/space/evolution-scope-service';
+import { clearModelsCache, setModelsCache } from '../../../src/lib/model-service';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
 import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
 import { SpaceGoalEventRepository } from '../../../src/storage/repositories/space-goal-event-repository';
@@ -51,6 +52,7 @@ describe('EvolutionEpisodeService', () => {
 	});
 
 	afterEach(() => {
+		clearModelsCache('global');
 		db.close();
 	});
 
@@ -88,6 +90,47 @@ describe('EvolutionEpisodeService', () => {
 				{ getSpace: () => ({ defaultModel: 'claude-sonnet-4-5' }) as never }
 			)
 		).resolves.toEqual({ provider: 'anthropic', modelId: 'claude-sonnet-4-5' });
+	});
+
+	it('resolves episode judge model provider from cached model catalog', async () => {
+		setModelsCache(
+			new Map([
+				[
+					'global',
+					[
+						{
+							id: 'shared-model',
+							name: 'Shared model',
+							alias: 'shared',
+							family: 'sonnet',
+							provider: 'openrouter',
+							contextWindow: 200000,
+							description: 'Shared model ID with provider context',
+							releaseDate: '2026-01-01',
+							available: true,
+						},
+					],
+				],
+			])
+		);
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Judge scope',
+			objective: 'Select judge model',
+			policy: { episodeJudgeModel: 'shared' },
+		});
+
+		await expect(
+			resolveEpisodeJudgeModel({
+				scope,
+				evidence: [],
+				metricSnapshots: [],
+				tasks: [],
+				workflowRuns: [],
+				timeWindow: null,
+			})
+		).resolves.toEqual({ provider: 'openrouter', modelId: 'shared-model' });
 	});
 
 	it('builds episode input with task results, workflow artifacts, metrics, and notes', () => {

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -54,6 +54,42 @@ describe('EvolutionEpisodeService', () => {
 		db.close();
 	});
 
+	it('resolves episode judge model from scope policy before Space default', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Judge scope',
+			objective: 'Select judge model',
+			policy: { episodeJudgeModel: 'claude-opus-4-5', maxActiveLessons: 5 },
+		});
+		const input = {
+			scope,
+			evidence: [],
+			metricSnapshots: [],
+			tasks: [],
+			workflowRuns: [],
+			timeWindow: null,
+		};
+
+		await expect(
+			resolveEpisodeJudgeModel(input, {
+				getSpace: () => ({ defaultModel: 'claude-sonnet-4-5' }) as never,
+			})
+		).resolves.toEqual({ provider: 'anthropic', modelId: 'claude-opus-4-5' });
+
+		const cleared = evolutionRepo.updateScope(scope.id, {
+			policy: { maxActiveLessons: 5 },
+		});
+
+		expect(cleared?.policy).toEqual({ maxActiveLessons: 5 });
+		await expect(
+			resolveEpisodeJudgeModel(
+				{ ...input, scope: cleared as NonNullable<typeof cleared> },
+				{ getSpace: () => ({ defaultModel: 'claude-sonnet-4-5' }) as never }
+			)
+		).resolves.toEqual({ provider: 'anthropic', modelId: 'claude-sonnet-4-5' });
+	});
+
 	it('builds episode input with task results, workflow artifacts, metrics, and notes', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -24,6 +24,7 @@ export type EvolutionFindingKind =
 export type EvolutionImpact = 'low' | 'medium' | 'high';
 export interface EvolutionPolicy extends Record<string, unknown> {
 	episodeJudgeModel?: string;
+	episodeJudgeProvider?: string;
 }
 export type MetricSnapshotValues = Record<string, string | number | boolean | null>;
 

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -1450,9 +1450,20 @@ function ScopeDetail({
 	const [tab, setTab] = useState<ScopeTab>('overview');
 	const [settingsError, setSettingsError] = useState<string | null>(null);
 	const [savingJudgeModel, setSavingJudgeModel] = useState(false);
+	const judgeModelRequestVersion = useRef(0);
+	const judgeModelScopeId = useRef(scope.id);
 	const goal = getGoal(scope, goals);
 
+	useEffect(() => {
+		if (judgeModelScopeId.current === scope.id) return;
+		judgeModelScopeId.current = scope.id;
+		judgeModelRequestVersion.current += 1;
+		setSavingJudgeModel(false);
+		setSettingsError(null);
+	}, [scope.id]);
+
 	const handleJudgeModelChange = async (value: string | undefined) => {
+		const version = ++judgeModelRequestVersion.current;
 		try {
 			setSavingJudgeModel(true);
 			setSettingsError(null);
@@ -1466,6 +1477,7 @@ function ScopeDetail({
 				id: scope.id,
 				params: { policy: nextPolicy },
 			});
+			if (judgeModelRequestVersion.current !== version) return;
 			if (response.scope) {
 				onScopeUpdated(response.scope);
 				toast.success(
@@ -1473,9 +1485,13 @@ function ScopeDetail({
 				);
 			}
 		} catch (err) {
-			setSettingsError(err instanceof Error ? err.message : 'Failed to update judge model');
+			if (judgeModelRequestVersion.current === version) {
+				setSettingsError(err instanceof Error ? err.message : 'Failed to update judge model');
+			}
 		} finally {
-			setSavingJudgeModel(false);
+			if (judgeModelRequestVersion.current === version) {
+				setSavingJudgeModel(false);
+			}
 		}
 	};
 

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -11,6 +11,7 @@ import type {
 	EvolutionScopeCreateResponse,
 	EvolutionScopeKind,
 	EvolutionScopeListResponse,
+	EvolutionScopeUpdateResponse,
 	EvolutionEvidenceListResponse,
 	EvolutionMetricSnapshotCreateResponse,
 	EvolutionMetricSnapshotListResponse,
@@ -1436,9 +1437,47 @@ function MetricsTab({ scope }: { scope: EvolutionScope }) {
 	);
 }
 
-function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal[] }) {
+function ScopeDetail({
+	scope,
+	goals,
+	onScopeUpdated,
+}: {
+	scope: EvolutionScope;
+	goals: SpaceGoal[];
+	onScopeUpdated: (scope: EvolutionScope) => void;
+}) {
+	const { request } = useMessageHub();
 	const [tab, setTab] = useState<ScopeTab>('overview');
+	const [settingsError, setSettingsError] = useState<string | null>(null);
+	const [savingJudgeModel, setSavingJudgeModel] = useState(false);
 	const goal = getGoal(scope, goals);
+
+	const handleJudgeModelChange = async (value: string | undefined) => {
+		try {
+			setSavingJudgeModel(true);
+			setSettingsError(null);
+			const nextPolicy = { ...scope.policy };
+			if (value) {
+				nextPolicy.episodeJudgeModel = value;
+			} else {
+				delete nextPolicy.episodeJudgeModel;
+			}
+			const response = await request<EvolutionScopeUpdateResponse>('evolution.scope.update', {
+				id: scope.id,
+				params: { policy: nextPolicy },
+			});
+			if (response.scope) {
+				onScopeUpdated(response.scope);
+				toast.success(
+					value ? 'Episode judge model updated' : 'Episode judge model override cleared'
+				);
+			}
+		} catch (err) {
+			setSettingsError(err instanceof Error ? err.message : 'Failed to update judge model');
+		} finally {
+			setSavingJudgeModel(false);
+		}
+	};
 
 	return (
 		<div class="flex h-full min-w-0 flex-1 flex-col overflow-hidden">
@@ -1490,6 +1529,26 @@ function ScopeDetail({ scope, goals }: { scope: EvolutionScope; goals: SpaceGoal
 								</p>
 							</div>
 						</div>
+						<section class="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+							<div class="mb-3">
+								<h3 class="text-sm font-medium text-gray-100">Episode judge model</h3>
+								<p class="mt-1 text-xs text-gray-500">
+									Override model for episode judging, or clear to use Space default.
+								</p>
+							</div>
+							<WorkflowModelSelect
+								value={
+									typeof scope.policy.episodeJudgeModel === 'string'
+										? scope.policy.episodeJudgeModel
+										: undefined
+								}
+								onChange={handleJudgeModelChange}
+								testId="scope-episode-judge-model-select"
+								className="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none disabled:opacity-50"
+							/>
+							{savingJudgeModel && <p class="mt-2 text-xs text-gray-500">Saving…</p>}
+							{settingsError && <p class="mt-2 text-xs text-red-400">{settingsError}</p>}
+						</section>
 					</div>
 				)}
 				{tab === 'evidence' && <EvidenceTab scope={scope} />}
@@ -1568,6 +1627,11 @@ export function SpaceForge({ spaceId }: SpaceForgeProps) {
 		setSelectedScopeId(scope.id);
 	};
 
+	const handleScopeUpdated = (scope: EvolutionScope) => {
+		localMutationVersion.current += 1;
+		setScopes((current) => current.map((item) => (item.id === scope.id ? scope : item)));
+	};
+
 	return (
 		<div class="flex h-full min-h-0 overflow-hidden">
 			<aside class="flex w-80 flex-shrink-0 flex-col border-r border-white/10 bg-app-sidebar/40">
@@ -1628,7 +1692,7 @@ export function SpaceForge({ spaceId }: SpaceForgeProps) {
 			</aside>
 
 			{selectedScope ? (
-				<ScopeDetail scope={selectedScope} goals={goals} />
+				<ScopeDetail scope={selectedScope} goals={goals} onScopeUpdated={handleScopeUpdated} />
 			) : (
 				<div class="flex flex-1 items-center justify-center p-8 text-center">
 					<div>

--- a/packages/web/src/components/space/SpaceForge.tsx
+++ b/packages/web/src/components/space/SpaceForge.tsx
@@ -31,7 +31,10 @@ import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
-import { WorkflowModelSelect } from './visual-editor/WorkflowModelSelect';
+import {
+	WorkflowModelSelect,
+	type WorkflowModelSelection,
+} from './visual-editor/WorkflowModelSelect';
 
 type ScopeTab = 'overview' | 'evidence' | 'metrics' | 'lessons' | 'episodes';
 
@@ -139,6 +142,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 	const [kind, setKind] = useState<EvolutionScopeKind>('project');
 	const [spaceGoalId, setSpaceGoalId] = useState('');
 	const [episodeJudgeModel, setEpisodeJudgeModel] = useState<string | undefined>(undefined);
+	const [episodeJudgeProvider, setEpisodeJudgeProvider] = useState<string | undefined>(undefined);
 	const [metrics, setMetrics] = useState<MetricDefinitionDraft[]>([]);
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -153,6 +157,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 		setKind('project');
 		setSpaceGoalId('');
 		setEpisodeJudgeModel(undefined);
+		setEpisodeJudgeProvider(undefined);
 		setMetrics([]);
 		setError(null);
 	};
@@ -160,6 +165,14 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 	const handleClose = () => {
 		reset();
 		onClose();
+	};
+
+	const handleEpisodeJudgeModelChange = (
+		value: string | undefined,
+		selection?: WorkflowModelSelection
+	) => {
+		setEpisodeJudgeModel(value);
+		setEpisodeJudgeProvider(selection?.provider);
 	};
 
 	const addMetric = () => {
@@ -209,7 +222,7 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 					objective: objective.trim(),
 					spaceGoalId: spaceGoalId || null,
 					metricDefinitions,
-					...(episodeJudgeModel ? { policy: { episodeJudgeModel } } : {}),
+					...(episodeJudgeModel ? { policy: { episodeJudgeModel, episodeJudgeProvider } } : {}),
 				},
 			});
 			toast.success(`Scope "${response.scope.name}" created`);
@@ -294,7 +307,8 @@ function ScopeCreateDialog({ isOpen, spaceId, goals, onClose, onCreated }: Scope
 					<label class="mb-1.5 block text-sm font-medium text-gray-300">Episode judge model</label>
 					<WorkflowModelSelect
 						value={episodeJudgeModel}
-						onChange={setEpisodeJudgeModel}
+						provider={episodeJudgeProvider}
+						onChange={handleEpisodeJudgeModelChange}
 						testId="forge-scope-model-select"
 						className="w-full rounded-lg border border-dark-700 bg-dark-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
 					/>
@@ -1462,7 +1476,10 @@ function ScopeDetail({
 		setSettingsError(null);
 	}, [scope.id]);
 
-	const handleJudgeModelChange = async (value: string | undefined) => {
+	const handleJudgeModelChange = async (
+		value: string | undefined,
+		selection?: WorkflowModelSelection
+	) => {
 		const version = ++judgeModelRequestVersion.current;
 		try {
 			setSavingJudgeModel(true);
@@ -1470,8 +1487,14 @@ function ScopeDetail({
 			const nextPolicy = { ...scope.policy };
 			if (value) {
 				nextPolicy.episodeJudgeModel = value;
+				if (selection?.provider) {
+					nextPolicy.episodeJudgeProvider = selection.provider;
+				} else {
+					delete nextPolicy.episodeJudgeProvider;
+				}
 			} else {
 				delete nextPolicy.episodeJudgeModel;
+				delete nextPolicy.episodeJudgeProvider;
 			}
 			const response = await request<EvolutionScopeUpdateResponse>('evolution.scope.update', {
 				id: scope.id,
@@ -1556,6 +1579,11 @@ function ScopeDetail({
 								value={
 									typeof scope.policy.episodeJudgeModel === 'string'
 										? scope.policy.episodeJudgeModel
+										: undefined
+								}
+								provider={
+									typeof scope.policy.episodeJudgeProvider === 'string'
+										? scope.policy.episodeJudgeProvider
 										: undefined
 								}
 								onChange={handleJudgeModelChange}
@@ -1643,6 +1671,11 @@ export function SpaceForge({ spaceId }: SpaceForgeProps) {
 		setSelectedScopeId(scope.id);
 	};
 
+	const handleScopeSelected = (scopeId: string) => {
+		localMutationVersion.current += 1;
+		setSelectedScopeId(scopeId);
+	};
+
 	const handleScopeUpdated = (scope: EvolutionScope) => {
 		localMutationVersion.current += 1;
 		setScopes((current) => current.map((item) => (item.id === scope.id ? scope : item)));
@@ -1690,7 +1723,7 @@ export function SpaceForge({ spaceId }: SpaceForgeProps) {
 									<button
 										key={scope.id}
 										type="button"
-										onClick={() => setSelectedScopeId(scope.id)}
+										onClick={() => handleScopeSelected(scope.id)}
 										class={`w-full rounded-xl border p-3 text-left transition-colors ${selected ? 'border-cyan-500/40 bg-cyan-500/10' : 'border-white/10 bg-white/[0.02] hover:bg-white/[0.04]'}`}
 									>
 										<div class="mb-1 flex items-center justify-between gap-2">

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -33,12 +33,17 @@ vi.mock('../visual-editor/WorkflowModelSelect', () => ({
 		className,
 	}: {
 		value?: string;
-		onChange: (value: string | undefined) => void;
+		onChange: (
+			value: string | undefined,
+			selection?: { modelId: string; provider: string }
+		) => void;
 		testId: string;
 		className?: string;
 	}) => {
-		const handleChange = (event: Event) =>
-			onChange((event.currentTarget as HTMLSelectElement).value || undefined);
+		const handleChange = (event: Event) => {
+			const modelId = (event.currentTarget as HTMLSelectElement).value || undefined;
+			onChange(modelId, modelId ? { modelId, provider: 'anthropic' } : undefined);
+		};
 		return (
 			<select
 				data-testid={testId}
@@ -350,13 +355,25 @@ describe('SpaceForge', () => {
 		);
 		expect(mockRequest).toHaveBeenCalledWith('evolution.scope.update', {
 			id: 'scope-1',
-			params: { policy: { maxActiveLessons: 3, episodeJudgeModel: 'claude-sonnet-4-6' } },
+			params: {
+				policy: {
+					maxActiveLessons: 3,
+					episodeJudgeModel: 'claude-sonnet-4-6',
+					episodeJudgeProvider: 'anthropic',
+				},
+			},
 		});
 	});
 
 	it('clears existing scope judge model override', async () => {
 		setupRequests(
-			makeScope({ policy: { maxActiveLessons: 3, episodeJudgeModel: 'claude-sonnet-4-5' } })
+			makeScope({
+				policy: {
+					maxActiveLessons: 3,
+					episodeJudgeModel: 'claude-sonnet-4-5',
+					episodeJudgeProvider: 'anthropic',
+				},
+			})
 		);
 		render(<SpaceForge spaceId="space-1" />);
 
@@ -417,6 +434,43 @@ describe('SpaceForge', () => {
 		expect(
 			(screen.getByTestId('scope-episode-judge-model-select') as HTMLSelectElement).value
 		).toBe('claude-opus-4-5');
+	});
+
+	it('invalidates pending judge model saves before scope selection commits', async () => {
+		let resolveFirst: (value: { scope: EvolutionScope }) => void = () => undefined;
+		mockRequest.mockImplementation(async (method: string, data?: unknown) => {
+			if (method === 'evolution.scope.list') {
+				return {
+					scopes: [
+						makeScope({ id: 'scope-1', name: 'Review quality scope' }),
+						makeScope({ id: 'scope-2', name: 'Other scope', policy: {} }),
+					],
+				};
+			}
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.metricSnapshot.list') return { snapshots: [makeSnapshot()] };
+			if (method === 'evolution.review.get') {
+				return { episodes: [makeEpisode()], lessons: [makeLesson()], proposals: [makeProposal()] };
+			}
+			if (method === 'evolution.scope.update') {
+				return new Promise((resolve) => {
+					resolveFirst = resolve;
+				});
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: 'claude-sonnet-4-6' },
+		});
+		fireEvent.click(screen.getByRole('button', { name: /Other scope/ }));
+		resolveFirst({ scope: makeScope({ policy: { episodeJudgeModel: 'claude-sonnet-4-6' } }) });
+
+		expect(await screen.findByRole('heading', { name: 'Other scope' })).toBeTruthy();
+		expect(mockToastSuccess).not.toHaveBeenCalledWith('Episode judge model updated');
+		expect(screen.queryByText('Saving…')).toBeNull();
 	});
 
 	it('clears judge model save state after scope selection changes', async () => {
@@ -782,7 +836,10 @@ describe('SpaceForge', () => {
 						targetValue: undefined,
 					},
 				],
-				policy: { episodeJudgeModel: 'claude-sonnet-4-6' },
+				policy: {
+					episodeJudgeModel: 'claude-sonnet-4-6',
+					episodeJudgeProvider: 'anthropic',
+				},
 			},
 		});
 	});

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -30,20 +30,29 @@ vi.mock('../visual-editor/WorkflowModelSelect', () => ({
 		value,
 		onChange,
 		testId,
+		className,
 	}: {
 		value?: string;
 		onChange: (value: string | undefined) => void;
-		testId?: string;
-	}) => (
-		<select
-			data-testid={testId}
-			value={value ?? ''}
-			onInput={(event) => onChange(event.currentTarget.value || undefined)}
-		>
-			<option value="">No override</option>
-			<option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
-		</select>
-	),
+		testId: string;
+		className?: string;
+	}) => {
+		const handleChange = (event: Event) =>
+			onChange((event.currentTarget as HTMLSelectElement).value || undefined);
+		return (
+			<select
+				data-testid={testId}
+				value={value ?? ''}
+				onChange={handleChange}
+				onInput={handleChange}
+				class={className}
+			>
+				<option value="">— No override —</option>
+				<option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+				<option value="claude-opus-4-5">Claude Opus 4.5</option>
+			</select>
+		);
+	},
 }));
 
 import { spaceStore } from '../../../lib/space-store';
@@ -293,6 +302,11 @@ function setupRequests(scope = makeScope()) {
 				scope: makeScope({ id: 'scope-2', name: 'New scope', objective: 'Track review loop' }),
 			};
 		}
+		if (method === 'evolution.scope.update') {
+			const payload = data as { id: string; params: { policy: EvolutionScope['policy'] } };
+			expect(payload.id).toBe(scope.id);
+			return { scope: makeScope({ policy: payload.params.policy }) };
+		}
 		throw new Error(`Unexpected RPC ${method}`);
 	});
 }
@@ -320,6 +334,44 @@ describe('SpaceForge', () => {
 
 		fireEvent.click(screen.getByRole('button', { name: 'metrics' }));
 		expect(screen.getAllByText('Review latency').length).toBeGreaterThan(0);
+	});
+
+	it('updates existing scope judge model while preserving policy keys', async () => {
+		setupRequests(makeScope({ policy: { maxActiveLessons: 3 } }));
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: 'claude-sonnet-4-6' },
+		});
+
+		await waitFor(() =>
+			expect(mockToastSuccess).toHaveBeenCalledWith('Episode judge model updated')
+		);
+		expect(mockRequest).toHaveBeenCalledWith('evolution.scope.update', {
+			id: 'scope-1',
+			params: { policy: { maxActiveLessons: 3, episodeJudgeModel: 'claude-sonnet-4-6' } },
+		});
+	});
+
+	it('clears existing scope judge model override', async () => {
+		setupRequests(
+			makeScope({ policy: { maxActiveLessons: 3, episodeJudgeModel: 'claude-sonnet-4-5' } })
+		);
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: '' },
+		});
+
+		await waitFor(() =>
+			expect(mockToastSuccess).toHaveBeenCalledWith('Episode judge model override cleared')
+		);
+		expect(mockRequest).toHaveBeenCalledWith('evolution.scope.update', {
+			id: 'scope-1',
+			params: { policy: { maxActiveLessons: 3 } },
+		});
 	});
 
 	it('attaches manual evidence note', async () => {

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -374,6 +374,85 @@ describe('SpaceForge', () => {
 		});
 	});
 
+	it('ignores stale judge model update responses', async () => {
+		let resolveFirst: (value: { scope: EvolutionScope }) => void = () => undefined;
+		mockRequest.mockImplementation(async (method: string, data?: unknown) => {
+			if (method === 'evolution.scope.list') return { scopes: [makeScope()] };
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.metricSnapshot.list') return { snapshots: [makeSnapshot()] };
+			if (method === 'evolution.review.get') {
+				return { episodes: [makeEpisode()], lessons: [makeLesson()], proposals: [makeProposal()] };
+			}
+			if (method === 'evolution.scope.update') {
+				const payload = data as { params: { policy: EvolutionScope['policy'] } };
+				if (payload.params.policy.episodeJudgeModel === 'claude-sonnet-4-6') {
+					return new Promise((resolve) => {
+						resolveFirst = resolve;
+					});
+				}
+				return { scope: makeScope({ policy: payload.params.policy }) };
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: 'claude-sonnet-4-6' },
+		});
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: 'claude-opus-4-5' },
+		});
+
+		await waitFor(() =>
+			expect(mockToastSuccess).toHaveBeenCalledWith('Episode judge model updated')
+		);
+		expect(
+			(screen.getByTestId('scope-episode-judge-model-select') as HTMLSelectElement).value
+		).toBe('claude-opus-4-5');
+
+		resolveFirst({ scope: makeScope({ policy: { episodeJudgeModel: 'claude-sonnet-4-6' } }) });
+
+		await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledTimes(1));
+		expect(
+			(screen.getByTestId('scope-episode-judge-model-select') as HTMLSelectElement).value
+		).toBe('claude-opus-4-5');
+	});
+
+	it('clears judge model save state after scope selection changes', async () => {
+		mockRequest.mockImplementation(async (method: string, data?: unknown) => {
+			if (method === 'evolution.scope.list') {
+				return {
+					scopes: [
+						makeScope({ id: 'scope-1', name: 'Review quality scope' }),
+						makeScope({ id: 'scope-2', name: 'Other scope', policy: {} }),
+					],
+				};
+			}
+			if (method === 'evolution.evidence.list') return { evidence: [makeEvidence()] };
+			if (method === 'evolution.metricSnapshot.list') return { snapshots: [makeSnapshot()] };
+			if (method === 'evolution.review.get') {
+				return { episodes: [makeEpisode()], lessons: [makeLesson()], proposals: [makeProposal()] };
+			}
+			if (method === 'evolution.scope.update') {
+				return new Promise(() => undefined);
+			}
+			throw new Error(`Unexpected RPC ${method}`);
+		});
+		render(<SpaceForge spaceId="space-1" />);
+
+		await screen.findByRole('heading', { name: 'Review quality scope' });
+		fireEvent.change(screen.getByTestId('scope-episode-judge-model-select'), {
+			target: { value: 'claude-sonnet-4-6' },
+		});
+		expect(await screen.findByText('Saving…')).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: /Other scope/ }));
+
+		expect(await screen.findByRole('heading', { name: 'Other scope' })).toBeTruthy();
+		expect(screen.queryByText('Saving…')).toBeNull();
+	});
+
 	it('attaches manual evidence note', async () => {
 		render(<SpaceForge spaceId="space-1" />);
 

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -24,20 +24,20 @@ interface WorkflowModelSelectProps {
 
 type LoadState = 'loading' | 'ready' | 'no-providers';
 
+function encodeModelValue(model: Pick<ModelInfo, 'provider' | 'id'>): string {
+	return encodeURIComponent(JSON.stringify([model.provider, model.id]));
+}
+
 function dedupeModelsByProviderAndId(models: ModelInfo[]): ModelInfo[] {
 	const seen = new Set<string>();
 	const deduped: ModelInfo[] = [];
 	for (const model of models) {
-		const key = `${model.provider}:${model.id}`;
+		const key = encodeModelValue(model);
 		if (seen.has(key)) continue;
 		seen.add(key);
 		deduped.push(model);
 	}
 	return deduped;
-}
-
-function encodeModelValue(model: ModelInfo): string {
-	return encodeURIComponent(JSON.stringify([model.provider, model.id]));
 }
 
 function decodeModelValue(value: string, models: ModelInfo[]): WorkflowModelSelection {
@@ -71,10 +71,21 @@ export function WorkflowModelSelect({
 	const [models, setModels] = useState<ModelInfo[]>([]);
 	const [loadState, setLoadState] = useState<LoadState>('loading');
 	const [selectedProvider, setSelectedProvider] = useState<string | undefined>(provider);
+	const [selectedModelId, setSelectedModelId] = useState<string | undefined>(value);
 
 	useEffect(() => {
-		if (provider) setSelectedProvider(provider);
-	}, [provider]);
+		if (!value) {
+			setSelectedModelId(undefined);
+			setSelectedProvider(undefined);
+			return;
+		}
+		if (value === selectedModelId) {
+			if (provider) setSelectedProvider(provider);
+			return;
+		}
+		setSelectedModelId(value);
+		setSelectedProvider(provider);
+	}, [provider, selectedModelId, value]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -104,17 +115,19 @@ export function WorkflowModelSelect({
 		};
 	}, []);
 
+	const effectiveProvider = provider ?? selectedProvider;
 	const selectedValue = (() => {
 		if (!value) return '';
-		if (selectedProvider)
-			return encodeModelValue({ provider: selectedProvider, id: value } as ModelInfo);
+		if (effectiveProvider) return encodeModelValue({ provider: effectiveProvider, id: value });
 		const match = models.find((model) => model.id === value);
 		return match ? encodeModelValue(match) : value;
 	})();
 	const groupedModels = useMemo(() => groupModelsByProvider(models), [models]);
 	const hasCurrentOutsideList =
 		!!value &&
-		!models.some((model) => model.id === value && (!provider || model.provider === provider));
+		!models.some(
+			(model) => model.id === value && (!effectiveProvider || model.provider === effectiveProvider)
+		);
 
 	if (loadState === 'loading') {
 		return (
@@ -141,11 +154,13 @@ export function WorkflowModelSelect({
 			onChange={(e) => {
 				const nextValue = (e.currentTarget as HTMLSelectElement).value;
 				if (!nextValue) {
+					setSelectedModelId(undefined);
 					setSelectedProvider(undefined);
 					onChange(undefined);
 					return;
 				}
 				const selection = decodeModelValue(nextValue, models);
+				setSelectedModelId(selection.modelId);
 				setSelectedProvider(selection.provider);
 				onChange(selection.modelId, selection);
 			}}
@@ -155,7 +170,7 @@ export function WorkflowModelSelect({
 			{hasCurrentOutsideList && (
 				<option
 					value={selectedValue}
-				>{`Current (${provider ? `${provider}:` : ''}${value})`}</option>
+				>{`Current (${effectiveProvider ? `${effectiveProvider}:` : ''}${value})`}</option>
 			)}
 			{Array.from(groupedModels.entries()).map(([provider, providerModels]) => (
 				<optgroup key={provider} label={PROVIDER_LABELS[provider] || getProviderLabel(provider)}>

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { ModelInfo } from '@neokai/shared';
 import { connectionManager } from '../../../lib/connection-manager';
 import {
@@ -54,11 +54,9 @@ function decodeModelValue(value: string, models: ModelInfo[]): WorkflowModelSele
 			return { provider: parsed[0], modelId: parsed[1] };
 		}
 	} catch {
-		// Fall through to legacy provider:model parsing.
+		// Fall through to raw model ID parsing.
 	}
-	const legacySeparator = value.lastIndexOf(':');
-	if (legacySeparator === -1) return { provider: '', modelId: value };
-	return { provider: value.slice(0, legacySeparator), modelId: value.slice(legacySeparator + 1) };
+	return { provider: '', modelId: value };
 }
 
 export function WorkflowModelSelect({
@@ -72,15 +70,18 @@ export function WorkflowModelSelect({
 	const [loadState, setLoadState] = useState<LoadState>('loading');
 	const [selectedProvider, setSelectedProvider] = useState<string | undefined>(provider);
 	const [selectedModelId, setSelectedModelId] = useState<string | undefined>(value);
+	const previousProvider = useRef<string | undefined>(provider);
 
 	useEffect(() => {
+		const providerChanged = provider !== previousProvider.current;
+		previousProvider.current = provider;
 		if (!value) {
 			setSelectedModelId(undefined);
 			setSelectedProvider(undefined);
 			return;
 		}
 		if (value === selectedModelId) {
-			if (provider) setSelectedProvider(provider);
+			if (providerChanged) setSelectedProvider(provider);
 			return;
 		}
 		setSelectedModelId(value);
@@ -175,7 +176,7 @@ export function WorkflowModelSelect({
 			{Array.from(groupedModels.entries()).map(([provider, providerModels]) => (
 				<optgroup key={provider} label={PROVIDER_LABELS[provider] || getProviderLabel(provider)}>
 					{providerModels.map((model) => (
-						<option key={`${provider}:${model.id}`} value={encodeModelValue(model)}>
+						<option key={encodeModelValue(model)} value={encodeModelValue(model)}>
 							{`${model.name} (${model.id})`}
 						</option>
 					))}

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -9,28 +9,46 @@ import {
 	type RawModelEntry,
 } from '../../../hooks/useModelSwitcher';
 
+export interface WorkflowModelSelection {
+	modelId: string;
+	provider: string;
+}
+
 interface WorkflowModelSelectProps {
 	value?: string;
-	onChange: (value: string | undefined) => void;
+	provider?: string;
+	onChange: (value: string | undefined, selection?: WorkflowModelSelection) => void;
 	testId: string;
 	className?: string;
 }
 
 type LoadState = 'loading' | 'ready' | 'no-providers';
 
-function dedupeModelsById(models: ModelInfo[]): ModelInfo[] {
+function dedupeModelsByProviderAndId(models: ModelInfo[]): ModelInfo[] {
 	const seen = new Set<string>();
 	const deduped: ModelInfo[] = [];
 	for (const model of models) {
-		if (seen.has(model.id)) continue;
-		seen.add(model.id);
+		const key = `${model.provider}:${model.id}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
 		deduped.push(model);
 	}
 	return deduped;
 }
 
+function encodeModelValue(model: ModelInfo): string {
+	return `${model.provider}:${model.id}`;
+}
+
+function decodeModelValue(value: string): WorkflowModelSelection {
+	const separator = value.indexOf(':');
+	if (separator === -1) return { provider: '', modelId: value };
+	return { provider: value.slice(0, separator), modelId: value.slice(separator + 1) };
+}
+
 export function WorkflowModelSelect({
 	value,
+	provider,
 	onChange,
 	testId,
 	className = 'w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed',
@@ -49,7 +67,7 @@ export function WorkflowModelSelect({
 					useCache: true,
 				})) as { models: RawModelEntry[] };
 				if (cancelled) return;
-				const loaded = dedupeModelsById(mapRawModelsToModelInfos(response.models ?? []));
+				const loaded = dedupeModelsByProviderAndId(mapRawModelsToModelInfos(response.models ?? []));
 				setModels(loaded);
 				setLoadState(loaded.length > 0 ? 'ready' : 'no-providers');
 			} catch {
@@ -66,8 +84,11 @@ export function WorkflowModelSelect({
 		};
 	}, []);
 
+	const selectedValue = provider && value ? `${provider}:${value}` : value || '';
 	const groupedModels = useMemo(() => groupModelsByProvider(models), [models]);
-	const hasCurrentOutsideList = !!value && !models.some((model) => model.id === value);
+	const hasCurrentOutsideList =
+		!!value &&
+		!models.some((model) => model.id === value && (!provider || model.provider === provider));
 
 	if (loadState === 'loading') {
 		return (
@@ -90,19 +111,28 @@ export function WorkflowModelSelect({
 	return (
 		<select
 			data-testid={testId}
-			value={value ?? ''}
+			value={selectedValue}
 			onChange={(e) => {
 				const nextValue = (e.currentTarget as HTMLSelectElement).value;
-				onChange(nextValue || undefined);
+				if (!nextValue) {
+					onChange(undefined);
+					return;
+				}
+				const selection = decodeModelValue(nextValue);
+				onChange(selection.modelId, selection);
 			}}
 			class={className}
 		>
 			<option value="">— No override —</option>
-			{hasCurrentOutsideList && <option value={value}>{`Current (${value})`}</option>}
+			{hasCurrentOutsideList && (
+				<option
+					value={selectedValue}
+				>{`Current (${provider ? `${provider}:` : ''}${value})`}</option>
+			)}
 			{Array.from(groupedModels.entries()).map(([provider, providerModels]) => (
 				<optgroup key={provider} label={PROVIDER_LABELS[provider] || getProviderLabel(provider)}>
 					{providerModels.map((model) => (
-						<option key={`${provider}:${model.id}`} value={model.id}>
+						<option key={`${provider}:${model.id}`} value={encodeModelValue(model)}>
 							{`${model.name} (${model.id})`}
 						</option>
 					))}

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -84,7 +84,12 @@ export function WorkflowModelSelect({
 		};
 	}, []);
 
-	const selectedValue = provider && value ? `${provider}:${value}` : value || '';
+	const selectedValue = (() => {
+		if (!value) return '';
+		if (provider) return `${provider}:${value}`;
+		const match = models.find((model) => model.id === value);
+		return match ? encodeModelValue(match) : value;
+	})();
 	const groupedModels = useMemo(() => groupModelsByProvider(models), [models]);
 	const hasCurrentOutsideList =
 		!!value &&

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -40,8 +40,10 @@ function encodeModelValue(model: ModelInfo): string {
 	return `${model.provider}:${model.id}`;
 }
 
-function decodeModelValue(value: string): WorkflowModelSelection {
-	const separator = value.indexOf(':');
+function decodeModelValue(value: string, models: ModelInfo[]): WorkflowModelSelection {
+	const match = models.find((model) => encodeModelValue(model) === value);
+	if (match) return { provider: match.provider, modelId: match.id };
+	const separator = value.lastIndexOf(':');
 	if (separator === -1) return { provider: '', modelId: value };
 	return { provider: value.slice(0, separator), modelId: value.slice(separator + 1) };
 }
@@ -123,7 +125,7 @@ export function WorkflowModelSelect({
 					onChange(undefined);
 					return;
 				}
-				const selection = decodeModelValue(nextValue);
+				const selection = decodeModelValue(nextValue, models);
 				onChange(selection.modelId, selection);
 			}}
 			class={className}

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -37,15 +37,28 @@ function dedupeModelsByProviderAndId(models: ModelInfo[]): ModelInfo[] {
 }
 
 function encodeModelValue(model: ModelInfo): string {
-	return `${model.provider}:${model.id}`;
+	return encodeURIComponent(JSON.stringify([model.provider, model.id]));
 }
 
 function decodeModelValue(value: string, models: ModelInfo[]): WorkflowModelSelection {
 	const match = models.find((model) => encodeModelValue(model) === value);
 	if (match) return { provider: match.provider, modelId: match.id };
-	const separator = value.lastIndexOf(':');
-	if (separator === -1) return { provider: '', modelId: value };
-	return { provider: value.slice(0, separator), modelId: value.slice(separator + 1) };
+	try {
+		const parsed = JSON.parse(decodeURIComponent(value)) as unknown;
+		if (
+			Array.isArray(parsed) &&
+			parsed.length === 2 &&
+			typeof parsed[0] === 'string' &&
+			typeof parsed[1] === 'string'
+		) {
+			return { provider: parsed[0], modelId: parsed[1] };
+		}
+	} catch {
+		// Fall through to legacy provider:model parsing.
+	}
+	const legacySeparator = value.lastIndexOf(':');
+	if (legacySeparator === -1) return { provider: '', modelId: value };
+	return { provider: value.slice(0, legacySeparator), modelId: value.slice(legacySeparator + 1) };
 }
 
 export function WorkflowModelSelect({
@@ -57,6 +70,11 @@ export function WorkflowModelSelect({
 }: WorkflowModelSelectProps) {
 	const [models, setModels] = useState<ModelInfo[]>([]);
 	const [loadState, setLoadState] = useState<LoadState>('loading');
+	const [selectedProvider, setSelectedProvider] = useState<string | undefined>(provider);
+
+	useEffect(() => {
+		if (provider) setSelectedProvider(provider);
+	}, [provider]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -88,7 +106,8 @@ export function WorkflowModelSelect({
 
 	const selectedValue = (() => {
 		if (!value) return '';
-		if (provider) return `${provider}:${value}`;
+		if (selectedProvider)
+			return encodeModelValue({ provider: selectedProvider, id: value } as ModelInfo);
 		const match = models.find((model) => model.id === value);
 		return match ? encodeModelValue(match) : value;
 	})();
@@ -122,10 +141,12 @@ export function WorkflowModelSelect({
 			onChange={(e) => {
 				const nextValue = (e.currentTarget as HTMLSelectElement).value;
 				if (!nextValue) {
+					setSelectedProvider(undefined);
 					onChange(undefined);
 					return;
 				}
 				const selection = decodeModelValue(nextValue, models);
+				setSelectedProvider(selection.provider);
 				onChange(selection.modelId, selection);
 			}}
 			class={className}

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -84,6 +84,7 @@ vi.mock('../../../../lib/connection-manager', () => ({
 	},
 }));
 
+import { WorkflowModelSelect } from '../WorkflowModelSelect';
 import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
 import type { NodeDraft } from '../../WorkflowNodeCard';
@@ -217,6 +218,25 @@ describe('NodeConfigPanel', () => {
 			);
 		});
 
+		it('preserves raw colon IDs in out-of-list current selections', async () => {
+			const onChange = vi.fn();
+			const { getByTestId } = render(
+				<WorkflowModelSelect
+					value="stale:model:with:colon"
+					onChange={onChange}
+					testId="stale-colon-model-select"
+				/>
+			);
+			const input = getByTestId('stale-colon-model-select') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			expect(input.value).toBe('stale:model:with:colon');
+			fireEvent.change(input);
+			expect(onChange).toHaveBeenCalledWith('stale:model:with:colon', {
+				modelId: 'stale:model:with:colon',
+				provider: '',
+			});
+		});
+
 		it('keeps selected provider for duplicate model IDs without provider prop', async () => {
 			function Wrapper() {
 				const [step, setStep] = useState(makeStep());
@@ -250,6 +270,31 @@ describe('NodeConfigPanel', () => {
 			expect(input.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
 			fireEvent.click(getByText('Switch model'));
 			expect(input.value).toBe('%5B%22anthropic%22%2C%22claude-sonnet-4-6%22%5D');
+		});
+
+		it('clears cached provider when provider prop is removed for the same value', async () => {
+			function Wrapper() {
+				const [provider, setProvider] = useState<string | undefined>('custom:endpoint-2');
+				return (
+					<div>
+						<button type="button" onClick={() => setProvider(undefined)}>
+							Clear provider
+						</button>
+						<WorkflowModelSelect
+							value="gpt-5.4"
+							provider={provider}
+							onChange={vi.fn()}
+							testId="provider-clear-model-select"
+						/>
+					</div>
+				);
+			}
+			const { getByTestId, getByText } = render(<Wrapper />);
+			const input = getByTestId('provider-clear-model-select') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			expect(input.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
+			fireEvent.click(getByText('Clear provider'));
+			expect(input.value).toBe('%5B%22openai%22%2C%22gpt-5.4%22%5D');
 		});
 
 		it('keeps provider/model pairs distinct when colon-delimited keys collide', async () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -25,33 +25,47 @@ import { render, fireEvent, cleanup, act, waitFor } from '@testing-library/preac
 import { useState } from 'preact/hooks';
 import type { SpaceAgent } from '@neokai/shared';
 
+const mockModels = [
+	{
+		id: 'claude-sonnet-4-6',
+		display_name: 'Claude Sonnet 4.6',
+		description: '',
+		provider: 'anthropic',
+	},
+	{
+		id: 'gpt-5.4',
+		display_name: 'GPT-5.4',
+		description: '',
+		provider: 'openai',
+	},
+	{
+		id: 'gpt-5.4',
+		display_name: 'GPT-5.4 via Custom',
+		description: '',
+		provider: 'custom:endpoint-2',
+	},
+	{
+		id: 'custom/model:with:colon',
+		display_name: 'Colon Model',
+		description: '',
+		provider: 'custom:endpoint-1',
+	},
+	{
+		id: 'endpoint-1:shared',
+		display_name: 'Collision A',
+		description: '',
+		provider: 'custom',
+	},
+	{
+		id: 'shared',
+		display_name: 'Collision B',
+		description: '',
+		provider: 'custom:endpoint-1',
+	},
+];
+
 const mockModelsResponse = {
-	models: [
-		{
-			id: 'claude-sonnet-4-6',
-			display_name: 'Claude Sonnet 4.6',
-			description: '',
-			provider: 'anthropic',
-		},
-		{
-			id: 'gpt-5.4',
-			display_name: 'GPT-5.4',
-			description: '',
-			provider: 'openai',
-		},
-		{
-			id: 'gpt-5.4',
-			display_name: 'GPT-5.4 via Custom',
-			description: '',
-			provider: 'custom:endpoint-2',
-		},
-		{
-			id: 'custom/model:with:colon',
-			display_name: 'Colon Model',
-			description: '',
-			provider: 'custom:endpoint-1',
-		},
-	],
+	models: mockModels.map((model) => ({ ...model })),
 };
 
 const mockHub = {
@@ -74,7 +88,10 @@ import { NodeConfigPanel } from '../NodeConfigPanel';
 import type { NodeConfigPanelProps } from '../NodeConfigPanel';
 import type { NodeDraft } from '../../WorkflowNodeCard';
 
-afterEach(() => cleanup());
+afterEach(() => {
+	cleanup();
+	mockModelsResponse.models = mockModels.map((model) => ({ ...model }));
+});
 
 // ============================================================================
 // Fixtures
@@ -211,6 +228,62 @@ describe('NodeConfigPanel', () => {
 			input.value = '%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D';
 			fireEvent.change(input);
 			expect(input.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
+		});
+
+		it('resets cached provider when providerless value changes', async () => {
+			function Wrapper() {
+				const [step, setStep] = useState(makeStep());
+				return (
+					<div>
+						<button type="button" onClick={() => setStep(makeStep({ model: 'claude-sonnet-4-6' }))}>
+							Switch model
+						</button>
+						<NodeConfigPanel {...makeProps({ step, onUpdate: setStep })} />
+					</div>
+				);
+			}
+			const { getByTestId, getByText } = render(<Wrapper />);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			input.value = '%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D';
+			fireEvent.change(input);
+			expect(input.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
+			fireEvent.click(getByText('Switch model'));
+			expect(input.value).toBe('%5B%22anthropic%22%2C%22claude-sonnet-4-6%22%5D');
+		});
+
+		it('keeps provider/model pairs distinct when colon-delimited keys collide', async () => {
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			const optionValues = Array.from(input.options).map((option) => option.value);
+			expect(optionValues).toContain('%5B%22custom%22%2C%22endpoint-1%3Ashared%22%5D');
+			expect(optionValues).toContain('%5B%22custom%3Aendpoint-1%22%2C%22shared%22%5D');
+		});
+
+		it('shows current fallback when cached provider value disappears but same model id remains', async () => {
+			mockModelsResponse.models = mockModels
+				.filter((model) => model.provider !== 'custom:endpoint-2')
+				.map((model) => ({ ...model }));
+			const { getByTestId, unmount } = render(
+				<NodeConfigPanel {...makeProps({ step: makeStep({ model: 'gpt-5.4' }) })} />
+			);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			expect(input.value).toBe('%5B%22openai%22%2C%22gpt-5.4%22%5D');
+			unmount();
+
+			function Wrapper() {
+				const [step, setStep] = useState(makeStep());
+				return <NodeConfigPanel {...makeProps({ step, onUpdate: setStep })} />;
+			}
+			mockModelsResponse.models = mockModels.map((model) => ({ ...model }));
+			const { getByTestId: getByTestIdWithCustom } = render(<Wrapper />);
+			const customInput = getByTestIdWithCustom('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(customInput.options.length).toBeGreaterThan(1));
+			customInput.value = '%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D';
+			fireEvent.change(customInput);
+			expect(customInput.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
 		});
 
 		it('renders close button', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -167,6 +167,15 @@ describe('NodeConfigPanel', () => {
 			expect(input.value).toBe('');
 		});
 
+		it('shows selected single-agent model when provider is omitted', async () => {
+			const { getByTestId } = render(
+				<NodeConfigPanel {...makeProps({ step: makeStep({ model: 'gpt-5.4' }) })} />
+			);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			expect(input.value).toBe('openai:gpt-5.4');
+		});
+
 		it('renders close button', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps()} />);
 			expect(getByTestId('close-button')).toBeTruthy();
@@ -307,7 +316,7 @@ describe('NodeConfigPanel', () => {
 				).toBeGreaterThan(1)
 			);
 			fireEvent.change(getByTestId('single-agent-model-input'), {
-				target: { value: 'gpt-5.4' },
+				target: { value: 'openai:gpt-5.4' },
 			});
 			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
 		});

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -39,6 +39,12 @@ const mockModelsResponse = {
 			description: '',
 			provider: 'openai',
 		},
+		{
+			id: 'model:with:colon',
+			display_name: 'Colon Model',
+			description: '',
+			provider: 'custom:endpoint-1',
+		},
 	],
 };
 
@@ -174,6 +180,17 @@ describe('NodeConfigPanel', () => {
 			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
 			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
 			expect(input.value).toBe('openai:gpt-5.4');
+		});
+
+		it('preserves provider-qualified selections containing colons', async () => {
+			const onUpdate = vi.fn();
+			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			fireEvent.change(input, {
+				target: { value: 'custom:endpoint-1:model:with:colon' },
+			});
+			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ model: 'model:with:colon' }));
 		});
 
 		it('renders close button', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -40,7 +40,13 @@ const mockModelsResponse = {
 			provider: 'openai',
 		},
 		{
-			id: 'model:with:colon',
+			id: 'gpt-5.4',
+			display_name: 'GPT-5.4 via Custom',
+			description: '',
+			provider: 'custom:endpoint-2',
+		},
+		{
+			id: 'custom/model:with:colon',
 			display_name: 'Colon Model',
 			description: '',
 			provider: 'custom:endpoint-1',
@@ -179,7 +185,7 @@ describe('NodeConfigPanel', () => {
 			);
 			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
 			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
-			expect(input.value).toBe('openai:gpt-5.4');
+			expect(input.value).toBe('%5B%22openai%22%2C%22gpt-5.4%22%5D');
 		});
 
 		it('preserves provider-qualified selections containing colons', async () => {
@@ -187,10 +193,24 @@ describe('NodeConfigPanel', () => {
 			const { getByTestId } = render(<NodeConfigPanel {...makeProps({ onUpdate })} />);
 			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
 			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
-			fireEvent.change(input, {
-				target: { value: 'custom:endpoint-1:model:with:colon' },
-			});
-			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ model: 'model:with:colon' }));
+			input.value = '%5B%22custom%3Aendpoint-1%22%2C%22custom%2Fmodel%3Awith%3Acolon%22%5D';
+			fireEvent.change(input);
+			expect(onUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: 'custom/model:with:colon' })
+			);
+		});
+
+		it('keeps selected provider for duplicate model IDs without provider prop', async () => {
+			function Wrapper() {
+				const [step, setStep] = useState(makeStep());
+				return <NodeConfigPanel {...makeProps({ step, onUpdate: setStep })} />;
+			}
+			const { getByTestId } = render(<Wrapper />);
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			await waitFor(() => expect(input.options.length).toBeGreaterThan(1));
+			input.value = '%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D';
+			fireEvent.change(input);
+			expect(input.value).toBe('%5B%22custom%3Aendpoint-2%22%2C%22gpt-5.4%22%5D');
 		});
 
 		it('renders close button', () => {
@@ -332,9 +352,9 @@ describe('NodeConfigPanel', () => {
 					(getByTestId('single-agent-model-input') as HTMLSelectElement).options.length
 				).toBeGreaterThan(1)
 			);
-			fireEvent.change(getByTestId('single-agent-model-input'), {
-				target: { value: 'openai:gpt-5.4' },
-			});
+			const input = getByTestId('single-agent-model-input') as HTMLSelectElement;
+			input.value = '%5B%22openai%22%2C%22gpt-5.4%22%5D';
+			fireEvent.change(input);
 			expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-5.4' }));
 		});
 


### PR DESCRIPTION
Adds an Episode judge model selector to existing Forge scopes, with save/clear behavior backed by evolution.scope.update.

Also updates episode generation to resolve judge models from scope policy before Space default, and covers policy preservation plus UI RPC behavior in tests.

Validated with focused daemon/web tests, bun run check, and manual browser flow on local dev server.