### PR TITLE
Capture Forge evidence on task completion

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -385,6 +385,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	});
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
+	const evolutionScopeService = new EvolutionScopeService({
+		evolutionRepo: deps.db.evolution,
+		spaceRepo,
+		goalRepo: spaceGoalRepo,
+		taskRepo: spaceTaskRepo,
+		workflowRunRepo: spaceWorkflowRunRepo,
+		artifactRepo,
+	});
+
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
 	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
 	const agentLookup: SpaceAgentLookup = {
@@ -397,7 +406,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const spaceWorkflowManager = new SpaceWorkflowManager(spaceWorkflowRepo, agentLookup);
 
 	const spaceTaskManagerFactory: SpaceTaskManagerFactory = (spaceId: string) => {
-		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
+		return new SpaceTaskManager(
+			deps.db.getDatabase(),
+			spaceId,
+			deps.reactiveDb,
+			evolutionScopeService
+		);
 	};
 
 	// Space agent handlers
@@ -459,14 +473,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Reply Routing Registry — shared between space-agent-tools (register)
 	// and task-agent-tools / node-agent-tools (lookup).
 	const replyRoutingRegistry = new ReplyRoutingRegistry();
-
-	const evolutionScopeService = new EvolutionScopeService({
-		evolutionRepo: deps.db.evolution,
-		spaceRepo,
-		goalRepo: spaceGoalRepo,
-		taskRepo: spaceTaskRepo,
-		workflowRunRepo: spaceWorkflowRunRepo,
-	});
 	const evolutionEpisodeService = new EvolutionEpisodeService({
 		evolutionRepo: deps.db.evolution,
 		spaceRepo,
@@ -705,7 +711,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space workflow run handlers — reuse the same factory pattern as spaceTask handlers
 	const spaceWorkflowRunTaskManagerFactory: SpaceWorkflowRunTaskManagerFactory = (spaceId) => {
-		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
+		return new SpaceTaskManager(
+			deps.db.getDatabase(),
+			spaceId,
+			deps.reactiveDb,
+			evolutionScopeService
+		);
 	};
 	setupSpaceWorkflowRunHandlers(
 		deps.messageHub,

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -185,7 +185,7 @@ export class EvolutionScopeService {
 			: this.requireScopeForTask(task.id, task.evolutionScopeId ?? null, task.goalId ?? null);
 		if (scope.spaceId !== task.spaceId)
 			throw new Error('Task and scope must belong to the same space');
-		return this.createEvidenceOnce({
+		return this.createEvidence({
 			scopeId: scope.id,
 			kind: 'task',
 			sourceId: task.id,
@@ -209,7 +209,7 @@ export class EvolutionScopeService {
 		if (scope.spaceId !== run.spaceId) {
 			throw new Error('Workflow run and scope must belong to the same space');
 		}
-		return this.createEvidenceOnce({
+		return this.createEvidence({
 			scopeId: scope.id,
 			kind: 'workflow_run',
 			sourceId: run.id,
@@ -233,7 +233,7 @@ export class EvolutionScopeService {
 		if (!scope || scope.spaceId !== task.spaceId) return { scope: null, evidence: [] };
 
 		const evidence: EvidenceRef[] = [
-			this.createEvidenceOnce({
+			this.createAutoEvidenceOnce({
 				scopeId: scope.id,
 				kind: 'task_result',
 				sourceId: task.id,
@@ -254,7 +254,7 @@ export class EvolutionScopeService {
 			if (run && run.spaceId === task.spaceId) {
 				const artifacts = this.deps.artifactRepo?.listByRun(run.id) ?? [];
 				evidence.push(
-					this.createEvidenceOnce({
+					this.createAutoEvidenceOnce({
 						scopeId: scope.id,
 						kind: selectWorkflowEvidenceKind(run, artifacts),
 						sourceId: run.id,
@@ -348,18 +348,24 @@ export class EvolutionScopeService {
 		return goal;
 	}
 
-	private createEvidenceOnce(params: CreateEvidenceRefParams): EvidenceRef {
+	private createAutoEvidenceOnce(params: CreateEvidenceRefParams): EvidenceRef {
 		const sourceId = params.sourceId ?? null;
 		const existing = this.deps.evolutionRepo
 			.listEvidence(params.scopeId)
-			.find((item) => item.kind === params.kind && item.sourceId === sourceId);
+			.find(
+				(item) =>
+					item.kind === params.kind &&
+					item.sourceId === sourceId &&
+					item.metadata.autoCaptured === true
+			);
+		const metadata = { ...params.metadata, autoCaptured: true };
 		if (existing) {
 			return this.deps.evolutionRepo.updateEvidence(existing.id, {
 				summary: params.summary,
-				metadata: params.metadata,
+				metadata,
 			});
 		}
-		return this.deps.evolutionRepo.createEvidence(params);
+		return this.deps.evolutionRepo.createEvidence({ ...params, metadata });
 	}
 
 	private requireScope(scopeId: string): EvolutionScope {
@@ -416,7 +422,7 @@ function selectWorkflowEvidenceKind(
 	run: SpaceWorkflowRun,
 	artifacts: WorkflowRunArtifactRecord[]
 ): EvidenceKind {
-	if (run.status === 'blocked' || run.status === 'cancelled' || run.failureReason) return 'error';
+	if (run.status === 'blocked' || run.status === 'cancelled') return 'error';
 	return artifacts.length > 0 ? 'artifact' : 'workflow_run';
 }
 

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -2,11 +2,14 @@ import type {
 	CreateEvidenceRefParams,
 	CreateEvolutionScopeParams,
 	CreateMetricSnapshotParams,
+	EvidenceKind,
 	EvidenceRef,
 	EvolutionLesson,
 	EvolutionScope,
 	EvolutionScopeListParams,
 	MetricSnapshot,
+	SpaceTask,
+	SpaceWorkflowRun,
 	UpdateEvolutionScopeParams,
 } from '@neokai/shared';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
@@ -14,6 +17,10 @@ import type { SpaceGoalRepository } from '../../storage/repositories/space-goal-
 import type { SpaceRepository } from '../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
+import type {
+	WorkflowRunArtifactRecord,
+	WorkflowRunArtifactRepository,
+} from '../../storage/repositories/workflow-run-artifact-repository';
 
 export interface EvolutionScopeServiceDeps {
 	evolutionRepo: EvolutionRepository;
@@ -21,6 +28,7 @@ export interface EvolutionScopeServiceDeps {
 	goalRepo: SpaceGoalRepository;
 	taskRepo: SpaceTaskRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
+	artifactRepo?: WorkflowRunArtifactRepository;
 }
 
 export interface CreateScopeFromGoalParams {
@@ -73,6 +81,15 @@ export interface ResolveScopeForTaskParams {
 export interface SelectTaskLessonsParams {
 	taskId: string;
 	limit?: number;
+}
+
+export interface CaptureCompletedTaskEvidenceParams {
+	taskId: string;
+}
+
+export interface CaptureCompletedTaskEvidenceResult {
+	scope: EvolutionScope | null;
+	evidence: EvidenceRef[];
 }
 
 export interface ScopeTimeline {
@@ -168,7 +185,7 @@ export class EvolutionScopeService {
 			: this.requireScopeForTask(task.id, task.evolutionScopeId ?? null, task.goalId ?? null);
 		if (scope.spaceId !== task.spaceId)
 			throw new Error('Task and scope must belong to the same space');
-		return this.deps.evolutionRepo.createEvidence({
+		return this.createEvidenceOnce({
 			scopeId: scope.id,
 			kind: 'task',
 			sourceId: task.id,
@@ -192,7 +209,7 @@ export class EvolutionScopeService {
 		if (scope.spaceId !== run.spaceId) {
 			throw new Error('Workflow run and scope must belong to the same space');
 		}
-		return this.deps.evolutionRepo.createEvidence({
+		return this.createEvidenceOnce({
 			scopeId: scope.id,
 			kind: 'workflow_run',
 			sourceId: run.id,
@@ -203,6 +220,60 @@ export class EvolutionScopeService {
 				...params.metadata,
 			},
 		});
+	}
+
+	captureCompletedTaskEvidence(
+		params: CaptureCompletedTaskEvidenceParams
+	): CaptureCompletedTaskEvidenceResult {
+		const task = this.deps.taskRepo.getTask(params.taskId);
+		if (!task) throw new Error(`Task not found: ${params.taskId}`);
+		if (task.status !== 'done') return { scope: null, evidence: [] };
+
+		const scope = this.findScopeForTask(task.evolutionScopeId ?? null, task.goalId ?? null);
+		if (!scope || scope.spaceId !== task.spaceId) return { scope: null, evidence: [] };
+
+		const evidence: EvidenceRef[] = [
+			this.createEvidenceOnce({
+				scopeId: scope.id,
+				kind: 'task_result',
+				sourceId: task.id,
+				summary: buildTaskResultEvidenceSummary(task),
+				metadata: {
+					status: task.status,
+					priority: task.priority,
+					workflowRunId: task.workflowRunId ?? null,
+					result: task.result ?? null,
+					reportedSummary: task.reportedSummary ?? null,
+					completedAt: task.completedAt ?? null,
+				},
+			}),
+		];
+
+		if (task.workflowRunId) {
+			const run = this.deps.workflowRunRepo.getRun(task.workflowRunId);
+			if (run && run.spaceId === task.spaceId) {
+				const artifacts = this.deps.artifactRepo?.listByRun(run.id) ?? [];
+				evidence.push(
+					this.createEvidenceOnce({
+						scopeId: scope.id,
+						kind: selectWorkflowEvidenceKind(run, artifacts),
+						sourceId: run.id,
+						summary: buildWorkflowRunEvidenceSummary(run, artifacts),
+						metadata: {
+							status: run.status,
+							workflowId: run.workflowId,
+							failureReason: run.failureReason ?? null,
+							completedAt: run.completedAt ?? null,
+							artifactCount: artifacts.length,
+							artifactTypes: summarizeArtifactTypes(artifacts),
+							artifacts: artifacts.map(summarizeArtifact),
+						},
+					})
+				);
+			}
+		}
+
+		return { scope, evidence };
 	}
 
 	addManualNoteEvidence(params: AddManualNoteEvidenceParams): EvidenceRef {
@@ -277,6 +348,16 @@ export class EvolutionScopeService {
 		return goal;
 	}
 
+	private createEvidenceOnce(params: CreateEvidenceRefParams): EvidenceRef {
+		const sourceId = params.sourceId ?? null;
+		const duplicateKinds = dedupeKindGroup(params.kind);
+		const existing = this.deps.evolutionRepo
+			.listEvidence(params.scopeId)
+			.find((item) => duplicateKinds.has(item.kind) && item.sourceId === sourceId);
+		if (existing) return existing;
+		return this.deps.evolutionRepo.createEvidence(params);
+	}
+
 	private requireScope(scopeId: string): EvolutionScope {
 		if (!scopeId) throw new Error('scopeId is required');
 		const scope = this.deps.evolutionRepo.getScope(scopeId);
@@ -320,4 +401,82 @@ export class EvolutionScopeService {
 		if (!task) throw new Error(`Task not found for workflow run: ${workflowRunId}`);
 		return this.requireScopeForTask(task.id, task.evolutionScopeId ?? null, task.goalId ?? null);
 	}
+}
+
+function dedupeKindGroup(kind: EvidenceKind): Set<EvidenceKind> {
+	if (kind === 'workflow_run' || kind === 'artifact' || kind === 'error') {
+		return new Set(['workflow_run', 'artifact', 'error']);
+	}
+	return new Set([kind]);
+}
+
+function buildTaskResultEvidenceSummary(task: SpaceTask): string {
+	const outcome = task.result ?? task.reportedSummary ?? 'completed without task.result';
+	return `Task #${task.taskNumber} done: ${task.title} — ${truncateText(outcome, 180)}`;
+}
+
+function selectWorkflowEvidenceKind(
+	run: SpaceWorkflowRun,
+	artifacts: WorkflowRunArtifactRecord[]
+): EvidenceKind {
+	if (run.status === 'blocked' || run.status === 'cancelled' || run.failureReason) return 'error';
+	return artifacts.length > 0 ? 'artifact' : 'workflow_run';
+}
+
+function buildWorkflowRunEvidenceSummary(
+	run: SpaceWorkflowRun,
+	artifacts: WorkflowRunArtifactRecord[]
+): string {
+	const labels = summarizeArtifactTypes(artifacts);
+	const detail = findArtifactDetail(artifacts) ?? run.failureReason ?? 'no artifacts captured';
+	return `Workflow run ${run.status}: ${run.title} — ${labels.join(', ') || 'no artifact types'} — ${truncateText(detail, 180)}`;
+}
+
+function summarizeArtifactTypes(artifacts: WorkflowRunArtifactRecord[]): string[] {
+	return Array.from(new Set(artifacts.map((artifact) => artifact.artifactType))).sort();
+}
+
+function summarizeArtifact(artifact: WorkflowRunArtifactRecord): Record<string, unknown> {
+	return {
+		nodeId: artifact.nodeId,
+		type: artifact.artifactType,
+		key: artifact.artifactKey,
+		data: truncateStructuredData(artifact.data),
+		createdAt: artifact.createdAt,
+		updatedAt: artifact.updatedAt,
+	};
+}
+
+function findArtifactDetail(artifacts: WorkflowRunArtifactRecord[]): string | null {
+	for (const artifact of artifacts) {
+		const detail = extractArtifactDetail(artifact.data);
+		if (detail) return `${artifact.artifactType}/${artifact.artifactKey}: ${detail}`;
+	}
+	return null;
+}
+
+function extractArtifactDetail(data: Record<string, unknown>): string | null {
+	for (const key of [
+		'summary',
+		'result',
+		'status',
+		'pr_url',
+		'review_url',
+		'merge_commit',
+		'error',
+	]) {
+		const value = data[key];
+		if (typeof value === 'string' && value.trim()) return value.trim();
+	}
+	return null;
+}
+
+function truncateStructuredData(value: Record<string, unknown>): Record<string, unknown> {
+	const serialized = JSON.stringify(value);
+	if (serialized.length <= 2000) return value;
+	return { truncated: truncateText(serialized, 2000) };
+}
+
+function truncateText(value: string, max: number): string {
+	return value.length > max ? `${value.slice(0, max - 1)}…` : value;
 }

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -431,8 +431,15 @@ function buildWorkflowRunEvidenceSummary(
 	artifacts: WorkflowRunArtifactRecord[]
 ): string {
 	const labels = summarizeArtifactTypes(artifacts);
-	const detail = findArtifactDetail(artifacts) ?? run.failureReason ?? 'no artifacts captured';
+	const detail =
+		findArtifactDetail(artifacts) ?? activeFailureReason(run) ?? 'no artifacts captured';
 	return `Workflow run ${run.status}: ${run.title} — ${labels.join(', ') || 'no artifact types'} — ${truncateText(detail, 180)}`;
+}
+
+function activeFailureReason(run: SpaceWorkflowRun): string | null {
+	return run.status === 'blocked' || run.status === 'cancelled'
+		? (run.failureReason ?? null)
+		: null;
 }
 
 function summarizeArtifactTypes(artifacts: WorkflowRunArtifactRecord[]): string[] {

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -350,11 +350,15 @@ export class EvolutionScopeService {
 
 	private createEvidenceOnce(params: CreateEvidenceRefParams): EvidenceRef {
 		const sourceId = params.sourceId ?? null;
-		const duplicateKinds = dedupeKindGroup(params.kind);
 		const existing = this.deps.evolutionRepo
 			.listEvidence(params.scopeId)
-			.find((item) => duplicateKinds.has(item.kind) && item.sourceId === sourceId);
-		if (existing) return existing;
+			.find((item) => item.kind === params.kind && item.sourceId === sourceId);
+		if (existing) {
+			return this.deps.evolutionRepo.updateEvidence(existing.id, {
+				summary: params.summary,
+				metadata: params.metadata,
+			});
+		}
 		return this.deps.evolutionRepo.createEvidence(params);
 	}
 
@@ -401,13 +405,6 @@ export class EvolutionScopeService {
 		if (!task) throw new Error(`Task not found for workflow run: ${workflowRunId}`);
 		return this.requireScopeForTask(task.id, task.evolutionScopeId ?? null, task.goalId ?? null);
 	}
-}
-
-function dedupeKindGroup(kind: EvidenceKind): Set<EvidenceKind> {
-	if (kind === 'workflow_run' || kind === 'artifact' || kind === 'error') {
-		return new Set(['workflow_run', 'artifact', 'error']);
-	}
-	return new Set([kind]);
 }
 
 function buildTaskResultEvidenceSummary(task: SpaceTask): string {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -18,7 +18,10 @@ import type {
 } from '@neokai/shared';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import { Logger } from '../../logger';
 import type { EvolutionScopeService } from '../evolution-scope-service';
+
+const log = new Logger('space-task-manager');
 
 /**
  * Valid task status transitions for space tasks
@@ -289,9 +292,10 @@ export class SpaceTaskManager {
 		if (newStatus === 'done') {
 			try {
 				this.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
-			} catch {
-				// Best-effort: Forge evidence capture must not roll back the
-				// already-committed done transition.
+			} catch (err) {
+				log.warn(
+					`Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+				);
 			}
 			try {
 				const unblocked = await this.unblockDependentTasks(taskId);

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -18,6 +18,7 @@ import type {
 } from '@neokai/shared';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { EvolutionScopeService } from '../evolution-scope-service';
 
 /**
  * Valid task status transitions for space tasks
@@ -66,7 +67,8 @@ export class SpaceTaskManager {
 	constructor(
 		private db: BunDatabase,
 		private spaceId: string,
-		private reactiveDb?: ReactiveDatabase
+		private reactiveDb?: ReactiveDatabase,
+		private evolutionScopeService?: EvolutionScopeService
 	) {
 		this.taskRepo = new SpaceTaskRepository(db, reactiveDb);
 	}
@@ -285,6 +287,12 @@ export class SpaceTaskManager {
 		// change making blocked→open invalid) does not abort the parent
 		// `done` transition — the parent write is already committed.
 		if (newStatus === 'done') {
+			try {
+				this.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
+			} catch {
+				// Best-effort: Forge evidence capture must not roll back the
+				// already-committed done transition.
+			}
 			try {
 				const unblocked = await this.unblockDependentTasks(taskId);
 				if (unblocked.length > 0 && options?.onCascadedTasks) {

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -135,6 +135,11 @@ export interface PostApprovalRouterDeps {
 	livenessProbe?: SessionLivenessProbe;
 	/** Optional goal service for processing terminal goal-task side effects. */
 	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
+	/** Optional Forge scope service for automatic terminal task evidence capture. */
+	evolutionScopeService?: Pick<
+		import('../evolution-scope-service').EvolutionScopeService,
+		'captureCompletedTaskEvidence'
+	>;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +270,14 @@ export class PostApprovalRouter {
 				postApprovalBlockedReason: null,
 			};
 			this.deps.taskRepo.updateTask(task.id, updates);
+			// Best-effort Forge evidence capture — must not block approval routing.
+			try {
+				this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId: task.id });
+			} catch (err) {
+				log.warn(
+					`Forge evidence capture threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
 			// Best-effort goal terminal handling — must not block approval routing.
 			try {
 				this.deps.goalService?.handleTaskTerminal(task.id);

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -639,7 +639,12 @@ export class SpaceRuntimeService {
 			taskRepo: this.config.taskRepo,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
-			taskManager: new SpaceTaskManager(this.config.db, space.id, this.config.reactiveDb),
+			taskManager: new SpaceTaskManager(
+				this.config.db,
+				space.id,
+				this.config.reactiveDb,
+				this.config.evolutionScopeService
+			),
 			spaceAgentManager: this.config.spaceAgentManager,
 			taskAgentManager: this.taskAgentManager ?? undefined,
 			gateDataRepo: this.config.gateDataRepo,
@@ -1246,7 +1251,12 @@ export class SpaceRuntimeService {
 			taskRepo: this.config.taskRepo,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
-			taskManager: new SpaceTaskManager(this.config.db, space.id, this.config.reactiveDb),
+			taskManager: new SpaceTaskManager(
+				this.config.db,
+				space.id,
+				this.config.reactiveDb,
+				this.config.evolutionScopeService
+			),
 			spaceAgentManager: this.config.spaceAgentManager,
 			taskAgentManager: this.taskAgentManager ?? undefined,
 			gateDataRepo: this.config.gateDataRepo,
@@ -1364,7 +1374,12 @@ export class SpaceRuntimeService {
 			taskRepo,
 			nodeExecutionRepo: this.nodeExecutionRepo,
 			workflowRunRepo,
-			taskManager: new SpaceTaskManager(db, space.id, this.config.reactiveDb),
+			taskManager: new SpaceTaskManager(
+				db,
+				space.id,
+				this.config.reactiveDb,
+				this.config.evolutionScopeService
+			),
 			spaceAgentManager,
 			taskAgentManager: this.taskAgentManager ?? undefined,
 			gateDataRepo: this.config.gateDataRepo,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -234,6 +234,8 @@ export interface SpaceRuntimeConfig {
 	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
 	/** Optional goal service for processing terminal goal-task side effects. */
 	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
+	/** Optional Forge scope service for automatic terminal task evidence capture. */
+	evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
 }
 
 interface StartWorkflowRunOptions {
@@ -1815,6 +1817,7 @@ export class SpaceRuntime {
 				isSessionAlive: (sessionId) => manager.isSessionAlive(sessionId),
 			},
 			goalService: this.config.goalService,
+			evolutionScopeService: this.config.evolutionScopeService,
 		});
 		return this.postApprovalRouter;
 	}
@@ -5670,7 +5673,12 @@ export class SpaceRuntime {
 	private getOrCreateTaskManager(spaceId: string): SpaceTaskManager {
 		let manager = this.taskManagers.get(spaceId);
 		if (!manager) {
-			manager = new SpaceTaskManager(this.config.db, spaceId, this.config.reactiveDb);
+			manager = new SpaceTaskManager(
+				this.config.db,
+				spaceId,
+				this.config.reactiveDb,
+				this.config.evolutionScopeService
+			);
 			this.taskManagers.set(spaceId, manager);
 		}
 		return manager;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3546,7 +3546,8 @@ export class TaskAgentManager {
 		const boundTaskManager = new SpaceTaskManager(
 			this.config.db.getDatabase(),
 			spaceId,
-			this.config.reactiveDb
+			this.config.reactiveDb,
+			this.config.evolutionScopeService
 		);
 		const endNodeHandlers = isEndNode
 			? createEndNodeHandlers({

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -137,6 +137,16 @@ export class EvolutionRepository {
 		return row ? rowToEvidence(row) : null;
 	}
 
+	updateEvidence(
+		id: string,
+		params: Pick<CreateEvidenceRefParams, 'summary' | 'metadata'>
+	): EvidenceRef {
+		this.db
+			.prepare(`UPDATE evolution_evidence SET summary = ?, metadata_json = ? WHERE id = ?`)
+			.run(params.summary, JSON.stringify(params.metadata ?? {}), id);
+		return this.getEvidence(id) as EvidenceRef;
+	}
+
 	listEvidence(scopeId: string): EvidenceRef[] {
 		const rows = this.db
 			.prepare(

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -208,6 +208,120 @@ describe('Forge evidence capture on task completion', () => {
 		);
 	});
 
+	it('preserves manual workflow_run evidence when auto-capturing a run without artifacts', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Manual run evidence',
+			objective: 'Keep user-authored workflow evidence',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Manual workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Run without artifacts',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Complete with manual run evidence',
+			description: 'Auto workflow_run evidence should not overwrite manual note',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Done without artifacts' });
+		const manual = evolutionScopeService.attachWorkflowRunEvidence({
+			workflowRunId: run.id,
+			summary: 'Manual reviewer context',
+			metadata: { source: 'manual' },
+		});
+
+		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		const runEvidence = evidence.filter((item) => item.kind === 'workflow_run');
+		expect(runEvidence).toHaveLength(2);
+		expect(evolutionRepo.getEvidence(manual.id)?.summary).toBe('Manual reviewer context');
+		expect(runEvidence.map((item) => item.summary)).toContain(
+			'Workflow run pending: Run without artifacts — no artifact types — no artifacts captured'
+		);
+	});
+
+	it('keeps manual task evidence append-only for repeated task attachments', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Manual task evidence',
+			objective: 'Keep task evidence timeline append-only',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Attach task evidence twice',
+			description: 'Manual task evidence should append',
+			evolutionScopeId: scope.id,
+		});
+
+		const before = evolutionScopeService.attachTaskEvidence({
+			taskId: task.id,
+			summary: 'Before implementation',
+		});
+		const after = evolutionScopeService.attachTaskEvidence({
+			taskId: task.id,
+			summary: 'After implementation',
+		});
+
+		const taskEvidence = evolutionRepo
+			.listEvidence(scope.id)
+			.filter((item) => item.kind === 'task');
+		expect(taskEvidence).toHaveLength(2);
+		expect(after.id).not.toBe(before.id);
+		expect(taskEvidence.map((item) => item.summary).sort()).toEqual([
+			'After implementation',
+			'Before implementation',
+		]);
+	});
+
+	it('ignores stale failureReason when completed workflow run has artifacts', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Recovered run scope',
+			objective: 'Recovered runs should not look like failures',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Recovered workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Recovered run',
+		});
+		workflowRunRepo.updateRun(run.id, {
+			status: 'done',
+			failureReason: 'agentCrash',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Capture recovered run',
+			description: 'Stale failureReason should not force error kind',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Recovered and shipped' });
+		artifactRepo.upsert({
+			id: 'artifact-recovered',
+			runId: run.id,
+			nodeId: 'CI',
+			artifactType: 'ci',
+			artifactKey: 'summary',
+			data: { summary: 'Recovered CI passed' },
+		});
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.evidence.find((item) => item.kind === 'error')).toBeUndefined();
+		const artifactEvidence = result.evidence.find((item) => item.kind === 'artifact');
+		expect(artifactEvidence?.summary).toContain('Recovered CI passed');
+		expect(artifactEvidence?.metadata.failureReason).toBe('agentCrash');
+	});
+
 	it('updates existing task_result evidence when a task is completed again', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -322,6 +322,40 @@ describe('Forge evidence capture on task completion', () => {
 		expect(artifactEvidence?.metadata.failureReason).toBe('agentCrash');
 	});
 
+	it('does not include stale failureReason in recovered run summary without artifacts', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Recovered run without artifacts',
+			objective: 'Avoid stale failure details in success summaries',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Recovered workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Recovered run without artifacts',
+		});
+		workflowRunRepo.updateRun(run.id, {
+			status: 'done',
+			failureReason: 'agentCrash',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Capture recovered run without artifacts',
+			description: 'Stale failureReason should stay out of summary',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Recovered without artifacts' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const runEvidence = result.evidence.find((item) => item.kind === 'workflow_run');
+		expect(runEvidence?.summary).toContain('no artifacts captured');
+		expect(runEvidence?.summary).not.toContain('agentCrash');
+		expect(runEvidence?.metadata.failureReason).toBe('agentCrash');
+	});
+
 	it('updates existing task_result evidence when a task is completed again', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -164,6 +164,131 @@ describe('Forge evidence capture on task completion', () => {
 		expect(evidence[0]?.kind).toBe('task_result');
 	});
 
+	it('keeps manual workflow_run evidence and adds artifact evidence for the same run', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Run evidence kinds',
+			objective: 'Keep distinct workflow evidence kinds',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Coding workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Run with artifacts',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Capture artifacts after manual run evidence',
+			description: 'Manual workflow_run evidence already exists',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Done with artifact' });
+		evolutionScopeService.attachWorkflowRunEvidence({ workflowRunId: run.id });
+		artifactRepo.upsert({
+			id: 'artifact-ci',
+			runId: run.id,
+			nodeId: 'CI',
+			artifactType: 'ci',
+			artifactKey: 'summary',
+			data: { summary: 'CI passed after retry' },
+		});
+
+		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence.map((item) => item.kind).sort()).toEqual([
+			'artifact',
+			'task_result',
+			'workflow_run',
+		]);
+		expect(evidence.find((item) => item.kind === 'artifact')?.summary).toContain(
+			'CI passed after retry'
+		);
+	});
+
+	it('updates existing task_result evidence when a task is completed again', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Recompleted task',
+			objective: 'Keep evidence current after reactivation',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Complete twice',
+			description: 'Second completion supersedes first evidence data',
+			evolutionScopeId: scope.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'First result' });
+		const first = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+		taskRepo.updateTask(task.id, { result: 'Second result' });
+
+		const second = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence).toHaveLength(1);
+		expect(second.evidence[0]?.id).toBe(first.evidence[0]?.id);
+		expect(evidence[0]?.summary).toContain('Second result');
+		expect(evidence[0]?.metadata.result).toBe('Second result');
+	});
+
+	it('creates error evidence for failed workflow runs', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Failed run scope',
+			objective: 'Capture blockers as evidence',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Blocked workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Blocked run',
+		});
+		workflowRunRepo.updateRun(run.id, {
+			status: 'cancelled',
+			failureReason: 'agentCrash',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Capture failed run',
+			description: 'Workflow failed before merge',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Closed with blocker' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const errorEvidence = result.evidence.find((item) => item.kind === 'error');
+		expect(errorEvidence?.summary).toContain('agentCrash');
+		expect(errorEvidence?.metadata.failureReason).toBe('agentCrash');
+	});
+
+	it('does not create Forge evidence for non-done tasks', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Active task scope',
+			objective: 'Only done tasks become evidence',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Still running',
+			description: 'Should not produce evidence yet',
+			evolutionScopeId: scope.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'in_progress' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.scope).toBeNull();
+		expect(result.evidence).toEqual([]);
+		expect(evolutionRepo.listEvidence(scope.id)).toEqual([]);
+	});
+
 	it('does not create Forge evidence for unscoped tasks', () => {
 		const task = taskRepo.createTask({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { EvolutionScopeService } from '../../../src/lib/space/evolution-scope-service';
+import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager';
+import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
+import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
+import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { SpaceWorkflowRepository } from '../../../src/storage/repositories/space-workflow-repository';
+import { SpaceWorkflowRunRepository } from '../../../src/storage/repositories/space-workflow-run-repository';
+import { WorkflowRunArtifactRepository } from '../../../src/storage/repositories/workflow-run-artifact-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('Forge evidence capture on task completion', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let goalRepo: SpaceGoalRepository;
+	let taskRepo: SpaceTaskRepository;
+	let workflowRepo: SpaceWorkflowRepository;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let artifactRepo: WorkflowRunArtifactRepository;
+	let evolutionRepo: EvolutionRepository;
+	let evolutionScopeService: EvolutionScopeService;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as never);
+		goalRepo = new SpaceGoalRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+		workflowRepo = new SpaceWorkflowRepository(db as never);
+		workflowRunRepo = new SpaceWorkflowRunRepository(
+			db as never,
+			new GateOpenStateRepository(db as never)
+		);
+		artifactRepo = new WorkflowRunArtifactRepository(db as never);
+		evolutionRepo = new EvolutionRepository(db as never);
+		spaceId = spaceRepo.createSpace({
+			workspacePath: '/workspace/forge-evidence-capture',
+			slug: 'forge-evidence-capture',
+			name: 'Forge Evidence Capture',
+		}).id;
+		evolutionScopeService = new EvolutionScopeService({
+			evolutionRepo,
+			spaceRepo,
+			goalRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+	});
+
+	it('creates task_result and workflow artifact evidence for scoped task completion', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Forge hardening',
+			objective: 'Capture useful scoped task evidence',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Coding workflow' });
+		const run = workflowRunRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Task run' });
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Ship Forge capture',
+			description: 'Complete implementation',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		artifactRepo.upsert({
+			id: 'artifact-result',
+			runId: run.id,
+			nodeId: 'Coding',
+			artifactType: 'result',
+			artifactKey: 'final',
+			data: {
+				summary: 'Implemented capture and opened PR',
+				pr_url: 'https://github.com/x/y/pull/1',
+			},
+		});
+		await taskRepo.updateTask(task.id, { status: 'in_progress' });
+		const manager = new SpaceTaskManager(db as never, spaceId, undefined, evolutionScopeService);
+
+		await manager.setTaskStatus(task.id, 'done', { result: 'PR ready and tests pass' });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence.map((item) => item.kind).sort()).toEqual(['artifact', 'task_result']);
+		expect(evidence.find((item) => item.kind === 'task_result')?.summary).toContain(
+			'PR ready and tests pass'
+		);
+		const artifactEvidence = evidence.find((item) => item.kind === 'artifact');
+		expect(artifactEvidence?.summary).toContain('result/final');
+		expect(artifactEvidence?.metadata.artifactTypes).toEqual(['result']);
+		expect(artifactEvidence?.metadata.artifactCount).toBe(1);
+	});
+
+	it('captures useful workflow artifact evidence when task result is null', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Artifact-only task',
+			objective: 'Learn from artifacts when task.result is empty',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Review workflow' });
+		const run = workflowRunRepo.createRun({
+			spaceId,
+			workflowId: workflow.id,
+			title: 'Artifact run',
+		});
+		workflowRunRepo.updateRun(run.id, { status: 'done' });
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Finish with artifacts',
+			description: 'Result stays null',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: null });
+		artifactRepo.upsert({
+			id: 'artifact-review',
+			runId: run.id,
+			nodeId: 'Review',
+			artifactType: 'review',
+			artifactKey: 'approval',
+			data: {
+				summary: 'Reviewer approved after CI passed',
+				review_url: 'https://github.com/x/y/pull/2#review',
+			},
+		});
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.evidence).toHaveLength(2);
+		const taskEvidence = result.evidence.find((item) => item.kind === 'task_result');
+		expect(taskEvidence?.summary).toContain('completed without task.result');
+		const artifactEvidence = result.evidence.find((item) => item.kind === 'artifact');
+		expect(artifactEvidence?.summary).toContain('Reviewer approved after CI passed');
+		expect(artifactEvidence?.metadata.artifacts).toEqual([
+			expect.objectContaining({ nodeId: 'Review', type: 'review', key: 'approval' }),
+		]);
+	});
+
+	it('deduplicates repeated completion evidence capture', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Dedupe task',
+			objective: 'Do not duplicate evidence',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Complete once',
+			description: 'Repeat event should be idempotent',
+			evolutionScopeId: scope.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Done once' });
+
+		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence).toHaveLength(1);
+		expect(evidence[0]?.kind).toBe('task_result');
+	});
+
+	it('does not create Forge evidence for unscoped tasks', () => {
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Unscoped task',
+			description: 'No scope or scoped goal',
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Done' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.scope).toBeNull();
+		expect(result.evidence).toEqual([]);
+	});
+
+	it('uses linked goal Forge scope when task has no direct evolutionScopeId', () => {
+		const goal = goalRepo.create({
+			spaceId,
+			title: 'Forge goal',
+			description: 'Goal owns scope',
+		});
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			spaceGoalId: goal.id,
+			kind: 'mission',
+			name: 'Goal scope',
+			objective: 'Capture linked goal tasks',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Goal-linked task',
+			description: 'Scope resolved through goal',
+			goalId: goal.id,
+		});
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Goal task done' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.scope?.id).toBe(scope.id);
+		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Automatically captures Forge task_result evidence plus workflow-run artifact evidence when scoped tasks reach done, including artifact metadata for review/QA/CI/PR signals.

Adds focused daemon coverage for scoped completion, null task.result with artifacts, duplicate completion events, unscoped tasks, and goal-linked scopes.