### PR TITLE
Propagate workflow result artifacts to tasks

### DIFF
--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -133,6 +133,8 @@ export interface PostApprovalRouterDeps {
 	taskRepo: Pick<SpaceTaskRepository, 'updateTask' | 'getTask'>;
 	spawner: PostApprovalSubSessionSpawner;
 	livenessProbe?: SessionLivenessProbe;
+	/** Optional hook that fills task outcome fields before terminal side effects run. */
+	resolveCompletionOutcome?: (task: SpaceTask) => UpdateSpaceTaskParams | null;
 	/** Optional goal service for processing terminal goal-task side effects. */
 	goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
 	/** Optional Forge scope service for automatic terminal task evidence capture. */
@@ -262,7 +264,9 @@ export class PostApprovalRouter {
 		// 1. No postApproval declared → close the task directly.
 		// -------------------------------------------------------------------
 		if (!route || !route.targetAgent) {
+			const outcomeUpdates = this.deps.resolveCompletionOutcome?.(task) ?? null;
 			const updates: UpdateSpaceTaskParams = {
+				...outcomeUpdates,
 				status: 'done',
 				completedAt: Date.now(),
 				postApprovalSessionId: null,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5292,10 +5292,12 @@ export class SpaceRuntime {
 		if (!this.config.artifactRepo) return undefined;
 
 		try {
-			const artifact = this.config.artifactRepo
-				.listByRun(runId, { artifactType: 'result' })
-				.find((item) => typeof item.data.summary === 'string' && item.data.summary.trim());
-			return typeof artifact?.data.summary === 'string' ? artifact.data.summary : undefined;
+			const artifacts = this.config.artifactRepo.listByRun(runId, { artifactType: 'result' });
+			for (let i = artifacts.length - 1; i >= 0; i--) {
+				const summary = artifacts[i]?.data.summary;
+				if (typeof summary === 'string' && summary.trim()) return summary;
+			}
+			return undefined;
 		} catch (err) {
 			log.warn(
 				`SpaceRuntime.resolvePrimaryResultArtifactSummary: failed to read artifacts for run ${runId}: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2259,9 +2259,10 @@ export class SpaceRuntime {
 				.find((task) => !!task.result)?.result;
 			const reportedSummary = canonicalTask.reportedSummary ?? null;
 			const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
-			const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? summaryFromSibling ?? null;
-			const nextResult = freshSummary ?? existingResult ?? reportedSummary ?? null;
-			const nextReportedSummary = freshSummary ?? reportedSummary ?? null;
+			const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? null;
+			const nextResult =
+				freshSummary ?? existingResult ?? reportedSummary ?? summaryFromSibling ?? null;
+			const nextReportedSummary = freshSummary ?? reportedSummary ?? summaryFromSibling ?? null;
 
 			// Skip tasks already at a terminal or paused state — matches the
 			// active-tick guard (`taskAlreadyResolved`) at processRunTick.
@@ -5287,11 +5288,16 @@ export class SpaceRuntime {
 
 		try {
 			const artifacts = this.config.artifactRepo.listByRun(runId, { artifactType: 'result' });
-			for (let i = artifacts.length - 1; i >= 0; i--) {
-				const summary = artifacts[i]?.data.summary;
-				if (typeof summary === 'string' && summary.trim()) return summary;
-			}
-			return undefined;
+			const artifact = artifacts
+				.map((item, index) => ({ item, index }))
+				.filter(({ item }) => typeof item.data.summary === 'string' && item.data.summary.trim())
+				.toSorted(
+					(a, b) =>
+						b.item.updatedAt - a.item.updatedAt ||
+						b.item.createdAt - a.item.createdAt ||
+						b.index - a.index
+				)[0]?.item;
+			return typeof artifact?.data.summary === 'string' ? artifact.data.summary : undefined;
 		} catch (err) {
 			log.warn(
 				`SpaceRuntime.resolvePrimaryResultArtifactSummary: failed to read artifacts for run ${runId}: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1816,8 +1816,8 @@ export class SpaceRuntime {
 					: undefined;
 				return this.buildTaskOutcomeUpdates(
 					task,
-					task.result?.trim() ? task.result : (artifactSummary ?? task.reportedSummary ?? null),
-					task.reportedSummary ?? artifactSummary ?? null
+					artifactSummary ?? (task.result?.trim() ? task.result : (task.reportedSummary ?? null)),
+					artifactSummary ?? task.reportedSummary ?? null
 				);
 			},
 			spawner: {
@@ -2259,15 +2259,9 @@ export class SpaceRuntime {
 				.find((task) => !!task.result)?.result;
 			const reportedSummary = canonicalTask.reportedSummary ?? null;
 			const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
-			const nextResult =
-				existingResult ??
-				summaryFromArtifact ??
-				summaryFromWorkflow ??
-				reportedSummary ??
-				summaryFromSibling ??
-				null;
-			const nextReportedSummary =
-				reportedSummary ?? summaryFromArtifact ?? summaryFromWorkflow ?? summaryFromSibling ?? null;
+			const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? summaryFromSibling ?? null;
+			const nextResult = freshSummary ?? existingResult ?? reportedSummary ?? null;
+			const nextReportedSummary = freshSummary ?? reportedSummary ?? null;
 
 			// Skip tasks already at a terminal or paused state — matches the
 			// active-tick guard (`taskAlreadyResolved`) at processRunTick.
@@ -4293,9 +4287,9 @@ export class SpaceRuntime {
 				const summary = this.resolveCompletionSummary(runId, meta.workflow);
 				const reportedSummary = canonicalTask.reportedSummary ?? null;
 				const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
-				const nextTaskResult =
-					existingResult ?? summaryFromArtifact ?? summary ?? reportedSummary ?? null;
-				const nextReportedSummary = reportedSummary ?? summaryFromArtifact ?? summary ?? null;
+				const freshSummary = summaryFromArtifact ?? summary ?? null;
+				const nextTaskResult = freshSummary ?? existingResult ?? reportedSummary ?? null;
+				const nextReportedSummary = freshSummary ?? reportedSummary ?? null;
 
 				// Skip re-resolution when the task is already at a non-`open`/non-`in_progress`
 				// status — `done`/`cancelled` are terminal; `approved` means

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1810,6 +1810,16 @@ export class SpaceRuntime {
 		if (!manager) return null;
 		this.postApprovalRouter = new PostApprovalRouter({
 			taskRepo: this.config.taskRepo,
+			resolveCompletionOutcome: (task) => {
+				const artifactSummary = task.workflowRunId
+					? this.resolvePrimaryResultArtifactSummary(task.workflowRunId)
+					: undefined;
+				return this.buildTaskOutcomeUpdates(
+					task,
+					task.result?.trim() ? task.result : (artifactSummary ?? task.reportedSummary ?? null),
+					task.reportedSummary ?? artifactSummary ?? null
+				);
+			},
 			spawner: {
 				spawnPostApprovalSubSession: (args) => manager.spawnPostApprovalSubSession(args),
 			},
@@ -2240,6 +2250,7 @@ export class SpaceRuntime {
 				this.executorMeta.get(run.id)?.workflow ??
 				this.config.spaceWorkflowManager.getWorkflow(run.workflowId) ??
 				null;
+			const summaryFromArtifact = this.resolvePrimaryResultArtifactSummary(run.id);
 			const summaryFromWorkflow = workflow
 				? this.resolveCompletionSummary(run.id, workflow)
 				: undefined;
@@ -2247,12 +2258,16 @@ export class SpaceRuntime {
 				.filter((task) => task.id !== canonicalTask.id)
 				.find((task) => !!task.result)?.result;
 			const reportedSummary = canonicalTask.reportedSummary ?? null;
+			const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
 			const nextResult =
+				existingResult ??
+				summaryFromArtifact ??
 				summaryFromWorkflow ??
 				reportedSummary ??
-				canonicalTask.result ??
 				summaryFromSibling ??
 				null;
+			const nextReportedSummary =
+				reportedSummary ?? summaryFromArtifact ?? summaryFromWorkflow ?? summaryFromSibling ?? null;
 
 			// Skip tasks already at a terminal or paused state — matches the
 			// active-tick guard (`taskAlreadyResolved`) at processRunTick.
@@ -2268,12 +2283,24 @@ export class SpaceRuntime {
 			) {
 				// Preserve the computed result on the task before routing —
 				// dispatchPostApproval handles the status transition itself.
-				if (nextResult && canonicalTask.result !== nextResult) {
-					await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, { result: nextResult });
+				const updates = this.buildTaskOutcomeUpdates(
+					canonicalTask,
+					nextResult,
+					nextReportedSummary
+				);
+				if (updates) {
+					await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, updates);
 				}
 				await this.dispatchPostApproval(canonicalTask.id, 'agent');
-			} else if (nextResult && canonicalTask.result !== nextResult) {
-				await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, { result: nextResult });
+			} else {
+				const updates = this.buildTaskOutcomeUpdates(
+					canonicalTask,
+					nextResult,
+					nextReportedSummary
+				);
+				if (updates) {
+					await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, updates);
+				}
 			}
 			return;
 		}
@@ -4262,9 +4289,13 @@ export class SpaceRuntime {
 			// `setTaskStatus` directly.
 			if (runIsComplete) {
 				await this.transitionRunStatusAndEmit(runId, 'done');
+				const summaryFromArtifact = this.resolvePrimaryResultArtifactSummary(runId);
 				const summary = this.resolveCompletionSummary(runId, meta.workflow);
 				const reportedSummary = canonicalTask.reportedSummary ?? null;
-				const nextTaskResult = summary ?? reportedSummary ?? canonicalTask.result ?? null;
+				const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
+				const nextTaskResult =
+					existingResult ?? summaryFromArtifact ?? summary ?? reportedSummary ?? null;
+				const nextReportedSummary = reportedSummary ?? summaryFromArtifact ?? summary ?? null;
 
 				// Skip re-resolution when the task is already at a non-`open`/non-`in_progress`
 				// status — `done`/`cancelled` are terminal; `approved` means
@@ -4285,10 +4316,13 @@ export class SpaceRuntime {
 				let finalTaskStatus: SpaceTask['status'] = canonicalTask.status;
 
 				if (!taskAlreadyResolved) {
-					if (nextTaskResult && canonicalTask.result !== nextTaskResult) {
-						await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
-							result: nextTaskResult,
-						});
+					const updates = this.buildTaskOutcomeUpdates(
+						canonicalTask,
+						nextTaskResult,
+						nextReportedSummary
+					);
+					if (updates) {
+						await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, updates);
 					}
 					const result = await this.dispatchPostApproval(canonicalTask.id, 'agent');
 					// Resolve the final status from the router result. 'no-route'
@@ -4300,8 +4334,15 @@ export class SpaceRuntime {
 							: result.mode === 'skipped'
 								? canonicalTask.status
 								: 'approved';
-				} else if (summary && canonicalTask.result !== summary) {
-					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, { result: summary });
+				} else {
+					const updates = this.buildTaskOutcomeUpdates(
+						canonicalTask,
+						nextTaskResult,
+						nextReportedSummary
+					);
+					if (updates) {
+						await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, updates);
+					}
 				}
 
 				// Sibling NodeExecution quiescing: interrupt siblings still in_progress
@@ -5245,6 +5286,37 @@ export class SpaceRuntime {
 		}
 
 		return '';
+	}
+
+	private resolvePrimaryResultArtifactSummary(runId: string): string | undefined {
+		if (!this.config.artifactRepo) return undefined;
+
+		try {
+			const artifact = this.config.artifactRepo
+				.listByRun(runId, { artifactType: 'result' })
+				.find((item) => typeof item.data.summary === 'string' && item.data.summary.trim());
+			return typeof artifact?.data.summary === 'string' ? artifact.data.summary : undefined;
+		} catch (err) {
+			log.warn(
+				`SpaceRuntime.resolvePrimaryResultArtifactSummary: failed to read artifacts for run ${runId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+			return undefined;
+		}
+	}
+
+	private buildTaskOutcomeUpdates(
+		task: SpaceTask,
+		result: string | null,
+		reportedSummary: string | null
+	): UpdateSpaceTaskParams | null {
+		const updates: UpdateSpaceTaskParams = {};
+		if (result && task.result !== result) {
+			updates.result = result;
+		}
+		if (reportedSummary && task.reportedSummary !== reportedSummary) {
+			updates.reportedSummary = reportedSummary;
+		}
+		return Object.keys(updates).length > 0 ? updates : null;
 	}
 
 	private resolveCompletionSummary(runId: string, workflow: SpaceWorkflow): string | undefined {

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -95,6 +95,46 @@ describe('Forge evidence capture on task completion', () => {
 		expect(artifactEvidence?.metadata.artifactCount).toBe(1);
 	});
 
+	it('auto-captured task_result evidence includes summary populated from result artifact', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Populated result task',
+			objective: 'Learn from propagated task summaries',
+		});
+		const workflow = workflowRepo.createWorkflow({ spaceId, name: 'Coding workflow' });
+		const run = workflowRunRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Task run' });
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Ship propagated summary',
+			description: 'Complete implementation',
+			evolutionScopeId: scope.id,
+			workflowRunId: run.id,
+		});
+		artifactRepo.upsert({
+			id: 'artifact-populated-result',
+			runId: run.id,
+			nodeId: 'Coding',
+			artifactType: 'result',
+			artifactKey: 'final',
+			data: { summary: 'Propagated summary reaches task evidence' },
+		});
+		await taskRepo.updateTask(task.id, {
+			status: 'in_progress',
+			result: 'Propagated summary reaches task evidence',
+			reportedSummary: 'Propagated summary reaches task evidence',
+		});
+		const manager = new SpaceTaskManager(db as never, spaceId, undefined, evolutionScopeService);
+
+		await manager.setTaskStatus(task.id, 'done');
+
+		const taskEvidence = evolutionRepo
+			.listEvidence(scope.id)
+			.find((item) => item.kind === 'task_result');
+		expect(taskEvidence?.summary).toContain('Propagated summary reaches task evidence');
+		expect(taskEvidence?.metadata.reportedSummary).toBe('Propagated summary reaches task evidence');
+	});
+
 	it('captures useful workflow artifact evidence when task result is null', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -14,6 +14,7 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
@@ -291,6 +292,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	let db: BunDatabase;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let artifactRepo: WorkflowRunArtifactRepository;
 	let taskRepo: SpaceTaskRepository;
 	let agentManager: SpaceAgentManager;
 	let workflowManager: SpaceWorkflowManager;
@@ -316,6 +318,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			workflowRunRepo,
 			taskRepo,
 			nodeExecutionRepo,
+			artifactRepo,
 			internalEventBus: bus,
 			taskAgentManager: new MockTaskAgentManager(nodeExecutionRepo) as unknown as TaskAgentManager,
 			...extraConfig,
@@ -332,6 +335,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 		seedAgentRow(db, AGENT_C, SPACE_ID);
 
 		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		artifactRepo = new WorkflowRunArtifactRepository(db);
 		taskRepo = new SpaceTaskRepository(db);
 
 		const agentRepo = new SpaceAgentRepository(db);
@@ -1443,6 +1447,114 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			await expect(rt.startWorkflowRun(SPACE_ID, legacyWorkflow.id, 'Run')).rejects.toThrow(
 				'is missing endNodeId'
 			);
+		});
+
+		test('result artifact summary populates task outcome on run completion', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Artifact Result Completion ${Date.now()}`,
+				description: '',
+				nodes: [{ id: 'artifact-end', name: 'End', agentId: AGENT_A }],
+				startNodeId: 'artifact-end',
+				endNodeId: 'artifact-end',
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			artifactRepo.upsert({
+				id: 'artifact-result-summary',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'final',
+				data: { summary: 'Implemented artifact summary propagation' },
+			});
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress', reportedStatus: 'done' });
+			seedNodeExec(db, run.id, 'artifact-end', 'End', 'idle');
+
+			await rt.executeTick();
+
+			const taskAfter = taskRepo.getTask(tasks[0].id);
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+			expect(taskAfter?.result).toBe('Implemented artifact summary propagation');
+			expect(taskAfter?.reportedSummary).toBe('Implemented artifact summary propagation');
+		});
+
+		test('null task result is filled from result artifact summary', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Null Result Artifact Fill ${Date.now()}`,
+				description: '',
+				nodes: [{ id: 'null-result-end', name: 'End', agentId: AGENT_A }],
+				startNodeId: 'null-result-end',
+				endNodeId: 'null-result-end',
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			artifactRepo.upsert({
+				id: 'artifact-null-result-summary',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'final',
+				data: { summary: 'Filled null task result' },
+			});
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'in_progress',
+				result: null,
+				reportedStatus: 'done',
+			});
+			seedNodeExec(db, run.id, 'null-result-end', 'End', 'idle');
+
+			await rt.executeTick();
+
+			const taskAfter = taskRepo.getTask(tasks[0].id);
+			expect(taskAfter?.result).toBe('Filled null task result');
+			expect(taskAfter?.reportedSummary).toBe('Filled null task result');
+		});
+
+		test('existing task result is preserved when result artifact exists', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Preserve Existing Result ${Date.now()}`,
+				description: '',
+				nodes: [{ id: 'preserve-end', name: 'End', agentId: AGENT_A }],
+				startNodeId: 'preserve-end',
+				endNodeId: 'preserve-end',
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			artifactRepo.upsert({
+				id: 'artifact-preserve-summary',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'final',
+				data: { summary: 'Short artifact summary' },
+			});
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'in_progress',
+				result: 'Manual result with richer detail',
+				reportedStatus: 'done',
+			});
+			seedNodeExec(db, run.id, 'preserve-end', 'End', 'idle');
+
+			await rt.executeTick();
+
+			const taskAfter = taskRepo.getTask(tasks[0].id);
+			expect(taskAfter?.result).toBe('Manual result with richer detail');
+			expect(taskAfter?.reportedSummary).toBe('Short artifact summary');
 		});
 
 		test('reportedStatus alone is enough to mark a run for completion resolution', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1465,6 +1465,14 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 			artifactRepo.upsert({
+				id: 'artifact-result-summary-old',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'old-cycle',
+				data: { summary: 'Stale requested changes summary' },
+			});
+			artifactRepo.upsert({
 				id: 'artifact-result-summary',
 				runId: run.id,
 				nodeId: 'End',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1491,6 +1491,64 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(taskAfter?.reportedSummary).toBe('Implemented artifact summary propagation');
 		});
 
+		test('updated result artifact summary wins over newer-created stale artifact', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Updated Artifact Result Completion ${Date.now()}`,
+				description: '',
+				nodes: [{ id: 'updated-artifact-end', name: 'End', agentId: AGENT_A }],
+				startNodeId: 'updated-artifact-end',
+				endNodeId: 'updated-artifact-end',
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			artifactRepo.upsert({
+				id: 'artifact-reused-result',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'final',
+				data: { summary: 'Initial reused-key summary' },
+			});
+			artifactRepo.upsert({
+				id: 'artifact-newer-stale-result',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'later-created-stale',
+				data: { summary: 'Stale summary from later-created row' },
+			});
+			const staleArtifact = artifactRepo.listByRun(run.id, {
+				artifactType: 'result',
+			})[1];
+			artifactRepo.upsert({
+				id: 'artifact-reused-result-updated',
+				runId: run.id,
+				nodeId: 'End',
+				artifactType: 'result',
+				artifactKey: 'final',
+				data: { summary: 'Updated reused-key summary' },
+			});
+			if (staleArtifact) {
+				db.prepare(`UPDATE workflow_run_artifacts SET updated_at = ? WHERE id = ?`).run(
+					staleArtifact.updatedAt - 1,
+					staleArtifact.id
+				);
+			}
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress', reportedStatus: 'done' });
+			seedNodeExec(db, run.id, 'updated-artifact-end', 'End', 'idle');
+
+			await rt.executeTick();
+
+			const taskAfter = taskRepo.getTask(tasks[0].id);
+			expect(taskAfter?.result).toBe('Updated reused-key summary');
+			expect(taskAfter?.reportedSummary).toBe('Updated reused-key summary');
+		});
+
 		test('null task result is filled from result artifact summary', async () => {
 			const rt = makeRuntimeWithTam();
 
@@ -1676,6 +1734,38 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			// Strict one-task-per-run repair archives duplicate helper/orchestration tasks.
 			const orchTaskAfter = taskRepo.getTask(orchTask.id);
 			expect(orchTaskAfter?.status).toBe('archived');
+		});
+
+		test('canonical task result wins over duplicate sibling result during terminal reconcile', async () => {
+			const rt = makeRuntimeWithTam();
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'canonical-sibling-node', name: 'Step', agentId: AGENT_A },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Canonical Run');
+			const duplicateTask = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Duplicate stale result',
+				description: 'Older duplicate task from previous cycle',
+				workflowRunId: run.id,
+				status: 'done',
+				result: 'Stale sibling result',
+			});
+
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'done',
+				result: 'Canonical final result',
+			});
+			seedNodeExec(db, run.id, 'canonical-sibling-node', 'agent', 'idle');
+
+			await rt.executeTick();
+
+			const canonicalAfter = taskRepo.getTask(tasks[0].id);
+			const duplicateAfter = taskRepo.getTask(duplicateTask.id);
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+			expect(canonicalAfter?.result).toBe('Canonical final result');
+			expect(duplicateAfter?.status).toBe('archived');
 		});
 
 		test('open orchestration task is skipped on run completion (no throw)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1528,7 +1528,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(taskAfter?.reportedSummary).toBe('Filled null task result');
 		});
 
-		test('existing task result is preserved when result artifact exists', async () => {
+		test('fresh result artifact replaces stale task result from prior review cycle', async () => {
 			const rt = makeRuntimeWithTam();
 
 			const workflow = workflowManager.createWorkflow({
@@ -1549,20 +1549,21 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				nodeId: 'End',
 				artifactType: 'result',
 				artifactKey: 'final',
-				data: { summary: 'Short artifact summary' },
+				data: { summary: 'Fresh artifact summary after retry' },
 			});
 			taskRepo.updateTask(tasks[0].id, {
 				status: 'in_progress',
-				result: 'Manual result with richer detail',
+				result: 'Stale result from rejected cycle',
 				reportedStatus: 'done',
+				reportedSummary: 'Stale reported summary from rejected cycle',
 			});
 			seedNodeExec(db, run.id, 'preserve-end', 'End', 'idle');
 
 			await rt.executeTick();
 
 			const taskAfter = taskRepo.getTask(tasks[0].id);
-			expect(taskAfter?.result).toBe('Manual result with richer detail');
-			expect(taskAfter?.reportedSummary).toBe('Short artifact summary');
+			expect(taskAfter?.result).toBe('Fresh artifact summary after retry');
+			expect(taskAfter?.reportedSummary).toBe('Fresh artifact summary after retry');
 		});
 
 		test('reportedStatus alone is enough to mark a run for completion resolution', async () => {


### PR DESCRIPTION
## Summary
- Copy first result artifact summary into task result/reportedSummary on workflow completion
- Preserve existing task results while filling missing outcome fields
- Cover runtime propagation and Forge task_result evidence capture

## Tests
- cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-completion.test.ts tests/unit/5-space/forge-evidence-capture.test.ts
- bun run check