### PR TITLE
Fix Forge trace evidence capture on task completion

### DIFF
--- a/packages/daemon/src/lib/job-handlers/conversation-friction-evidence.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/conversation-friction-evidence.handler.ts
@@ -1,0 +1,23 @@
+import type { Job } from '../../storage/repositories/job-queue-repository';
+import type { EvolutionConversationAnalysisService } from '../space/evolution-conversation-analysis-service';
+
+export interface ConversationFrictionEvidenceJobPayload {
+	scopeId: string;
+	taskId: string;
+}
+
+export function createConversationFrictionEvidenceHandler(
+	service: EvolutionConversationAnalysisService
+): (job: Job) => Promise<Record<string, unknown>> {
+	return async (job) => {
+		const payload = job.payload as Partial<ConversationFrictionEvidenceJobPayload>;
+		if (typeof payload.scopeId !== 'string' || typeof payload.taskId !== 'string') {
+			throw new Error('Invalid conversation friction evidence job payload');
+		}
+		const evidence = await service.captureForTask({
+			scopeId: payload.scopeId,
+			taskId: payload.taskId,
+		});
+		return { evidenceCount: evidence.length };
+	};
+}

--- a/packages/daemon/src/lib/job-queue-constants.ts
+++ b/packages/daemon/src/lib/job-queue-constants.ts
@@ -9,6 +9,7 @@ export const ROOM_TICK = 'room.tick';
 export const JOB_QUEUE_CLEANUP = 'job_queue.cleanup';
 export const SKILL_VALIDATE = 'skill.validate';
 export const MEMORY_CONSOLIDATION = 'memory_consolidation';
+export const SPACE_CONVERSATION_FRICTION_ANALYZE = 'space.conversationFriction.analyze';
 
 // ─── Task schedule ────────────────────────────────────────────────────────────
 export const TASK_SCHEDULE_FIRE = 'taskSchedule.fire';

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -60,8 +60,10 @@ import { GateDataRepository } from '../../storage/repositories/gate-data-reposit
 import { GateOpenStateRepository } from '../../storage/repositories/gate-open-state-repository';
 import { WorkflowRunArtifactRepository } from '../../storage/repositories/workflow-run-artifact-repository';
 import { WorkflowRunArtifactCacheRepository } from '../../storage/repositories/workflow-run-artifact-cache-repository';
+import { createConversationFrictionEvidenceHandler } from '../job-handlers/conversation-friction-evidence.handler';
 import { createSyncArtifactHandlers } from '../job-handlers/space-workflow-run-artifact.handler';
 import {
+	SPACE_CONVERSATION_FRICTION_ANALYZE,
 	SPACE_WORKFLOW_RUN_SYNC_GATE_ARTIFACTS,
 	SPACE_WORKFLOW_RUN_SYNC_COMMITS,
 	SPACE_WORKFLOW_RUN_SYNC_FILE_DIFF,
@@ -99,6 +101,7 @@ import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { setupAgentMemoryHandlers } from './agent-memory-handlers';
 import { setupSpaceGoalHandlers } from './space-goal-handlers';
 import { setupEvolutionHandlers } from './evolution-handlers';
+import { EvolutionConversationAnalysisService } from '../space/evolution-conversation-analysis-service';
 import { EvolutionEpisodeService } from '../space/evolution-episode-service';
 import { EvolutionScopeService } from '../space/evolution-scope-service';
 import { EvolutionTraceEvidenceService } from '../space/evolution-trace-evidence-service';
@@ -391,6 +394,16 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		evolutionRepo: deps.db.evolution,
 		taskRepo: spaceTaskRepo,
 	});
+	const evolutionConversationAnalysisService = new EvolutionConversationAnalysisService({
+		db: deps.db.getDatabase(),
+		evolutionRepo: deps.db.evolution,
+		taskRepo: spaceTaskRepo,
+		spaceRepo,
+	});
+	deps.jobProcessor.register(
+		SPACE_CONVERSATION_FRICTION_ANALYZE,
+		createConversationFrictionEvidenceHandler(evolutionConversationAnalysisService)
+	);
 	const evolutionScopeService = new EvolutionScopeService({
 		evolutionRepo: deps.db.evolution,
 		spaceRepo,
@@ -399,6 +412,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		workflowRunRepo: spaceWorkflowRunRepo,
 		artifactRepo,
 		traceEvidenceService: evolutionTraceEvidenceService,
+		jobQueue: deps.jobQueue,
 	});
 
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -10,6 +10,7 @@ import type { SpaceRepository } from '../../storage/repositories/space-repositor
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
 import { getAvailableModels } from '../model-service';
+import { Logger } from '../logger';
 import { getProviderService, mergeProviderEnvVars } from '../provider-service';
 import { inferProviderForModel } from '../providers/registry';
 
@@ -26,6 +27,7 @@ const PATTERN_KINDS = [
 	'synthetic_interruption',
 ] as const;
 const SEVERITIES = ['low', 'medium', 'high'] as const;
+const log = new Logger('EvolutionConversationAnalysisService');
 
 export type TraceMessageRole = 'human' | 'synthetic_user' | 'assistant' | 'thinking';
 export type ConversationFrictionKind = (typeof PATTERN_KINDS)[number];
@@ -107,9 +109,7 @@ export class EvolutionConversationAnalysisService {
 			params.confidenceThreshold ?? readConfidenceThreshold(scope)
 		);
 		const analysis = await this.analyze({ scope, task, messages, confidenceThreshold });
-		const patterns = analysis.patterns.filter(
-			(pattern) => pattern.confidence >= confidenceThreshold && pattern.involvedMessages.length > 0
-		);
+		const patterns = filterResolvedPatterns(analysis.patterns, messages, confidenceThreshold);
 		if (patterns.length === 0) return [];
 
 		const existingByFingerprint = new Map(
@@ -147,7 +147,7 @@ export class EvolutionConversationAnalysisService {
 				 FROM (
 					 SELECT id, session_id, message_type, sdk_message, timestamp, origin
 					 FROM sdk_messages
-					 WHERE task_id = ?
+					 WHERE task_id = ? AND send_status IN ('consumed', 'failed')
 					 ORDER BY timestamp DESC, id DESC
 					 LIMIT ?
 				 ) recent_trace_rows
@@ -161,6 +161,12 @@ export class EvolutionConversationAnalysisService {
 			timestamp: string;
 			origin: string | null;
 		}>;
+		if (rows.length === MAX_ROWS) {
+			log.info('Conversation friction trace rows reached MAX_ROWS; context may be truncated', {
+				taskId,
+				maxRows: MAX_ROWS,
+			});
+		}
 		return rows.map((row) => ({
 			id: row.id,
 			sessionId: row.session_id,
@@ -343,10 +349,11 @@ function buildEvidenceParams(
 	pattern: ConversationFrictionPattern,
 	options: { confidenceThreshold: number }
 ): CreateEvidenceRefParams {
+	const canonicalMessageIds = canonicalizeMessageIds(pattern.involvedMessages);
 	const involved = messages.filter((message) =>
-		pattern.involvedMessages.includes(message.metadata.messageId)
+		canonicalMessageIds.includes(message.metadata.messageId)
 	);
-	const fingerprint = `conversation_friction:${pattern.kind}:${pattern.involvedMessages.join(',')}`;
+	const fingerprint = `conversation_friction:${pattern.kind}:${canonicalMessageIds.join(',')}`;
 	return {
 		scopeId,
 		kind: 'conversation_friction',
@@ -359,12 +366,12 @@ function buildEvidenceParams(
 			taskId: task.id,
 			workflowRunId: task.workflowRunId ?? null,
 			confidenceThreshold: options.confidenceThreshold,
-			pattern,
+			pattern: { ...pattern, involvedMessages: canonicalMessageIds },
 			humanInterventionCount: analysis.humanInterventionCount,
 			syntheticInterventionCount: analysis.syntheticInterventionCount,
 			agentUncertaintyCount: analysis.agentUncertaintyCount,
 			overallAssessment: analysis.overallAssessment,
-			rawTraceRefs: rawRefs(involved.length > 0 ? involved : messages, messages),
+			rawTraceRefs: rawRefs(involved, messages),
 		},
 	};
 }
@@ -394,8 +401,28 @@ function classifyBlock(
 	if (block.type !== 'text') return null;
 	if (row.messageType === 'assistant') return 'assistant';
 	if (row.messageType !== 'user') return null;
-	if (message.isSynthetic === true || row.origin !== 'human') return 'synthetic_user';
+	if (message.isSynthetic === true || row.origin === 'system') return 'synthetic_user';
 	return 'human';
+}
+
+function filterResolvedPatterns(
+	patterns: ConversationFrictionPattern[],
+	messages: TraceMessage[],
+	confidenceThreshold: number
+): ConversationFrictionPattern[] {
+	const messageIds = new Set(messages.map((message) => message.metadata.messageId));
+	return patterns.filter((pattern) => {
+		const involvedMessageIds = canonicalizeMessageIds(pattern.involvedMessages);
+		return (
+			pattern.confidence >= confidenceThreshold &&
+			involvedMessageIds.length > 0 &&
+			involvedMessageIds.every((messageId) => messageIds.has(messageId))
+		);
+	});
+}
+
+function canonicalizeMessageIds(messageIds: string[]): string[] {
+	return unique(messageIds).sort();
 }
 
 function readTextBlock(block: Record<string, unknown>): string | null {
@@ -419,7 +446,15 @@ function parseJsonRecord(value: string): Record<string, unknown> | null {
 function normalizeAnalysis(value: unknown): ConversationFrictionAnalysis {
 	const record = requireRecord(value, 'conversation friction analysis');
 	return {
-		patterns: Array.isArray(record.patterns) ? record.patterns.map(normalizePattern) : [],
+		patterns: Array.isArray(record.patterns)
+			? record.patterns.flatMap((pattern) => {
+					try {
+						return [normalizePattern(pattern)];
+					} catch {
+						return [];
+					}
+				})
+			: [],
 		humanInterventionCount: readCount(record.humanInterventionCount),
 		syntheticInterventionCount: readCount(record.syntheticInterventionCount),
 		agentUncertaintyCount: readCount(record.agentUncertaintyCount),

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -151,7 +151,9 @@ export class EvolutionConversationAnalysisService {
 				 FROM (
 					 SELECT id, session_id, message_type, sdk_message, timestamp, origin
 					 FROM sdk_messages
-					 WHERE task_id = ? AND send_status IN ('consumed', 'failed')
+					 WHERE task_id = ?
+						 AND parent_tool_use_id IS NULL
+						 AND COALESCE(send_status, 'consumed') IN ('consumed', 'failed')
 					 ORDER BY timestamp DESC, id DESC
 					 LIMIT ?
 				 ) recent_trace_rows

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -257,18 +257,16 @@ ${transcript}`;
 }
 
 export function parseConversationFrictionJson(raw: string): ConversationFrictionAnalysis {
-	let text = raw.trim();
-	if (text.startsWith('```')) {
-		text = text
-			.replace(/^```(?:json)?\s*/i, '')
-			.replace(/\s*```$/i, '')
-			.trim();
-	} else {
-		const start = text.indexOf('{');
-		const end = text.lastIndexOf('}');
-		if (start >= 0 && end > start) text = text.slice(start, end + 1);
-	}
+	const text = extractJsonText(raw.trim());
 	return normalizeAnalysis(JSON.parse(text));
+}
+
+function extractJsonText(raw: string): string {
+	const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)?.[1]?.trim();
+	if (fenced) return fenced;
+	const start = raw.indexOf('{');
+	const end = raw.lastIndexOf('}');
+	return start >= 0 && end > start ? raw.slice(start, end + 1) : raw;
 }
 
 async function analyzeConversationWithModel(

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -1,0 +1,486 @@
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type {
+	CreateEvidenceRefParams,
+	EvidenceRef,
+	EvolutionScope,
+	SpaceTask,
+} from '@neokai/shared';
+import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
+import type { SpaceRepository } from '../../storage/repositories/space-repository';
+import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import { isRunningUnderBun, resolveSDKCliPath } from '../agent/sdk-cli-resolver';
+import { getAvailableModels } from '../model-service';
+import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+import { inferProviderForModel } from '../providers/registry';
+
+const CONVERSATION_ANALYSIS_VERSION = 1;
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.5;
+const MAX_ROWS = 1000;
+const PATTERN_KINDS = [
+	'human_correction',
+	'human_repetition',
+	'agent_misunderstanding',
+	'scope_creep',
+	'requirement_confusion',
+	'agent_apology',
+	'synthetic_interruption',
+] as const;
+const SEVERITIES = ['low', 'medium', 'high'] as const;
+
+export type TraceMessageRole = 'human' | 'synthetic_user' | 'assistant' | 'thinking';
+export type ConversationFrictionKind = (typeof PATTERN_KINDS)[number];
+export type ConversationFrictionSeverity = (typeof SEVERITIES)[number];
+
+export interface TraceMessage {
+	role: TraceMessageRole;
+	text: string;
+	timestamp: number;
+	metadata: {
+		sessionId: string;
+		messageId: string;
+	};
+}
+
+export interface ConversationFrictionPattern {
+	kind: ConversationFrictionKind;
+	confidence: number;
+	summary: string;
+	involvedMessages: string[];
+	severity: ConversationFrictionSeverity;
+}
+
+export interface ConversationFrictionAnalysis {
+	patterns: ConversationFrictionPattern[];
+	humanInterventionCount: number;
+	syntheticInterventionCount: number;
+	agentUncertaintyCount: number;
+	overallAssessment: string;
+}
+
+export interface ConversationFrictionPromptInput {
+	scope: EvolutionScope;
+	task: SpaceTask;
+	messages: TraceMessage[];
+	confidenceThreshold: number;
+}
+
+export interface EvolutionConversationAnalysisServiceDeps {
+	db: BunDatabase;
+	evolutionRepo: EvolutionRepository;
+	taskRepo: Pick<SpaceTaskRepository, 'getTask'>;
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>;
+	analyzeConversation?: (
+		input: ConversationFrictionPromptInput
+	) => Promise<ConversationFrictionAnalysis>;
+}
+
+export interface CaptureConversationFrictionForTaskParams {
+	scopeId: string;
+	taskId: string;
+	confidenceThreshold?: number;
+}
+
+interface TraceRow {
+	id: string;
+	sessionId: string;
+	messageType: string;
+	sdkMessage: string;
+	timestamp: string;
+	origin: string | null;
+}
+
+export class EvolutionConversationAnalysisService {
+	constructor(private deps: EvolutionConversationAnalysisServiceDeps) {}
+
+	async captureForTask(params: CaptureConversationFrictionForTaskParams): Promise<EvidenceRef[]> {
+		const task = this.deps.taskRepo.getTask(params.taskId);
+		if (!task) throw new Error(`Task not found: ${params.taskId}`);
+		const scope = this.deps.evolutionRepo.getScope(params.scopeId);
+		if (!scope) throw new Error(`EvolutionScope not found: ${params.scopeId}`);
+		if (scope.spaceId !== task.spaceId)
+			throw new Error('Task and scope must belong to the same space');
+
+		const messages = extractConversationMessages(this.loadTraceRows(task.id));
+		if (messages.length === 0) return [];
+
+		const confidenceThreshold = normalizeConfidence(
+			params.confidenceThreshold ?? readConfidenceThreshold(scope)
+		);
+		const analysis = await this.analyze({ scope, task, messages, confidenceThreshold });
+		const patterns = analysis.patterns.filter(
+			(pattern) => pattern.confidence >= confidenceThreshold && pattern.involvedMessages.length > 0
+		);
+		if (patterns.length === 0) return [];
+
+		const existingByFingerprint = new Map(
+			this.deps.evolutionRepo
+				.listEvidence(scope.id)
+				.filter(
+					(item) =>
+						item.kind === 'conversation_friction' &&
+						item.sourceId === task.id &&
+						item.metadata.conversationFrictionCaptureVersion === CONVERSATION_ANALYSIS_VERSION
+				)
+				.map((item) => [String(item.metadata.frictionFingerprint ?? ''), item])
+		);
+
+		return patterns.map((pattern) => {
+			const evidenceParams = buildEvidenceParams(scope.id, task, messages, analysis, pattern, {
+				confidenceThreshold,
+			});
+			const fingerprint = String(evidenceParams.metadata?.frictionFingerprint ?? '');
+			const existing = existingByFingerprint.get(fingerprint);
+			if (existing) {
+				return this.deps.evolutionRepo.updateEvidence(existing.id, {
+					summary: evidenceParams.summary,
+					metadata: evidenceParams.metadata,
+				});
+			}
+			return this.deps.evolutionRepo.createEvidence(evidenceParams);
+		});
+	}
+
+	private loadTraceRows(taskId: string): TraceRow[] {
+		const rows = this.deps.db
+			.prepare(
+				`SELECT id, session_id, message_type, sdk_message, timestamp, origin
+				 FROM (
+					 SELECT id, session_id, message_type, sdk_message, timestamp, origin
+					 FROM sdk_messages
+					 WHERE task_id = ?
+					 ORDER BY timestamp DESC, id DESC
+					 LIMIT ?
+				 ) recent_trace_rows
+				 ORDER BY timestamp ASC, id ASC`
+			)
+			.all(taskId, MAX_ROWS) as Array<{
+			id: string;
+			session_id: string;
+			message_type: string;
+			sdk_message: string;
+			timestamp: string;
+			origin: string | null;
+		}>;
+		return rows.map((row) => ({
+			id: row.id,
+			sessionId: row.session_id,
+			messageType: row.message_type,
+			sdkMessage: row.sdk_message,
+			timestamp: row.timestamp,
+			origin: row.origin,
+		}));
+	}
+
+	private async analyze(
+		input: ConversationFrictionPromptInput
+	): Promise<ConversationFrictionAnalysis> {
+		if (this.deps.analyzeConversation) return this.deps.analyzeConversation(input);
+		return analyzeConversationWithModel(input, this.deps.spaceRepo);
+	}
+}
+
+export function extractConversationMessages(rows: TraceRow[]): TraceMessage[] {
+	return rows.flatMap((row) => {
+		const parsed = parseJsonRecord(row.sdkMessage);
+		if (!parsed) return [];
+		const content = readContent(parsed);
+		if (!Array.isArray(content)) return [];
+		const timestamp = Date.parse(row.timestamp);
+		const messages: TraceMessage[] = [];
+		for (const blockValue of content) {
+			const block = asRecord(blockValue);
+			if (!block) continue;
+			const text = readTextBlock(block);
+			if (!text) continue;
+			const role = classifyBlock(row, parsed, block);
+			if (!role) continue;
+			messages.push({
+				role,
+				text,
+				timestamp,
+				metadata: { sessionId: row.sessionId, messageId: row.id },
+			});
+		}
+		return messages;
+	});
+}
+
+export function buildConversationFrictionPrompt(input: ConversationFrictionPromptInput): string {
+	const transcript = input.messages
+		.map(
+			(message, index) =>
+				`[${index + 1}] id=${message.metadata.messageId} role=${message.role} session=${message.metadata.sessionId}\n${message.text}`
+		)
+		.join('\n\n');
+	return `Analyze this task conversation for conversation friction patterns that rule-based tool analysis cannot detect.
+
+Return only JSON matching this TypeScript shape:
+{
+  "patterns": [{
+    "kind": "human_correction" | "human_repetition" | "agent_misunderstanding" | "scope_creep" | "requirement_confusion" | "agent_apology" | "synthetic_interruption",
+    "confidence": number,
+    "summary": string,
+    "involvedMessages": string[],
+    "severity": "low" | "medium" | "high"
+  }],
+  "humanInterventionCount": number,
+  "syntheticInterventionCount": number,
+  "agentUncertaintyCount": number,
+  "overallAssessment": string
+}
+
+Rules:
+- Use only supplied message ids in involvedMessages.
+- Focus on actionable struggle patterns, miscommunications, repeated corrections, interruptions, uncertainty, apologies, or scope drift.
+- Do not report ordinary tool failures or test failures unless conversation text shows misunderstanding or friction.
+- Include only patterns with confidence >= ${input.confidenceThreshold}.
+- Keep summaries concise and actionable.
+
+Task: ${input.task.title}
+Task description: ${input.task.description}
+Scope: ${input.scope.name} — ${input.scope.objective}
+
+Transcript:
+${transcript}`;
+}
+
+export function parseConversationFrictionJson(raw: string): ConversationFrictionAnalysis {
+	let text = raw.trim();
+	if (text.startsWith('```')) {
+		text = text
+			.replace(/^```(?:json)?\s*/i, '')
+			.replace(/\s*```$/i, '')
+			.trim();
+	} else {
+		const start = text.indexOf('{');
+		const end = text.lastIndexOf('}');
+		if (start >= 0 && end > start) text = text.slice(start, end + 1);
+	}
+	return normalizeAnalysis(JSON.parse(text));
+}
+
+async function analyzeConversationWithModel(
+	input: ConversationFrictionPromptInput,
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>
+): Promise<ConversationFrictionAnalysis> {
+	const providerService = getProviderService();
+	const { provider, modelId } = await resolveConversationFrictionModel(input, spaceRepo);
+	const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+	try {
+		const { query } = await import('@anthropic-ai/claude-agent-sdk');
+		const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
+		const agentQuery = query({
+			prompt: buildConversationFrictionPrompt(input),
+			options: {
+				model: provider === 'glm' ? 'haiku' : modelId,
+				maxTurns: 1,
+				permissionMode: 'acceptEdits',
+				allowDangerouslySkipPermissions: false,
+				mcpServers: {},
+				settingSources: [],
+				tools: [],
+				pathToClaudeCodeExecutable: resolveSDKCliPath(),
+				executable: isRunningUnderBun() ? 'bun' : undefined,
+				env: mergeProviderEnvVars(
+					providerService.getEnvVarsForModel(modelId, provider) as Record<
+						string,
+						string | undefined
+					>
+				),
+				thinking: { type: 'disabled' },
+			},
+		});
+		let raw = '';
+		for await (const message of agentQuery) {
+			if (isSDKAssistantMessage(message)) {
+				const textBlocks = message.message.content.filter(
+					(block: { type: string }) => block.type === 'text'
+				) as Array<{ text?: string }>;
+				raw = textBlocks
+					.map((block) => block.text ?? '')
+					.join('\n')
+					.trim();
+				if (raw) break;
+			}
+		}
+		if (!raw) throw new Error('Conversation friction analyzer returned no text');
+		return parseConversationFrictionJson(raw);
+	} finally {
+		providerService.restoreEnvVars(originalEnv);
+	}
+}
+
+async function resolveConversationFrictionModel(
+	input: ConversationFrictionPromptInput,
+	spaceRepo?: Pick<SpaceRepository, 'getSpace'>
+): Promise<{ provider: string; modelId: string }> {
+	const spaceModel = spaceRepo?.getSpace(input.scope.spaceId)?.defaultModel?.trim();
+	if (spaceModel) {
+		const cachedModel = findCachedModel(spaceModel);
+		return {
+			provider: cachedModel?.provider ?? inferProviderForModel(spaceModel),
+			modelId: cachedModel?.id ?? spaceModel,
+		};
+	}
+	const providerService = getProviderService();
+	const provider = await providerService.getDefaultProvider();
+	const cfg = await providerService.getTitleGenerationConfig(provider);
+	return { provider, modelId: cfg.modelId };
+}
+
+function findCachedModel(modelId: string): { id: string; provider: string } | undefined {
+	const models = getAvailableModels('global');
+	return (
+		models.find((model) => model.id === modelId) ?? models.find((model) => model.alias === modelId)
+	);
+}
+
+function buildEvidenceParams(
+	scopeId: string,
+	task: SpaceTask,
+	messages: TraceMessage[],
+	analysis: ConversationFrictionAnalysis,
+	pattern: ConversationFrictionPattern,
+	options: { confidenceThreshold: number }
+): CreateEvidenceRefParams {
+	const involved = messages.filter((message) =>
+		pattern.involvedMessages.includes(message.metadata.messageId)
+	);
+	const fingerprint = `conversation_friction:${pattern.kind}:${pattern.involvedMessages.join(',')}`;
+	return {
+		scopeId,
+		kind: 'conversation_friction',
+		sourceId: task.id,
+		summary: `Conversation friction (${pattern.severity}): ${pattern.summary}`,
+		metadata: {
+			conversationFrictionDerived: true,
+			conversationFrictionCaptureVersion: CONVERSATION_ANALYSIS_VERSION,
+			frictionFingerprint: fingerprint,
+			taskId: task.id,
+			workflowRunId: task.workflowRunId ?? null,
+			confidenceThreshold: options.confidenceThreshold,
+			pattern,
+			humanInterventionCount: analysis.humanInterventionCount,
+			syntheticInterventionCount: analysis.syntheticInterventionCount,
+			agentUncertaintyCount: analysis.agentUncertaintyCount,
+			overallAssessment: analysis.overallAssessment,
+			rawTraceRefs: rawRefs(involved.length > 0 ? involved : messages, messages),
+		},
+	};
+}
+
+function rawRefs(messages: TraceMessage[], allMessages: TraceMessage[]): Record<string, unknown> {
+	const indices = messages
+		.map((message) => allMessages.indexOf(message))
+		.filter((index) => index >= 0);
+	return {
+		sessionIds: unique(messages.map((message) => message.metadata.sessionId)),
+		messageIds: unique(messages.map((message) => message.metadata.messageId)),
+		messageIndexRange:
+			indices.length > 0 ? { start: Math.min(...indices), end: Math.max(...indices) } : null,
+		traceSpan: {
+			startMessageId: allMessages[0]?.metadata.messageId ?? null,
+			endMessageId: allMessages.at(-1)?.metadata.messageId ?? null,
+		},
+	};
+}
+
+function classifyBlock(
+	row: TraceRow,
+	message: Record<string, unknown>,
+	block: Record<string, unknown>
+): TraceMessageRole | null {
+	if (block.type === 'thinking') return 'thinking';
+	if (block.type !== 'text') return null;
+	if (row.messageType === 'assistant') return 'assistant';
+	if (row.messageType !== 'user') return null;
+	if (message.isSynthetic === true || row.origin !== 'human') return 'synthetic_user';
+	return 'human';
+}
+
+function readTextBlock(block: Record<string, unknown>): string | null {
+	const text = typeof block.text === 'string' ? block.text.trim() : '';
+	return text.length > 0 ? text : null;
+}
+
+function readContent(message: Record<string, unknown>): unknown {
+	const nested = asRecord(message.message);
+	return nested?.content;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+	try {
+		return asRecord(JSON.parse(value));
+	} catch {
+		return null;
+	}
+}
+
+function normalizeAnalysis(value: unknown): ConversationFrictionAnalysis {
+	const record = requireRecord(value, 'conversation friction analysis');
+	return {
+		patterns: Array.isArray(record.patterns) ? record.patterns.map(normalizePattern) : [],
+		humanInterventionCount: readCount(record.humanInterventionCount),
+		syntheticInterventionCount: readCount(record.syntheticInterventionCount),
+		agentUncertaintyCount: readCount(record.agentUncertaintyCount),
+		overallAssessment:
+			typeof record.overallAssessment === 'string' ? record.overallAssessment : 'No assessment',
+	};
+}
+
+function normalizePattern(value: unknown): ConversationFrictionPattern {
+	const record = requireRecord(value, 'conversation friction pattern');
+	return {
+		kind: enumValue(record.kind, PATTERN_KINDS, 'pattern.kind'),
+		confidence: normalizeConfidence(record.confidence),
+		summary: typeof record.summary === 'string' ? record.summary : 'Conversation friction detected',
+		involvedMessages: stringArray(record.involvedMessages),
+		severity: enumValue(record.severity ?? 'low', SEVERITIES, 'pattern.severity'),
+	};
+}
+
+function readConfidenceThreshold(scope: EvolutionScope): number {
+	return normalizeConfidence(
+		scope.policy.conversationFrictionConfidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD
+	);
+}
+
+function normalizeConfidence(value: unknown): number {
+	const number =
+		typeof value === 'number' && Number.isFinite(value) ? value : DEFAULT_CONFIDENCE_THRESHOLD;
+	return Math.max(0, Math.min(1, number));
+}
+
+function readCount(value: unknown): number {
+	return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function enumValue<T extends readonly string[]>(
+	value: unknown,
+	allowed: T,
+	label: string
+): T[number] {
+	if (typeof value === 'string' && allowed.includes(value)) return value as T[number];
+	throw new Error(`Invalid ${label}: ${String(value)}`);
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string')
+		: [];
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+	const record = asRecord(value);
+	if (!record) throw new Error(`Expected ${label} object`);
+	return record;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function unique(values: string[]): string[] {
+	return Array.from(new Set(values));
+}

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -124,19 +124,23 @@ export class EvolutionConversationAnalysisService {
 				.map((item) => [String(item.metadata.frictionFingerprint ?? ''), item])
 		);
 
-		return patterns.map((pattern) => {
+		return uniquePatternsByFingerprint(patterns).map((pattern) => {
 			const evidenceParams = buildEvidenceParams(scope.id, task, messages, analysis, pattern, {
 				confidenceThreshold,
 			});
 			const fingerprint = String(evidenceParams.metadata?.frictionFingerprint ?? '');
 			const existing = existingByFingerprint.get(fingerprint);
 			if (existing) {
-				return this.deps.evolutionRepo.updateEvidence(existing.id, {
+				const updated = this.deps.evolutionRepo.updateEvidence(existing.id, {
 					summary: evidenceParams.summary,
 					metadata: evidenceParams.metadata,
 				});
+				existingByFingerprint.set(fingerprint, updated);
+				return updated;
 			}
-			return this.deps.evolutionRepo.createEvidence(evidenceParams);
+			const created = this.deps.evolutionRepo.createEvidence(evidenceParams);
+			existingByFingerprint.set(fingerprint, created);
+			return created;
 		});
 	}
 
@@ -353,7 +357,7 @@ function buildEvidenceParams(
 	const involved = messages.filter((message) =>
 		canonicalMessageIds.includes(message.metadata.messageId)
 	);
-	const fingerprint = `conversation_friction:${pattern.kind}:${canonicalMessageIds.join(',')}`;
+	const fingerprint = patternFingerprint(pattern);
 	return {
 		scopeId,
 		kind: 'conversation_friction',
@@ -421,12 +425,29 @@ function filterResolvedPatterns(
 	});
 }
 
+function uniquePatternsByFingerprint(
+	patterns: ConversationFrictionPattern[]
+): ConversationFrictionPattern[] {
+	const seen = new Set<string>();
+	return patterns.filter((pattern) => {
+		const fingerprint = patternFingerprint(pattern);
+		if (seen.has(fingerprint)) return false;
+		seen.add(fingerprint);
+		return true;
+	});
+}
+
+function patternFingerprint(pattern: ConversationFrictionPattern): string {
+	return `conversation_friction:${pattern.kind}:${canonicalizeMessageIds(pattern.involvedMessages).join(',')}`;
+}
+
 function canonicalizeMessageIds(messageIds: string[]): string[] {
 	return unique(messageIds).sort();
 }
 
 function readTextBlock(block: Record<string, unknown>): string | null {
-	const text = typeof block.text === 'string' ? block.text.trim() : '';
+	const textValue = block.type === 'thinking' ? block.thinking : block.text;
+	const text = typeof textValue === 'string' ? textValue.trim() : '';
 	return text.length > 0 ? text : null;
 }
 

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -380,7 +380,8 @@ export class EvolutionEpisodeService {
 				item.kind !== 'retry_loop' &&
 				item.kind !== 'tool_failure' &&
 				item.kind !== 'test_failure' &&
-				item.kind !== 'permission_block'
+				item.kind !== 'permission_block' &&
+				item.kind !== 'slow_tool_call'
 			)
 				return [];
 			if (!item.sourceId || seenTaskIds.has(item.sourceId)) return [];

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -381,7 +381,8 @@ export class EvolutionEpisodeService {
 				item.kind !== 'tool_failure' &&
 				item.kind !== 'test_failure' &&
 				item.kind !== 'permission_block' &&
-				item.kind !== 'slow_tool_call'
+				item.kind !== 'slow_tool_call' &&
+				item.kind !== 'conversation_friction'
 			)
 				return [];
 			if (!item.sourceId || seenTaskIds.has(item.sourceId)) return [];

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -53,7 +53,7 @@ export interface EvolutionScopeServiceDeps {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo?: WorkflowRunArtifactRepository;
 	traceEvidenceService?: EvolutionTraceEvidenceService;
-	jobQueue?: Pick<JobQueueRepository, 'enqueue' | 'listJobs' | 'countByStatus'>;
+	jobQueue?: Pick<JobQueueRepository, 'enqueueUniquePending'>;
 }
 
 export interface CreateScopeFromGoalParams {
@@ -502,20 +502,10 @@ export class EvolutionScopeService {
 	}
 
 	private enqueueConversationFrictionAnalysis(scopeId: string, taskId: string): void {
-		const jobQueue = this.deps.jobQueue;
-		if (!jobQueue) return;
-		const counts = jobQueue.countByStatus(SPACE_CONVERSATION_FRICTION_ANALYZE);
-		const existing = jobQueue.listJobs({
-			queue: SPACE_CONVERSATION_FRICTION_ANALYZE,
-			status: ['pending', 'processing'],
-			limit: counts.pending + counts.processing,
-		});
-		if (existing.some((job) => job.payload.scopeId === scopeId && job.payload.taskId === taskId)) {
-			return;
-		}
-		jobQueue.enqueue({
+		this.deps.jobQueue?.enqueueUniquePending({
 			queue: SPACE_CONVERSATION_FRICTION_ANALYZE,
 			payload: { scopeId, taskId },
+			matchPayload: { scopeId, taskId },
 			maxRetries: 3,
 		});
 	}

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -249,7 +249,13 @@ export class EvolutionScopeService {
 			},
 		});
 		try {
-			this.deps.traceEvidenceService?.captureForTask({ scopeId: scope.id, taskId: task.id });
+			const traceResult = this.deps.traceEvidenceService?.captureForTaskWithDiagnostic({
+				scopeId: scope.id,
+				taskId: task.id,
+			});
+			if (traceResult && traceResult.evidence.length > 0) {
+				this.clearTraceDiagnosticEvidence(scope.id, task.id, traceResult.diagnostic);
+			}
 		} catch (err) {
 			this.createTraceDiagnosticEvidence(scope.id, task.id, traceCaptureErrorDiagnostic(err));
 			log.warn('Trace evidence capture failed; keeping primary task evidence:', err);
@@ -476,7 +482,7 @@ export class EvolutionScopeService {
 			if (result.evidence.length === 0) {
 				this.createTraceDiagnosticEvidence(scopeId, taskId, result.diagnostic);
 			} else {
-				this.clearTraceDiagnosticEvidence(scopeId, taskId);
+				this.clearTraceDiagnosticEvidence(scopeId, taskId, result.diagnostic);
 			}
 			return result;
 		} catch (err) {
@@ -504,7 +510,11 @@ export class EvolutionScopeService {
 		});
 	}
 
-	private clearTraceDiagnosticEvidence(scopeId: string, taskId: string): void {
+	private clearTraceDiagnosticEvidence(
+		scopeId: string,
+		taskId: string,
+		diagnostic: TraceEvidenceDiagnostic
+	): void {
 		const existing = this.deps.evolutionRepo
 			.listEvidence(scopeId)
 			.find(
@@ -516,14 +526,11 @@ export class EvolutionScopeService {
 			);
 		if (!existing) return;
 		this.deps.evolutionRepo.updateEvidence(existing.id, {
-			summary: 'Trace-derived evidence generated',
+			summary: diagnostic.message,
 			metadata: {
-				...existing.metadata,
 				traceDiagnostic: true,
-				status: 'generated',
-				message: 'Trace-derived evidence generated',
-				evidenceCount: 0,
 				clearedByTraceEvidence: true,
+				...diagnostic,
 			},
 		});
 	}

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -24,7 +24,10 @@ import type {
 	WorkflowRunArtifactRepository,
 } from '../../storage/repositories/workflow-run-artifact-repository';
 import { Logger } from '../logger';
-import type { EvolutionTraceEvidenceService } from './evolution-trace-evidence-service';
+import type {
+	EvolutionTraceEvidenceService,
+	TraceEvidenceDiagnostic,
+} from './evolution-trace-evidence-service';
 
 const MAX_PREFLIGHT_ARTIFACTS_PER_RUN = 8;
 const MAX_PREFLIGHT_ARTIFACT_TEXT = 500;
@@ -109,6 +112,7 @@ export interface CaptureCompletedTaskEvidenceParams {
 export interface CaptureCompletedTaskEvidenceResult {
 	scope: EvolutionScope | null;
 	evidence: EvidenceRef[];
+	traceDiagnostic?: TraceEvidenceDiagnostic;
 }
 
 export interface ScopeTimeline {
@@ -118,6 +122,29 @@ export interface ScopeTimeline {
 }
 
 const log = new Logger('evolution-scope-service');
+
+function traceCaptureUnavailableDiagnostic(): TraceEvidenceDiagnostic {
+	return {
+		status: 'no_trace_rows',
+		message: 'No trace evidence generated: trace capture service is not configured',
+		messageCount: 0,
+		toolCallCount: 0,
+		failedToolCallCount: 0,
+		evidenceCount: 0,
+	};
+}
+
+function traceCaptureErrorDiagnostic(err: unknown): TraceEvidenceDiagnostic {
+	return {
+		status: 'error',
+		message: 'Trace evidence capture failed',
+		messageCount: 0,
+		toolCallCount: 0,
+		failedToolCallCount: 0,
+		evidenceCount: 0,
+		error: err instanceof Error ? err.message : String(err),
+	};
+}
 
 export class EvolutionScopeService {
 	constructor(private deps: EvolutionScopeServiceDeps) {}
@@ -222,6 +249,7 @@ export class EvolutionScopeService {
 		try {
 			this.deps.traceEvidenceService?.captureForTask({ scopeId: scope.id, taskId: task.id });
 		} catch (err) {
+			this.createTraceDiagnosticEvidence(scope.id, task.id, traceCaptureErrorDiagnostic(err));
 			log.warn('Trace evidence capture failed; keeping primary task evidence:', err);
 		}
 		return evidence;
@@ -300,7 +328,10 @@ export class EvolutionScopeService {
 			}
 		}
 
-		return { scope, evidence };
+		const traceResult = this.captureTraceEvidenceForCompletedTask(scope.id, task.id);
+		evidence.push(...traceResult.evidence);
+
+		return { scope, evidence, traceDiagnostic: traceResult.diagnostic };
 	}
 
 	addManualNoteEvidence(params: AddManualNoteEvidenceParams): EvidenceRef {
@@ -430,6 +461,43 @@ export class EvolutionScopeService {
 		const goal = this.requireGoal(goalId);
 		if (goal.spaceId !== spaceId) throw new Error(`SpaceGoal not found in space: ${goalId}`);
 		return goal;
+	}
+
+	private captureTraceEvidenceForCompletedTask(
+		scopeId: string,
+		taskId: string
+	): { evidence: EvidenceRef[]; diagnostic: TraceEvidenceDiagnostic } {
+		const service = this.deps.traceEvidenceService;
+		if (!service) return { evidence: [], diagnostic: traceCaptureUnavailableDiagnostic() };
+		try {
+			const result = service.captureForTaskWithDiagnostic({ scopeId, taskId });
+			if (result.evidence.length === 0) {
+				this.createTraceDiagnosticEvidence(scopeId, taskId, result.diagnostic);
+			}
+			return result;
+		} catch (err) {
+			const diagnostic = traceCaptureErrorDiagnostic(err);
+			this.createTraceDiagnosticEvidence(scopeId, taskId, diagnostic);
+			log.warn('Trace evidence capture failed; keeping primary completion evidence:', err);
+			return { evidence: [], diagnostic };
+		}
+	}
+
+	private createTraceDiagnosticEvidence(
+		scopeId: string,
+		taskId: string,
+		diagnostic: TraceEvidenceDiagnostic
+	): EvidenceRef {
+		return this.createAutoEvidenceOnce({
+			scopeId,
+			kind: 'session',
+			sourceId: taskId,
+			summary: diagnostic.message,
+			metadata: {
+				traceDiagnostic: true,
+				...diagnostic,
+			},
+		});
 	}
 
 	private createAutoEvidenceOnce(params: CreateEvidenceRefParams): EvidenceRef {

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -130,6 +130,7 @@ function traceCaptureUnavailableDiagnostic(): TraceEvidenceDiagnostic {
 		messageCount: 0,
 		toolCallCount: 0,
 		failedToolCallCount: 0,
+		slowToolCallCount: 0,
 		evidenceCount: 0,
 	};
 }
@@ -141,6 +142,7 @@ function traceCaptureErrorDiagnostic(err: unknown): TraceEvidenceDiagnostic {
 		messageCount: 0,
 		toolCallCount: 0,
 		failedToolCallCount: 0,
+		slowToolCallCount: 0,
 		evidenceCount: 0,
 		error: err instanceof Error ? err.message : String(err),
 	};

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -53,7 +53,7 @@ export interface EvolutionScopeServiceDeps {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo?: WorkflowRunArtifactRepository;
 	traceEvidenceService?: EvolutionTraceEvidenceService;
-	jobQueue?: Pick<JobQueueRepository, 'enqueue' | 'listJobs'>;
+	jobQueue?: Pick<JobQueueRepository, 'enqueue' | 'listJobs' | 'countByStatus'>;
 }
 
 export interface CreateScopeFromGoalParams {
@@ -504,10 +504,11 @@ export class EvolutionScopeService {
 	private enqueueConversationFrictionAnalysis(scopeId: string, taskId: string): void {
 		const jobQueue = this.deps.jobQueue;
 		if (!jobQueue) return;
+		const counts = jobQueue.countByStatus(SPACE_CONVERSATION_FRICTION_ANALYZE);
 		const existing = jobQueue.listJobs({
 			queue: SPACE_CONVERSATION_FRICTION_ANALYZE,
 			status: ['pending', 'processing'],
-			limit: 100,
+			limit: counts.pending + counts.processing,
 		});
 		if (existing.some((job) => job.payload.scopeId === scopeId && job.payload.taskId === taskId)) {
 			return;

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -253,8 +253,12 @@ export class EvolutionScopeService {
 				scopeId: scope.id,
 				taskId: task.id,
 			});
-			if (traceResult && traceResult.evidence.length > 0) {
-				this.clearTraceDiagnosticEvidence(scope.id, task.id, traceResult.diagnostic);
+			if (traceResult) {
+				if (traceResult.evidence.length > 0) {
+					this.clearTraceDiagnosticEvidence(scope.id, task.id, traceResult.diagnostic);
+				} else {
+					this.createTraceDiagnosticEvidence(scope.id, task.id, traceResult.diagnostic);
+				}
 			}
 		} catch (err) {
 			this.createTraceDiagnosticEvidence(scope.id, task.id, traceCaptureErrorDiagnostic(err));
@@ -528,6 +532,7 @@ export class EvolutionScopeService {
 		this.deps.evolutionRepo.updateEvidence(existing.id, {
 			summary: diagnostic.message,
 			metadata: {
+				autoCaptured: true,
 				traceDiagnostic: true,
 				clearedByTraceEvidence: true,
 				...diagnostic,

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -15,6 +15,7 @@ import type {
 	EvolutionPreflightTaskSummary,
 } from '@neokai/shared';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { SpaceGoalRepository } from '../../storage/repositories/space-goal-repository';
 import type { SpaceRepository } from '../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
@@ -24,6 +25,7 @@ import type {
 	WorkflowRunArtifactRepository,
 } from '../../storage/repositories/workflow-run-artifact-repository';
 import { Logger } from '../logger';
+import { SPACE_CONVERSATION_FRICTION_ANALYZE } from '../job-queue-constants';
 import type {
 	EvolutionTraceEvidenceService,
 	TraceEvidenceDiagnostic,
@@ -51,6 +53,7 @@ export interface EvolutionScopeServiceDeps {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo?: WorkflowRunArtifactRepository;
 	traceEvidenceService?: EvolutionTraceEvidenceService;
+	jobQueue?: Pick<JobQueueRepository, 'enqueue' | 'listJobs'>;
 }
 
 export interface CreateScopeFromGoalParams {
@@ -342,6 +345,7 @@ export class EvolutionScopeService {
 
 		const traceResult = this.captureTraceEvidenceForCompletedTask(scope.id, task.id);
 		evidence.push(...traceResult.evidence);
+		this.enqueueConversationFrictionAnalysis(scope.id, task.id);
 
 		return { scope, evidence, traceDiagnostic: traceResult.diagnostic };
 	}
@@ -495,6 +499,24 @@ export class EvolutionScopeService {
 			log.warn('Trace evidence capture failed; keeping primary completion evidence:', err);
 			return { evidence: [], diagnostic };
 		}
+	}
+
+	private enqueueConversationFrictionAnalysis(scopeId: string, taskId: string): void {
+		const jobQueue = this.deps.jobQueue;
+		if (!jobQueue) return;
+		const existing = jobQueue.listJobs({
+			queue: SPACE_CONVERSATION_FRICTION_ANALYZE,
+			status: ['pending', 'processing'],
+			limit: 100,
+		});
+		if (existing.some((job) => job.payload.scopeId === scopeId && job.payload.taskId === taskId)) {
+			return;
+		}
+		jobQueue.enqueue({
+			queue: SPACE_CONVERSATION_FRICTION_ANALYZE,
+			payload: { scopeId, taskId },
+			maxRetries: 3,
+		});
 	}
 
 	private createTraceDiagnosticEvidence(

--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -473,6 +473,8 @@ export class EvolutionScopeService {
 			const result = service.captureForTaskWithDiagnostic({ scopeId, taskId });
 			if (result.evidence.length === 0) {
 				this.createTraceDiagnosticEvidence(scopeId, taskId, result.diagnostic);
+			} else {
+				this.clearTraceDiagnosticEvidence(scopeId, taskId);
 			}
 			return result;
 		} catch (err) {
@@ -496,6 +498,30 @@ export class EvolutionScopeService {
 			metadata: {
 				traceDiagnostic: true,
 				...diagnostic,
+			},
+		});
+	}
+
+	private clearTraceDiagnosticEvidence(scopeId: string, taskId: string): void {
+		const existing = this.deps.evolutionRepo
+			.listEvidence(scopeId)
+			.find(
+				(item) =>
+					item.kind === 'session' &&
+					item.sourceId === taskId &&
+					item.metadata.autoCaptured === true &&
+					item.metadata.traceDiagnostic === true
+			);
+		if (!existing) return;
+		this.deps.evolutionRepo.updateEvidence(existing.id, {
+			summary: 'Trace-derived evidence generated',
+			metadata: {
+				...existing.metadata,
+				traceDiagnostic: true,
+				status: 'generated',
+				message: 'Trace-derived evidence generated',
+				evidenceCount: 0,
+				clearedByTraceEvidence: true,
 			},
 		});
 	}

--- a/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
+++ b/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
@@ -10,6 +10,7 @@ const TRACE_EVIDENCE_KINDS: EvidenceKind[] = [
 	'tool_failure',
 	'test_failure',
 	'permission_block',
+	'slow_tool_call',
 ];
 const EDIT_TOOL_NAMES = new Set(['Edit', 'MultiEdit', 'Write', 'NotebookEdit']);
 const VERIFICATION_PATTERN =
@@ -18,6 +19,7 @@ const TEST_PATTERN = /\b(test|vitest|playwright)\b/i;
 const PERMISSION_PATTERN =
 	/(permission denied|operation not permitted|not allowed|requires approval|user denied|blocked by|permission block)/i;
 const MAX_ROWS = 500;
+const SLOW_TOOL_CALL_THRESHOLD_MS = 30_000;
 
 export interface EvolutionTraceEvidenceServiceDeps {
 	db: BunDatabase;
@@ -36,6 +38,7 @@ export interface TraceEvidenceDiagnostic {
 	messageCount: number;
 	toolCallCount: number;
 	failedToolCallCount: number;
+	slowToolCallCount: number;
 	evidenceCount: number;
 	error?: string;
 }
@@ -80,6 +83,16 @@ interface ToolResultRecord {
 	filePath: string | null;
 }
 
+interface SlowToolCallRecord {
+	toolUseId: string;
+	toolName: string;
+	commandKey: string;
+	durationMs: number;
+	filePath: string | null;
+	rowId: string;
+	sessionId: string;
+}
+
 interface TraceAnalysis {
 	rows: TraceRow[];
 	toolUses: ToolUseRecord[];
@@ -89,6 +102,7 @@ interface TraceAnalysis {
 	editFailures: ToolResultRecord[];
 	testFailures: ToolResultRecord[];
 	permissionBlocks: ToolResultRecord[];
+	slowToolCalls: SlowToolCallRecord[];
 	repeatedErrors: Array<{ fingerprint: string; count: number; results: ToolResultRecord[] }>;
 	retryLoops: Array<{
 		key: string;
@@ -269,6 +283,25 @@ function analyzeTrace(rows: TraceRow[]): TraceAnalysis {
 		).entries()
 	).flatMap(([key, results]) => detectRetryLoops(key, results));
 
+	const slowToolCalls = toolResults.flatMap((result): SlowToolCallRecord[] => {
+		if (!result.toolUseId) return [];
+		const toolUse = toolUsesById.get(result.toolUseId);
+		if (!toolUse) return [];
+		const durationMs = result.timestamp - toolUse.timestamp;
+		if (!Number.isFinite(durationMs) || durationMs < SLOW_TOOL_CALL_THRESHOLD_MS) return [];
+		return [
+			{
+				toolUseId: result.toolUseId,
+				toolName: result.toolName,
+				commandKey: result.commandKey,
+				durationMs,
+				filePath: result.filePath,
+				rowId: result.rowId,
+				sessionId: result.sessionId,
+			},
+		];
+	});
+
 	const verificationSuccesses = toolResults.filter(
 		(result) => !result.failed && (result.category === 'test' || result.category === 'verification')
 	);
@@ -283,6 +316,7 @@ function analyzeTrace(rows: TraceRow[]): TraceAnalysis {
 		editFailures: failedResults.filter((result) => result.category === 'edit'),
 		testFailures: failedResults.filter((result) => result.category === 'test'),
 		permissionBlocks: failedResults.filter((result) => result.category === 'permission'),
+		slowToolCalls,
 		repeatedErrors,
 		retryLoops,
 		fileChurn: Array.from(editCountsByFile.entries())
@@ -365,6 +399,22 @@ function buildEvidenceParams(
 		});
 	}
 
+	if (analysis.slowToolCalls.length > 0) {
+		params.push({
+			scopeId,
+			kind: 'slow_tool_call',
+			sourceId: task.id,
+			summary: `Slow tool calls took over ${SLOW_TOOL_CALL_THRESHOLD_MS / 1000}s ${analysis.slowToolCalls.length} time${plural(analysis.slowToolCalls.length)}`,
+			metadata: {
+				...base,
+				traceFingerprint: 'slow_tool_call',
+				slowToolCallCount: analysis.slowToolCalls.length,
+				slowToolCalls: analysis.slowToolCalls.map(summarizeSlowToolCall),
+				rawTraceRefs: rawRefsForSlowToolCalls(analysis.slowToolCalls, analysis),
+			},
+		});
+	}
+
 	if (analysis.failedToolCallCount > 0 && params.length === 0) {
 		params.push({
 			scopeId,
@@ -396,6 +446,7 @@ function buildBaseMetadata(task: SpaceTask, analysis: TraceAnalysis): Record<str
 		editFailureCount: analysis.editFailures.length,
 		testFailureCycles: analysis.testFailures.length,
 		permissionBlockCount: analysis.permissionBlocks.length,
+		slowToolCallCount: analysis.slowToolCalls.length,
 		fileChurn: analysis.fileChurn,
 		messageCount: analysis.rows.length,
 		traceSpan: {
@@ -410,7 +461,8 @@ function hasProcessFriction(analysis: TraceAnalysis): boolean {
 		analysis.failedToolCallCount > 0 ||
 		analysis.repeatedErrors.length > 0 ||
 		analysis.retryLoops.length > 0 ||
-		analysis.permissionBlocks.length > 0
+		analysis.permissionBlocks.length > 0 ||
+		analysis.slowToolCalls.length > 0
 	);
 }
 
@@ -426,6 +478,7 @@ function buildTraceDiagnostic(
 		messageCount,
 		toolCallCount: analysis?.toolCallCount ?? 0,
 		failedToolCallCount: analysis?.failedToolCallCount ?? 0,
+		slowToolCallCount: analysis?.slowToolCalls.length ?? 0,
 		evidenceCount,
 	};
 }
@@ -435,9 +488,34 @@ function traceDiagnosticMessage(status: TraceEvidenceDiagnostic['status']): stri
 	if (status === 'no_trace_rows')
 		return 'No trace evidence generated: no SDK messages found for task';
 	if (status === 'no_friction') {
-		return 'No trace evidence generated: task trace had no meaningful failures, retries, or permission blocks';
+		return 'No trace evidence generated: task trace had no meaningful failures, retries, permission blocks, or slow operations';
 	}
 	return 'Trace evidence capture failed';
+}
+
+function summarizeSlowToolCall(record: SlowToolCallRecord): Record<string, unknown> {
+	return {
+		toolUseId: record.toolUseId,
+		toolName: record.toolName,
+		commandKey: record.commandKey,
+		durationMs: record.durationMs,
+		filePath: record.filePath,
+	};
+}
+
+function rawRefsForSlowToolCalls(
+	calls: SlowToolCallRecord[],
+	analysis: TraceAnalysis
+): Record<string, unknown> {
+	return {
+		sessionIds: unique(calls.map((call) => call.sessionId)),
+		messageIds: unique(calls.map((call) => call.rowId)),
+		toolUseIds: unique(calls.map((call) => call.toolUseId)),
+		traceSpan: {
+			startMessageId: analysis.rows[0]?.id ?? null,
+			endMessageId: analysis.rows.at(-1)?.id ?? null,
+		},
+	};
 }
 
 function rawRefs(results: ToolResultRecord[], analysis: TraceAnalysis): Record<string, unknown> {

--- a/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
+++ b/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
@@ -30,6 +30,21 @@ export interface CaptureTraceEvidenceForTaskParams {
 	taskId: string;
 }
 
+export interface TraceEvidenceDiagnostic {
+	status: 'generated' | 'no_trace_rows' | 'no_friction' | 'error';
+	message: string;
+	messageCount: number;
+	toolCallCount: number;
+	failedToolCallCount: number;
+	evidenceCount: number;
+	error?: string;
+}
+
+export interface CaptureTraceEvidenceForTaskResult {
+	evidence: EvidenceRef[];
+	diagnostic: TraceEvidenceDiagnostic;
+}
+
 interface TraceRow {
 	id: string;
 	sessionId: string;
@@ -88,13 +103,29 @@ export class EvolutionTraceEvidenceService {
 	constructor(private deps: EvolutionTraceEvidenceServiceDeps) {}
 
 	captureForTask(params: CaptureTraceEvidenceForTaskParams): EvidenceRef[] {
+		return this.captureForTaskWithDiagnostic(params).evidence;
+	}
+
+	captureForTaskWithDiagnostic(
+		params: CaptureTraceEvidenceForTaskParams
+	): CaptureTraceEvidenceForTaskResult {
 		const task = this.deps.taskRepo.getTask(params.taskId);
 		if (!task) throw new Error(`Task not found: ${params.taskId}`);
 		const rows = this.loadTraceRows(task.id);
-		if (rows.length === 0) return [];
+		if (rows.length === 0) {
+			return {
+				evidence: [],
+				diagnostic: buildTraceDiagnostic('no_trace_rows', rows.length),
+			};
+		}
 
 		const analysis = analyzeTrace(rows);
-		if (!hasProcessFriction(analysis)) return [];
+		if (!hasProcessFriction(analysis)) {
+			return {
+				evidence: [],
+				diagnostic: buildTraceDiagnostic('no_friction', rows.length, analysis),
+			};
+		}
 
 		const existingByFingerprint = new Map(
 			this.deps.evolutionRepo
@@ -108,7 +139,7 @@ export class EvolutionTraceEvidenceService {
 				.map((item) => [String(item.metadata.traceFingerprint ?? ''), item])
 		);
 
-		return buildEvidenceParams(params.scopeId, task, analysis).map((item) => {
+		const evidence = buildEvidenceParams(params.scopeId, task, analysis).map((item) => {
 			const fingerprint = String(item.metadata?.traceFingerprint ?? '');
 			const existing = existingByFingerprint.get(fingerprint);
 			if (existing) {
@@ -119,6 +150,10 @@ export class EvolutionTraceEvidenceService {
 			}
 			return this.deps.evolutionRepo.createEvidence(item);
 		});
+		return {
+			evidence,
+			diagnostic: buildTraceDiagnostic('generated', rows.length, analysis, evidence.length),
+		};
 	}
 
 	private loadTraceRows(taskId: string): TraceRow[] {
@@ -377,6 +412,32 @@ function hasProcessFriction(analysis: TraceAnalysis): boolean {
 		analysis.retryLoops.length > 0 ||
 		analysis.permissionBlocks.length > 0
 	);
+}
+
+function buildTraceDiagnostic(
+	status: TraceEvidenceDiagnostic['status'],
+	messageCount: number,
+	analysis?: TraceAnalysis,
+	evidenceCount = 0
+): TraceEvidenceDiagnostic {
+	return {
+		status,
+		message: traceDiagnosticMessage(status),
+		messageCount,
+		toolCallCount: analysis?.toolCallCount ?? 0,
+		failedToolCallCount: analysis?.failedToolCallCount ?? 0,
+		evidenceCount,
+	};
+}
+
+function traceDiagnosticMessage(status: TraceEvidenceDiagnostic['status']): string {
+	if (status === 'generated') return 'Trace-derived evidence generated';
+	if (status === 'no_trace_rows')
+		return 'No trace evidence generated: no SDK messages found for task';
+	if (status === 'no_friction') {
+		return 'No trace evidence generated: task trace had no meaningful failures, retries, or permission blocks';
+	}
+	return 'Trace evidence capture failed';
 }
 
 function rawRefs(results: ToolResultRecord[], analysis: TraceAnalysis): Record<string, unknown> {

--- a/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
+++ b/packages/daemon/src/lib/space/evolution-trace-evidence-service.ts
@@ -415,7 +415,8 @@ function buildEvidenceParams(
 		});
 	}
 
-	if (analysis.failedToolCallCount > 0 && params.length === 0) {
+	const hasFailureEvidence = params.some((param) => param.kind !== 'slow_tool_call');
+	if (analysis.failedToolCallCount > 0 && !hasFailureEvidence) {
 		params.push({
 			scopeId,
 			kind: 'tool_failure',

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -214,7 +214,9 @@ export class JobQueueRepository {
 	): Job | null {
 		if (activeStatuses.length === 0) return null;
 		const statusPlaceholders = activeStatuses.map(() => '?').join(',');
-		const payloadPredicates = Object.keys(matchPayload).map(() => `json_extract(payload, ?) = ?`);
+		const payloadPredicates = Object.values(matchPayload).map((value) =>
+			value === null ? `json_type(payload, ?) = 'null'` : `json_extract(payload, ?) = ?`
+		);
 		const stmt = this.db.prepare(
 			`SELECT * FROM job_queue
 			 WHERE queue = ?
@@ -225,7 +227,8 @@ export class JobQueueRepository {
 		);
 		const params: (string | number | null)[] = [queue, ...activeStatuses];
 		for (const [key, value] of Object.entries(matchPayload)) {
-			params.push(`$.${key}`, sqliteJsonScalar(value));
+			params.push(`$.${key}`);
+			if (value !== null) params.push(sqliteJsonScalar(value));
 		}
 		const row = stmt.get(...params) as Record<string, unknown> | undefined;
 		return row ? this.rowToJob(row) : null;

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -27,6 +27,11 @@ export interface EnqueueParams {
 	runAt?: number;
 }
 
+export interface EnqueueUniquePendingParams extends EnqueueParams {
+	matchPayload: Record<string, unknown>;
+	activeStatuses?: JobStatus[];
+}
+
 export class JobQueueRepository {
 	constructor(private db: BunDatabase) {}
 
@@ -56,6 +61,15 @@ export class JobQueueRepository {
 		);
 
 		return this.getJob(id)!;
+	}
+
+	enqueueUniquePending(params: EnqueueUniquePendingParams): Job | null {
+		return this.db.transaction(() => {
+			if (this.findMatchingActiveJob(params.queue, params.matchPayload, params.activeStatuses)) {
+				return null;
+			}
+			return this.enqueue(params);
+		})();
 	}
 
 	dequeue(queue: string, limit: number = 1): Job[] {
@@ -193,6 +207,30 @@ export class JobQueueRepository {
 		return result.changes > 0;
 	}
 
+	private findMatchingActiveJob(
+		queue: string,
+		matchPayload: Record<string, unknown>,
+		activeStatuses: JobStatus[] = ['pending', 'processing']
+	): Job | null {
+		if (activeStatuses.length === 0) return null;
+		const statusPlaceholders = activeStatuses.map(() => '?').join(',');
+		const payloadPredicates = Object.keys(matchPayload).map(() => `json_extract(payload, ?) = ?`);
+		const stmt = this.db.prepare(
+			`SELECT * FROM job_queue
+			 WHERE queue = ?
+				 AND status IN (${statusPlaceholders})
+				 ${payloadPredicates.length > 0 ? `AND ${payloadPredicates.join(' AND ')}` : ''}
+			 ORDER BY created_at DESC
+			 LIMIT 1`
+		);
+		const params: (string | number | null)[] = [queue, ...activeStatuses];
+		for (const [key, value] of Object.entries(matchPayload)) {
+			params.push(`$.${key}`, sqliteJsonScalar(value));
+		}
+		const row = stmt.get(...params) as Record<string, unknown> | undefined;
+		return row ? this.rowToJob(row) : null;
+	}
+
 	reclaimStale(staleBefore: number): number {
 		const result = this.db
 			.prepare(
@@ -220,4 +258,11 @@ export class JobQueueRepository {
 			completedAt: (row.completed_at as number | null) ?? null,
 		};
 	}
+}
+
+function sqliteJsonScalar(value: unknown): string | number | null {
+	if (typeof value === 'string' || typeof value === 'number') return value;
+	if (typeof value === 'boolean') return value ? 1 : 0;
+	if (value === null) return null;
+	throw new Error('enqueueUniquePending matchPayload values must be JSON scalar values');
 }

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -35,7 +35,7 @@ export function createEvolutionTables(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			scope_id TEXT NOT NULL,
 			kind TEXT NOT NULL
-				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call')),
+				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call', 'conversation_friction')),
 			summary TEXT NOT NULL,
 			source_id TEXT,
 			metadata_json TEXT NOT NULL DEFAULT '{}',

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -35,7 +35,7 @@ export function createEvolutionTables(db: BunDatabase): void {
 			id TEXT PRIMARY KEY,
 			scope_id TEXT NOT NULL,
 			kind TEXT NOT NULL
-				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block')),
+				CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call')),
 			summary TEXT NOT NULL,
 			source_id TEXT,
 			metadata_json TEXT NOT NULL DEFAULT '{}',

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9505,7 +9505,8 @@ function widenEvolutionEvidenceKinds(db: BunDatabase): void {
 		sql.includes("'retry_loop'") &&
 		sql.includes("'tool_failure'") &&
 		sql.includes("'test_failure'") &&
-		sql.includes("'permission_block'")
+		sql.includes("'permission_block'") &&
+		sql.includes("'slow_tool_call'")
 	) {
 		return;
 	}
@@ -9518,7 +9519,7 @@ function widenEvolutionEvidenceKinds(db: BunDatabase): void {
 				id TEXT PRIMARY KEY,
 				scope_id TEXT NOT NULL,
 				kind TEXT NOT NULL
-					CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block')),
+					CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call')),
 				summary TEXT NOT NULL,
 				source_id TEXT,
 				metadata_json TEXT NOT NULL DEFAULT '{}',

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9506,7 +9506,8 @@ function widenEvolutionEvidenceKinds(db: BunDatabase): void {
 		sql.includes("'tool_failure'") &&
 		sql.includes("'test_failure'") &&
 		sql.includes("'permission_block'") &&
-		sql.includes("'slow_tool_call'")
+		sql.includes("'slow_tool_call'") &&
+		sql.includes("'conversation_friction'")
 	) {
 		return;
 	}
@@ -9519,7 +9520,7 @@ function widenEvolutionEvidenceKinds(db: BunDatabase): void {
 				id TEXT PRIMARY KEY,
 				scope_id TEXT NOT NULL,
 				kind TEXT NOT NULL
-					CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call')),
+					CHECK(kind IN ('task', 'workflow_run', 'session', 'manual_note', 'metric_snapshot', 'task_result', 'artifact', 'error', 'error_cluster', 'retry_loop', 'tool_failure', 'test_failure', 'permission_block', 'slow_tool_call', 'conversation_friction')),
 				summary TEXT NOT NULL,
 				source_id TEXT,
 				metadata_json TEXT NOT NULL DEFAULT '{}',

--- a/packages/daemon/tests/unit/4-space-storage/storage/job-queue-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/job-queue-repository.test.ts
@@ -87,6 +87,16 @@ describe('JobQueueRepository', () => {
 				payload: { scopeId: 'scope-1', taskId: 'task-1' },
 				matchPayload: { scopeId: 'scope-1', taskId: 'task-1' },
 			});
+			const nullKey = repository.enqueueUniquePending({
+				queue: 'conversation-friction',
+				payload: { scopeId: 'scope-1', taskId: null },
+				matchPayload: { scopeId: 'scope-1', taskId: null },
+			});
+			const nullKeyDuplicate = repository.enqueueUniquePending({
+				queue: 'conversation-friction',
+				payload: { scopeId: 'scope-1', taskId: null },
+				matchPayload: { scopeId: 'scope-1', taskId: null },
+			});
 			const other = repository.enqueueUniquePending({
 				queue: 'conversation-friction',
 				payload: { scopeId: 'scope-1', taskId: 'task-2' },
@@ -95,8 +105,10 @@ describe('JobQueueRepository', () => {
 
 			expect(first).not.toBeNull();
 			expect(duplicate).toBeNull();
+			expect(nullKey).not.toBeNull();
+			expect(nullKeyDuplicate).toBeNull();
 			expect(other).not.toBeNull();
-			expect(repository.listJobs({ queue: 'conversation-friction', limit: 10 })).toHaveLength(2);
+			expect(repository.listJobs({ queue: 'conversation-friction', limit: 10 })).toHaveLength(3);
 		});
 
 		it('assigns each job a unique UUID', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/job-queue-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/job-queue-repository.test.ts
@@ -76,6 +76,29 @@ describe('JobQueueRepository', () => {
 			expect(job.payload).toEqual(payload);
 		});
 
+		it('atomically skips duplicate active jobs by payload fields', () => {
+			const first = repository.enqueueUniquePending({
+				queue: 'conversation-friction',
+				payload: { scopeId: 'scope-1', taskId: 'task-1' },
+				matchPayload: { scopeId: 'scope-1', taskId: 'task-1' },
+			});
+			const duplicate = repository.enqueueUniquePending({
+				queue: 'conversation-friction',
+				payload: { scopeId: 'scope-1', taskId: 'task-1' },
+				matchPayload: { scopeId: 'scope-1', taskId: 'task-1' },
+			});
+			const other = repository.enqueueUniquePending({
+				queue: 'conversation-friction',
+				payload: { scopeId: 'scope-1', taskId: 'task-2' },
+				matchPayload: { scopeId: 'scope-1', taskId: 'task-2' },
+			});
+
+			expect(first).not.toBeNull();
+			expect(duplicate).toBeNull();
+			expect(other).not.toBeNull();
+			expect(repository.listJobs({ queue: 'conversation-friction', limit: 10 })).toHaveLength(2);
+		});
+
 		it('assigns each job a unique UUID', () => {
 			const job1 = repository.enqueue({ queue: 'test', payload: {} });
 			const job2 = repository.enqueue({ queue: 'test', payload: {} });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
@@ -240,5 +240,22 @@ describe('Migration 142: Forge MVP evidence backfill', () => {
 				)
 				.run('manual-slow-tool', SCOPE_ID, 'slow_tool_call', 'Slow tool', 'task-425', '{}', 201)
 		).not.toThrow();
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO evolution_evidence (
+						id, scope_id, kind, summary, source_id, metadata_json, created_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run(
+					'manual-conversation-friction',
+					SCOPE_ID,
+					'conversation_friction',
+					'Conversation friction',
+					'task-425',
+					'{}',
+					202
+				)
+		).not.toThrow();
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-142-forge-evidence.test.ts
@@ -231,5 +231,14 @@ describe('Migration 142: Forge MVP evidence backfill', () => {
 				)
 				.run('manual-retry-loop', SCOPE_ID, 'retry_loop', 'Retry loop', 'task-425', '{}', 200)
 		).not.toThrow();
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO evolution_evidence (
+						id, scope_id, kind, summary, source_id, metadata_json, created_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?)`
+				)
+				.run('manual-slow-tool', SCOPE_ID, 'slow_tool_call', 'Slow tool', 'task-425', '{}', 201)
+		).not.toThrow();
 	});
 });

--- a/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+	EvolutionConversationAnalysisService,
+	extractConversationMessages,
+} from '../../../src/lib/space/evolution-conversation-analysis-service';
+import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('EvolutionConversationAnalysisService', () => {
+	let db: Database;
+	let evolutionRepo: EvolutionRepository;
+	let spaceRepo: SpaceRepository;
+	let taskRepo: SpaceTaskRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		evolutionRepo = new EvolutionRepository(db as never);
+		spaceRepo = new SpaceRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+		spaceId = spaceRepo.createSpace({
+			workspacePath: '/workspace/conversation-friction',
+			slug: 'conversation-friction',
+			name: 'Conversation Friction',
+		}).id;
+	});
+
+	it('classifies human, synthetic user, assistant, and thinking text', () => {
+		const rows = [
+			traceRow('human-1', 'user', 'human', {
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'Please keep this scoped.' }] },
+			}),
+			traceRow('synthetic-1', 'user', null, {
+				type: 'user',
+				isSynthetic: true,
+				message: { role: 'user', content: [{ type: 'text', text: 'Reviewer requested changes.' }] },
+			}),
+			traceRow('assistant-1', 'assistant', null, {
+				type: 'assistant',
+				message: {
+					role: 'assistant',
+					content: [
+						{ type: 'thinking', text: 'I may have misunderstood the requirement.' },
+						{ type: 'text', text: 'Sorry, I will fix the scoped behavior.' },
+					],
+				},
+			}),
+		];
+
+		const messages = extractConversationMessages(rows);
+
+		expect(messages.map((message) => message.role)).toEqual([
+			'human',
+			'synthetic_user',
+			'thinking',
+			'assistant',
+		]);
+		expect(messages.map((message) => message.metadata.messageId)).toEqual([
+			'human-1',
+			'synthetic-1',
+			'assistant-1',
+			'assistant-1',
+		]);
+	});
+
+	it('emits conversation friction evidence above threshold and upserts repeated capture', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Friction scope',
+			objective: 'Capture communication friction',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Fix repeated misunderstanding',
+			description: 'Human corrected the agent twice',
+			evolutionScopeId: scope.id,
+		});
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: {
+				role: 'user',
+				content: [{ type: 'text', text: 'No, keep the change in this PR.' }],
+			},
+		});
+		insertTextMessage(task.id, 'message-assistant-1', 'assistant', null, {
+			type: 'assistant',
+			message: { role: 'assistant', content: [{ type: 'text', text: 'Sorry, I misunderstood.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => ({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.8,
+						summary: 'Human corrected agent scope misunderstanding.',
+						involvedMessages: ['message-human-1', 'message-assistant-1'],
+						severity: 'medium',
+					},
+					{
+						kind: 'agent_apology',
+						confidence: 0.4,
+						summary: 'Low-confidence apology.',
+						involvedMessages: ['message-assistant-1'],
+						severity: 'low',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 1,
+				overallAssessment: 'Scope misunderstanding slowed completion.',
+			}),
+		});
+
+		const first = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+		const second = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+		expect(
+			evolutionRepo.listEvidence(scope.id).filter((item) => item.kind === 'conversation_friction')
+		).toHaveLength(1);
+		expect(first[0]?.metadata.conversationFrictionDerived).toBe(true);
+		expect(first[0]?.metadata.humanInterventionCount).toBe(1);
+		expect((first[0]?.metadata.pattern as { kind?: string }).kind).toBe('human_correction');
+	});
+
+	function traceRow(
+		id: string,
+		messageType: string,
+		origin: string | null,
+		message: Record<string, unknown>
+	) {
+		return {
+			id,
+			sessionId: 'session-1',
+			messageType,
+			sdkMessage: JSON.stringify(message),
+			timestamp: new Date(1_700_000_000_000).toISOString(),
+			origin,
+		};
+	}
+
+	function insertTextMessage(
+		taskId: string,
+		id: string,
+		messageType: string,
+		origin: string | null,
+		message: Record<string, unknown>
+	): void {
+		db.prepare(
+			`INSERT INTO sdk_messages (
+				id, session_id, message_type, sdk_message, timestamp, origin,
+				is_renderable, is_terminal, task_id
+			) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?)`
+		).run(
+			id,
+			'session-1',
+			messageType,
+			JSON.stringify(message),
+			new Date(1_700_000_000_000).toISOString(),
+			origin,
+			taskId
+		);
+	}
+});

--- a/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
@@ -355,6 +355,26 @@ describe('EvolutionConversationAnalysisService', () => {
 		expect(analysis.patterns[0]?.kind).toBe('human_correction');
 	});
 
+	it('parses fenced analyzer JSON when trailing prose follows the closing fence', () => {
+		const analysis = parseConversationFrictionJson(`Here is the analysis:
+	some intro
+		skip
+
+		\`\`\`json
+		{
+			"patterns": [],
+			"humanInterventionCount": 0,
+			"syntheticInterventionCount": 0,
+			"agentUncertaintyCount": 0,
+			"overallAssessment": "No friction detected."
+		}
+		\`\`\`
+		Extra explanation after the JSON.`);
+
+		expect(analysis.patterns).toEqual([]);
+		expect(analysis.overallAssessment).toBe('No friction detected.');
+	});
+
 	it('returns no evidence when LLM returns empty patterns', async () => {
 		const { scope, task } = createScopedTask();
 		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {

--- a/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
@@ -3,6 +3,8 @@ import { Database } from 'bun:sqlite';
 import {
 	EvolutionConversationAnalysisService,
 	extractConversationMessages,
+	parseConversationFrictionJson,
+	type TraceMessage,
 } from '../../../src/lib/space/evolution-conversation-analysis-service';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
@@ -29,16 +31,24 @@ describe('EvolutionConversationAnalysisService', () => {
 		}).id;
 	});
 
-	it('classifies human, synthetic user, assistant, and thinking text', () => {
+	it('classifies null-origin users as human and explicit synthetic rows as synthetic', () => {
 		const rows = [
 			traceRow('human-1', 'user', 'human', {
 				type: 'user',
 				message: { role: 'user', content: [{ type: 'text', text: 'Please keep this scoped.' }] },
 			}),
+			traceRow('null-human-1', 'user', null, {
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'This is normal user input.' }] },
+			}),
 			traceRow('synthetic-1', 'user', null, {
 				type: 'user',
 				isSynthetic: true,
 				message: { role: 'user', content: [{ type: 'text', text: 'Reviewer requested changes.' }] },
+			}),
+			traceRow('system-1', 'user', 'system', {
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'Workflow dispatched work.' }] },
 			}),
 			traceRow('assistant-1', 'assistant', null, {
 				type: 'assistant',
@@ -56,31 +66,24 @@ describe('EvolutionConversationAnalysisService', () => {
 
 		expect(messages.map((message) => message.role)).toEqual([
 			'human',
+			'human',
+			'synthetic_user',
 			'synthetic_user',
 			'thinking',
 			'assistant',
 		]);
 		expect(messages.map((message) => message.metadata.messageId)).toEqual([
 			'human-1',
+			'null-human-1',
 			'synthetic-1',
+			'system-1',
 			'assistant-1',
 			'assistant-1',
 		]);
 	});
 
 	it('emits conversation friction evidence above threshold and upserts repeated capture', async () => {
-		const scope = evolutionRepo.createScope({
-			spaceId,
-			kind: 'custom',
-			name: 'Friction scope',
-			objective: 'Capture communication friction',
-		});
-		const task = taskRepo.createTask({
-			spaceId,
-			title: 'Fix repeated misunderstanding',
-			description: 'Human corrected the agent twice',
-			evolutionScopeId: scope.id,
-		});
+		const { scope, task } = createScopedTask();
 		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
 			type: 'user',
 			message: {
@@ -133,6 +136,249 @@ describe('EvolutionConversationAnalysisService', () => {
 		expect((first[0]?.metadata.pattern as { kind?: string }).kind).toBe('human_correction');
 	});
 
+	it('excludes unsent messages from conversation friction input', async () => {
+		const { scope, task } = createScopedTask();
+		let analyzedMessages: TraceMessage[] = [];
+		insertTextMessage(task.id, 'consumed-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
+		});
+		insertTextMessage(
+			task.id,
+			'deferred-human-1',
+			'user',
+			'human',
+			{
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'Not sent yet.' }] },
+			},
+			'deferred'
+		);
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async (input) => {
+				analyzedMessages = input.messages;
+				return emptyAnalysis();
+			},
+		});
+
+		await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(analyzedMessages.map((message) => message.metadata.messageId)).toEqual([
+			'consumed-human-1',
+		]);
+	});
+
+	it('canonicalizes involved message IDs for stable fingerprints', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'No, this is wrong.' }] },
+		});
+		insertTextMessage(task.id, 'message-assistant-1', 'assistant', null, {
+			type: 'assistant',
+			message: { role: 'assistant', content: [{ type: 'text', text: 'Sorry, I misunderstood.' }] },
+		});
+		let reversed = false;
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => ({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.9,
+						summary: 'Human corrected a misunderstanding.',
+						involvedMessages: reversed
+							? ['message-assistant-1', 'message-human-1']
+							: ['message-human-1', 'message-assistant-1'],
+						severity: 'high',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 1,
+				overallAssessment: 'Correction needed.',
+			}),
+		});
+
+		const first = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+		reversed = true;
+		const second = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(first[0]?.id).toBe(second[0]?.id);
+		expect(
+			evolutionRepo.listEvidence(scope.id).filter((item) => item.kind === 'conversation_friction')
+		).toHaveLength(1);
+		expect(second[0]?.metadata.frictionFingerprint).toBe(
+			'conversation_friction:human_correction:message-assistant-1,message-human-1'
+		);
+	});
+
+	it('rejects patterns whose message IDs do not resolve in trace', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => ({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.9,
+						summary: 'References a missing message.',
+						involvedMessages: ['message-human-1', 'missing-message'],
+						severity: 'medium',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 0,
+				overallAssessment: 'Missing reference.',
+			}),
+		});
+
+		const evidence = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(evidence).toEqual([]);
+		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(0);
+	});
+
+	it('skips malformed patterns while retaining valid patterns', () => {
+		const analysis = parseConversationFrictionJson(
+			JSON.stringify({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.8,
+						summary: 'Valid correction.',
+						involvedMessages: ['message-human-1'],
+						severity: 'medium',
+					},
+					{
+						kind: 'not_allowed',
+						confidence: 0.9,
+						summary: 'Invalid kind.',
+						involvedMessages: ['message-human-1'],
+						severity: 'medium',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 0,
+				overallAssessment: 'One valid pattern.',
+			})
+		);
+
+		expect(analysis.patterns).toHaveLength(1);
+		expect(analysis.patterns[0]?.kind).toBe('human_correction');
+	});
+
+	it('returns no evidence when LLM returns empty patterns', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => emptyAnalysis(),
+		});
+
+		const evidence = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(evidence).toEqual([]);
+		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(0);
+	});
+
+	it('propagates LLM failures so the job queue can retry', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => {
+				throw new Error('LLM unavailable');
+			},
+		});
+
+		expect(service.captureForTask({ scopeId: scope.id, taskId: task.id })).rejects.toThrow(
+			'LLM unavailable'
+		);
+	});
+
+	it('emits no evidence when all patterns are below threshold', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => ({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.4,
+						summary: 'Below threshold.',
+						involvedMessages: ['message-human-1'],
+						severity: 'low',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 0,
+				overallAssessment: 'Below threshold only.',
+			}),
+		});
+
+		const evidence = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(evidence).toEqual([]);
+		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(0);
+	});
+
+	function createScopedTask() {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Friction scope',
+			objective: 'Capture communication friction',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Fix repeated misunderstanding',
+			description: 'Human corrected the agent twice',
+			evolutionScopeId: scope.id,
+		});
+		return { scope, task };
+	}
+
+	function emptyAnalysis() {
+		return {
+			patterns: [],
+			humanInterventionCount: 0,
+			syntheticInterventionCount: 0,
+			agentUncertaintyCount: 0,
+			overallAssessment: 'No friction detected.',
+		};
+	}
+
 	function traceRow(
 		id: string,
 		messageType: string,
@@ -154,13 +400,14 @@ describe('EvolutionConversationAnalysisService', () => {
 		id: string,
 		messageType: string,
 		origin: string | null,
-		message: Record<string, unknown>
+		message: Record<string, unknown>,
+		sendStatus = 'consumed'
 	): void {
 		db.prepare(
 			`INSERT INTO sdk_messages (
 				id, session_id, message_type, sdk_message, timestamp, origin,
-				is_renderable, is_terminal, task_id
-			) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?)`
+				is_renderable, is_terminal, task_id, send_status
+			) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?, ?)`
 		).run(
 			id,
 			'session-1',
@@ -168,7 +415,8 @@ describe('EvolutionConversationAnalysisService', () => {
 			JSON.stringify(message),
 			new Date(1_700_000_000_000).toISOString(),
 			origin,
-			taskId
+			taskId,
+			sendStatus
 		);
 	}
 });

--- a/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
@@ -55,7 +55,7 @@ describe('EvolutionConversationAnalysisService', () => {
 				message: {
 					role: 'assistant',
 					content: [
-						{ type: 'thinking', text: 'I may have misunderstood the requirement.' },
+						{ type: 'thinking', thinking: 'I may have misunderstood the requirement.' },
 						{ type: 'text', text: 'Sorry, I will fix the scoped behavior.' },
 					],
 				},
@@ -80,6 +80,9 @@ describe('EvolutionConversationAnalysisService', () => {
 			'assistant-1',
 			'assistant-1',
 		]);
+		expect(messages.find((message) => message.role === 'thinking')?.text).toBe(
+			'I may have misunderstood the requirement.'
+		);
 	});
 
 	it('emits conversation friction evidence above threshold and upserts repeated capture', async () => {
@@ -216,6 +219,53 @@ describe('EvolutionConversationAnalysisService', () => {
 		expect(second[0]?.metadata.frictionFingerprint).toBe(
 			'conversation_friction:human_correction:message-assistant-1,message-human-1'
 		);
+	});
+
+	it('deduplicates duplicate patterns with the same fingerprint in one capture', async () => {
+		const { scope, task } = createScopedTask();
+		insertTextMessage(task.id, 'message-human-1', 'user', 'human', {
+			type: 'user',
+			message: { role: 'user', content: [{ type: 'text', text: 'No, this is wrong.' }] },
+		});
+		insertTextMessage(task.id, 'message-assistant-1', 'assistant', null, {
+			type: 'assistant',
+			message: { role: 'assistant', content: [{ type: 'text', text: 'Sorry, I misunderstood.' }] },
+		});
+		const service = new EvolutionConversationAnalysisService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+			analyzeConversation: async () => ({
+				patterns: [
+					{
+						kind: 'human_correction',
+						confidence: 0.9,
+						summary: 'Human corrected a misunderstanding.',
+						involvedMessages: ['message-human-1', 'message-assistant-1'],
+						severity: 'high',
+					},
+					{
+						kind: 'human_correction',
+						confidence: 0.8,
+						summary: 'Duplicate pattern for same messages.',
+						involvedMessages: ['message-assistant-1', 'message-human-1'],
+						severity: 'medium',
+					},
+				],
+				humanInterventionCount: 1,
+				syntheticInterventionCount: 0,
+				agentUncertaintyCount: 1,
+				overallAssessment: 'Correction needed.',
+			}),
+		});
+
+		const evidence = await service.captureForTask({ scopeId: scope.id, taskId: task.id });
+
+		expect(evidence).toHaveLength(1);
+		expect(
+			evolutionRepo.listEvidence(scope.id).filter((item) => item.kind === 'conversation_friction')
+		).toHaveLength(1);
+		expect(evidence[0]?.summary).toContain('Human corrected a misunderstanding.');
 	});
 
 	it('rejects patterns whose message IDs do not resolve in trace', async () => {

--- a/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-conversation-analysis-service.test.ts
@@ -139,13 +139,24 @@ describe('EvolutionConversationAnalysisService', () => {
 		expect((first[0]?.metadata.pattern as { kind?: string }).kind).toBe('human_correction');
 	});
 
-	it('excludes unsent messages from conversation friction input', async () => {
+	it('includes legacy null send_status rows and excludes unsent or subagent messages', async () => {
 		const { scope, task } = createScopedTask();
 		let analyzedMessages: TraceMessage[] = [];
 		insertTextMessage(task.id, 'consumed-human-1', 'user', 'human', {
 			type: 'user',
 			message: { role: 'user', content: [{ type: 'text', text: 'Please fix this.' }] },
 		});
+		insertTextMessage(
+			task.id,
+			'legacy-human-1',
+			'user',
+			'human',
+			{
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'Legacy message.' }] },
+			},
+			null
+		);
 		insertTextMessage(
 			task.id,
 			'deferred-human-1',
@@ -156,6 +167,18 @@ describe('EvolutionConversationAnalysisService', () => {
 				message: { role: 'user', content: [{ type: 'text', text: 'Not sent yet.' }] },
 			},
 			'deferred'
+		);
+		insertTextMessage(
+			task.id,
+			'subagent-assistant-1',
+			'assistant',
+			null,
+			{
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'Internal apology.' }] },
+			},
+			'consumed',
+			'tool-parent-1'
 		);
 		const service = new EvolutionConversationAnalysisService({
 			db: db as never,
@@ -171,6 +194,7 @@ describe('EvolutionConversationAnalysisService', () => {
 
 		expect(analyzedMessages.map((message) => message.metadata.messageId)).toEqual([
 			'consumed-human-1',
+			'legacy-human-1',
 		]);
 	});
 
@@ -451,13 +475,14 @@ describe('EvolutionConversationAnalysisService', () => {
 		messageType: string,
 		origin: string | null,
 		message: Record<string, unknown>,
-		sendStatus = 'consumed'
+		sendStatus: string | null = 'consumed',
+		parentToolUseId: string | null = null
 	): void {
 		db.prepare(
 			`INSERT INTO sdk_messages (
 				id, session_id, message_type, sdk_message, timestamp, origin,
-				is_renderable, is_terminal, task_id, send_status
-			) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?, ?)`
+				is_renderable, is_terminal, task_id, send_status, parent_tool_use_id
+			) VALUES (?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?)`
 		).run(
 			id,
 			'session-1',
@@ -466,7 +491,8 @@ describe('EvolutionConversationAnalysisService', () => {
 			new Date(1_700_000_000_000).toISOString(),
 			origin,
 			taskId,
-			sendStatus
+			sendStatus,
+			parentToolUseId
 		);
 	}
 });

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -563,6 +563,12 @@ describe('EvolutionEpisodeService', () => {
 			sourceId: task.id,
 			summary: 'Retry loop evidence',
 		});
+		const conversationEvidence = evolutionRepo.createEvidence({
+			scopeId: scope.id,
+			kind: 'conversation_friction',
+			sourceId: task.id,
+			summary: 'Conversation friction evidence',
+		});
 		const service = new EvolutionEpisodeService({
 			evolutionRepo,
 			taskRepo,
@@ -572,10 +578,10 @@ describe('EvolutionEpisodeService', () => {
 
 		const input = service.buildEpisodeInput({
 			scopeId: scope.id,
-			evidenceIds: [taskEvidence.id, retryEvidence.id],
+			evidenceIds: [taskEvidence.id, retryEvidence.id, conversationEvidence.id],
 		});
 
-		expect(input.evidence).toHaveLength(2);
+		expect(input.evidence).toHaveLength(3);
 		expect(input.tasks).toHaveLength(1);
 		expect(input.tasks[0]?.task.id).toBe(task.id);
 	});

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { EvolutionScopeService } from '../../../src/lib/space/evolution-scope-service';
+import { EvolutionTraceEvidenceService } from '../../../src/lib/space/evolution-trace-evidence-service';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
 import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
@@ -42,6 +43,11 @@ describe('Forge evidence capture on task completion', () => {
 			slug: 'forge-evidence-capture',
 			name: 'Forge Evidence Capture',
 		}).id;
+		const traceEvidenceService = new EvolutionTraceEvidenceService({
+			db: db as never,
+			evolutionRepo,
+			taskRepo,
+		});
 		evolutionScopeService = new EvolutionScopeService({
 			evolutionRepo,
 			spaceRepo,
@@ -49,6 +55,7 @@ describe('Forge evidence capture on task completion', () => {
 			taskRepo,
 			workflowRunRepo,
 			artifactRepo,
+			traceEvidenceService,
 		});
 	});
 
@@ -85,7 +92,12 @@ describe('Forge evidence capture on task completion', () => {
 		await manager.setTaskStatus(task.id, 'done', { result: 'PR ready and tests pass' });
 
 		const evidence = evolutionRepo.listEvidence(scope.id);
-		expect(evidence.map((item) => item.kind).sort()).toEqual(['artifact', 'task_result']);
+		expect(evidence.map((item) => item.kind).sort()).toEqual([
+			'artifact',
+			'session',
+			'task_result',
+		]);
+		expect(evidence.find((item) => item.kind === 'session')?.metadata.traceDiagnostic).toBe(true);
 		expect(evidence.find((item) => item.kind === 'task_result')?.summary).toContain(
 			'PR ready and tests pass'
 		);
@@ -172,6 +184,7 @@ describe('Forge evidence capture on task completion', () => {
 		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
 
 		expect(result.evidence).toHaveLength(2);
+		expect(result.traceDiagnostic?.status).toBe('no_trace_rows');
 		const taskEvidence = result.evidence.find((item) => item.kind === 'task_result');
 		expect(taskEvidence?.summary).toContain('completed without task.result');
 		const artifactEvidence = result.evidence.find((item) => item.kind === 'artifact');
@@ -200,8 +213,8 @@ describe('Forge evidence capture on task completion', () => {
 		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
 
 		const evidence = evolutionRepo.listEvidence(scope.id);
-		expect(evidence).toHaveLength(1);
-		expect(evidence[0]?.kind).toBe('task_result');
+		expect(evidence).toHaveLength(2);
+		expect(evidence.map((item) => item.kind).sort()).toEqual(['session', 'task_result']);
 	});
 
 	it('keeps manual workflow_run evidence and adds artifact evidence for the same run', () => {
@@ -240,6 +253,7 @@ describe('Forge evidence capture on task completion', () => {
 		const evidence = evolutionRepo.listEvidence(scope.id);
 		expect(evidence.map((item) => item.kind).sort()).toEqual([
 			'artifact',
+			'session',
 			'task_result',
 			'workflow_run',
 		]);
@@ -278,6 +292,9 @@ describe('Forge evidence capture on task completion', () => {
 		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
 
 		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence.find((item) => item.kind === 'session')?.summary).toContain(
+			'No trace evidence generated'
+		);
 		const runEvidence = evidence.filter((item) => item.kind === 'workflow_run');
 		expect(runEvidence).toHaveLength(2);
 		expect(evolutionRepo.getEvidence(manual.id)?.summary).toBe('Manual reviewer context');
@@ -416,10 +433,11 @@ describe('Forge evidence capture on task completion', () => {
 		const second = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
 
 		const evidence = evolutionRepo.listEvidence(scope.id);
-		expect(evidence).toHaveLength(1);
+		expect(evidence).toHaveLength(2);
 		expect(second.evidence[0]?.id).toBe(first.evidence[0]?.id);
-		expect(evidence[0]?.summary).toContain('Second result');
-		expect(evidence[0]?.metadata.result).toBe('Second result');
+		const taskEvidence = evidence.find((item) => item.kind === 'task_result');
+		expect(taskEvidence?.summary).toContain('Second result');
+		expect(taskEvidence?.metadata.result).toBe('Second result');
 	});
 
 	it('creates error evidence for failed workflow runs', () => {
@@ -453,6 +471,79 @@ describe('Forge evidence capture on task completion', () => {
 		const errorEvidence = result.evidence.find((item) => item.kind === 'error');
 		expect(errorEvidence?.summary).toContain('agentCrash');
 		expect(errorEvidence?.metadata.failureReason).toBe('agentCrash');
+	});
+
+	it('captures trace-derived evidence for completed scoped task failures', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Trace task scope',
+			objective: 'Capture process friction',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Finish with failed test first',
+			description: 'Synthetic failed test trace',
+			evolutionScopeId: scope.id,
+		});
+		insertToolExchange(
+			task.id,
+			'session-trace',
+			'tool-test-1',
+			'Bash',
+			{ command: 'bun test' },
+			true,
+			{
+				text: 'Error: expected true to be false',
+			}
+		);
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Fixed after failed test' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.traceDiagnostic?.status).toBe('generated');
+		expect(result.traceDiagnostic?.failedToolCallCount).toBe(1);
+		expect(result.evidence.some((item) => item.kind === 'test_failure')).toBe(true);
+		expect(evolutionRepo.listEvidence(scope.id).some((item) => item.kind === 'test_failure')).toBe(
+			true
+		);
+	});
+
+	it('records a trace diagnostic when completed task trace has no friction', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Clean trace scope',
+			objective: 'Explain missing trace evidence',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Clean trace task',
+			description: 'No friction trace',
+			evolutionScopeId: scope.id,
+		});
+		insertToolExchange(
+			task.id,
+			'session-clean',
+			'tool-test-pass',
+			'Bash',
+			{ command: 'bun test' },
+			false,
+			{
+				text: '1 pass',
+			}
+		);
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Clean pass' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.traceDiagnostic?.status).toBe('no_friction');
+		const diagnostic = evolutionRepo
+			.listEvidence(scope.id)
+			.find((item) => item.kind === 'session' && item.metadata.traceDiagnostic === true);
+		expect(diagnostic?.summary).toContain('No trace evidence generated');
+		expect(diagnostic?.metadata.toolCallCount).toBe(1);
+		expect(diagnostic?.metadata.failedToolCallCount).toBe(0);
 	});
 
 	it('does not create Forge evidence for non-done tasks', () => {
@@ -515,6 +606,67 @@ describe('Forge evidence capture on task completion', () => {
 		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
 
 		expect(result.scope?.id).toBe(scope.id);
-		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(1);
+		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(2);
 	});
+
+	function insertToolExchange(
+		taskId: string,
+		sessionId: string,
+		toolUseId: string,
+		toolName: string,
+		input: Record<string, unknown>,
+		failed: boolean,
+		options: { text: string }
+	) {
+		insertMessage(taskId, sessionId, 'assistant', {
+			type: 'assistant',
+			uuid: `${toolUseId}-assistant`,
+			session_id: sessionId,
+			message: {
+				role: 'assistant',
+				content: [{ type: 'tool_use', id: toolUseId, name: toolName, input }],
+			},
+		});
+		insertMessage(taskId, sessionId, 'user', {
+			type: 'user',
+			uuid: `${toolUseId}-result`,
+			session_id: sessionId,
+			message: {
+				role: 'user',
+				content: [
+					{
+						type: 'tool_result',
+						tool_use_id: toolUseId,
+						is_error: failed,
+						content: options.text,
+					},
+				],
+			},
+		});
+	}
+
+	function insertMessage(
+		taskId: string,
+		sessionId: string,
+		messageType: string,
+		message: Record<string, unknown>
+	) {
+		const count = db.prepare('SELECT COUNT(*) AS count FROM sdk_messages').get() as {
+			count: number;
+		};
+		const sequence = count.count + 1;
+		db.prepare(
+			`INSERT INTO sdk_messages (
+				id, session_id, message_type, sdk_message, timestamp, send_status,
+				is_renderable, is_terminal, task_id
+			) VALUES (?, ?, ?, ?, ?, 'consumed', 1, 0, ?)`
+		).run(
+			`message-${sequence}`,
+			sessionId,
+			messageType,
+			JSON.stringify(message),
+			new Date(1_700_000_000_000 + sequence * 1000).toISOString(),
+			taskId
+		);
+	}
 });

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -4,6 +4,7 @@ import { EvolutionScopeService } from '../../../src/lib/space/evolution-scope-se
 import { EvolutionTraceEvidenceService } from '../../../src/lib/space/evolution-trace-evidence-service';
 import { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager';
 import { EvolutionRepository } from '../../../src/storage/repositories/evolution-repository';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
 import { GateOpenStateRepository } from '../../../src/storage/repositories/gate-open-state-repository';
 import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
@@ -22,12 +23,31 @@ describe('Forge evidence capture on task completion', () => {
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let artifactRepo: WorkflowRunArtifactRepository;
 	let evolutionRepo: EvolutionRepository;
+	let jobQueue: JobQueueRepository;
 	let evolutionScopeService: EvolutionScopeService;
 	let spaceId: string;
 
 	beforeEach(() => {
 		db = new Database(':memory:');
 		createSpaceTables(db);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS job_queue (
+				id TEXT PRIMARY KEY,
+				queue TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+				payload TEXT NOT NULL DEFAULT '{}',
+				result TEXT,
+				error TEXT,
+				priority INTEGER NOT NULL DEFAULT 0,
+				max_retries INTEGER NOT NULL DEFAULT 3,
+				retry_count INTEGER NOT NULL DEFAULT 0,
+				run_at INTEGER NOT NULL,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER
+			)
+		`);
 		spaceRepo = new SpaceRepository(db as never);
 		goalRepo = new SpaceGoalRepository(db as never);
 		taskRepo = new SpaceTaskRepository(db as never);
@@ -38,6 +58,7 @@ describe('Forge evidence capture on task completion', () => {
 		);
 		artifactRepo = new WorkflowRunArtifactRepository(db as never);
 		evolutionRepo = new EvolutionRepository(db as never);
+		jobQueue = new JobQueueRepository(db as never);
 		spaceId = spaceRepo.createSpace({
 			workspacePath: '/workspace/forge-evidence-capture',
 			slug: 'forge-evidence-capture',
@@ -51,6 +72,7 @@ describe('Forge evidence capture on task completion', () => {
 		evolutionScopeService = new EvolutionScopeService({
 			...createScopeServiceDeps(),
 			traceEvidenceService,
+			jobQueue,
 		});
 	});
 
@@ -92,6 +114,16 @@ describe('Forge evidence capture on task completion', () => {
 			'session',
 			'task_result',
 		]);
+		expect(
+			(
+				db
+					.prepare(
+						`SELECT COUNT(*) AS count FROM job_queue
+					 WHERE queue = 'space.conversationFriction.analyze' AND json_extract(payload, '$.taskId') = ?`
+					)
+					.get(task.id) as { count: number }
+			).count
+		).toBe(1);
 		expect(evidence.find((item) => item.kind === 'session')?.metadata.traceDiagnostic).toBe(true);
 		expect(evidence.find((item) => item.kind === 'task_result')?.summary).toContain(
 			'PR ready and tests pass'

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -509,6 +509,64 @@ describe('Forge evidence capture on task completion', () => {
 		);
 	});
 
+	it('clears stale trace diagnostics when later completion generates trace evidence', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Retried trace scope',
+			objective: 'Avoid stale trace diagnostics',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Retried trace task',
+			description: 'First clean, then failed trace',
+			evolutionScopeId: scope.id,
+		});
+		insertToolExchange(
+			task.id,
+			'session-retry',
+			'tool-test-pass-first',
+			'Bash',
+			{ command: 'bun test' },
+			false,
+			{
+				text: '1 pass',
+			}
+		);
+		taskRepo.updateTask(task.id, { status: 'done', result: 'First clean pass' });
+		evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+		expect(
+			evolutionRepo
+				.listEvidence(scope.id)
+				.some((item) => item.kind === 'session' && item.metadata.status === 'no_friction')
+		).toBe(true);
+		insertToolExchange(
+			task.id,
+			'session-retry',
+			'tool-test-fail-later',
+			'Bash',
+			{ command: 'bun test' },
+			true,
+			{
+				text: 'Error: later retry failed',
+			}
+		);
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.traceDiagnostic?.status).toBe('generated');
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence.some((item) => item.kind === 'test_failure')).toBe(true);
+		expect(
+			evidence.some(
+				(item) =>
+					item.kind === 'session' &&
+					item.metadata.traceDiagnostic === true &&
+					item.metadata.status !== 'generated'
+			)
+		).toBe(false);
+	});
+
 	it('records a trace diagnostic when completed task trace has no friction', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -567,6 +567,45 @@ describe('Forge evidence capture on task completion', () => {
 		).toBe(false);
 	});
 
+	it('captures slow successful tool calls as trace-derived evidence', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Slow tool scope',
+			objective: 'Capture slow successful operations',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Slow successful tool call',
+			description: 'Slow Bash call should count as friction',
+			evolutionScopeId: scope.id,
+		});
+		insertToolExchangeAt(
+			task.id,
+			'session-slow',
+			'tool-slow-1',
+			'Bash',
+			{ command: 'bun run check' },
+			false,
+			{ text: 'Checks passed' },
+			1_700_000_000_000,
+			1_700_000_045_000
+		);
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Slow check passed' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.traceDiagnostic?.status).toBe('generated');
+		expect(result.traceDiagnostic?.slowToolCallCount).toBe(1);
+		const slowEvidence = evolutionRepo
+			.listEvidence(scope.id)
+			.find((item) => item.kind === 'slow_tool_call');
+		expect(slowEvidence?.metadata.slowToolCallCount).toBe(1);
+		expect(
+			(slowEvidence?.metadata.slowToolCalls as Array<{ durationMs: number }>)[0]?.durationMs
+		).toBe(45_000);
+	});
+
 	it('records a trace diagnostic when completed task trace has no friction', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,
@@ -676,38 +715,75 @@ describe('Forge evidence capture on task completion', () => {
 		failed: boolean,
 		options: { text: string }
 	) {
-		insertMessage(taskId, sessionId, 'assistant', {
-			type: 'assistant',
-			uuid: `${toolUseId}-assistant`,
-			session_id: sessionId,
-			message: {
-				role: 'assistant',
-				content: [{ type: 'tool_use', id: toolUseId, name: toolName, input }],
-			},
-		});
-		insertMessage(taskId, sessionId, 'user', {
-			type: 'user',
-			uuid: `${toolUseId}-result`,
-			session_id: sessionId,
-			message: {
-				role: 'user',
-				content: [
-					{
-						type: 'tool_result',
-						tool_use_id: toolUseId,
-						is_error: failed,
-						content: options.text,
-					},
-				],
-			},
-		});
+		insertToolExchangeAt(
+			taskId,
+			sessionId,
+			toolUseId,
+			toolName,
+			input,
+			failed,
+			options,
+			nextMessageTime(),
+			nextMessageTime()
+		);
 	}
 
-	function insertMessage(
+	function insertToolExchangeAt(
+		taskId: string,
+		sessionId: string,
+		toolUseId: string,
+		toolName: string,
+		input: Record<string, unknown>,
+		failed: boolean,
+		options: { text: string },
+		toolUseTimestamp: number,
+		toolResultTimestamp: number
+	) {
+		insertMessageAt(
+			taskId,
+			sessionId,
+			'assistant',
+			{
+				type: 'assistant',
+				uuid: `${toolUseId}-assistant`,
+				session_id: sessionId,
+				message: {
+					role: 'assistant',
+					content: [{ type: 'tool_use', id: toolUseId, name: toolName, input }],
+				},
+			},
+			toolUseTimestamp
+		);
+		insertMessageAt(
+			taskId,
+			sessionId,
+			'user',
+			{
+				type: 'user',
+				uuid: `${toolUseId}-result`,
+				session_id: sessionId,
+				message: {
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: toolUseId,
+							is_error: failed,
+							content: options.text,
+						},
+					],
+				},
+			},
+			toolResultTimestamp
+		);
+	}
+
+	function insertMessageAt(
 		taskId: string,
 		sessionId: string,
 		messageType: string,
-		message: Record<string, unknown>
+		message: Record<string, unknown>,
+		timestamp: number
 	) {
 		const count = db.prepare('SELECT COUNT(*) AS count FROM sdk_messages').get() as {
 			count: number;
@@ -723,8 +799,15 @@ describe('Forge evidence capture on task completion', () => {
 			sessionId,
 			messageType,
 			JSON.stringify(message),
-			new Date(1_700_000_000_000 + sequence * 1000).toISOString(),
+			new Date(timestamp).toISOString(),
 			taskId
 		);
+	}
+
+	function nextMessageTime(): number {
+		const count = db.prepare('SELECT COUNT(*) AS count FROM sdk_messages').get() as {
+			count: number;
+		};
+		return 1_700_000_000_000 + (count.count + 1) * 1000;
 	}
 });

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -703,6 +703,45 @@ describe('Forge evidence capture on task completion', () => {
 		expect(diagnostics[0]?.metadata.error).toBeUndefined();
 	});
 
+	it('does not enqueue duplicate conversation friction analysis beyond the newest 100 jobs', async () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Large queue scope',
+			objective: 'Avoid duplicate analyzer jobs',
+		});
+		const duplicateTask = taskRepo.createTask({
+			spaceId,
+			title: 'Already queued task',
+			description: 'Existing old job should be found',
+			evolutionScopeId: scope.id,
+		});
+		for (let index = 0; index < 101; index += 1) {
+			jobQueue.enqueue({
+				queue: 'space.conversationFriction.analyze',
+				payload: {
+					scopeId: scope.id,
+					taskId: index === 0 ? duplicateTask.id : `other-task-${index}`,
+				},
+			});
+		}
+		await taskRepo.updateTask(duplicateTask.id, { status: 'in_progress', result: 'Done' });
+		const manager = new SpaceTaskManager(db as never, spaceId, undefined, evolutionScopeService);
+
+		await manager.setTaskStatus(duplicateTask.id, 'done');
+
+		expect(
+			(
+				db
+					.prepare(
+						`SELECT COUNT(*) AS count FROM job_queue
+						 WHERE queue = 'space.conversationFriction.analyze' AND json_extract(payload, '$.taskId') = ?`
+					)
+					.get(duplicateTask.id) as { count: number }
+			).count
+		).toBe(1);
+	});
+
 	it('captures slow successful tool calls as trace-derived evidence', () => {
 		const scope = evolutionRepo.createScope({
 			spaceId,
@@ -740,6 +779,42 @@ describe('Forge evidence capture on task completion', () => {
 		expect(
 			(slowEvidence?.metadata.slowToolCalls as Array<{ durationMs: number }>)[0]?.durationMs
 		).toBe(45_000);
+	});
+
+	it('captures tool failure evidence for slow failed generic commands', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Slow failed tool scope',
+			objective: 'Preserve failure signal for slow failed operations',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Slow failed generic command',
+			description: 'Slow failed Bash call should emit both slow and failure evidence',
+			evolutionScopeId: scope.id,
+		});
+		insertToolExchangeAt(
+			task.id,
+			'session-slow-failed',
+			'tool-slow-failed-1',
+			'Bash',
+			{ command: 'curl https://example.invalid' },
+			true,
+			{ text: 'Error: connection timed out' },
+			1_700_000_000_000,
+			1_700_000_045_000
+		);
+		taskRepo.updateTask(task.id, { status: 'done', result: 'Recovered after slow failure' });
+
+		const result = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(result.traceDiagnostic?.status).toBe('generated');
+		expect(result.traceDiagnostic?.failedToolCallCount).toBe(1);
+		expect(result.traceDiagnostic?.slowToolCallCount).toBe(1);
+		const evidenceKinds = evolutionRepo.listEvidence(scope.id).map((item) => item.kind);
+		expect(evidenceKinds).toContain('slow_tool_call');
+		expect(evidenceKinds).toContain('tool_failure');
 	});
 
 	it('records a trace diagnostic when completed task trace has no friction', () => {

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -49,12 +49,7 @@ describe('Forge evidence capture on task completion', () => {
 			taskRepo,
 		});
 		evolutionScopeService = new EvolutionScopeService({
-			evolutionRepo,
-			spaceRepo,
-			goalRepo,
-			taskRepo,
-			workflowRunRepo,
-			artifactRepo,
+			...createScopeServiceDeps(),
 			traceEvidenceService,
 		});
 	});
@@ -557,14 +552,63 @@ describe('Forge evidence capture on task completion', () => {
 		expect(result.traceDiagnostic?.status).toBe('generated');
 		const evidence = evolutionRepo.listEvidence(scope.id);
 		expect(evidence.some((item) => item.kind === 'test_failure')).toBe(true);
+		const diagnostic = evidence.find(
+			(item) => item.kind === 'session' && item.metadata.traceDiagnostic === true
+		);
+		expect(diagnostic?.metadata.status).toBe('generated');
+		expect(diagnostic?.metadata.failedToolCallCount).toBe(1);
+		expect(diagnostic?.metadata.evidenceCount).toBeGreaterThan(0);
+		expect(diagnostic?.metadata.error).toBeUndefined();
+	});
+
+	it('clears attach-time trace diagnostics when later attachment generates trace evidence', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Attachment retry scope',
+			objective: 'Avoid stale attach diagnostics',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Attach task evidence twice',
+			description: 'First throws, then captures trace evidence',
+			evolutionScopeId: scope.id,
+		});
+		const throwingService = new EvolutionScopeService({
+			...createScopeServiceDeps(),
+			traceEvidenceService: {
+				captureForTaskWithDiagnostic: () => {
+					throw new Error('temporary trace failure');
+				},
+			} as never,
+		});
+		throwingService.attachTaskEvidence({ taskId: task.id });
 		expect(
-			evidence.some(
-				(item) =>
-					item.kind === 'session' &&
-					item.metadata.traceDiagnostic === true &&
-					item.metadata.status !== 'generated'
-			)
-		).toBe(false);
+			evolutionRepo
+				.listEvidence(scope.id)
+				.find((item) => item.kind === 'session' && item.metadata.traceDiagnostic === true)?.metadata
+				.error
+		).toBe('temporary trace failure');
+		insertToolExchange(
+			task.id,
+			'session-attach-retry',
+			'tool-attach-fail',
+			'Bash',
+			{ command: 'bun test' },
+			true,
+			{ text: 'Error: attach retry failed test' }
+		);
+
+		evolutionScopeService.attachTaskEvidence({ taskId: task.id });
+
+		const evidence = evolutionRepo.listEvidence(scope.id);
+		expect(evidence.some((item) => item.kind === 'test_failure')).toBe(true);
+		const diagnostic = evidence.find(
+			(item) => item.kind === 'session' && item.metadata.traceDiagnostic === true
+		);
+		expect(diagnostic?.metadata.status).toBe('generated');
+		expect(diagnostic?.metadata.error).toBeUndefined();
+		expect(diagnostic?.metadata.evidenceCount).toBeGreaterThan(0);
 	});
 
 	it('captures slow successful tool calls as trace-derived evidence', () => {
@@ -705,6 +749,17 @@ describe('Forge evidence capture on task completion', () => {
 		expect(result.scope?.id).toBe(scope.id);
 		expect(evolutionRepo.listEvidence(scope.id)).toHaveLength(2);
 	});
+
+	function createScopeServiceDeps() {
+		return {
+			evolutionRepo,
+			spaceRepo,
+			goalRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		};
+	}
 
 	function insertToolExchange(
 		taskId: string,

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -555,10 +555,20 @@ describe('Forge evidence capture on task completion', () => {
 		const diagnostic = evidence.find(
 			(item) => item.kind === 'session' && item.metadata.traceDiagnostic === true
 		);
+		expect(diagnostic?.metadata.autoCaptured).toBe(true);
 		expect(diagnostic?.metadata.status).toBe('generated');
 		expect(diagnostic?.metadata.failedToolCallCount).toBe(1);
 		expect(diagnostic?.metadata.evidenceCount).toBeGreaterThan(0);
 		expect(diagnostic?.metadata.error).toBeUndefined();
+
+		const cleanResult = evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+		expect(cleanResult.traceDiagnostic?.status).toBe('generated');
+		expect(
+			evolutionRepo
+				.listEvidence(scope.id)
+				.filter((item) => item.kind === 'session' && item.metadata.traceDiagnostic === true)
+		).toHaveLength(1);
 	});
 
 	it('clears attach-time trace diagnostics when later attachment generates trace evidence', () => {
@@ -606,9 +616,59 @@ describe('Forge evidence capture on task completion', () => {
 		const diagnostic = evidence.find(
 			(item) => item.kind === 'session' && item.metadata.traceDiagnostic === true
 		);
+		expect(diagnostic?.metadata.autoCaptured).toBe(true);
 		expect(diagnostic?.metadata.status).toBe('generated');
 		expect(diagnostic?.metadata.error).toBeUndefined();
 		expect(diagnostic?.metadata.evidenceCount).toBeGreaterThan(0);
+	});
+
+	it('clears attach-time trace errors when later attachment has no trace friction', () => {
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Clean attachment retry scope',
+			objective: 'Clear stale attach errors without generated evidence',
+		});
+		const task = taskRepo.createTask({
+			spaceId,
+			title: 'Attach clean task evidence twice',
+			description: 'First throws, then has clean trace',
+			evolutionScopeId: scope.id,
+		});
+		const throwingService = new EvolutionScopeService({
+			...createScopeServiceDeps(),
+			traceEvidenceService: {
+				captureForTaskWithDiagnostic: () => {
+					throw new Error('temporary trace failure');
+				},
+			} as never,
+		});
+		throwingService.attachTaskEvidence({ taskId: task.id });
+		expect(
+			evolutionRepo
+				.listEvidence(scope.id)
+				.find((item) => item.kind === 'session' && item.metadata.traceDiagnostic === true)?.metadata
+				.error
+		).toBe('temporary trace failure');
+		insertToolExchange(
+			task.id,
+			'session-attach-clean-retry',
+			'tool-attach-clean',
+			'Bash',
+			{ command: 'bun test' },
+			false,
+			{ text: '1 pass' }
+		);
+
+		evolutionScopeService.attachTaskEvidence({ taskId: task.id });
+
+		const diagnostics = evolutionRepo
+			.listEvidence(scope.id)
+			.filter((item) => item.kind === 'session' && item.metadata.traceDiagnostic === true);
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]?.metadata.autoCaptured).toBe(true);
+		expect(diagnostics[0]?.metadata.status).toBe('no_friction');
+		expect(diagnostics[0]?.metadata.error).toBeUndefined();
 	});
 
 	it('captures slow successful tool calls as trace-derived evidence', () => {

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -15,7 +15,8 @@ export type EvidenceKind =
 	| 'tool_failure'
 	| 'test_failure'
 	| 'permission_block'
-	| 'slow_tool_call';
+	| 'slow_tool_call'
+	| 'conversation_friction';
 export type EvolutionEpisodeStatus = 'draft' | 'accepted' | 'dismissed';
 export type EvolutionLessonStatus = 'candidate' | 'active' | 'dismissed';
 export type TaskProposalStatus = 'proposed' | 'accepted' | 'dismissed' | 'created';

--- a/packages/shared/src/types/evolution.ts
+++ b/packages/shared/src/types/evolution.ts
@@ -14,7 +14,8 @@ export type EvidenceKind =
 	| 'retry_loop'
 	| 'tool_failure'
 	| 'test_failure'
-	| 'permission_block';
+	| 'permission_block'
+	| 'slow_tool_call';
 export type EvolutionEpisodeStatus = 'draft' | 'accepted' | 'dismissed';
 export type EvolutionLessonStatus = 'candidate' | 'active' | 'dismissed';
 export type TaskProposalStatus = 'proposed' | 'accepted' | 'dismissed' | 'created';


### PR DESCRIPTION
Adds Forge trace evidence capture for completed scoped tasks and expands trace-derived evidence coverage.

Also adds async conversation friction analysis for completed scoped tasks, emitting `conversation_friction` evidence from SDK message text/thinking via job queue.

Tests: focused daemon Forge/evolution tests and `bun run check`.