### PR TITLE
chore(release): bump version to 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.30.0] - 2026-05-22
+
+Forge evidence reliability, mobile Goal/Forge navigation, and workflow result propagation. 4 commits since v0.29.0.
+
+### Added
+
+- **Forge evidence preflight**: Score task results, workflow artifacts, metric snapshots, concrete outcomes, and manual-note-only risk before episode judging
+- **Forge trace evidence**: Capture trace-derived task evidence from persisted SDK message/tool spans with friction clustering
+
+### Changed
+
+- Goal and Forge views now use mobile-friendly navigation and list-or-detail panes on small screens
+- Workflow completion now propagates result artifact summaries into task results and reported summaries
+
+### Fixed
+
+- Preserve existing task results while filling missing workflow outcome fields
+- Improve Forge evidence capture coverage for completed scoped tasks
+
 ## [0.29.0] - 2026-05-21
 
 Forge self-evolution system, actor messaging UI, and memory consolidation. 20 commits since v0.28.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/desktop",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"private": true,
 	"description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
 	"scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.29.0"
+version = "0.30.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Kai",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"identifier": "io.neokai.kai",
 	"build": {
 		"frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.29.0",
+	"version": "0.30.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Bumps NeoKai packages to 0.30.0 and adds changelog notes for Forge evidence reliability, mobile Goal/Forge navigation, and workflow result propagation.

Validated with `bun run check`.