### PR TITLE
Cover long-term agent MCP lifecycle

### DIFF
--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -523,7 +523,11 @@ export class SessionManager {
 		await this.messagePersistence.persist(data);
 	}
 
-	listSessions(options?: { status?: string; includeArchived?: boolean }): Session[] {
+	listSessions(options?: {
+		status?: string;
+		includeArchived?: boolean;
+		includeSpaceSessions?: boolean;
+	}): Session[] {
 		return this.db.listSessions(options);
 	}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1188,7 +1188,10 @@ export class SpaceRuntimeService {
 		if (!sessionManager) return;
 
 		try {
-			const all = sessionManager.listSessions({ includeArchived: false });
+			const all = sessionManager.listSessions({
+				includeArchived: false,
+				includeSpaceSessions: true,
+			});
 			for (const session of all) {
 				const policy = this.resolveMcpSessionPolicy(session);
 				if (policy.owner !== 'space-runtime') continue;

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -160,7 +160,11 @@ export class Database {
 		return this.sessionRepo.getSession(id);
 	}
 
-	listSessions(options?: { status?: string; includeArchived?: boolean }): Session[] {
+	listSessions(options?: {
+		status?: string;
+		includeArchived?: boolean;
+		includeSpaceSessions?: boolean;
+	}): Session[] {
 		return this.sessionRepo.listSessions(options);
 	}
 

--- a/packages/daemon/src/storage/repositories/session-repository.ts
+++ b/packages/daemon/src/storage/repositories/session-repository.ts
@@ -77,12 +77,18 @@ export class SessionRepository {
 	 * @param options.status - Filter by status ('active', 'archived'). If omitted, excludes archived.
 	 * @param options.includeArchived - If true, returns all sessions regardless of status.
 	 */
-	listSessions(options?: { status?: string; includeArchived?: boolean }): Session[] {
+	listSessions(options?: {
+		status?: string;
+		includeArchived?: boolean;
+		includeSpaceSessions?: boolean;
+	}): Session[] {
 		let sql = `SELECT * FROM sessions
 				WHERE type NOT IN ('lobby', 'spaces_global', 'room_chat', 'planner', 'coder', 'leader', 'space_chat', 'space_task_agent')
-				AND json_extract(session_context, '$.roomId') IS NULL
-				AND json_extract(session_context, '$.spaceId') IS NULL`;
+				AND json_extract(session_context, '$.roomId') IS NULL`;
 		const params: string[] = [];
+		if (!options?.includeSpaceSessions) {
+			sql += ` AND json_extract(session_context, '$.spaceId') IS NULL`;
+		}
 
 		if (options?.status) {
 			sql += ` AND status = ?`;

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -27,10 +27,11 @@ import type { SessionManager } from '../../../../src/lib/session-manager.ts';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import type { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import type { McpServerConfig, Session, Space } from '@neokai/shared';
-import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { createTables, runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository as SpaceWorkflowRunRepo } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository as SpaceTaskRepo } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SessionRepository } from '../../../../src/storage/repositories/session-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager as AgentMgr } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager as WorkflowMgr } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -793,6 +794,26 @@ describe('SpaceRuntimeService', () => {
 			};
 		}
 
+		function insertSession(db: BunDatabase, session: Session): void {
+			db.prepare(
+				`INSERT INTO sessions (id, title, workspace_path, created_at, last_active_at, status, config, metadata,
+						is_worktree, worktree_path, main_repo_path, worktree_branch, git_branch, sdk_session_id,
+						sdk_origin_path, available_commands, processing_state, archived_at, type, session_context)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, null, null, null, null, null, null, null, null, null, ?, ?)`
+			).run(
+				session.id,
+				session.title,
+				session.workspacePath,
+				session.createdAt,
+				session.lastActiveAt,
+				session.status,
+				JSON.stringify(session.config),
+				JSON.stringify(session.metadata),
+				session.type ?? 'worker',
+				session.context ? JSON.stringify(session.context) : null
+			);
+		}
+
 		function makeMemberSession(overrides: Partial<Session> = {}): Session {
 			return {
 				id: 'worker-session-1',
@@ -975,6 +996,73 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
+		test('session repository includes persisted Space sessions only when requested', () => {
+			const db = new BunDatabase(':memory:');
+			createTables(db);
+			try {
+				const repo = new SessionRepository(db);
+				const memberSession = makeMemberSession({ id: 'member-1' });
+				const longTermSession = makeMemberSession({
+					id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+					metadata: {
+						promptProvenance: {
+							source: 'test',
+							hash: 'hash',
+							agentId: 'agent-1',
+							agentName: 'Long Term',
+						},
+					},
+				});
+				const nonSpaceSession = makeMemberSession({ id: 'plain-worker', context: undefined });
+				insertSession(db, memberSession);
+				insertSession(db, longTermSession);
+				insertSession(db, nonSpaceSession);
+
+				expect(repo.listSessions({ includeArchived: false }).map((session) => session.id)).toEqual([
+					'plain-worker',
+				]);
+				expect(
+					repo
+						.listSessions({ includeArchived: false, includeSpaceSessions: true })
+						.map((session) => session.id)
+						.sort()
+				).toEqual([longTermSession.id, memberSession.id, 'plain-worker'].sort());
+			} finally {
+				db.close();
+			}
+		});
+
+		test('start() requests persisted Space sessions during daemon-restart reattach sweep', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const longTermSession = makeMemberSession({
+				id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+						agentName: 'Long Term',
+					},
+				},
+			});
+			const svc = new SpaceRuntimeService(
+				buildMemberConfig({ sessionManager, listSessionsResult: [longTermSession] })
+			);
+
+			svc.start();
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			expect(sessionManager.listSessions).toHaveBeenCalledWith({
+				includeArchived: false,
+				includeSpaceSessions: true,
+			});
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			expect(agent.getSessionData().config.mcpServers).toHaveProperty('space-agent-tools');
+
+			await svc.stop();
+		});
+
 		test('start() derives long-term agent names from repository when metadata lacks agentName', async () => {
 			const agent = makeMemberAgentSession();
 			const sessionManager = makeSessionManager(agent);
@@ -1048,6 +1136,96 @@ describe('SpaceRuntimeService', () => {
 
 			// Self-heal should re-call attachSpaceToolsToMemberSession, which calls merge again
 			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(2);
+		});
+
+		test('long-term agent reattach preserves existing runtime MCP servers and avoids duplicate server names', async () => {
+			const preservedServer = { type: 'sdk', name: 'external-runtime' } as McpServerConfig;
+			const agent = makeMemberAgentSession({
+				id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+				config: {
+					tools: {},
+					mcpServers: {
+						'external-runtime': preservedServer,
+					},
+				},
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+						agentName: 'Long Term',
+					},
+				},
+			});
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await (
+				svc as unknown as {
+					attachLongTermAgentMcpServersForSession(session: Session): Promise<void>;
+				}
+			).attachLongTermAgentMcpServersForSession(agent.getSessionData());
+			await (
+				svc as unknown as {
+					attachLongTermAgentMcpServersForSession(session: Session): Promise<void>;
+				}
+			).attachLongTermAgentMcpServersForSession(agent.getSessionData());
+
+			expect(agent.mergeRuntimeMcpServers).toHaveBeenCalledTimes(2);
+			const serverNames = Object.keys(agent.getSessionData().config.mcpServers ?? {});
+			expect(serverNames.sort()).toEqual(['external-runtime', 'space-agent-tools']);
+			expect(agent.getSessionData().config.mcpServers?.['external-runtime']).toBe(preservedServer);
+		});
+
+		test('long-term agent deleted sessions release db-query runtime server handles', async () => {
+			const sessionId = longTermAgentSessionId(mockSpace.id, 'agent-1');
+			const agent = makeMemberAgentSession({
+				id: sessionId,
+				metadata: {
+					promptProvenance: {
+						source: 'test',
+						hash: 'hash',
+						agentId: 'agent-1',
+						agentName: 'Long Term',
+					},
+				},
+			});
+			const sessionManager = makeSessionManager(agent);
+			const dir = join(
+				process.cwd(),
+				'tmp',
+				'test-long-term-agent-tools',
+				`db-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			mkdirSync(dir, { recursive: true });
+			const dbPath = join(dir, 'test.db');
+			const tmpDb = new BunDatabase(dbPath);
+			tmpDb.close();
+
+			try {
+				const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager, dbPath }));
+				await (
+					svc as unknown as {
+						attachLongTermAgentMcpServersForSession(session: Session): Promise<void>;
+					}
+				).attachLongTermAgentMcpServersForSession(agent.getSessionData());
+				const dbQueryServers = (
+					svc as unknown as { longTermAgentDbQueryServers: Map<string, { close: () => void }> }
+				).longTermAgentDbQueryServers;
+				const server = dbQueryServers.get(sessionId);
+				expect(server).toBeDefined();
+				const closeMock = mock(() => {});
+				dbQueryServers.set(sessionId, { close: closeMock });
+
+				(
+					svc as unknown as { releaseLongTermAgentDbQuery(sessionId: string): void }
+				).releaseLongTermAgentDbQuery(sessionId);
+
+				expect(closeMock).toHaveBeenCalledTimes(1);
+				expect(dbQueryServers.has(sessionId)).toBe(false);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
 		});
 	});
 


### PR DESCRIPTION
Adds regression coverage for long-term Space agent MCP lifecycle behavior and fixes restart reattach discovery so persisted Space sessions can be included when requested.

Tests:
- bun test tests/unit/5-space/runtime/space-runtime-service.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/add-mcp-lifecycle-integration-tests-for-long-term-agent check