### PR TITLE
Rename Space Agent UI to Agents

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -1,19 +1,20 @@
 /**
  * Space Preset Agent Seeding
  *
- * Seeds the six default SpaceAgent records when a new Space is created.
+ * Seeds the seven default SpaceAgent records when a new Space is created.
  * Preset agents are regular SpaceAgent rows — fully editable by users — that
  * have sensible defaults for tools and model.
  * SpaceRuntime resolves all agents by ID at runtime; there is no special
  * builtin code path.
  *
  * Preset agents seeded per Space:
- *   - Coder    — implementation worker
- *   - General  — general-purpose worker
- *   - Planner  — planning/orchestration worker
- *   - Research — research specialist (investigates topics, writes findings, opens PRs)
- *   - Reviewer — code review specialist
- *   - QA       — quality assurance specialist
+ *   - Coordinator — built-in long-horizon Space agent
+ *   - Coder       — implementation worker
+ *   - General     — general-purpose worker
+ *   - Planner     — planning/orchestration worker
+ *   - Research    — research specialist (investigates topics, writes findings, opens PRs)
+ *   - Reviewer    — code review specialist
+ *   - QA          — quality assurance specialist
  */
 
 import type { SpaceAgent } from '@neokai/shared';
@@ -93,6 +94,7 @@ const QA_TOOLS: string[] = [
  * Tool profiles per preset agent name. Exported for testing and external consumption.
  */
 export const PRESET_AGENT_TOOLS: Record<string, string[]> = {
+	coordinator: GENERAL_TOOLS,
 	coder: CODER_TOOLS,
 	general: GENERAL_TOOLS,
 	planner: PLANNER_TOOLS,
@@ -268,6 +270,16 @@ summary: <1–2 sentence summary of key findings>
 Treat the code as work from a competent but unfamiliar developer — it likely handles the happy path but may miss edge cases and project-specific constraints. Be critical, honest, and actionable; always include file paths and line numbers. Don't nitpick what a linter already covers. Always include the identity block in every PR comment you post.`;
 
 const PRESET_AGENTS: PresetDefinition[] = [
+	{
+		name: 'Coordinator',
+		description:
+			'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
+		tools: GENERAL_TOOLS,
+		customPrompt:
+			'You are the Coordinator for this Space. Maintain long-horizon context across goals, Forge evidence, reminders, and external events. ' +
+			'Use available Space tools to inspect current work, create or update tasks, and route work to specialist agents when useful.\n\n' +
+			'Keep managed goals, Forge scopes, reminders, and event subscriptions visible to the operator. Ask for confirmation before destructive changes.',
+	},
 	{
 		name: 'Coder',
 		description:

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -283,16 +283,6 @@ const PRESET_AGENTS: PresetDefinition[] = [
 			'Before finishing: ensure all tests pass, commit all changes, and open a PR with a clear description.',
 	},
 	{
-		name: 'Coordinator',
-		description:
-			'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
-		tools: GENERAL_TOOLS,
-		customPrompt:
-			'You are the Coordinator for this Space. Maintain long-horizon context across goals, Forge evidence, reminders, and external events. ' +
-			'Use available Space tools to inspect current work, create or update tasks, and route work to specialist agents when useful.\n\n' +
-			'Keep managed goals, Forge scopes, reminders, and event subscriptions visible to the operator. Ask for confirmation before destructive changes.',
-	},
-	{
 		name: 'General',
 		description:
 			'General-purpose worker. Handles a wide range of tasks including coding, documentation, ' +
@@ -322,6 +312,16 @@ const PRESET_AGENTS: PresetDefinition[] = [
 			'You are a research specialist. You investigate topics thoroughly using web search and code ' +
 			'exploration, synthesize findings clearly, and document results in well-structured markdown files.\n\n' +
 			'Save all findings to a markdown file, commit the file, and open a PR with a summary of what you found.',
+	},
+	{
+		name: 'Coordinator',
+		description:
+			'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
+		tools: GENERAL_TOOLS,
+		customPrompt:
+			'You are the Coordinator for this Space. Maintain long-horizon context across goals, Forge evidence, reminders, and external events. ' +
+			'Use available Space tools to inspect current work, create or update tasks, and route work to specialist agents when useful.\n\n' +
+			'Keep managed goals, Forge scopes, reminders, and event subscriptions visible to the operator. Ask for confirmation before destructive changes.',
 	},
 	{
 		name: 'Reviewer',

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -8,8 +8,8 @@
  * builtin code path.
  *
  * Preset agents seeded per Space:
- *   - Coordinator — built-in long-horizon Space agent
  *   - Coder       — implementation worker
+ *   - Coordinator — built-in long-horizon Space agent
  *   - General     — general-purpose worker
  *   - Planner     — planning/orchestration worker
  *   - Research    — research specialist (investigates topics, writes findings, opens PRs)
@@ -271,16 +271,6 @@ Treat the code as work from a competent but unfamiliar developer — it likely h
 
 const PRESET_AGENTS: PresetDefinition[] = [
 	{
-		name: 'Coordinator',
-		description:
-			'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
-		tools: GENERAL_TOOLS,
-		customPrompt:
-			'You are the Coordinator for this Space. Maintain long-horizon context across goals, Forge evidence, reminders, and external events. ' +
-			'Use available Space tools to inspect current work, create or update tasks, and route work to specialist agents when useful.\n\n' +
-			'Keep managed goals, Forge scopes, reminders, and event subscriptions visible to the operator. Ask for confirmation before destructive changes.',
-	},
-	{
 		name: 'Coder',
 		description:
 			'Implementation worker. Writes code, runs tests, commits changes, and opens pull requests.',
@@ -291,6 +281,16 @@ const PRESET_AGENTS: PresetDefinition[] = [
 			'and open pull requests for review. Do NOT merge PRs. Your job is implementation only. ' +
 			'When the reviewer approves, your work is done. The reviewer handles the merge.\n\n' +
 			'Before finishing: ensure all tests pass, commit all changes, and open a PR with a clear description.',
+	},
+	{
+		name: 'Coordinator',
+		description:
+			'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
+		tools: GENERAL_TOOLS,
+		customPrompt:
+			'You are the Coordinator for this Space. Maintain long-horizon context across goals, Forge evidence, reminders, and external events. ' +
+			'Use available Space tools to inspect current work, create or update tasks, and route work to specialist agents when useful.\n\n' +
+			'Keep managed goals, Forge scopes, reminders, and event subscriptions visible to the operator. Ask for confirmation before destructive changes.',
 	},
 	{
 		name: 'General',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -155,9 +155,10 @@ describe('Space Agent RPC Handlers', () => {
 			});
 
 			expect(Array.isArray(result.templates)).toBe(true);
-			expect(result.templates).toHaveLength(6);
+			expect(result.templates).toHaveLength(7);
 			expect(result.templates.map((template) => template.name).sort()).toEqual([
 				'Coder',
+				'Coordinator',
 				'General',
 				'Planner',
 				'QA',

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -1,7 +1,7 @@
 /**
  * seedPresetAgents Unit Tests
  *
- * Verifies that the six preset SpaceAgent records are created with correct
+ * Verifies that the seven preset SpaceAgent records are created with correct
  * defaults (role, tools, description) and that seeding is idempotent (errors
  * on name collision are captured but do not abort remaining seeds).
  */
@@ -38,10 +38,10 @@ describe('seedPresetAgents', () => {
 		setModelsCache(new Map());
 	});
 
-	it('creates exactly six preset agents', async () => {
+	it('creates exactly seven preset agents', async () => {
 		const result = await seedPresetAgents('space-1', manager);
 
-		expect(result.seeded).toHaveLength(6);
+		expect(result.seeded).toHaveLength(7);
 		expect(result.errors).toHaveLength(0);
 	});
 
@@ -49,14 +49,30 @@ describe('seedPresetAgents', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 
 		const names = seeded.map((a) => a.name.toLowerCase()).sort();
-		expect(names).toEqual(['coder', 'general', 'planner', 'qa', 'research', 'reviewer']);
+		expect(names).toEqual([
+			'coder',
+			'coordinator',
+			'general',
+			'planner',
+			'qa',
+			'research',
+			'reviewer',
+		]);
 	});
 
 	it('creates agents with correct names', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 
 		const names = seeded.map((a) => a.name).sort();
-		expect(names).toEqual(['Coder', 'General', 'Planner', 'QA', 'Research', 'Reviewer']);
+		expect(names).toEqual([
+			'Coder',
+			'Coordinator',
+			'General',
+			'Planner',
+			'QA',
+			'Research',
+			'Reviewer',
+		]);
 	});
 
 	it('sets tools on each preset agent', async () => {
@@ -77,6 +93,20 @@ describe('seedPresetAgents', () => {
 		expect(reviewer?.tools).not.toContain('Edit');
 		expect(reviewer?.tools).toContain('Read');
 		expect(reviewer?.tools).toContain('Bash');
+	});
+
+	it('Coordinator is the default long-horizon Space agent', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coordinator = seeded.find((a) => a.name === 'Coordinator');
+
+		expect(coordinator).toBeDefined();
+		expect(coordinator?.description).toContain('Built-in long-horizon Space agent');
+		expect(coordinator?.customPrompt).toContain('long-horizon context');
+		expect(coordinator?.customPrompt).toContain('managed goals');
+		expect(coordinator?.customPrompt).toContain('Forge scopes');
+		expect(coordinator?.tools).toContain('Read');
+		expect(coordinator?.tools).toContain('Write');
+		expect(coordinator?.tools).toContain('Bash');
 	});
 
 	it('coder has full coding toolset and explicit no-merge prompt', async () => {
@@ -123,11 +153,11 @@ describe('seedPresetAgents', () => {
 		// Seed once
 		await seedPresetAgents('space-1', manager);
 
-		// Seed again — all six names are now taken
+		// Seed again — all seven names are now taken
 		const second = await seedPresetAgents('space-1', manager);
 
 		expect(second.seeded).toHaveLength(0);
-		expect(second.errors).toHaveLength(6);
+		expect(second.errors).toHaveLength(7);
 		for (const err of second.errors) {
 			expect(err.error).toMatch(/already exists/i);
 		}
@@ -139,8 +169,8 @@ describe('seedPresetAgents', () => {
 		const r1 = await seedPresetAgents('space-1', manager);
 		const r2 = await seedPresetAgents('space-2', manager);
 
-		expect(r1.seeded).toHaveLength(6);
-		expect(r2.seeded).toHaveLength(6);
+		expect(r1.seeded).toHaveLength(7);
+		expect(r2.seeded).toHaveLength(7);
 		expect(r1.errors).toHaveLength(0);
 		expect(r2.errors).toHaveLength(0);
 
@@ -156,7 +186,7 @@ describe('seedPresetAgents', () => {
 		const result = await seedPresetAgents('space-1', manager);
 
 		// Coder fails, others succeed
-		expect(result.seeded).toHaveLength(5);
+		expect(result.seeded).toHaveLength(6);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].name).toBe('Coder');
 	});
@@ -400,6 +430,12 @@ describe('preset agent exact definitions', () => {
 	// can dispatch the built-in `general-purpose` sub-agent for exploration.
 	const EXPECTED_REVIEWER_TOOLS = [...EXPECTED_READONLY_TOOLS, 'Task', 'TaskOutput', 'TaskStop'];
 
+	it('Coordinator has exact GENERAL_TOOLS (same as CODER_TOOLS)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const coordinator = seeded.find((a) => a.name === 'Coordinator')!;
+		expect(coordinator.tools).toEqual(EXPECTED_CODER_TOOLS);
+	});
+
 	it('Coder has exact CODER_TOOLS (KNOWN_TOOLS minus Task/TaskOutput/TaskStop)', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const coder = seeded.find((a) => a.name === 'Coder')!;
@@ -529,6 +565,8 @@ describe('preset agent exact definitions', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 
 		const expected: Record<string, string> = {
+			Coordinator:
+				'Built-in long-horizon Space agent. Tracks goals, Forge scope, reminders, and event subscriptions for the Space.',
 			Coder:
 				'Implementation worker. Writes code, runs tests, commits changes, and opens pull requests.',
 			General:
@@ -572,15 +610,20 @@ describe('PRESET_AGENT_TOOLS export', () => {
 	// `general-purpose` sub-agent delegation.
 	const EXPECTED_REVIEWER_TOOLS = [...EXPECTED_READONLY_TOOLS, 'Task', 'TaskOutput', 'TaskStop'];
 
-	it('has entries for all 6 preset roles', () => {
+	it('has entries for all 7 preset roles', () => {
 		expect(Object.keys(PRESET_AGENT_TOOLS).sort()).toEqual([
 			'coder',
+			'coordinator',
 			'general',
 			'planner',
 			'qa',
 			'research',
 			'reviewer',
 		]);
+	});
+
+	it('coordinator role maps to GENERAL_TOOLS (same as CODER_TOOLS)', () => {
+		expect(PRESET_AGENT_TOOLS.coordinator).toEqual(EXPECTED_CODER_TOOLS);
 	});
 
 	it('coder role maps to CODER_TOOLS', () => {
@@ -655,15 +698,23 @@ describe('SUB_SESSION_FEATURES export', () => {
 // ---------------------------------------------------------------------------
 
 describe('getPresetAgentTemplates', () => {
-	it('returns exactly 6 templates', () => {
+	it('returns exactly 7 templates', () => {
 		const templates = getPresetAgentTemplates();
-		expect(templates).toHaveLength(6);
+		expect(templates).toHaveLength(7);
 	});
 
 	it('returns all expected agent names', () => {
 		const templates = getPresetAgentTemplates();
 		const names = templates.map((t) => t.name).sort();
-		expect(names).toEqual(['Coder', 'General', 'Planner', 'QA', 'Research', 'Reviewer']);
+		expect(names).toEqual([
+			'Coder',
+			'Coordinator',
+			'General',
+			'Planner',
+			'QA',
+			'Research',
+			'Reviewer',
+		]);
 	});
 
 	it('each template has name, description, tools, and customPrompt', () => {

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -99,6 +99,7 @@ describe('seedPresetAgents', () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const coordinator = seeded.find((a) => a.name === 'Coordinator');
 
+		expect(seeded[0]?.name).toBe('Coder');
 		expect(coordinator).toBeDefined();
 		expect(coordinator?.description).toContain('Built-in long-horizon Space agent');
 		expect(coordinator?.customPrompt).toContain('long-horizon context');

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import type { AgentDriftReport, SpaceAgent } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
-import { createSpaceForgePath, createSpaceGoalsPath } from '../../lib/router';
+import { navigateToSpaceForge, navigateToSpaceGoals } from '../../lib/router';
 import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
@@ -203,6 +203,11 @@ export function SpaceAgentList() {
 
 	useEffect(() => {
 		if (!spaceId) return;
+		spaceStore.listSchedules().catch(() => {});
+	}, [spaceId]);
+
+	useEffect(() => {
+		if (!spaceId) return;
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) return;
 
@@ -284,6 +289,16 @@ export function SpaceAgentList() {
 		}
 	};
 
+	const handleGoalsClick = () => {
+		if (!spaceId) return;
+		navigateToSpaceGoals(spaceId);
+	};
+
+	const handleForgeClick = () => {
+		if (!spaceId) return;
+		navigateToSpaceForge(spaceId);
+	};
+
 	const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
 	const coordinator = agents.find(isCoordinatorAgent);
 	const otherAgents = agents.filter((agent) => agent.id !== coordinator?.id);
@@ -329,12 +344,14 @@ export function SpaceAgentList() {
 								<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
 									Managed goals
 								</p>
-								<a
-									class="text-xs text-blue-300 hover:text-blue-200"
-									href={spaceId ? createSpaceGoalsPath(spaceId) : '#'}
+								<button
+									type="button"
+									class="text-xs text-blue-300 hover:text-blue-200 disabled:opacity-50"
+									onClick={handleGoalsClick}
+									disabled={!spaceId}
 								>
 									View
-								</a>
+								</button>
 							</div>
 							<p class="mt-2 text-2xl font-semibold text-gray-100">{activeGoals.length}</p>
 							<p class="mt-1 text-xs text-gray-500">Active goals Coordinator can track.</p>
@@ -344,12 +361,14 @@ export function SpaceAgentList() {
 								<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
 									Forge scopes
 								</p>
-								<a
-									class="text-xs text-blue-300 hover:text-blue-200"
-									href={spaceId ? createSpaceForgePath(spaceId) : '#'}
+								<button
+									type="button"
+									class="text-xs text-blue-300 hover:text-blue-200 disabled:opacity-50"
+									onClick={handleForgeClick}
+									disabled={!spaceId}
 								>
 									Open Forge
-								</a>
+								</button>
 							</div>
 							<div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-500">
 								Per-Agent Forge scope policy coming soon.

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -1,43 +1,78 @@
 /**
- * SpaceAgentList Component
+ * Agents page for a Space.
  *
- * Displays all agents configured for a Space.
- * - Agent cards: name, model, description preview
- * - "Create Agent" button to open the editor
- * - Empty state: "No custom agents yet. Create one to get started."
- * - Subscribes to spaceAgent.* events via SpaceStore
- * - Delete confirmation with workflow reference blocking:
- *   When an agent is referenced by workflow steps, deletion is blocked
- *   with a clear message. When unreferenced, a standard confirm dialog is shown.
+ * Shows the built-in Coordinator plus editable specialist agents, with basic
+ * long-horizon configuration affordances for managed goals, Forge scopes,
+ * reminders, and event subscriptions.
  */
 
-import { useState, useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
+import type { AgentDriftReport, SpaceAgent } from '@neokai/shared';
+import { connectionManager } from '../../lib/connection-manager';
+import { createSpaceForgePath, createSpaceGoalsPath } from '../../lib/router';
 import { spaceStore } from '../../lib/space-store';
+import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
 import { ConfirmModal } from '../ui/ConfirmModal';
-import type { SpaceAgent, AgentDriftReport } from '@neokai/shared';
 import { SpaceAgentEditor } from './SpaceAgentEditor';
-import { connectionManager } from '../../lib/connection-manager';
-import { toast } from '../../lib/toast';
 
 interface AgentCardProps {
 	agent: SpaceAgent;
 	drifted: boolean;
 	syncing: boolean;
+	managedGoalCount: number;
+	forgeScopeCount: number;
+	reminderCount: number;
+	eventSubscriptionCount: number;
 	onEdit: (agent: SpaceAgent) => void;
 	onDelete: (agent: SpaceAgent) => void;
 	onSync: (agent: SpaceAgent) => void;
 }
 
-function AgentCard({ agent, drifted, syncing, onEdit, onDelete, onSync }: AgentCardProps) {
+function isCoordinatorAgent(agent: SpaceAgent): boolean {
+	return agent.name.toLowerCase() === 'coordinator' || agent.templateName === 'Coordinator';
+}
+
+function AgentStat({ label, value }: { label: string; value: string | number }) {
+	return (
+		<span class="rounded border border-white/10 bg-white/[0.025] px-2 py-1 text-xs text-gray-400">
+			<span class="text-gray-200">{value}</span> {label}
+		</span>
+	);
+}
+
+function AgentCard({
+	agent,
+	drifted,
+	syncing,
+	managedGoalCount,
+	forgeScopeCount,
+	reminderCount,
+	eventSubscriptionCount,
+	onEdit,
+	onDelete,
+	onSync,
+}: AgentCardProps) {
 	const toolCount = agent.tools?.length ?? 0;
+	const isCoordinator = isCoordinatorAgent(agent);
 
 	return (
-		<div class="group border-b border-white/10 py-3 last:border-b-0">
+		<div
+			class={`group rounded-lg border px-3 py-3 ${
+				isCoordinator
+					? 'border-purple-400/30 bg-purple-500/[0.06]'
+					: 'border-white/10 bg-white/[0.025]'
+			}`}
+		>
 			<div class="flex items-start justify-between gap-4">
 				<div class="min-w-0 flex-1">
-					<div class="flex min-w-0 items-center gap-2">
+					<div class="flex min-w-0 flex-wrap items-center gap-2">
 						<span class="truncate text-sm font-medium text-gray-100">{agent.name}</span>
+						{isCoordinator && (
+							<span class="rounded bg-purple-500/15 px-1.5 py-0.5 text-xs font-medium text-purple-200">
+								Default Coordinator
+							</span>
+						)}
 						{drifted && (
 							<span
 								class="inline-flex flex-shrink-0 items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-xs text-amber-300"
@@ -60,6 +95,24 @@ function AgentCard({ agent, drifted, syncing, onEdit, onDelete, onSync }: AgentC
 							</span>
 						))}
 					</div>
+					{isCoordinator && (
+						<div class="mt-3 grid gap-2 rounded-lg border border-purple-400/15 bg-black/10 p-3 sm:grid-cols-2">
+							<div>
+								<p class="text-xs font-medium text-purple-100">Long-horizon scope</p>
+								<div class="mt-2 flex flex-wrap gap-1.5">
+									<AgentStat label="managed goals" value={managedGoalCount} />
+									<AgentStat label="Forge scopes" value={forgeScopeCount} />
+								</div>
+							</div>
+							<div>
+								<p class="text-xs font-medium text-purple-100">Automation</p>
+								<div class="mt-2 flex flex-wrap gap-1.5">
+									<AgentStat label="reminders" value={reminderCount} />
+									<AgentStat label="event subscriptions" value={eventSubscriptionCount} />
+								</div>
+							</div>
+						</div>
+					)}
 				</div>
 				<div class="flex flex-shrink-0 items-center gap-1 opacity-70 transition-opacity group-hover:opacity-100">
 					{drifted && (
@@ -134,23 +187,21 @@ export function SpaceAgentList() {
 	const agents = spaceStore.agents.value;
 	const loading = spaceStore.loading.value;
 	const spaceId = spaceStore.spaceId.value;
+	const goals = spaceStore.goals.value;
+	const schedules = spaceStore.schedules.value;
+	const workflows = spaceStore.workflows.value;
 
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editingAgent, setEditingAgent] = useState<SpaceAgent | null>(null);
 	const [deletingAgent, setDeletingAgent] = useState<SpaceAgent | null>(null);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const [deleting, setDeleting] = useState(false);
+	const [forgeScopeFilter, setForgeScopeFilter] = useState('episodes, lessons, proposals');
+	const [eventTopicPattern, setEventTopicPattern] = useState('github/*/*/pull_request/*');
 
-	// Drift detection: set of agent IDs that have drifted from their preset.
-	// Empty until the first successful drift report fetch — agents not in the
-	// set render without the badge or sync button (the safe default when the
-	// daemon hasn't responded yet).
 	const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
 	const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
 
-	// Re-fetch drift report whenever the agent set changes. We watch a
-	// concatenated key of (id, updatedAt) so the effect fires for adds,
-	// removes, and edits — but not for unrelated re-renders.
 	const driftKey = agents
 		.map((a) => `${a.id}:${a.updatedAt}`)
 		.sort()
@@ -172,15 +223,11 @@ export function SpaceAgentList() {
 				}
 				setDriftedAgentIds(ids);
 			})
-			.catch(() => {
-				// Drift detection is best-effort — silently swallow errors so
-				// list rendering never depends on the report succeeding.
-			});
+			.catch(() => {});
 
 		return () => {
 			cancelled = true;
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- driftKey captures the list identity
 	}, [spaceId, driftKey]);
 
 	const handleSync = async (agent: SpaceAgent) => {
@@ -196,9 +243,6 @@ export function SpaceAgentList() {
 				spaceId,
 				agentId: agent.id,
 			});
-			// Clear drift state for this agent eagerly so the badge disappears
-			// before the next refresh cycle. The spaceAgent.updated event will
-			// re-trigger the effect and reconcile authoritatively.
 			setDriftedAgentIds((prev) => {
 				const next = new Set(prev);
 				next.delete(agent.id);
@@ -246,10 +290,17 @@ export function SpaceAgentList() {
 		}
 	};
 
-	// Workflow reference check removed: SpaceWorkflowSummary no longer includes
-	// node/agent details. The daemon still blocks deletion of in-use agents.
-
 	const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
+	const coordinator = agents.find(isCoordinatorAgent);
+	const otherAgents = agents.filter((agent) => agent.id !== coordinator?.id);
+	const visibleAgents = coordinator ? [coordinator, ...otherAgents] : agents;
+	const activeGoals = goals.filter((goal) => goal.status !== 'archived');
+	const activeSchedules = schedules.filter((schedule) => schedule.status === 'active');
+	const forgeScopeCount = forgeScopeFilter
+		.split(',')
+		.map((scope) => scope.trim())
+		.filter(Boolean).length;
+	const eventSubscriptionCount = eventTopicPattern.trim() ? 1 : 0;
 
 	if (loading) {
 		return (
@@ -263,15 +314,16 @@ export function SpaceAgentList() {
 
 	return (
 		<div class="flex h-full min-h-0 flex-col">
-			<div class="mb-3 flex flex-shrink-0 items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.035] px-3 py-3">
+			<div class="mb-3 flex flex-shrink-0 flex-col gap-3 rounded-lg border border-white/10 bg-white/[0.035] px-3 py-3 lg:flex-row lg:items-start lg:justify-between">
 				<div class="flex min-w-0 items-start gap-3">
-					<div class="mt-0.5 h-8 w-1 flex-shrink-0 rounded-full bg-blue-400/70" />
+					<div class="mt-0.5 h-8 w-1 flex-shrink-0 rounded-full bg-purple-400/70" />
 					<div class="min-w-0">
 						<p class="text-xs font-semibold uppercase tracking-wider text-gray-300">
-							{agents.length} configured {agents.length === 1 ? 'agent' : 'agents'}
+							Agents · {agents.length} configured
 						</p>
 						<p class="mt-1 text-xs text-gray-500">
-							Reusable workers and reviewers available to this space.
+							Coordinator is the default long-horizon Space agent. Create specialists for coding,
+							review, research, and QA.
 						</p>
 					</div>
 				</div>
@@ -280,39 +332,107 @@ export function SpaceAgentList() {
 				</Button>
 			</div>
 
-			{/* Agent list or empty state */}
-			{agents.length === 0 ? (
-				<div class="flex flex-1 flex-col items-center justify-center py-12 text-center">
-					<div class="w-10 h-10 rounded-full bg-dark-800 flex items-center justify-center mb-3">
-						<AgentIcon />
-					</div>
-					<p class="text-sm text-gray-400 font-medium">No custom agents yet</p>
-					<p class="text-xs text-gray-600 mt-1">Create one to get started.</p>
-					<div class="mt-4">
-						<Button size="sm" variant="secondary" onClick={handleCreate}>
-							Create Agent
-						</Button>
-					</div>
-				</div>
-			) : (
-				<div class="scrollbar-dark min-h-0 flex-1 overflow-y-auto pr-3">
-					<div class="min-h-[calc(100%+1px)]">
-						{agents.map((agent) => (
-							<AgentCard
-								key={agent.id}
-								agent={agent}
-								drifted={driftedAgentIds.has(agent.id)}
-								syncing={syncingAgentId === agent.id}
-								onEdit={handleEdit}
-								onDelete={handleDeleteClick}
-								onSync={handleSync}
+			<div class="scrollbar-dark min-h-0 flex-1 overflow-y-auto pr-3">
+				<div class="min-h-[calc(100%+1px)] space-y-3 pb-4">
+					<div class="grid gap-3 lg:grid-cols-3">
+						<div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
+							<div class="flex items-center justify-between gap-2">
+								<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
+									Managed goals
+								</p>
+								<a
+									class="text-xs text-blue-300 hover:text-blue-200"
+									href={spaceId ? createSpaceGoalsPath(spaceId) : '#'}
+								>
+									View
+								</a>
+							</div>
+							<p class="mt-2 text-2xl font-semibold text-gray-100">{activeGoals.length}</p>
+							<p class="mt-1 text-xs text-gray-500">Active goals Coordinator can track.</p>
+						</div>
+						<div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
+							<div class="flex items-center justify-between gap-2">
+								<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
+									Forge scopes
+								</p>
+								<a
+									class="text-xs text-blue-300 hover:text-blue-200"
+									href={spaceId ? createSpaceForgePath(spaceId) : '#'}
+								>
+									Open Forge
+								</a>
+							</div>
+							<input
+								value={forgeScopeFilter}
+								onInput={(event) => setForgeScopeFilter((event.target as HTMLInputElement).value)}
+								class="mt-2 w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
+								aria-label="Forge scope filter"
 							/>
-						))}
+							<p class="mt-1 text-xs text-gray-500">
+								Basic scope list until per-agent Forge policy lands.
+							</p>
+						</div>
+						<div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
+							<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
+								Reminders and events
+							</p>
+							<input
+								value={eventTopicPattern}
+								onInput={(event) => setEventTopicPattern((event.target as HTMLInputElement).value)}
+								class="mt-2 w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
+								aria-label="Event subscription pattern"
+							/>
+							<p class="mt-1 text-xs text-gray-500">
+								{activeSchedules.length} active reminders · {eventSubscriptionCount} event pattern
+							</p>
+						</div>
+					</div>
+
+					{visibleAgents.length === 0 ? (
+						<div class="flex flex-col items-center justify-center py-12 text-center">
+							<div class="w-10 h-10 rounded-full bg-dark-800 flex items-center justify-center mb-3">
+								<AgentIcon />
+							</div>
+							<p class="text-sm text-gray-400 font-medium">No agents yet</p>
+							<p class="text-xs text-gray-600 mt-1">Create one to get started.</p>
+							<div class="mt-4">
+								<Button size="sm" variant="secondary" onClick={handleCreate}>
+									Create Agent
+								</Button>
+							</div>
+						</div>
+					) : (
+						<div class="space-y-2">
+							{visibleAgents.map((agent) => (
+								<AgentCard
+									key={agent.id}
+									agent={agent}
+									drifted={driftedAgentIds.has(agent.id)}
+									syncing={syncingAgentId === agent.id}
+									managedGoalCount={activeGoals.length}
+									forgeScopeCount={forgeScopeCount}
+									reminderCount={activeSchedules.length}
+									eventSubscriptionCount={eventSubscriptionCount}
+									onEdit={handleEdit}
+									onDelete={handleDeleteClick}
+									onSync={handleSync}
+								/>
+							))}
+						</div>
+					)}
+
+					<div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
+						<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
+							Workflow usage
+						</p>
+						<p class="mt-1 text-xs text-gray-500">
+							{workflows.length} workflows can reference these agents. Edit workflows to assign
+							specialists.
+						</p>
 					</div>
 				</div>
-			)}
+			</div>
 
-			{/* Editor Modal */}
 			{editorOpen && (
 				<SpaceAgentEditor
 					agent={editingAgent}
@@ -322,8 +442,6 @@ export function SpaceAgentList() {
 				/>
 			)}
 
-			{/* Standard delete confirmation */}
-			{/* Standard delete confirmation: agent is not referenced by any workflow */}
 			{deletingAgent && (
 				<ConfirmModal
 					isOpen

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -31,6 +31,10 @@ function isCoordinatorAgent(agent: SpaceAgent): boolean {
 	return agent.name.toLowerCase() === 'coordinator' || agent.templateName === 'Coordinator';
 }
 
+function isConnectionUnavailableError(error: unknown): boolean {
+	return error instanceof Error && error.message === 'Not connected';
+}
+
 function AgentStat({ label, value }: { label: string; value: string | number }) {
 	return (
 		<span class="rounded border border-white/10 bg-white/[0.025] px-2 py-1 text-xs text-gray-400">
@@ -208,8 +212,8 @@ export function SpaceAgentList() {
 		let unsubscribe: (() => void) | null = null;
 		const loadSchedules = () => {
 			if (cancelled) return;
-			spaceStore.listSchedules().catch(() => {
-				if (cancelled) return;
+			spaceStore.listSchedules().catch((error) => {
+				if (cancelled || !isConnectionUnavailableError(error)) return;
 				unsubscribe?.();
 				unsubscribe = connectionManager.onceConnected(loadSchedules);
 			});

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -203,7 +203,24 @@ export function SpaceAgentList() {
 
 	useEffect(() => {
 		if (!spaceId) return;
-		spaceStore.listSchedules().catch(() => {});
+
+		let cancelled = false;
+		let unsubscribe: (() => void) | null = null;
+		const loadSchedules = () => {
+			if (cancelled) return;
+			spaceStore.listSchedules().catch(() => {
+				if (cancelled) return;
+				unsubscribe?.();
+				unsubscribe = connectionManager.onceConnected(loadSchedules);
+			});
+		};
+
+		loadSchedules();
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
 	}, [spaceId]);
 
 	useEffect(() => {

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -32,7 +32,7 @@ function isCoordinatorAgent(agent: SpaceAgent): boolean {
 }
 
 function isConnectionUnavailableError(error: unknown): boolean {
-	return error instanceof Error && error.message === 'Not connected';
+	return error instanceof Error && error.message.startsWith('Not connected');
 }
 
 function AgentStat({ label, value }: { label: string; value: string | number }) {

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -21,9 +21,7 @@ interface AgentCardProps {
 	drifted: boolean;
 	syncing: boolean;
 	managedGoalCount: number;
-	forgeScopeCount: number;
 	reminderCount: number;
-	eventSubscriptionCount: number;
 	onEdit: (agent: SpaceAgent) => void;
 	onDelete: (agent: SpaceAgent) => void;
 	onSync: (agent: SpaceAgent) => void;
@@ -46,9 +44,7 @@ function AgentCard({
 	drifted,
 	syncing,
 	managedGoalCount,
-	forgeScopeCount,
 	reminderCount,
-	eventSubscriptionCount,
 	onEdit,
 	onDelete,
 	onSync,
@@ -101,14 +97,14 @@ function AgentCard({
 								<p class="text-xs font-medium text-purple-100">Long-horizon scope</p>
 								<div class="mt-2 flex flex-wrap gap-1.5">
 									<AgentStat label="managed goals" value={managedGoalCount} />
-									<AgentStat label="Forge scopes" value={forgeScopeCount} />
+									<AgentStat label="Forge scopes" value="Coming soon" />
 								</div>
 							</div>
 							<div>
 								<p class="text-xs font-medium text-purple-100">Automation</p>
 								<div class="mt-2 flex flex-wrap gap-1.5">
 									<AgentStat label="reminders" value={reminderCount} />
-									<AgentStat label="event subscriptions" value={eventSubscriptionCount} />
+									<AgentStat label="event subscriptions" value="Coming soon" />
 								</div>
 							</div>
 						</div>
@@ -196,8 +192,6 @@ export function SpaceAgentList() {
 	const [deletingAgent, setDeletingAgent] = useState<SpaceAgent | null>(null);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const [deleting, setDeleting] = useState(false);
-	const [forgeScopeFilter, setForgeScopeFilter] = useState('episodes, lessons, proposals');
-	const [eventTopicPattern, setEventTopicPattern] = useState('github/*/*/pull_request/*');
 
 	const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
 	const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
@@ -294,13 +288,8 @@ export function SpaceAgentList() {
 	const coordinator = agents.find(isCoordinatorAgent);
 	const otherAgents = agents.filter((agent) => agent.id !== coordinator?.id);
 	const visibleAgents = coordinator ? [coordinator, ...otherAgents] : agents;
-	const activeGoals = goals.filter((goal) => goal.status !== 'archived');
+	const activeGoals = goals.filter((goal) => goal.status === 'active');
 	const activeSchedules = schedules.filter((schedule) => schedule.status === 'active');
-	const forgeScopeCount = forgeScopeFilter
-		.split(',')
-		.map((scope) => scope.trim())
-		.filter(Boolean).length;
-	const eventSubscriptionCount = eventTopicPattern.trim() ? 1 : 0;
 
 	if (loading) {
 		return (
@@ -322,8 +311,8 @@ export function SpaceAgentList() {
 							Agents · {agents.length} configured
 						</p>
 						<p class="mt-1 text-xs text-gray-500">
-							Coordinator is the default long-horizon Space agent. Create specialists for coding,
-							review, research, and QA.
+							Coordinator is the default long-horizon Agent for this Space. Create specialists for
+							coding, review, research, and QA.
 						</p>
 					</div>
 				</div>
@@ -362,28 +351,22 @@ export function SpaceAgentList() {
 									Open Forge
 								</a>
 							</div>
-							<input
-								value={forgeScopeFilter}
-								onInput={(event) => setForgeScopeFilter((event.target as HTMLInputElement).value)}
-								class="mt-2 w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
-								aria-label="Forge scope filter"
-							/>
+							<div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-500">
+								Per-Agent Forge scope policy coming soon.
+							</div>
 							<p class="mt-1 text-xs text-gray-500">
-								Basic scope list until per-agent Forge policy lands.
+								Open Forge to review current evidence, lessons, and proposals.
 							</p>
 						</div>
 						<div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
 							<p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
 								Reminders and events
 							</p>
-							<input
-								value={eventTopicPattern}
-								onInput={(event) => setEventTopicPattern((event.target as HTMLInputElement).value)}
-								class="mt-2 w-full rounded border border-dark-600 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
-								aria-label="Event subscription pattern"
-							/>
+							<div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-500">
+								Event subscriptions coming soon.
+							</div>
 							<p class="mt-1 text-xs text-gray-500">
-								{activeSchedules.length} active reminders · {eventSubscriptionCount} event pattern
+								{activeSchedules.length} active reminders · event subscriptions not yet configured
 							</p>
 						</div>
 					</div>
@@ -410,9 +393,7 @@ export function SpaceAgentList() {
 									drifted={driftedAgentIds.has(agent.id)}
 									syncing={syncingAgentId === agent.id}
 									managedGoalCount={activeGoals.length}
-									forgeScopeCount={forgeScopeCount}
 									reminderCount={activeSchedules.length}
-									eventSubscriptionCount={eventSubscriptionCount}
 									onEdit={handleEdit}
 									onDelete={handleDeleteClick}
 									onSync={handleSync}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -472,7 +472,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				? 'View Worker Session'
 				: agentSessionId
 					? 'View Agent Session'
-					: 'Open Space Agent';
+					: 'Open Coordinator';
 	const visibleTarget = visibleTargetName
 		? composerTargets.find(
 				(target) =>

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -36,6 +36,7 @@ const {
 	mockCreateAgent,
 	mockUpdateAgent,
 	mockListSchedules,
+	mockOnceConnected,
 	mockNavigateToSpaceGoals,
 	mockNavigateToSpaceForge,
 } = vi.hoisted(() => ({
@@ -43,6 +44,7 @@ const {
 	mockCreateAgent: vi.fn(),
 	mockUpdateAgent: vi.fn(),
 	mockListSchedules: vi.fn(),
+	mockOnceConnected: vi.fn(),
 	mockNavigateToSpaceGoals: vi.fn(),
 	mockNavigateToSpaceForge: vi.fn(),
 }));
@@ -74,6 +76,7 @@ const mockHubRequest = vi.fn();
 vi.mock('../../../lib/connection-manager', () => ({
 	connectionManager: {
 		getHubIfConnected: () => ({ request: mockHubRequest }),
+		onceConnected: mockOnceConnected,
 	},
 }));
 
@@ -270,6 +273,8 @@ describe('SpaceAgentList', () => {
 		mockUpdateAgent.mockReset();
 		mockListSchedules.mockReset();
 		mockListSchedules.mockResolvedValue([]);
+		mockOnceConnected.mockReset();
+		mockOnceConnected.mockReturnValue(() => {});
 		mockNavigateToSpaceGoals.mockReset();
 		mockNavigateToSpaceForge.mockReset();
 		mockHubRequest.mockReset();
@@ -373,6 +378,22 @@ describe('SpaceAgentList', () => {
 	it('loads schedules for reminder totals', () => {
 		render(<SpaceAgentList {...DEFAULT_PROPS} />);
 		expect(mockListSchedules).toHaveBeenCalledOnce();
+	});
+
+	it('retries loading schedules when the connection recovers', async () => {
+		let reconnect: (() => void) | undefined;
+		mockListSchedules.mockRejectedValueOnce(new Error('Not connected'));
+		mockOnceConnected.mockImplementation((callback) => {
+			reconnect = callback;
+			return vi.fn();
+		});
+
+		render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		await waitFor(() => expect(mockOnceConnected).toHaveBeenCalledOnce());
+
+		mockListSchedules.mockResolvedValue([]);
+		reconnect?.();
+		expect(mockListSchedules).toHaveBeenCalledTimes(2);
 	});
 
 	it('uses SPA navigation for goals and Forge links', () => {

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -396,6 +396,15 @@ describe('SpaceAgentList', () => {
 		expect(mockListSchedules).toHaveBeenCalledTimes(2);
 	});
 
+	it('does not retry loading schedules after non-connection errors', async () => {
+		mockListSchedules.mockRejectedValueOnce(new Error('Request failed'));
+
+		render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		await waitFor(() => expect(mockListSchedules).toHaveBeenCalledOnce());
+
+		expect(mockOnceConnected).not.toHaveBeenCalled();
+	});
+
 	it('uses SPA navigation for goals and Forge links', () => {
 		render(<SpaceAgentList {...DEFAULT_PROPS} />);
 

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -4,7 +4,7 @@
  *
  * Tests:
  * - Loading state
- * - Empty state: "No custom agents yet. Create one to get started."
+ * - Empty state: "No agents yet. Create one to get started."
  * - Agent cards render name, model, description preview
  * - Tool count and preview tags render
  * - Create Agent button opens editor
@@ -25,6 +25,8 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+let mockGoals: ReturnType<typeof signal<any[]>>;
+let mockSchedules: ReturnType<typeof signal<any[]>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockSpaceId: ReturnType<typeof signal<string | null>>;
 let mockSpace: ReturnType<typeof signal<any>>;
@@ -38,6 +40,8 @@ vi.mock('../../../lib/space-store', () => ({
 		return {
 			agents: mockAgents,
 			workflows: mockWorkflows,
+			goals: mockGoals,
+			schedules: mockSchedules,
 			loading: mockLoading,
 			spaceId: mockSpaceId,
 			space: mockSpace,
@@ -193,6 +197,8 @@ vi.mock('../../ui/Modal', () => ({
 // Initialize signals before import
 mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
+mockGoals = signal<any[]>([]);
+mockSchedules = signal<any[]>([]);
 mockLoading = signal(false);
 mockSpaceId = signal<string | null>('space-1');
 mockSpace = signal<any>({ id: 'space-1', defaultModel: undefined, taskAgentConfig: undefined });
@@ -237,6 +243,8 @@ describe('SpaceAgentList', () => {
 		cleanup();
 		mockAgents.value = [];
 		mockWorkflows.value = [];
+		mockGoals.value = [];
+		mockSchedules.value = [];
 		mockLoading.value = false;
 		mockSpaceId.value = 'space-1';
 		mockDeleteAgent.mockReset();
@@ -265,7 +273,7 @@ describe('SpaceAgentList', () => {
 
 	it('renders empty state when no agents exist', () => {
 		const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-		expect(getByText('No custom agents yet')).toBeTruthy();
+		expect(getByText('No agents yet')).toBeTruthy();
 		expect(getByText('Create one to get started.')).toBeTruthy();
 	});
 
@@ -338,6 +346,30 @@ describe('SpaceAgentList', () => {
 		const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
 		expect(getByText('Agent Alpha')).toBeTruthy();
 		expect(getByText('Agent Beta')).toBeTruthy();
+	});
+
+	it('shows Coordinator as default long-horizon agent with basic scopes', () => {
+		mockAgents.value = [
+			makeAgent({
+				id: 'coordinator-1',
+				name: 'Coordinator',
+				templateName: 'Coordinator',
+				description: 'Built-in long-horizon Space agent.',
+			}),
+			makeAgent({ id: 'coder-1', name: 'Coder' }),
+		];
+		mockGoals.value = [{ id: 'goal-1', status: 'active' }];
+		mockSchedules.value = [{ id: 'schedule-1', status: 'active' }];
+
+		const { container, getByText, getByLabelText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+
+		expect(getByText('Default Coordinator')).toBeTruthy();
+		expect(container.textContent).toContain('managed goals');
+		expect(container.textContent).toContain('Forge scopes');
+		expect(container.textContent).toContain('reminders');
+		expect(container.textContent).toContain('event subscriptions');
+		expect(getByLabelText('Forge scope filter')).toBeTruthy();
+		expect(getByLabelText('Event subscription pattern')).toBeTruthy();
 	});
 
 	// ── Editor opening ─────────────────────────────────────────────────────────

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -380,9 +380,12 @@ describe('SpaceAgentList', () => {
 		expect(mockListSchedules).toHaveBeenCalledOnce();
 	});
 
-	it('retries loading schedules when the connection recovers', async () => {
+	it.each([
+		'Not connected',
+		'Not connected to transport',
+	])('retries loading schedules when the connection recovers after %s', async (message) => {
 		let reconnect: (() => void) | undefined;
-		mockListSchedules.mockRejectedValueOnce(new Error('Not connected'));
+		mockListSchedules.mockRejectedValueOnce(new Error(message));
 		mockOnceConnected.mockImplementation((callback) => {
 			reconnect = callback;
 			return vi.fn();

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -358,18 +358,26 @@ describe('SpaceAgentList', () => {
 			}),
 			makeAgent({ id: 'coder-1', name: 'Coder' }),
 		];
-		mockGoals.value = [{ id: 'goal-1', status: 'active' }];
+		mockGoals.value = [
+			{ id: 'goal-1', status: 'active' },
+			{ id: 'goal-2', status: 'completed' },
+			{ id: 'goal-3', status: 'paused' },
+		];
 		mockSchedules.value = [{ id: 'schedule-1', status: 'active' }];
 
-		const { container, getByText, getByLabelText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		const { container, getByText, queryByLabelText } = render(
+			<SpaceAgentList {...DEFAULT_PROPS} />
+		);
 
 		expect(getByText('Default Coordinator')).toBeTruthy();
 		expect(container.textContent).toContain('managed goals');
 		expect(container.textContent).toContain('Forge scopes');
 		expect(container.textContent).toContain('reminders');
 		expect(container.textContent).toContain('event subscriptions');
-		expect(getByLabelText('Forge scope filter')).toBeTruthy();
-		expect(getByLabelText('Event subscription pattern')).toBeTruthy();
+		expect(container.textContent).toContain('Per-Agent Forge scope policy coming soon.');
+		expect(container.textContent).toContain('Event subscriptions coming soon.');
+		expect(queryByLabelText('Forge scope filter')).toBeNull();
+		expect(queryByLabelText('Event subscription pattern')).toBeNull();
 	});
 
 	// ── Editor opening ─────────────────────────────────────────────────────────

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+import { render, fireEvent, waitFor, cleanup, screen } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
@@ -31,9 +31,26 @@ let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockSpaceId: ReturnType<typeof signal<string | null>>;
 let mockSpace: ReturnType<typeof signal<any>>;
 
-const mockDeleteAgent = vi.fn();
-const mockCreateAgent = vi.fn();
-const mockUpdateAgent = vi.fn();
+const {
+	mockDeleteAgent,
+	mockCreateAgent,
+	mockUpdateAgent,
+	mockListSchedules,
+	mockNavigateToSpaceGoals,
+	mockNavigateToSpaceForge,
+} = vi.hoisted(() => ({
+	mockDeleteAgent: vi.fn(),
+	mockCreateAgent: vi.fn(),
+	mockUpdateAgent: vi.fn(),
+	mockListSchedules: vi.fn(),
+	mockNavigateToSpaceGoals: vi.fn(),
+	mockNavigateToSpaceForge: vi.fn(),
+}));
+
+vi.mock('../../../lib/router', () => ({
+	navigateToSpaceGoals: mockNavigateToSpaceGoals,
+	navigateToSpaceForge: mockNavigateToSpaceForge,
+}));
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -48,6 +65,7 @@ vi.mock('../../../lib/space-store', () => ({
 			deleteAgent: mockDeleteAgent,
 			createAgent: mockCreateAgent,
 			updateAgent: mockUpdateAgent,
+			listSchedules: mockListSchedules,
 		};
 	},
 }));
@@ -250,6 +268,10 @@ describe('SpaceAgentList', () => {
 		mockDeleteAgent.mockReset();
 		mockCreateAgent.mockReset();
 		mockUpdateAgent.mockReset();
+		mockListSchedules.mockReset();
+		mockListSchedules.mockResolvedValue([]);
+		mockNavigateToSpaceGoals.mockReset();
+		mockNavigateToSpaceForge.mockReset();
 		mockHubRequest.mockReset();
 		// Default: drift report returns no drifted agents so the list renders cleanly.
 		mockHubRequest.mockResolvedValue({
@@ -346,6 +368,21 @@ describe('SpaceAgentList', () => {
 		const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
 		expect(getByText('Agent Alpha')).toBeTruthy();
 		expect(getByText('Agent Beta')).toBeTruthy();
+	});
+
+	it('loads schedules for reminder totals', () => {
+		render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		expect(mockListSchedules).toHaveBeenCalledOnce();
+	});
+
+	it('uses SPA navigation for goals and Forge links', () => {
+		render(<SpaceAgentList {...DEFAULT_PROPS} />);
+
+		fireEvent.click(screen.getByText('View'));
+		fireEvent.click(screen.getByText('Open Forge'));
+
+		expect(mockNavigateToSpaceGoals).toHaveBeenCalledWith('space-1');
+		expect(mockNavigateToSpaceForge).toHaveBeenCalledWith('space-1');
 	});
 
 	it('shows Coordinator as default long-horizon agent with basic scopes', () => {

--- a/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/NodeConfigPanel.tsx
@@ -33,6 +33,10 @@ import { GateEditorPanel } from './GateEditorPanel';
 import { skillsStore } from '../../../lib/skills-store';
 import { normalizeThinkingLevel } from '@neokai/shared';
 
+function isCoordinatorAgent(agent: SpaceAgent): boolean {
+	return agent.name.toLowerCase() === 'coordinator' || agent.templateName === 'Coordinator';
+}
+
 const THINKING_LEVEL_OPTIONS: Array<{ value: '' | ThinkingLevel; label: string }> = [
 	{ value: '', label: 'Inherit' },
 	{ value: 'off', label: 'Off' },
@@ -333,7 +337,10 @@ function AgentsSection({
 								customPrompt: selectedSingleCustomPrompt,
 							};
 
-							const secondaryAgent = agents.find((a) => a.id !== primaryAgentId) ?? agents[0];
+							const secondaryAgent =
+								agents.find((a) => a.id !== primaryAgentId && !isCoordinatorAgent(a)) ??
+								agents.find((a) => a.id !== primaryAgentId) ??
+								agents[0];
 							const secondarySlot: WorkflowNodeAgent = {
 								agentId: secondaryAgent?.id ?? '',
 								name: buildUniqueRole(secondaryAgent?.name ?? 'agent'),

--- a/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/NodeConfigPanel.test.tsx
@@ -616,6 +616,26 @@ describe('NodeConfigPanel', () => {
 			expect(updatedStep.agentId).toBe('');
 		});
 
+		it('does not auto-select Coordinator as the secondary agent', () => {
+			const onUpdate = vi.fn();
+			const agents = [
+				makeAgent('coder-1', 'Coder'),
+				makeAgent('coordinator-1', 'Coordinator'),
+				makeAgent('general-1', 'General'),
+			];
+			const { getByTestId } = render(
+				<NodeConfigPanel
+					{...makeProps({ agents, step: makeStep({ agentId: 'coder-1' }), onUpdate })}
+				/>
+			);
+
+			fireEvent.click(getByTestId('add-agent-button'));
+
+			const updatedStep = onUpdate.mock.calls[0][0];
+			expect(updatedStep.agents[0].agentId).toBe('coder-1');
+			expect(updatedStep.agents[1].agentId).toBe('general-1');
+		});
+
 		it('shows agents list in multi-agent mode', () => {
 			const step = makeStep({
 				agentId: '',

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -135,7 +135,7 @@ const SPACE_BOTTOM_TABS: TabItem[] = [
 	{ id: 'space-overview', label: 'Overview', icon: SpaceOverviewIcon },
 	{ id: 'space-tasks', label: 'Tasks', icon: SpaceTasksIcon },
 	{ id: 'space-sessions', label: 'Sessions', icon: SpaceSessionsIcon },
-	{ id: 'space-agent', label: 'Agent', icon: SpaceChatIcon },
+	{ id: 'space-agent', label: 'Agents', icon: SpaceChatIcon },
 	{ id: 'space-settings', label: 'Settings', icon: SpaceSettingsIcon },
 ];
 

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -297,7 +297,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					}
 				/>
 				<SpaceNavItem
-					label="Space Agent"
+					label="Agents"
 					active={isSpaceAgentSelected}
 					onClick={handleSpaceAgentClick}
 					testId="space-detail-agent"

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -223,7 +223,7 @@ export default function SpaceIsland({
 				<ChatContainer
 					key={sessionViewId}
 					sessionId={sessionViewId}
-					titleOverride={isSpaceAgentSession ? 'Space Agent' : undefined}
+					titleOverride={isSpaceAgentSession ? 'Coordinator' : undefined}
 				/>
 				{overlay}
 			</>

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -163,10 +163,10 @@ describe('SpaceDetailPanel', () => {
 		expect(screen.getByText('Loading…')).toBeTruthy();
 	});
 
-	it('renders Overview and Space Agent buttons', () => {
+	it('renders Overview and Agents buttons', () => {
 		render(<SpaceDetailPanel spaceId="space-1" />);
 		expect(screen.getByText('Overview')).toBeTruthy();
-		expect(screen.getByText('Space Agent')).toBeTruthy();
+		expect(screen.getByText('Agents')).toBeTruthy();
 	});
 
 	it('removes the old Space Activity header block', () => {
@@ -187,7 +187,7 @@ describe('SpaceDetailPanel', () => {
 	it('navigates to the space agent and calls onNavigate', () => {
 		const onNavigate = vi.fn();
 		render(<SpaceDetailPanel spaceId="space-1" onNavigate={onNavigate} />);
-		fireEvent.click(screen.getByText('Space Agent'));
+		fireEvent.click(screen.getByText('Agents'));
 		expect(mockNavigateToSpaceAgent).toHaveBeenCalledWith('space-1');
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
@@ -198,10 +198,10 @@ describe('SpaceDetailPanel', () => {
 		expect(button?.className).toContain('bg-white/10');
 	});
 
-	it('highlights Space Agent when its synthetic session is selected', () => {
+	it('highlights Agents when the Coordinator synthetic session is selected', () => {
 		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-1';
 		render(<SpaceDetailPanel spaceId="space-1" />);
-		const button = screen.getByText('Space Agent').closest('button');
+		const button = screen.getByText('Agents').closest('button');
 		expect(button?.className).toContain('bg-white/10');
 	});
 

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -109,7 +109,7 @@ describe('router', () => {
 		expect(getSpaceIdFromPath(`/space/${SPACE_ID}/forge`)).toBe(SPACE_ID);
 		expect(createSpaceTasksPath(SPACE_ID, 'action')).toBe(`/space/${SPACE_ID}/tasks/action`);
 		expect(createSpaceSessionsPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/sessions`);
-		expect(createSpaceAgentPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/agent`);
+		expect(createSpaceAgentPath(SPACE_ID)).toBe(`/space/${SPACE_ID}/agents`);
 		expect(createSpaceSessionPath(SPACE_ID, SESSION_ID)).toBe(
 			`/space/${SPACE_ID}/session/${SESSION_ID}`
 		);

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -43,7 +43,7 @@ const SPACE_TASKS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks$/;
 const SPACE_TASKS_ARCHIVED_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks\/archived$/;
 const SPACE_TASKS_TAB_ROUTE_PATTERN =
 	/^\/space\/([a-z0-9-]+)\/tasks\/(action|active|draft|completed|scheduled)$/;
-const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
+const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/(?:agent|agents)$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-fA-F0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)$/;
 const SPACE_TASK_VIEW_ROUTE_PATTERN =
@@ -256,7 +256,7 @@ export function createSpaceSessionsPath(spaceId: string): string {
 }
 
 export function createSpaceAgentPath(spaceId: string): string {
-	return `/space/${spaceId}/agent`;
+	return `/space/${spaceId}/agents`;
 }
 
 export function createSettingsPath(section?: SettingsSection): string {


### PR DESCRIPTION
## Summary
- Rename Space Agent navigation/UI labels to Agents while keeping legacy `/agent` routes working.
- Add Coordinator as the default seeded long-horizon Space agent.
- Surface Coordinator goal, Forge scope, reminder, and event subscription affordances in the Agents page.

## Tests
- `cd packages/web && bunx vitest run src/components/space/__tests__/SpaceAgentList.test.tsx src/islands/__tests__/SpaceDetailPanel.test.tsx`
- `cd packages/daemon && bun test tests/unit/5-space/other/seed-agents.test.ts`
- `bun run check`