### PR TITLE
Stop agents when new dependency blocks task

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -25,18 +25,13 @@ const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>([
 	'cancelled',
 	'archived',
 ]);
-
-function arraysEqual(a: string[], b: string[]): boolean {
-	if (a.length !== b.length) return false;
-	const setA = new Set(a);
-	return b.every((item) => setA.has(item));
-}
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import type { SpaceGoalService } from '../space/goals/goal-service';
+import { arraysEqual } from '../utils/array-utils';
 
 const log = new Logger('space-task-handlers');
 
@@ -411,19 +406,27 @@ export function setupSpaceTaskHandlers(
 			if (!currentTask) {
 				throw new Error(`Task not found: ${taskId}`);
 			}
-			const dependencyAddedToActiveWorkflow =
+			let dependencyCheckResult: SpaceTask | null = null;
+			let runtimeForDependencyBlock: SpaceRuntimeService | null = null;
+			let dependencyAddedToActiveWorkflow = false;
+			if (
 				spaceRuntimeService &&
 				updateParams.dependsOn !== undefined &&
 				currentTask.status === 'in_progress' &&
 				currentTask.workflowRunId &&
-				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn) &&
-				!(await taskManager.areDependenciesMet({
-					...currentTask,
-					dependsOn: updateParams.dependsOn,
-				}));
+				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn)
+			) {
+				dependencyCheckResult = await taskManager.updateTask(taskId, updateParams, {
+					onCascadedTasks: emitCascadedTasks,
+				});
+				dependencyAddedToActiveWorkflow =
+					dependencyCheckResult.status === 'blocked' &&
+					dependencyCheckResult.blockReason === 'dependency_added';
+				runtimeForDependencyBlock = spaceRuntimeService;
+			}
 
-			if (dependencyAddedToActiveWorkflow) {
-				task = await spaceRuntimeService.stopWorkflowBackedTask(spaceId, taskId, {
+			if (dependencyAddedToActiveWorkflow && runtimeForDependencyBlock) {
+				task = await runtimeForDependencyBlock.stopWorkflowBackedTask(spaceId, taskId, {
 					...updateParams,
 					status: 'blocked',
 					blockReason: 'dependency_added',
@@ -431,6 +434,8 @@ export function setupSpaceTaskHandlers(
 					completedAt: null,
 				});
 				emitTaskUpdated = false;
+			} else if (dependencyCheckResult) {
+				task = dependencyCheckResult;
 			} else {
 				task = await taskManager.updateTask(taskId, updateParams, {
 					onCascadedTasks: emitCascadedTasks,

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -299,6 +299,21 @@ export function setupSpaceTaskHandlers(
 				};
 			}
 
+			if (dependencyCheckResult) {
+				const pointerParams: UpdateSpaceTaskParams = {};
+				if ('taskAgentSessionId' in updateParams) {
+					pointerParams.taskAgentSessionId = updateParams.taskAgentSessionId;
+				}
+				if ('workflowRunId' in updateParams) {
+					pointerParams.workflowRunId = updateParams.workflowRunId;
+				}
+				if (Object.keys(pointerParams).length > 0) {
+					dependencyCheckResult = await taskManager.updateTask(taskId, pointerParams, {
+						onCascadedTasks: emitCascadedTasks,
+					});
+				}
+			}
+
 			return {
 				task:
 					dependencyCheckResult ??

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -272,7 +272,12 @@ export function setupSpaceTaskHandlers(
 				currentTask.workflowRunId &&
 				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn)
 			) {
-				dependencyCheckResult = await taskManager.updateTask(taskId, updateParams, {
+				const {
+					taskAgentSessionId: _taskAgentSessionId,
+					workflowRunId: _workflowRunId,
+					...safeParams
+				} = updateParams;
+				dependencyCheckResult = await taskManager.updateTask(taskId, safeParams, {
 					onCascadedTasks: emitCascadedTasks,
 				});
 				dependencyAddedToActiveWorkflow =

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -366,6 +366,10 @@ export function setupSpaceTaskHandlers(
 						});
 					}
 				} else {
+					const shouldStopWorkflowForStatus =
+						currentTask.workflowRunId &&
+						(currentTask.status === 'in_progress' || currentTask.status === 'blocked') &&
+						(updateParams.status === 'open' || updateParams.status === 'cancelled');
 					// Reject bare transitions into `review`. Every task that lands in
 					// `review` MUST carry the pending-completion fields so
 					// `PendingTaskCompletionBanner` renders and approvals route through
@@ -401,60 +405,75 @@ export function setupSpaceTaskHandlers(
 								`approval metadata and dispatch the configured post-approval step.`
 						);
 					}
-					// Status is changing — validate via setTaskStatus (enforces transitions).
-					// `approvalReason` is stamped on review→done; `cancelReason` is
-					// persisted into the same underlying column for review→cancelled
-					// transitions (and other terminal rejections). We map both onto the
-					// manager's `approvalReason` option because the DB schema keeps a
-					// single `approval_reason` column doubling as audit trail for
-					// approvals *and* rejections.
-					const mappedReason =
-						updateParams.status === 'cancelled'
-							? (updateParams.cancelReason ?? updateParams.approvalReason ?? undefined)
-							: (updateParams.approvalReason ?? undefined);
-
-					task = await taskManager.setTaskStatus(taskId, updateParams.status, {
-						result: updateParams.result ?? undefined,
-						// Human-initiated approval when transitioning from review → done
-						approvalSource:
-							currentTask.status === 'review' && updateParams.status === 'done'
-								? 'human'
-								: undefined,
-						approvalReason: mappedReason,
-					});
-
-					// When the transition alone cannot carry the rejection reason (e.g.
-					// review → cancelled — setTaskStatus only stamps approvalReason on
-					// review→done), apply it in a follow-up write. Keeps the audit trail
-					// complete regardless of direction.
-					if (
-						updateParams.status === 'cancelled' &&
-						(updateParams.cancelReason ?? updateParams.approvalReason)
-					) {
-						task = await taskManager.updateTask(
+					if (shouldStopWorkflowForStatus) {
+						if (!spaceRuntimeService) {
+							throw new Error(
+								`Cannot stop workflow-backed task ${taskId}: SpaceRuntimeService is unavailable.`
+							);
+						}
+						task = await spaceRuntimeService.stopWorkflowBackedTaskForStatus(
+							spaceId,
 							taskId,
-							{
-								approvalReason: updateParams.cancelReason ?? updateParams.approvalReason ?? null,
-							},
-							{ onCascadedTasks: emitCascadedTasks }
+							updateParams
 						);
-					}
+						emitTaskUpdated = false;
+						handleGoalTerminal = false;
+					} else {
+						// Status is changing — validate via setTaskStatus (enforces transitions).
+						// `approvalReason` is stamped on review→done; `cancelReason` is
+						// persisted into the same underlying column for review→cancelled
+						// transitions (and other terminal rejections). We map both onto the
+						// manager's `approvalReason` option because the DB schema keeps a
+						// single `approval_reason` column doubling as audit trail for
+						// approvals *and* rejections.
+						const mappedReason =
+							updateParams.status === 'cancelled'
+								? (updateParams.cancelReason ?? updateParams.approvalReason ?? undefined)
+								: (updateParams.approvalReason ?? undefined);
 
-					// When a status transition is combined with other field updates
-					// (e.g. taskAgentSessionId), those fields are silently dropped by
-					// setTaskStatus. Apply them in a follow-up updateTask call so
-					// callers can atomically set status + metadata in one RPC.
-					const {
-						status: _s,
-						result: _r,
-						approvalReason: _ar,
-						cancelReason: _cr,
-						...otherFields
-					} = updateParams;
-					if (Object.keys(otherFields).length > 0) {
-						task = await taskManager.updateTask(taskId, otherFields, {
-							onCascadedTasks: emitCascadedTasks,
+						task = await taskManager.setTaskStatus(taskId, updateParams.status, {
+							result: updateParams.result ?? undefined,
+							// Human-initiated approval when transitioning from review → done
+							approvalSource:
+								currentTask.status === 'review' && updateParams.status === 'done'
+									? 'human'
+									: undefined,
+							approvalReason: mappedReason,
 						});
+
+						// When the transition alone cannot carry the rejection reason (e.g.
+						// review → cancelled — setTaskStatus only stamps approvalReason on
+						// review→done), apply it in a follow-up write. Keeps the audit trail
+						// complete regardless of direction.
+						if (
+							updateParams.status === 'cancelled' &&
+							(updateParams.cancelReason ?? updateParams.approvalReason)
+						) {
+							task = await taskManager.updateTask(
+								taskId,
+								{
+									approvalReason: updateParams.cancelReason ?? updateParams.approvalReason ?? null,
+								},
+								{ onCascadedTasks: emitCascadedTasks }
+							);
+						}
+
+						// When a status transition is combined with other field updates
+						// (e.g. taskAgentSessionId), those fields are silently dropped by
+						// setTaskStatus. Apply them in a follow-up updateTask call so
+						// callers can atomically set status + metadata in one RPC.
+						const {
+							status: _s,
+							result: _r,
+							approvalReason: _ar,
+							cancelReason: _cr,
+							...otherFields
+						} = updateParams;
+						if (Object.keys(otherFields).length > 0) {
+							task = await taskManager.updateTask(taskId, otherFields, {
+								onCascadedTasks: emitCascadedTasks,
+							});
+						}
 					}
 				}
 			} else {

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -259,6 +259,51 @@ export function setupSpaceTaskHandlers(
 			}
 		};
 
+		const updateTaskWithRuntimeDependencyBlock = async (
+			currentTask: SpaceTask
+		): Promise<{ task: SpaceTask; handledByRuntime: boolean }> => {
+			let dependencyCheckResult: SpaceTask | null = null;
+			let runtimeForDependencyBlock: SpaceRuntimeService | null = null;
+			let dependencyAddedToActiveWorkflow = false;
+			if (
+				spaceRuntimeService &&
+				updateParams.dependsOn !== undefined &&
+				currentTask.status === 'in_progress' &&
+				currentTask.workflowRunId &&
+				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn)
+			) {
+				dependencyCheckResult = await taskManager.updateTask(taskId, updateParams, {
+					onCascadedTasks: emitCascadedTasks,
+				});
+				dependencyAddedToActiveWorkflow =
+					dependencyCheckResult.status === 'blocked' &&
+					dependencyCheckResult.blockReason === 'dependency_added';
+				runtimeForDependencyBlock = spaceRuntimeService;
+			}
+
+			if (dependencyAddedToActiveWorkflow && runtimeForDependencyBlock) {
+				return {
+					task: await runtimeForDependencyBlock.stopWorkflowBackedTask(spaceId, taskId, {
+						...updateParams,
+						status: 'blocked',
+						blockReason: 'dependency_added',
+						result: 'Dependency added while task was in progress',
+						completedAt: null,
+					}),
+					handledByRuntime: true,
+				};
+			}
+
+			return {
+				task:
+					dependencyCheckResult ??
+					(await taskManager.updateTask(taskId, updateParams, {
+						onCascadedTasks: emitCascadedTasks,
+					})),
+				handledByRuntime: false,
+			};
+		};
+
 		// Route to setTaskStatus only when the status is actually changing.
 		// Sending the current status as part of a broader metadata update must not
 		// trigger a transition check (same→same is not in the transition table and
@@ -397,9 +442,12 @@ export function setupSpaceTaskHandlers(
 				// updateParams still contains the unchanged status field; SpaceTaskManager.updateTask
 				// strips it internally (guard: params.status !== task.status is false) so no
 				// transition check fires and the status column is left untouched in the DB.
-				task = await taskManager.updateTask(taskId, updateParams, {
-					onCascadedTasks: emitCascadedTasks,
-				});
+				const dependencyUpdate = await updateTaskWithRuntimeDependencyBlock(currentTask);
+				task = dependencyUpdate.task;
+				if (dependencyUpdate.handledByRuntime) {
+					emitTaskUpdated = false;
+					handleGoalTerminal = false;
+				}
 			}
 		} else {
 			// No status field — general field update
@@ -407,41 +455,11 @@ export function setupSpaceTaskHandlers(
 			if (!currentTask) {
 				throw new Error(`Task not found: ${taskId}`);
 			}
-			let dependencyCheckResult: SpaceTask | null = null;
-			let runtimeForDependencyBlock: SpaceRuntimeService | null = null;
-			let dependencyAddedToActiveWorkflow = false;
-			if (
-				spaceRuntimeService &&
-				updateParams.dependsOn !== undefined &&
-				currentTask.status === 'in_progress' &&
-				currentTask.workflowRunId &&
-				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn)
-			) {
-				dependencyCheckResult = await taskManager.updateTask(taskId, updateParams, {
-					onCascadedTasks: emitCascadedTasks,
-				});
-				dependencyAddedToActiveWorkflow =
-					dependencyCheckResult.status === 'blocked' &&
-					dependencyCheckResult.blockReason === 'dependency_added';
-				runtimeForDependencyBlock = spaceRuntimeService;
-			}
-
-			if (dependencyAddedToActiveWorkflow && runtimeForDependencyBlock) {
-				task = await runtimeForDependencyBlock.stopWorkflowBackedTask(spaceId, taskId, {
-					...updateParams,
-					status: 'blocked',
-					blockReason: 'dependency_added',
-					result: 'Dependency added while task was in progress',
-					completedAt: null,
-				});
+			const dependencyUpdate = await updateTaskWithRuntimeDependencyBlock(currentTask);
+			task = dependencyUpdate.task;
+			if (dependencyUpdate.handledByRuntime) {
 				emitTaskUpdated = false;
 				handleGoalTerminal = false;
-			} else if (dependencyCheckResult) {
-				task = dependencyCheckResult;
-			} else {
-				task = await taskManager.updateTask(taskId, updateParams, {
-					onCascadedTasks: emitCascadedTasks,
-				});
 			}
 		}
 

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -246,6 +246,7 @@ export function setupSpaceTaskHandlers(
 
 		let task: SpaceTask;
 		let emitTaskUpdated = true;
+		let handleGoalTerminal = true;
 		const emitCascadedTasks = async (cascadedTasks: SpaceTask[]) => {
 			if (!emitTaskUpdated) return;
 			for (const cascadedTask of cascadedTasks) {
@@ -434,6 +435,7 @@ export function setupSpaceTaskHandlers(
 					completedAt: null,
 				});
 				emitTaskUpdated = false;
+				handleGoalTerminal = false;
 			} else if (dependencyCheckResult) {
 				task = dependencyCheckResult;
 			} else {
@@ -444,7 +446,7 @@ export function setupSpaceTaskHandlers(
 		}
 
 		// Best-effort goal terminal handling — must not abort the RPC response.
-		if (spaceGoalService && TERMINAL_TASK_STATUSES.has(task.status)) {
+		if (handleGoalTerminal && spaceGoalService && TERMINAL_TASK_STATUSES.has(task.status)) {
 			try {
 				spaceGoalService.handleTaskTerminal(task.id);
 			} catch (err) {

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -25,6 +25,12 @@ const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>([
 	'cancelled',
 	'archived',
 ]);
+
+function arraysEqual(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const setA = new Set(a);
+	return b.every((item) => setA.has(item));
+}
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -401,9 +407,35 @@ export function setupSpaceTaskHandlers(
 			}
 		} else {
 			// No status field — general field update
-			task = await taskManager.updateTask(taskId, updateParams, {
-				onCascadedTasks: emitCascadedTasks,
-			});
+			const currentTask = await taskManager.getTask(taskId);
+			if (!currentTask) {
+				throw new Error(`Task not found: ${taskId}`);
+			}
+			const dependencyAddedToActiveWorkflow =
+				spaceRuntimeService &&
+				updateParams.dependsOn !== undefined &&
+				currentTask.status === 'in_progress' &&
+				currentTask.workflowRunId &&
+				!arraysEqual(currentTask.dependsOn ?? [], updateParams.dependsOn) &&
+				!(await taskManager.areDependenciesMet({
+					...currentTask,
+					dependsOn: updateParams.dependsOn,
+				}));
+
+			if (dependencyAddedToActiveWorkflow) {
+				task = await spaceRuntimeService.stopWorkflowBackedTask(spaceId, taskId, {
+					...updateParams,
+					status: 'blocked',
+					blockReason: 'dependency_added',
+					result: 'Dependency added while task was in progress',
+					completedAt: null,
+				});
+				emitTaskUpdated = false;
+			} else {
+				task = await taskManager.updateTask(taskId, updateParams, {
+					onCascadedTasks: emitCascadedTasks,
+				});
+			}
 		}
 
 		// Best-effort goal terminal handling — must not abort the RPC response.

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -388,30 +388,7 @@ export function setupSpaceWorkflowRunHandlers(
 			throw new Error('Cannot cancel a done workflow run');
 		}
 
-		// Cancel all pending tasks belonging to this run
-		const taskManager = taskManagerFactory(run.spaceId);
-		const tasks = await taskManager.listTasksByWorkflowRun(run.id);
-		for (const task of tasks) {
-			if (task.status === 'open' || task.status === 'in_progress') {
-				await taskManager.cancelTask(task.id).catch((err: unknown) => {
-					log.warn(`Failed to cancel task ${task.id} for run ${run.id}:`, err);
-				});
-			}
-		}
-
-		// Cancel the run (pending/in_progress/blocked → cancelled)
-		const updated = workflowRunRepo.transitionStatus(params.id, 'cancelled');
-
-		internalEventBus
-			.publish('space.workflowRun.updated', {
-				sessionId: 'global',
-				spaceId: run.spaceId,
-				runId: run.id,
-				run: updated,
-			})
-			.catch((err) => {
-				log.warn('Failed to emit space.workflowRun.updated:', err);
-			});
+		await spaceRuntimeService.cancelWorkflowRun(run.spaceId, run.id);
 
 		return { success: true };
 	});

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -20,6 +20,7 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import { Logger } from '../../logger';
 import type { EvolutionScopeService } from '../evolution-scope-service';
+import { arraysEqual } from '../../utils/array-utils';
 
 const log = new Logger('space-task-manager');
 
@@ -833,14 +834,4 @@ export class SpaceTaskManager {
 		}
 		return false;
 	}
-}
-
-/**
- * Order-independent comparison for two string arrays.
- */
-function arraysEqual(a: string[], b: string[]): boolean {
-	if (a.length !== b.length) return false;
-	const sortedA = [...a].sort();
-	const sortedB = [...b].sort();
-	return sortedA.every((v, i) => v === sortedB[i]);
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -16,6 +16,7 @@ import type {
 	Session,
 	Space,
 	SpaceTask,
+	SpaceWorkflowRun,
 	UpdateSpaceTaskParams,
 } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
@@ -1756,6 +1757,22 @@ export class SpaceRuntimeService {
 			throw new Error(`Failed to block workflow-backed task ${taskId}`);
 		}
 		return updated;
+	}
+
+	async stopWorkflowBackedTaskForStatus(
+		spaceId: string,
+		taskId: string,
+		params: UpdateSpaceTaskParams
+	): Promise<SpaceTask> {
+		const updated = await this.runtime.stopWorkflowBackedTaskForStatus(spaceId, taskId, params);
+		if (!updated) {
+			throw new Error(`Failed to stop workflow-backed task ${taskId}`);
+		}
+		return updated;
+	}
+
+	async cancelWorkflowRun(spaceId: string, runId: string): Promise<SpaceWorkflowRun> {
+		return this.runtime.cancelWorkflowRun(spaceId, runId);
 	}
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -10,7 +10,14 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import type { AgentDefinition, McpServerConfig, Session, Space, SpaceTask } from '@neokai/shared';
+import type {
+	AgentDefinition,
+	McpServerConfig,
+	Session,
+	Space,
+	SpaceTask,
+	UpdateSpaceTaskParams,
+} from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { MessageRecord, ActorRef } from '../../../../../messaging/src/types';
 import { SpaceActorRegistryAdapter } from '../actor-registry';
@@ -1737,6 +1744,18 @@ export class SpaceRuntimeService {
 	): Promise<SpaceTask> {
 		const recovered = await this.runtime.recoverWorkflowBackedTask(spaceId, taskId, targetStatus);
 		return recovered.task;
+	}
+
+	async stopWorkflowBackedTask(
+		spaceId: string,
+		taskId: string,
+		params: UpdateSpaceTaskParams
+	): Promise<SpaceTask> {
+		const updated = await this.runtime.blockWorkflowBackedTask(spaceId, taskId, params);
+		if (!updated) {
+			throw new Error(`Failed to block workflow-backed task ${taskId}`);
+		}
+		return updated;
 	}
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2132,6 +2132,117 @@ export class SpaceRuntime {
 		return cleared ?? task;
 	}
 
+	private async stopActiveWorkflowTaskAgents(task: SpaceTask, reason: string): Promise<SpaceTask> {
+		if (!task.workflowRunId) return task;
+
+		const now = Date.now();
+		for (const execution of this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId)) {
+			if (!execution.agentSessionId) continue;
+			this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'cancelled',
+				agentSessionId: null,
+				result: reason,
+				completedAt: now,
+			});
+		}
+
+		if (task.taskAgentSessionId) {
+			this.config.taskAgentManager?.cancelBySessionId(task.taskAgentSessionId);
+		}
+		this.clearAgentStuckStateForRun(task.workflowRunId);
+		return (
+			this.config.taskRepo.updateTask(task.id, {
+				workflowRunId: task.workflowRunId,
+				taskAgentSessionId: null,
+			}) ?? task
+		);
+	}
+
+	async stopWorkflowBackedTaskForStatus(
+		spaceId: string,
+		taskId: string,
+		params: UpdateSpaceTaskParams
+	): Promise<SpaceTask | null> {
+		const previous = this.config.taskRepo.getTask(taskId);
+		if (!previous) return null;
+		const nextStatus = params.status;
+		if (nextStatus && previous.status !== nextStatus) {
+			const taskManager = this.getOrCreateTaskManager(spaceId);
+			let updated = await taskManager.setTaskStatus(taskId, nextStatus, {
+				result: params.result ?? undefined,
+				approvalReason:
+					nextStatus === 'cancelled'
+						? (params.cancelReason ?? params.approvalReason ?? undefined)
+						: (params.approvalReason ?? undefined),
+			});
+
+			const {
+				status: _status,
+				result: _result,
+				approvalReason: _approvalReason,
+				cancelReason: _cancelReason,
+				...otherFields
+			} = params;
+			if (Object.keys(otherFields).length > 0) {
+				updated = this.config.taskRepo.updateTask(taskId, otherFields) ?? updated;
+			}
+			if (
+				nextStatus === 'cancelled' &&
+				(params.cancelReason ?? params.approvalReason) &&
+				updated.approvalReason !== (params.cancelReason ?? params.approvalReason)
+			) {
+				updated =
+					this.config.taskRepo.updateTask(taskId, {
+						approvalReason: params.cancelReason ?? params.approvalReason ?? null,
+					}) ?? updated;
+			}
+			if (!previous.workflowRunId) {
+				await this.safeOnTaskUpdated(spaceId, updated);
+				return updated;
+			}
+
+			const reason = params.result ?? updated.result ?? `Task ${nextStatus}`;
+			updated = await this.stopActiveWorkflowTaskAgents(
+				{
+					...updated,
+					workflowRunId: previous.workflowRunId,
+					taskAgentSessionId: previous.taskAgentSessionId ?? updated.taskAgentSessionId,
+				},
+				reason
+			);
+			await this.safeOnTaskUpdated(spaceId, updated);
+
+			if (nextStatus === 'open' || nextStatus === 'cancelled') {
+				const run = this.config.workflowRunRepo.getRun(previous.workflowRunId);
+				if (run && canTransitionRunStatus(run.status, 'cancelled')) {
+					await this.transitionRunStatusAndEmit(previous.workflowRunId, 'cancelled');
+				}
+			}
+			return updated;
+		}
+
+		const updated = this.config.taskRepo.updateTask(taskId, params);
+		if (updated) await this.safeOnTaskUpdated(spaceId, updated);
+		return updated;
+	}
+
+	async cancelWorkflowRun(spaceId: string, runId: string): Promise<SpaceWorkflowRun> {
+		const run = this.config.workflowRunRepo.getRun(runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${runId}`);
+		for (const task of this.config.taskRepo.listByWorkflowRun(runId)) {
+			if (task.status === 'open' || task.status === 'in_progress' || task.status === 'blocked') {
+				await this.stopWorkflowBackedTaskForStatus(spaceId, task.id, { status: 'cancelled' });
+			}
+		}
+		const updated = this.config.workflowRunRepo.getRun(runId) ?? run;
+		if (updated.status === 'cancelled') return updated;
+		if (canTransitionRunStatus(updated.status, 'cancelled')) {
+			return this.transitionRunStatusAndEmit(runId, 'cancelled');
+		}
+		return updated;
+	}
+
 	async blockWorkflowBackedTask(
 		spaceId: string,
 		taskId: string,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2137,7 +2137,13 @@ export class SpaceRuntime {
 
 		const now = Date.now();
 		for (const execution of this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId)) {
-			if (!execution.agentSessionId) continue;
+			if (
+				!execution.agentSessionId ||
+				execution.status === 'idle' ||
+				execution.status === 'cancelled'
+			) {
+				continue;
+			}
 			this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
 			this.config.nodeExecutionRepo.update(execution.id, {
 				status: 'cancelled',
@@ -2185,7 +2191,7 @@ export class SpaceRuntime {
 				...otherFields
 			} = params;
 			if (Object.keys(otherFields).length > 0) {
-				updated = this.config.taskRepo.updateTask(taskId, otherFields) ?? updated;
+				updated = await taskManager.updateTask(taskId, otherFields);
 			}
 			if (
 				nextStatus === 'cancelled' &&
@@ -2213,7 +2219,7 @@ export class SpaceRuntime {
 			);
 			await this.safeOnTaskUpdated(spaceId, updated);
 
-			if (nextStatus === 'open' || nextStatus === 'cancelled') {
+			if (nextStatus === 'cancelled') {
 				const run = this.config.workflowRunRepo.getRun(previous.workflowRunId);
 				if (run && canTransitionRunStatus(run.status, 'cancelled')) {
 					await this.transitionRunStatusAndEmit(previous.workflowRunId, 'cancelled');

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2122,6 +2122,7 @@ export class SpaceRuntime {
 			this.config.taskAgentManager?.cancelBySessionId(task.taskAgentSessionId);
 		}
 		const cleared = this.config.taskRepo.updateTask(task.id, {
+			workflowRunId: task.workflowRunId,
 			taskAgentSessionId: null,
 		});
 		if (cleared) {
@@ -2163,6 +2164,7 @@ export class SpaceRuntime {
 						spaceId,
 						{
 							...updated,
+							workflowRunId: previous?.workflowRunId ?? updated.workflowRunId,
 							taskAgentSessionId: previous?.taskAgentSessionId ?? updated.taskAgentSessionId,
 						},
 						reason

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2102,17 +2102,20 @@ export class SpaceRuntime {
 
 		const now = Date.now();
 		for (const execution of this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId)) {
-			if (execution.agentSessionId) {
-				this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
+			if (
+				!execution.agentSessionId ||
+				execution.status === 'idle' ||
+				execution.status === 'cancelled'
+			) {
+				continue;
 			}
-			if (execution.status !== 'cancelled') {
-				this.config.nodeExecutionRepo.update(execution.id, {
-					status: 'cancelled',
-					agentSessionId: null,
-					result: reason,
-					completedAt: now,
-				});
-			}
+			this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'cancelled',
+				agentSessionId: null,
+				result: reason,
+				completedAt: now,
+			});
 		}
 
 		if (task.taskAgentSessionId) {
@@ -2144,7 +2147,7 @@ export class SpaceRuntime {
 	): Promise<SpaceTask | null> {
 		let updated = this.config.taskRepo.updateTask(taskId, params);
 		if (updated) {
-			await this.safeOnTaskUpdated(spaceId, updated, opts);
+			let emitUpdated = true;
 
 			// Cascade dependent-task state changes based on the parent's terminal status.
 			//   - `blocked` (transient, retryable): only abort `in_progress` dependents.
@@ -2156,6 +2159,7 @@ export class SpaceRuntime {
 				const reason = params.result ?? updated.result ?? 'Task blocked';
 				if (params.blockReason === 'dependency_added') {
 					updated = await this.stopBlockedWorkflowTask(spaceId, updated, reason);
+					emitUpdated = false;
 					await this.safeNotify({
 						kind: 'task_blocked',
 						spaceId,
@@ -2196,6 +2200,9 @@ export class SpaceRuntime {
 						}
 					}
 				}
+			}
+			if (emitUpdated) {
+				await this.safeOnTaskUpdated(spaceId, updated, opts);
 			}
 		}
 		return updated;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2092,8 +2092,8 @@ export class SpaceRuntime {
 		spaceId: string,
 		task: SpaceTask,
 		reason: string
-	): Promise<void> {
-		if (!task.workflowRunId) return;
+	): Promise<SpaceTask> {
+		if (!task.workflowRunId) return task;
 
 		const run = this.config.workflowRunRepo.getRun(task.workflowRunId);
 		if (run && canTransitionRunStatus(run.status, 'blocked')) {
@@ -2120,13 +2120,13 @@ export class SpaceRuntime {
 		}
 		const cleared = this.config.taskRepo.updateTask(task.id, {
 			taskAgentSessionId: null,
-			workflowRunId: null,
 		});
 		if (cleared) {
 			await this.safeOnTaskUpdated(spaceId, cleared);
 		}
 		this.clearRunInterests(task.workflowRunId);
 		this.clearAgentStuckStateForRun(task.workflowRunId);
+		return cleared ?? task;
 	}
 
 	async blockWorkflowBackedTask(
@@ -2143,7 +2143,7 @@ export class SpaceRuntime {
 		params: UpdateSpaceTaskParams,
 		opts?: { archiveSource?: 'user' | 'system_reconcile' }
 	): Promise<SpaceTask | null> {
-		const updated = this.config.taskRepo.updateTask(taskId, params);
+		let updated = this.config.taskRepo.updateTask(taskId, params);
 		if (updated) {
 			await this.safeOnTaskUpdated(spaceId, updated, opts);
 
@@ -2156,7 +2156,7 @@ export class SpaceRuntime {
 			if (params.status === 'blocked') {
 				const reason = params.result ?? updated.result ?? 'Task blocked';
 				if (params.blockReason === 'dependency_added') {
-					await this.stopBlockedWorkflowTask(spaceId, updated, reason);
+					updated = await this.stopBlockedWorkflowTask(spaceId, updated, reason);
 					await this.safeNotify({
 						kind: 'task_blocked',
 						spaceId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2213,7 +2213,7 @@ export class SpaceRuntime {
 				{
 					...updated,
 					workflowRunId: previous.workflowRunId,
-					taskAgentSessionId: previous.taskAgentSessionId ?? updated.taskAgentSessionId,
+					taskAgentSessionId: previous.taskAgentSessionId,
 				},
 				reason
 			);
@@ -2282,7 +2282,7 @@ export class SpaceRuntime {
 						{
 							...updated,
 							workflowRunId: previous?.workflowRunId ?? updated.workflowRunId,
-							taskAgentSessionId: previous?.taskAgentSessionId ?? updated.taskAgentSessionId,
+							taskAgentSessionId: previous?.taskAgentSessionId,
 						},
 						reason
 					);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2124,7 +2124,6 @@ export class SpaceRuntime {
 		if (cleared) {
 			await this.safeOnTaskUpdated(spaceId, cleared);
 		}
-		this.clearRunInterests(task.workflowRunId);
 		this.clearAgentStuckStateForRun(task.workflowRunId);
 		return cleared ?? task;
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2088,6 +2088,55 @@ export class SpaceRuntime {
 		return spaces.filter((s) => !s.paused && !s.stopped);
 	}
 
+	private async stopBlockedWorkflowTask(
+		spaceId: string,
+		task: SpaceTask,
+		reason: string
+	): Promise<void> {
+		if (!task.workflowRunId) return;
+
+		const run = this.config.workflowRunRepo.getRun(task.workflowRunId);
+		if (run && canTransitionRunStatus(run.status, 'blocked')) {
+			await this.transitionRunStatusAndEmit(run.id, 'blocked');
+		}
+
+		const now = Date.now();
+		for (const execution of this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId)) {
+			if (execution.agentSessionId) {
+				this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
+			}
+			if (execution.status !== 'cancelled') {
+				this.config.nodeExecutionRepo.update(execution.id, {
+					status: 'cancelled',
+					agentSessionId: null,
+					result: reason,
+					completedAt: now,
+				});
+			}
+		}
+
+		if (task.taskAgentSessionId) {
+			this.config.taskAgentManager?.cancelBySessionId(task.taskAgentSessionId);
+		}
+		const cleared = this.config.taskRepo.updateTask(task.id, {
+			taskAgentSessionId: null,
+			workflowRunId: null,
+		});
+		if (cleared) {
+			await this.safeOnTaskUpdated(spaceId, cleared);
+		}
+		this.clearRunInterests(task.workflowRunId);
+		this.clearAgentStuckStateForRun(task.workflowRunId);
+	}
+
+	async blockWorkflowBackedTask(
+		spaceId: string,
+		taskId: string,
+		params: UpdateSpaceTaskParams
+	): Promise<SpaceTask | null> {
+		return this.updateTaskAndEmit(spaceId, taskId, params);
+	}
+
 	private async updateTaskAndEmit(
 		spaceId: string,
 		taskId: string,
@@ -2105,6 +2154,26 @@ export class SpaceRuntime {
 			//   - `cancelled` (terminal, will not auto-resume): cancel both `open` and
 			//     `in_progress` dependents so they don't wait forever on an unmet dep.
 			if (params.status === 'blocked') {
+				const reason = params.result ?? updated.result ?? 'Task blocked';
+				if (params.blockReason === 'dependency_added') {
+					await this.stopBlockedWorkflowTask(spaceId, updated, reason);
+					await this.safeNotify({
+						kind: 'task_blocked',
+						spaceId,
+						taskId: updated.id,
+						reason,
+						timestamp: new Date().toISOString(),
+					});
+					if (updated.workflowRunId) {
+						await this.safeNotify({
+							kind: 'workflow_run_blocked',
+							spaceId,
+							runId: updated.workflowRunId,
+							reason,
+							timestamp: new Date().toISOString(),
+						});
+					}
+				}
 				const taskManager = this.getOrCreateTaskManager(spaceId);
 				const cascaded = await taskManager.blockDependentTasks(taskId);
 				for (const blocked of cascaded) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2145,6 +2145,7 @@ export class SpaceRuntime {
 		params: UpdateSpaceTaskParams,
 		opts?: { archiveSource?: 'user' | 'system_reconcile' }
 	): Promise<SpaceTask | null> {
+		const previous = this.config.taskRepo.getTask(taskId);
 		let updated = this.config.taskRepo.updateTask(taskId, params);
 		if (updated) {
 			let emitUpdated = true;
@@ -2158,7 +2159,14 @@ export class SpaceRuntime {
 			if (params.status === 'blocked') {
 				const reason = params.result ?? updated.result ?? 'Task blocked';
 				if (params.blockReason === 'dependency_added') {
-					updated = await this.stopBlockedWorkflowTask(spaceId, updated, reason);
+					updated = await this.stopBlockedWorkflowTask(
+						spaceId,
+						{
+							...updated,
+							taskAgentSessionId: previous?.taskAgentSessionId ?? updated.taskAgentSessionId,
+						},
+						reason
+					);
 					emitUpdated = false;
 					await this.safeNotify({
 						kind: 'task_blocked',

--- a/packages/daemon/src/lib/utils/array-utils.ts
+++ b/packages/daemon/src/lib/utils/array-utils.ts
@@ -1,0 +1,6 @@
+export function arraysEqual(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return false;
+	const sortedA = [...a].sort();
+	const sortedB = [...b].sort();
+	return sortedA.every((value, index) => value === sortedB[index]);
+}

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -769,6 +769,72 @@ describe('space-task-handlers', () => {
 			});
 		});
 
+		it('routes workflow-backed pause transitions through runtime cleanup', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'task-session-1',
+			};
+			const pausedTask = {
+				...activeTask,
+				status: 'open' as const,
+				taskAgentSessionId: undefined,
+			};
+			const runtime = {
+				stopWorkflowBackedTaskForStatus: mock(async () => pausedTask),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'open',
+			});
+
+			expect(result).toEqual(pausedTask);
+			expect(runtime.stopWorkflowBackedTaskForStatus).toHaveBeenCalledWith('space-1', 'task-1', {
+				status: 'open',
+			});
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect(internalEventBus.publish).not.toHaveBeenCalledWith(
+				'space.task.updated',
+				expect.objectContaining({ taskId: 'task-1' })
+			);
+		});
+
+		it('routes workflow-backed blocked task cancellation through runtime cleanup', async () => {
+			const blockedTask = {
+				...mockTask,
+				status: 'blocked' as const,
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'task-session-1',
+			};
+			const cancelledTask = {
+				...blockedTask,
+				status: 'cancelled' as const,
+				taskAgentSessionId: undefined,
+			};
+			const runtime = {
+				stopWorkflowBackedTaskForStatus: mock(async () => cancelledTask),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, blockedTask, runtime);
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'cancelled',
+				cancelReason: 'user cancelled',
+			});
+
+			expect(result).toEqual(cancelledTask);
+			expect(runtime.stopWorkflowBackedTaskForStatus).toHaveBeenCalledWith('space-1', 'task-1', {
+				status: 'cancelled',
+				cancelReason: 'user cancelled',
+			});
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+		});
+
 		it('routes unmet dependency updates for workflow-backed in-progress tasks through runtime', async () => {
 			const activeTask = {
 				...mockTask,

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -858,6 +858,54 @@ describe('space-task-handlers', () => {
 			expect((result as SpaceTask).status).toBe('blocked');
 		});
 
+		it('does not pre-check overwrite runtime pointers before dependency block cleanup', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'task-session-1',
+				dependsOn: ['dep-done'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => ({
+					...activeTask,
+					dependsOn: ['dep-open'],
+					status: 'blocked' as const,
+					blockReason: 'dependency_added' as const,
+				})),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+			(taskManager.updateTask as ReturnType<typeof mock>).mockResolvedValue({
+				...activeTask,
+				dependsOn: ['dep-open'],
+				status: 'blocked' as const,
+				blockReason: 'dependency_added' as const,
+			});
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-open'],
+				taskAgentSessionId: null,
+				workflowRunId: null,
+			});
+
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{ dependsOn: ['dep-open'] },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+			expect(runtime.stopWorkflowBackedTask).toHaveBeenCalledWith('space-1', 'task-1', {
+				dependsOn: ['dep-open'],
+				taskAgentSessionId: null,
+				workflowRunId: null,
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+			});
+		});
+
 		it('does not double-run goal terminal handling after runtime dependency block', async () => {
 			const activeTask = {
 				...mockTask,

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -969,6 +969,57 @@ describe('space-task-handlers', () => {
 			expect(taskManager.updateTask).toHaveBeenCalledTimes(1);
 		});
 
+		it('preserves pointer field updates on non-blocking dependency changes', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'task-session-1',
+				dependsOn: ['dep-old'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => activeTask),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+			(taskManager.updateTask as ReturnType<typeof mock>)
+				.mockResolvedValueOnce({
+					...activeTask,
+					dependsOn: ['dep-done'],
+					status: 'in_progress' as const,
+				})
+				.mockResolvedValueOnce({
+					...activeTask,
+					dependsOn: ['dep-done'],
+					taskAgentSessionId: 'replacement-session',
+					workflowRunId: 'replacement-run',
+					status: 'in_progress' as const,
+				});
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-done'],
+				taskAgentSessionId: 'replacement-session',
+				workflowRunId: 'replacement-run',
+			});
+
+			expect(runtime.stopWorkflowBackedTask).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).toHaveBeenNthCalledWith(
+				1,
+				'task-1',
+				{ dependsOn: ['dep-done'] },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+			expect(taskManager.updateTask).toHaveBeenNthCalledWith(
+				2,
+				'task-1',
+				{ taskAgentSessionId: 'replacement-session', workflowRunId: 'replacement-run' },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+			expect((result as SpaceTask).taskAgentSessionId).toBe('replacement-session');
+			expect((result as SpaceTask).workflowRunId).toBe('replacement-run');
+		});
+
 		it('keeps non-workflow dependency updates on normal updateTask path', async () => {
 			const activeTask = {
 				...mockTask,

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -761,6 +761,102 @@ describe('space-task-handlers', () => {
 			});
 		});
 
+		it('routes unmet dependency updates for workflow-backed in-progress tasks through runtime', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				dependsOn: ['dep-done'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => ({
+					...activeTask,
+					dependsOn: ['dep-open'],
+					status: 'blocked' as const,
+					blockReason: 'dependency_added' as const,
+				})),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+			(taskManager.updateTask as ReturnType<typeof mock>).mockResolvedValue({
+				...activeTask,
+				dependsOn: ['dep-open'],
+				status: 'blocked' as const,
+				blockReason: 'dependency_added' as const,
+			});
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-open'],
+			});
+
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{ dependsOn: ['dep-open'] },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+			expect(runtime.stopWorkflowBackedTask).toHaveBeenCalledWith('space-1', 'task-1', {
+				dependsOn: ['dep-open'],
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+			});
+			expect((result as SpaceTask).status).toBe('blocked');
+		});
+
+		it('keeps met dependency updates on normal updateTask path', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				dependsOn: ['dep-old'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => activeTask),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+			(taskManager.updateTask as ReturnType<typeof mock>).mockResolvedValue({
+				...activeTask,
+				dependsOn: ['dep-done'],
+				status: 'in_progress' as const,
+			});
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-done'],
+			});
+
+			expect(runtime.stopWorkflowBackedTask).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).toHaveBeenCalledTimes(1);
+		});
+
+		it('keeps non-workflow dependency updates on normal updateTask path', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				dependsOn: ['dep-old'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => activeTask),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-open'],
+			});
+
+			expect(runtime.stopWorkflowBackedTask).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{ dependsOn: ['dep-open'] },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+		});
+
 		it('publishes space.task.updated for cascaded dependency changes', async () => {
 			const cascadedTask = {
 				...mockTask,

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -140,7 +140,8 @@ describe('space-task-handlers', () => {
 	function setup(
 		space: Space | null = mockSpace,
 		task: SpaceTask | null = mockTask,
-		runtime?: SpaceRuntimeService
+		runtime?: SpaceRuntimeService,
+		goalService?: { handleTaskTerminal: (taskId: string) => void }
 	) {
 		const mh = createMockMessageHub();
 		hub = mh.hub;
@@ -149,7 +150,14 @@ describe('space-task-handlers', () => {
 		spaceManager = createMockSpaceManager(space);
 		taskManager = createMockTaskManager(task);
 		taskManagerFactory = mock((_spaceId: string) => taskManager);
-		setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, internalEventBus, runtime);
+		setupSpaceTaskHandlers(
+			hub,
+			spaceManager,
+			taskManagerFactory,
+			internalEventBus,
+			runtime,
+			goalService
+		);
 	}
 
 	const call = (method: string, data: unknown) => {
@@ -803,6 +811,42 @@ describe('space-task-handlers', () => {
 				completedAt: null,
 			});
 			expect((result as SpaceTask).status).toBe('blocked');
+		});
+
+		it('does not double-run goal terminal handling after runtime dependency block', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				dependsOn: ['dep-done'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => ({
+					...activeTask,
+					dependsOn: ['dep-open'],
+					status: 'blocked' as const,
+					blockReason: 'dependency_added' as const,
+				})),
+			} as unknown as SpaceRuntimeService;
+			const goalService = {
+				handleTaskTerminal: mock(() => {}),
+			};
+			setup(mockSpace, activeTask, runtime, goalService);
+			(taskManager.updateTask as ReturnType<typeof mock>).mockResolvedValue({
+				...activeTask,
+				dependsOn: ['dep-open'],
+				status: 'blocked' as const,
+				blockReason: 'dependency_added' as const,
+			});
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				dependsOn: ['dep-open'],
+			});
+
+			expect(runtime.stopWorkflowBackedTask).toHaveBeenCalledTimes(1);
+			expect(goalService.handleTaskTerminal).not.toHaveBeenCalled();
 		});
 
 		it('keeps met dependency updates on normal updateTask path', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -813,6 +813,51 @@ describe('space-task-handlers', () => {
 			expect((result as SpaceTask).status).toBe('blocked');
 		});
 
+		it('routes same-status unmet dependency updates through runtime', async () => {
+			const activeTask = {
+				...mockTask,
+				status: 'in_progress' as const,
+				workflowRunId: 'run-1',
+				dependsOn: ['dep-done'],
+			};
+			const runtime = {
+				stopWorkflowBackedTask: mock(async () => ({
+					...activeTask,
+					dependsOn: ['dep-open'],
+					status: 'blocked' as const,
+					blockReason: 'dependency_added' as const,
+				})),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, activeTask, runtime);
+			(taskManager.updateTask as ReturnType<typeof mock>).mockResolvedValue({
+				...activeTask,
+				dependsOn: ['dep-open'],
+				status: 'blocked' as const,
+				blockReason: 'dependency_added' as const,
+			});
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'in_progress',
+				dependsOn: ['dep-open'],
+			});
+
+			expect(taskManager.updateTask).toHaveBeenCalledWith(
+				'task-1',
+				{ status: 'in_progress', dependsOn: ['dep-open'] },
+				expect.objectContaining({ onCascadedTasks: expect.any(Function) })
+			);
+			expect(runtime.stopWorkflowBackedTask).toHaveBeenCalledWith('space-1', 'task-1', {
+				status: 'blocked',
+				dependsOn: ['dep-open'],
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+			});
+			expect((result as SpaceTask).status).toBe('blocked');
+		});
+
 		it('does not double-run goal terminal handling after runtime dependency block', async () => {
 			const activeTask = {
 				...mockTask,

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -201,6 +201,7 @@ function createMockRuntimeService(
 			if (!space) throw new Error(`Space not found: ${spaceId}`);
 			return runtime;
 		}),
+		cancelWorkflowRun: mock(async () => ({ ...mockRun, status: 'cancelled' as const })),
 		start: mock(() => {}),
 		stop: mock(() => {}),
 		stopRuntime: mock(() => {}),
@@ -621,104 +622,31 @@ describe('space-workflow-run-handlers', () => {
 			);
 		});
 
-		it('cancels the run and emits space.workflowRun.updated (no tasks)', async () => {
+		it('delegates cancellation to the runtime service', async () => {
 			setup({ tasks: [] });
 
 			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
 			expect(result).toEqual({ success: true });
 
-			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'cancelled');
-			expect(
-				(internalEventBus as unknown as { publish: ReturnType<typeof mock> }).publish
-			).toHaveBeenCalledWith('space.workflowRun.updated', {
-				sessionId: 'global',
-				spaceId: 'space-1',
-				runId: 'run-1',
-				run: expect.objectContaining({ status: 'cancelled' }),
-			});
+			expect(runtimeService.cancelWorkflowRun).toHaveBeenCalledWith('space-1', 'run-1');
+			expect(runRepo.transitionStatus).not.toHaveBeenCalled();
+			expect(taskManager.cancelTask).not.toHaveBeenCalled();
 		});
 
-		it('cancels open and in_progress tasks before cancelling the run', async () => {
+		it('does not cancel tasks in the RPC handler when delegating to runtime', async () => {
 			const inProgressTask: SpaceTask = {
 				...mockTask,
 				id: 'task-2',
 				status: 'in_progress',
 			};
-			const doneTask: SpaceTask = {
-				...mockTask,
-				id: 'task-3',
-				status: 'done',
-			};
-			setup({ tasks: [mockTask, inProgressTask, doneTask] });
+			setup({ tasks: [mockTask, inProgressTask] });
 
 			await call('spaceWorkflowRun.cancel', { id: 'run-1' });
 
-			// Factory should have been called with the run's spaceId
-			expect(taskManagerFactory).toHaveBeenCalledWith('space-1');
-
-			// cancelTask should be called for open and in_progress but not done
-			expect(taskManager.cancelTask).toHaveBeenCalledTimes(2);
-			expect(taskManager.cancelTask).toHaveBeenCalledWith('task-1');
-			expect(taskManager.cancelTask).toHaveBeenCalledWith('task-2');
-			// done task should not be cancelled
-			const callArgs = (taskManager.cancelTask as ReturnType<typeof mock>).mock.calls.map(
-				(c) => c[0]
-			);
-			expect(callArgs).not.toContain('task-3');
-
-			// Run should also be cancelled
-			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'cancelled');
-		});
-
-		it('continues cancelling remaining tasks even if one cancelTask fails', async () => {
-			const task2: SpaceTask = { ...mockTask, id: 'task-2', status: 'open' };
-			setup({ tasks: [mockTask, task2] });
-
-			// Make the first cancelTask fail
-			let callCount = 0;
-			taskManager = {
-				listTasksByWorkflowRun: mock(async () => [mockTask, task2]),
-				cancelTask: mock(async (taskId: string) => {
-					callCount++;
-					if (callCount === 1) throw new Error('cancel failed');
-					return { ...mockTask, id: taskId, status: 'cancelled' as const };
-				}),
-			} as unknown as SpaceTaskManager;
-			taskManagerFactory = mock(() => taskManager);
-
-			// Re-setup with new mocks
-			const mh = createMockMessageHub();
-			hub = mh.hub;
-			handlers = mh.handlers;
-			internalEventBus = createMockInternalEventBus();
-			spaceManager = createMockSpaceManager();
-			workflowManager = createMockWorkflowManager();
-			runRepo = createMockRunRepo();
-
-			setupSpaceWorkflowRunHandlers(
-				hub,
-				spaceManager,
-				workflowManager,
-				runRepo,
-				createMockGateDataRepo(),
-				createMockRuntimeService(),
-				taskManagerFactory,
-				internalEventBus,
-				createMockSpaceTaskRepo([mockTask]),
-				createMockSpaceWorktreeManager(),
-				createMockArtifactRepo(),
-				createMockArtifactCacheRepo(),
-				createMockJobQueue()
-			);
-
-			// Should not throw even though one cancelTask failed
-			const result = await call('spaceWorkflowRun.cancel', { id: 'run-1' });
-			expect(result).toEqual({ success: true });
-
-			// Both tasks were attempted
-			expect(taskManager.cancelTask).toHaveBeenCalledTimes(2);
-			// Run still gets cancelled
-			expect(runRepo.transitionStatus).toHaveBeenCalledWith('run-1', 'cancelled');
+			expect(runtimeService.cancelWorkflowRun).toHaveBeenCalledWith('space-1', 'run-1');
+			expect(taskManagerFactory).not.toHaveBeenCalled();
+			expect(taskManager.cancelTask).not.toHaveBeenCalled();
+			expect(runRepo.transitionStatus).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -616,6 +616,114 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(cancelledExecution.agentSessionId).toBeNull();
 		});
 
+		test('pausing a workflow-backed task stops node agents and clears task session pointer', async () => {
+			const tam = new MockTaskAgentManager();
+			const updates = new TaskUpdateCollector();
+			const rt = makeRuntime({
+				taskAgentManager: tam as never,
+				onTaskUpdated: async (event) => updates.handle(event),
+			});
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-pause', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-pause',
+			});
+			taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: 'task-session-pause',
+			});
+			updates.tasks.length = 0;
+
+			const paused = await rt.stopWorkflowBackedTaskForStatus(SPACE_ID, task.id, {
+				status: 'open',
+			});
+
+			expect(paused?.status).toBe('open');
+			expect(paused?.workflowRunId).toBe(run.id);
+			expect(paused?.taskAgentSessionId).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
+			expect(tam.cancelledSessions).toEqual(['node-session-pause', 'task-session-pause']);
+			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+			expect(updates.tasks).toHaveLength(1);
+			expect(updates.tasks[0].status).toBe('open');
+			expect(updates.tasks[0].taskAgentSessionId).toBeUndefined();
+		});
+
+		test('cancelling a workflow-backed task stops sessions and cancels run', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-cancel-task', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-cancel-task',
+			});
+			taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: 'task-session-cancel-task',
+			});
+
+			const cancelled = await rt.stopWorkflowBackedTaskForStatus(SPACE_ID, task.id, {
+				status: 'cancelled',
+				cancelReason: 'user cancelled',
+			});
+
+			expect(cancelled?.status).toBe('cancelled');
+			expect(cancelled?.approvalReason).toBe('user cancelled');
+			expect(cancelled?.workflowRunId).toBe(run.id);
+			expect(cancelled?.taskAgentSessionId).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
+			expect(tam.cancelledSessions).toEqual([
+				'node-session-cancel-task',
+				'task-session-cancel-task',
+			]);
+			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+		});
+
+		test('cancelling a workflow run stops active task and node sessions', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-cancel-run', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-cancel-run',
+			});
+			taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: 'task-session-cancel-run',
+			});
+
+			const cancelledRun = await rt.cancelWorkflowRun(SPACE_ID, run.id);
+
+			expect(cancelledRun.status).toBe('cancelled');
+			const cancelledTask = taskRepo.getTask(task.id)!;
+			expect(cancelledTask.status).toBe('cancelled');
+			expect(cancelledTask.workflowRunId).toBe(run.id);
+			expect(cancelledTask.taskAgentSessionId).toBeUndefined();
+			expect(tam.cancelledSessions).toEqual(['node-session-cancel-run', 'task-session-cancel-run']);
+			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+		});
+
 		test('preserves completed executions and emits only post-cleanup task update', async () => {
 			const tam = new MockTaskAgentManager();
 			const updates = new TaskUpdateCollector();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
+import type { SpaceTask } from '@neokai/shared';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
@@ -128,6 +129,14 @@ class MockTaskAgentManager {
 
 	cancelBySessionId(sessionId: string): void {
 		this.cancelledSessions.push(sessionId);
+	}
+}
+
+class TaskUpdateCollector {
+	readonly tasks: SpaceTask[] = [];
+
+	handle({ task }: { task: SpaceTask }): void {
+		this.tasks.push(task);
 	}
 }
 
@@ -565,6 +574,58 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(clearedTask.taskAgentSessionId).toBeUndefined();
 			expect(collector.events.filter((e) => e.kind === 'task_blocked')).toHaveLength(1);
 			expect(collector.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);
+		});
+
+		test('preserves completed executions and emits only post-cleanup task update', async () => {
+			const tam = new MockTaskAgentManager();
+			const updates = new TaskUpdateCollector();
+			const rt = makeRuntime({
+				taskAgentManager: tam as never,
+				onTaskUpdated: async (event) => updates.handle(event),
+			});
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-complete', name: 'Completed Step', agentId: AGENT },
+				{ id: 'step-active', name: 'Active Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [firstExecution] = nodeExecutionRepo.listByNode(run.id, 'step-complete');
+			nodeExecutionRepo.update(firstExecution.id, {
+				status: 'idle',
+				result: 'completed output',
+				completedAt: Date.now() - 1000,
+			});
+			const activeExecution = nodeExecutionRepo.create({
+				workflowRunId: run.id,
+				workflowNodeId: 'step-active',
+				agentName: 'agent-1',
+				agentId: AGENT,
+				status: 'in_progress',
+				agentSessionId: 'node-session-2',
+			});
+			taskRepo.updateTask(task.id, { taskAgentSessionId: 'task-session-2' });
+			updates.tasks.length = 0;
+
+			const blocked = await rt.blockWorkflowBackedTask(SPACE_ID, task.id, {
+				dependsOn: ['missing-dep'],
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+			});
+
+			expect(blocked?.taskAgentSessionId).toBeUndefined();
+			expect(updates.tasks).toHaveLength(1);
+			expect(updates.tasks[0].status).toBe('blocked');
+			expect(updates.tasks[0].taskAgentSessionId).toBeUndefined();
+			const preservedExecution = nodeExecutionRepo.getById(firstExecution.id)!;
+			expect(preservedExecution.status).toBe('idle');
+			expect(preservedExecution.result).toBe('completed output');
+			expect(preservedExecution.agentSessionId).toBeNull();
+			const cancelledExecution = nodeExecutionRepo.getById(activeExecution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+			expect(tam.cancelledSessions).toEqual(['node-session-2', 'task-session-2']);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -576,6 +576,33 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(collector.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);
 		});
 
+		test('cancels original task session when block payload overwrites taskAgentSessionId', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-session-overwrite', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			taskRepo.updateTask(task.id, { taskAgentSessionId: 'original-task-session' });
+
+			const blocked = await rt.blockWorkflowBackedTask(SPACE_ID, task.id, {
+				dependsOn: ['missing-dep'],
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+				taskAgentSessionId: 'payload-task-session',
+			});
+
+			expect(blocked?.status).toBe('blocked');
+			expect(blocked?.taskAgentSessionId).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(tam.cancelledSessions).toContain('original-task-session');
+			expect(tam.cancelledSessions).not.toContain('payload-task-session');
+			expect(taskRepo.getTask(task.id)?.taskAgentSessionId).toBeUndefined();
+		});
+
 		test('preserves completed executions and emits only post-cleanup task update', async () => {
 			const tam = new MockTaskAgentManager();
 			const updates = new TaskUpdateCollector();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -576,14 +576,19 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(collector.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);
 		});
 
-		test('cancels original task session when block payload overwrites taskAgentSessionId', async () => {
+		test('uses original runtime pointers when block payload overwrites them', async () => {
 			const tam = new MockTaskAgentManager();
 			const rt = makeRuntime({ taskAgentManager: tam as never });
 			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
-				{ id: 'step-session-overwrite', name: 'Only Step', agentId: AGENT },
+				{ id: 'step-pointer-overwrite', name: 'Only Step', agentId: AGENT },
 			]);
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
 			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-1',
+			});
 			taskRepo.updateTask(task.id, { taskAgentSessionId: 'original-task-session' });
 
 			const blocked = await rt.blockWorkflowBackedTask(SPACE_ID, task.id, {
@@ -593,14 +598,22 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 				result: 'Dependency added while task was in progress',
 				completedAt: null,
 				taskAgentSessionId: 'payload-task-session',
+				workflowRunId: null,
 			});
 
 			expect(blocked?.status).toBe('blocked');
+			expect(blocked?.workflowRunId).toBe(run.id);
 			expect(blocked?.taskAgentSessionId).toBeUndefined();
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(tam.cancelledSessions).toContain('node-session-1');
 			expect(tam.cancelledSessions).toContain('original-task-session');
 			expect(tam.cancelledSessions).not.toContain('payload-task-session');
-			expect(taskRepo.getTask(task.id)?.taskAgentSessionId).toBeUndefined();
+			const clearedTask = taskRepo.getTask(task.id)!;
+			expect(clearedTask.workflowRunId).toBe(run.id);
+			expect(clearedTask.taskAgentSessionId).toBeUndefined();
+			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
 		});
 
 		test('preserves completed executions and emits only post-cleanup task update', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -123,6 +123,14 @@ function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
 	).run(agentId, spaceId, `Agent ${agentId}`, Date.now(), Date.now());
 }
 
+class MockTaskAgentManager {
+	readonly cancelledSessions: string[] = [];
+
+	cancelBySessionId(sessionId: string): void {
+		this.cancelledSessions.push(sessionId);
+	}
+}
+
 function buildLinearWorkflow(
 	spaceId: string,
 	workflowManager: SpaceWorkflowManager,
@@ -516,7 +524,50 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// 5. External run cancellation — no stale notifications
+	// 5. Workflow-backed dependency block cleanup
+	// -------------------------------------------------------------------------
+
+	describe('workflow-backed dependency block cleanup', () => {
+		test('blocking an in-progress workflow task stops run and active node agents', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-dep-block', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-1',
+			});
+			taskRepo.updateTask(task.id, { taskAgentSessionId: 'task-session-1' });
+
+			const blocked = await rt.blockWorkflowBackedTask(SPACE_ID, task.id, {
+				dependsOn: ['missing-dep'],
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+			});
+
+			expect(blocked?.status).toBe('blocked');
+			expect(blocked?.blockReason).toBe('dependency_added');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(tam.cancelledSessions).toEqual(['node-session-1', 'task-session-1']);
+			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+			const clearedTask = taskRepo.getTask(task.id)!;
+			expect(clearedTask.workflowRunId).toBeUndefined();
+			expect(clearedTask.taskAgentSessionId).toBeUndefined();
+			expect(collector.events.filter((e) => e.kind === 'task_blocked')).toHaveLength(1);
+			expect(collector.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// 6. External run cancellation — no stale notifications
 	// -------------------------------------------------------------------------
 
 	describe('external run cancellation — no stale notifications', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -646,7 +646,7 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(paused?.status).toBe('open');
 			expect(paused?.workflowRunId).toBe(run.id);
 			expect(paused?.taskAgentSessionId).toBeUndefined();
-			expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(tam.cancelledSessions).toEqual(['node-session-pause', 'task-session-pause']);
 			const cancelledExecution = nodeExecutionRepo.getById(execution.id)!;
 			expect(cancelledExecution.status).toBe('cancelled');
@@ -654,6 +654,66 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(updates.tasks).toHaveLength(1);
 			expect(updates.tasks[0].status).toBe('open');
 			expect(updates.tasks[0].taskAgentSessionId).toBeUndefined();
+		});
+
+		test('pausing a workflow-backed task preserves idle execution history', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-pause-idle', name: 'Idle Step', agentId: AGENT },
+				{ id: 'step-pause-active', name: 'Active Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [idleExecution] = nodeExecutionRepo.listByNode(run.id, 'step-pause-idle');
+			nodeExecutionRepo.update(idleExecution.id, {
+				status: 'idle',
+				agentSessionId: 'idle-session-pause',
+				result: 'idle output',
+				completedAt: Date.now() - 1000,
+			});
+			const activeExecution = nodeExecutionRepo.create({
+				workflowRunId: run.id,
+				workflowNodeId: 'step-pause-active',
+				agentName: 'agent-1',
+				agentId: AGENT,
+				status: 'in_progress',
+				agentSessionId: 'active-session-pause',
+			});
+			taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: 'task-session-pause-idle',
+			});
+
+			await rt.stopWorkflowBackedTaskForStatus(SPACE_ID, task.id, { status: 'open' });
+
+			const preservedExecution = nodeExecutionRepo.getById(idleExecution.id)!;
+			expect(preservedExecution.status).toBe('idle');
+			expect(preservedExecution.agentSessionId).toBe('idle-session-pause');
+			expect(preservedExecution.result).toBe('idle output');
+			const cancelledExecution = nodeExecutionRepo.getById(activeExecution.id)!;
+			expect(cancelledExecution.status).toBe('cancelled');
+			expect(cancelledExecution.agentSessionId).toBeNull();
+			expect(tam.cancelledSessions).toEqual(['active-session-pause', 'task-session-pause-idle']);
+		});
+
+		test('validates metadata fields when stopping workflow-backed task status', async () => {
+			const rt = makeRuntime();
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-status-metadata', name: 'Only Step', agentId: AGENT },
+			]);
+			const { tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			taskRepo.updateTask(task.id, { status: 'in_progress' });
+
+			await expect(
+				rt.stopWorkflowBackedTaskForStatus(SPACE_ID, task.id, {
+					status: 'cancelled',
+					dependsOn: [task.id],
+				})
+			).rejects.toThrow('A task cannot depend on itself');
+			expect(taskRepo.getTask(task.id)?.dependsOn).toEqual([]);
+			expect(taskRepo.getTask(task.id)?.status).toBe('cancelled');
 		});
 
 		test('cancelling a workflow-backed task stops sessions and cancels run', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -559,7 +559,9 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(cancelledExecution.status).toBe('cancelled');
 			expect(cancelledExecution.agentSessionId).toBeNull();
 			const clearedTask = taskRepo.getTask(task.id)!;
-			expect(clearedTask.workflowRunId).toBeUndefined();
+			expect(blocked?.workflowRunId).toBe(run.id);
+			expect(blocked?.taskAgentSessionId).toBeUndefined();
+			expect(clearedTask.workflowRunId).toBe(run.id);
 			expect(clearedTask.taskAgentSessionId).toBeUndefined();
 			expect(collector.events.filter((e) => e.kind === 'task_blocked')).toHaveLength(1);
 			expect(collector.events.filter((e) => e.kind === 'workflow_run_blocked')).toHaveLength(1);

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -616,6 +616,34 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(cancelledExecution.agentSessionId).toBeNull();
 		});
 
+		test('ignores payload task session when dependency-block task had no session pointer', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-dep-payload-session', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-dep-payload-ignore',
+			});
+			taskRepo.updateTask(task.id, { taskAgentSessionId: null });
+
+			await rt.blockWorkflowBackedTask(SPACE_ID, task.id, {
+				dependsOn: ['missing-dep'],
+				status: 'blocked',
+				blockReason: 'dependency_added',
+				result: 'Dependency added while task was in progress',
+				completedAt: null,
+				taskAgentSessionId: 'unrelated-session',
+			});
+
+			expect(tam.cancelledSessions).toEqual(['node-session-dep-payload-ignore']);
+			expect(tam.cancelledSessions).not.toContain('unrelated-session');
+		});
+
 		test('pausing a workflow-backed task stops node agents and clears task session pointer', async () => {
 			const tam = new MockTaskAgentManager();
 			const updates = new TaskUpdateCollector();
@@ -695,6 +723,34 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			expect(cancelledExecution.status).toBe('cancelled');
 			expect(cancelledExecution.agentSessionId).toBeNull();
 			expect(tam.cancelledSessions).toEqual(['active-session-pause', 'task-session-pause-idle']);
+		});
+
+		test('ignores payload task session when status-stop task had no session pointer', async () => {
+			const tam = new MockTaskAgentManager();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
+			const wf = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'step-status-payload-session', name: 'Only Step', agentId: AGENT },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, wf.id, 'Run');
+			const task = tasks[0];
+			const [execution] = nodeExecutionRepo.listByWorkflowRun(run.id);
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'node-session-payload-ignore',
+			});
+			taskRepo.updateTask(task.id, {
+				status: 'in_progress',
+				taskAgentSessionId: null,
+			});
+
+			const cancelled = await rt.stopWorkflowBackedTaskForStatus(SPACE_ID, task.id, {
+				status: 'cancelled',
+				taskAgentSessionId: 'unrelated-session',
+			});
+
+			expect(cancelled?.taskAgentSessionId).toBeUndefined();
+			expect(tam.cancelledSessions).toEqual(['node-session-payload-ignore']);
+			expect(tam.cancelledSessions).not.toContain('unrelated-session');
 		});
 
 		test('validates metadata fields when stopping workflow-backed task status', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -93,6 +93,10 @@ class MockTaskAgentManager {
 
 	async tryResumeNodeAgentSession(): Promise<void> {}
 
+	cancelBySessionId(sessionId: string): void {
+		this.alive.delete(sessionId);
+	}
+
 	async prepareSubSessionForWorkflowResume(): Promise<boolean> {
 		return true;
 	}
@@ -127,7 +131,10 @@ describe('SpaceRuntime external event subscriptions', () => {
 	let tam: MockTaskAgentManager;
 	let bus: ReturnType<typeof createDaemonInternalEventBus>;
 
-	function createWorkflow(nodeId = 'code'): SpaceWorkflow {
+	function createWorkflow(
+		nodeId = 'code',
+		options: { eventInterests?: Array<{ topic: string }> } = {}
+	): SpaceWorkflow {
 		return workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Workflow ${Math.random()}`,
@@ -140,6 +147,7 @@ describe('SpaceRuntime external event subscriptions', () => {
 						{
 							agentId: AGENT_ID,
 							name: 'coder',
+							...(options.eventInterests ? { eventInterests: options.eventInterests } : {}),
 						},
 					],
 				},
@@ -157,16 +165,22 @@ describe('SpaceRuntime external event subscriptions', () => {
 	 */
 	async function startRunWithSubscription(
 		topic = DEFAULT_TOPIC,
-		nodeId = 'code'
+		nodeId = 'code',
+		options: { staticInterest?: boolean } = {}
 	): Promise<{
 		workflow: SpaceWorkflow;
 		run: Awaited<ReturnType<typeof runtime.startWorkflowRun>>['run'];
 		task: SpaceTask;
 	}> {
-		const workflow = createWorkflow(nodeId);
+		const workflow = createWorkflow(
+			nodeId,
+			options.staticInterest ? { eventInterests: [{ topic }] } : {}
+		);
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 		const task = tasks[0]!;
-		runtime.registerSubscription(run.id, task.id, nodeId, 'coder', topic);
+		if (!options.staticInterest) {
+			runtime.registerSubscription(run.id, task.id, nodeId, 'coder', topic);
+		}
 		return { workflow, run, task };
 	}
 
@@ -454,6 +468,51 @@ describe('SpaceRuntime external event subscriptions', () => {
 		expect(eventStore.listDeliveries(event.id)).toHaveLength(1);
 		expect(injected).toHaveLength(1);
 		expect(injected[0]!.sessionId).toBe('session-dedupe');
+		expect(eventStore.getById(event.id)?.state).toBe('delivered');
+	});
+
+	test('preserves subscriptions across dependency-added block and recovery', async () => {
+		const { run, task } = await startRunWithSubscription(DEFAULT_TOPIC);
+		const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+		nodeExecutionRepo.update(execution.id, {
+			status: 'in_progress',
+			agentSessionId: 'session-before-block',
+			startedAt: Date.now(),
+		});
+		tam.alive.add('session-before-block');
+
+		await runtime.blockWorkflowBackedTask(SPACE_ID, task.id, {
+			status: 'blocked',
+			blockReason: 'dependency_added',
+			result: 'Dependency added while task was in progress',
+			completedAt: null,
+		});
+		const blockedEvent = makeEvent({
+			id: 'evt-blocked-preserved-subscription',
+			dedupeKey: 'dedupe-blocked-preserved-subscription',
+		});
+		await eventService.publish(blockedEvent);
+		expect(eventStore.getById(blockedEvent.id)?.state).toBe('published');
+		expect(eventStore.listDeliveries(blockedEvent.id)).toHaveLength(0);
+
+		await runtime.recoverWorkflowBackedTask(SPACE_ID, task.id, 'in_progress');
+		const recoveredExecution = [...nodeExecutionRepo.listByNode(run.id, 'code')]
+			.filter((execution) => execution.completedAt === null && execution.status !== 'cancelled')
+			.sort((a, b) => b.updatedAt - a.updatedAt)[0]!;
+		const sessionId = recoveredExecution.agentSessionId ?? 'session-after-recover';
+		nodeExecutionRepo.update(recoveredExecution.id, {
+			status: 'in_progress',
+			agentSessionId: sessionId,
+			startedAt: Date.now(),
+			completedAt: null,
+		});
+		tam.alive.add(sessionId);
+
+		const event = makeEvent();
+		await eventService.publish(event);
+
+		expect(injected).toHaveLength(1);
+		expect(injected[0]!.sessionId).toBe(sessionId);
 		expect(eventStore.getById(event.id)?.state).toBe('delivered');
 	});
 


### PR DESCRIPTION
Fixes workflow-backed task updates when adding an unmet dependency to an in-progress task.

- Route dependency-added blocking through SpaceRuntime so workflow runs and node executions stop together
- Cancel active node/task sessions and clear task session/run pointers
- Add regression coverage for dependency blocking cleanup and emitted events

Tests:
- cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts tests/unit/5-space/runtime/task-dependency-enforcement.test.ts
- bun run check