### PR TITLE
Support dependencies for Forge task creation

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -73,11 +73,12 @@ export function setupSpaceTaskHandlers(
 		const {
 			spaceId,
 			draft,
+			id: _id,
 			goalId: _goalId,
 			createdBy: _cb,
 			createdBySession: _cbs,
 			...rest
-		} = params;
+		} = params as typeof params & { id?: unknown };
 
 		// The draft flag is an alias for status: 'draft'. Reject contradictory
 		// input instead of silently allowing status to override draft: true.

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -23,7 +23,7 @@ import type {
 	UpdateEvolutionLessonParams,
 	UpdateTaskProposalParams,
 } from '@neokai/shared';
-import { scoreEvolutionEvidenceQuality } from '@neokai/shared';
+import { generateUUID, scoreEvolutionEvidenceQuality } from '@neokai/shared';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
 import type { SpaceRepository } from '../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
@@ -111,6 +111,7 @@ export interface EvolutionEpisodeServiceDeps {
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	artifactRepo: WorkflowRunArtifactRepository;
 	goalService?: Pick<SpaceGoalService, 'getGoal' | 'updateGoal'>;
+	taskIdFactory?: () => string;
 	db?: BunDatabase;
 	taskCreatedEventHub?: {
 		publish: (event: string, data: Record<string, unknown>) => Promise<unknown>;
@@ -291,15 +292,15 @@ export class EvolutionEpisodeService {
 	): CreateTaskFromProposalResult {
 		const result = this.runAtomic(() => {
 			const existing = this.deps.evolutionRepo.getTaskProposal(id);
+			const taskId = this.deps.taskIdFactory?.() ?? generateUUID();
 			const dependsOn = params.dependsOn ?? [];
 			if (!existing) throw new Error(`TaskProposal not found: ${id}`);
 			const scope = this.requireScope(existing.scopeId);
-			for (const depId of dependsOn) {
-				const dep = this.deps.taskRepo.getTask(depId);
-				if (!dep || dep.spaceId !== scope.spaceId) {
-					throw new Error(`Dependency task not found in space: ${depId}`);
-				}
-			}
+			validateTaskDependencies({
+				taskId,
+				dependsOn,
+				tasks: this.deps.taskRepo.listBySpace(scope.spaceId, true),
+			});
 			if (existing.status === 'created' && existing.createdTaskId) {
 				const existingTask = this.deps.taskRepo.getTask(existing.createdTaskId);
 				if (existingTask) return { proposal: existing, task: existingTask, created: false };
@@ -328,6 +329,7 @@ export class EvolutionEpisodeService {
 			const priority = params.priority ?? existing.priority;
 			if (!title.trim()) throw new Error('title is required');
 			const task = this.deps.taskRepo.createTask({
+				id: taskId,
 				spaceId: scope.spaceId,
 				title,
 				description: buildProposalTaskDescription(description, reason, existing.evidenceEpisodeIds),
@@ -750,6 +752,52 @@ function buildProposalTaskDescription(
 		parts.push(`Forge evidence episodes:\n${evidenceEpisodeIds.map((id) => `- ${id}`).join('\n')}`);
 	}
 	return parts.filter(Boolean).join('\n\n');
+}
+
+function validateTaskDependencies(params: {
+	taskId: string;
+	dependsOn: string[];
+	tasks: SpaceTask[];
+}): void {
+	const taskIds = new Set(params.tasks.map((task) => task.id));
+	for (const depId of params.dependsOn) {
+		if (depId === params.taskId) throw new Error('A task cannot depend on itself');
+		if (!taskIds.has(depId)) throw new Error(`Dependency task not found in space: ${depId}`);
+	}
+	if (params.dependsOn.length === 0) return;
+
+	const adj = new Map<string, string[]>();
+	for (const task of params.tasks) {
+		adj.set(task.id, [...(task.dependsOn ?? [])]);
+	}
+	adj.set(params.taskId, [...params.dependsOn]);
+	if (hasDependencyCycle(adj)) {
+		throw new Error('Adding these dependencies would create a circular dependency');
+	}
+}
+
+function hasDependencyCycle(adj: Map<string, string[]>): boolean {
+	const white = 0;
+	const gray = 1;
+	const black = 2;
+	const color = new Map<string, number>();
+	for (const id of adj.keys()) color.set(id, white);
+
+	const dfs = (node: string): boolean => {
+		color.set(node, gray);
+		for (const neighbor of adj.get(node) ?? []) {
+			const state = color.get(neighbor);
+			if (state === gray) return true;
+			if (state === white && dfs(neighbor)) return true;
+		}
+		color.set(node, black);
+		return false;
+	};
+
+	for (const id of adj.keys()) {
+		if (color.get(id) === white && dfs(id)) return true;
+	}
+	return false;
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -81,6 +81,7 @@ export interface CreateTaskFromProposalParams {
 	description?: string;
 	reason?: string;
 	priority?: SpaceTaskPriority;
+	dependsOn?: string[];
 }
 
 export interface CreateTaskFromProposalResult {
@@ -290,7 +291,15 @@ export class EvolutionEpisodeService {
 	): CreateTaskFromProposalResult {
 		const result = this.runAtomic(() => {
 			const existing = this.deps.evolutionRepo.getTaskProposal(id);
+			const dependsOn = params.dependsOn ?? [];
 			if (!existing) throw new Error(`TaskProposal not found: ${id}`);
+			const scope = this.requireScope(existing.scopeId);
+			for (const depId of dependsOn) {
+				const dep = this.deps.taskRepo.getTask(depId);
+				if (!dep || dep.spaceId !== scope.spaceId) {
+					throw new Error(`Dependency task not found in space: ${depId}`);
+				}
+			}
 			if (existing.status === 'created' && existing.createdTaskId) {
 				const existingTask = this.deps.taskRepo.getTask(existing.createdTaskId);
 				if (existingTask) return { proposal: existing, task: existingTask, created: false };
@@ -313,7 +322,6 @@ export class EvolutionEpisodeService {
 				throw new Error('Task proposal is already being created');
 			}
 
-			const scope = this.requireScope(existing.scopeId);
 			const title = params.title?.trim() || existing.title;
 			const description = params.description?.trim() || existing.description;
 			const reason = params.reason?.trim() || existing.reason;
@@ -326,6 +334,7 @@ export class EvolutionEpisodeService {
 				priority,
 				goalId: scope.spaceGoalId,
 				evolutionScopeId: scope.id,
+				dependsOn,
 			});
 			const proposal = this.deps.evolutionRepo.updateTaskProposal(existing.id, {
 				title,

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -328,8 +328,7 @@ export class EvolutionEpisodeService {
 			const reason = params.reason?.trim() || existing.reason;
 			const priority = params.priority ?? existing.priority;
 			if (!title.trim()) throw new Error('title is required');
-			const task = this.deps.taskRepo.createTask({
-				id: taskId,
+			const task = this.deps.taskRepo.createTaskWithId(taskId, {
 				spaceId: scope.spaceId,
 				title,
 				description: buildProposalTaskDescription(description, reason, existing.evidenceEpisodeIds),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2294,6 +2294,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			description?: string;
 			reason?: string;
 			priority?: SpaceTaskPriority;
+			depends_on?: string[];
 		}): Promise<ToolResult> {
 			try {
 				requireTaskProposalInSpace(args.proposal_id);
@@ -2302,10 +2303,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					description: args.description,
 					reason: args.reason,
 					priority: args.priority,
+					dependsOn: args.depends_on,
 				});
 				logAudit(
 					'create_task_from_forge_proposal',
-					{ proposal_id: args.proposal_id },
+					{ proposal_id: args.proposal_id, depends_on: args.depends_on },
 					result.task.id
 				);
 				return jsonResult({ success: true, ...result });
@@ -3216,13 +3218,19 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 			),
 			tool(
 				'create_task_from_forge_proposal',
-				'Create a real SpaceTask from a Forge proposal, preserving linked goalId and evolutionScopeId. Idempotent when task already exists.',
+				'Create a real SpaceTask from a Forge proposal, preserving linked goalId and evolutionScopeId. Supports structured dependencies via depends_on so prerequisite checks are attached atomically before runtime pickup. Idempotent when task already exists.',
 				{
 					proposal_id: z.string().describe('TaskProposal ID'),
 					title: z.string().optional().describe('Optional edited task title'),
 					description: z.string().optional().describe('Optional edited task description'),
 					reason: z.string().optional().describe('Optional edited proposal reason'),
 					priority: prioritySchema.optional(),
+					depends_on: z
+						.array(z.string())
+						.optional()
+						.describe(
+							'List of task IDs this task depends on. All must be in the same space. Dependencies are persisted during task creation so the runtime cannot launch the task before they are attached.'
+						),
 				},
 				(args) => handlers.create_task_from_forge_proposal(args)
 			),

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -109,7 +109,7 @@ export class SpaceTaskRepository {
 	 * Create a new space task
 	 */
 	createTask(params: InternalCreateSpaceTaskParams): SpaceTask {
-		const id = generateUUID();
+		const id = params.id ?? generateUUID();
 		const now = Date.now();
 
 		// Wrap SELECT MAX + INSERT in an explicit transaction to prevent concurrent

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -109,7 +109,10 @@ export class SpaceTaskRepository {
 	 * Create a new space task
 	 */
 	createTask(params: InternalCreateSpaceTaskParams): SpaceTask {
-		const id = params.id ?? generateUUID();
+		return this.createTaskWithId(generateUUID(), params);
+	}
+
+	createTaskWithId(id: string, params: InternalCreateSpaceTaskParams): SpaceTask {
 		const now = Date.now();
 
 		// Wrap SELECT MAX + INSERT in an explicit transaction to prevent concurrent

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -186,6 +186,19 @@ describe('space-task-handlers', () => {
 			).resolves.toBeDefined();
 		});
 
+		it('strips untrusted task id from create requests', async () => {
+			await call('spaceTask.create', {
+				spaceId: 'space-1',
+				id: 'client-controlled-id',
+				title: 'Do work',
+				description: 'description',
+			});
+
+			expect(taskManager.createTask).toHaveBeenCalledWith(
+				expect.not.objectContaining({ id: 'client-controlled-id' })
+			);
+		});
+
 		it('throws when spaceId is missing', async () => {
 			await expect(call('spaceTask.create', { title: 'T', description: 'D' })).rejects.toThrow(
 				'spaceId is required'

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -928,6 +928,81 @@ describe('EvolutionEpisodeService', () => {
 		);
 	});
 
+	it('rejects proposal-to-task dependencies missing from the scope space', () => {
+		const otherSpaceId = spaceRepo.createSpace({
+			workspacePath: '/workspace/other-space',
+			slug: 'other-space',
+			name: 'Other Space',
+		}).id;
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Dependency scope',
+			objective: 'Validate dependency space',
+		});
+		const proposal = evolutionRepo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Dependent task',
+			description: 'Should reject cross-space deps',
+			reason: 'Avoid invalid dependency graph',
+		});
+		const otherSpaceTask = taskRepo.createTask({
+			spaceId: otherSpaceId,
+			title: 'Other space task',
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+		});
+
+		expect(() =>
+			service.createTaskFromProposal(proposal.id, { dependsOn: [otherSpaceTask.id] })
+		).toThrow(`Dependency task not found in space: ${otherSpaceTask.id}`);
+	});
+
+	it('rejects self-dependency and cycles during proposal-to-task creation', () => {
+		const taskId = 'proposal-cycle-task';
+		const scope = evolutionRepo.createScope({
+			spaceId,
+			kind: 'custom',
+			name: 'Dependency scope',
+			objective: 'Validate dependency graph',
+		});
+		const selfProposal = evolutionRepo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Self-dependent task',
+			description: 'Should reject self dependency',
+			reason: 'Avoid impossible dependency ordering',
+		});
+		const cycleProposal = evolutionRepo.createTaskProposal({
+			scopeId: scope.id,
+			title: 'Cycle task',
+			description: 'Should reject bad graph',
+			reason: 'Avoid impossible dependency ordering',
+		});
+		const upstream = taskRepo.createTask({
+			spaceId,
+			title: 'Upstream task',
+			dependsOn: [taskId],
+		});
+		const service = new EvolutionEpisodeService({
+			evolutionRepo,
+			taskRepo,
+			workflowRunRepo,
+			artifactRepo,
+			taskIdFactory: () => taskId,
+		});
+
+		expect(() => service.createTaskFromProposal(selfProposal.id, { dependsOn: [taskId] })).toThrow(
+			'A task cannot depend on itself'
+		);
+		expect(() =>
+			service.createTaskFromProposal(cycleProposal.id, { dependsOn: [upstream.id] })
+		).toThrow('Adding these dependencies would create a circular dependency');
+	});
+
 	it('rejects invalid rollup writeback requests', () => {
 		const goal = goalRepo.create({ spaceId, title: 'Recurring review goal', type: 'recurring' });
 		const oneShotGoal = goalRepo.create({ spaceId, title: 'One-shot goal', type: 'one_shot' });

--- a/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/evolution-episode-service.test.ts
@@ -763,7 +763,7 @@ describe('EvolutionEpisodeService', () => {
 		).toThrow('finding.domain must be one of');
 	});
 
-	it('creates a scoped SpaceTask from a proposal and records evidence context', async () => {
+	it('atomically creates a scoped SpaceTask from a proposal with dependencies', async () => {
 		const goal = goalRepo.create({
 			spaceId,
 			title: 'Improve review loop',
@@ -789,6 +789,11 @@ describe('EvolutionEpisodeService', () => {
 			priority: 'high',
 			evidenceEpisodeIds: [episode.id],
 		});
+		const dependency = taskRepo.createTask({
+			spaceId,
+			title: 'Dependency task',
+			description: 'Must finish first',
+		});
 		const publishedEvents: Array<{ event: string; data: Record<string, unknown> }> = [];
 		const service = new EvolutionEpisodeService({
 			evolutionRepo,
@@ -803,13 +808,14 @@ describe('EvolutionEpisodeService', () => {
 			},
 		});
 
-		const result = service.createTaskFromProposal(proposal.id);
+		const result = service.createTaskFromProposal(proposal.id, { dependsOn: [dependency.id] });
 		const duplicate = service.createTaskFromProposal(proposal.id);
 
 		expect(duplicate.task.id).toBe(result.task.id);
 		expect(
 			taskRepo.listBySpace(spaceId).filter((item) => item.title === 'Improve review UI')
 		).toHaveLength(1);
+		expect(taskRepo.getTask(result.task.id)?.dependsOn).toEqual([dependency.id]);
 		expect(publishedEvents).toHaveLength(1);
 		expect(publishedEvents[0]).toMatchObject({
 			event: 'space.task.created',
@@ -825,6 +831,7 @@ describe('EvolutionEpisodeService', () => {
 			evolutionScopeId: scope.id,
 			title: 'Improve review UI',
 			priority: 'high',
+			dependsOn: [dependency.id],
 		});
 		expect(result.task.description).toContain('Make actions clearer');
 		expect(result.task.description).toContain('Proposal reason:\nUsers miss next steps');

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1028,6 +1028,54 @@ describe('createSpaceAgentToolHandlers — Forge tools', () => {
 		expect(reactivated.error).toContain('Dismissed lessons cannot be reactivated');
 	});
 
+	test('creates proposal task with unmet dependencies before runtime can launch it', async () => {
+		const handlers = makeHandlers(ctx);
+		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Coding workflow');
+		const dependency = await ctx.taskManager.createTask({
+			title: 'Dependency task',
+			description: 'Finish first',
+		});
+		const scope = JSON.parse(
+			(
+				await handlers.create_forge_scope({
+					kind: 'custom',
+					name: 'Dependent proposal scope',
+					objective: 'Create dependent task',
+				})
+			).content[0].text
+		).scope;
+		const proposal = JSON.parse(
+			(
+				await handlers.create_forge_task_proposal({
+					scope_id: scope.id,
+					title: 'Dependent proposal',
+					description: 'Wait for dependency',
+					reason: 'Prevent premature launch',
+				})
+			).content[0].text
+		).proposal;
+
+		const taskResult = JSON.parse(
+			(
+				await handlers.create_task_from_forge_proposal({
+					proposal_id: proposal.id,
+					depends_on: [dependency.id],
+				})
+			).content[0].text
+		);
+		expect(taskResult.success).toBe(true);
+		expect(taskResult.task.dependsOn).toEqual([dependency.id]);
+		expect(taskResult.task.status).toBe('open');
+		expect(taskResult.task.workflowRunId).toBeUndefined();
+
+		await ctx.runtime.executeTick();
+
+		const taskAfterTick = ctx.taskRepo.getTask(taskResult.task.id);
+		expect(taskAfterTick?.dependsOn).toEqual([dependency.id]);
+		expect(taskAfterTick?.status).toBe('open');
+		expect(taskAfterTick?.workflowRunId).toBeUndefined();
+	});
+
 	test('rejects unsafe proposal status updates', async () => {
 		const handlers = makeHandlers(ctx);
 		const scope = JSON.parse(

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -794,7 +794,9 @@ export interface EvolutionTaskProposalListResponse {
 
 export interface EvolutionTaskProposalCreateTaskRequest {
 	id: string;
-	params?: Partial<Pick<TaskProposal, 'title' | 'description' | 'reason' | 'priority'>>;
+	params?: Partial<Pick<TaskProposal, 'title' | 'description' | 'reason' | 'priority'>> & {
+		dependsOn?: string[];
+	};
 }
 
 export interface EvolutionTaskProposalCreateTaskResponse {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -764,6 +764,8 @@ export interface CreateSpaceTaskParams {
  * Internal parameters for creating SpaceTask rows with system-owned linkage.
  */
 export interface InternalCreateSpaceTaskParams extends CreateSpaceTaskParams {
+	/** System-provided ID for atomic pre-validation flows; generated when omitted. */
+	id?: string;
 	/** ID of the SpaceGoal this task should be linked to. */
 	goalId?: string | null;
 	/** ID of the EvolutionScope this task explicitly contributes evidence to. */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -764,8 +764,6 @@ export interface CreateSpaceTaskParams {
  * Internal parameters for creating SpaceTask rows with system-owned linkage.
  */
 export interface InternalCreateSpaceTaskParams extends CreateSpaceTaskParams {
-	/** System-provided ID for atomic pre-validation flows; generated when omitted. */
-	id?: string;
 	/** ID of the SpaceGoal this task should be linked to. */
 	goalId?: string | null;
 	/** ID of the EvolutionScope this task explicitly contributes evidence to. */


### PR DESCRIPTION
Support `depends_on` when creating SpaceTasks from Forge proposals.

- Persist dependencies during proposal conversion before runtime pickup
- Expose dependency input in shared RPC and MCP tool schema
- Cover unmet-dependency conversion staying open and unattached after runtime tick

Tests:
- cd packages/daemon && bun test tests/unit/5-space/evolution-episode-service.test.ts tests/unit/5-space/runtime/space-agent-tools.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/support-dependencies-when-creating-tasks-from-forge check