### PR TITLE
Promote Space sessions to agents

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -429,7 +429,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.messageHub,
 		deps.internalEventBus,
 		deps.spaceAgentManager,
-		deps.spaceManager
+		deps.spaceManager,
+		deps.db
 	);
 	setupSpaceLongHorizonAgentHandlers(deps.messageHub, deps.spaceManager);
 

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -54,10 +54,9 @@ function extractTools(session: Session): string[] | undefined {
 }
 
 function extractSettingSources(session: Session): SettingSource[] | undefined {
-	const configSources = session.config.settingSources;
-	if (configSources?.length) return configSources;
+	if (session.config.settingSources !== undefined) return session.config.settingSources;
 	const toolSources = session.config.tools?.settingSources;
-	return toolSources?.length ? toolSources : undefined;
+	return toolSources !== undefined ? toolSources : undefined;
 }
 
 function buildPromotionDraft(session: Session, db: Database): SpaceAgentPromotionDraft {

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -12,7 +12,16 @@
  * - spaceAgent.syncFromTemplate - Reset a preset-tracked agent to the current preset definition
  */
 
-import type { MessageHub } from '@neokai/shared';
+import type {
+	MessageHub,
+	Session,
+	SettingSource,
+	SpaceAgent,
+	SpaceAgentPromotionDraft,
+	ThinkingLevel,
+} from '@neokai/shared';
+import { KNOWN_TOOLS } from '@neokai/shared';
+import type { Database } from '../../storage';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -21,11 +30,108 @@ import { Logger } from '../logger';
 
 const log = new Logger('space-agent-handlers');
 
+const PROMOTION_MESSAGE_LIMIT = 24;
+const PROMOTION_CONTEXT_CHAR_LIMIT = 6000;
+
+function clampText(value: string, limit: number): string {
+	if (value.length <= limit) return value;
+	return `${value.slice(0, limit - 1).trimEnd()}…`;
+}
+
+function deriveAgentName(session: Session): string {
+	const base = (session.title || 'Promoted Agent')
+		.replace(/^space chat:?\s*/i, '')
+		.replace(/[^\p{L}\p{N}\s_-]/gu, '')
+		.trim();
+	return clampText(base || 'Promoted Agent', 64);
+}
+
+function extractTools(session: Session): string[] | undefined {
+	const allowedTools = session.config.allowedTools ?? [];
+	const known = new Set<string>(KNOWN_TOOLS);
+	const tools = allowedTools.filter((tool) => known.has(tool));
+	return tools.length > 0 ? [...new Set(tools)] : undefined;
+}
+
+function extractSettingSources(session: Session): SettingSource[] | undefined {
+	const configSources = session.config.settingSources;
+	if (configSources?.length) return configSources;
+	const toolSources = session.config.tools?.settingSources;
+	return toolSources?.length ? toolSources : undefined;
+}
+
+function buildPromotionDraft(session: Session, db: Database): SpaceAgentPromotionDraft {
+	const messages = db.getRenderableTextMessages(session.id, PROMOTION_MESSAGE_LIMIT);
+	const context = messages.length
+		? messages
+				.map((message) => {
+					const speaker = message.type === 'assistant' ? 'Assistant' : 'User';
+					return `${speaker}: ${message.text}`;
+				})
+				.join('\n\n---\n\n')
+		: 'No renderable chat messages were available. Fill in standing context manually before creating this agent.';
+	const standingContext = clampText(context, PROMOTION_CONTEXT_CHAR_LIMIT);
+	const name = deriveAgentName(session);
+	const responsibility = `Continue the durable role that emerged in "${session.title || session.id}".`;
+	const standingInstructions =
+		'Use the standing context below as background, not as a transcript to replay. Keep future work goal-oriented, cite uncertainty, and ask for human input before high-impact actions.';
+	const autonomy =
+		'Supervised by default: propose actions and wait for explicit approval before destructive, external, or irreversible changes.';
+	const managedGoals =
+		'Review and narrow this list to the goals this long-horizon agent should own.';
+	const managedScopes =
+		'Review and narrow this list to repositories, files, systems, or product areas this agent may manage.';
+	const reminders =
+		'Periodically summarize progress, blockers, decisions, and needed human follow-up.';
+	const eventSubscriptions =
+		'Review and list events this agent should react to, such as task changes, PR reviews, CI failures, mentions, or scheduled check-ins.';
+	const customPrompt = `## Responsibility\n${responsibility}\n\n## Standing Instructions\n${standingInstructions}\n\n## Autonomy\n${autonomy}\n\n## Managed Goals\n${managedGoals}\n\n## Managed Scopes\n${managedScopes}\n\n## Reminders\n${reminders}\n\n## Event Subscriptions\n${eventSubscriptions}\n\n## Standing Context From Promoted Session\n${standingContext}`;
+
+	return {
+		sourceSessionId: session.id,
+		sourceSessionTitle: session.title || session.id,
+		name,
+		description: responsibility,
+		model: session.config.model,
+		thinkingLevel: session.config.thinkingLevel as ThinkingLevel | undefined,
+		provider: session.config.provider,
+		customPrompt,
+		tools: extractTools(session),
+		settingSources: extractSettingSources(session),
+		profile: {
+			responsibility,
+			standingInstructions,
+			autonomy,
+			managedGoals,
+			managedScopes,
+			reminders,
+			eventSubscriptions,
+			standingContext,
+		},
+	};
+}
+
+async function publishAgentCreated(
+	internalEventBus: InternalEventBus<DaemonInternalEventMap>,
+	agent: SpaceAgent
+): Promise<void> {
+	await internalEventBus
+		.publish('spaceAgent.created', {
+			sessionId: `space:${agent.spaceId}`,
+			spaceId: agent.spaceId,
+			agent,
+		})
+		.catch((err) => {
+			log.warn('Failed to emit spaceAgent.created:', err);
+		});
+}
+
 export function setupSpaceAgentHandlers(
 	messageHub: MessageHub,
 	internalEventBus: InternalEventBus<DaemonInternalEventMap>,
 	spaceAgentManager: SpaceAgentManager,
-	spaceManager: SpaceManager
+	spaceManager: SpaceManager,
+	db: Database
 ): void {
 	// spaceAgent.listBuiltInTemplates — return built-in templates from seeding source
 	messageHub.onRequest('spaceAgent.listBuiltInTemplates', async (data) => {
@@ -70,16 +176,71 @@ export function setupSpaceAgentHandlers(
 
 		if (!result.ok) throw new Error(result.error);
 
-		internalEventBus
-			.publish('spaceAgent.created', {
-				sessionId: `space:${result.value.spaceId}`,
-				spaceId: result.value.spaceId,
-				agent: result.value,
-			})
-			.catch((err) => {
-				log.warn('Failed to emit spaceAgent.created:', err);
-			});
+		await publishAgentCreated(internalEventBus, result.value);
 
+		return { agent: result.value };
+	});
+
+	messageHub.onRequest('spaceAgent.getPromotionDraft', async (data) => {
+		const params = data as { spaceId: string; sessionId: string };
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.sessionId) throw new Error('sessionId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		const session = db.getSession(params.sessionId);
+		if (!session) throw new Error(`Session not found: ${params.sessionId}`);
+		if (session.context?.spaceId !== params.spaceId) {
+			throw new Error(`Session not found: ${params.sessionId}`);
+		}
+		if (session.type === 'space_task_agent') {
+			throw new Error('Task agent sessions cannot be promoted');
+		}
+
+		return { draft: buildPromotionDraft(session, db) };
+	});
+
+	messageHub.onRequest('spaceAgent.promoteSession', async (data) => {
+		const params = data as {
+			spaceId: string;
+			sessionId: string;
+			name: string;
+			description?: string;
+			model?: string;
+			thinkingLevel?: import('@neokai/shared').ThinkingLevel;
+			provider?: string;
+			customPrompt?: string | null;
+			tools?: string[];
+			settingSources?: import('@neokai/shared').SettingSource[];
+		};
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.sessionId) throw new Error('sessionId is required');
+		if (!params.name) throw new Error('name is required');
+
+		const session = db.getSession(params.sessionId);
+		if (!session) throw new Error(`Session not found: ${params.sessionId}`);
+		if (session.context?.spaceId !== params.spaceId) {
+			throw new Error(`Session not found: ${params.sessionId}`);
+		}
+		if (session.type === 'space_task_agent') {
+			throw new Error('Task agent sessions cannot be promoted');
+		}
+
+		const result = await spaceAgentManager.create({
+			spaceId: params.spaceId,
+			name: params.name,
+			description: params.description,
+			model: params.model,
+			thinkingLevel: params.thinkingLevel,
+			provider: params.provider,
+			customPrompt: params.customPrompt,
+			tools: params.tools,
+			settingSources: params.settingSources,
+		});
+		if (!result.ok) throw new Error(result.error);
+
+		await publishAgentCreated(internalEventBus, result.value);
 		return { agent: result.value };
 	});
 

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -38,6 +38,11 @@ function clampText(value: string, limit: number): string {
 	return `${value.slice(0, limit - 1).trimEnd()}…`;
 }
 
+function clampTextEnd(value: string, limit: number): string {
+	if (value.length <= limit) return value;
+	return `…${value.slice(value.length - limit + 1).trimStart()}`;
+}
+
 function deriveAgentName(session: Session): string {
 	const base = (session.title || 'Promoted Agent')
 		.replace(/^space chat:?\s*/i, '')
@@ -47,10 +52,13 @@ function deriveAgentName(session: Session): string {
 }
 
 function extractTools(session: Session): string[] | undefined {
-	const allowedTools = session.config.allowedTools ?? [];
 	const known = new Set<string>(KNOWN_TOOLS);
-	const tools = allowedTools.filter((tool) => known.has(tool));
-	return tools.length > 0 ? [...new Set(tools)] : undefined;
+	const preset = session.config.sdkToolsPreset;
+	if (Array.isArray(preset)) {
+		const tools = preset.filter((tool) => known.has(tool));
+		return [...new Set(tools)];
+	}
+	return undefined;
 }
 
 function extractSettingSources(session: Session): SettingSource[] | undefined {
@@ -69,7 +77,7 @@ function buildPromotionDraft(session: Session, db: Database): SpaceAgentPromotio
 				})
 				.join('\n\n---\n\n')
 		: 'No renderable chat messages were available. Fill in standing context manually before creating this agent.';
-	const standingContext = clampText(context, PROMOTION_CONTEXT_CHAR_LIMIT);
+	const standingContext = clampTextEnd(context, PROMOTION_CONTEXT_CHAR_LIMIT);
 	const name = deriveAgentName(session);
 	const responsibility = `Continue the durable role that emerged in "${session.title || session.id}".`;
 	const standingInstructions =

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -58,7 +58,12 @@ function extractTools(session: Session): string[] | undefined {
 		const tools = preset.filter((tool) => known.has(tool));
 		return [...new Set(tools)];
 	}
-	return undefined;
+
+	const disallowedTools = session.config.disallowedTools?.filter((tool) => known.has(tool)) ?? [];
+	if (disallowedTools.length === 0) return undefined;
+
+	const disallowed = new Set(disallowedTools);
+	return KNOWN_TOOLS.filter((tool) => !disallowed.has(tool));
 }
 
 function extractSettingSources(session: Session): SettingSource[] | undefined {
@@ -224,6 +229,9 @@ export function setupSpaceAgentHandlers(
 		if (!params.spaceId) throw new Error('spaceId is required');
 		if (!params.sessionId) throw new Error('sessionId is required');
 		if (!params.name) throw new Error('name is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
 
 		const session = db.getSession(params.sessionId);
 		if (!session) throw new Error(`Session not found: ${params.sessionId}`);

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -211,6 +211,13 @@ export class Database {
 		return this.sdkMessageRepo.getSDKMessagesByType(sessionId, messageType, messageSubtype, limit);
 	}
 
+	getRenderableTextMessages(
+		sessionId: string,
+		limit?: number
+	): Array<{ id: string; type: string; text: string; timestamp: number }> {
+		return this.sdkMessageRepo.getRenderableTextMessages(sessionId, limit);
+	}
+
 	getSDKMessageCount(sessionId: string): number {
 		return this.sdkMessageRepo.getSDKMessageCount(sessionId);
 	}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -455,7 +455,12 @@ export class SDKMessageRepository {
 			if (rows.length === 0) break;
 
 			for (const row of rows) {
-				const message = JSON.parse(row.sdk_message) as SDKMessage;
+				let message: SDKMessage;
+				try {
+					message = JSON.parse(row.sdk_message) as SDKMessage;
+				} catch {
+					continue;
+				}
 				const text = this.extractVisibleText(message as unknown as Record<string, unknown>);
 				if (text.length === 0) continue;
 				messages.push({

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -436,28 +436,30 @@ export class SDKMessageRepository {
 				   AND is_renderable = 1
 				   AND message_type IN ('user', 'assistant')
 				   AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
-				 ORDER BY timestamp DESC, rowid DESC
-				 LIMIT ?`
+				 ORDER BY timestamp DESC, rowid DESC`
 			)
-			.all(sessionId, limit) as Array<{
+			.all(sessionId) as Array<{
 			id: string;
 			message_type: string;
 			sdk_message: string;
 			timestamp: string;
 		}>;
 
-		return rows
-			.reverse()
-			.map((row) => {
-				const message = JSON.parse(row.sdk_message) as SDKMessage;
-				return {
-					id: row.id,
-					type: row.message_type,
-					text: this.extractVisibleText(message as unknown as Record<string, unknown>),
-					timestamp: new Date(row.timestamp).getTime(),
-				};
-			})
-			.filter((row) => row.text.length > 0);
+		const messages: Array<{ id: string; type: string; text: string; timestamp: number }> = [];
+		for (const row of rows) {
+			const message = JSON.parse(row.sdk_message) as SDKMessage;
+			const text = this.extractVisibleText(message as unknown as Record<string, unknown>);
+			if (text.length === 0) continue;
+			messages.push({
+				id: row.id,
+				type: row.message_type,
+				text,
+				timestamp: new Date(row.timestamp).getTime(),
+			});
+			if (messages.length >= limit) break;
+		}
+
+		return messages.reverse();
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -424,6 +424,42 @@ export class SDKMessageRepository {
 		return this._getSDKMessagesImpl(sessionId, limit ?? 100, before, since);
 	}
 
+	getRenderableTextMessages(
+		sessionId: string,
+		limit = 20
+	): Array<{ id: string; type: string; text: string; timestamp: number }> {
+		const rows = this.db
+			.prepare(
+				`SELECT id, message_type, sdk_message, timestamp FROM sdk_messages
+				 WHERE session_id = ?
+				   AND parent_tool_use_id IS NULL
+				   AND is_renderable = 1
+				   AND message_type IN ('user', 'assistant')
+				   AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
+				 ORDER BY timestamp DESC, rowid DESC
+				 LIMIT ?`
+			)
+			.all(sessionId, limit) as Array<{
+			id: string;
+			message_type: string;
+			sdk_message: string;
+			timestamp: string;
+		}>;
+
+		return rows
+			.reverse()
+			.map((row) => {
+				const message = JSON.parse(row.sdk_message) as SDKMessage;
+				return {
+					id: row.id,
+					type: row.message_type,
+					text: this.extractVisibleText(message as unknown as Record<string, unknown>),
+					timestamp: new Date(row.timestamp).getTime(),
+				};
+			})
+			.filter((row) => row.text.length > 0);
+	}
+
 	/**
 	 * Internal implementation for getSDKMessages
 	 * @private
@@ -1118,6 +1154,10 @@ export class SDKMessageRepository {
 	}
 
 	private extractAssistantText(msg: Record<string, unknown>): string {
+		return this.extractVisibleText(msg);
+	}
+
+	private extractVisibleText(msg: Record<string, unknown>): string {
 		const parts: string[] = [];
 		const message = msg.message as Record<string, unknown> | undefined;
 		const content = message?.content;

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -29,6 +29,8 @@ const ROOM_SESSION_PREFIXES = ['room:chat:', 'planner:', 'coder:', 'leader:', 'g
 const ROOM_SESSION_TYPES = new Set(['room_chat', 'planner', 'coder', 'leader', 'general']);
 const TERMINAL_SPACE_TASK_STATUSES = new Set(['done', 'cancelled', 'completed']);
 const SEARCHABLE_MESSAGE_TYPES = new Set(['system', 'user', 'assistant']);
+const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
+const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
 
 function isOlderThanMessageSearchTtl(value: string | number | null | undefined): boolean {
 	if (value === null || value === undefined) return false;
@@ -428,35 +430,44 @@ export class SDKMessageRepository {
 		sessionId: string,
 		limit = 20
 	): Array<{ id: string; type: string; text: string; timestamp: number }> {
-		const rows = this.db
-			.prepare(
-				`SELECT id, message_type, sdk_message, timestamp FROM sdk_messages
-				 WHERE session_id = ?
-				   AND parent_tool_use_id IS NULL
-				   AND is_renderable = 1
-				   AND message_type IN ('user', 'assistant')
-				   AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
-				 ORDER BY timestamp DESC, rowid DESC`
-			)
-			.all(sessionId) as Array<{
-			id: string;
-			message_type: string;
-			sdk_message: string;
-			timestamp: string;
-		}>;
-
 		const messages: Array<{ id: string; type: string; text: string; timestamp: number }> = [];
-		for (const row of rows) {
-			const message = JSON.parse(row.sdk_message) as SDKMessage;
-			const text = this.extractVisibleText(message as unknown as Record<string, unknown>);
-			if (text.length === 0) continue;
-			messages.push({
-				id: row.id,
-				type: row.message_type,
-				text,
-				timestamp: new Date(row.timestamp).getTime(),
-			});
-			if (messages.length >= limit) break;
+		const stmt = this.db.prepare(
+			`SELECT id, message_type, sdk_message, timestamp FROM sdk_messages
+			 WHERE session_id = ?
+			   AND parent_tool_use_id IS NULL
+			   AND is_renderable = 1
+			   AND message_type IN ('user', 'assistant')
+			   AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
+			 ORDER BY timestamp DESC, rowid DESC
+			 LIMIT ? OFFSET ?`
+		);
+		const maxScan = Math.max(limit, RENDERABLE_TEXT_MESSAGE_MAX_SCAN);
+		let scanned = 0;
+
+		while (messages.length < limit && scanned < maxScan) {
+			const batchSize = Math.min(RENDERABLE_TEXT_MESSAGE_BATCH_SIZE, maxScan - scanned);
+			const rows = stmt.all(sessionId, batchSize, scanned) as Array<{
+				id: string;
+				message_type: string;
+				sdk_message: string;
+				timestamp: string;
+			}>;
+			if (rows.length === 0) break;
+
+			for (const row of rows) {
+				const message = JSON.parse(row.sdk_message) as SDKMessage;
+				const text = this.extractVisibleText(message as unknown as Record<string, unknown>);
+				if (text.length === 0) continue;
+				messages.push({
+					id: row.id,
+					type: row.message_type,
+					text,
+					timestamp: new Date(row.timestamp).getTime(),
+				});
+				if (messages.length >= limit) break;
+			}
+			scanned += rows.length;
+			if (rows.length < batchSize) break;
 		}
 
 		return messages.reverse();

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -276,7 +276,7 @@ describe('Space Agent RPC Handlers', () => {
 			});
 
 			expect(result.draft.name).toBe('Release captain');
-			expect(result.draft.tools).toEqual(['Read', 'Grep']);
+			expect(result.draft.tools).toBeUndefined();
 			expect(result.draft.customPrompt).toContain('## Responsibility');
 			expect(result.draft.customPrompt).toContain('## Event Subscriptions');
 			expect(result.draft.customPrompt).toContain('User: Track release blockers.');
@@ -304,6 +304,54 @@ describe('Space Agent RPC Handlers', () => {
 			);
 
 			expect(result.draft.settingSources).toEqual([]);
+		});
+
+		it('preserves explicit sdk tool presets in the draft', async () => {
+			insertSession(db, {
+				id: 'session-read-only-tools',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+				config: {
+					model: 'claude-sonnet-4-5',
+					maxTokens: 4096,
+					temperature: 0,
+					sdkToolsPreset: ['Read', 'Grep'],
+					allowedTools: ['Bash'],
+				},
+			});
+
+			const result = await call<{ draft: { tools?: string[] } }>(
+				hubData.handlers,
+				'spaceAgent.getPromotionDraft',
+				{ spaceId: 'space-1', sessionId: 'session-read-only-tools' }
+			);
+
+			expect(result.draft.tools).toEqual(['Read', 'Grep']);
+		});
+
+		it('keeps the newest standing context when truncating long drafts', async () => {
+			insertSession(db, {
+				id: 'session-long-context',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+			});
+			insertMessage(db, 'session-long-context', 'msg-1', {
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'old '.repeat(3000) }] },
+			} as SDKMessage);
+			insertMessage(db, 'session-long-context', 'msg-2', {
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'newest marker' }] },
+			} as SDKMessage);
+
+			const result = await call<{ draft: { customPrompt: string } }>(
+				hubData.handlers,
+				'spaceAgent.getPromotionDraft',
+				{ spaceId: 'space-1', sessionId: 'session-long-context' }
+			);
+
+			expect(result.draft.customPrompt).toContain('…');
+			expect(result.draft.customPrompt).toContain('Assistant: newest marker');
 		});
 
 		it('rejects drafts for sessions outside the requested space', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -14,10 +14,12 @@
 
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import type { MessageHub } from '@neokai/shared';
+import type { MessageHub, SDKMessage, Session } from '@neokai/shared';
 import { setupSpaceAgentHandlers } from '../../../../src/lib/rpc-handlers/space-agent-handlers';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
+import { SessionRepository } from '../../../../src/storage/repositories/session-repository';
+import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
 import type {
 	DaemonInternalEventMap,
 	InternalEventBus,
@@ -92,6 +94,63 @@ function createMockSpaceManager(): {
 
 // ─── helpers ───────────────────────────────────────────────────────────────
 
+function createTestDatabaseFacade(db: Database) {
+	const sessionRepo = new SessionRepository(db as any);
+	const sdkMessageRepo = new SDKMessageRepository(db as any);
+	return {
+		getSession: (id: string) => sessionRepo.getSession(id),
+		getRenderableTextMessages: (sessionId: string, limit?: number) =>
+			sdkMessageRepo.getRenderableTextMessages(sessionId, limit),
+	} as any;
+}
+
+function insertSession(db: Database, session: Partial<Session> & { id: string }): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO sessions (
+			id, title, workspace_path, created_at, last_active_at, status, config, metadata,
+			is_worktree, type, session_context
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		session.id,
+		session.title ?? session.id,
+		session.workspacePath ?? null,
+		session.createdAt ?? now,
+		session.lastActiveAt ?? now,
+		session.status ?? 'active',
+		JSON.stringify(
+			session.config ?? {
+				model: 'claude-sonnet-4-5',
+				maxTokens: 4096,
+				temperature: 0,
+			}
+		),
+		JSON.stringify(session.metadata ?? {}),
+		session.worktree?.isWorktree ? 1 : 0,
+		session.type ?? 'space_chat',
+		session.context ? JSON.stringify(session.context) : null
+	);
+}
+
+function insertMessage(db: Database, sessionId: string, id: string, message: SDKMessage): void {
+	db.prepare(
+		`INSERT INTO sdk_messages (
+			id, session_id, message_type, sdk_message, timestamp, send_status, is_renderable, is_terminal,
+			parent_tool_use_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		id,
+		sessionId,
+		message.type,
+		JSON.stringify(message),
+		new Date(Date.now() + Number(id.replace(/\D/g, '') || 0)).toISOString(),
+		'consumed',
+		1,
+		0,
+		null
+	);
+}
+
 /** Call a registered handler and cast the result */
 async function call<T>(
 	handlers: Map<string, RequestHandler>,
@@ -130,7 +189,8 @@ describe('Space Agent RPC Handlers', () => {
 			hubData.hub,
 			daemonData.internalEventBus,
 			manager,
-			spaceManagerData.spaceManager
+			spaceManagerData.spaceManager,
+			createTestDatabaseFacade(db)
 		);
 	});
 
@@ -181,6 +241,88 @@ describe('Space Agent RPC Handlers', () => {
 			await expect(
 				call(hubData.handlers, 'spaceAgent.listBuiltInTemplates', { spaceId: 'missing-space' })
 			).rejects.toThrow('Space not found: missing-space');
+		});
+	});
+
+	describe('spaceAgent.promotion', () => {
+		it('generates a draft from recent renderable session messages', async () => {
+			insertSession(db, {
+				id: 'session-1',
+				title: 'Release captain',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+				config: {
+					model: 'claude-sonnet-4-5',
+					maxTokens: 4096,
+					temperature: 0,
+					thinkingLevel: 'think8k',
+					allowedTools: ['Read', 'Grep', 'UnknownTool'],
+				},
+			});
+			insertMessage(db, 'session-1', 'msg-1', {
+				type: 'user',
+				message: { role: 'user', content: [{ type: 'text', text: 'Track release blockers.' }] },
+			} as SDKMessage);
+			insertMessage(db, 'session-1', 'msg-2', {
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'I will monitor CI.' }] },
+			} as SDKMessage);
+
+			const result = await call<{
+				draft: { name: string; customPrompt: string; tools?: string[] };
+			}>(hubData.handlers, 'spaceAgent.getPromotionDraft', {
+				spaceId: 'space-1',
+				sessionId: 'session-1',
+			});
+
+			expect(result.draft.name).toBe('Release captain');
+			expect(result.draft.tools).toEqual(['Read', 'Grep']);
+			expect(result.draft.customPrompt).toContain('## Responsibility');
+			expect(result.draft.customPrompt).toContain('## Event Subscriptions');
+			expect(result.draft.customPrompt).toContain('User: Track release blockers.');
+			expect(result.draft.customPrompt).toContain('Assistant: I will monitor CI.');
+		});
+
+		it('rejects drafts for sessions outside the requested space', async () => {
+			insertSession(db, {
+				id: 'session-2',
+				type: 'space_chat',
+				context: { spaceId: 'space-other' },
+			});
+
+			await expect(
+				call(hubData.handlers, 'spaceAgent.getPromotionDraft', {
+					spaceId: 'space-1',
+					sessionId: 'session-2',
+				})
+			).rejects.toThrow('Session not found: session-2');
+		});
+
+		it('creates an agent from a reviewed promotion draft', async () => {
+			insertSession(db, {
+				id: 'session-3',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+			});
+
+			const result = await call<{ agent: { name: string; customPrompt: string | null } }>(
+				hubData.handlers,
+				'spaceAgent.promoteSession',
+				{
+					spaceId: 'space-1',
+					sessionId: 'session-3',
+					name: 'Release Agent',
+					customPrompt: 'Reviewed profile',
+					tools: ['Read'],
+				}
+			);
+
+			expect(result.agent.name).toBe('Release Agent');
+			expect(result.agent.customPrompt).toBe('Reviewed profile');
+			expect(daemonData.publishMock).toHaveBeenCalledWith(
+				'spaceAgent.created',
+				expect.objectContaining({ spaceId: 'space-1' })
+			);
 		});
 	});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -329,6 +329,31 @@ describe('Space Agent RPC Handlers', () => {
 			expect(result.draft.tools).toEqual(['Read', 'Grep']);
 		});
 
+		it('preserves disallowed tool restrictions in the draft', async () => {
+			insertSession(db, {
+				id: 'session-disallowed-tools',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+				config: {
+					model: 'claude-sonnet-4-5',
+					maxTokens: 4096,
+					temperature: 0,
+					sdkToolsPreset: { type: 'preset', preset: 'claude_code' },
+					disallowedTools: ['Bash', 'Write', 'UnknownTool'],
+				},
+			});
+
+			const result = await call<{ draft: { tools?: string[] } }>(
+				hubData.handlers,
+				'spaceAgent.getPromotionDraft',
+				{ spaceId: 'space-1', sessionId: 'session-disallowed-tools' }
+			);
+
+			expect(result.draft.tools).not.toContain('Bash');
+			expect(result.draft.tools).not.toContain('Write');
+			expect(result.draft.tools).toContain('Read');
+		});
+
 		it('keeps the newest standing context when truncating long drafts', async () => {
 			insertSession(db, {
 				id: 'session-long-context',
@@ -367,6 +392,23 @@ describe('Space Agent RPC Handlers', () => {
 					sessionId: 'session-2',
 				})
 			).rejects.toThrow('Session not found: session-2');
+		});
+
+		it('rejects promotion when the target space no longer exists', async () => {
+			insertSession(db, {
+				id: 'session-deleted-space',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+			});
+			spaceManagerData.getSpaceMock.mockResolvedValue(null as never);
+
+			await expect(
+				call(hubData.handlers, 'spaceAgent.promoteSession', {
+					spaceId: 'space-1',
+					sessionId: 'session-deleted-space',
+					name: 'Deleted Space Agent',
+				})
+			).rejects.toThrow('Space not found: space-1');
 		});
 
 		it('creates an agent from a reviewed promotion draft', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -283,6 +283,29 @@ describe('Space Agent RPC Handlers', () => {
 			expect(result.draft.customPrompt).toContain('Assistant: I will monitor CI.');
 		});
 
+		it('preserves explicit empty setting sources in the draft', async () => {
+			insertSession(db, {
+				id: 'session-empty-settings',
+				type: 'space_chat',
+				context: { spaceId: 'space-1' },
+				config: {
+					model: 'claude-sonnet-4-5',
+					maxTokens: 4096,
+					temperature: 0,
+					settingSources: [],
+					tools: { settingSources: ['user'] },
+				},
+			});
+
+			const result = await call<{ draft: { settingSources?: string[] } }>(
+				hubData.handlers,
+				'spaceAgent.getPromotionDraft',
+				{ spaceId: 'space-1', sessionId: 'session-empty-settings' }
+			);
+
+			expect(result.draft.settingSources).toEqual([]);
+		});
+
 		it('rejects drafts for sessions outside the requested space', async () => {
 			insertSession(db, {
 				id: 'session-2',

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -222,6 +222,22 @@ describe('SDKMessageRepository', () => {
 
 			expect(messages.map((message) => message.text)).toEqual(['Older text', 'Newest text']);
 		});
+		it('caps scanned renderable rows while collecting text messages', () => {
+			repository.saveSDKMessage('session-1', createUserMessage('Too old text'));
+			for (let i = 0; i < 250; i++) {
+				repository.saveSDKMessage('session-1', {
+					type: 'assistant',
+					message: {
+						role: 'assistant',
+						content: [{ type: 'tool_use', id: `tool-${i}`, name: 'Read' }],
+					},
+				} as unknown as SDKMessage);
+			}
+
+			const messages = repository.getRenderableTextMessages('session-1', 1);
+
+			expect(messages).toEqual([]);
+		});
 	});
 
 	describe('getSDKMessages', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -209,6 +209,21 @@ describe('SDKMessageRepository', () => {
 		});
 	});
 
+	describe('getRenderableTextMessages', () => {
+		it('continues past empty renderable rows until the text limit is reached', async () => {
+			repository.saveSDKMessage('session-1', createUserMessage('Older text'));
+			repository.saveSDKMessage('session-1', {
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'tool_use', id: 'tool-1', name: 'Read' }] },
+			} as unknown as SDKMessage);
+			repository.saveSDKMessage('session-1', createAssistantMessage('Newest text'));
+
+			const messages = repository.getRenderableTextMessages('session-1', 2);
+
+			expect(messages.map((message) => message.text)).toEqual(['Older text', 'Newest text']);
+		});
+	});
+
 	describe('getSDKMessages', () => {
 		it('should return messages in chronological order', async () => {
 			repository.saveSDKMessage('session-1', createUserMessage('First'));

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -60,6 +60,48 @@ export function createSpaceAgentSchema(db: Database): void {
 	db.exec(`CREATE INDEX idx_space_agents_space_id ON space_agents(space_id)`);
 
 	db.exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			workspace_path TEXT,
+			created_at TEXT NOT NULL,
+			last_active_at TEXT NOT NULL,
+			status TEXT NOT NULL,
+			config TEXT NOT NULL,
+			metadata TEXT NOT NULL,
+			is_worktree INTEGER NOT NULL DEFAULT 0,
+			worktree_path TEXT,
+			main_repo_path TEXT,
+			worktree_branch TEXT,
+			git_branch TEXT,
+			sdk_session_id TEXT,
+			sdk_origin_path TEXT,
+			available_commands TEXT,
+			processing_state TEXT,
+			archived_at TEXT,
+			type TEXT,
+			session_context TEXT
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE sdk_messages (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			message_type TEXT NOT NULL,
+			message_subtype TEXT,
+			sdk_message TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			send_status TEXT,
+			origin TEXT DEFAULT NULL CHECK(origin IS NULL OR origin IN ('human', 'system')),
+			is_renderable INTEGER NOT NULL DEFAULT 1,
+			is_terminal INTEGER NOT NULL DEFAULT 0,
+			parent_tool_use_id TEXT,
+			task_id TEXT
+		)
+	`);
+
+	db.exec(`
 		CREATE TABLE space_workflows (
 			id TEXT PRIMARY KEY,
 			space_id TEXT NOT NULL,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1208,6 +1208,31 @@ export interface SpaceAgent {
 /**
  * Parameters for creating a new SpaceAgent
  */
+export interface SpaceAgentPromotionProfile {
+	responsibility: string;
+	standingInstructions: string;
+	autonomy: string;
+	managedGoals: string;
+	managedScopes: string;
+	reminders: string;
+	eventSubscriptions: string;
+	standingContext: string;
+}
+
+export interface SpaceAgentPromotionDraft {
+	sourceSessionId: string;
+	sourceSessionTitle: string;
+	name: string;
+	description?: string;
+	model?: string;
+	thinkingLevel?: ThinkingLevel;
+	provider?: string;
+	customPrompt: string;
+	tools?: string[];
+	settingSources?: SettingSource[];
+	profile: SpaceAgentPromotionProfile;
+}
+
 export interface CreateSpaceAgentParams {
 	spaceId: string;
 	name: string;

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -16,7 +16,12 @@
  * Validation: name required + unique, model required, at least one tool selected.
  */
 
-import type { SpaceAgent, ThinkingLevel, SettingSource } from '@neokai/shared';
+import type {
+	SpaceAgent,
+	SpaceAgentPromotionDraft,
+	ThinkingLevel,
+	SettingSource,
+} from '@neokai/shared';
 import { KNOWN_TOOLS, normalizeThinkingLevel } from '@neokai/shared';
 import { useState } from 'preact/hooks';
 import type { SpaceAgentTemplate } from '../../lib/space-store';
@@ -117,6 +122,8 @@ function LineNumberedTextarea({
 export interface SpaceAgentEditorProps {
 	/** Existing agent to edit. Null = create mode. */
 	agent: SpaceAgent | null;
+	/** Draft generated from an ad-hoc Space session. */
+	promotionDraft?: SpaceAgentPromotionDraft | null;
 	/** Names of other agents in this space (for uniqueness validation) */
 	existingAgentNames: string[];
 	/** Called after a successful save */
@@ -127,31 +134,45 @@ export interface SpaceAgentEditorProps {
 
 export function SpaceAgentEditor({
 	agent,
+	promotionDraft,
 	existingAgentNames,
 	onSave,
 	onCancel,
 }: SpaceAgentEditorProps) {
 	const isEdit = agent !== null;
+	const isPromotion = !isEdit && promotionDraft !== null && promotionDraft !== undefined;
 	const builtInTemplates = spaceStore.agentTemplates.value;
 
 	// Form state
-	const [name, setName] = useState(agent?.name ?? '');
-	const [description, setDescription] = useState(agent?.description ?? '');
-	const [model, setModel] = useState(agent?.model ?? '');
-	const [thinkingLevel, setThinkingLevel] = useState<'' | ThinkingLevel>(
-		agent?.thinkingLevel ? normalizeThinkingLevel(agent.thinkingLevel) : ''
+	const [name, setName] = useState(agent?.name ?? promotionDraft?.name ?? '');
+	const [description, setDescription] = useState(
+		agent?.description ?? promotionDraft?.description ?? ''
 	);
-	const [tools, setTools] = useState<string[]>(agent?.tools ?? [...TOOL_PRESETS['Full Coding']]);
-	const [customPrompt, setCustomPrompt] = useState(agent?.customPrompt ?? '');
+	const [model, setModel] = useState(agent?.model ?? promotionDraft?.model ?? '');
+	const [thinkingLevel, setThinkingLevel] = useState<'' | ThinkingLevel>(
+		agent?.thinkingLevel
+			? normalizeThinkingLevel(agent.thinkingLevel)
+			: promotionDraft?.thinkingLevel
+				? normalizeThinkingLevel(promotionDraft.thinkingLevel)
+				: ''
+	);
+	const [tools, setTools] = useState<string[]>(
+		agent?.tools ?? promotionDraft?.tools ?? [...TOOL_PRESETS['Full Coding']]
+	);
+	const [customPrompt, setCustomPrompt] = useState(
+		agent?.customPrompt ?? promotionDraft?.customPrompt ?? ''
+	);
 	const inheritedSettingSources = spaceStore.space?.value?.settingSources ?? [
 		'user',
 		'project',
 		'local',
 	];
 	const [settingSources, setSettingSources] = useState<SettingSource[]>(
-		agent?.settingSources ?? inheritedSettingSources
+		agent?.settingSources ?? promotionDraft?.settingSources ?? inheritedSettingSources
 	);
-	const [activePreset, setActivePreset] = useState<string>(() => detectPreset(agent?.tools));
+	const [activePreset, setActivePreset] = useState<string>(() =>
+		detectPreset(agent?.tools ?? promotionDraft?.tools)
+	);
 	const [selectedTemplateName, setSelectedTemplateName] = useState<string>('');
 
 	// UI state
@@ -239,6 +260,11 @@ export function SpaceAgentEditor({
 					...baseParams,
 					thinkingLevel: thinkingLevel || null,
 				});
+			} else if (promotionDraft) {
+				await spaceStore.promoteSessionToAgent(promotionDraft.sourceSessionId, {
+					...baseParams,
+					thinkingLevel: thinkingLevel || undefined,
+				});
 			} else {
 				await spaceStore.createAgent({
 					...baseParams,
@@ -254,7 +280,11 @@ export function SpaceAgentEditor({
 		}
 	};
 
-	const title = isEdit ? `Edit Agent: ${agent!.name}` : 'Create Agent';
+	const title = isEdit
+		? `Edit Agent: ${agent!.name}`
+		: isPromotion
+			? `Promote Session: ${promotionDraft!.sourceSessionTitle}`
+			: 'Create Agent';
 
 	return (
 		<Modal isOpen onClose={onCancel} title={title} size="lg">
@@ -263,6 +293,16 @@ export function SpaceAgentEditor({
 				{saveError && (
 					<div class="bg-red-900/20 border border-red-800 rounded-lg px-4 py-3 text-red-400 text-sm">
 						{saveError}
+					</div>
+				)}
+
+				{isPromotion && promotionDraft && (
+					<div class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-100">
+						<p class="font-medium">Review generated long-horizon profile before creating agent.</p>
+						<p class="mt-1 text-xs text-blue-200/80">
+							Draft uses recent renderable messages from "{promotionDraft.sourceSessionTitle}" as
+							standing context instead of copying raw chat history.
+						</p>
 					</div>
 				)}
 
@@ -520,16 +560,22 @@ export function SpaceAgentEditor({
 				{/* Custom Prompt */}
 				<div>
 					<label class="block text-sm font-medium text-gray-300 mb-2">
-						Custom Prompt
+						{isPromotion ? 'Long-Horizon Profile' : 'Custom Prompt'}
 						<span class="text-gray-500 text-xs ml-2">
 							(optional — appended after NeoKai contract)
 						</span>
 					</label>
+					{isPromotion && (
+						<p class="mb-2 text-xs text-gray-500">
+							Edit responsibility, standing instructions, autonomy, managed goals/scopes, reminders,
+							event subscriptions, and standing context here.
+						</p>
+					)}
 					<LineNumberedTextarea
 						value={customPrompt}
 						onChange={setCustomPrompt}
 						placeholder="Persona, operating procedure, or any additional context for this agent..."
-						rows={8}
+						rows={isPromotion ? 14 : 8}
 					/>
 				</div>
 
@@ -539,7 +585,7 @@ export function SpaceAgentEditor({
 						Cancel
 					</Button>
 					<Button type="submit" loading={saving} fullWidth>
-						{isEdit ? 'Save Changes' : 'Create Agent'}
+						{isEdit ? 'Save Changes' : isPromotion ? 'Create Long-Horizon Agent' : 'Create Agent'}
 					</Button>
 				</div>
 			</form>

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -10,9 +10,12 @@
  */
 
 import { useMemo, useState } from 'preact/hooks';
+import type { SpaceAgentPromotionDraft } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceSession } from '../../lib/router';
 import { getRelativeTime } from '../../lib/utils';
+import { toast } from '../../lib/toast';
+import { SpaceAgentEditor } from './SpaceAgentEditor';
 
 type Session = { id: string; title: string; status: string; lastActiveAt: number };
 
@@ -55,12 +58,14 @@ function PaginatedSessionGroup({
 	variant,
 	sessions,
 	spaceId,
+	onPromote,
 }: {
 	title: string;
 	count: number;
 	variant: 'green' | 'yellow' | 'gray';
 	sessions: Session[];
 	spaceId: string;
+	onPromote: (session: Session) => void;
 }) {
 	const [page, setPage] = useState(0);
 	const totalPages = Math.ceil(sessions.length / ACTIVE_PAGE_SIZE);
@@ -88,7 +93,7 @@ function PaginatedSessionGroup({
 			</div>
 			<div class="divide-y divide-dark-700">
 				{displayed.map((session) => (
-					<SessionItem key={session.id} session={session} spaceId={spaceId} />
+					<SessionItem key={session.id} session={session} spaceId={spaceId} onPromote={onPromote} />
 				))}
 			</div>
 			{totalPages > 1 && (
@@ -123,6 +128,7 @@ function SessionGroup({
 	sessions,
 	spaceId,
 	hardLimit,
+	onPromote,
 }: {
 	title: string;
 	count: number;
@@ -130,6 +136,7 @@ function SessionGroup({
 	sessions: Session[];
 	spaceId: string;
 	hardLimit?: number;
+	onPromote: (session: Session) => void;
 }) {
 	const displayed = hardLimit ? sessions.slice(0, hardLimit) : sessions;
 	const hidden = hardLimit ? Math.max(0, sessions.length - hardLimit) : 0;
@@ -156,7 +163,7 @@ function SessionGroup({
 			</div>
 			<div class="divide-y divide-dark-700">
 				{displayed.map((session) => (
-					<SessionItem key={session.id} session={session} spaceId={spaceId} />
+					<SessionItem key={session.id} session={session} spaceId={spaceId} onPromote={onPromote} />
 				))}
 				{hidden > 0 && (
 					<div class="px-4 py-2 text-xs text-gray-600 text-center">+{hidden} more not shown</div>
@@ -166,7 +173,15 @@ function SessionGroup({
 	);
 }
 
-function SessionItem({ session, spaceId }: { session: Session; spaceId: string }) {
+function SessionItem({
+	session,
+	spaceId,
+	onPromote,
+}: {
+	session: Session;
+	spaceId: string;
+	onPromote: (session: Session) => void;
+}) {
 	const borderColor = STATUS_BORDER[session.status] ?? 'border-l-transparent';
 
 	return (
@@ -186,7 +201,17 @@ function SessionItem({ session, spaceId }: { session: Session; spaceId: string }
 						)}
 					</div>
 				</div>
-				<div class="ml-4 flex items-center flex-shrink-0">
+				<div class="ml-4 flex flex-shrink-0 items-center gap-2">
+					<button
+						type="button"
+						onClick={(event) => {
+							event.stopPropagation();
+							onPromote(session);
+						}}
+						class="rounded-md border border-blue-500/30 px-2 py-1 text-xs text-blue-300 transition-colors hover:bg-blue-500/10 hover:text-blue-200"
+					>
+						Promote
+					</button>
 					<span class="text-xs text-gray-600">&rarr;</span>
 				</div>
 			</div>
@@ -200,6 +225,8 @@ interface SpaceSessionsPageProps {
 
 export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 	const storeSessions = spaceStore.sessions.value;
+	const agents = spaceStore.agents.value;
+	const [promotionDraft, setPromotionDraft] = useState<SpaceAgentPromotionDraft | null>(null);
 
 	const sessions = useMemo(() => {
 		const isSystemSpaceSession = (sessionId: string): boolean =>
@@ -210,6 +237,19 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 			.filter((s) => !isSystemSpaceSession(s.id))
 			.sort((a, b) => (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0));
 	}, [storeSessions, spaceId]);
+
+	const existingAgentNames = agents.map((agent) => agent.name);
+
+	const handlePromote = async (session: Session) => {
+		try {
+			const draft = await spaceStore.getAgentPromotionDraft(session.id);
+			setPromotionDraft(draft);
+		} catch (err) {
+			toast.error(
+				`Failed to generate promotion draft: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+	};
 
 	if (sessions.length === 0) {
 		return (
@@ -234,36 +274,49 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 	}
 
 	return (
-		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
-			<div class="min-h-[calc(100%+1px)] space-y-4">
-				{SESSION_GROUPS.map((group) => {
-					const groupSessions = sessions.filter((s) => group.statuses.includes(s.status));
-					if (groupSessions.length === 0) return null;
-					if (group.paginated) {
+		<>
+			<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
+				<div class="min-h-[calc(100%+1px)] space-y-4">
+					{SESSION_GROUPS.map((group) => {
+						const groupSessions = sessions.filter((s) => group.statuses.includes(s.status));
+						if (groupSessions.length === 0) return null;
+						if (group.paginated) {
+							return (
+								<PaginatedSessionGroup
+									key={group.title}
+									title={group.title}
+									count={groupSessions.length}
+									variant={group.variant}
+									sessions={groupSessions}
+									spaceId={spaceId}
+									onPromote={handlePromote}
+								/>
+							);
+						}
 						return (
-							<PaginatedSessionGroup
+							<SessionGroup
 								key={group.title}
 								title={group.title}
 								count={groupSessions.length}
 								variant={group.variant}
 								sessions={groupSessions}
 								spaceId={spaceId}
+								hardLimit={group.hardLimit}
+								onPromote={handlePromote}
 							/>
 						);
-					}
-					return (
-						<SessionGroup
-							key={group.title}
-							title={group.title}
-							count={groupSessions.length}
-							variant={group.variant}
-							sessions={groupSessions}
-							spaceId={spaceId}
-							hardLimit={group.hardLimit}
-						/>
-					);
-				})}
+					})}
+				</div>
 			</div>
-		</div>
+			{promotionDraft && (
+				<SpaceAgentEditor
+					agent={null}
+					promotionDraft={promotionDraft}
+					existingAgentNames={existingAgentNames}
+					onSave={() => setPromotionDraft(null)}
+					onCancel={() => setPromotionDraft(null)}
+				/>
+			)}
+		</>
 	);
 }

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -17,7 +17,7 @@ import { getRelativeTime } from '../../lib/utils';
 import { toast } from '../../lib/toast';
 import { SpaceAgentEditor } from './SpaceAgentEditor';
 
-type Session = { id: string; title: string; status: string; lastActiveAt: number };
+type Session = { id: string; title: string; status: string; lastActiveAt: number; type?: string };
 
 const STATUS_BORDER: Record<string, string> = {
 	active: 'border-l-green-500',
@@ -183,6 +183,7 @@ function SessionItem({
 	onPromote: (session: Session) => void;
 }) {
 	const borderColor = STATUS_BORDER[session.status] ?? 'border-l-transparent';
+	const canPromote = session.type !== 'space_task_agent';
 
 	return (
 		<div
@@ -201,19 +202,21 @@ function SessionItem({
 						)}
 					</div>
 				</div>
-				<div class="ml-4 flex flex-shrink-0 items-center gap-2">
-					<button
-						type="button"
-						onClick={(event) => {
-							event.stopPropagation();
-							onPromote(session);
-						}}
-						class="rounded-md border border-blue-500/30 px-2 py-1 text-xs text-blue-300 transition-colors hover:bg-blue-500/10 hover:text-blue-200"
-					>
-						Promote
-					</button>
-					<span class="text-xs text-gray-600">&rarr;</span>
-				</div>
+				{canPromote && (
+					<div class="ml-4 flex flex-shrink-0 items-center gap-2">
+						<button
+							type="button"
+							onClick={(event) => {
+								event.stopPropagation();
+								onPromote(session);
+							}}
+							class="rounded-md border border-blue-500/30 px-2 py-1 text-xs text-blue-300 transition-colors hover:bg-blue-500/10 hover:text-blue-200"
+						>
+							Promote
+						</button>
+						<span class="text-xs text-gray-600">&rarr;</span>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -9,7 +9,7 @@
  * where handlePopState restores spaceViewMode = 'sessions'.
  */
 
-import { useMemo, useState } from 'preact/hooks';
+import { useMemo, useRef, useState } from 'preact/hooks';
 import type { SpaceAgentPromotionDraft } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceSession } from '../../lib/router';
@@ -227,6 +227,7 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 	const storeSessions = spaceStore.sessions.value;
 	const agents = spaceStore.agents.value;
 	const [promotionDraft, setPromotionDraft] = useState<SpaceAgentPromotionDraft | null>(null);
+	const promotionRequestId = useRef(0);
 
 	const sessions = useMemo(() => {
 		const isSystemSpaceSession = (sessionId: string): boolean =>
@@ -241,10 +242,14 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 	const existingAgentNames = agents.map((agent) => agent.name);
 
 	const handlePromote = async (session: Session) => {
+		const requestId = promotionRequestId.current + 1;
+		promotionRequestId.current = requestId;
 		try {
 			const draft = await spaceStore.getAgentPromotionDraft(session.id);
+			if (promotionRequestId.current !== requestId) return;
 			setPromotionDraft(draft);
 		} catch (err) {
+			if (promotionRequestId.current !== requestId) return;
 			toast.error(
 				`Failed to generate promotion draft: ${err instanceof Error ? err.message : String(err)}`
 			);

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -310,6 +310,7 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 			</div>
 			{promotionDraft && (
 				<SpaceAgentEditor
+					key={promotionDraft.sourceSessionId}
 					agent={null}
 					promotionDraft={promotionDraft}
 					existingAgentNames={existingAgentNames}

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -205,7 +205,11 @@ describe('SpaceGoals', () => {
 	});
 
 	it('writes the current goal selection for the right-panel toggle', async () => {
-		mockGoals.value = [makeGoal(), makeGoal({ id: 'goal-2', title: 'Second goal' })];
+		const now = Date.now();
+		mockGoals.value = [
+			makeGoal({ updatedAt: now }),
+			makeGoal({ id: 'goal-2', title: 'Second goal', updatedAt: now - 1 }),
+		];
 
 		const { unmount } = render(<SpaceGoals spaceId="space-1" />);
 

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -251,6 +251,18 @@ function makeMockHub() {
 			if (method === 'spaceTask.recoverWorkflow') return makeTask('t1', 'in_progress');
 			// spaceAgent handlers return wrapped { agent }
 			if (method === 'spaceAgent.create') return { agent: makeAgent('new-agent') };
+			if (method === 'spaceAgent.getPromotionDraft') {
+				return {
+					draft: {
+						sourceSessionId: params?.sessionId,
+						sourceSessionTitle: 'Session title',
+						name: 'Promoted Agent',
+						customPrompt: 'Generated profile',
+						profile: {},
+					},
+				};
+			}
+			if (method === 'spaceAgent.promoteSession') return { agent: makeAgent('promoted-agent') };
 			if (method === 'spaceAgent.update') return { agent: makeAgent('a1') };
 			// spaceWorkflow handlers return wrapped { workflow }
 			if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
@@ -1254,6 +1266,32 @@ describe('SpaceStore — CRUD methods', () => {
 		expect(mockHub.request).toHaveBeenCalledWith('spaceAgent.create', {
 			spaceId: 'space-1',
 			name: 'Coder',
+		});
+	});
+
+	it('getAgentPromotionDraft calls spaceAgent.getPromotionDraft RPC', async () => {
+		await spaceStore.selectSpace('space-1');
+		const draft = await spaceStore.getAgentPromotionDraft('session-1');
+
+		expect(draft.name).toBe('Promoted Agent');
+		expect(mockHub.request).toHaveBeenCalledWith('spaceAgent.getPromotionDraft', {
+			spaceId: 'space-1',
+			sessionId: 'session-1',
+		});
+	});
+
+	it('promoteSessionToAgent calls spaceAgent.promoteSession RPC', async () => {
+		await spaceStore.selectSpace('space-1');
+		await spaceStore.promoteSessionToAgent('session-1', {
+			name: 'Promoted Agent',
+			customPrompt: 'Reviewed profile',
+		});
+
+		expect(mockHub.request).toHaveBeenCalledWith('spaceAgent.promoteSession', {
+			spaceId: 'space-1',
+			sessionId: 'session-1',
+			name: 'Promoted Agent',
+			customPrompt: 'Reviewed profile',
 		});
 	});
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -36,6 +36,7 @@ import type {
 	RuntimeState,
 	Space,
 	SpaceAgent,
+	SpaceAgentPromotionDraft,
 	SpaceBlockReason,
 	SpaceGoal,
 	SpaceGoalEvent,
@@ -2012,6 +2013,38 @@ class SpaceStore {
 	/**
 	 * Update an agent
 	 */
+	async getAgentPromotionDraft(sessionId: string): Promise<SpaceAgentPromotionDraft> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { draft } = await hub.request<{ draft: SpaceAgentPromotionDraft }>(
+			'spaceAgent.getPromotionDraft',
+			{ spaceId, sessionId }
+		);
+		return draft;
+	}
+
+	async promoteSessionToAgent(
+		sessionId: string,
+		params: Omit<CreateSpaceAgentParams, 'spaceId'>
+	): Promise<SpaceAgent> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { agent } = await hub.request<{ agent: SpaceAgent }>('spaceAgent.promoteSession', {
+			...params,
+			spaceId,
+			sessionId,
+		});
+		return agent;
+	}
+
 	async updateAgent(agentId: string, params: UpdateSpaceAgentParams): Promise<SpaceAgent> {
 		const spaceId = this.spaceId.value;
 		if (!spaceId) throw new Error('No space selected');


### PR DESCRIPTION
Adds a Space session promotion flow that drafts a long-horizon agent profile from recent renderable messages, lets the user review/edit it in the existing agent editor, then creates the agent.

Tests: targeted daemon handler test, web space store test, `bun run check`.