### PR TITLE
Suppress Space Agent idle noise

### DIFF
--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -483,19 +483,6 @@ export interface SpaceAgentRecoveredEvent {
 	timestamp: string;
 }
 
-/** A node agent went idle without a terminal SDK message or reported status. */
-export interface SpaceAgentIdleNonTerminalEvent {
-	sessionId: string;
-	spaceId: string;
-	taskId: string;
-	runId: string;
-	executionId: string;
-	nodeId: string;
-	agentName: string;
-	reason: string;
-	timestamp: string;
-}
-
 /** A workflow run has reached a terminal state. */
 export interface SpaceWorkflowRunCompletedEvent {
 	sessionId: string;
@@ -593,7 +580,6 @@ export interface SpaceEvents {
 	'space.task.failed': SpaceTaskFailedEvent;
 	'space.agent.crashed': SpaceAgentCrashedEvent;
 	'space.agent.recovered': SpaceAgentRecoveredEvent;
-	'space.agent.idleNonTerminal': SpaceAgentIdleNonTerminalEvent;
 	'space.workflowRun.completed': SpaceWorkflowRunCompletedEvent;
 	'space.workflowRun.failed': SpaceWorkflowRunFailedEvent;
 	'space.workflowRun.blocked': SpaceWorkflowRunBlockedEvent;

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -376,20 +376,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		},
 	});
 
-	// When a space is resumed/started, re-seed any of its active schedules
-	// whose fire jobs were skipped during the inactive window so cron/at
-	// schedules pick up forward progress without waiting for daemon restart.
-	deps.spaceManager.onSpaceResumedRegister((spaceId) => {
-		try {
-			const recovered = scheduleService.recoverSchedulesForSpace(spaceId);
-			if (recovered > 0) {
-				log.info('recovered schedules after space resume', { spaceId, recovered });
-			}
-		} catch (err) {
-			log.error('schedule recovery after space resume failed (non-fatal)', err);
-		}
-	});
-
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const evolutionTraceEvidenceService = new EvolutionTraceEvidenceService({
 		db: deps.db.getDatabase(),
@@ -549,6 +535,20 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		goalService: spaceGoalService,
 		evolutionScopeService,
 		evolutionEpisodeService,
+	});
+
+	// When a space is resumed/started, re-seed skipped schedules and re-run restart
+	// stalled recovery for active runs that were skipped while inactive.
+	deps.spaceManager.onSpaceResumedRegister((spaceId) => {
+		try {
+			const recovered = scheduleService.recoverSchedulesForSpace(spaceId);
+			if (recovered > 0) {
+				log.info('recovered schedules after space resume', { spaceId, recovered });
+			}
+		} catch (err) {
+			log.error('schedule recovery after space resume failed (non-fatal)', err);
+		}
+		spaceRuntimeService.recoverStalledWorkflowRunsAfterSpaceResume(spaceId);
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -124,16 +124,6 @@ export class SpaceAgentNotificationService {
 				{ subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.agent.crashed` }
 			),
 			this.internalEventBus.subscribe(
-				'space.agent.idleNonTerminal',
-				(event) => {
-					if (event.spaceId !== this.spaceId) return;
-					void this.notify(formatAgentIdleNonTerminal(event, this.autonomyLevel));
-				},
-				{
-					subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.agent.idleNonTerminal`,
-				}
-			),
-			this.internalEventBus.subscribe(
 				'space.workflowRun.retry',
 				(event) => {
 					if (event.spaceId !== this.spaceId) return;
@@ -304,36 +294,6 @@ function formatAgentCrash(
 		autonomyLevel,
 	};
 	return buildMessage('agent_crash', humanReadable, payload);
-}
-
-function formatAgentIdleNonTerminal(
-	event: {
-		spaceId: string;
-		taskId: string;
-		runId: string;
-		executionId: string;
-		nodeId: string;
-		agentName: string;
-		reason: string;
-		timestamp: string;
-	},
-	autonomyLevel: SpaceAutonomyLevel
-): string {
-	const humanReadable =
-		`Node ${event.nodeId} (${event.agentName}) in workflow run ${event.runId} went idle with a non-terminal last message. ` +
-		`The runtime will not advance the workflow from this idle state. Reason: ${event.reason}`;
-	return buildMessage('agent_idle_non_terminal', humanReadable, {
-		kind: 'agent_idle_non_terminal',
-		spaceId: event.spaceId,
-		taskId: event.taskId,
-		runId: event.runId,
-		executionId: event.executionId,
-		nodeId: event.nodeId,
-		agentName: event.agentName,
-		reason: event.reason,
-		timestamp: event.timestamp,
-		autonomyLevel,
-	});
 }
 
 function formatTaskRetry(

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -225,6 +225,7 @@ export class SpaceRuntimeService {
 	 */
 	private readonly spaceAgentNotificationUnsubs = new Map<string, () => void>();
 	private readonly longTermAgentFlushes = new Map<string, Promise<void>>();
+	private resumeStalledRecoveryPromise: Promise<void> = Promise.resolve();
 	/**
 	 * Resolves when startup-time session provisioning has completed:
 	 *   - every existing space's space:chat session has had MCP tools +
@@ -819,13 +820,18 @@ export class SpaceRuntimeService {
 	}
 
 	recoverStalledWorkflowRunsAfterSpaceResume(spaceId: string): void {
-		this.runtime.resetStalledRunRecovery();
-		void this.recoverStalledWorkflowRuns().catch((err) => {
-			log.error(
-				`SpaceRuntimeService: recoverStalledWorkflowRuns after space resume failed for ${spaceId}:`,
-				err
-			);
-		});
+		this.resumeStalledRecoveryPromise = this.resumeStalledRecoveryPromise
+			.catch(() => {})
+			.then(async () => {
+				try {
+					await this.runtime.recoverStalledRunsForSpace(spaceId);
+				} catch (err) {
+					log.error(
+						`SpaceRuntimeService: recoverStalledWorkflowRuns after space resume failed for ${spaceId}:`,
+						err
+					);
+				}
+			});
 	}
 
 	private async recoverLongTermAgentInbox(): Promise<void> {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -818,6 +818,16 @@ export class SpaceRuntimeService {
 		}
 	}
 
+	recoverStalledWorkflowRunsAfterSpaceResume(spaceId: string): void {
+		this.runtime.resetStalledRunRecovery();
+		void this.recoverStalledWorkflowRuns().catch((err) => {
+			log.error(
+				`SpaceRuntimeService: recoverStalledWorkflowRuns after space resume failed for ${spaceId}:`,
+				err
+			);
+		});
+	}
+
 	private async recoverLongTermAgentInbox(): Promise<void> {
 		const inboxRepo = this.config.spaceAgentInboxRepo;
 		if (!inboxRepo) return;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -307,6 +307,16 @@ interface AgentStuckRecoveryState {
 	pendingRestartNotice: string | null;
 }
 
+interface NonTerminalIdleState {
+	lastSessionId: string | null;
+	lastObservedMessageId: string | null;
+	lastObservedProgressMessageId: string | null;
+	lastObservedProgressMessageAt: number | null;
+	lastRuntimeNudgeMessageId: string | null;
+	nudgeCount: number;
+	lastNudgeAt: number | null;
+}
+
 const EXTERNAL_EVENT_RETRY_DELAY_MS = 1000;
 const EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS = 5;
 const EXTERNAL_EVENT_RATE_WINDOW_MS = 60_000;
@@ -704,11 +714,11 @@ export class SpaceRuntime {
 	/**
 	 * Tracks idle executions whose last SDK message was non-terminal.
 	 *
-	 * This is an in-memory duplicate-notification guard only. Naturally idle
-	 * incomplete executions are preserved; Layer 1 no longer respawns or blocks
-	 * them solely because the canonical task remains incomplete.
+	 * This is an in-memory guard only. Naturally idle incomplete executions are
+	 * preserved; qualified stale idle sessions receive one direct runtime nudge,
+	 * then repeated qualified idle is logged for human visibility.
 	 */
-	private nonTerminalIdleCounts = new Map<string, number>();
+	private nonTerminalIdleStates = new Map<string, NonTerminalIdleState>();
 
 	/**
 	 * In-memory Layer 1 recovery state keyed by `${runId}:${nodeExecutionId}`.
@@ -2888,11 +2898,10 @@ export class SpaceRuntime {
 				this.config.pendingMessageRepo.clearTerminalForRun(preTxRunId);
 			}
 			this.blockedRetryCounts.delete(preTxRunId);
-			// Clear non-terminal idle retry counters so a manually recovered run
-			// starts with a fresh retry budget instead of re-blocking immediately.
-			for (const key of this.nonTerminalIdleCounts.keys()) {
+			// Clear non-terminal idle state so a manually recovered run starts fresh.
+			for (const key of this.nonTerminalIdleStates.keys()) {
 				if (key.startsWith(preTxRunId + ':')) {
-					this.nonTerminalIdleCounts.delete(key);
+					this.nonTerminalIdleStates.delete(key);
 				}
 			}
 			// Clear Layer 1 alive-stuck state so manually recovered workflow runs get
@@ -3477,7 +3486,8 @@ export class SpaceRuntime {
 			const nonTerminalIdleOutcome = await this.handleNonTerminalIdleExecutions(
 				run.id,
 				run.spaceId,
-				canonicalTask
+				canonicalTask,
+				workflow
 			);
 			if (nonTerminalIdleOutcome === 'blocked') return 'blocked';
 			if (nonTerminalIdleOutcome === 'retried' || nonTerminalIdleOutcome === 'preserved') {
@@ -3955,9 +3965,9 @@ export class SpaceRuntime {
 				this.agentStuckRecovery.delete(key);
 			}
 		}
-		for (const key of this.nonTerminalIdleCounts.keys()) {
+		for (const key of this.nonTerminalIdleStates.keys()) {
 			if (key.startsWith(runId + ':')) {
-				this.nonTerminalIdleCounts.delete(key);
+				this.nonTerminalIdleStates.delete(key);
 			}
 		}
 	}
@@ -3988,6 +3998,10 @@ export class SpaceRuntime {
 			'',
 			'Please continue your assigned work from the current state. If work is complete, report completion through the workflow tools. If you are blocked, report the blocker clearly through the available tools. Do not wait silently.',
 		].join('\n');
+	}
+
+	private buildNonTerminalIdleNudgeMessage(): string {
+		return 'Runtime noticed no recent progress. Continue current work, or report a blocker.';
 	}
 
 	private buildRuntimeRestartNotice(execution: NodeExecution): string {
@@ -4448,7 +4462,9 @@ export class SpaceRuntime {
 			const nonTerminalIdleOutcome = await this.handleNonTerminalIdleExecutions(
 				runId,
 				meta.spaceId,
-				canonicalTask
+				canonicalTask,
+				meta.workflow,
+				tam
 			);
 			if (nonTerminalIdleOutcome === 'blocked') {
 				return;
@@ -5124,7 +5140,9 @@ export class SpaceRuntime {
 	private async handleNonTerminalIdleExecutions(
 		runId: string,
 		spaceId: string,
-		canonicalTask: SpaceTask
+		canonicalTask: SpaceTask,
+		workflow?: SpaceWorkflow,
+		tam?: TaskAgentManager
 	): Promise<'none' | 'retried' | 'blocked' | 'preserved'> {
 		// Explicit task completion or pause signals are authoritative. A final tool
 		// call may have set reportedStatus or parked the task for human/post-approval
@@ -5149,31 +5167,109 @@ export class SpaceRuntime {
 			if (!sessionId) continue;
 			const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
 			const classification = classifyLastMessageForIdleAgent(lastMessage);
+			const key = `${runId}:${execution.id}`;
 			if (classification.terminal) {
-				this.nonTerminalIdleCounts.delete(`${runId}:${execution.id}`);
+				this.nonTerminalIdleStates.delete(key);
 				continue;
 			}
 
 			preservedAny = true;
-			const key = `${runId}:${execution.id}`;
-			if (this.nonTerminalIdleCounts.has(key)) continue;
-			this.nonTerminalIdleCounts.set(key, 1);
+			const state = this.nonTerminalIdleStates.get(key) ?? {
+				lastSessionId: sessionId,
+				lastObservedMessageId: null,
+				lastObservedProgressMessageId: null,
+				lastObservedProgressMessageAt: null,
+				lastRuntimeNudgeMessageId: null,
+				nudgeCount: 0,
+				lastNudgeAt: null,
+			};
+			this.nonTerminalIdleStates.set(key, state);
+
+			const isRuntimeNudgeMessage =
+				lastMessage?.type === 'user' && lastMessage.dbId === state.lastRuntimeNudgeMessageId;
+			const progressMessage = lastMessage && !isRuntimeNudgeMessage ? lastMessage : null;
+			if (state.lastSessionId !== sessionId) {
+				state.lastSessionId = sessionId;
+				state.lastObservedMessageId = lastMessage?.dbId ?? null;
+				state.lastObservedProgressMessageId = progressMessage?.dbId ?? null;
+				state.lastObservedProgressMessageAt = progressMessage?.timestamp ?? null;
+				state.lastRuntimeNudgeMessageId = null;
+				state.nudgeCount = 0;
+				state.lastNudgeAt = null;
+			} else if (state.lastObservedMessageId !== (lastMessage?.dbId ?? null)) {
+				state.lastObservedMessageId = lastMessage?.dbId ?? null;
+				if (progressMessage && state.lastObservedProgressMessageId !== progressMessage.dbId) {
+					state.lastObservedProgressMessageId = progressMessage.dbId;
+					state.lastObservedProgressMessageAt = progressMessage.timestamp;
+					state.lastRuntimeNudgeMessageId = null;
+					state.nudgeCount = 0;
+					state.lastNudgeAt = null;
+				}
+			}
+
+			const observedAt =
+				state.lastObservedProgressMessageAt ??
+				progressMessage?.timestamp ??
+				execution.startedAt ??
+				Date.now();
+			const thresholdMs = workflow
+				? this.getAgentNoProgressThresholdMs(workflow, execution)
+				: (this.config.agentNoProgressThresholdMs ?? DEFAULT_AGENT_NO_PROGRESS_THRESHOLD_MS);
+			const now = Date.now();
 			const reason = `Agent went idle without completing — non-terminal last message (${classification.reason})`;
-			log.warn(
-				`Node ${execution.workflowNodeId} went idle with non-terminal last message; preserving idle session: ` +
-					`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
-			);
-			await this.safeNotify({
-				kind: 'agent_idle_non_terminal',
-				spaceId,
-				taskId: canonicalTask.id,
-				runId,
-				executionId: execution.id,
-				nodeId: execution.workflowNodeId,
-				agentName: execution.agentName,
-				reason,
-				timestamp: new Date().toISOString(),
-			});
+			if (now - observedAt <= thresholdMs) {
+				log.debug(
+					`Node ${execution.workflowNodeId} is idle with non-terminal last message but within threshold; preserving idle session: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+				);
+				continue;
+			}
+			if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id)) {
+				log.debug(
+					`Node ${execution.workflowNodeId} is idle with non-terminal last message but has active tool use; preserving idle session: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId}`
+				);
+				continue;
+			}
+			if (this.toolContinuationRepo.listPendingInboxForExecution(execution.id).length > 0) {
+				log.debug(
+					`Node ${execution.workflowNodeId} is idle with non-terminal last message but has pending tool continuation; preserving idle session: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId}`
+				);
+				continue;
+			}
+			if (state.nudgeCount > 0) {
+				log.warn(
+					`Node ${execution.workflowNodeId} remains idle with non-terminal last message after runtime nudge; needs attention: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+				);
+				continue;
+			}
+			const manager = tam ?? this.config.taskAgentManager;
+			if (!manager) {
+				log.warn(
+					`Node ${execution.workflowNodeId} qualified as idle with non-terminal last message, but TaskAgentManager is unavailable; needs attention: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+				);
+				continue;
+			}
+			try {
+				state.lastRuntimeNudgeMessageId = await manager.injectRuntimeRecoveryMessage(
+					sessionId,
+					this.buildNonTerminalIdleNudgeMessage()
+				);
+				state.nudgeCount += 1;
+				state.lastNudgeAt = now;
+				log.warn(
+					`Node ${execution.workflowNodeId} went idle with non-terminal last message; sent direct runtime nudge: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+				);
+			} catch (error) {
+				log.warn(
+					`Failed to nudge idle non-terminal node ${execution.workflowNodeId}; needs attention: ` +
+						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${reason}: ${formatCommandError(error)}`
+				);
+			}
 		}
 		return preservedAny ? 'preserved' : 'none';
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3347,6 +3347,10 @@ export class SpaceRuntime {
 	 * Must be called *after* `rehydrateExecutors()` so executor metadata is
 	 * available for any run we might transition.
 	 */
+	resetStalledRunRecovery(): void {
+		this.recoveryDone = false;
+	}
+
 	async recoverStalledRuns(): Promise<void> {
 		if (this.recoveryDone) return;
 		this.recoveryDone = true;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4054,6 +4054,18 @@ export class SpaceRuntime {
 			const processingState = session?.getProcessingState();
 			if (processingState?.status === 'waiting_for_input') continue;
 
+			// Skip nag when task is awaiting human approval — the agent has already
+			// submitted its work and is intentionally idle pending review.
+			if (canonicalTask.pendingCheckpointType === 'task_completion') continue;
+			// Skip nag when the execution already has a result and the task is in a
+			// review/approved state — the node agent reported completion and is waiting
+			// for the workflow to advance through the approval gate.
+			if (
+				execution.result &&
+				(canonicalTask.status === 'review' || canonicalTask.status === 'approved')
+			)
+				continue;
+
 			const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(execution.agentSessionId);
 			const classification = classifyLastMessageForIdleAgent(lastMessage);
 			const state = this.getAgentStuckState(runId, execution);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -315,8 +315,10 @@ interface NonTerminalIdleState {
 	lastRuntimeNudgeMessageId: string | null;
 	nudgeCount: number;
 	lastNudgeAt: number | null;
+	lastAttentionLogAt: number | null;
 }
 
+const NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS = 5 * 60 * 1000;
 const EXTERNAL_EVENT_RETRY_DELAY_MS = 1000;
 const EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS = 5;
 const EXTERNAL_EVENT_RATE_WINDOW_MS = 60_000;
@@ -390,17 +392,6 @@ type SpaceNotificationEvent =
 			kind: 'agent_crash';
 			spaceId: string;
 			taskId: string;
-			timestamp: string;
-	  }
-	| {
-			kind: 'agent_idle_non_terminal';
-			spaceId: string;
-			taskId: string;
-			runId: string;
-			executionId: string;
-			nodeId: string;
-			agentName: string;
-			reason: string;
 			timestamp: string;
 	  }
 	| {
@@ -555,21 +546,6 @@ function mapNotificationEventToInternalEvent(event: SpaceNotificationEvent): {
 					namespaceId,
 					spaceId: event.spaceId,
 					taskId: event.taskId,
-					timestamp: event.timestamp,
-				},
-			};
-		case 'agent_idle_non_terminal':
-			return {
-				event: 'space.agent.idleNonTerminal',
-				payload: {
-					namespaceId,
-					spaceId: event.spaceId,
-					taskId: event.taskId,
-					runId: event.runId,
-					executionId: event.executionId,
-					nodeId: event.nodeId,
-					agentName: event.agentName,
-					reason: event.reason,
 					timestamp: event.timestamp,
 				},
 			};
@@ -1262,13 +1238,7 @@ export class SpaceRuntime {
 			// Re-check run deliverability before queueing a retry — the run may
 			// have transitioned to terminal while the dispatch was in flight.
 			const currentRun = this.config.workflowRunRepo.getRun(target.workflowRunId);
-			const blockedWithoutActiveExec =
-				currentRun?.status === 'blocked' && !this.hasActiveExecutionForRun(currentRun.id);
-			if (
-				!currentRun ||
-				!isExternallyDeliverableRun(currentRun.status) ||
-				blockedWithoutActiveExec
-			) {
+			if (!currentRun || !isExternallyDeliverableRun(currentRun.status)) {
 				store.markDeliveryFailed(event.eventId, deliveryKey, {
 					terminal: true,
 					reason: 'run_not_externally_deliverable',
@@ -1361,8 +1331,7 @@ export class SpaceRuntime {
 			// Re-check run deliverability before dispatching — the run may have
 			// transitioned to terminal while the retry timer was pending.
 			const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
-			const blockedNoExec = run?.status === 'blocked' && !this.hasActiveExecutionForRun(run.id);
-			if (!run || !isExternallyDeliverableRun(run.status) || blockedNoExec) {
+			if (!run || !isExternallyDeliverableRun(run.status)) {
 				this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
 					terminal: true,
 					reason: 'run_not_externally_deliverable',
@@ -3425,6 +3394,8 @@ export class SpaceRuntime {
 			await this.blockRunWithMissingWorkflow(run, executions);
 			return 'blocked';
 		}
+		const space = await this.config.spaceManager.getSpace(run.spaceId);
+		if (space?.paused || space?.stopped) return 'skipped';
 		if (executions.length === 0) return 'skipped';
 
 		// If the tick loop has any work it can drive — `pending` (about
@@ -3487,7 +3458,9 @@ export class SpaceRuntime {
 				run.id,
 				run.spaceId,
 				canonicalTask,
-				workflow
+				workflow,
+				undefined,
+				space ?? null
 			);
 			if (nonTerminalIdleOutcome === 'blocked') return 'blocked';
 			if (nonTerminalIdleOutcome === 'retried' || nonTerminalIdleOutcome === 'preserved') {
@@ -4464,7 +4437,8 @@ export class SpaceRuntime {
 				meta.spaceId,
 				canonicalTask,
 				meta.workflow,
-				tam
+				tam,
+				space ?? null
 			);
 			if (nonTerminalIdleOutcome === 'blocked') {
 				return;
@@ -5142,8 +5116,11 @@ export class SpaceRuntime {
 		spaceId: string,
 		canonicalTask: SpaceTask,
 		workflow?: SpaceWorkflow,
-		tam?: TaskAgentManager
+		tam?: TaskAgentManager,
+		space?: Space | null
 	): Promise<'none' | 'retried' | 'blocked' | 'preserved'> {
+		if (space?.paused || space?.stopped) return 'none';
+
 		// Explicit task completion or pause signals are authoritative. A final tool
 		// call may have set reportedStatus or parked the task for human/post-approval
 		// review even if the SDK result row has not been persisted yet.
@@ -5182,6 +5159,7 @@ export class SpaceRuntime {
 				lastRuntimeNudgeMessageId: null,
 				nudgeCount: 0,
 				lastNudgeAt: null,
+				lastAttentionLogAt: null,
 			};
 			this.nonTerminalIdleStates.set(key, state);
 
@@ -5196,6 +5174,7 @@ export class SpaceRuntime {
 				state.lastRuntimeNudgeMessageId = null;
 				state.nudgeCount = 0;
 				state.lastNudgeAt = null;
+				state.lastAttentionLogAt = null;
 			} else if (state.lastObservedMessageId !== (lastMessage?.dbId ?? null)) {
 				state.lastObservedMessageId = lastMessage?.dbId ?? null;
 				if (progressMessage && state.lastObservedProgressMessageId !== progressMessage.dbId) {
@@ -5239,10 +5218,16 @@ export class SpaceRuntime {
 				continue;
 			}
 			if (state.nudgeCount > 0) {
-				log.warn(
-					`Node ${execution.workflowNodeId} remains idle with non-terminal last message after runtime nudge; needs attention: ` +
-						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
-				);
+				if (
+					state.lastAttentionLogAt === null ||
+					now - state.lastAttentionLogAt >= NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS
+				) {
+					state.lastAttentionLogAt = now;
+					log.warn(
+						`Node ${execution.workflowNodeId} remains idle with non-terminal last message after runtime nudge; needs attention: ` +
+							`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+					);
+				}
 				continue;
 			}
 			const manager = tam ?? this.config.taskAgentManager;
@@ -5253,18 +5238,19 @@ export class SpaceRuntime {
 				);
 				continue;
 			}
+			state.nudgeCount += 1;
+			state.lastNudgeAt = now;
 			try {
 				state.lastRuntimeNudgeMessageId = await manager.injectRuntimeRecoveryMessage(
 					sessionId,
 					this.buildNonTerminalIdleNudgeMessage()
 				);
-				state.nudgeCount += 1;
-				state.lastNudgeAt = now;
 				log.warn(
 					`Node ${execution.workflowNodeId} went idle with non-terminal last message; sent direct runtime nudge: ` +
 						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
 				);
 			} catch (error) {
+				state.lastAttentionLogAt = now;
 				log.warn(
 					`Failed to nudge idle non-terminal node ${execution.workflowNodeId}; needs attention: ` +
 						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${reason}: ${formatCommandError(error)}`

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1238,7 +1238,13 @@ export class SpaceRuntime {
 			// Re-check run deliverability before queueing a retry — the run may
 			// have transitioned to terminal while the dispatch was in flight.
 			const currentRun = this.config.workflowRunRepo.getRun(target.workflowRunId);
-			if (!currentRun || !isExternallyDeliverableRun(currentRun.status)) {
+			const blockedWithoutActiveExec =
+				currentRun?.status === 'blocked' && !this.hasActiveExecutionForRun(currentRun.id);
+			if (
+				!currentRun ||
+				!isExternallyDeliverableRun(currentRun.status) ||
+				blockedWithoutActiveExec
+			) {
 				store.markDeliveryFailed(event.eventId, deliveryKey, {
 					terminal: true,
 					reason: 'run_not_externally_deliverable',
@@ -1331,7 +1337,8 @@ export class SpaceRuntime {
 			// Re-check run deliverability before dispatching — the run may have
 			// transitioned to terminal while the retry timer was pending.
 			const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
-			if (!run || !isExternallyDeliverableRun(run.status)) {
+			const blockedNoExec = run?.status === 'blocked' && !this.hasActiveExecutionForRun(run.id);
+			if (!run || !isExternallyDeliverableRun(run.status) || blockedNoExec) {
 				this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
 					terminal: true,
 					reason: 'run_not_externally_deliverable',

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -314,10 +314,12 @@ interface NonTerminalIdleState {
 	lastObservedProgressMessageAt: number | null;
 	lastRuntimeNudgeMessageId: string | null;
 	nudgeCount: number;
+	failedNudgeCount: number;
 	lastNudgeAt: number | null;
 	lastAttentionLogAt: number | null;
 }
 
+const NON_TERMINAL_IDLE_FAILED_NUDGE_RETRY_MS = 60 * 1000;
 const NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS = 5 * 60 * 1000;
 const EXTERNAL_EVENT_RETRY_DELAY_MS = 1000;
 const EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS = 5;
@@ -3352,8 +3354,13 @@ export class SpaceRuntime {
 		const spaces = await this.config.spaceManager.listSpaces(false);
 		let blockedCount = 0;
 		let completionPendingCount = 0;
+		let skippedPausedCount = 0;
 
 		for (const space of spaces) {
+			if (space.paused || space.stopped) {
+				if (this.config.workflowRunRepo.getActiveRuns(space.id).length > 0) skippedPausedCount += 1;
+				continue;
+			}
 			const inProgressRuns = this.config.workflowRunRepo.getActiveRuns(space.id);
 			for (const run of inProgressRuns) {
 				try {
@@ -3367,6 +3374,10 @@ export class SpaceRuntime {
 					);
 				}
 			}
+		}
+
+		if (skippedPausedCount > 0) {
+			this.recoveryDone = false;
 		}
 
 		if (blockedCount + completionPendingCount > 0) {
@@ -3402,7 +3413,6 @@ export class SpaceRuntime {
 			return 'blocked';
 		}
 		const space = await this.config.spaceManager.getSpace(run.spaceId);
-		if (space?.paused || space?.stopped) return 'skipped';
 		if (executions.length === 0) return 'skipped';
 
 		// If the tick loop has any work it can drive — `pending` (about
@@ -5165,6 +5175,7 @@ export class SpaceRuntime {
 				lastObservedProgressMessageAt: null,
 				lastRuntimeNudgeMessageId: null,
 				nudgeCount: 0,
+				failedNudgeCount: 0,
 				lastNudgeAt: null,
 				lastAttentionLogAt: null,
 			};
@@ -5180,6 +5191,7 @@ export class SpaceRuntime {
 				state.lastObservedProgressMessageAt = progressMessage?.timestamp ?? null;
 				state.lastRuntimeNudgeMessageId = null;
 				state.nudgeCount = 0;
+				state.failedNudgeCount = 0;
 				state.lastNudgeAt = null;
 				state.lastAttentionLogAt = null;
 			} else if (state.lastObservedMessageId !== (lastMessage?.dbId ?? null)) {
@@ -5225,17 +5237,34 @@ export class SpaceRuntime {
 				continue;
 			}
 			if (state.nudgeCount > 0) {
-				if (
-					state.lastAttentionLogAt === null ||
-					now - state.lastAttentionLogAt >= NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS
-				) {
-					state.lastAttentionLogAt = now;
-					log.warn(
-						`Node ${execution.workflowNodeId} remains idle with non-terminal last message after runtime nudge; needs attention: ` +
-							`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
-					);
+				if (state.failedNudgeCount > 0 && state.lastNudgeAt !== null) {
+					const retryAfter = state.lastNudgeAt + NON_TERMINAL_IDLE_FAILED_NUDGE_RETRY_MS;
+					if (now < retryAfter) {
+						if (
+							state.lastAttentionLogAt === null ||
+							now - state.lastAttentionLogAt >= NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS
+						) {
+							state.lastAttentionLogAt = now;
+							log.warn(
+								`Node ${execution.workflowNodeId} remains idle with non-terminal last message after failed runtime nudge; needs attention: ` +
+									`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+							);
+						}
+						continue;
+					}
+				} else {
+					if (
+						state.lastAttentionLogAt === null ||
+						now - state.lastAttentionLogAt >= NON_TERMINAL_IDLE_ATTENTION_LOG_COOLDOWN_MS
+					) {
+						state.lastAttentionLogAt = now;
+						log.warn(
+							`Node ${execution.workflowNodeId} remains idle with non-terminal last message after runtime nudge; needs attention: ` +
+								`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+						);
+					}
+					continue;
 				}
-				continue;
 			}
 			const manager = tam ?? this.config.taskAgentManager;
 			if (!manager) {
@@ -5252,11 +5281,13 @@ export class SpaceRuntime {
 					sessionId,
 					this.buildNonTerminalIdleNudgeMessage()
 				);
+				state.failedNudgeCount = 0;
 				log.warn(
 					`Node ${execution.workflowNodeId} went idle with non-terminal last message; sent direct runtime nudge: ` +
 						`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
 				);
 			} catch (error) {
+				state.failedNudgeCount += 1;
 				state.lastAttentionLogAt = now;
 				log.warn(
 					`Failed to nudge idle non-terminal node ${execution.workflowNodeId}; needs attention: ` +

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3347,8 +3347,31 @@ export class SpaceRuntime {
 	 * Must be called *after* `rehydrateExecutors()` so executor metadata is
 	 * available for any run we might transition.
 	 */
-	resetStalledRunRecovery(): void {
-		this.recoveryDone = false;
+	async recoverStalledRunsForSpace(spaceId: string): Promise<void> {
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space || space.paused || space.stopped) return;
+
+		let blockedCount = 0;
+		let completionPendingCount = 0;
+		const inProgressRuns = this.config.workflowRunRepo.getActiveRuns(space.id);
+		for (const run of inProgressRuns) {
+			try {
+				const outcome = await this.recoverSingleRun(run);
+				if (outcome === 'blocked') blockedCount++;
+				else if (outcome === 'completion-pending') completionPendingCount++;
+			} catch (err) {
+				log.error(
+					`SpaceRuntime.recoverStalledRunsForSpace: failed to recover run ${run.id} (space ${space.id}):`,
+					err
+				);
+			}
+		}
+
+		if (blockedCount + completionPendingCount > 0) {
+			log.info(
+				`SpaceRuntime.recoverStalledRunsForSpace: space=${space.id} blocked=${blockedCount} completion-pending=${completionPendingCount}`
+			);
+		}
 	}
 
 	async recoverStalledRuns(): Promise<void> {

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -301,25 +301,6 @@ describe('SpaceAgentNotificationService', () => {
 		});
 	});
 
-	describe('space.agent.idleNonTerminal event', () => {
-		it('does not inject idle non-terminal events into Space Agent chat', async () => {
-			const { factory, bus } = makeService();
-			await bus.publish('space.agent.idleNonTerminal', {
-				sessionId: 'global',
-				spaceId: SPACE_ID,
-				taskId: 'task-idle',
-				runId: 'run-idle',
-				executionId: 'exec-1',
-				nodeId: 'node-1',
-				agentName: 'coder',
-				reason: 'Agent stopped responding',
-				timestamp: TIMESTAMP,
-			});
-
-			expect(factory.calls).toHaveLength(0);
-		});
-	});
-
 	describe('space.workflowRun.retry event', () => {
 		it('formats retry message', async () => {
 			const { factory, bus } = makeService();

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -302,7 +302,7 @@ describe('SpaceAgentNotificationService', () => {
 	});
 
 	describe('space.agent.idleNonTerminal event', () => {
-		it('formats idle non-terminal message', async () => {
+		it('does not inject idle non-terminal events into Space Agent chat', async () => {
 			const { factory, bus } = makeService();
 			await bus.publish('space.agent.idleNonTerminal', {
 				sessionId: 'global',
@@ -316,16 +316,7 @@ describe('SpaceAgentNotificationService', () => {
 				timestamp: TIMESTAMP,
 			});
 
-			const { message } = factory.calls[0];
-			expect(message).toContain('[TASK_EVENT] agent_idle_non_terminal');
-			expect(message).toContain('node-1');
-			expect(message).toContain('coder');
-			expect(message).toContain('Agent stopped responding');
-
-			const json = extractJson(message);
-			expect(json.kind).toBe('agent_idle_non_terminal');
-			expect(json.nodeId).toBe('node-1');
-			expect(json.agentName).toBe('coder');
+			expect(factory.calls).toHaveLength(0);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -43,7 +43,6 @@ type BusEventKind =
 	| 'workflow_run_completed'
 	| 'workflow_run_reopened'
 	| 'agent_crash'
-	| 'agent_idle_non_terminal'
 	| 'task_retry'
 	| 'workflow_run_needs_attention'
 	| 'task_awaiting_approval';
@@ -60,7 +59,6 @@ const EVENT_MAP: Record<string, BusEventKind> = {
 	'space.workflowRun.completed': 'workflow_run_completed',
 	'space.workflowRun.reopened': 'workflow_run_reopened',
 	'space.agent.crashed': 'agent_crash',
-	'space.agent.idleNonTerminal': 'agent_idle_non_terminal',
 	'space.workflowRun.retry': 'task_retry',
 	'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
 	'space.task.awaitingApproval': 'task_awaiting_approval',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -39,7 +39,6 @@ type BusEventKind =
 	| 'workflow_run_completed'
 	| 'workflow_run_reopened'
 	| 'agent_crash'
-	| 'agent_idle_non_terminal'
 	| 'task_retry'
 	| 'workflow_run_needs_attention'
 	| 'task_awaiting_approval';
@@ -56,7 +55,6 @@ const EVENT_MAP: Record<string, BusEventKind> = {
 	'space.workflowRun.completed': 'workflow_run_completed',
 	'space.workflowRun.reopened': 'workflow_run_reopened',
 	'space.agent.crashed': 'agent_crash',
-	'space.agent.idleNonTerminal': 'agent_idle_non_terminal',
 	'space.workflowRun.retry': 'task_retry',
 	'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
 	'space.task.awaitingApproval': 'task_awaiting_approval',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2494,10 +2494,10 @@ describe('SpaceRuntime external event subscriptions', () => {
 		await new Promise((resolve) => setTimeout(resolve, 1100));
 		await runtime.executeTick();
 
-		// Runtime recovery keeps the blocked run retryable and leaves delivery queued.
+		// Blocked runs without active executions are not externally deliverable.
 		const delivery = eventStore.listDeliveries(event.id)[0]!;
-		expect(delivery.state).toBe('pending');
-		expect(delivery.failureReason).toContain('simulated transient failure');
+		expect(delivery.state).toBe('failed');
+		expect(delivery.failureReason).toBe('run_not_externally_deliverable');
 	});
 
 	test('re-registers interests when recovering a terminal workflow run', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -42,7 +42,6 @@ type BusEventKind =
 	| 'workflow_run_completed'
 	| 'workflow_run_reopened'
 	| 'agent_crash'
-	| 'agent_idle_non_terminal'
 	| 'task_retry'
 	| 'workflow_run_needs_attention'
 	| 'task_awaiting_approval';
@@ -59,7 +58,6 @@ const EVENT_MAP: Record<string, BusEventKind> = {
 	'space.workflowRun.completed': 'workflow_run_completed',
 	'space.workflowRun.reopened': 'workflow_run_reopened',
 	'space.agent.crashed': 'agent_crash',
-	'space.agent.idleNonTerminal': 'agent_idle_non_terminal',
 	'space.workflowRun.retry': 'task_retry',
 	'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
 	'space.task.awaitingApproval': 'task_awaiting_approval',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -395,6 +395,30 @@ describe('SpaceRuntimeService', () => {
 
 			await svc.stop();
 		});
+
+		test('space resume hook resets and schedules stalled recovery', async () => {
+			const svc = new SpaceRuntimeService(buildConfig(spaceManager));
+			const calls: string[] = [];
+			const runtime = (
+				svc as unknown as {
+					runtime: {
+						resetStalledRunRecovery: () => void;
+						recoverStalledRuns: () => Promise<void>;
+					};
+				}
+			).runtime;
+			runtime.resetStalledRunRecovery = () => {
+				calls.push('reset');
+			};
+			runtime.recoverStalledRuns = async () => {
+				calls.push('recover');
+			};
+
+			svc.recoverStalledWorkflowRunsAfterSpaceResume('space-1');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(calls).toEqual(['reset', 'recover']);
+		});
 	});
 
 	// ─── setupSpaceAgentSession ──────────────────────────────────────────────

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -396,28 +396,57 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
-		test('space resume hook resets and schedules stalled recovery', async () => {
+		test('space resume hook schedules recovery only for the resumed space', async () => {
 			const svc = new SpaceRuntimeService(buildConfig(spaceManager));
 			const calls: string[] = [];
 			const runtime = (
 				svc as unknown as {
 					runtime: {
-						resetStalledRunRecovery: () => void;
-						recoverStalledRuns: () => Promise<void>;
+						recoverStalledRunsForSpace: (spaceId: string) => Promise<void>;
 					};
 				}
 			).runtime;
-			runtime.resetStalledRunRecovery = () => {
-				calls.push('reset');
-			};
-			runtime.recoverStalledRuns = async () => {
-				calls.push('recover');
+			runtime.recoverStalledRunsForSpace = async (spaceId: string) => {
+				calls.push(spaceId);
 			};
 
 			svc.recoverStalledWorkflowRunsAfterSpaceResume('space-1');
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
-			expect(calls).toEqual(['reset', 'recover']);
+			expect(calls).toEqual(['space-1']);
+		});
+
+		test('space resume recovery calls are serialized', async () => {
+			const svc = new SpaceRuntimeService(buildConfig(spaceManager));
+			const calls: string[] = [];
+			let releaseFirst!: () => void;
+			const firstRecovery = new Promise<void>((resolve) => {
+				releaseFirst = resolve;
+			});
+			const runtime = (
+				svc as unknown as {
+					runtime: {
+						recoverStalledRunsForSpace: (spaceId: string) => Promise<void>;
+					};
+				}
+			).runtime;
+			runtime.recoverStalledRunsForSpace = async (spaceId: string) => {
+				calls.push(`start:${spaceId}`);
+				if (spaceId === 'space-1') await firstRecovery;
+				calls.push(`finish:${spaceId}`);
+			};
+
+			svc.recoverStalledWorkflowRunsAfterSpaceResume('space-1');
+			svc.recoverStalledWorkflowRunsAfterSpaceResume('space-2');
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(calls).toEqual(['start:space-1']);
+
+			releaseFirst();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(calls).toEqual(['start:space-1', 'finish:space-1', 'start:space-2', 'finish:space-2']);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -282,7 +282,73 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 	// 1. Stalled with no completion signal → blocked
 	// -------------------------------------------------------------------------
 
+	function saveSystemMessage(sessionId: string, timestamp: string) {
+		db.prepare(
+			`INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status, origin, is_renderable, is_terminal)
+			 VALUES (?, ?, 'system', ?, ?, 'consumed', 'sdk', 1, 0)`
+		).run(
+			`${sessionId}-system-${timestamp}`,
+			sessionId,
+			JSON.stringify({
+				type: 'system',
+				session_id: sessionId,
+				uuid: `${sessionId}-system-uuid-${timestamp}`,
+				subtype: 'init',
+			}),
+			timestamp
+		);
+	}
+
 	describe('non-terminal idle last-message recovery', () => {
+		test('idle coder with recent system last message is preserved without Space Agent notification', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recent System Idle Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recent System Idle Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle', {
+				agentSessionId: 'recent-system-session',
+			});
+			saveSystemMessage('recent-system-session', new Date().toISOString());
+			const nudges: string[] = [];
+			const rt = makeRuntime({
+				taskAgentManager: {
+					rehydrate: async () => {},
+					isSessionAlive: () => false,
+					getAgentSessionById: () => null,
+					isExecutionSpawning: () => false,
+					injectRuntimeRecoveryMessage: async (_sessionId: string, message: string) => {
+						nudges.push(message);
+						return 'nudge-message-id';
+					},
+				} as any,
+				agentNoProgressThresholdMs: 60_000,
+			});
+			(rt as any).recoveryDone = true;
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('idle');
+			expect(updated.agentSessionId).toBe('recent-system-session');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+			expect(nudges).toHaveLength(0);
+			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
+		});
+
 		test('idle execution with unresolved tool_use is preserved and not advanced', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },
@@ -327,7 +393,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(updated.agentSessionId).toBe('non-terminal-session');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
-			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(true);
+			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(false);
 		});
 
@@ -367,7 +433,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(updated.agentSessionId).toBe('restart-non-terminal-session');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
-			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(true);
+			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(false);
 			expect(notifications.some((event) => event.kind === 'workflow_run_needs_attention')).toBe(
 				false
@@ -406,7 +472,15 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				} as any,
 			});
 			(rt as any).recoveryDone = true;
-			(rt as any).nonTerminalIdleCounts.set(`${run.id}:${execution.id}`, 3);
+			(rt as any).nonTerminalIdleStates.set(`${run.id}:${execution.id}`, {
+				lastSessionId: 'non-terminal-repeat',
+				lastObservedMessageId: 'message-id',
+				lastObservedProgressMessageId: 'message-id',
+				lastObservedProgressMessageAt: Date.now() - 60_000,
+				lastRuntimeNudgeMessageId: 'nudge-id',
+				nudgeCount: 3,
+				lastNudgeAt: Date.now() - 60_000,
+			});
 			await rt.executeTick();
 
 			const updated = nodeExecutionRepo.getById(execution.id)!;
@@ -446,13 +520,22 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			);
 
 			const rt = makeRuntime();
-			// Even a previously-counted idle execution should be preserved rather than blocked.
-			(rt as any).nonTerminalIdleCounts.set(`${run.id}:${execution.id}`, 3);
+			// Even a previously-noticed idle execution should be preserved rather than blocked.
+			(rt as any).nonTerminalIdleStates.set(`${run.id}:${execution.id}`, {
+				lastSessionId: 'non-terminal-blocked-session',
+				lastObservedMessageId: 'message-id',
+				lastObservedProgressMessageId: 'message-id',
+				lastObservedProgressMessageAt: Date.now() - 60_000,
+				lastRuntimeNudgeMessageId: 'nudge-id',
+				nudgeCount: 3,
+				lastNudgeAt: Date.now() - 60_000,
+			});
 			// Simulate the handler being called directly (as it would be from processRunTick)
 			const outcome = await (rt as any).handleNonTerminalIdleExecutions(
 				run.id,
 				SPACE_ID,
-				taskRepo.getTask(task.id)!
+				taskRepo.getTask(task.id)!,
+				workflow
 			);
 
 			expect(outcome).toBe('preserved');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -396,6 +396,43 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(false);
 		});
 
+		test('recoverStalledRuns rechecks paused runs after the space resumes', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Paused Restart Stall Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Paused Restart Stall Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle');
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			expect((rt as unknown as { recoveryDone: boolean }).recoveryDone).toBe(false);
+			expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('idle');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+
+			db.prepare(`UPDATE spaces SET paused = 0 WHERE id = ?`).run(SPACE_ID);
+			await rt.recoverStalledRuns();
+
+			expect((rt as unknown as { recoveryDone: boolean }).recoveryDone).toBe(true);
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.status).toBe('blocked');
+		});
+
 		test('recoverStalledRuns preserves non-terminal idle execution instead of blocking', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },
@@ -478,6 +515,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				lastObservedProgressMessageAt: Date.now() - 60_000,
 				lastRuntimeNudgeMessageId: 'nudge-id',
 				nudgeCount: 3,
+				failedNudgeCount: 0,
 				lastNudgeAt: Date.now() - 60_000,
 				lastAttentionLogAt: null,
 			});
@@ -528,6 +566,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				lastObservedProgressMessageAt: Date.now() - 60_000,
 				lastRuntimeNudgeMessageId: 'nudge-id',
 				nudgeCount: 3,
+				failedNudgeCount: 0,
 				lastNudgeAt: Date.now() - 60_000,
 				lastAttentionLogAt: null,
 			});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -159,7 +159,6 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 		'space.workflowRun.completed': 'workflow_run_completed',
 		'space.workflowRun.reopened': 'workflow_run_reopened',
 		'space.agent.crashed': 'agent_crash',
-		'space.agent.idleNonTerminal': 'agent_idle_non_terminal',
 		'space.workflowRun.retry': 'task_retry',
 		'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
 		'space.task.awaitingApproval': 'task_awaiting_approval',
@@ -346,7 +345,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
 			expect(nudges).toHaveLength(0);
-			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
+			expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
 		});
 
 		test('idle execution with unresolved tool_use is preserved and not advanced', async () => {
@@ -393,7 +392,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(updated.agentSessionId).toBe('non-terminal-session');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
-			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
+			expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(false);
 		});
 
@@ -433,7 +432,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(updated.agentSessionId).toBe('restart-non-terminal-session');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
-			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(false);
+			expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(false);
 			expect(notifications.some((event) => event.kind === 'workflow_run_needs_attention')).toBe(
 				false
@@ -480,6 +479,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				lastRuntimeNudgeMessageId: 'nudge-id',
 				nudgeCount: 3,
 				lastNudgeAt: Date.now() - 60_000,
+				lastAttentionLogAt: null,
 			});
 			await rt.executeTick();
 
@@ -529,6 +529,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				lastRuntimeNudgeMessageId: 'nudge-id',
 				nudgeCount: 3,
 				lastNudgeAt: Date.now() - 60_000,
+				lastAttentionLogAt: null,
 			});
 			// Simulate the handler being called directly (as it would be from processRunTick)
 			const outcome = await (rt as any).handleNonTerminalIdleExecutions(

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1421,13 +1421,14 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			expect(nudges).toEqual([]);
 		});
 
-		test('throttles failed and repeated idle nudge attempts', async () => {
+		test('backs off then retries failed idle nudge attempts', async () => {
 			let attempts = 0;
 			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isSessionAlive: () => false,
-				injectRuntimeRecoveryMessage: async () => {
+				injectRuntimeRecoveryMessage: async (sessionId) => {
 					attempts += 1;
-					throw new Error('session gone');
+					if (attempts === 1) throw new Error('session gone');
+					return `nudge:${sessionId}`;
 				},
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -1445,11 +1446,24 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			await rt.executeTick();
 			await rt.executeTick();
 
+			type IdleStateForTest = {
+				nudgeCount: number;
+				failedNudgeCount: number;
+				lastNudgeAt: number;
+			};
+			const states = (rt as unknown as { nonTerminalIdleStates: Map<string, IdleStateForTest> })
+				.nonTerminalIdleStates;
+			const state = states.get(`${run.id}:${execution.id}`)!;
 			expect(attempts).toBe(1);
-			const state = (
-				rt as unknown as { nonTerminalIdleStates: Map<string, { nudgeCount: number }> }
-			).nonTerminalIdleStates.get(`${run.id}:${execution.id}`);
-			expect(state?.nudgeCount).toBe(1);
+			expect(state.nudgeCount).toBe(1);
+			expect(state.failedNudgeCount).toBe(1);
+
+			state.lastNudgeAt = Date.now() - 61_000;
+			await rt.executeTick();
+
+			expect(attempts).toBe(2);
+			expect(state.nudgeCount).toBe(2);
+			expect(state.failedNudgeCount).toBe(0);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1441,7 +1441,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			).toBe(0);
 		});
 
-		test('clears preserved idle counters when removing done run executor', async () => {
+		test('clears preserved idle state when removing done run executor', async () => {
 			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isSessionAlive: () => false,
 			});
@@ -1460,7 +1460,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 			await rt.executeTick();
 			expect(
-				(rt as unknown as { nonTerminalIdleCounts: Map<string, unknown> }).nonTerminalIdleCounts
+				(rt as unknown as { nonTerminalIdleStates: Map<string, unknown> }).nonTerminalIdleStates
 					.size
 			).toBe(1);
 
@@ -1472,7 +1472,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 			expect(rt.getExecutor(run.id)).toBeUndefined();
 			expect(
-				(rt as unknown as { nonTerminalIdleCounts: Map<string, unknown> }).nonTerminalIdleCounts
+				(rt as unknown as { nonTerminalIdleStates: Map<string, unknown> }).nonTerminalIdleStates
 					.size
 			).toBe(0);
 		});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1355,9 +1355,14 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			expect(nags).toEqual([]);
 		});
 
-		test('preserves naturally idle incomplete executions', async () => {
+		test('nudges naturally idle incomplete executions after threshold', async () => {
+			const nudges: string[] = [];
 			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isSessionAlive: () => false,
+				injectRuntimeRecoveryMessage: async (sessionId) => {
+					nudges.push(sessionId);
+					return `nudge:${sessionId}`;
+				},
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
@@ -1377,6 +1382,74 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			expect(updated?.status).toBe('idle');
 			expect(updated?.agentSessionId).toBe('session:idle');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(nudges).toEqual(['session:idle']);
+			const state = (
+				rt as unknown as { nonTerminalIdleStates: Map<string, { nudgeCount: number }> }
+			).nonTerminalIdleStates.get(`${run.id}:${execution.id}`);
+			expect(state?.nudgeCount).toBe(1);
+		});
+
+		test('does not nudge idle incomplete executions while space is paused', async () => {
+			const nudges: string[] = [];
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+				isSessionAlive: () => false,
+				injectRuntimeRecoveryMessage: async (sessionId) => {
+					nudges.push(sessionId);
+					return `nudge:${sessionId}`;
+				},
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			(rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(execution.id, {
+				status: 'idle',
+				agentSessionId: 'session:paused-idle',
+			});
+			saveAssistantMessage('session:paused-idle', { minutesAgo: 20, toolUse: true });
+
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id);
+			expect(updated?.status).toBe('idle');
+			expect(updated?.agentSessionId).toBe('session:paused-idle');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(nudges).toEqual([]);
+		});
+
+		test('throttles failed and repeated idle nudge attempts', async () => {
+			let attempts = 0;
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+				isSessionAlive: () => false,
+				injectRuntimeRecoveryMessage: async () => {
+					attempts += 1;
+					throw new Error('session gone');
+				},
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(execution.id, {
+				status: 'idle',
+				agentSessionId: 'session:failed-idle-nudge',
+			});
+			saveAssistantMessage('session:failed-idle-nudge', { minutesAgo: 20, toolUse: true });
+
+			await rt.executeTick();
+			await rt.executeTick();
+
+			expect(attempts).toBe(1);
+			const state = (
+				rt as unknown as { nonTerminalIdleStates: Map<string, { nudgeCount: number }> }
+			).nonTerminalIdleStates.get(`${run.id}:${execution.id}`);
+			expect(state?.nudgeCount).toBe(1);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1630,6 +1630,75 @@ describe('SpaceRuntime — tick loop correctness', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Approval-gate and success-result nag suppression
+	// -------------------------------------------------------------------------
+
+	describe('approval-gate and success-result nag suppression', () => {
+		test('does not nag when task is pending task_completion approval', async () => {
+			const nags: string[] = [];
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+				isSessionAlive: () => true,
+				getAgentSessionById: () => processingState('processing'),
+				injectRuntimeRecoveryMessage: async (sessionId) => {
+					nags.push(sessionId);
+					return `nag:${sessionId}`;
+				},
+			});
+			const rt = new SpaceRuntime(buildConfig(tam, { agentNoProgressThresholdMs: 60_000 }));
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'session:awaiting-approval',
+				startedAt: Date.now() - 20 * 60_000,
+			});
+			// Mark task as awaiting approval
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'review',
+				pendingCheckpointType: 'task_completion',
+			});
+
+			await rt.executeTick();
+
+			expect(nags).toHaveLength(0);
+		});
+
+		test('does not nag when execution has a result and task is in review', async () => {
+			const nags: string[] = [];
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+				isSessionAlive: () => true,
+				getAgentSessionById: () => processingState('processing'),
+				injectRuntimeRecoveryMessage: async (sessionId) => {
+					nags.push(sessionId);
+					return `nag:${sessionId}`;
+				},
+			});
+			const rt = new SpaceRuntime(buildConfig(tam, { agentNoProgressThresholdMs: 60_000 }));
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+			]);
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: 'session:has-result',
+				startedAt: Date.now() - 20 * 60_000,
+				result: 'PR #42 opened at https://github.com/example/repo/pull/42',
+			});
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'review',
+			});
+
+			await rt.executeTick();
+
+			expect(nags).toHaveLength(0);
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// Multiple independent workflow runs processed in same tick
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
Suppresses `agent_idle_non_terminal` notifications from Space Agent chat and qualifies stale idle sessions before sending a short direct runtime nudge to the affected node agent.

Tests:
- `bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/suppress-space-agent-idle-notifications-and-nudge-idle-node check`
- `/Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/suppress-space-agent-idle-notifications-and-nudge-idle-node/scripts/test-daemon.sh 5-space`