### PR TITLE
Add long-horizon agent templates

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -73,6 +73,7 @@ import { PendingAgentMessageRepository } from '../../storage/repositories/pendin
 import { SpaceAgentInboxRepository } from '../../storage/repositories/space-agent-inbox-repository';
 import { SessionRepository } from '../../storage/repositories/session-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
+import { setupSpaceLongHorizonAgentHandlers } from './space-long-horizon-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
@@ -444,6 +445,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceAgentManager,
 		deps.spaceManager
 	);
+	setupSpaceLongHorizonAgentHandlers(deps.messageHub, deps.spaceManager);
 
 	setupSpaceWorkflowHandlers(
 		deps.messageHub,

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -1,0 +1,18 @@
+import type { MessageHub } from '@neokai/shared';
+import type { SpaceManager } from '../space/managers/space-manager';
+import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
+
+export function setupSpaceLongHorizonAgentHandlers(
+	messageHub: MessageHub,
+	spaceManager: SpaceManager
+): void {
+	messageHub.onRequest('spaceLongHorizonAgent.listBuiltInTemplates', async (data) => {
+		const params = data as { spaceId: string };
+		if (!params.spaceId) throw new Error('spaceId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		return { templates: getLongHorizonAgentTemplates() };
+	});
+}

--- a/packages/daemon/src/lib/space/agents/long-horizon-agent-templates.ts
+++ b/packages/daemon/src/lib/space/agents/long-horizon-agent-templates.ts
@@ -312,16 +312,7 @@ const LONG_HORIZON_AGENT_TEMPLATES: SpaceLongHorizonAgentTemplate[] = [
 ];
 
 export function getLongHorizonAgentTemplates(): SpaceLongHorizonAgentTemplate[] {
-	return LONG_HORIZON_AGENT_TEMPLATES.map((template) => ({
-		...template,
-		suggestedEventSubscriptions: template.suggestedEventSubscriptions.map((subscription) => ({
-			...subscription,
-			filter: { ...subscription.filter },
-		})),
-		reminderDefaults: template.reminderDefaults.map((reminder) => ({ ...reminder })),
-		ownershipPatterns: template.ownershipPatterns.map((pattern) => ({ ...pattern })),
-		toolPermissions: { ...template.toolPermissions },
-	}));
+	return structuredClone(LONG_HORIZON_AGENT_TEMPLATES);
 }
 
 export function getLongHorizonAgentTemplate(

--- a/packages/daemon/src/lib/space/agents/long-horizon-agent-templates.ts
+++ b/packages/daemon/src/lib/space/agents/long-horizon-agent-templates.ts
@@ -1,0 +1,331 @@
+import type { SpaceLongHorizonAgentTemplate } from '@neokai/shared';
+
+const LONG_HORIZON_AGENT_TEMPLATES: SpaceLongHorizonAgentTemplate[] = [
+	{
+		key: 'coordinator.default',
+		handle: 'coordinator',
+		displayName: 'Coordinator',
+		description:
+			'Orchestrates goals, reminders, reactive subscriptions, and handoffs across the Space.',
+		instructions:
+			'Coordinate long-horizon Space activity. Keep goals moving, route work to suitable agents, maintain reminders, monitor event subscriptions, surface blockers early, and keep durable summaries current. Prefer creating clear tasks with owners over doing all work yourself.',
+		suggestedAutonomyLevel: 2,
+		suggestedEventSubscriptions: [
+			{
+				source: 'space',
+				topic: 'task.*',
+				filter: { statuses: ['blocked', 'review', 'done'] },
+			},
+			{
+				source: 'space',
+				topic: 'goal.*',
+				filter: { statuses: ['active', 'blocked', 'done'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review Space plan',
+				body: 'Review active goals, blocked work, stale tasks, and needed follow-ups.',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * 1',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'manager',
+				description: 'Manage cross-cutting recurring goals and delegate execution tasks.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'watcher',
+				description: 'Watch broad Forge scopes for new lessons and proposed work.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'product-quality-manager.default',
+		handle: 'product-quality-manager',
+		displayName: 'Product Quality Manager',
+		description:
+			'Turns dogfood feedback, QA signals, and completed work into prioritized quality improvements.',
+		instructions:
+			'Own product quality learning loops. Review completed tasks, review feedback, QA artifacts, telemetry, and user dogfood notes. Identify bugs, UX gaps, reliability risks, and recurring friction. Convert useful findings into prioritized goals or tasks with evidence and preserve lessons for future work.',
+		suggestedAutonomyLevel: 2,
+		suggestedEventSubscriptions: [
+			{
+				source: 'space',
+				topic: 'task.done',
+				filter: { labels: ['neokai-product', 'quality'] },
+			},
+			{
+				source: 'github',
+				topic: 'pull_request.closed',
+				filter: { merged: true },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review quality signals',
+				body: 'Review recent completed tasks, QA failures, dogfood notes, and unresolved quality findings.',
+				triggerType: 'cron',
+				cronExpression: '0 10 * * 1,4',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'owner',
+				description: 'Own recurring product-quality goals and keep progress summaries current.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'manager',
+				description: 'Manage Forge scopes for bugs, UX gaps, reliability, and workflow friction.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'release-manager.default',
+		handle: 'release-manager',
+		displayName: 'Release Manager',
+		description:
+			'Coordinates release readiness, changelog inputs, validation gates, and post-release checks.',
+		instructions:
+			'Manage releases from readiness through follow-up. Track candidate changes, verify required checks, coordinate QA and approvals, prepare release notes inputs, watch deployment signals, and create follow-up tasks for regressions or missing validation.',
+		suggestedAutonomyLevel: 2,
+		suggestedEventSubscriptions: [
+			{
+				source: 'github',
+				topic: 'pull_request.closed',
+				filter: { merged: true, base: 'dev' },
+			},
+			{
+				source: 'github',
+				topic: 'workflow_run.completed',
+				filter: { branches: ['dev'], conclusions: ['failure', 'success'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Check release readiness',
+				body: 'Review merged changes, failing checks, release blockers, and validation tasks.',
+				triggerType: 'cron',
+				cronExpression: '0 16 * * 2,4',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'manager',
+				description: 'Manage release-readiness goals and coordinate pre/post-release tasks.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'watcher',
+				description: 'Watch release and CI scopes for recurring regressions.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'security-auditor.default',
+		handle: 'security-auditor',
+		displayName: 'Security Auditor',
+		description:
+			'Monitors code, dependencies, permissions, and operational changes for security risk.',
+		instructions:
+			'Audit security-relevant changes. Watch dependency, auth, permission, networking, storage, and secret-handling changes. Produce evidence-backed findings, recommend scoped mitigations, and escalate high-risk issues before release.',
+		suggestedAutonomyLevel: 1,
+		suggestedEventSubscriptions: [
+			{
+				source: 'github',
+				topic: 'pull_request.opened',
+				filter: { paths: ['**/auth/**', '**/security/**', '**/storage/**', 'bun.lock'] },
+			},
+			{
+				source: 'github',
+				topic: 'dependabot.alert.*',
+				filter: { severities: ['high', 'critical'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review security posture',
+				body: 'Review dependency alerts, auth changes, permission changes, and unresolved security findings.',
+				triggerType: 'cron',
+				cronExpression: '0 11 * * 3',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'watcher',
+				description: 'Watch security-sensitive goals and request tasks when risk appears.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'manager',
+				description: 'Manage Forge scopes for security lessons, risky patterns, and mitigations.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'marketing.default',
+		handle: 'marketing',
+		displayName: 'Marketing',
+		description:
+			'Turns product progress and customer signals into positioning, content ideas, and launch assets.',
+		instructions:
+			'Maintain marketing momentum. Track shipped capabilities, user pain points, customer language, launch timing, and content opportunities. Draft concise positioning, campaign ideas, and asset tasks while coordinating with product and release owners.',
+		suggestedAutonomyLevel: 2,
+		suggestedEventSubscriptions: [
+			{
+				source: 'github',
+				topic: 'release.published',
+				filter: {},
+			},
+			{
+				source: 'space',
+				topic: 'goal.done',
+				filter: { labels: ['launch', 'marketing', 'customer'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review marketing opportunities',
+				body: 'Review shipped features, upcoming releases, customer signals, and content follow-ups.',
+				triggerType: 'cron',
+				cronExpression: '0 15 * * 1',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'manager',
+				description: 'Manage launch, content, and positioning goals.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'watcher',
+				description: 'Watch customer-language and product-learning scopes for messaging inputs.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'sales.default',
+		handle: 'sales',
+		displayName: 'Sales',
+		description:
+			'Tracks pipeline follow-ups, account context, objections, and product asks from prospects.',
+		instructions:
+			'Support sales execution. Track prospect follow-ups, account context, objections, feature asks, and handoffs. Prepare next-step reminders, summarize buying signals, and convert repeated objections or product gaps into actionable tasks.',
+		suggestedAutonomyLevel: 2,
+		suggestedEventSubscriptions: [
+			{
+				source: 'crm',
+				topic: 'deal.*',
+				filter: { stages: ['qualified', 'proposal', 'at_risk'] },
+			},
+			{
+				source: 'calendar',
+				topic: 'meeting.ended',
+				filter: { tags: ['sales', 'customer'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review sales follow-ups',
+				body: 'Review open deals, overdue follow-ups, customer asks, and next-step commitments.',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * 1-5',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'manager',
+				description: 'Manage pipeline, account, and follow-up goals.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'watcher',
+				description: 'Watch customer objections and product-request scopes for trends.',
+			},
+		],
+		toolPermissions: {},
+	},
+	{
+		key: 'family-ops-chores.default',
+		handle: 'family-ops-chores',
+		displayName: 'Family Ops/Chores',
+		description:
+			'Coordinates household routines, chores, appointments, errands, and recurring family logistics.',
+		instructions:
+			'Coordinate household operations. Track chores, errands, appointments, recurring maintenance, family commitments, and reminders. Keep plans practical, assign clear owners when known, escalate time-sensitive conflicts, and avoid making commitments without human confirmation.',
+		suggestedAutonomyLevel: 1,
+		suggestedEventSubscriptions: [
+			{
+				source: 'calendar',
+				topic: 'event.*',
+				filter: { calendars: ['family', 'home'] },
+			},
+			{
+				source: 'tasks',
+				topic: 'task.overdue',
+				filter: { lists: ['chores', 'errands', 'home'] },
+			},
+		],
+		reminderDefaults: [
+			{
+				title: 'Review household plan',
+				body: 'Review chores, errands, appointments, maintenance reminders, and unresolved family logistics.',
+				triggerType: 'cron',
+				cronExpression: '0 18 * * 0',
+				timezone: 'UTC',
+			},
+		],
+		ownershipPatterns: [
+			{
+				target: 'goal',
+				relationship: 'manager',
+				description: 'Manage recurring home, chores, errands, and family logistics goals.',
+			},
+			{
+				target: 'forge_scope',
+				relationship: 'watcher',
+				description: 'Watch household-routine scopes for recurring friction and missed reminders.',
+			},
+		],
+		toolPermissions: {},
+	},
+];
+
+export function getLongHorizonAgentTemplates(): SpaceLongHorizonAgentTemplate[] {
+	return LONG_HORIZON_AGENT_TEMPLATES.map((template) => ({
+		...template,
+		suggestedEventSubscriptions: template.suggestedEventSubscriptions.map((subscription) => ({
+			...subscription,
+			filter: { ...subscription.filter },
+		})),
+		reminderDefaults: template.reminderDefaults.map((reminder) => ({ ...reminder })),
+		ownershipPatterns: template.ownershipPatterns.map((pattern) => ({ ...pattern })),
+		toolPermissions: { ...template.toolPermissions },
+	}));
+}
+
+export function getLongHorizonAgentTemplate(
+	key: string
+): SpaceLongHorizonAgentTemplate | undefined {
+	return getLongHorizonAgentTemplates().find((template) => template.key === key);
+}

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -13,6 +13,7 @@ import type {
 	SpaceLongHorizonAgentStatus,
 	UpdateSpaceLongHorizonAgentParams,
 } from '@neokai/shared';
+import { getLongHorizonAgentTemplate } from '../../lib/space/agents/long-horizon-agent-templates';
 import type { SQLiteValue } from '../types';
 
 const DEFAULT_TOOL_PERMISSIONS: Record<string, never> = {};
@@ -82,15 +83,21 @@ export class SpaceLongHorizonAgentRepository {
 		const existingByHandle = this.getCoordinator(spaceId);
 		if (existingByHandle) return existingByHandle;
 
+		const template = getLongHorizonAgentTemplate('coordinator.default');
+
 		return this.create({
 			id: coordinatorLongHorizonAgentId(spaceId),
 			spaceId,
-			handle: 'coordinator',
-			displayName: 'Coordinator',
-			templateKey: 'coordinator.default',
+			handle: template?.handle ?? 'coordinator',
+			displayName: template?.displayName ?? 'Coordinator',
+			templateKey: template?.key ?? 'coordinator.default',
 			status: 'active',
 			sessionId: coordinatorSessionId(spaceId),
-			instructions: 'Coordinate goals, tasks, reminders, event subscriptions, and Space activity.',
+			instructions:
+				template?.instructions ??
+				'Coordinate goals, tasks, reminders, event subscriptions, and Space activity.',
+			autonomyLevel: template?.suggestedAutonomyLevel,
+			toolPermissions: template?.toolPermissions,
 		});
 	}
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { MessageHub } from '@neokai/shared';
+import { setupSpaceLongHorizonAgentHandlers } from '../../../../src/lib/rpc-handlers/space-long-horizon-agent-handlers';
+import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockMessageHub(): { hub: MessageHub; handlers: Map<string, RequestHandler> } {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockSpaceManager(): SpaceManager {
+	type GetSpaceResult = Awaited<ReturnType<SpaceManager['getSpace']>>;
+	return {
+		getSpace: mock(async (spaceId: string): Promise<GetSpaceResult> => {
+			return spaceId === 'space-1' ? ({ id: 'space-1' } as Exclude<GetSpaceResult, null>) : null;
+		}),
+	} as unknown as SpaceManager;
+}
+
+async function call<T>(
+	handlers: Map<string, RequestHandler>,
+	method: string,
+	params: unknown
+): Promise<T> {
+	const handler = handlers.get(method);
+	if (!handler) throw new Error(`Handler not registered: ${method}`);
+	return (await handler(params, {})) as T;
+}
+
+describe('Space long-horizon agent handlers', () => {
+	let hubData: ReturnType<typeof createMockMessageHub>;
+
+	beforeEach(() => {
+		hubData = createMockMessageHub();
+		setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager());
+	});
+
+	describe('spaceLongHorizonAgent.listBuiltInTemplates', () => {
+		it('registers the handler', () => {
+			expect(hubData.handlers.has('spaceLongHorizonAgent.listBuiltInTemplates')).toBe(true);
+		});
+
+		it('returns built-in long-horizon agent templates', async () => {
+			const result = await call<{
+				templates: Array<{
+					key: string;
+					suggestedEventSubscriptions: unknown[];
+					reminderDefaults: unknown[];
+					ownershipPatterns: unknown[];
+				}>;
+			}>(hubData.handlers, 'spaceLongHorizonAgent.listBuiltInTemplates', {
+				spaceId: 'space-1',
+			});
+
+			expect(result.templates).toHaveLength(7);
+			expect(result.templates.map((template) => template.key)).toContain('coordinator.default');
+			for (const template of result.templates) {
+				expect(template.suggestedEventSubscriptions.length).toBeGreaterThan(0);
+				expect(template.reminderDefaults.length).toBeGreaterThan(0);
+				expect(template.ownershipPatterns.length).toBeGreaterThan(0);
+			}
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceLongHorizonAgent.listBuiltInTemplates', {})
+			).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when space does not exist', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceLongHorizonAgent.listBuiltInTemplates', {
+					spaceId: 'missing-space',
+				})
+			).rejects.toThrow('Space not found: missing-space');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -39,7 +39,8 @@ describe('SpaceLongHorizonAgentRepository', () => {
 		expect(coordinator.templateKey).toBe('coordinator.default');
 		expect(coordinator.status).toBe('active');
 		expect(coordinator.sessionId).toBe(coordinatorSessionId('space-1'));
-		expect(coordinator.instructions).toContain('Coordinate goals');
+		expect(coordinator.instructions).toContain('Coordinate long-horizon Space activity');
+		expect(coordinator.autonomyLevel).toBe(2);
 		expect(coordinator.toolPermissions).toEqual({});
 		expect(repo.listBySpaceId('space-1')).toHaveLength(1);
 	});

--- a/packages/daemon/tests/unit/5-space/other/long-horizon-agent-templates.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/long-horizon-agent-templates.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { getLongHorizonAgentTemplates } from '../../../../src/lib/space/agents/long-horizon-agent-templates';
+
+describe('long-horizon agent templates', () => {
+	test('exports built-in templates for common evergreen roles', () => {
+		const templates = getLongHorizonAgentTemplates();
+
+		expect(templates.map((template) => template.key)).toEqual([
+			'coordinator.default',
+			'product-quality-manager.default',
+			'release-manager.default',
+			'security-auditor.default',
+			'marketing.default',
+			'sales.default',
+			'family-ops-chores.default',
+		]);
+		expect(templates.map((template) => template.displayName)).toEqual([
+			'Coordinator',
+			'Product Quality Manager',
+			'Release Manager',
+			'Security Auditor',
+			'Marketing',
+			'Sales',
+			'Family Ops/Chores',
+		]);
+	});
+
+	test('defines instructions, autonomy, subscriptions, reminders, and ownership patterns', () => {
+		for (const template of getLongHorizonAgentTemplates()) {
+			expect(template.handle).toMatch(/^[a-z0-9-]+$/);
+			expect(template.description.length).toBeGreaterThan(20);
+			expect(template.instructions.length).toBeGreaterThan(80);
+			expect(template.suggestedAutonomyLevel).toBeGreaterThanOrEqual(1);
+			expect(template.suggestedAutonomyLevel).toBeLessThanOrEqual(5);
+			expect(template.suggestedEventSubscriptions.length).toBeGreaterThan(0);
+			expect(template.reminderDefaults.length).toBeGreaterThan(0);
+			expect(template.ownershipPatterns.length).toBeGreaterThan(0);
+		}
+	});
+
+	test('marks human-confirmation roles with low autonomy', () => {
+		const templates = getLongHorizonAgentTemplates();
+		const securityAuditor = templates.find(
+			(template) => template.key === 'security-auditor.default'
+		);
+		const familyOps = templates.find((template) => template.key === 'family-ops-chores.default');
+
+		expect(securityAuditor?.suggestedAutonomyLevel).toBe(1);
+		expect(familyOps?.suggestedAutonomyLevel).toBe(1);
+		expect(securityAuditor?.instructions).toContain('escalate high-risk issues');
+		expect(familyOps?.instructions).toContain(
+			'avoid making commitments without human confirmation'
+		);
+	});
+
+	test('returns cloned template data', () => {
+		const [template] = getLongHorizonAgentTemplates();
+		template.suggestedEventSubscriptions[0].filter.mutated = true;
+		template.reminderDefaults[0].title = 'Mutated';
+		template.ownershipPatterns[0].description = 'Mutated';
+		template.toolPermissions.mutated = true;
+
+		const [again] = getLongHorizonAgentTemplates();
+
+		expect(again.suggestedEventSubscriptions[0].filter).not.toHaveProperty('mutated');
+		expect(again.reminderDefaults[0].title).not.toBe('Mutated');
+		expect(again.ownershipPatterns[0].description).not.toBe('Mutated');
+		expect(again.toolPermissions).not.toHaveProperty('mutated');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/other/long-horizon-agent-templates.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/long-horizon-agent-templates.test.ts
@@ -55,6 +55,8 @@ describe('long-horizon agent templates', () => {
 
 	test('returns cloned template data', () => {
 		const [template] = getLongHorizonAgentTemplates();
+		const statuses = template.suggestedEventSubscriptions[0].filter.statuses as string[];
+		statuses.push('mutated');
 		template.suggestedEventSubscriptions[0].filter.mutated = true;
 		template.reminderDefaults[0].title = 'Mutated';
 		template.ownershipPatterns[0].description = 'Mutated';
@@ -63,6 +65,11 @@ describe('long-horizon agent templates', () => {
 		const [again] = getLongHorizonAgentTemplates();
 
 		expect(again.suggestedEventSubscriptions[0].filter).not.toHaveProperty('mutated');
+		expect(again.suggestedEventSubscriptions[0].filter.statuses).toEqual([
+			'blocked',
+			'review',
+			'done',
+		]);
 		expect(again.reminderDefaults[0].title).not.toBe('Mutated');
 		expect(again.ownershipPatterns[0].description).not.toBe('Mutated');
 		expect(again.toolPermissions).not.toHaveProperty('mutated');

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -37,6 +37,39 @@ export type SpaceLongHorizonAgentReminderStatus = 'active' | 'paused' | 'fired' 
 export type SpaceLongHorizonAgentReminderTriggerType = 'at' | 'cron';
 export type SpaceLongHorizonAgentEventSubscriptionStatus = 'active' | 'paused' | 'disabled';
 
+export interface SpaceLongHorizonAgentTemplateReminderDefault {
+	title: string;
+	body: string;
+	triggerType: SpaceLongHorizonAgentReminderTriggerType;
+	cronExpression: string | null;
+	timezone: string;
+}
+
+export interface SpaceLongHorizonAgentTemplateEventSubscription {
+	source: string;
+	topic: string;
+	filter: Record<string, unknown>;
+}
+
+export interface SpaceLongHorizonAgentTemplateOwnershipPattern {
+	target: 'goal' | 'forge_scope';
+	relationship: SpaceLongHorizonAgentRelationship;
+	description: string;
+}
+
+export interface SpaceLongHorizonAgentTemplate {
+	key: string;
+	handle: string;
+	displayName: string;
+	description: string;
+	instructions: string;
+	suggestedAutonomyLevel: SpaceAgentAutonomyLevel;
+	suggestedEventSubscriptions: SpaceLongHorizonAgentTemplateEventSubscription[];
+	reminderDefaults: SpaceLongHorizonAgentTemplateReminderDefault[];
+	ownershipPatterns: SpaceLongHorizonAgentTemplateOwnershipPattern[];
+	toolPermissions: Record<string, unknown>;
+}
+
 export interface SpaceLongHorizonAgent {
 	id: string;
 	spaceId: string;


### PR DESCRIPTION
Adds built-in long-horizon agent templates for Coordinator, Product Quality Manager, Release Manager, Security Auditor, Marketing, Sales, and Family Ops/Chores.

Also exposes them through a new RPC handler and uses the Coordinator template as the default Coordinator seed source.

Tests: targeted daemon unit tests; bun run check.