### PR TITLE
Fix dynamic agent reply targets

### DIFF
--- a/packages/daemon/src/lib/space/actor-registry.ts
+++ b/packages/daemon/src/lib/space/actor-registry.ts
@@ -179,21 +179,48 @@ function sessionActorForSession(session: Session, spaceId: string): ActorRef | n
 	};
 }
 
+export function canonicalAgentHandle(
+	agents: SpaceAgent[],
+	agent: SpaceAgent,
+	reserved: string[] = reservedHandles()
+): string {
+	const handleCounts = new Map<string, number>();
+	for (const handle of reserved) {
+		handleCounts.set(handle, 1);
+	}
+	for (const candidate of agents) {
+		const slug = baseHandleSlug(candidate.name, candidate.id);
+		handleCounts.set(slug, (handleCounts.get(slug) ?? 0) + 1);
+	}
+
+	const slug = baseHandleSlug(agent.name, agent.id);
+	const handleSlug = handleCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
+	return `@${handleSlug}`;
+}
+
 function agentActor(
 	agent: SpaceAgent,
 	handleCounts: Map<string, number>,
 	session: Session | null
 ): ActorRef {
-	const slug = baseHandleSlug(agent.name, agent.id);
-	const handleSlug = handleCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
+	const handle = canonicalAgentHandleFromCounts(agent, handleCounts);
 	return {
 		actorId: `agent:${encodeActorIdComponent(agent.id)}`,
 		kind: 'agent',
 		spaceId: agent.spaceId,
-		handle: `@${handleSlug}`,
-		roles: unique(['space-agent', routingRole(handleSlug)]),
+		handle,
+		roles: unique(['space-agent', routingRole(handle.slice(1))]),
 		status: session ? statusFromSession(session) : 'inactive',
 	};
+}
+
+function canonicalAgentHandleFromCounts(
+	agent: SpaceAgent,
+	handleCounts: Map<string, number>
+): string {
+	const slug = baseHandleSlug(agent.name, agent.id);
+	const handleSlug = handleCounts.get(slug) === 1 ? slug : `${slug}-${shortId(agent.id)}`;
+	return `@${handleSlug}`;
 }
 
 function workerActorFromExecution(spaceId: string, execution: NodeExecution): ActorRef {

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -34,6 +34,7 @@ function replyTargetSuffix(options: FormatAgentMessageOptions): string {
 
 function replyTargetHandle(options: FormatAgentMessageOptions): string {
 	if (options.replyTargetHandle) return options.replyTargetHandle;
+	if (options.fromAgentName === 'space-agent') return '@coordinator';
 	return `@${options.fromAgentName}`;
 }
 

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -1,21 +1,23 @@
-export type AgentMessageLevel = 'space-agent' | 'task-agent' | 'node-agent';
+export type AgentMessageLevel = 'space-agent' | 'task-agent' | 'node-agent' | 'session-agent';
 
 export interface FormatAgentMessageOptions {
 	fromLevel: AgentMessageLevel;
 	fromAgentName: string;
 	toLevel: AgentMessageLevel;
 	body: string;
-	/** Parent task UUID. Required for Space Agent reply instructions when known. */
+	/** Parent task UUID. Required for coordinator reply instructions when known. */
 	taskId?: string | null;
 	/** Space-scoped task number for human-readable context. */
 	taskNumber?: number | null;
 	/** Sender/target node agent name for reply routing. */
 	nodeId?: string | null;
+	/** Agent handle to use in visible reply instructions. */
+	replyTargetHandle?: string | null;
 	/**
 	 * Session ID that should receive the reply when the target agent responds
-	 * via `send_message({ target: 'space-agent' })`. When set, the routing
-	 * layer delivers the reply to this session instead of the default
-	 * `space:chat:${spaceId}`. Null/undefined means "use default routing".
+	 * via the visible reply instructions. When set, the routing layer delivers
+	 * the reply to this session instead of the default coordinator session.
+	 * Null/undefined means "use default routing".
 	 */
 	replyToSessionId?: string | null;
 }
@@ -30,11 +32,17 @@ function replyTargetSuffix(options: FormatAgentMessageOptions): string {
 	return ` and target node "${target}"`;
 }
 
+function replyTargetHandle(options: FormatAgentMessageOptions): string {
+	if (options.replyTargetHandle) return options.replyTargetHandle;
+	if (options.replyToSessionId) return `@session:${options.replyToSessionId}`;
+	return `@${options.fromAgentName}`;
+}
+
 /**
  * Build the reply-routing metadata footer appended to messages that carry
  * `replyToSessionId`. The footer is a machine-readable XML block that the
- * routing layer parses when the receiving agent replies via
- * `send_message({ target: 'space-agent' })`.
+ * routing layer parses when the receiving agent replies via the visible reply
+ * instructions.
  */
 function replyRoutingFooter(options: FormatAgentMessageOptions): string {
 	if (!options.replyToSessionId) return '';
@@ -49,9 +57,9 @@ function replyRoutingFooter(options: FormatAgentMessageOptions): string {
  * session so the transcript records sender identity and concise reply guidance.
  *
  * When `replyToSessionId` is set, a `<reply-routing>` XML block is appended.
- * The routing layer extracts this when the agent replies via
- * `send_message({ target: 'space-agent' })` to deliver the reply back to the
- * originating session instead of the default `space:chat:${spaceId}`.
+ * The routing layer extracts this when the agent replies via the visible reply
+ * instructions to deliver the reply back to the originating session instead of
+ * the default coordinator session.
  */
 export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 	const body = options.body;
@@ -68,12 +76,12 @@ export function formatAgentMessage(options: FormatAgentMessageOptions): string {
 		);
 	}
 
-	if (options.fromLevel === 'space-agent') {
+	if (options.fromLevel === 'space-agent' || options.fromLevel === 'session-agent') {
 		return (
-			`─── Message from Space Agent ───\n\n` +
+			`─── Message from ${options.fromAgentName} ───\n\n` +
 			`${body}${footer}\n\n` +
 			`─── Reply ───\n` +
-			`To reply, use: send_message with target "space-agent"`
+			`To reply, use: send_message with target "${replyTargetHandle(options)}"`
 		);
 	}
 

--- a/packages/daemon/src/lib/space/agent-message-envelope.ts
+++ b/packages/daemon/src/lib/space/agent-message-envelope.ts
@@ -34,7 +34,6 @@ function replyTargetSuffix(options: FormatAgentMessageOptions): string {
 
 function replyTargetHandle(options: FormatAgentMessageOptions): string {
 	if (options.replyTargetHandle) return options.replyTargetHandle;
-	if (options.replyToSessionId) return `@session:${options.replyToSessionId}`;
 	return `@${options.fromAgentName}`;
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -15,13 +15,14 @@ import type {
 	McpServerConfig,
 	Session,
 	Space,
+	SpaceAgent,
 	SpaceTask,
 	SpaceWorkflowRun,
 	UpdateSpaceTaskParams,
 } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { MessageRecord, ActorRef } from '../../../../../messaging/src/types';
-import { SpaceActorRegistryAdapter } from '../actor-registry';
+import { canonicalAgentHandle, SpaceActorRegistryAdapter } from '../actor-registry';
 import { SpaceMessageResolver } from '../messaging-adapter';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
@@ -542,7 +543,7 @@ export class SpaceRuntimeService {
 			});
 		}
 		if (created || this.missingLongTermAgentMcpServers(session)) {
-			this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId);
+			this.attachLongTermAgentMcpServers(session, space, agent.name, sessionId, agent);
 		}
 		return session;
 	}
@@ -576,7 +577,7 @@ export class SpaceRuntimeService {
 		}
 		const agentName =
 			session.metadata.promptProvenance?.agentName ?? persistedAgent?.name ?? 'Space Agent';
-		this.attachLongTermAgentMcpServers(agentSession, space, agentName, session.id);
+		this.attachLongTermAgentMcpServers(agentSession, space, agentName, session.id, persistedAgent);
 		agentSession.onMissingMemberSpaceMcpServers = async (_sessionId, missing) => {
 			log.warn(
 				`Long-term Space agent session ${session.id} missing MCP servers [${missing.join(', ')}]; re-attaching space-agent-tools before query start`
@@ -596,13 +597,15 @@ export class SpaceRuntimeService {
 		},
 		space: Space,
 		agentName: string,
-		sessionId: string
+		sessionId: string,
+		agent: SpaceAgent | null
 	): void {
 		const mcpServers: Record<string, McpServerConfig> = {
 			'space-agent-tools': this.buildLongTermAgentMcpServer(
 				space,
 				agentName,
-				sessionId
+				sessionId,
+				agent
 			) as unknown as McpServerConfig,
 		};
 		if (this.config.memoryRepo) {
@@ -641,7 +644,14 @@ export class SpaceRuntimeService {
 		this.longTermAgentDbQueryServers.delete(sessionId);
 	}
 
-	private buildLongTermAgentMcpServer(space: Space, agentName: string, sessionId: string) {
+	private buildLongTermAgentMcpServer(
+		space: Space,
+		agentName: string,
+		sessionId: string,
+		agent: SpaceAgent | null
+	) {
+		const agents = this.config.spaceAgentManager.listBySpaceId(space.id);
+		const agentHandle = agent ? canonicalAgentHandle(agents, agent) : undefined;
 		return createSpaceAgentMcpServer({
 			spaceId: space.id,
 			db: this.config.db,
@@ -670,6 +680,7 @@ export class SpaceRuntimeService {
 				return s?.autonomyLevel ?? 1;
 			},
 			myAgentName: agentName,
+			myAgentNameAliases: agentHandle ? [agentHandle] : undefined,
 			mySessionId: sessionId,
 			auditLogRepo: this.auditLogRepo,
 			scheduleService: this.config.scheduleService,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -129,8 +129,8 @@ function pendingSourceLevel(sourceAgentName: string): AgentMessageLevel {
 	return 'node-agent';
 }
 
-function expectedEnvelopeSenderName(sourceAgentName: string): string {
-	return sourceAgentName;
+function expectedEnvelopeSenderNames(sourceAgentName: string): string[] {
+	return sourceAgentName === 'space-agent' ? ['space-agent', 'Space Agent'] : [sourceAgentName];
 }
 
 export function hasAgentMessageEnvelopeForTest(
@@ -142,9 +142,14 @@ export function hasAgentMessageEnvelopeForTest(
 	if (!match) return false;
 
 	const fromLevel = pendingSourceLevel(sourceAgentName);
-	const expectedSender = expectedEnvelopeSenderName(sourceAgentName);
+	const expectedSenders = expectedEnvelopeSenderNames(sourceAgentName);
 	const headerSender = match[1];
-	if (headerSender !== expectedSender && !headerSender.startsWith(`${expectedSender} (task #`)) {
+	if (
+		!expectedSenders.some(
+			(expectedSender) =>
+				headerSender === expectedSender || headerSender.startsWith(`${expectedSender} (task #`)
+		)
+	) {
 		return false;
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -125,14 +125,15 @@ const AGENT_MESSAGE_ENVELOPE_REPLY_BLOCK = '\n\n─── Reply ───\nTo re
 function pendingSourceLevel(sourceAgentName: string): AgentMessageLevel {
 	if (sourceAgentName === 'task-agent') return 'task-agent';
 	if (sourceAgentName === 'space-agent') return 'space-agent';
+	if (sourceAgentName === 'space-member') return 'session-agent';
 	return 'node-agent';
 }
 
 function expectedEnvelopeSenderName(sourceAgentName: string): string {
-	return sourceAgentName === 'space-agent' ? 'Space Agent' : sourceAgentName;
+	return sourceAgentName;
 }
 
-function hasAgentMessageEnvelope(
+export function hasAgentMessageEnvelopeForTest(
 	message: string,
 	sourceAgentName: string,
 	toLevel: AgentMessageLevel
@@ -1156,7 +1157,7 @@ export class TaskAgentManager {
 		for (const row of pending) {
 			const isSyntheticMessage = row.sourceAgentName !== 'human';
 			const message = isSyntheticMessage
-				? hasAgentMessageEnvelope(row.message, row.sourceAgentName, 'node-agent')
+				? hasAgentMessageEnvelopeForTest(row.message, row.sourceAgentName, 'node-agent')
 					? row.message
 					: formatAgentMessage({
 							fromLevel: pendingSourceLevel(row.sourceAgentName),
@@ -1243,7 +1244,11 @@ export class TaskAgentManager {
 		);
 
 		for (const row of pending) {
-			const message = hasAgentMessageEnvelope(row.message, row.sourceAgentName, 'space-agent')
+			const message = hasAgentMessageEnvelopeForTest(
+				row.message,
+				row.sourceAgentName,
+				'space-agent'
+			)
 				? row.message
 				: formatAgentMessage({
 						fromLevel: pendingSourceLevel(row.sourceAgentName),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -132,6 +132,7 @@ function handleFromName(value: string): string | null {
 function normalizeReplyTargetHandle(value: string): string | null {
 	const trimmed = value.trim();
 	if (!trimmed) return null;
+	if (trimmed === 'space-agent') return '@coordinator';
 	return trimmed.startsWith('@') ? trimmed : handleFromName(trimmed);
 }
 

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -120,18 +120,18 @@ function normalizeAgentNameToken(value: string): string {
 	return value.trim().toLowerCase();
 }
 
-function handleFromName(value: string): string {
+function handleFromName(value: string): string | null {
 	const slug = value
 		.trim()
 		.toLowerCase()
 		.replace(/[^a-z0-9_-]+/g, '-')
 		.replace(/^-+|-+$/g, '');
-	return slug ? `@${slug}` : '@space-agent';
+	return slug ? `@${slug}` : null;
 }
 
-function normalizeReplyTargetHandle(value: string): string {
+function normalizeReplyTargetHandle(value: string): string | null {
 	const trimmed = value.trim();
-	if (!trimmed) return '@space-agent';
+	if (!trimmed) return null;
 	return trimmed.startsWith('@') ? trimmed : handleFromName(trimmed);
 }
 
@@ -394,10 +394,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				: 'session-agent';
 	const outboundSenderDisplayName = outboundSenderName;
 	const outboundReplyTargetHandle = myAgentName
-		? normalizeReplyTargetHandle(myAgentNameAliases?.[0] ?? outboundSenderName)
-		: mySessionId
-			? `@session:${mySessionId}`
-			: normalizeReplyTargetHandle(outboundSenderName);
+		? (normalizeReplyTargetHandle(myAgentNameAliases?.[0] ?? '') ??
+			normalizeReplyTargetHandle(outboundSenderName))
+		: !mySessionId
+			? normalizeReplyTargetHandle(outboundSenderName)
+			: null;
 
 	function requireGoalService() {
 		if (!config.goalService) throw new Error('Goal management not available');

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -396,9 +396,9 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 	const outboundReplyTargetHandle = myAgentName
 		? (normalizeReplyTargetHandle(myAgentNameAliases?.[0] ?? '') ??
 			normalizeReplyTargetHandle(outboundSenderName))
-		: !mySessionId
-			? normalizeReplyTargetHandle(outboundSenderName)
-			: null;
+		: mySessionId
+			? `@session:${mySessionId}`
+			: normalizeReplyTargetHandle(outboundSenderName);
 
 	function requireGoalService() {
 		if (!config.goalService) throw new Error('Goal management not available');

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -120,6 +120,21 @@ function normalizeAgentNameToken(value: string): string {
 	return value.trim().toLowerCase();
 }
 
+function handleFromName(value: string): string {
+	const slug = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+	return slug ? `@${slug}` : '@space-agent';
+}
+
+function normalizeReplyTargetHandle(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return '@space-agent';
+	return trimmed.startsWith('@') ? trimmed : handleFromName(trimmed);
+}
+
 function normalizeSpaceAgentUpdateArgs(args: SpaceAgentUpdateArgs) {
 	return {
 		name: args.name,
@@ -377,15 +392,12 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			: myAgentName || !mySessionId
 				? 'space-agent'
 				: 'session-agent';
-	const outboundSenderDisplayName =
-		outboundSenderName === 'space-agent'
-			? (myAgentNameAliases?.[0] ?? outboundSenderName)
-			: outboundSenderName;
+	const outboundSenderDisplayName = outboundSenderName;
 	const outboundReplyTargetHandle = myAgentName
-		? `@${outboundSenderDisplayName}`
+		? normalizeReplyTargetHandle(myAgentNameAliases?.[0] ?? outboundSenderName)
 		: mySessionId
 			? `@session:${mySessionId}`
-			: `@${outboundSenderDisplayName}`;
+			: normalizeReplyTargetHandle(outboundSenderName);
 
 	function requireGoalService() {
 		if (!config.goalService) throw new Error('Goal management not available');

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -370,10 +370,22 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			.map((v) => normalizeAgentNameToken(v))
 			.filter((v) => v.length > 0)
 	);
-	const outboundSenderName = myAgentName ?? 'space-agent';
-	const outboundSenderLevel = outboundSenderName === 'task-agent' ? 'task-agent' : 'space-agent';
+	const outboundSenderName = myAgentName ?? (mySessionId ? 'space-member' : 'space-agent');
+	const outboundSenderLevel =
+		outboundSenderName === 'task-agent'
+			? 'task-agent'
+			: myAgentName || !mySessionId
+				? 'space-agent'
+				: 'session-agent';
 	const outboundSenderDisplayName =
-		outboundSenderName === 'space-agent' ? 'Space Agent' : outboundSenderName;
+		outboundSenderName === 'space-agent'
+			? (myAgentNameAliases?.[0] ?? outboundSenderName)
+			: outboundSenderName;
+	const outboundReplyTargetHandle = myAgentName
+		? `@${outboundSenderDisplayName}`
+		: mySessionId
+			? `@session:${mySessionId}`
+			: `@${outboundSenderDisplayName}`;
 
 	function requireGoalService() {
 		if (!config.goalService) throw new Error('Goal management not available');
@@ -1570,6 +1582,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							taskId: task.id,
 							taskNumber: task.taskNumber,
 							replyToSessionId: mySessionId,
+							replyTargetHandle: outboundReplyTargetHandle,
 						}),
 						kind: 'message',
 						workflowRunId: task.workflowRunId,
@@ -1644,6 +1657,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							taskNumber: task.taskNumber,
 							nodeId: resolved.agentName,
 							replyToSessionId: mySessionId,
+							replyTargetHandle: outboundReplyTargetHandle,
 						}),
 						true
 					);
@@ -1694,6 +1708,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 							taskNumber: task.taskNumber,
 							nodeId: resolved.agentName,
 							replyToSessionId: mySessionId,
+							replyTargetHandle: outboundReplyTargetHandle,
 						}),
 						true
 					);
@@ -1732,6 +1747,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 						taskNumber: task.taskNumber,
 						nodeId: resolved.agentName,
 						replyToSessionId: mySessionId,
+						replyTargetHandle: outboundReplyTargetHandle,
 					}),
 				});
 				queuedMessageId = record.id;

--- a/packages/daemon/tests/unit/5-space/actor-registry.test.ts
+++ b/packages/daemon/tests/unit/5-space/actor-registry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { parseAddress } from '../../../../messaging/src/address';
-import { SpaceActorRegistryAdapter } from '../../../src/lib/space/actor-registry';
+import {
+	canonicalAgentHandle,
+	SpaceActorRegistryAdapter,
+} from '../../../src/lib/space/actor-registry';
 import { longTermAgentSessionId } from '../../../src/lib/space/long-term-agent-session';
 import { NodeExecutionRepository } from '../../../src/storage/repositories/node-execution-repository';
 import { PendingAgentMessageRepository } from '../../../src/storage/repositories/pending-agent-message-repository';
@@ -259,6 +262,10 @@ describe('SpaceActorRegistryAdapter', () => {
 		});
 
 		const actors = registry.listActors(space.id);
+
+		expect(canonicalAgentHandle([agent, reservedNameAgent], reservedNameAgent)).toBe(
+			`@coordinator-${reservedNameAgent.id.slice(0, 8)}`
+		);
 
 		expect(actors).toContainEqual({
 			actorId: `human:${member.id}`,

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -24,19 +24,38 @@ describe('formatAgentMessage', () => {
 		);
 	});
 
-	test('formats space-agent messages with node reply instructions', () => {
+	test('formats long-horizon agent messages with dynamic reply instructions', () => {
 		expect(
 			formatAgentMessage({
 				fromLevel: 'space-agent',
-				fromAgentName: 'Space Agent',
+				fromAgentName: 'coordinator',
 				toLevel: 'node-agent',
 				body: 'Proceed with option A',
+				replyTargetHandle: '@coordinator',
 			})
 		).toBe(
-			'─── Message from Space Agent ───\n\n' +
+			'─── Message from coordinator ───\n\n' +
 				'Proceed with option A\n\n' +
 				'─── Reply ───\n' +
-				'To reply, use: send_message with target "space-agent"'
+				'To reply, use: send_message with target "@coordinator"'
+		);
+	});
+
+	test('formats ad-hoc session messages with session reply instructions', () => {
+		expect(
+			formatAgentMessage({
+				fromLevel: 'session-agent',
+				fromAgentName: 'space-member',
+				toLevel: 'node-agent',
+				body: 'Ad-hoc follow-up',
+				replyToSessionId: 'session-adhoc-42',
+			})
+		).toBe(
+			'─── Message from space-member ───\n\n' +
+				'Ad-hoc follow-up\n\n' +
+				'<reply-routing replyToSessionId="session-adhoc-42" />\n\n' +
+				'─── Reply ───\n' +
+				'To reply, use: send_message with target "@session:session-adhoc-42"'
 		);
 	});
 
@@ -54,7 +73,7 @@ describe('formatAgentMessage', () => {
 	test('appends reply-routing XML footer when replyToSessionId is set (space-agent → node-agent)', () => {
 		const result = formatAgentMessage({
 			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
+			fromAgentName: 'coordinator',
 			toLevel: 'node-agent',
 			body: 'Proceed with option A',
 			replyToSessionId: 'session-adhoc-42',
@@ -66,7 +85,7 @@ describe('formatAgentMessage', () => {
 	test('appends reply-routing XML footer when replyToSessionId is set (space-agent → task-agent)', () => {
 		const result = formatAgentMessage({
 			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
+			fromAgentName: 'coordinator',
 			toLevel: 'task-agent',
 			body: 'Do the thing',
 			taskId: 'task-999',
@@ -91,7 +110,7 @@ describe('formatAgentMessage', () => {
 	test('does not append reply-routing footer when replyToSessionId is null or undefined', () => {
 		const result1 = formatAgentMessage({
 			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
+			fromAgentName: 'coordinator',
 			toLevel: 'node-agent',
 			body: 'No reply routing',
 			replyToSessionId: null,
@@ -100,7 +119,7 @@ describe('formatAgentMessage', () => {
 
 		const result2 = formatAgentMessage({
 			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
+			fromAgentName: 'coordinator',
 			toLevel: 'node-agent',
 			body: 'No reply routing',
 		});

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -42,7 +42,7 @@ describe('formatAgentMessage', () => {
 		);
 	});
 
-	test('formats ad-hoc session messages with session reply instructions', () => {
+	test('formats ad-hoc session messages with fallback reply instructions', () => {
 		expect(
 			formatAgentMessage({
 				fromLevel: 'session-agent',
@@ -56,7 +56,7 @@ describe('formatAgentMessage', () => {
 				'Ad-hoc follow-up\n\n' +
 				'<reply-routing replyToSessionId="session-adhoc-42" />\n\n' +
 				'─── Reply ───\n' +
-				'To reply, use: send_message with target "@session:session-adhoc-42"'
+				'To reply, use: send_message with target "@space-member"'
 		);
 	});
 
@@ -186,7 +186,16 @@ describe('hasAgentMessageEnvelopeForTest', () => {
 		});
 
 		expect(hasAgentMessageEnvelopeForTest(message, 'space-agent', 'node-agent')).toBe(true);
-		expect(hasAgentMessageEnvelopeForTest(message, 'Space Agent', 'node-agent')).toBe(false);
+	});
+
+	test('recognizes legacy queued Space Agent envelopes during flush', () => {
+		const message =
+			'─── Message from Space Agent ───\n\n' +
+			'Legacy queued message\n\n' +
+			'─── Reply ───\n' +
+			'To reply, use: send_message with target "space-agent"';
+
+		expect(hasAgentMessageEnvelopeForTest(message, 'space-agent', 'node-agent')).toBe(true);
 	});
 
 	test('recognizes queued ad-hoc session envelopes from space-member', () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -42,6 +42,22 @@ describe('formatAgentMessage', () => {
 		);
 	});
 
+	test('defaults space-agent reply target to coordinator handle', () => {
+		expect(
+			formatAgentMessage({
+				fromLevel: 'space-agent',
+				fromAgentName: 'space-agent',
+				toLevel: 'node-agent',
+				body: 'Legacy queued follow-up',
+			})
+		).toBe(
+			'─── Message from space-agent ───\n\n' +
+				'Legacy queued follow-up\n\n' +
+				'─── Reply ───\n' +
+				'To reply, use: send_message with target "@coordinator"'
+		);
+	});
+
 	test('formats ad-hoc session messages with explicit reply instructions', () => {
 		expect(
 			formatAgentMessage({

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -3,6 +3,7 @@ import {
 	formatAgentMessage,
 	extractReplyToSessionId,
 } from '../../../../src/lib/space/agent-message-envelope.ts';
+import { hasAgentMessageEnvelopeForTest } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 
 describe('formatAgentMessage', () => {
 	test('formats node to space-agent messages with task context and reply instructions', () => {
@@ -169,5 +170,36 @@ describe('extractReplyToSessionId', () => {
 			'To reply, use: send_message_to_task\n\n' +
 			'<reply-routing replyToSessionId="session-adhoc-99" />';
 		expect(extractReplyToSessionId(message)).toBe('session-adhoc-99');
+	});
+});
+
+describe('hasAgentMessageEnvelopeForTest', () => {
+	test('recognizes queued space-agent envelopes with canonical sender label', () => {
+		const message = formatAgentMessage({
+			fromLevel: 'space-agent',
+			fromAgentName: 'space-agent',
+			toLevel: 'node-agent',
+			body: 'Queued message',
+			taskId: 'task-123',
+			nodeId: 'coder',
+			replyTargetHandle: '@coordinator',
+		});
+
+		expect(hasAgentMessageEnvelopeForTest(message, 'space-agent', 'node-agent')).toBe(true);
+		expect(hasAgentMessageEnvelopeForTest(message, 'Space Agent', 'node-agent')).toBe(false);
+	});
+
+	test('recognizes queued ad-hoc session envelopes from space-member', () => {
+		const message = formatAgentMessage({
+			fromLevel: 'session-agent',
+			fromAgentName: 'space-member',
+			toLevel: 'node-agent',
+			body: 'Queued ad-hoc message',
+			taskId: 'task-123',
+			nodeId: 'coder',
+			replyToSessionId: 'session-adhoc-42',
+		});
+
+		expect(hasAgentMessageEnvelopeForTest(message, 'space-member', 'node-agent')).toBe(true);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-envelope.test.ts
@@ -42,7 +42,7 @@ describe('formatAgentMessage', () => {
 		);
 	});
 
-	test('formats ad-hoc session messages with fallback reply instructions', () => {
+	test('formats ad-hoc session messages with explicit reply instructions', () => {
 		expect(
 			formatAgentMessage({
 				fromLevel: 'session-agent',
@@ -50,13 +50,14 @@ describe('formatAgentMessage', () => {
 				toLevel: 'node-agent',
 				body: 'Ad-hoc follow-up',
 				replyToSessionId: 'session-adhoc-42',
+				replyTargetHandle: '@session:session-adhoc-42',
 			})
 		).toBe(
 			'─── Message from space-member ───\n\n' +
 				'Ad-hoc follow-up\n\n' +
 				'<reply-routing replyToSessionId="session-adhoc-42" />\n\n' +
 				'─── Reply ───\n' +
-				'To reply, use: send_message with target "@space-member"'
+				'To reply, use: send_message with target "@session:session-adhoc-42"'
 		);
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3566,6 +3566,7 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			pendingMessageQueue?: FakePendingMessageQueue;
 			myAgentName?: string;
 			myAgentNameAliases?: string[];
+			mySessionId?: string;
 		} = {}
 	) {
 		const fakeQueue = opts.pendingMessageQueue;
@@ -3582,6 +3583,7 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			activateNode: opts.activateNode,
 			myAgentName: opts.myAgentName,
 			myAgentNameAliases: opts.myAgentNameAliases,
+			mySessionId: opts.mySessionId,
 			pendingMessageQueue: fakeQueue
 				? {
 						enqueue(input) {
@@ -3706,6 +3708,36 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('99999');
+	});
+
+	test('ad-hoc sender uses routable session target in reply instructions', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Session');
+		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Session target');
+		const task = tasks[0];
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: task.workflowRunId,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'coder',
+			agentSessionId: 'coder-session-live',
+			status: 'idle',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {},
+			mySessionId: 'member-session-42',
+		});
+
+		await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'coder',
+			message: 'ad-hoc question',
+		});
+
+		expect(tam.subSessionInjects[0]?.message).toContain('─── Message from space-member ───');
+		expect(tam.subSessionInjects[0]?.message).toContain(
+			'To reply, use: send_message with target "@session:member-session-42"'
+		);
 	});
 
 	test('long-horizon sender uses canonical handle alias without double prefix', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3740,6 +3740,42 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		);
 	});
 
+	test('coordinator sender falls back to coordinator handle when no alias exists', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'WF Coordinator'
+		);
+		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Coordinator target');
+		const task = tasks[0];
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: task.workflowRunId,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'coder',
+			agentSessionId: 'coder-session-live',
+			status: 'idle',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {},
+			myAgentName: 'space-agent',
+		});
+
+		await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'coder',
+			message: 'check coordinator fallback',
+		});
+
+		expect(tam.subSessionInjects[0]?.message).toContain('─── Message from space-agent ───');
+		expect(tam.subSessionInjects[0]?.message).toContain(
+			'To reply, use: send_message with target "@coordinator"'
+		);
+		expect(tam.subSessionInjects[0]?.message).not.toContain('target "@space-agent"');
+	});
+
 	test('long-horizon sender uses canonical handle alias without double prefix', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Handle');
 		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Handle target');

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3564,6 +3564,8 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		opts: {
 			activateNode?: (runId: string, nodeId: string) => Promise<void>;
 			pendingMessageQueue?: FakePendingMessageQueue;
+			myAgentName?: string;
+			myAgentNameAliases?: string[];
 		} = {}
 	) {
 		const fakeQueue = opts.pendingMessageQueue;
@@ -3578,6 +3580,8 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			nodeExecutionRepo: ctx.nodeExecutionRepo,
 			taskAgentManager: tam.manager,
 			activateNode: opts.activateNode,
+			myAgentName: opts.myAgentName,
+			myAgentNameAliases: opts.myAgentNameAliases,
 			pendingMessageQueue: fakeQueue
 				? {
 						enqueue(input) {
@@ -3702,6 +3706,68 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
 		expect(parsed.error).toContain('99999');
+	});
+
+	test('long-horizon sender uses canonical handle alias without double prefix', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Handle');
+		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Handle target');
+		const task = tasks[0];
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: task.workflowRunId,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'coder',
+			agentSessionId: 'coder-session-live',
+			status: 'idle',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {},
+			myAgentName: 'space-agent',
+			myAgentNameAliases: ['@coordinator'],
+		});
+
+		await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'coder',
+			message: 'check routing',
+		});
+
+		expect(tam.subSessionInjects[0]?.message).toContain('─── Message from space-agent ───');
+		expect(tam.subSessionInjects[0]?.message).toContain(
+			'To reply, use: send_message with target "@coordinator"'
+		);
+		expect(tam.subSessionInjects[0]?.message).not.toContain('@@coordinator');
+	});
+
+	test('long-horizon sender derives slug handle from display name when no alias exists', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Slug');
+		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Slug target');
+		const task = tasks[0];
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: task.workflowRunId,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'coder',
+			agentSessionId: 'coder-session-live',
+			status: 'idle',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {},
+			myAgentName: 'Plan Reviewer',
+		});
+
+		await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'coder',
+			message: 'check slug',
+		});
+
+		expect(tam.subSessionInjects[0]?.message).toContain('─── Message from Plan Reviewer ───');
+		expect(tam.subSessionInjects[0]?.message).toContain(
+			'To reply, use: send_message with target "@plan-reviewer"'
+		);
 	});
 
 	test('node_id by agent name routes directly to the live sub-session', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3740,7 +3740,7 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(tam.subSessionInjects[0]?.message).not.toContain('@@coordinator');
 	});
 
-	test('long-horizon sender derives slug handle from display name when no alias exists', async () => {
+	test('long-horizon sender falls back to display-name handle only when no alias exists', async () => {
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Slug');
 		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Slug target');
 		const task = tasks[0];
@@ -3768,6 +3768,42 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(tam.subSessionInjects[0]?.message).toContain(
 			'To reply, use: send_message with target "@plan-reviewer"'
 		);
+	});
+
+	test('long-horizon sender omits invalid fallback when name slug is empty', async () => {
+		const wf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'WF Empty Slug'
+		);
+		const { tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Empty slug target');
+		const task = tasks[0];
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: task.workflowRunId,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'coder',
+			agentSessionId: 'coder-session-live',
+			status: 'idle',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {},
+			myAgentName: '!!!',
+		});
+
+		await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'coder',
+			message: 'check empty slug',
+		});
+
+		expect(tam.subSessionInjects[0]?.message).toContain('─── Message from !!! ───');
+		expect(tam.subSessionInjects[0]?.message).toContain(
+			'To reply, use: send_message with target "@!!!"'
+		);
+		expect(tam.subSessionInjects[0]?.message).not.toContain('target "@space-agent"');
 	});
 
 	test('node_id by agent name routes directly to the live sub-session', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3526,17 +3526,6 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		return created;
 	}
 
-	function spaceAgentToTaskEnvelope(task: SpaceTask, message: string): string {
-		return formatAgentMessage({
-			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
-			toLevel: 'task-agent',
-			body: message,
-			taskId: task.id,
-			taskNumber: task.taskNumber,
-		});
-	}
-
 	function spaceAgentToNodeEnvelope(
 		task: SpaceTask,
 		message: string,
@@ -3544,7 +3533,7 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 	): string {
 		return formatAgentMessage({
 			fromLevel: 'space-agent',
-			fromAgentName: 'Space Agent',
+			fromAgentName: 'space-agent',
 			toLevel: 'node-agent',
 			body: message,
 			taskId: task.id,


### PR DESCRIPTION
Fix inter-agent message footers to show actual sender names and reply targets for long-horizon agents and ad-hoc sessions.

Tests: bun run check; ./scripts/test-daemon.sh 5-space