### PR TITLE
chore(release): bump version to 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.32.0] - 2026-05-25
+
+Goal/Forge automation triggers, Space session promotion, daemon log evidence capture, dynamic agent reply target fixes, and compressed agent output evaluation. 6 commits since v0.31.0.
+
+### Added
+
+- **Goal/Forge automation triggers**: Server-side triggers for completed-task thresholds, self-nag schedules, and external event subscriptions
+- **Space session promotion**: Promote recent Space session context into long-horizon agent profiles through the agent editor
+- **Daemon log evidence capture**: Structured daemon warning, error, crash, and uncaught exception events now feed Forge evidence
+- **Compressed agent output evaluation**: Documented Caveman-style compressed output primitives and rollout considerations
+
+### Changed
+
+- Repository formatting switched from tabs to spaces
+
+### Fixed
+
+- Dynamic inter-agent message footers now show actual sender names and reply targets
+
 ## [0.31.0] - 2026-05-23
 
 Long-horizon Space agents, Forge task dependencies, workflow gate validation, and Forge evidence fixes. 15 commits since v0.30.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neokai",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "NeoKai - Claude Agent SDK Web Interface",
   "bin": {
     "kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/cli",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/daemon",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/desktop",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.31.0"
+version = "0.32.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kai",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "identifier": "io.neokai.kai",
   "build": {
     "frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/e2e",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/shared",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/web",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps NeoKai to v0.32.0 and updates the changelog for the six commits merged since v0.31.0.

Checks: bun run check; version verification script.