### PR TITLE
Cover clean Forge trace diagnostics

### DIFF
--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -261,6 +261,56 @@ describe('Forge evidence capture on task completion', () => {
     ).toBe(1);
   });
 
+  it('records clean-trace diagnostics through the normal task completion path', async () => {
+    const manager = new SpaceTaskManager(db as never, spaceId, undefined, evolutionScopeService);
+    const scope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Clean normal completion path',
+      objective: 'Record diagnostics when completed task trace has no friction',
+    });
+    const task = taskRepo.createTask({
+      spaceId,
+      title: 'Finish clean trace task',
+      description: 'Normal completion should record no-friction trace diagnostics',
+      evolutionScopeId: scope.id,
+    });
+    insertToolExchange(
+      task.id,
+      'session-clean-normal',
+      'tool-clean-normal',
+      'Bash',
+      { command: 'bun test packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts' },
+      false,
+      { text: '1 pass' }
+    );
+    await taskRepo.updateTask(task.id, {
+      status: 'in_progress',
+      result: 'Clean trace validation complete',
+    });
+
+    await manager.setTaskStatus(task.id, 'done');
+
+    const evidence = evolutionRepo.listEvidence(scope.id);
+    const diagnostic = evidence.find(
+      (item) => item.kind === 'session' && item.metadata.traceDiagnostic === true
+    );
+    expect(evidence.some((item) => item.kind === 'task_result')).toBe(true);
+    expect(diagnostic?.metadata.status).toBe('no_friction');
+    expect(diagnostic?.metadata.toolCallCount).toBe(1);
+    expect(diagnostic?.metadata.failedToolCallCount).toBe(0);
+    expect(
+      (
+        db
+          .prepare(
+            `SELECT COUNT(*) AS count FROM job_queue
+							 WHERE queue = 'space.conversationFriction.analyze' AND json_extract(payload, '$.taskId') = ?`
+          )
+          .get(task.id) as { count: number }
+      ).count
+    ).toBe(1);
+  });
+
   it('auto-captured task_result evidence includes summary populated from result artifact', async () => {
     const scope = evolutionRepo.createScope({
       spaceId,


### PR DESCRIPTION
Adds normal completion coverage proving clean scoped task traces record no-friction diagnostics and enqueue conversation friction analysis.

Validated task #451 already produced live trace diagnostic evidence on task #452: ce1cd063-b7e7-45c6-f4c1-19c59ba9bbe2, kind=session, status=no_friction.

Tests:
- cd packages/daemon && bun test tests/unit/5-space/forge-evidence-capture.test.ts
- bun run check