### PR TITLE
Set workflow agent session titles

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -121,6 +121,9 @@ export interface AgentSessionInit {
   /** Session ID (e.g., 'space:chat:abc123', or UUID for worker) */
   sessionId: string;
 
+  /** Optional display title for this session */
+  title?: string;
+
   /** Workspace path for this session */
   workspacePath: string;
 
@@ -668,7 +671,7 @@ export class AgentSession
 
     return {
       id: init.sessionId,
-      title: 'New Session',
+      title: init.title ?? 'New Session',
       workspacePath: init.workspacePath,
       createdAt: now,
       lastActiveAt: now,

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -666,6 +666,7 @@ export class AgentSession
       outputTokens: 0,
       totalCost: 0,
       toolCallCount: 0,
+      titleGenerated: Boolean(init.title),
       ...(init.promptProvenance ? { promptProvenance: init.promptProvenance } : {}),
     };
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -489,7 +489,7 @@ export class SpaceRuntimeService {
         await sessionManager.createSession({
           sessionId,
           workspacePath: space.workspacePath,
-          title: `${agent.name} inbox`,
+          title: agent.name,
           spaceId: space.id,
           worktreeMode: 'direct',
           config: {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -133,6 +133,12 @@ function expectedEnvelopeSenderNames(sourceAgentName: string): string[] {
   return sourceAgentName === 'space-agent' ? ['space-agent', 'Space Agent'] : [sourceAgentName];
 }
 
+function formatWorkflowNodeSessionTitle(task: SpaceTask, agentName?: string): string {
+  const agentDisplayName = agentName ? agentName[0].toUpperCase() + agentName.slice(1) : '';
+  const agentLabel = agentDisplayName ? ` — ${agentDisplayName}` : '';
+  return `Task #${task.taskNumber}: ${task.title}${agentLabel}`;
+}
+
 export function hasAgentMessageEnvelopeForTest(
   message: string,
   sourceAgentName: string,
@@ -660,6 +666,7 @@ export class TaskAgentManager {
 
       init = {
         ...init,
+        title: formatWorkflowNodeSessionTitle(task, execution.agentName),
         mcpServers: {
           ...init.mcpServers,
           'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
@@ -994,8 +1001,13 @@ export class TaskAgentManager {
     }
 
     // --- First execution for this agent: create a new session.
+    const parentTask = this.config.taskRepo.getTask(taskId);
+    const subSessionInit =
+      parentTask && !init.title
+        ? { ...init, title: formatWorkflowNodeSessionTitle(parentTask, memberInfo?.agentName) }
+        : init;
     const subSession = AgentSession.fromInit(
-      init,
+      subSessionInit,
       this.config.db,
       this.config.messageHub,
       this.config.internalEventBus,
@@ -1026,7 +1038,7 @@ export class TaskAgentManager {
       }) ?? {};
     const mergedSubSessionMcpServers = {
       ...subSessionRegistryMcpServers,
-      ...init.mcpServers,
+      ...subSessionInit.mcpServers,
     };
     if (Object.keys(mergedSubSessionMcpServers).length > 0) {
       // Use merge semantics: the session is freshly created here so the map is
@@ -3890,6 +3902,7 @@ export class TaskAgentManager {
     );
     init = {
       ...init,
+      title: formatWorkflowNodeSessionTitle(task, matchedSlot.name),
       mcpServers: {
         ...init.mcpServers,
         'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -2178,6 +2178,33 @@ describe('AgentSession', () => {
   });
 
   describe('createSessionFromInit', () => {
+    it('uses provided title when creating a session', () => {
+      const session = AgentSession.createSessionFromInit(
+        {
+          sessionId: 'node-agent:coder',
+          title: 'Task #427: Forge MVP 3 — Coder',
+          workspacePath: '/test/workspace',
+          type: 'worker',
+        },
+        'claude-sonnet-4-5-20250929'
+      );
+
+      expect(session.title).toBe('Task #427: Forge MVP 3 — Coder');
+    });
+
+    it('falls back to New Session when title is omitted', () => {
+      const session = AgentSession.createSessionFromInit(
+        {
+          sessionId: 'node-agent:untitled',
+          workspacePath: '/test/workspace',
+          type: 'worker',
+        },
+        'claude-sonnet-4-5-20250929'
+      );
+
+      expect(session.title).toBe('New Session');
+    });
+
     it('should create a session without mcpServers in config to avoid cyclic serialization errors', () => {
       // Simulate what createSdkMcpServer returns - an object with a non-serializable instance
       const mockMcpServer = {

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -2190,6 +2190,7 @@ describe('AgentSession', () => {
       );
 
       expect(session.title).toBe('Task #427: Forge MVP 3 — Coder');
+      expect(session.metadata.titleGenerated).toBe(true);
     });
 
     it('falls back to New Session when title is omitted', () => {
@@ -2203,6 +2204,7 @@ describe('AgentSession', () => {
       );
 
       expect(session.title).toBe('New Session');
+      expect(session.metadata.titleGenerated).toBe(false);
     });
 
     it('should create a session without mcpServers in config to avoid cyclic serialization errors', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -17,6 +17,7 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntimeServiceConfig } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
 import { longTermAgentSessionId } from '../../../../src/lib/space/long-term-agent-session.ts';
+import type { ActorRef, MessageRecord } from '../../../../../messaging/src/types.ts';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
 import type { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import type { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -695,6 +696,63 @@ describe('SpaceRuntimeService', () => {
       expect(session.setRuntimeSystemPrompt).toHaveBeenCalled();
 
       await svc.stop();
+    });
+
+    test('long-term Space agent sessions use the agent name as title', async () => {
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({
+          id: longTermAgentSessionId(mockSpace.id, 'agent-1'),
+          metadata: {},
+          config: {},
+        })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => longTermAgentSessionId(mockSpace.id, 'agent-1'));
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const spaceManager = createMockSpaceManager(mockSpace);
+      const spaceAgentManager = {
+        getById: mock(() => ({
+          id: 'agent-1',
+          spaceId: mockSpace.id,
+          name: 'Researcher',
+          customPrompt: null,
+        })),
+        listBySpaceId: mock(() => []),
+      } as unknown as SpaceAgentManager;
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, spaceManager),
+        spaceAgentManager,
+        spaceAgentInboxRepo: {} as SpaceRuntimeServiceConfig['spaceAgentInboxRepo'],
+      });
+
+      const delivery = svc.longTermAgentDeliveryCallbacks();
+      await delivery?.deliverToSession(
+        {
+          actorId: 'agent:agent-1',
+          kind: 'agent',
+          spaceId: mockSpace.id,
+          status: 'active',
+        } as ActorRef,
+        {
+          messageId: 'message-1',
+          spaceId: mockSpace.id,
+          senderActorId: 'space:space-1:human:user-1',
+          kind: 'message',
+          body: 'hello',
+          createdAt: Date.now(),
+        } as MessageRecord
+      );
+
+      expect(sessionManager.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Researcher' })
+      );
     });
 
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {


### PR DESCRIPTION
Sets descriptive titles for workflow node-agent sessions and long-term Space agent sessions so session lists no longer show generic New Session entries.

Also adds coverage for AgentSession title creation and long-term Space agent session title wiring.

Tests:
- bun run check
- cd packages/daemon && bun test tests/unit/1-core/agent/agent-session.test.ts --timeout 30000
- cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-service.test.ts -t "long-term Space agent sessions use the agent name as title" --timeout 30000