### PR TITLE
Fix task result capture fallback

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -167,6 +167,7 @@ export class SpaceTaskManager {
     newStatus: SpaceTaskStatus,
     options?: {
       result?: string;
+      reportedSummary?: string;
       blockReason?: SpaceBlockReason;
       approvalSource?: SpaceApprovalSource;
       // `null` explicitly clears a prior value; `undefined` leaves any
@@ -193,6 +194,7 @@ export class SpaceTaskManager {
 
     if (newStatus === 'done' || newStatus === 'blocked') {
       if (options?.result) updates.result = options.result;
+      if (options?.reportedSummary) updates.reportedSummary = options.reportedSummary;
     }
 
     // Stamp blockReason when entering blocked, clear when leaving

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2447,9 +2447,10 @@ export class SpaceRuntime {
       const summaryFromWorkflow = workflow
         ? this.resolveCompletionSummary(run.id, workflow)
         : undefined;
-      const summaryFromSibling = runTasks
-        .filter((task) => task.id !== canonicalTask.id)
-        .find((task) => !!task.result)?.result;
+      const summaryFromSibling = normalizeMeaningfulTaskResult(
+        runTasks.filter((task) => task.id !== canonicalTask.id).find((task) => !!task.result)
+          ?.result
+      );
       const reportedSummary = normalizeMeaningfulTaskResult(canonicalTask.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(canonicalTask.result);
       const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? null;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2447,10 +2447,10 @@ export class SpaceRuntime {
       const summaryFromWorkflow = workflow
         ? this.resolveCompletionSummary(run.id, workflow)
         : undefined;
-      const summaryFromSibling = normalizeMeaningfulTaskResult(
-        runTasks.filter((task) => task.id !== canonicalTask.id).find((task) => !!task.result)
-          ?.result
-      );
+      const summaryFromSibling = runTasks
+        .filter((task) => task.id !== canonicalTask.id)
+        .map((task) => normalizeMeaningfulTaskResult(task.result))
+        .find((result) => result !== null);
       const reportedSummary = normalizeMeaningfulTaskResult(canonicalTask.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(canonicalTask.result);
       const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? null;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -46,6 +46,7 @@ import type { ExternalEventStore } from '../../external-events/external-event-st
 import type { ExternalEvent } from '../../external-events/types';
 import { validateGlobPattern } from '../../external-events/topic-validator';
 import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
@@ -1804,8 +1805,10 @@ export class SpaceRuntime {
           : undefined;
         return this.buildTaskOutcomeUpdates(
           task,
-          artifactSummary ?? (task.result?.trim() ? task.result : (task.reportedSummary ?? null)),
-          artifactSummary ?? task.reportedSummary ?? null
+          artifactSummary ??
+            normalizeMeaningfulTaskResult(task.result) ??
+            normalizeMeaningfulTaskResult(task.reportedSummary),
+          artifactSummary ?? normalizeMeaningfulTaskResult(task.reportedSummary)
         );
       },
       spawner: {
@@ -2447,8 +2450,8 @@ export class SpaceRuntime {
       const summaryFromSibling = runTasks
         .filter((task) => task.id !== canonicalTask.id)
         .find((task) => !!task.result)?.result;
-      const reportedSummary = canonicalTask.reportedSummary ?? null;
-      const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
+      const reportedSummary = normalizeMeaningfulTaskResult(canonicalTask.reportedSummary);
+      const existingResult = normalizeMeaningfulTaskResult(canonicalTask.result);
       const freshSummary = summaryFromArtifact ?? summaryFromWorkflow ?? null;
       const nextResult =
         freshSummary ?? existingResult ?? reportedSummary ?? summaryFromSibling ?? null;
@@ -4534,8 +4537,8 @@ export class SpaceRuntime {
         await this.transitionRunStatusAndEmit(runId, 'done');
         const summaryFromArtifact = this.resolvePrimaryResultArtifactSummary(runId);
         const summary = this.resolveCompletionSummary(runId, meta.workflow);
-        const reportedSummary = canonicalTask.reportedSummary ?? null;
-        const existingResult = canonicalTask.result?.trim() ? canonicalTask.result : null;
+        const reportedSummary = normalizeMeaningfulTaskResult(canonicalTask.reportedSummary);
+        const existingResult = normalizeMeaningfulTaskResult(canonicalTask.result);
         const freshSummary = summaryFromArtifact ?? summary ?? null;
         const nextTaskResult = freshSummary ?? existingResult ?? reportedSummary ?? null;
         const nextReportedSummary = freshSummary ?? reportedSummary ?? null;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3594,6 +3594,22 @@ export class TaskAgentManager {
       taskManager: boundTaskManager,
       internalEventBus: this.config.internalEventBus,
       goalService: this.config.goalService,
+      resolveResultArtifactSummary: (task) => {
+        if (!task.workflowRunId || !this.config.artifactRepo) return null;
+        const artifacts = this.config.artifactRepo.listByRun(task.workflowRunId, {
+          artifactType: 'result',
+        });
+        const artifact = artifacts
+          .map((item, index) => ({ item, index }))
+          .filter(({ item }) => typeof item.data.summary === 'string' && item.data.summary.trim())
+          .toSorted(
+            (a, b) =>
+              b.item.updatedAt - a.item.updatedAt ||
+              b.item.createdAt - a.item.createdAt ||
+              b.index - a.index
+          )[0]?.item;
+        return typeof artifact?.data.summary === 'string' ? artifact.data.summary : null;
+      },
     });
 
     // Self-heal callback for the agent-callable `restore_node_agent` tool.

--- a/packages/daemon/src/lib/space/task-result-utils.ts
+++ b/packages/daemon/src/lib/space/task-result-utils.ts
@@ -1,0 +1,10 @@
+const GENERIC_TASK_RESULT_STRINGS = new Set([
+  'An unexpected error occurred. Please try again or contact support if the issue persists.',
+]);
+
+export function normalizeMeaningfulTaskResult(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (GENERIC_TASK_RESULT_STRINGS.has(trimmed)) return null;
+  return trimmed;
+}

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -185,7 +185,7 @@ export function createMarkCompleteHandler(
       const artifactSummary = normalizeMeaningfulTaskResult(resolveResultArtifactSummary?.(task));
       const reportedSummary = normalizeMeaningfulTaskResult(task.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(task.result);
-      const result = artifactSummary ?? reportedSummary ?? existingResult ?? 'Task completed.';
+      const result = artifactSummary ?? existingResult ?? reportedSummary ?? 'Task completed.';
       if (result !== task.result || (artifactSummary && artifactSummary !== task.reportedSummary)) {
         await taskManager.updateTask(taskId, {
           result,

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -186,15 +186,10 @@ export function createMarkCompleteHandler(
       const reportedSummary = normalizeMeaningfulTaskResult(task.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(task.result);
       const result = artifactSummary ?? existingResult ?? reportedSummary ?? 'Task completed.';
-      if (result !== task.result || (artifactSummary && artifactSummary !== task.reportedSummary)) {
-        await taskManager.updateTask(taskId, {
-          result,
-          reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
-        });
-      }
       const updated = await taskManager.setTaskStatus(taskId, 'done', {
         approvalSource: task.approvalSource ?? 'agent',
         result,
+        reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
         onCascadedTasks: async (cascadedTasks) => {
           for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
         },

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -35,6 +35,7 @@ import type {
 } from './task-agent-tool-schemas';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
+import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 
 const log = new Logger('end-node-handlers');
 
@@ -89,6 +90,8 @@ export interface MarkCompleteHandlerDeps {
   spaceId: string;
   /** Task repository — used to read the current status before transitioning. */
   taskRepo: Pick<SpaceTaskRepository, 'getTask'>;
+  /** Optional summary captured from the latest result artifact for this task's workflow run. */
+  resolveResultArtifactSummary?: (task: SpaceTask) => string | null;
   /** Task manager — used to transition and update the task atomically. */
   taskManager: Pick<SpaceTaskManager, 'setTaskStatus' | 'updateTask'>;
   /** Optional hub for emitting `space.task.updated` events. */
@@ -105,7 +108,15 @@ export interface MarkCompleteHandlerDeps {
 export function createMarkCompleteHandler(
   deps: MarkCompleteHandlerDeps
 ): (args: MarkCompleteInput) => Promise<ToolResult> {
-  const { taskId, spaceId, taskRepo, taskManager, internalEventBus, goalService } = deps;
+  const {
+    taskId,
+    spaceId,
+    taskRepo,
+    taskManager,
+    internalEventBus,
+    goalService,
+    resolveResultArtifactSummary,
+  } = deps;
 
   const handleGoalTerminal = (task: SpaceTask): void => {
     if (!goalService) return;
@@ -171,8 +182,19 @@ export function createMarkCompleteHandler(
       // "exit approved" branch in `SpaceTaskManager.setTaskStatus` nulls
       // `postApprovalSessionId`, `postApprovalStartedAt`, and
       // `postApprovalBlockedReason` in the same UPDATE.
+      const artifactSummary = normalizeMeaningfulTaskResult(resolveResultArtifactSummary?.(task));
+      const reportedSummary = normalizeMeaningfulTaskResult(task.reportedSummary);
+      const existingResult = normalizeMeaningfulTaskResult(task.result);
+      const result = artifactSummary ?? reportedSummary ?? existingResult ?? 'Task completed.';
+      if (result !== task.result || (artifactSummary && artifactSummary !== task.reportedSummary)) {
+        await taskManager.updateTask(taskId, {
+          result,
+          reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
+        });
+      }
       const updated = await taskManager.setTaskStatus(taskId, 'done', {
         approvalSource: task.approvalSource ?? 'agent',
+        result,
         onCascadedTasks: async (cascadedTasks) => {
           for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
         },

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -69,6 +69,7 @@ import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
+import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 
 const log = new Logger('space-agent-tools');
 
@@ -2033,7 +2034,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
       try {
         const updated = await taskManager.setTaskStatus(args.task_id, 'done', {
-          result: task.result ?? undefined,
+          result:
+            normalizeMeaningfulTaskResult(task.result) ??
+            normalizeMeaningfulTaskResult(task.reportedSummary) ??
+            undefined,
           approvalSource: 'agent',
           approvalReason: args.reason,
           onCascadedTasks: async (cascadedTasks) => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -254,6 +254,7 @@ describe('createMarkCompleteHandler', () => {
     expect(parsed.success).toBe(false);
     expect(parsed.error).toBe('transition raced');
     expect(ctx.taskRepo.getTask(task.id)?.status).toBe('approved');
+    expect(ctx.taskRepo.getTask(task.id)?.result).toBeNull();
     const unchangedGoal = ctx.goalService.getGoal(goal.id);
     expect(unchangedGoal?.summary).toBe('');
     expect(unchangedGoal?.progress).toBe(0);

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -284,6 +284,68 @@ describe('createMarkCompleteHandler', () => {
     expect(ctx.taskRepo.getTask(task.id)?.status).toBe('approved');
   });
 
+  test('mark_complete uses result artifact before stale generic task result', async () => {
+    const task = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'T',
+      description: '',
+      status: 'approved',
+    });
+    ctx.taskRepo.updateTask(task.id, {
+      result:
+        'An unexpected error occurred. Please try again or contact support if the issue persists.',
+      reportedSummary: 'PR #2007 merged to dev via squash merge.',
+    });
+    const handler = createMarkCompleteHandler({
+      taskId: task.id,
+      spaceId: ctx.spaceId,
+      taskRepo: ctx.taskRepo,
+      taskManager: ctx.taskManager,
+      resolveResultArtifactSummary: () =>
+        'Merge artifact: PR #2007 merged to dev via squash merge.',
+    });
+
+    const out = await handler({});
+    const parsed = JSON.parse(out.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const updated = ctx.taskRepo.getTask(task.id);
+    expect(updated?.status).toBe('done');
+    expect(updated?.result).toBe('Merge artifact: PR #2007 merged to dev via squash merge.');
+    expect(updated?.reportedSummary).toBe(
+      'Merge artifact: PR #2007 merged to dev via squash merge.'
+    );
+  });
+
+  test('mark_complete falls back to reported summary instead of generic task result', async () => {
+    const task = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'T',
+      description: '',
+      status: 'approved',
+    });
+    ctx.taskRepo.updateTask(task.id, {
+      result:
+        'An unexpected error occurred. Please try again or contact support if the issue persists.',
+      reportedSummary: 'PR #2007 merged to dev via squash merge.',
+    });
+    const handler = createMarkCompleteHandler({
+      taskId: task.id,
+      spaceId: ctx.spaceId,
+      taskRepo: ctx.taskRepo,
+      taskManager: ctx.taskManager,
+    });
+
+    const out = await handler({});
+    const parsed = JSON.parse(out.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const updated = ctx.taskRepo.getTask(task.id);
+    expect(updated?.status).toBe('done');
+    expect(updated?.result).toBe('PR #2007 merged to dev via squash merge.');
+    expect(updated?.reportedSummary).toBe('PR #2007 merged to dev via squash merge.');
+  });
+
   test('emits space.task.updated for cascaded dependent tasks', async () => {
     const task = ctx.taskRepo.createTask({
       spaceId: ctx.spaceId,

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -346,6 +346,34 @@ describe('createMarkCompleteHandler', () => {
     expect(updated?.reportedSummary).toBe('PR #2007 merged to dev via squash merge.');
   });
 
+  test('mark_complete preserves meaningful task result before reported summary', async () => {
+    const task = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'T',
+      description: '',
+      status: 'approved',
+    });
+    ctx.taskRepo.updateTask(task.id, {
+      result: 'Manual correction: deployment verified.',
+      reportedSummary: 'Older reported summary from previous cycle.',
+    });
+    const handler = createMarkCompleteHandler({
+      taskId: task.id,
+      spaceId: ctx.spaceId,
+      taskRepo: ctx.taskRepo,
+      taskManager: ctx.taskManager,
+    });
+
+    const out = await handler({});
+    const parsed = JSON.parse(out.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const updated = ctx.taskRepo.getTask(task.id);
+    expect(updated?.status).toBe('done');
+    expect(updated?.result).toBe('Manual correction: deployment verified.');
+    expect(updated?.reportedSummary).toBe('Older reported summary from previous cycle.');
+  });
+
   test('emits space.task.updated for cascaded dependent tasks', async () => {
     const task = ctx.taskRepo.createTask({
       spaceId: ctx.spaceId,

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -3421,6 +3421,32 @@ describe('createSpaceAgentToolHandlers — approve_task plain path', () => {
     expect(parsed.task.status).toBe('done');
   });
 
+  test('falls back to reported summary when review approval result is generic', async () => {
+    await ctx.spaceManager.updateSpace(ctx.spaceId, { autonomyLevel: 5 });
+    const createResult = await makeHandlers(ctx).create_standalone_task({
+      title: 'plain review task',
+      description: 'no pending action',
+    });
+    const taskId = JSON.parse(createResult.content[0].text).task.id;
+    ctx.taskRepo.updateTask(taskId, {
+      status: 'review',
+      result:
+        'An unexpected error occurred. Please try again or contact support if the issue persists.',
+      reportedSummary: 'PR #2007 merged to dev via squash merge.',
+    });
+
+    const result = await makeHandlers(ctx).approve_task({
+      task_id: taskId,
+      reason: 'looks good',
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.task.status).toBe('done');
+    expect(parsed.task.result).toBe('PR #2007 merged to dev via squash merge.');
+    expect(ctx.taskRepo.getTask(taskId)?.result).toBe('PR #2007 merged to dev via squash merge.');
+  });
+
   test('publishes space.task.updated for cascaded dependent tasks', async () => {
     await ctx.spaceManager.updateSpace(ctx.spaceId, { autonomyLevel: 5 });
     const task = await ctx.taskManager.createTask({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1684,6 +1684,37 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
       expect(taskAfter?.reportedSummary).toBe('Fresh artifact summary after retry');
     });
 
+    test('reported summary replaces generic error task result when no artifact exists', async () => {
+      const rt = makeRuntimeWithTam();
+
+      const workflow = workflowManager.createWorkflow({
+        spaceId: SPACE_ID,
+        name: `Generic Error Fallback ${Date.now()}`,
+        description: '',
+        nodes: [{ id: 'generic-error-end', name: 'End', agentId: AGENT_A }],
+        startNodeId: 'generic-error-end',
+        endNodeId: 'generic-error-end',
+        tags: [],
+        completionAutonomyLevel: 3,
+      });
+
+      const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      taskRepo.updateTask(tasks[0].id, {
+        status: 'in_progress',
+        result:
+          'An unexpected error occurred. Please try again or contact support if the issue persists.',
+        reportedStatus: 'done',
+        reportedSummary: 'PR #2007 merged to dev via squash merge.',
+      });
+      seedNodeExec(db, run.id, 'generic-error-end', 'End', 'idle');
+
+      await rt.executeTick();
+
+      const taskAfter = taskRepo.getTask(tasks[0].id);
+      expect(taskAfter?.result).toBe('PR #2007 merged to dev via squash merge.');
+      expect(taskAfter?.reportedSummary).toBe('PR #2007 merged to dev via squash merge.');
+    });
+
     test('reportedStatus alone is enough to mark a run for completion resolution', async () => {
       // Even when task.status has not yet flipped to a terminal state, a
       // non-null `reportedStatus` signals the runtime to resolve completion

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1754,6 +1754,54 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
       expect(taskAfter?.reportedSummary).toBeNull();
     });
 
+    test('uses later meaningful sibling result after earlier generic sibling result', async () => {
+      const rt = makeRuntimeWithTam();
+
+      const workflow = workflowManager.createWorkflow({
+        spaceId: SPACE_ID,
+        name: `Meaningful Sibling Fallback ${Date.now()}`,
+        description: '',
+        nodes: [{ id: 'meaningful-sibling-end', name: 'End', agentId: AGENT_A }],
+        startNodeId: 'meaningful-sibling-end',
+        endNodeId: 'meaningful-sibling-end',
+        tags: [],
+        completionAutonomyLevel: 3,
+      });
+
+      const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      taskRepo.updateTask(tasks[0].id, {
+        status: 'done',
+        result: null,
+        reportedSummary: null,
+      });
+      const genericDuplicate = await rt.getTaskManagerForSpace(SPACE_ID).createTask({
+        title: 'duplicate generic sibling',
+        description: '',
+        workflowRunId: run.id,
+        status: 'done',
+      });
+      taskRepo.updateTask(genericDuplicate.id, {
+        result:
+          'An unexpected error occurred. Please try again or contact support if the issue persists.',
+      });
+      const meaningfulDuplicate = await rt.getTaskManagerForSpace(SPACE_ID).createTask({
+        title: 'duplicate meaningful sibling',
+        description: '',
+        workflowRunId: run.id,
+        status: 'done',
+      });
+      taskRepo.updateTask(meaningfulDuplicate.id, {
+        result: 'PR #2007 merged to dev via squash merge.',
+      });
+      workflowRunRepo.updateRun(run.id, { status: 'done' });
+
+      await rt.executeTick();
+
+      const taskAfter = taskRepo.getTask(tasks[0].id);
+      expect(taskAfter?.result).toBe('PR #2007 merged to dev via squash merge.');
+      expect(taskAfter?.reportedSummary).toBe('PR #2007 merged to dev via squash merge.');
+    });
+
     test('reportedStatus alone is enough to mark a run for completion resolution', async () => {
       // Even when task.status has not yet flipped to a terminal state, a
       // non-null `reportedStatus` signals the runtime to resolve completion

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1715,6 +1715,45 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
       expect(taskAfter?.reportedSummary).toBe('PR #2007 merged to dev via squash merge.');
     });
 
+    test('ignores generic error sibling result when filling terminal run result', async () => {
+      const rt = makeRuntimeWithTam();
+
+      const workflow = workflowManager.createWorkflow({
+        spaceId: SPACE_ID,
+        name: `Generic Sibling Fallback ${Date.now()}`,
+        description: '',
+        nodes: [{ id: 'generic-sibling-end', name: 'End', agentId: AGENT_A }],
+        startNodeId: 'generic-sibling-end',
+        endNodeId: 'generic-sibling-end',
+        tags: [],
+        completionAutonomyLevel: 3,
+      });
+
+      const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      taskRepo.updateTask(tasks[0].id, {
+        status: 'done',
+        result: null,
+        reportedSummary: null,
+      });
+      const duplicate = await rt.getTaskManagerForSpace(SPACE_ID).createTask({
+        title: 'duplicate generic sibling',
+        description: '',
+        workflowRunId: run.id,
+        status: 'done',
+      });
+      taskRepo.updateTask(duplicate.id, {
+        result:
+          'An unexpected error occurred. Please try again or contact support if the issue persists.',
+      });
+      workflowRunRepo.updateRun(run.id, { status: 'done' });
+
+      await rt.executeTick();
+
+      const taskAfter = taskRepo.getTask(tasks[0].id);
+      expect(taskAfter?.result).toBeNull();
+      expect(taskAfter?.reportedSummary).toBeNull();
+    });
+
     test('reportedStatus alone is enough to mark a run for completion resolution', async () => {
       // Even when task.status has not yet flipped to a terminal state, a
       // non-null `reportedStatus` signals the runtime to resolve completion


### PR DESCRIPTION
Fix task result auto-capture so meaningful result artifacts and reported summaries win over stale generic error strings when tasks close.

Tests:
- cd packages/daemon && bun test tests/unit/5-space/agent/end-node-handlers.test.ts && bun test tests/unit/5-space/runtime/space-runtime-completion.test.ts
- bun run check