### PR TITLE
Stabilize SpaceGoals component test

### DIFF
--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -10,6 +10,7 @@ const mockTasks = signal<SpaceTask[]>([]);
 const mockWorkflows = signal<unknown[]>([]);
 const mockListGoals = vi.fn(async () => [] as SpaceGoal[]);
 const mockListGoalEvents = vi.fn(async () => [] as SpaceGoalEvent[]);
+const mockEnsureConfigData = vi.fn(async () => {});
 const mockPauseGoal = vi.fn();
 const mockResumeGoal = vi.fn();
 const mockArchiveGoal = vi.fn();
@@ -50,6 +51,7 @@ const mutableSpaceStore = spaceStore as unknown as {
   workflows: Signal<unknown[]>;
   listGoals: typeof mockListGoals;
   listGoalEvents: typeof mockListGoalEvents;
+  ensureConfigData: typeof mockEnsureConfigData;
   pauseGoal: typeof mockPauseGoal;
   resumeGoal: typeof mockResumeGoal;
   archiveGoal: typeof mockArchiveGoal;
@@ -64,6 +66,7 @@ mutableSpaceStore.tasks = mockTasks;
 mutableSpaceStore.workflows = mockWorkflows;
 mutableSpaceStore.listGoals = mockListGoals;
 mutableSpaceStore.listGoalEvents = mockListGoalEvents;
+mutableSpaceStore.ensureConfigData = mockEnsureConfigData;
 mutableSpaceStore.pauseGoal = mockPauseGoal;
 mutableSpaceStore.resumeGoal = mockResumeGoal;
 mutableSpaceStore.archiveGoal = mockArchiveGoal;
@@ -166,6 +169,7 @@ describe('SpaceGoals', () => {
     mockWorkflows.value = [];
     mockListGoals.mockResolvedValue([]);
     mockListGoalEvents.mockResolvedValue([]);
+    mockEnsureConfigData.mockResolvedValue(undefined);
     mockPauseGoal.mockImplementation(async (goalId: string) =>
       makeGoal({ id: goalId, status: 'paused' })
     );


### PR DESCRIPTION
## Summary
- Mock `spaceStore.ensureConfigData` in `SpaceGoals.test.tsx` to stop background config loading from using shared store state / hub access during component tests.
- Verified focused test repeatedly and full web coverage locally.

## Test plan
- `cd packages/web && bunx vitest run src/components/space/__tests__/SpaceGoals.test.tsx --reporter verbose --test-timeout 10000`
- `cd packages/web && bunx vitest run src/components/space/__tests__/SpaceGoals.test.tsx --coverage --reporter dot --test-timeout 10000`
- 50x focused stress loop
- `cd packages/web && bun run coverage`