### PR TITLE
Cross-post Forge proposal evidence

### DIFF
--- a/packages/daemon/src/lib/space/evolution-scope-service.ts
+++ b/packages/daemon/src/lib/space/evolution-scope-service.ts
@@ -302,22 +302,23 @@ export class EvolutionScopeService {
     const scope = this.findScopeForTask(task.evolutionScopeId ?? null, task.goalId ?? null);
     if (!scope || scope.spaceId !== task.spaceId) return { scope: null, evidence: [] };
 
+    const taskResultSummary = buildTaskResultEvidenceSummary(task);
+    const taskResultMetadata = buildTaskResultEvidenceMetadata(task);
     const evidence: EvidenceRef[] = [
       this.createAutoEvidenceOnce({
         scopeId: scope.id,
         kind: 'task_result',
         sourceId: task.id,
-        summary: buildTaskResultEvidenceSummary(task),
-        metadata: {
-          status: task.status,
-          priority: task.priority,
-          workflowRunId: task.workflowRunId ?? null,
-          result: task.result ?? null,
-          reportedSummary: task.reportedSummary ?? null,
-          completedAt: task.completedAt ?? null,
-        },
+        summary: taskResultSummary,
+        metadata: taskResultMetadata,
       }),
     ];
+
+    const crossPost = this.createProposalOriginEvidence(scope.id, task, {
+      summary: taskResultSummary,
+      metadata: taskResultMetadata,
+    });
+    if (crossPost) evidence.push(crossPost);
 
     if (task.workflowRunId) {
       const run = this.deps.workflowRunRepo.getRun(task.workflowRunId);
@@ -510,6 +511,29 @@ export class EvolutionScopeService {
     });
   }
 
+  private createProposalOriginEvidence(
+    assignedScopeId: string,
+    task: SpaceTask,
+    params: Pick<CreateEvidenceRefParams, 'summary' | 'metadata'>
+  ): EvidenceRef | null {
+    const proposal = this.deps.evolutionRepo.getTaskProposalByCreatedTaskId(task.id);
+    if (!proposal || proposal.scopeId === assignedScopeId) return null;
+    const originScope = this.deps.evolutionRepo.getScope(proposal.scopeId);
+    if (!originScope || originScope.spaceId !== task.spaceId) return null;
+    return this.createAutoEvidenceOnce({
+      scopeId: originScope.id,
+      kind: 'task_result',
+      sourceId: task.id,
+      summary: params.summary,
+      metadata: {
+        ...params.metadata,
+        crossLinkedTaskId: task.id,
+        originatingProposalId: proposal.id,
+        assignedScopeId,
+      },
+    });
+  }
+
   private createTraceDiagnosticEvidence(
     scopeId: string,
     taskId: string,
@@ -621,6 +645,17 @@ export class EvolutionScopeService {
 function buildTaskResultEvidenceSummary(task: SpaceTask): string {
   const outcome = task.result ?? task.reportedSummary ?? 'completed without task.result';
   return `Task #${task.taskNumber} done: ${task.title} — ${truncateText(outcome, 180)}`;
+}
+
+function buildTaskResultEvidenceMetadata(task: SpaceTask): Record<string, unknown> {
+  return {
+    status: task.status,
+    priority: task.priority,
+    workflowRunId: task.workflowRunId ?? null,
+    result: task.result ?? null,
+    reportedSummary: task.reportedSummary ?? null,
+    completedAt: task.completedAt ?? null,
+  };
 }
 
 function summarizeTaskForPreflight(task: SpaceTask): EvolutionPreflightTaskSummary {

--- a/packages/daemon/src/storage/repositories/evolution-repository.ts
+++ b/packages/daemon/src/storage/repositories/evolution-repository.ts
@@ -347,6 +347,15 @@ export class EvolutionRepository {
     return rows.map(rowToTaskProposal);
   }
 
+  getTaskProposalByCreatedTaskId(taskId: string): TaskProposal | null {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM evolution_task_proposals WHERE created_task_id = ? ORDER BY updated_at DESC, id DESC LIMIT 1`
+      )
+      .get(taskId) as Record<string, unknown> | undefined;
+    return row ? rowToTaskProposal(row) : null;
+  }
+
   updateTaskProposal(id: string, params: UpdateTaskProposalParams): TaskProposal | null {
     return this.updateTaskProposalWhere(id, params);
   }

--- a/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
+++ b/packages/daemon/tests/unit/5-space/forge-evidence-capture.test.ts
@@ -421,6 +421,127 @@ describe('Forge evidence capture on task completion', () => {
     expect(evidence.map((item) => item.kind).sort()).toEqual(['session', 'task_result']);
   });
 
+  it('does not cross-post proposal evidence when proposal and task scopes match', () => {
+    const scope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Same-scope proposal',
+      objective: 'Avoid duplicate same-scope proposal evidence',
+    });
+    const task = taskRepo.createTask({
+      spaceId,
+      title: 'Complete same-scope proposal task',
+      description: 'Task stays with proposal scope',
+      evolutionScopeId: scope.id,
+    });
+    evolutionRepo.createTaskProposal({
+      scopeId: scope.id,
+      title: task.title,
+      description: task.description,
+      reason: 'Same scope proposal',
+      status: 'created',
+      createdTaskId: task.id,
+    });
+    taskRepo.updateTask(task.id, { status: 'done', result: 'Same scope done' });
+
+    evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+    const evidence = evolutionRepo.listEvidence(scope.id);
+    expect(evidence).toHaveLength(2);
+    expect(evidence.filter((item) => item.kind === 'task_result')).toHaveLength(1);
+    expect(evidence.some((item) => item.metadata.crossLinkedTaskId === task.id)).toBe(false);
+  });
+
+  it('cross-posts proposal-originating task evidence to different originating scope', () => {
+    const originScope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Originating Forge scope',
+      objective: 'Learn from proposed tasks',
+    });
+    const assignedScope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Assigned execution scope',
+      objective: 'Run tasks from other scopes',
+    });
+    const task = taskRepo.createTask({
+      spaceId,
+      title: 'Complete cross-scope proposal task',
+      description: 'Task runs under assigned scope',
+      evolutionScopeId: assignedScope.id,
+    });
+    const proposal = evolutionRepo.createTaskProposal({
+      scopeId: originScope.id,
+      title: task.title,
+      description: task.description,
+      reason: 'Origin scope proposed this work',
+      status: 'created',
+      createdTaskId: task.id,
+    });
+    taskRepo.updateTask(task.id, { status: 'done', result: 'Cross-scope done' });
+
+    evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+    const assignedEvidence = evolutionRepo.listEvidence(assignedScope.id);
+    const originEvidence = evolutionRepo.listEvidence(originScope.id);
+    expect(assignedEvidence.map((item) => item.kind).sort()).toEqual(['session', 'task_result']);
+    expect(originEvidence.map((item) => item.kind)).toEqual(['task_result']);
+    expect(originEvidence[0].sourceId).toBe(task.id);
+    expect(originEvidence[0].metadata).toMatchObject({
+      autoCaptured: true,
+      crossLinkedTaskId: task.id,
+      originatingProposalId: proposal.id,
+      assignedScopeId: assignedScope.id,
+      result: 'Cross-scope done',
+    });
+  });
+
+  it('deduplicates repeated proposal-origin evidence cross-posts', () => {
+    const originScope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Dedupe origin scope',
+      objective: 'Avoid duplicate cross-post evidence',
+    });
+    const assignedScope = evolutionRepo.createScope({
+      spaceId,
+      kind: 'custom',
+      name: 'Dedupe assigned scope',
+      objective: 'Run duplicated capture events',
+    });
+    const task = taskRepo.createTask({
+      spaceId,
+      title: 'Complete cross-post once',
+      description: 'Repeated capture should update existing cross-post',
+      evolutionScopeId: assignedScope.id,
+    });
+    const proposal = evolutionRepo.createTaskProposal({
+      scopeId: originScope.id,
+      title: task.title,
+      description: task.description,
+      reason: 'Needs dedupe',
+      status: 'created',
+      createdTaskId: task.id,
+    });
+    taskRepo.updateTask(task.id, { status: 'done', result: 'Initial result' });
+
+    evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+    taskRepo.updateTask(task.id, { result: 'Updated result' });
+    evolutionScopeService.captureCompletedTaskEvidence({ taskId: task.id });
+
+    const originEvidence = evolutionRepo.listEvidence(originScope.id);
+    expect(originEvidence).toHaveLength(1);
+    expect(originEvidence[0].summary).toContain('Updated result');
+    expect(originEvidence[0].metadata).toMatchObject({
+      autoCaptured: true,
+      crossLinkedTaskId: task.id,
+      originatingProposalId: proposal.id,
+      assignedScopeId: assignedScope.id,
+      result: 'Updated result',
+    });
+  });
+
   it('keeps manual workflow_run evidence and adds artifact evidence for the same run', () => {
     const scope = evolutionRepo.createScope({
       spaceId,


### PR DESCRIPTION
Cross-post completed task evidence back to the originating Forge scope when a proposal-created task runs under a different scope.

Adds reverse proposal lookup by created task ID and focused coverage for same-scope, cross-scope, and dedupe cases.

Tests:
- cd packages/daemon && bun test tests/unit/5-space/forge-evidence-capture.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/add-forge-evidence-cross-posting-from-proposal-originating check