### PR TITLE
Fix Copilot SDK binary bundling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,34 +5,34 @@
     "": {
       "name": "neokai",
       "devDependencies": {
-        "@biomejs/biome": "2.4.15",
+        "@biomejs/biome": "2.4.16",
         "@testing-library/preact": "3.2.4",
-        "knip": "6.13.1",
-        "oxlint": "1.64.0",
+        "knip": "6.14.2",
+        "oxlint": "1.67.0",
         "typescript": "6.0.3",
       },
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.27.1",
+      "version": "0.33.0",
       "bin": {
         "kai": "./main.ts",
       },
       "dependencies": {
         "@neokai/daemon": "workspace:*",
         "@neokai/shared": "workspace:*",
-        "hono": "4.12.18",
-        "vite": "8.0.13",
+        "hono": "4.12.23",
+        "vite": "8.0.14",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "playwright": "1.59.1",
+        "playwright": "1.60.0",
         "v8-to-istanbul": "9.3.0",
       },
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.27.1",
+      "version": "0.33.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.141",
         "@github/copilot-sdk": "0.3.0",
@@ -40,19 +40,19 @@
         "@neokai/shared": "workspace:*",
         "croner": "10.0.1",
         "simple-git": "3.36.0",
-        "zod": "4.3.6",
+        "zod": "4.4.3",
       },
       "devDependencies": {
-        "@types/bun": "1.3.13",
+        "@types/bun": "1.3.14",
       },
     },
     "packages/desktop": {
       "name": "@neokai/desktop",
-      "version": "0.27.1",
+      "version": "0.33.0",
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.27.1",
+      "version": "0.33.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
@@ -68,7 +68,7 @@
     },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.27.1",
+      "version": "0.33.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
@@ -95,19 +95,19 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.27.1",
+      "version": "0.33.0",
       "dependencies": {
-        "@preact/signals": "2.9.0",
+        "@preact/signals": "2.9.1",
         "clsx": "2.1.1",
         "highlight.js": "11.11.1",
-        "marked": "18.0.2",
-        "preact": "10.29.1",
+        "marked": "18.0.4",
+        "preact": "10.29.2",
       },
       "devDependencies": {
         "@preact/preset-vite": "2.10.5",
-        "@tailwindcss/vite": "4.2.4",
+        "@tailwindcss/vite": "4.3.0",
         "@testing-library/preact": "3.2.4",
-        "@types/bun": "1.3.13",
+        "@types/bun": "1.3.14",
         "@vitest/coverage-v8": "4.1.5",
         "@vitest/ui": "4.1.5",
         "happy-dom": "20.9.0",
@@ -185,23 +185,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -405,43 +405,43 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.64.0", "", { "os": "android", "cpu": "arm" }, "sha512-2r6Nq3XXGLHEXKkSj8JtmJ6N4gDw431DPFOg0ZoJHlNjnG6HVMm/ksQ10m0HJ8WBvwgMe1L50UHPaYZutCRPCw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.67.0", "", { "os": "android", "cpu": "arm" }, "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.64.0", "", { "os": "android", "cpu": "arm64" }, "sha512-ePJMpePgg7fBv+L/hVx1xXRU5/5gd5m0obLA6hPEfLXF3GjpR8idIDbY1dhQYhyz1ms2wdTccSboo6KEd2Oxtg=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.67.0", "", { "os": "android", "cpu": "arm64" }, "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.64.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-U4DMLQd10gJLuoSTLSGbfv3bGjTlUNsScm9Dgb8wwBqmCzidf1pE1pXV4doGNxqwH3KtVng1AGTINA0NvkGLvQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.67.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.64.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-GoRIL48QWm4/TAvjN8pB1nAG+1/uqc9EdnWT9zqHeb6wsmjZtywj8VRe5aGW47Fdb64YtLOsdLqVxOvQuz98Wg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.67.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.64.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5dFkv4tkg7PxJJGS9/OjrJwjhuHczrd3OQOkRE0wHcLM+ncUnULtzEPWjqGOxTXxZnLWcB91bGiIznx89TVXyQ=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.67.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.64.0", "", { "os": "linux", "cpu": "arm" }, "sha512-jsBqMLl/uOL5+Kq/+BtK9FrmiNGUbx8SiyZXv+WlUxA45KuwcLu9BfiSIL3I3DBDgWM3yZizDITnTK9BcqNBQg=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.64.0", "", { "os": "linux", "cpu": "arm" }, "sha512-1lrj8At/Uuc9GhjrVFBQo0NEjfBrTkzpmtHIGAhNnIXqn1CAyGL+qrztUsXb2GIluJrpl9Q7qRLJOb/NqydacQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.64.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-HpSQbubwh03mMhAdy2BYtad/fsY8vDFHDAb6bUwuCYg2VD3xCQgn6ArKcO0oZyLCheacKTv4PrF3Mfu5hgoE2g=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.64.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-00QQ0h0Y7u0G69BgiH3+ky2aaq/QvkDL6DYok8htIuJHxybiux5aQ8jwmg8qIk9wha6UagUP2BAwAzbemcJbpg=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.64.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2GaimTV6EMW+s5HS0An3oGbQme3BgHswvfVdGk3EB57Xe9+/gyT+Qd7lNVzb3rtir52vbIPzXfaYArzs5b5zcw=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.67.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.64.0", "", { "os": "linux", "cpu": "none" }, "sha512-H46AtFb9wypjoVwGdlxrm0DsD809NGmtiK9HiyPKTxkSte2YjhC4S+00rOIrwCaxcyPiGid3Y3OMXp5KMAkGZw=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.64.0", "", { "os": "linux", "cpu": "none" }, "sha512-HEgsidjjvvyzdg82icYkuFCf7REDV7B9JFwbIMbVwrKLBY0MrXX+bku3POn/hduZ2yW91IyVDUMq0Bf02KwXQw=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.64.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Axvm8qryotmKN00P5w4JapaSjvP2LOSbdbBJiX+2SuHd3QzhW7TUc8skqgw+ahQZ5DmzEYeHCqauvW8f32Ns6Q=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.67.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.64.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cR60vSd7+m+KRZ3GQGfDxWwahW5RMXg0qlGvAluZr0fTUYvw0H9N9AXAF/M/PMqgytyqvVNmBAkJG9l7U30Y1g=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.64.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2u/aPZ9pEg7HnvZPDsHxUGNnrpr4qaHi+mCgLgpt+LYRzPrS4Px4wPfkIdRdr2GvKnaYyt+XSlto0Vm5sbStTg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.64.0", "", { "os": "none", "cpu": "arm64" }, "sha512-kfhkGfCdoXLSxEkrhDlJrvBYajGmq+ma4EMc53dsOWTq+rIBOlI0vTBmpZNnM5oH2LY/K/w1HAK+UQEgjgpVUg=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.67.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.64.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-r/cNKBFieONoVu2bb1KkVouq9W+edDUgHumXJGphCRRj+U0xaD4nanrw8ZOqo0IsutPkEM4vCcGBpak6x5aXMg=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.67.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.64.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-tUw0xUUwEFVZbpJoeCblkv8SJA4Xz3CdXCJbAnBsiNLyxDrk2tLcxEAS6M73Q7hHHDg3OtwI8vZVK3t5RJt4Gw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.67.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.64.0", "", { "os": "win32", "cpu": "x64" }, "sha512-9CBR+LO0JVST87fNTzzNxS5I29jIUO5gxT9i9+M3SDHHALElj9sY1Prf12tad3vIRC6OD7Ehtvvh+sn13vSwHw=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.67.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ=="],
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
@@ -449,7 +449,7 @@
 
     "@preact/preset-vite": ["@preact/preset-vite@2.10.5", "", { "dependencies": { "@babel/plugin-transform-react-jsx": "^7.27.1", "@babel/plugin-transform-react-jsx-development": "^7.27.1", "@prefresh/vite": "^2.4.11", "@rollup/pluginutils": "^5.0.0", "babel-plugin-transform-hook-names": "^1.0.2", "debug": "^4.4.3", "magic-string": "^0.30.21", "picocolors": "^1.1.1", "vite-prerender-plugin": "^0.5.8", "zimmerframe": "^1.1.4" }, "peerDependencies": { "@babel/core": "7.x", "vite": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x" } }, "sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw=="],
 
-    "@preact/signals": ["@preact/signals@2.9.0", "", { "dependencies": { "@preact/signals-core": "^1.14.0" }, "peerDependencies": { "preact": ">= 10.25.0 || >=11.0.0-0" } }, "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug=="],
+    "@preact/signals": ["@preact/signals@2.9.1", "", { "dependencies": { "@preact/signals-core": "^1.14.0" }, "peerDependencies": { "preact": ">= 10.25.0 || >=11.0.0-0" } }, "sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw=="],
 
     "@preact/signals-core": ["@preact/signals-core@1.14.0", "", {}, "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ=="],
 
@@ -481,35 +481,35 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.2", "", { "os": "android", "cpu": "arm64" }, "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.2", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -873,7 +873,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -953,7 +953,7 @@
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
 
-    "knip": ["knip@6.13.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.130.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ=="],
+    "knip": ["knip@6.14.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.130.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q=="],
 
     "koa": ["koa@3.2.0", "", { "dependencies": { "accepts": "^1.3.8", "content-disposition": "~1.0.1", "content-type": "^1.0.5", "cookies": "~0.9.1", "delegates": "^1.0.0", "destroy": "^1.2.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.5.0", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "mime-types": "^3.0.1", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg=="],
 
@@ -1003,7 +1003,7 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
-    "marked": ["marked@18.0.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg=="],
+    "marked": ["marked@18.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
@@ -1029,7 +1029,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -1067,7 +1067,7 @@
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
-    "oxlint": ["oxlint@1.64.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.64.0", "@oxlint/binding-android-arm64": "1.64.0", "@oxlint/binding-darwin-arm64": "1.64.0", "@oxlint/binding-darwin-x64": "1.64.0", "@oxlint/binding-freebsd-x64": "1.64.0", "@oxlint/binding-linux-arm-gnueabihf": "1.64.0", "@oxlint/binding-linux-arm-musleabihf": "1.64.0", "@oxlint/binding-linux-arm64-gnu": "1.64.0", "@oxlint/binding-linux-arm64-musl": "1.64.0", "@oxlint/binding-linux-ppc64-gnu": "1.64.0", "@oxlint/binding-linux-riscv64-gnu": "1.64.0", "@oxlint/binding-linux-riscv64-musl": "1.64.0", "@oxlint/binding-linux-s390x-gnu": "1.64.0", "@oxlint/binding-linux-x64-gnu": "1.64.0", "@oxlint/binding-linux-x64-musl": "1.64.0", "@oxlint/binding-openharmony-arm64": "1.64.0", "@oxlint/binding-win32-arm64-msvc": "1.64.0", "@oxlint/binding-win32-ia32-msvc": "1.64.0", "@oxlint/binding-win32-x64-msvc": "1.64.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-Star3SNpWPeWFPw7kRXIhXUSn6fdiAl25q15CQzH/9WaOtG6e9CWTc25vNZOCr4PE1yEP1GtKJKIKglhj3OmEQ=="],
+    "oxlint": ["oxlint@1.67.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.67.0", "@oxlint/binding-android-arm64": "1.67.0", "@oxlint/binding-darwin-arm64": "1.67.0", "@oxlint/binding-darwin-x64": "1.67.0", "@oxlint/binding-freebsd-x64": "1.67.0", "@oxlint/binding-linux-arm-gnueabihf": "1.67.0", "@oxlint/binding-linux-arm-musleabihf": "1.67.0", "@oxlint/binding-linux-arm64-gnu": "1.67.0", "@oxlint/binding-linux-arm64-musl": "1.67.0", "@oxlint/binding-linux-ppc64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-musl": "1.67.0", "@oxlint/binding-linux-s390x-gnu": "1.67.0", "@oxlint/binding-linux-x64-gnu": "1.67.0", "@oxlint/binding-linux-x64-musl": "1.67.0", "@oxlint/binding-openharmony-arm64": "1.67.0", "@oxlint/binding-win32-arm64-msvc": "1.67.0", "@oxlint/binding-win32-ia32-msvc": "1.67.0", "@oxlint/binding-win32-x64-msvc": "1.67.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -1085,13 +1085,13 @@
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
-    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
@@ -1117,7 +1117,7 @@
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
-    "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
+    "rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
@@ -1229,7 +1229,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
+    "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 
     "vite-prerender-plugin": ["vite-prerender-plugin@0.5.13", "", { "dependencies": { "kolorist": "^1.8.0", "magic-string": "0.x >= 0.26.0", "node-html-parser": "^6.1.12", "simple-code-frame": "^1.3.0", "source-map": "^0.7.4", "stack-trace": "^1.0.0-pre2" }, "peerDependencies": { "vite": "5.x || 6.x || 7.x || 8.x" } }, "sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g=="],
 
@@ -1261,7 +1261,7 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -1271,9 +1271,11 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@github/copilot-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
-    "@neokai/daemon/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@neokai/messaging/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -1283,11 +1285,15 @@
 
     "@neokai/ui/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
-    "@neokai/web/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@neokai/web/@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
+
+    "@neokai/web/preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "@neokai/web/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@playwright/test/playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
 
     "@prefresh/vite/@rollup/pluginutils": ["@rollup/pluginutils@4.2.1", "", { "dependencies": { "estree-walker": "^2.0.1", "picomatch": "^2.2.2" } }, "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="],
 
@@ -1331,13 +1337,15 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
+
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "send/fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "@neokai/daemon/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "vitest/vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
 
     "@neokai/messaging/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -1347,17 +1355,27 @@
 
     "@neokai/ui/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "@neokai/ui/vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
     "@neokai/ui/vite/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
-    "@neokai/web/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
+
+    "@neokai/web/@tailwindcss/vite/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "@neokai/web/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@neokai/web/vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "@neokai/web/vite/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
+
+    "@playwright/test/playwright/playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "@prefresh/vite/@rollup/pluginutils/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1373,13 +1391,19 @@
 
     "http-assert/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
-    "@neokai/daemon/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "vitest/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
+    "vitest/vite/rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 
     "@neokai/messaging/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@neokai/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@neokai/ui/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@neokai/ui/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@neokai/ui/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
@@ -1415,7 +1439,33 @@
 
     "@neokai/ui/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
-    "@neokai/web/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
+
+    "@neokai/web/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@neokai/web/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
@@ -1453,7 +1503,37 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
-    "@neokai/daemon/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "vitest/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
 
     "@neokai/messaging/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1461,6 +1541,18 @@
 
     "@neokai/ui/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
-    "@neokai/web/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/node/enhanced-resolve/tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@neokai/web/@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
       "version": "0.27.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
-        "preact": "10.29.1",
+        "preact": "10.29.2",
       },
       "devDependencies": {
         "@preact/preset-vite": "2.10.5",
@@ -1093,7 +1093,7 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+    "preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -1286,8 +1286,6 @@
     "@neokai/ui/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
     "@neokai/web/@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
-
-    "@neokai/web/preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "@neokai/web/vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test:proxy:restart": "./scripts/dev-proxy.sh restart"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.15",
+    "@biomejs/biome": "2.4.16",
     "@testing-library/preact": "3.2.4",
-    "knip": "6.13.1",
-    "oxlint": "1.64.0",
+    "knip": "6.14.2",
+    "oxlint": "1.67.0",
     "typescript": "6.0.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "@neokai/daemon": "workspace:*",
     "@neokai/shared": "workspace:*",
-    "hono": "4.12.18",
-    "vite": "8.0.13"
+    "hono": "4.12.23",
+    "vite": "8.0.14"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "playwright": "1.59.1",
+    "playwright": "1.60.0",
     "v8-to-istanbul": "9.3.0"
   }
 }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -31,9 +31,9 @@
     "@neokai/shared": "workspace:*",
     "croner": "10.0.1",
     "simple-git": "3.36.0",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "devDependencies": {
-    "@types/bun": "1.3.13"
+    "@types/bun": "1.3.14"
   }
 }

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -53,6 +53,7 @@ import { requireModelContextWindow } from '../providers/codex-models';
 import {
   getProviderContextManager,
   getProviderRegistry,
+  initializeProviders,
   waitForOptionalProviderRegistration,
 } from '../providers/factory.js';
 import type { SettingsManager } from '../settings-manager';
@@ -320,6 +321,7 @@ export class QueryOptionsBuilder {
     // ['user', 'project', 'local'] so CLAUDE.md and on-disk settings are loaded.
     await this.ctx.settingsManager.prepareSDKOptions();
 
+    initializeProviders();
     await waitForOptionalProviderRegistration();
 
     // Translate model ID for SDK compatibility using provider context

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -50,7 +50,11 @@ import type { McpEnablementRepository } from '../../storage/repositories/mcp-ena
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
 import { getSessionModelInfo } from '../model-service.js';
 import { requireModelContextWindow } from '../providers/codex-models';
-import { getProviderContextManager, getProviderRegistry } from '../providers/factory.js';
+import {
+  getProviderContextManager,
+  getProviderRegistry,
+  waitForOptionalProviderRegistration,
+} from '../providers/factory.js';
 import type { SettingsManager } from '../settings-manager';
 import type { SkillsManager } from '../skills-manager';
 import {
@@ -315,6 +319,8 @@ export class QueryOptionsBuilder {
     // settingSources is configurable per session/space/agent and defaults to
     // ['user', 'project', 'local'] so CLAUDE.md and on-disk settings are loaded.
     await this.ctx.settingsManager.prepareSDKOptions();
+
+    await waitForOptionalProviderRegistration();
 
     // Translate model ID for SDK compatibility using provider context
     // FIX: Recreate context each time to pick up model changes from model switching

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -254,8 +254,11 @@ export class QueryRunner {
 
     try {
       // Verify authentication for the selected provider
-      const { initializeProviders } = await import('../providers/factory.js');
+      const { initializeProviders, waitForOptionalProviderRegistration } = await import(
+        '../providers/factory.js'
+      );
       const providerRegistry = initializeProviders();
+      await waitForOptionalProviderRegistration();
       const modelId = session.config.model || 'sonnet';
       // As of PR #466, all new agent sessions store an explicit provider ID in
       // session.config.provider. The registry.get('anthropic') fallback below is a

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -312,7 +312,9 @@ export async function initializeModels(): Promise<void> {
   }
 
   // Initialize the provider system (registers built-in providers)
+  const { waitForOptionalProviderRegistration } = await import('./providers/factory.js');
   initializeProviders();
+  await waitForOptionalProviderRegistration();
 
   try {
     const models = await loadModelsFromProviders();

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -241,6 +241,8 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
  * Load models from all available providers
  */
 async function loadModelsFromProviders(): Promise<ModelInfo[]> {
+  initializeProviders();
+  await waitForOptionalProviderRegistration();
   const providers = getAvailableProviders();
   const allModels: ModelInfo[] = [];
 

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -12,7 +12,7 @@
 
 import type { ModelInfo, Session } from '@neokai/shared';
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
-import { initializeProviders } from './providers/factory.js';
+import { initializeProviders, waitForOptionalProviderRegistration } from './providers/factory.js';
 import { getProviderRegistry } from './providers/registry.js';
 import type { Provider } from '@neokai/shared/provider';
 import { getCodexBridgeModelInfos, resolveCodexBridgeModelId } from './providers/codex-models.js';
@@ -312,7 +312,6 @@ export async function initializeModels(): Promise<void> {
   }
 
   // Initialize the provider system (registers built-in providers)
-  const { waitForOptionalProviderRegistration } = await import('./providers/factory.js');
   initializeProviders();
   await waitForOptionalProviderRegistration();
 

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -240,9 +240,18 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
 /**
  * Load models from all available providers
  */
+function shouldWaitForOptionalProviders(registry = getProviderRegistry()): boolean {
+  return process.env.NODE_ENV !== 'test' || registry.has('anthropic-copilot');
+}
+
 async function loadModelsFromProviders(): Promise<ModelInfo[]> {
-  initializeProviders();
-  await waitForOptionalProviderRegistration();
+  const registry = getProviderRegistry();
+  if (registry.size === 0) {
+    initializeProviders();
+    await waitForOptionalProviderRegistration();
+  } else if (shouldWaitForOptionalProviders(registry)) {
+    await waitForOptionalProviderRegistration(registry);
+  }
   const providers = getAvailableProviders();
   const allModels: ModelInfo[] = [];
 

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -139,8 +139,8 @@ export class ProviderService {
   }
 
   private async getReadyRegistry() {
-    const registry = initializeProviders();
-    await waitForOptionalProviderRegistration();
+    const registry = this.getRegistry();
+    await waitForOptionalProviderRegistration(registry);
     return registry;
   }
 

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -396,7 +396,8 @@ export class ProviderService {
    * @param modelId - The model ID (used for SDK config building)
    * @param providerId - The provider ID — must be explicit; routing is deterministic
    */
-  getEnvVarsForModel(modelId: string, providerId: string): ProviderEnvVars {
+  async getEnvVarsForModel(modelId: string, providerId: string): Promise<ProviderEnvVars> {
+    await this.getReadyRegistry();
     const registry = this.getRegistry();
     const provider = registry.detectProviderForModel(modelId, providerId);
 
@@ -489,8 +490,8 @@ export class ProviderService {
    * @param providerId - The provider ID — must be explicit; routing is deterministic
    * @returns Original env vars that should be restored after SDK query
    */
-  applyEnvVarsToProcess(modelId: string, providerId: string): OriginalEnvVars {
-    const envVars = this.getEnvVarsForModel(modelId, providerId);
+  async applyEnvVarsToProcess(modelId: string, providerId: string): Promise<OriginalEnvVars> {
+    const envVars = await this.getEnvVarsForModel(modelId, providerId);
 
     // For Anthropic (or any non-overriding provider), explicitly clear routing
     // overrides that may have leaked from a previous GLM query.
@@ -511,7 +512,11 @@ export class ProviderService {
    * @param modelId - The model ID for setting tier mappings
    * @returns Original env vars that should be restored after SDK query
    */
-  applyEnvVarsToProcessForProvider(providerId: string, modelId?: string): OriginalEnvVars {
+  async applyEnvVarsToProcessForProvider(
+    providerId: string,
+    modelId?: string
+  ): Promise<OriginalEnvVars> {
+    await this.getReadyRegistry();
     const registry = this.getRegistry();
     const provider = registry.get(providerId);
 

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -47,7 +47,7 @@
 
 import type { Provider, ProviderInfo, Session } from '@neokai/shared';
 import type { ProviderSdkConfig, ProviderInfo as NewProviderInfo } from '@neokai/shared/provider';
-import { initializeProviders } from './providers/factory.js';
+import { initializeProviders, waitForOptionalProviderRegistration } from './providers/factory.js';
 import { Logger } from './logger.js';
 
 /**
@@ -138,13 +138,19 @@ export class ProviderService {
     return initializeProviders();
   }
 
+  private async getReadyRegistry() {
+    const registry = initializeProviders();
+    await waitForOptionalProviderRegistration();
+    return registry;
+  }
+
   /**
    * Get the default provider based on environment configuration
    *
    * Delegates to registry.getDefaultProvider()
    */
   async getDefaultProvider(): Promise<Provider> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = await registry.getDefaultProvider();
     return provider.id as Provider;
   }
@@ -199,7 +205,7 @@ export class ProviderService {
    * Delegates to provider.isAvailable()
    */
   async isProviderAvailable(providerId: string): Promise<boolean> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
 
     if (!provider) {
@@ -215,7 +221,7 @@ export class ProviderService {
    * Delegates to registry.getProviderInfo()
    */
   async getProviderInfo(providerId: Provider): Promise<ProviderInfo> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
 
     if (!provider) {
@@ -260,7 +266,7 @@ export class ProviderService {
    * Delegates to registry.getProviderInfo()
    */
   async getAvailableProviders(): Promise<ProviderInfo[]> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const newProviderInfos = await registry.getProviderInfo();
     return newProviderInfos.map(toLegacyProviderInfo);
   }
@@ -274,7 +280,7 @@ export class ProviderService {
     providerId: Provider,
     apiKey?: string
   ): Promise<{ valid: boolean; error?: string }> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     return await registry.validateProviderSwitch(providerId, apiKey);
   }
 
@@ -282,7 +288,7 @@ export class ProviderService {
    * Get the default model for a provider
    */
   async getDefaultModelForProvider(providerId: Provider): Promise<string> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
 
     if (!provider) {
@@ -302,7 +308,7 @@ export class ProviderService {
     providerId: string,
     sessionModelId: string
   ): Promise<{ providerModelId: string; sdkModelId: string }> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
     const providerModelId = provider?.getTitleGenerationModel?.() ?? sessionModelId;
     return {
@@ -325,7 +331,7 @@ export class ProviderService {
     baseUrl: string;
     apiVersion: string;
   }> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
 
     if (!provider) {
@@ -371,7 +377,7 @@ export class ProviderService {
    * Check if a model is valid for a provider
    */
   async isModelValidForProvider(providerId: Provider, model: string): Promise<boolean> {
-    const registry = this.getRegistry();
+    const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
 
     if (!provider) {

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -188,26 +188,30 @@ function canonicalise(value: unknown): unknown {
 }
 
 function registerCopilotProvider(registry: ProviderRegistry): void {
-  copilotProviderRegistration ??= import('./anthropic-copilot/index.js')
-    .then((providerModule) => {
-      // This dynamic import must remain a literal string: bun build --compile
-      // discovers and embeds @github/copilot-sdk and vscode-jsonrpc through it.
-      if (!registry.has('anthropic-copilot')) {
-        registry.register(new providerModule.AnthropicToCopilotBridgeProvider(process.cwd()));
-      }
-    })
-    .catch((err) => {
-      logger.warn(`Skipping Anthropic Copilot provider registration: ${err}`);
-    });
+  copilotProviderModule ??= import('./anthropic-copilot/index.js').catch((err) => {
+    logger.warn(`Skipping Anthropic Copilot provider registration: ${err}`);
+    return null;
+  });
+  void registerLoadedCopilotProvider(registry);
 }
 
 export async function waitForOptionalProviderRegistration(): Promise<void> {
-  if (copilotProviderRegistration) {
-    await copilotProviderRegistration;
+  await registerLoadedCopilotProvider(getProviderRegistry());
+}
+
+async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promise<void> {
+  if (registry.has('anthropic-copilot')) return;
+
+  // This dynamic import must remain a literal string: bun build --compile
+  // discovers and embeds @github/copilot-sdk and vscode-jsonrpc through it.
+  const providerModule = await copilotProviderModule;
+  if (providerModule && !registry.has('anthropic-copilot')) {
+    registry.register(new providerModule.AnthropicToCopilotBridgeProvider(process.cwd()));
   }
 }
 
-let copilotProviderRegistration: Promise<void> | null = null;
+let copilotProviderModule: Promise<typeof import('./anthropic-copilot/index.js') | null> | null =
+  null;
 
 /** Tracks the last fingerprint we synced per provider so we can skip no-op rebuilds. */
 const lastSyncedConfigByProviderId = new Map<string, string>();
@@ -221,6 +225,9 @@ const lastSyncedConfigByProviderId = new Map<string, string>();
  */
 export function getProviderContextManager(): ProviderContextManager {
   const registry = initializeProviders();
+  if (!registry.has('anthropic-copilot')) {
+    logger.warn('Anthropic Copilot provider registration is still pending.');
+  }
   return new ProviderContextManager(registry);
 }
 
@@ -234,7 +241,7 @@ export function getProviderContextManager(): ProviderContextManager {
  */
 export function resetProviderFactory(): void {
   initialized = false;
-  copilotProviderRegistration = null;
+  copilotProviderModule = null;
   lastSyncedConfigByProviderId.clear();
 }
 

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -203,8 +203,10 @@ function registerCopilotProvider(registry: ProviderRegistry): void {
   void registerLoadedCopilotProvider(registry);
 }
 
-export async function waitForOptionalProviderRegistration(): Promise<void> {
-  await registerLoadedCopilotProvider(initializeProviders());
+export async function waitForOptionalProviderRegistration(
+  registry?: ProviderRegistry
+): Promise<void> {
+  await registerLoadedCopilotProvider(registry ?? initializeProviders());
 }
 
 async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promise<void> {

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -14,7 +14,6 @@ import { MinimaxProvider } from './minimax-provider.js';
 import { OpenRouterProvider } from './openrouter-provider.js';
 import { OllamaProvider } from './ollama-provider.js';
 import { AnthropicToCodexBridgeProvider } from './anthropic-to-codex-bridge-provider.js';
-import { AnthropicToCopilotBridgeProvider } from './anthropic-copilot/index.js';
 import {
   CustomEndpointProvider,
   customProviderIdFor,
@@ -83,7 +82,9 @@ export function initializeProviders(): ProviderRegistry {
   // Register Anthropic Copilot provider (embedded Anthropic-compatible server).
   // process.cwd() is the fallback cwd; per-session workspace is threaded via
   // ANTHROPIC_AUTH_TOKEN (encoded by buildSdkConfig) and parsed per-request in server.ts.
-  registry.register(new AnthropicToCopilotBridgeProvider(process.cwd()));
+  // Lazy registration keeps @github/copilot-sdk out of the startup import graph so
+  // bun build --compile can tree-shake and bundle the SDK without crashing startup.
+  registerCopilotProvider(registry);
 
   // Additional built-in providers can be registered here
   // Example:
@@ -186,6 +187,28 @@ function canonicalise(value: unknown): unknown {
   return out;
 }
 
+function registerCopilotProvider(registry: ProviderRegistry): void {
+  copilotProviderRegistration ??= import('./anthropic-copilot/index.js')
+    .then((providerModule) => {
+      // This dynamic import must remain a literal string: bun build --compile
+      // discovers and embeds @github/copilot-sdk and vscode-jsonrpc through it.
+      if (!registry.has('anthropic-copilot')) {
+        registry.register(new providerModule.AnthropicToCopilotBridgeProvider(process.cwd()));
+      }
+    })
+    .catch((err) => {
+      logger.warn(`Skipping Anthropic Copilot provider registration: ${err}`);
+    });
+}
+
+export async function waitForOptionalProviderRegistration(): Promise<void> {
+  if (copilotProviderRegistration) {
+    await copilotProviderRegistration;
+  }
+}
+
+let copilotProviderRegistration: Promise<void> | null = null;
+
 /** Tracks the last fingerprint we synced per provider so we can skip no-op rebuilds. */
 const lastSyncedConfigByProviderId = new Map<string, string>();
 
@@ -211,6 +234,7 @@ export function getProviderContextManager(): ProviderContextManager {
  */
 export function resetProviderFactory(): void {
   initialized = false;
+  copilotProviderRegistration = null;
   lastSyncedConfigByProviderId.clear();
 }
 

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -20,6 +20,7 @@ import {
   isCustomEndpointProviderId,
 } from './custom-endpoint-provider.js';
 import type { CustomEndpointConfig } from '@neokai/shared';
+import type { Provider } from '@neokai/shared/provider';
 import { getProviderRegistry, type ProviderRegistry } from './registry.js';
 export { getProviderRegistry };
 import { ProviderContextManager } from './context-manager.js';
@@ -41,43 +42,40 @@ let initialized = false;
  * @returns The global provider registry
  */
 export function initializeProviders(): ProviderRegistry {
-  // If already initialized, return the existing registry
-  // This handles the case where getProviderRegistry() was called but no providers were registered
-  if (initialized) {
-    const registry = getProviderRegistry();
-    // Check if registry has any providers - if not, we need to reinitialize
-    if (registry.size > 0) {
-      return registry;
-    }
-    // Registry was reset but initialized flag wasn't - need to reinitialize
-  }
-
   const registry = getProviderRegistry();
 
+  // If already initialized and the core providers are still present, return the
+  // existing registry. This handles the case where getProviderRegistry() was
+  // called but no providers were registered, and the case where the registry was
+  // reset without resetting the factory.
+  if (initialized && hasCoreProviders(registry)) {
+    return registry;
+  }
+
   // Register Anthropic provider (always available)
-  registry.register(new AnthropicProvider());
+  registerIfMissing(registry, new AnthropicProvider());
 
   // Register GLM provider (will be available if API key is set)
-  registry.register(new GlmProvider());
+  registerIfMissing(registry, new GlmProvider());
 
   // Register Kimi provider (will be available if KIMI_API_KEY or MOONSHOT_API_KEY is set)
-  registry.register(new KimiProvider());
+  registerIfMissing(registry, new KimiProvider());
 
   // Register MiniMax provider (will be available if MINIMAX_API_KEY is set)
-  registry.register(new MinimaxProvider());
+  registerIfMissing(registry, new MinimaxProvider());
 
   // Register OpenRouter provider (will be available if OPENROUTER_API_KEY is set)
-  registry.register(new OpenRouterProvider());
+  registerIfMissing(registry, new OpenRouterProvider());
 
   // Register Ollama providers. Local Ollama is available by default at localhost:11434;
   // Ollama Cloud requires OLLAMA_CLOUD_API_KEY.
-  registry.register(new OllamaProvider({ kind: 'local' }));
-  registry.register(new OllamaProvider({ kind: 'cloud' }));
+  registerIfMissing(registry, new OllamaProvider({ kind: 'local' }));
+  registerIfMissing(registry, new OllamaProvider({ kind: 'cloud' }));
 
   // Register Anthropic-to-Codex bridge provider for OpenAI/Codex-backed models.
   // Discovers credentials from env (OPENAI_API_KEY), ~/.neokai/auth.json,
   // and one-time import from ~/.codex/auth.json.
-  registry.register(new AnthropicToCodexBridgeProvider());
+  registerIfMissing(registry, new AnthropicToCodexBridgeProvider());
 
   // Register Anthropic Copilot provider (embedded Anthropic-compatible server).
   // process.cwd() is the fallback cwd; per-session workspace is threaded via
@@ -88,7 +86,7 @@ export function initializeProviders(): ProviderRegistry {
 
   // Additional built-in providers can be registered here
   // Example:
-  // registry.register(new DeepSeekProvider());
+  // registerIfMissing(registry, new DeepSeekProvider());
 
   initialized = true;
 
@@ -155,7 +153,7 @@ export async function syncCustomEndpointProviders(
       registry.unregister(providerId);
     }
     try {
-      registry.register(new CustomEndpointProvider(config));
+      registerIfMissing(registry, new CustomEndpointProvider(config));
       lastSyncedConfigByProviderId.set(providerId, fingerprint);
     } catch (err) {
       logger.warn(`Skipping invalid custom endpoint '${config.id}': ${err}`);
@@ -187,6 +185,16 @@ function canonicalise(value: unknown): unknown {
   return out;
 }
 
+function hasCoreProviders(registry: ProviderRegistry): boolean {
+  return CORE_PROVIDER_IDS.every((id) => registry.has(id));
+}
+
+function registerIfMissing(registry: ProviderRegistry, provider: Provider): void {
+  if (!registry.has(provider.id)) {
+    registry.register(provider);
+  }
+}
+
 function registerCopilotProvider(registry: ProviderRegistry): void {
   copilotProviderModule ??= import('./anthropic-copilot/index.js').catch((err) => {
     logger.warn(`Skipping Anthropic Copilot provider registration: ${err}`);
@@ -196,7 +204,7 @@ function registerCopilotProvider(registry: ProviderRegistry): void {
 }
 
 export async function waitForOptionalProviderRegistration(): Promise<void> {
-  await registerLoadedCopilotProvider(getProviderRegistry());
+  await registerLoadedCopilotProvider(initializeProviders());
 }
 
 async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promise<void> {
@@ -206,12 +214,23 @@ async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promis
   // discovers and embeds @github/copilot-sdk and vscode-jsonrpc through it.
   const providerModule = await copilotProviderModule;
   if (providerModule && !registry.has('anthropic-copilot')) {
-    registry.register(new providerModule.AnthropicToCopilotBridgeProvider(process.cwd()));
+    registerIfMissing(registry, new providerModule.AnthropicToCopilotBridgeProvider(process.cwd()));
   }
 }
 
 let copilotProviderModule: Promise<typeof import('./anthropic-copilot/index.js') | null> | null =
   null;
+
+const CORE_PROVIDER_IDS = [
+  'anthropic',
+  'glm',
+  'kimi',
+  'minimax',
+  'openrouter',
+  'ollama',
+  'ollama-cloud',
+  'anthropic-codex',
+];
 
 /** Tracks the last fingerprint we synced per provider so we can skip no-op rebuilds. */
 const lastSyncedConfigByProviderId = new Map<string, string>();

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -20,8 +20,15 @@ import type {
 import type { AuthManager } from '../auth-manager';
 import { getProviderRegistry } from '../providers/registry';
 import { Logger } from '../logger';
+import { initializeProviders, waitForOptionalProviderRegistration } from '../providers/factory';
 
 const log = new Logger('auth-handlers');
+
+async function getReadyProviderRegistry() {
+  initializeProviders();
+  await waitForOptionalProviderRegistration();
+  return getProviderRegistry();
+}
 
 /**
  * Setup authentication-related RPC handlers
@@ -35,7 +42,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 
   // List all providers with their auth status
   messageHub.onRequest('auth.providers', async (): Promise<ListProviderAuthStatusResponse> => {
-    const registry = getProviderRegistry();
+    const registry = await getReadyProviderRegistry();
     const providers = registry.getAll();
 
     const providerStatuses: ProviderAuthStatus[] = await Promise.all(
@@ -91,7 +98,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
     'auth.login',
     async (req: ProviderAuthRequest): Promise<ProviderAuthResponse> => {
       const { providerId } = req;
-      const registry = getProviderRegistry();
+      const registry = await getReadyProviderRegistry();
 
       const provider = registry.get(providerId);
       if (!provider) {
@@ -133,7 +140,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
     'auth.logout',
     async (req: ProviderLogoutRequest): Promise<{ success: boolean; error?: string }> => {
       const { providerId } = req;
-      const registry = getProviderRegistry();
+      const registry = await getReadyProviderRegistry();
 
       const provider = registry.get(providerId);
       if (!provider) {
@@ -168,7 +175,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
     'auth.refresh',
     async (req: ProviderRefreshRequest): Promise<ProviderRefreshResponse> => {
       const { providerId } = req;
-      const registry = getProviderRegistry();
+      const registry = await getReadyProviderRegistry();
 
       const provider = registry.get(providerId);
       if (!provider) {

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -1112,7 +1112,7 @@ export class SessionLifecycle {
     // Apply provider-specific environment variables to process.env.
     // Use provider-facing title model so SDK tier/default routing points at the
     // provider's title override, not the session model.
-    const originalEnv = providerService.applyEnvVarsToProcessForProvider(
+    const originalEnv = await providerService.applyEnvVarsToProcessForProvider(
       provider,
       titleModels.providerModelId
     );
@@ -1134,7 +1134,7 @@ ${messageText.slice(0, 2000)}`;
       // Pass the provider ID so that providers whose model IDs overlap with
       // Anthropic (e.g. anthropic-copilot using claude-opus-4.6) are looked up
       // by ID rather than auto-detected, which would return the wrong provider.
-      const providerEnvVars = providerService.getEnvVarsForModel(
+      const providerEnvVars = await providerService.getEnvVarsForModel(
         titleModels.providerModelId,
         provider
       );

--- a/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
+++ b/packages/daemon/src/lib/space/evolution-conversation-analysis-service.ts
@@ -275,7 +275,7 @@ async function analyzeConversationWithModel(
 ): Promise<ConversationFrictionAnalysis> {
   const providerService = getProviderService();
   const { provider, modelId } = await resolveConversationFrictionModel(input, spaceRepo);
-  const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+  const originalEnv = await providerService.applyEnvVarsToProcessForProvider(provider, modelId);
   try {
     const { query } = await import('@anthropic-ai/claude-agent-sdk');
     const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
@@ -292,7 +292,7 @@ async function analyzeConversationWithModel(
         pathToClaudeCodeExecutable: resolveSDKCliPath(),
         executable: isRunningUnderBun() ? 'bun' : undefined,
         env: mergeProviderEnvVars(
-          providerService.getEnvVarsForModel(modelId, provider) as Record<
+          (await providerService.getEnvVarsForModel(modelId, provider)) as Record<
             string,
             string | undefined
           >

--- a/packages/daemon/src/lib/space/evolution-episode-service.ts
+++ b/packages/daemon/src/lib/space/evolution-episode-service.ts
@@ -630,7 +630,7 @@ async function judgeEpisodeWithModel(
   const providerService = getProviderService();
   const { provider, modelId } = await resolveEpisodeJudgeModel(input, spaceRepo);
   const prompt = buildEpisodeJudgePrompt(input);
-  const originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+  const originalEnv = await providerService.applyEnvVarsToProcessForProvider(provider, modelId);
   try {
     const { query } = await import('@anthropic-ai/claude-agent-sdk');
     const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
@@ -647,7 +647,7 @@ async function judgeEpisodeWithModel(
         pathToClaudeCodeExecutable: resolveSDKCliPath(),
         executable: isRunningUnderBun() ? 'bun' : undefined,
         env: mergeProviderEnvVars(
-          providerService.getEnvVarsForModel(modelId, provider) as Record<
+          (await providerService.getEnvVarsForModel(modelId, provider)) as Record<
             string,
             string | undefined
           >

--- a/packages/daemon/src/lib/space/runtime/llm-workflow-selector.ts
+++ b/packages/daemon/src/lib/space/runtime/llm-workflow-selector.ts
@@ -79,9 +79,9 @@ export async function selectWorkflowWithLlmDefault(
 
   const prompt = buildSelectionPrompt(task, workflows);
 
-  let originalEnv: ReturnType<typeof providerService.applyEnvVarsToProcessForProvider>;
+  let originalEnv: Awaited<ReturnType<typeof providerService.applyEnvVarsToProcessForProvider>>;
   try {
-    originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+    originalEnv = await providerService.applyEnvVarsToProcessForProvider(provider, modelId);
   } catch (err) {
     log.warn('Failed to apply provider env vars for workflow selection:', err);
     return null;
@@ -89,7 +89,7 @@ export async function selectWorkflowWithLlmDefault(
 
   try {
     const { query } = await import('@anthropic-ai/claude-agent-sdk');
-    const providerEnvVars = providerService.getEnvVarsForModel(modelId, provider);
+    const providerEnvVars = await providerService.getEnvVarsForModel(modelId, provider);
     const mergedEnv = mergeProviderEnvVars(providerEnvVars as Record<string, string | undefined>);
     const cliPath = resolveSDKCliPath();
 

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1075,7 +1075,16 @@ describe('Model Service', () => {
       clearModelsCache();
       expect(getAvailableModels('global')).toEqual([]);
 
-      // With no registered providers available, refreshModels should restore fallbacks
+      const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
+      type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'empty-provider',
+        getModels: async () => [],
+        isAvailable: async () => true,
+      } as ProviderLike);
+
+      // With no providers returning models, refreshModels should restore fallbacks.
       const { refreshModels } = await import('../../../../src/lib/model-service');
       await refreshModels();
 
@@ -1087,6 +1096,15 @@ describe('Model Service', () => {
     });
 
     it('should preserve existing cache when refresh returns no models', async () => {
+      const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
+      type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'empty-provider',
+        getModels: async () => [],
+        isAvailable: async () => true,
+      } as ProviderLike);
+
       // Seed cache with mock models
       const testCache = new Map<string, ModelInfo[]>();
       testCache.set('global', mockModels);

--- a/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
@@ -342,57 +342,57 @@ describe('ProviderService', () => {
   });
 
   describe('getProviderApiKey', () => {
-    it('should return ANTHROPIC_API_KEY for anthropic provider', () => {
+    it('should return ANTHROPIC_API_KEY for anthropic provider', async () => {
       process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
       const key = service.getProviderApiKey('anthropic');
       expect(key).toBe('test-anthropic-key');
     });
 
-    it('should return CLAUDE_CODE_OAUTH_TOKEN for anthropic if no API key', () => {
+    it('should return CLAUDE_CODE_OAUTH_TOKEN for anthropic if no API key', async () => {
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
       const key = service.getProviderApiKey('anthropic');
       expect(key).toBe('test-oauth-token');
     });
 
-    it('should return GLM_API_KEY for glm provider', () => {
+    it('should return GLM_API_KEY for glm provider', async () => {
       process.env.GLM_API_KEY = 'test-glm-key';
       const key = service.getProviderApiKey('glm');
       expect(key).toBe('test-glm-key');
     });
 
-    it('should return ZHIPU_API_KEY for glm if no GLM_API_KEY', () => {
+    it('should return ZHIPU_API_KEY for glm if no GLM_API_KEY', async () => {
       process.env.ZHIPU_API_KEY = 'test-zhipu-key';
       const key = service.getProviderApiKey('glm');
       expect(key).toBe('test-zhipu-key');
     });
 
-    it('should return OPENROUTER_API_KEY for openrouter provider', () => {
+    it('should return OPENROUTER_API_KEY for openrouter provider', async () => {
       registry.register(new MockProvider('openrouter', 'OpenRouter', true, 'openrouter/'));
       process.env.OPENROUTER_API_KEY = 'sk-or-test';
       const key = service.getProviderApiKey('openrouter');
       expect(key).toBe('sk-or-test');
     });
 
-    it('should return KIMI_API_KEY for kimi provider', () => {
+    it('should return KIMI_API_KEY for kimi provider', async () => {
       registry.register(new MockProvider('kimi', 'Kimi', true, 'moonshot-'));
       process.env.KIMI_API_KEY = 'kimi-key';
       const key = service.getProviderApiKey('kimi');
       expect(key).toBe('kimi-key');
     });
 
-    it('should return MOONSHOT_API_KEY for kimi if no KIMI_API_KEY', () => {
+    it('should return MOONSHOT_API_KEY for kimi if no KIMI_API_KEY', async () => {
       registry.register(new MockProvider('kimi', 'Kimi', true, 'moonshot-'));
       process.env.MOONSHOT_API_KEY = 'moonshot-key';
       const key = service.getProviderApiKey('kimi');
       expect(key).toBe('moonshot-key');
     });
 
-    it('should return undefined for unknown provider', () => {
+    it('should return undefined for unknown provider', async () => {
       const key = service.getProviderApiKey('unknown' as unknown as ProviderId);
       expect(key).toBeUndefined();
     });
 
-    it('should return undefined for unregistered provider', () => {
+    it('should return undefined for unregistered provider', async () => {
       registry.clear();
       const key = service.getProviderApiKey('anthropic');
       expect(key).toBeUndefined();
@@ -582,47 +582,50 @@ describe('ProviderService', () => {
   });
 
   describe('getEnvVarsForModel', () => {
-    it('should return empty object for anthropic model', () => {
-      const envVars = service.getEnvVarsForModel('claude-3-opus', 'anthropic');
+    it('should return empty object for anthropic model', async () => {
+      const envVars = await service.getEnvVarsForModel('claude-3-opus', 'anthropic');
       expect(envVars).toEqual({});
     });
 
-    it('should return env vars for GLM model', () => {
-      const envVars = service.getEnvVarsForModel('glm-4', 'glm');
+    it('should return env vars for GLM model', async () => {
+      const envVars = await service.getEnvVarsForModel('glm-4', 'glm');
 
       expect(envVars.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
       expect(envVars.API_TIMEOUT_MS).toBe('120000');
     });
 
-    it('should return empty object for unknown provider', () => {
-      const envVars = service.getEnvVarsForModel('unknown-model', 'anthropic');
+    it('should return empty object for unknown provider', async () => {
+      const envVars = await service.getEnvVarsForModel('unknown-model', 'anthropic');
       expect(envVars).toEqual({});
     });
 
-    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', () => {
+    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', async () => {
       registry.register(new ThrowingMockProvider());
 
       // Must not throw
-      const envVars = service.getEnvVarsForModel('throwing-model', 'throwing');
+      const envVars = await service.getEnvVarsForModel('throwing-model', 'throwing');
       expect(envVars).toEqual({});
     });
 
-    it('uses explicit providerId to route to the correct provider for colliding model IDs', () => {
+    it('uses explicit providerId to route to the correct provider for colliding model IDs', async () => {
       // Both AnthropicMockProvider and CopilotMockProvider claim 'claude-opus-4.6'.
       // The provider ID selects deterministically: 'anthropic' → {} (no extra env vars),
       // 'anthropic-copilot' → has ANTHROPIC_BASE_URL.
       registry.register(new CopilotMockProvider());
 
-      const envVarsAnthropic = service.getEnvVarsForModel('claude-opus-4.6', 'anthropic');
+      const envVarsAnthropic = await service.getEnvVarsForModel('claude-opus-4.6', 'anthropic');
       expect(envVarsAnthropic.ANTHROPIC_BASE_URL).toBeUndefined();
 
-      const envVarsWithId = service.getEnvVarsForModel('claude-opus-4.6', 'anthropic-copilot');
+      const envVarsWithId = await service.getEnvVarsForModel(
+        'claude-opus-4.6',
+        'anthropic-copilot'
+      );
       expect(envVarsWithId.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:54321');
     });
   });
 
   describe('getProviderEnvVars', () => {
-    it('should return empty object for anthropic session', () => {
+    it('should return empty object for anthropic session', async () => {
       const session: Session = {
         id: 'test-session',
         title: 'Test',
@@ -650,7 +653,7 @@ describe('ProviderService', () => {
       expect(envVars).toEqual({});
     });
 
-    it('should return env vars for GLM session', () => {
+    it('should return env vars for GLM session', async () => {
       const session: Session = {
         id: 'test-session',
         title: 'Test',
@@ -678,7 +681,7 @@ describe('ProviderService', () => {
       expect(envVars.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
     });
 
-    it('should use session config API key override', () => {
+    it('should use session config API key override', async () => {
       const session: Session = {
         id: 'test-session',
         title: 'Test',
@@ -709,7 +712,7 @@ describe('ProviderService', () => {
       expect(envVars.ANTHROPIC_AUTH_TOKEN).toBe('custom-api-key');
     });
 
-    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', () => {
+    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', async () => {
       registry.register(new ThrowingMockProvider());
 
       const session: Session = {
@@ -740,7 +743,7 @@ describe('ProviderService', () => {
       expect(envVars).toEqual({});
     });
 
-    it('passes session id and effective worktree path to session-aware providers', () => {
+    it('passes session id and effective worktree path to session-aware providers', async () => {
       const provider = new SessionAwareBridgeMockProvider();
       registry.register(provider);
       const session: Session = {
@@ -782,18 +785,18 @@ describe('ProviderService', () => {
   });
 
   describe('applyEnvVarsToProcess', () => {
-    it('should return empty object for anthropic model', () => {
-      const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
+    it('should return empty object for anthropic model', async () => {
+      const original = await service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
       expect(original).toEqual({});
     });
 
-    it('should clear leaked GLM routing vars for anthropic model without clearing OAuth auth', () => {
+    it('should clear leaked GLM routing vars for anthropic model without clearing OAuth auth', async () => {
       process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
       process.env.API_TIMEOUT_MS = '120000';
       process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'glm-4';
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'user-oauth-token';
 
-      const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
+      const original = await service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
       expect(original.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
       expect(original.API_TIMEOUT_MS).toBe('120000');
@@ -804,11 +807,11 @@ describe('ProviderService', () => {
       expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('user-oauth-token');
     });
 
-    it('should apply GLM env vars and return original values', () => {
+    it('should apply GLM env vars and return original values', async () => {
       process.env.ANTHROPIC_AUTH_TOKEN = 'original-token';
       process.env.ANTHROPIC_BASE_URL = 'original-url';
 
-      const original = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const original = await service.applyEnvVarsToProcess('glm-4', 'glm');
 
       // Check original values were saved
       expect(original.ANTHROPIC_AUTH_TOKEN).toBe('original-token');
@@ -818,7 +821,7 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
     });
 
-    it('applies session-scoped bridge env vars from the full session', () => {
+    it('applies session-scoped bridge env vars from the full session', async () => {
       const provider = new SessionAwareBridgeMockProvider();
       registry.register(provider);
       const session: Session = {
@@ -856,11 +859,11 @@ describe('ProviderService', () => {
       service.restoreEnvVars(original);
     });
 
-    it('clears CLAUDE_CODE_OAUTH_TOKEN when provider returns empty-string sentinel, restores on restoreEnvVars', () => {
+    it('clears CLAUDE_CODE_OAUTH_TOKEN when provider returns empty-string sentinel, restores on restoreEnvVars', async () => {
       registry.register(new BridgeMockProvider());
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'real-oauth-token';
 
-      const original = service.applyEnvVarsToProcess('bridge-model', 'bridge');
+      const original = await service.applyEnvVarsToProcess('bridge-model', 'bridge');
 
       expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
       expect(original.CLAUDE_CODE_OAUTH_TOKEN).toBe('real-oauth-token');
@@ -870,13 +873,13 @@ describe('ProviderService', () => {
       expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('real-oauth-token');
     });
 
-    it('blanks ANTHROPIC_API_KEY when provider returns empty-string sentinel, restores on restoreEnvVars', () => {
+    it('blanks ANTHROPIC_API_KEY when provider returns empty-string sentinel, restores on restoreEnvVars', async () => {
       // Mirrors what AnthropicToCopilotBridgeProvider does: returning ANTHROPIC_API_KEY: ''
       // prevents the SDK subprocess from calling api.anthropic.com with the real key.
       registry.register(new CopilotMockProvider());
       process.env.ANTHROPIC_API_KEY = 'real-key';
 
-      const original = service.applyEnvVarsToProcess('claude-opus-4.6', 'anthropic-copilot');
+      const original = await service.applyEnvVarsToProcess('claude-opus-4.6', 'anthropic-copilot');
 
       // Key must be explicitly blank so SDK subprocess cannot call Anthropic directly.
       expect(process.env.ANTHROPIC_API_KEY).toBe('');
@@ -888,29 +891,32 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_API_KEY).toBe('real-key');
     });
 
-    it('should clear provider-leaked GLM base URL after GLM query', () => {
+    it('should clear provider-leaked GLM base URL after GLM query', async () => {
       // First simulate GLM was used (leaving its base URL)
       process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
 
       // Apply GLM env vars
-      const originalFromGlm = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const originalFromGlm = await service.applyEnvVarsToProcess('glm-4', 'glm');
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
 
       // Restore from GLM query
       service.restoreEnvVars(originalFromGlm);
 
       // Switch to anthropic - leaked GLM URL should be cleared
-      const originalFromAnthropic = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
+      const originalFromAnthropic = await service.applyEnvVarsToProcess(
+        'claude-3-opus',
+        'anthropic'
+      );
 
       // The leaked GLM URL should be cleared
       expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
     });
 
-    it('clears PORT from process.env for Anthropic model and restores it afterward', () => {
+    it('clears PORT from process.env for Anthropic model and restores it afterward', async () => {
       // Security invariant: the daemon's PORT must not be visible to SDK subprocesses
       process.env.PORT = '9283';
 
-      const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
+      const original = await service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
       expect(process.env.PORT).toBeUndefined(); // cleared — subprocess cannot lsof this port
       expect(original.PORT).toBe('9283'); // saved for restoration
@@ -919,10 +925,10 @@ describe('ProviderService', () => {
       expect(process.env.PORT).toBe('9283'); // restored for the daemon process itself
     });
 
-    it('clears NEOKAI_PORT from process.env for Anthropic model and restores it afterward', () => {
+    it('clears NEOKAI_PORT from process.env for Anthropic model and restores it afterward', async () => {
       process.env.NEOKAI_PORT = '9983';
 
-      const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
+      const original = await service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
       expect(process.env.NEOKAI_PORT).toBeUndefined();
       expect(original.NEOKAI_PORT).toBe('9983');
@@ -931,12 +937,12 @@ describe('ProviderService', () => {
       expect(process.env.NEOKAI_PORT).toBe('9983');
     });
 
-    it('clears PORT and NEOKAI_PORT from process.env for GLM model and restores them', () => {
+    it('clears PORT and NEOKAI_PORT from process.env for GLM model and restores them', async () => {
       // The kill-chain protection must apply regardless of provider
       process.env.PORT = '8399';
       process.env.NEOKAI_PORT = '9983';
 
-      const original = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const original = await service.applyEnvVarsToProcess('glm-4', 'glm');
 
       expect(process.env.PORT).toBeUndefined();
       expect(process.env.NEOKAI_PORT).toBeUndefined();
@@ -950,11 +956,11 @@ describe('ProviderService', () => {
   });
 
   describe('applyEnvVarsToProcessForProvider', () => {
-    it('should clear leaked GLM routing vars for anthropic provider', () => {
+    it('should clear leaked GLM routing vars for anthropic provider', async () => {
       process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
       process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'glm-4';
 
-      const original = service.applyEnvVarsToProcessForProvider('anthropic');
+      const original = await service.applyEnvVarsToProcessForProvider('anthropic');
 
       expect(original.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
       expect(original.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-4');
@@ -962,18 +968,18 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBeUndefined();
     });
 
-    it('should apply GLM env vars for GLM provider', () => {
-      const original = service.applyEnvVarsToProcessForProvider('glm', 'glm-4');
+    it('should apply GLM env vars for GLM provider', async () => {
+      const original = await service.applyEnvVarsToProcessForProvider('glm', 'glm-4');
 
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
       expect(original).toBeDefined();
     });
 
-    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', () => {
+    it('should return {} without throwing when buildSdkConfig throws (e.g. server not yet started)', async () => {
       registry.register(new ThrowingMockProvider());
 
       // Must not throw
-      const original = service.applyEnvVarsToProcessForProvider(
+      const original = await service.applyEnvVarsToProcessForProvider(
         'throwing' as unknown as ProviderId
       );
       expect(original).toEqual({});
@@ -981,12 +987,12 @@ describe('ProviderService', () => {
   });
 
   describe('restoreEnvVars', () => {
-    it('should restore original env vars', () => {
+    it('should restore original env vars', async () => {
       process.env.ANTHROPIC_AUTH_TOKEN = 'original-token';
       process.env.ANTHROPIC_BASE_URL = 'original-url';
 
       // Apply GLM env vars
-      const original = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const original = await service.applyEnvVarsToProcess('glm-4', 'glm');
 
       // Verify env vars changed
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -999,13 +1005,13 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_BASE_URL).toBe('original-url');
     });
 
-    it('should delete env vars that were not originally set', () => {
+    it('should delete env vars that were not originally set', async () => {
       // Ensure env vars are not set
       delete process.env.ANTHROPIC_AUTH_TOKEN;
       delete process.env.ANTHROPIC_BASE_URL;
 
       // Apply GLM env vars
-      const original = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const original = await service.applyEnvVarsToProcess('glm-4', 'glm');
 
       // Verify env vars were set
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.glm.example.com');
@@ -1018,7 +1024,7 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
     });
 
-    it('should do nothing for empty original object', () => {
+    it('should do nothing for empty original object', async () => {
       process.env.ANTHROPIC_AUTH_TOKEN = 'some-token';
 
       service.restoreEnvVars({});
@@ -1027,7 +1033,7 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe('some-token');
     });
 
-    it('should only restore keys captured in original', () => {
+    it('should only restore keys captured in original', async () => {
       process.env.ANTHROPIC_AUTH_TOKEN = 'keep-me';
       process.env.ANTHROPIC_BASE_URL = 'to-be-restored';
 
@@ -1037,7 +1043,7 @@ describe('ProviderService', () => {
       expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe('keep-me');
     });
 
-    it('should restore all supported env vars', () => {
+    it('should restore all supported env vars', async () => {
       // Set all supported env vars
       process.env.ANTHROPIC_AUTH_TOKEN = 'auth-token';
       process.env.ANTHROPIC_BASE_URL = 'base-url';
@@ -1048,7 +1054,7 @@ describe('ProviderService', () => {
       process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'opus-model';
 
       // Apply GLM env vars
-      const original = service.applyEnvVarsToProcess('glm-4', 'glm');
+      const original = await service.applyEnvVarsToProcess('glm-4', 'glm');
 
       // Restore
       service.restoreEnvVars(original);
@@ -1094,7 +1100,7 @@ describe('getProviderService', () => {
     resetProviderFactory();
   });
 
-  it('should return singleton instance', () => {
+  it('should return singleton instance', async () => {
     const service1 = getProviderService();
     const service2 = getProviderService();
 
@@ -1104,7 +1110,7 @@ describe('getProviderService', () => {
     expect(Object.is(service1, service2) || hasSameMethods(service1, service2)).toBe(true);
   });
 
-  it('should return ProviderService instance', () => {
+  it('should return ProviderService instance', async () => {
     const service = getProviderService();
     // Check the expected API surface instead of instanceof, which
     // breaks when Bun loads the class from a different module instance.
@@ -1123,7 +1129,7 @@ function hasSameMethods(a: object, b: object): boolean {
 }
 
 describe('mergeProviderEnvVars', () => {
-  it('should spread provider env vars over process.env', () => {
+  it('should spread provider env vars over process.env', async () => {
     // Verify the function spreads correctly by testing with a known env var
     // that exists in CI (NODE_ENV is always set to 'test' by setup.ts)
     const merged = mergeProviderEnvVars({
@@ -1136,7 +1142,7 @@ describe('mergeProviderEnvVars', () => {
     expect(merged.NEW_VAR).toBe('new');
   });
 
-  it('should return a new object when provider env vars is empty', () => {
+  it('should return a new object when provider env vars is empty', async () => {
     const merged = mergeProviderEnvVars({});
     // Verify it returns a new object (not the same reference)
     expect(merged).not.toBe(process.env);

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/provider.test.ts
@@ -22,6 +22,7 @@ import { AnthropicToCopilotBridgeProvider } from '../../../../../src/lib/provide
 import {
   initializeProviders,
   resetProviderFactory,
+  waitForOptionalProviderRegistration,
 } from '../../../../../src/lib/providers/factory';
 import {
   getProviderRegistry,
@@ -1055,8 +1056,9 @@ describe('factory registration', () => {
     resetProviderFactory();
   });
 
-  it('registers AnthropicToCopilotBridgeProvider with id anthropic-copilot', () => {
+  it('registers AnthropicToCopilotBridgeProvider with id anthropic-copilot', async () => {
     initializeProviders();
+    await waitForOptionalProviderRegistration();
     const registry = getProviderRegistry();
     const p = registry.get('anthropic-copilot');
     expect(p).toBeDefined();

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/server.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   initializeProviders,
   resetProviderFactory,
+  waitForOptionalProviderRegistration,
 } from '../../../../../src/lib/providers/factory';
 import {
   getProviderRegistry,
@@ -1261,8 +1262,9 @@ describe('factory registration', () => {
     resetProviderFactory();
   });
 
-  it('registers AnthropicToCopilotBridgeProvider with id anthropic-copilot', () => {
+  it('registers AnthropicToCopilotBridgeProvider with id anthropic-copilot', async () => {
     initializeProviders();
+    await waitForOptionalProviderRegistration();
     const registry = getProviderRegistry();
     const p = registry.get('anthropic-copilot');
     expect(p).toBeDefined();

--- a/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
@@ -404,6 +404,19 @@ describe('ProviderRegistry', () => {
       const globalReg = getProviderRegistry();
       expect(globalReg.size).toBe(9);
     });
+
+    it('should restore anthropic-copilot after the registry is reset without factory reset', async () => {
+      const reg = initializeProviders();
+      await waitForOptionalProviderRegistration();
+      expect(reg.has('anthropic-copilot')).toBe(true);
+
+      resetProviderRegistry();
+      const resetReg = initializeProviders();
+      await waitForOptionalProviderRegistration();
+
+      expect(resetReg.has('anthropic-copilot')).toBe(true);
+      expect(resetReg.size).toBe(9);
+    });
   });
 
   describe('ownsModel collision — anthropic vs anthropic-copilot vs anthropic-codex', () => {

--- a/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
@@ -6,7 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:te
 import type { ModelInfo } from '@neokai/shared';
 import { Logger } from '@neokai/shared/logger';
 import type { Provider, ProviderSdkConfig } from '@neokai/shared/provider';
-import { initializeProviders, resetProviderFactory } from '../../../../src/lib/providers/factory';
+import {
+  initializeProviders,
+  resetProviderFactory,
+  waitForOptionalProviderRegistration,
+} from '../../../../src/lib/providers/factory';
 import {
   ProviderRegistry,
   getProviderRegistry,
@@ -320,8 +324,9 @@ describe('ProviderRegistry', () => {
   describe('initializeProviders — all built-in providers registered', () => {
     // Outer beforeEach already resets registry+factory; no per-test resets needed.
 
-    it('should register exactly nine built-in providers', () => {
+    it('should register exactly nine built-in providers', async () => {
       const reg = initializeProviders();
+      await waitForOptionalProviderRegistration();
 
       const ids = reg
         .getAll()
@@ -378,21 +383,24 @@ describe('ProviderRegistry', () => {
       expect(reg.has('anthropic-codex')).toBe(true);
     });
 
-    it('should include anthropic-copilot provider', () => {
+    it('should include anthropic-copilot provider', async () => {
       const reg = initializeProviders();
+      await waitForOptionalProviderRegistration();
       expect(reg.has('anthropic-copilot')).toBe(true);
     });
 
-    it('should return the same singleton registry on repeated calls without reset', () => {
+    it('should return the same singleton registry on repeated calls without reset', async () => {
       const reg1 = initializeProviders();
+      await waitForOptionalProviderRegistration();
       const reg2 = initializeProviders();
       // The global singleton must be the same reference — not a new instance
       expect(reg1).toBe(reg2);
       expect(reg2.size).toBe(9);
     });
 
-    it('should use the global registry singleton', () => {
+    it('should use the global registry singleton', async () => {
       initializeProviders();
+      await waitForOptionalProviderRegistration();
       const globalReg = getProviderRegistry();
       expect(globalReg.size).toBe(9);
     });

--- a/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
@@ -405,7 +405,7 @@ describe('ProviderRegistry', () => {
       expect(globalReg.size).toBe(9);
     });
 
-    it('should restore anthropic-copilot after the registry is reset without factory reset', async () => {
+    it('should restore all providers after the registry is reset without factory reset', async () => {
       const reg = initializeProviders();
       await waitForOptionalProviderRegistration();
       expect(reg.has('anthropic-copilot')).toBe(true);
@@ -414,8 +414,23 @@ describe('ProviderRegistry', () => {
       const resetReg = initializeProviders();
       await waitForOptionalProviderRegistration();
 
-      expect(resetReg.has('anthropic-copilot')).toBe(true);
-      expect(resetReg.size).toBe(9);
+      const ids = resetReg
+        .getAll()
+        .map((p) => p.id)
+        .sort();
+      expect(ids).toEqual(
+        [
+          'anthropic',
+          'anthropic-codex',
+          'anthropic-copilot',
+          'glm',
+          'kimi',
+          'minimax',
+          'ollama',
+          'ollama-cloud',
+          'openrouter',
+        ].sort()
+      );
     });
   });
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.7.6",
-    "preact": "10.29.1"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,17 +19,17 @@
     "coverage": "vitest run --reporter dot --coverage"
   },
   "dependencies": {
-    "@preact/signals": "2.9.0",
+    "@preact/signals": "2.9.1",
     "clsx": "2.1.1",
     "highlight.js": "11.11.1",
-    "marked": "18.0.2",
-    "preact": "10.29.1"
+    "marked": "18.0.4",
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",
-    "@tailwindcss/vite": "4.2.4",
+    "@tailwindcss/vite": "4.3.0",
     "@testing-library/preact": "3.2.4",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@vitest/coverage-v8": "4.1.5",
     "@vitest/ui": "4.1.5",
     "happy-dom": "20.9.0",

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -45,7 +45,8 @@ function run(cmd: string) {
 
 function outputFileForTarget(target: string): string {
   const platformArch = target.replace('bun-', '');
-  return join(OUTPUT_DIR, `kai-${platformArch}`);
+  const extension = target.includes('windows') ? '.exe' : '';
+  return join(OUTPUT_DIR, `kai-${platformArch}${extension}`);
 }
 
 function verifyBundledDependency(outputPath: string, needle: string): void {

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -43,6 +43,20 @@ function run(cmd: string) {
   execSync(cmd, { cwd: ROOT, stdio: 'inherit' });
 }
 
+function outputFileForTarget(target: string): string {
+  const platformArch = target.replace('bun-', '');
+  return join(OUTPUT_DIR, `kai-${platformArch}`);
+}
+
+function verifyBundledDependency(outputPath: string, needle: string): void {
+  const escapedNeedle = needle.replace(/'/g, "'\\''");
+  try {
+    execSync(`strings '${outputPath}' | grep '${escapedNeedle}'`, { cwd: ROOT, stdio: 'ignore' });
+  } catch {
+    throw new Error(`Compiled binary is missing bundled dependency marker: ${needle}`);
+  }
+}
+
 // Step 1: Build web frontend
 console.log('Step 1: Building web frontend...\n');
 run('cd packages/web && bun run build');
@@ -55,12 +69,15 @@ run('bun run scripts/generate-embedded-assets.ts');
 mkdirSync(OUTPUT_DIR, { recursive: true });
 
 for (const target of targets) {
-  const platformArch = target.replace('bun-', '');
-  const outputPath = join(OUTPUT_DIR, `kai-${platformArch}`);
+  const outputPath = outputFileForTarget(target);
 
   console.log(`\nStep 3: Compiling binary for ${target}...`);
   run(`bun build --compile --target=${target} --outfile=${outputPath} packages/cli/prod-entry.ts`);
   console.log(`  -> ${outputPath}`);
+
+  console.log('  Verifying Copilot SDK bundle markers...');
+  verifyBundledDependency(outputPath, '@github/copilot-sdk');
+  verifyBundledDependency(outputPath, 'vscode-jsonrpc');
 }
 
 console.log('\nBuild complete!');


### PR DESCRIPTION
## Summary
- Lazy-load the Copilot provider so daemon startup no longer has a static @github/copilot-sdk import chain.
- Wait for optional provider registration before startup model discovery and update provider registry tests.
- Verify compiled binaries contain @github/copilot-sdk and vscode-jsonrpc markers after compile.

## Validation
- bun run check
- cd packages/daemon && bun test tests/unit/1-core/providers/provider-registry.test.ts
- bun run scripts/build-binary.ts --target bun-darwin-x64
- dist/bin/kai-darwin-x64 --help
- strings dist/bin/kai-darwin-x64 | grep copilot-sdk
- strings dist/bin/kai-darwin-x64 | grep vscode-jsonrpc