### PR TITLE
chore(release): bump version to 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.35.0] - 2026-05-29
+
+Unified provider registry with CRUD RPCs and credential store, rich markdown rendering with KaTeX and Mermaid, persisted Space agent handles, compacted Space workflow prompts, unified Providers settings UI, Codex thumbs-up review gate, test-quality audit, and composer draft race fix. 10 commits since v0.34.0.
+
+### Added
+
+- **Unified provider registry**: Full CRUD RPCs for providers (`providers.list`, `.get`, `.create`, `.update`, `.delete`, `.setDefault`, `.test`, `.healthCheck`), reactive DB repository, and startup migration from env vars and auth files
+- **Provider credential store**: Keychain-backed storage on macOS with AES-256-GCM SQLite fallback, OAuth refresh scheduler, and `ProviderCredentialManager` for high-level credential operations
+- **Unified Providers settings UI**: Replaces split Providers + Custom Endpoints with single view — provider rows with badges, health checks, OAuth flows, and `AddProviderModal` for quick-add of 9 built-in providers
+- **Rich markdown rendering**: Migrated from marked to unified/remark/rehype with lazy KaTeX math, lazy Mermaid diagram rendering, GFM, line breaks, and syntax highlighting
+- **Persisted Space agent handles**: Space agents now have persistent, user-configurable handles with reserved-name protection, DB-backed actor routing, and slug-based URL navigation
+- **Codex thumbs-up review gate**: Review workflow now requires `codex[bot]` +1 reaction before QA review gate opens, with 10-minute timeout warning path
+- **Test-quality audit**: Added `scripts/check-test-quality.ts` to CI which flags dead mock assertions and describe-scope mismatches via TypeScript AST analysis
+
+### Changed
+
+- **Compacted Space workflow prompts**: Centralized reviewer and QA contracts, trimmed coordinator and task prompts, and reduced dynamic activation context bloat without changing workflow semantics
+- Old `?tab=custom-endpoints` settings URL redirects to `?tab=providers`
+
+### Fixed
+
+- Composer no longer restores draft content after send due to stale `onInput` race against `clearDraft()`
+- Daemon startup no longer hangs on macOS when no Keychain entry exists and no TTY is available — falls back to encrypted SQLite credential store
+- Slug-based Space navigation preserves canonical state and resolves agent detail routes correctly
+
 ## [0.34.0] - 2026-05-28
 
 Forge proposal evidence, validation-only workflow completion, flaky test retry policy, long-horizon agent lifecycle coverage, task result capture fallback fixes, prompt builder token-cost audit, provider compatibility fixes, Copilot SDK binary bundling fix, workflow agent session titles, DB schema parity CI check, daemon unit test shard rebalance, and gate space task RPC handler test coverage. 13 commits since v0.33.0.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "bin": {
         "kai": "./main.ts",
       },
@@ -32,7 +32,7 @@
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.141",
         "@github/copilot-sdk": "0.3.0",
@@ -48,11 +48,11 @@
     },
     "packages/desktop": {
       "name": "@neokai/desktop",
-      "version": "0.34.0",
+      "version": "0.35.0",
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
@@ -68,7 +68,7 @@
     },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
@@ -95,7 +95,7 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "dependencies": {
         "@preact/signals": "2.9.1",
         "clsx": "2.1.1",

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neokai",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "NeoKai - Claude Agent SDK Web Interface",
   "bin": {
     "kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/cli",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/daemon",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/desktop",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "private": true,
   "description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.34.0"
+version = "0.35.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kai",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "identifier": "io.neokai.kai",
   "build": {
     "frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/e2e",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/shared",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/web",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Persist Space agent handles and compact space workflow prompts. 2 commits since v0.34.0.