### PR TITLE
feat: unified provider registry with CRUD RPCs, credential store, and migration

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -41,6 +41,8 @@ import {
 import { getProviderRegistry } from './lib/providers/registry.js';
 import { OAuthRefreshScheduler } from './lib/credentials/oauth-refresh-scheduler.js';
 import { ProviderCredentialManager } from './lib/credentials/provider-credential-manager.js';
+import { syncAllProviders } from './lib/providers/provider-sync.js';
+import { migrateProvidersIfNeeded } from './lib/credential-discovery';
 import { createReactiveDatabase } from './storage/reactive-database';
 import { LiveQueryEngine } from './storage/live-query';
 import { SpaceAgentRepository } from './storage/repositories/space-agent-repository';
@@ -314,12 +316,26 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       registry: providerRegistry,
     });
 
+    // One-time migration: env vars / auth files / customEndpoints → providers table.
+    try {
+      await migrateProvidersIfNeeded(db, credentialManager);
+    } catch (err) {
+      logError('[Daemon] Provider migration failed (non-fatal):', err);
+    }
+
     // Register user-defined OpenAI-compatible endpoints (LM Studio, vLLM, LiteLLM, etc.)
     // stored under `settings.customEndpoints`. Synchronous failure is non-fatal — bad
     // endpoint configs are logged and skipped rather than blocking daemon startup.
     {
       const { syncCustomEndpointProviders } = await import('./lib/providers/factory.js');
       await syncCustomEndpointProviders(settingsManager.getGlobalSettings().customEndpoints);
+    }
+
+    // Sync all enabled providers from the providers table into the registry.
+    try {
+      await syncAllProviders(() => db.providers.listEnabledProviders(), credentialManager);
+    } catch (err) {
+      logError('[Daemon] Provider sync failed (non-fatal):', err);
     }
 
     // Check authentication status.

--- a/packages/daemon/src/lib/credential-discovery.ts
+++ b/packages/daemon/src/lib/credential-discovery.ts
@@ -256,11 +256,15 @@ export async function migrateProvidersIfNeeded(
           sortOrder: sortOrder++,
         });
       }
-      await credentialManager.storeOAuthTokens('anthropic-codex', {
-        accessToken: openaiCreds.access,
-        refreshToken: openaiCreds.refresh,
-        expiresAt: openaiCreds.expires,
-      });
+      try {
+        await credentialManager.storeOAuthTokens('anthropic-codex', {
+          accessToken: openaiCreds.access,
+          refreshToken: openaiCreds.refresh,
+          expiresAt: openaiCreds.expires,
+        });
+      } catch {
+        // Non-fatal: the provider record exists; credentials can be re-entered.
+      }
     }
   }
 
@@ -279,9 +283,13 @@ export async function migrateProvidersIfNeeded(
           sortOrder: sortOrder++,
         });
       }
-      await credentialManager.storeOAuthTokens('anthropic-copilot', {
-        accessToken: copilotCreds.refresh,
-      });
+      try {
+        await credentialManager.storeOAuthTokens('anthropic-copilot', {
+          accessToken: copilotCreds.refresh,
+        });
+      } catch {
+        // Non-fatal: the provider record exists; credentials can be re-entered.
+      }
     }
   }
 

--- a/packages/daemon/src/lib/credential-discovery.ts
+++ b/packages/daemon/src/lib/credential-discovery.ts
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 import type { Database } from '../storage/database';
 import type { ProviderCredentialManager } from './credentials/provider-credential-manager';
 import type { GlobalSettings } from '@neokai/shared';
+import { customProviderIdFor } from './providers/custom-endpoint-provider.js';
 
 export interface DiscoveryResult {
   credentialSource: 'env' | 'credentials-file' | 'keychain' | 'settings-json' | 'none';
@@ -289,7 +290,7 @@ export async function migrateProvidersIfNeeded(
   if (globalSettings.customEndpoints) {
     for (const endpoint of globalSettings.customEndpoints) {
       db.providers.createProvider({
-        providerId: `custom:${endpoint.id}`,
+        providerId: customProviderIdFor(endpoint.id),
         displayName: endpoint.name,
         kind: 'custom_endpoint',
         authType: 'none',

--- a/packages/daemon/src/lib/credential-discovery.ts
+++ b/packages/daemon/src/lib/credential-discovery.ts
@@ -2,6 +2,9 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { execSync } from 'node:child_process';
+import type { Database } from '../storage/database';
+import type { ProviderCredentialManager } from './credentials/provider-credential-manager';
+import type { GlobalSettings } from '@neokai/shared';
 
 export interface DiscoveryResult {
   credentialSource: 'env' | 'credentials-file' | 'keychain' | 'settings-json' | 'none';
@@ -126,4 +129,176 @@ export function discoverCredentials(
     settingsEnvApplied,
     errors,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Provider migration — one-time import from env vars / auth files / settings
+// ---------------------------------------------------------------------------
+
+interface BuiltInProviderEnvMapping {
+  providerId: string;
+  displayName: string;
+  envVar: string;
+  altEnvVar?: string;
+  authType: 'api_key' | 'oauth' | 'none';
+}
+
+const BUILT_IN_PROVIDER_ENV_MAP: BuiltInProviderEnvMapping[] = [
+  {
+    providerId: 'anthropic',
+    displayName: 'Anthropic',
+    envVar: 'ANTHROPIC_API_KEY',
+    authType: 'api_key',
+  },
+  {
+    providerId: 'glm',
+    displayName: 'GLM',
+    envVar: 'GLM_API_KEY',
+    altEnvVar: 'ZHIPU_API_KEY',
+    authType: 'api_key',
+  },
+  {
+    providerId: 'kimi',
+    displayName: 'Kimi',
+    envVar: 'KIMI_API_KEY',
+    altEnvVar: 'MOONSHOT_API_KEY',
+    authType: 'api_key',
+  },
+  { providerId: 'minimax', displayName: 'MiniMax', envVar: 'MINIMAX_API_KEY', authType: 'api_key' },
+  {
+    providerId: 'openrouter',
+    displayName: 'OpenRouter',
+    envVar: 'OPENROUTER_API_KEY',
+    authType: 'api_key',
+  },
+  { providerId: 'ollama', displayName: 'Ollama', envVar: 'OLLAMA_API_KEY', authType: 'api_key' },
+  {
+    providerId: 'ollama-cloud',
+    displayName: 'Ollama Cloud',
+    envVar: 'OLLAMA_CLOUD_API_KEY',
+    authType: 'api_key',
+  },
+  {
+    providerId: 'anthropic-codex',
+    displayName: 'OpenAI (Codex)',
+    envVar: 'OPENAI_API_KEY',
+    authType: 'api_key',
+  },
+];
+
+function readNeokaiAuthJson(): Record<string, unknown> {
+  try {
+    const path = join(homedir(), '.neokai', 'auth.json');
+    if (!existsSync(path)) return {};
+    return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * One-time migration of provider configuration into the providers table.
+ * Idempotent: skips if the table already has rows.
+ */
+export async function migrateProvidersIfNeeded(
+  db: Database,
+  credentialManager: ProviderCredentialManager
+): Promise<void> {
+  if (db.providers.countProviders() > 0) {
+    return; // Already migrated.
+  }
+
+  let sortOrder = 0;
+
+  // 1. Env var providers.
+  for (const mapping of BUILT_IN_PROVIDER_ENV_MAP) {
+    const apiKey =
+      process.env[mapping.envVar] ||
+      (mapping.altEnvVar ? process.env[mapping.altEnvVar] : undefined);
+    if (!apiKey) continue;
+
+    db.providers.createProvider({
+      providerId: mapping.providerId,
+      displayName: mapping.displayName,
+      kind: 'built_in',
+      authType: mapping.authType,
+      isEnabled: true,
+      isDefault: mapping.providerId === 'anthropic',
+      sortOrder: sortOrder++,
+    });
+
+    try {
+      await credentialManager.storeApiKey(mapping.providerId, apiKey);
+    } catch {
+      // Non-fatal: the provider record exists; credentials can be re-entered.
+    }
+  }
+
+  // 2. OAuth tokens from ~/.neokai/auth.json
+  const neokaiAuth = readNeokaiAuthJson();
+  if (neokaiAuth['openai']) {
+    const openaiCreds = neokaiAuth['openai'] as {
+      access?: string;
+      refresh?: string;
+      expires?: number;
+    };
+    if (openaiCreds.access) {
+      const existing = db.providers.getProviderByProviderId('anthropic-codex');
+      if (!existing) {
+        db.providers.createProvider({
+          providerId: 'anthropic-codex',
+          displayName: 'OpenAI (Codex)',
+          kind: 'built_in',
+          authType: 'oauth',
+          isEnabled: true,
+          isDefault: false,
+          sortOrder: sortOrder++,
+        });
+      }
+      await credentialManager.storeOAuthTokens('anthropic-codex', {
+        accessToken: openaiCreds.access,
+        refreshToken: openaiCreds.refresh,
+        expiresAt: openaiCreds.expires,
+      });
+    }
+  }
+
+  if (neokaiAuth['copilot']) {
+    const copilotCreds = neokaiAuth['copilot'] as { refresh?: string };
+    if (copilotCreds.refresh) {
+      const existing = db.providers.getProviderByProviderId('anthropic-copilot');
+      if (!existing) {
+        db.providers.createProvider({
+          providerId: 'anthropic-copilot',
+          displayName: 'GitHub Copilot',
+          kind: 'built_in',
+          authType: 'oauth',
+          isEnabled: true,
+          isDefault: false,
+          sortOrder: sortOrder++,
+        });
+      }
+      await credentialManager.storeOAuthTokens('anthropic-copilot', {
+        accessToken: copilotCreds.refresh,
+      });
+    }
+  }
+
+  // 3. Custom endpoints from global_settings.
+  const globalSettings: GlobalSettings = db.getGlobalSettings();
+  if (globalSettings.customEndpoints) {
+    for (const endpoint of globalSettings.customEndpoints) {
+      db.providers.createProvider({
+        providerId: `custom:${endpoint.id}`,
+        displayName: endpoint.name,
+        kind: 'custom_endpoint',
+        authType: 'none',
+        isEnabled: true,
+        isDefault: false,
+        sortOrder: sortOrder++,
+        baseUrl: endpoint.baseUrl,
+        customEndpointConfigJson: JSON.stringify(endpoint),
+      });
+    }
+  }
 }

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -472,6 +472,8 @@ const EXCLUDED_TABLE_NAMES: string[] = [
   'auth_config',
   'global_tools_config',
   'global_settings',
+  // Provider registry and credential store — admin tables, not queryable by agents
+  'providers',
   'provider_credentials',
   // session_groups, session_group_members, and sdk_messages are now in SPACE_SCOPE_TABLES.
   // task_group_events remains excluded — internal event log, not useful for ad-hoc queries.

--- a/packages/daemon/src/lib/providers/provider-sync.ts
+++ b/packages/daemon/src/lib/providers/provider-sync.ts
@@ -1,0 +1,127 @@
+/**
+ * Provider Sync
+ *
+ * Bridges the providers table ↔ ProviderRegistry at runtime.
+ * - syncProviderToRegistry: creates/updates a Provider instance from a DB record
+ * - syncAllProviders: startup sweep that registers all enabled rows
+ * - removeProviderFromRegistry: shutdown + unregister
+ */
+
+import type { ProviderRecord, CustomEndpointConfig } from '@neokai/shared';
+import type { ProviderCredentials } from '@neokai/shared/provider';
+import { getProviderRegistry } from './registry.js';
+import { initializeProviders } from './factory.js';
+import { CustomEndpointProvider, customProviderIdFor } from './custom-endpoint-provider.js';
+import { Logger } from '../logger.js';
+import type { ProviderCredentialManager } from '../credentials/provider-credential-manager.js';
+
+const logger = new Logger('providers:sync');
+
+// ---------------------------------------------------------------------------
+// Sync a single DB record into the registry
+// ---------------------------------------------------------------------------
+
+export async function syncProviderToRegistry(
+  record: ProviderRecord,
+  credentials?: ProviderCredentials | null
+): Promise<void> {
+  const registry = getProviderRegistry();
+
+  // Built-in providers are already registered by initializeProviders().
+  // We only need to call setCredentials() on them.
+  if (record.kind === 'built_in') {
+    const provider = registry.get(record.providerId);
+    if (provider?.setCredentials && credentials) {
+      provider.setCredentials(credentials);
+      logger.info(`Applied credentials to built-in provider ${record.providerId}`);
+    }
+    return;
+  }
+
+  // Custom endpoint: create a new CustomEndpointProvider instance.
+  if (record.kind === 'custom_endpoint') {
+    if (!record.customEndpointConfigJson) {
+      logger.warn(`Custom endpoint provider ${record.providerId} has no config; skipping`);
+      return;
+    }
+
+    let config: CustomEndpointConfig;
+    try {
+      config = JSON.parse(record.customEndpointConfigJson) as CustomEndpointConfig;
+    } catch (err) {
+      logger.warn(`Failed to parse custom endpoint config for ${record.providerId}:`, err);
+      return;
+    }
+
+    // If baseUrl was overridden in the provider record, merge it into the config.
+    if (record.baseUrl) {
+      config = { ...config, baseUrl: record.baseUrl };
+    }
+
+    const providerId = customProviderIdFor(config.id);
+
+    // Shutdown existing instance if present.
+    const existing = registry.get(providerId);
+    if (existing?.shutdown) {
+      try {
+        await existing.shutdown();
+      } catch (err) {
+        logger.warn(`Failed to shut down custom endpoint provider ${providerId}:`, err);
+      }
+    }
+    if (existing) {
+      registry.unregister(providerId);
+    }
+
+    try {
+      const provider = new CustomEndpointProvider(config);
+      registry.register(provider);
+      logger.info(`Registered custom endpoint provider ${providerId}`);
+    } catch (err) {
+      logger.warn(`Failed to register custom endpoint provider ${providerId}:`, err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Startup: sync all enabled provider records
+// ---------------------------------------------------------------------------
+
+export async function syncAllProviders(
+  listEnabled: () => ProviderRecord[],
+  credentialManager: ProviderCredentialManager
+): Promise<void> {
+  // Ensure built-ins are registered first.
+  initializeProviders();
+
+  const records = listEnabled();
+  for (const record of records) {
+    try {
+      const credentials = await credentialManager.getCredentials(record.providerId);
+      await syncProviderToRegistry(record, credentials);
+    } catch (err) {
+      logger.warn(`Failed to sync provider ${record.providerId}:`, err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Remove a provider from the registry
+// ---------------------------------------------------------------------------
+
+export async function removeProviderFromRegistry(providerId: string): Promise<void> {
+  const registry = getProviderRegistry();
+  const provider = registry.get(providerId);
+  if (!provider) return;
+
+  if (provider.shutdown) {
+    try {
+      await provider.shutdown();
+    } catch (err) {
+      logger.warn(`Failed to shut down provider ${providerId}:`, err);
+    }
+  }
+
+  registry.unregister(providerId);
+  logger.info(`Unregistered provider ${providerId}`);
+}

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -9,6 +9,7 @@
 
 import type { MessageHub } from '@neokai/shared';
 import type { CustomEndpointConfig, CustomEndpointType } from '@neokai/shared';
+import { customProviderIdFor } from '../providers/custom-endpoint-provider.js';
 import type { SettingsManager } from '../settings-manager';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { Database } from '../../storage/database';
@@ -95,10 +96,6 @@ export function validateCustomEndpoints(configs: CustomEndpointConfig[] | undefi
   }
 }
 
-function customProviderIdForEndpoint(endpointId: string): string {
-  return `custom:${endpointId}`;
-}
-
 function endpointToProviderRecord(endpoint: CustomEndpointConfig): {
   providerId: string;
   displayName: string;
@@ -108,7 +105,7 @@ function endpointToProviderRecord(endpoint: CustomEndpointConfig): {
   customEndpointConfigJson: string;
 } {
   return {
-    providerId: customProviderIdForEndpoint(endpoint.id),
+    providerId: customProviderIdFor(endpoint.id),
     displayName: endpoint.name,
     kind: 'custom_endpoint' as const,
     authType: 'none' as const,
@@ -122,7 +119,7 @@ function syncEndpointToProviderTable(
   endpoint: CustomEndpointConfig
 ): void {
   if (!db) return;
-  const existing = db.providers.getProviderByProviderId(customProviderIdForEndpoint(endpoint.id));
+  const existing = db.providers.getProviderByProviderId(customProviderIdFor(endpoint.id));
   if (existing) {
     db.providers.updateProvider(existing.id, {
       displayName: endpoint.name,
@@ -143,7 +140,7 @@ function syncEndpointToProviderTable(
 
 function removeEndpointFromProviderTable(db: Database | undefined, endpointId: string): void {
   if (!db) return;
-  const existing = db.providers.getProviderByProviderId(customProviderIdForEndpoint(endpointId));
+  const existing = db.providers.getProviderByProviderId(customProviderIdFor(endpointId));
   if (existing) {
     db.providers.deleteProvider(existing.id);
   }
@@ -172,7 +169,7 @@ async function persistAndSync(
   // Compat: sync the full list to the providers table so the unified registry
   // stays in sync with the legacy customEndpoints JSON blob.
   if (db) {
-    const allProviderIds = new Set(endpoints.map((e) => customProviderIdForEndpoint(e.id)));
+    const allProviderIds = new Set(endpoints.map((e) => customProviderIdFor(e.id)));
     for (const endpoint of endpoints) {
       syncEndpointToProviderTable(db, endpoint);
     }

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -11,12 +11,16 @@ import type { MessageHub } from '@neokai/shared';
 import type { CustomEndpointConfig, CustomEndpointType } from '@neokai/shared';
 import type { SettingsManager } from '../settings-manager';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
+import type { Database } from '../../storage/database';
+import { Logger } from '../logger.js';
 
 const VALID_CUSTOM_ENDPOINT_TYPES: ReadonlySet<CustomEndpointType> = new Set([
   'openai-chat',
   'anthropic-messages',
   'ollama-native',
 ]);
+
+const log = new Logger('rpc-handlers:custom-endpoints');
 
 /**
  * Validate a single endpoint. Exported for callers (e.g. the generic
@@ -91,10 +95,65 @@ export function validateCustomEndpoints(configs: CustomEndpointConfig[] | undefi
   }
 }
 
+function customProviderIdForEndpoint(endpointId: string): string {
+  return `custom:${endpointId}`;
+}
+
+function endpointToProviderRecord(endpoint: CustomEndpointConfig): {
+  providerId: string;
+  displayName: string;
+  kind: 'custom_endpoint';
+  authType: 'api_key' | 'none';
+  baseUrl: string;
+  customEndpointConfigJson: string;
+} {
+  return {
+    providerId: customProviderIdForEndpoint(endpoint.id),
+    displayName: endpoint.name,
+    kind: 'custom_endpoint' as const,
+    authType: 'none' as const,
+    baseUrl: endpoint.baseUrl,
+    customEndpointConfigJson: JSON.stringify(endpoint),
+  };
+}
+
+function syncEndpointToProviderTable(
+  db: Database | undefined,
+  endpoint: CustomEndpointConfig
+): void {
+  if (!db) return;
+  const existing = db.providers.getProviderByProviderId(customProviderIdForEndpoint(endpoint.id));
+  if (existing) {
+    db.providers.updateProvider(existing.id, {
+      displayName: endpoint.name,
+      baseUrl: endpoint.baseUrl,
+      customEndpointConfigJson: JSON.stringify(endpoint),
+    });
+  } else {
+    try {
+      db.providers.createProvider({
+        ...endpointToProviderRecord(endpoint),
+        authType: 'none',
+      });
+    } catch (err) {
+      log.warn('Failed to create provider record for custom endpoint:', err);
+    }
+  }
+}
+
+function removeEndpointFromProviderTable(db: Database | undefined, endpointId: string): void {
+  if (!db) return;
+  const existing = db.providers.getProviderByProviderId(customProviderIdForEndpoint(endpointId));
+  if (existing) {
+    db.providers.deleteProvider(existing.id);
+  }
+}
+
 async function persistAndSync(
   settingsManager: SettingsManager,
   internalEventBus: InternalEventBus<DaemonInternalEventMap>,
-  endpoints: CustomEndpointConfig[]
+  endpoints: CustomEndpointConfig[],
+  db?: Database
 ): Promise<void> {
   const updated = settingsManager.updateGlobalSettings({ customEndpoints: endpoints });
   const { syncCustomEndpointProviders } = await import('../providers/factory.js');
@@ -109,6 +168,21 @@ async function persistAndSync(
     namespaceId: 'global',
     settings: updated,
   });
+
+  // Compat: sync the full list to the providers table so the unified registry
+  // stays in sync with the legacy customEndpoints JSON blob.
+  if (db) {
+    const allProviderIds = new Set(endpoints.map((e) => customProviderIdForEndpoint(e.id)));
+    for (const endpoint of endpoints) {
+      syncEndpointToProviderTable(db, endpoint);
+    }
+    // Remove any provider records for endpoints that no longer exist.
+    for (const record of db.providers.listProviders()) {
+      if (record.kind === 'custom_endpoint' && !allProviderIds.has(record.providerId)) {
+        db.providers.deleteProvider(record.id);
+      }
+    }
+  }
 }
 
 /**
@@ -136,7 +210,8 @@ export function withCustomEndpointsLock<T>(fn: () => Promise<T>): Promise<T> {
 export function registerCustomEndpointHandlers(
   messageHub: MessageHub,
   settingsManager: SettingsManager,
-  internalEventBus: InternalEventBus<DaemonInternalEventMap>
+  internalEventBus: InternalEventBus<DaemonInternalEventMap>,
+  db?: Database
 ): void {
   /** List all configured custom endpoints. */
   messageHub.onRequest('customEndpoints.list', async () => {
@@ -152,7 +227,7 @@ export function registerCustomEndpointHandlers(
         throw new Error(`Custom endpoint '${data.endpoint.id}' already exists`);
       }
       const next = [...current, data.endpoint];
-      await persistAndSync(settingsManager, internalEventBus, next);
+      await persistAndSync(settingsManager, internalEventBus, next, db);
       return { success: true, endpoint: data.endpoint };
     });
   });
@@ -167,7 +242,7 @@ export function registerCustomEndpointHandlers(
         const index = current.findIndex((e) => e.id === data.endpoint.id);
         if (index === -1) throw new Error(`Custom endpoint '${data.endpoint.id}' not found`);
         const next = [...current.slice(0, index), data.endpoint, ...current.slice(index + 1)];
-        await persistAndSync(settingsManager, internalEventBus, next);
+        await persistAndSync(settingsManager, internalEventBus, next, db);
         return { success: true, endpoint: data.endpoint };
       });
     }
@@ -181,7 +256,8 @@ export function registerCustomEndpointHandlers(
       if (next.length === current.length) {
         throw new Error(`Custom endpoint '${data.id}' not found`);
       }
-      await persistAndSync(settingsManager, internalEventBus, next);
+      removeEndpointFromProviderTable(db, data.id);
+      await persistAndSync(settingsManager, internalEventBus, next, db);
       return { success: true };
     });
   });

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -15,7 +15,6 @@ import type { ExternalEventStore } from '../external-events/external-event-store
 import type { ExternalEventService } from '../external-events/external-event-service';
 import type { SessionManager } from '../session-manager';
 import type { AuthManager } from '../auth-manager';
-import type { ProviderCredentialManager } from '../credentials/provider-credential-manager';
 import type { SettingsManager } from '../settings-manager';
 import type { Config } from '../../config';
 import type { Database } from '../../storage/database';
@@ -30,6 +29,8 @@ import { setupCommandHandlers } from './command-handlers';
 import { registerMcpHandlers } from './mcp-handlers';
 import { registerSettingsHandlers } from './settings-handlers';
 import { registerCustomEndpointHandlers } from './custom-endpoint-handlers';
+import { setupProviderHandlers } from './provider-handlers';
+import { ProviderCredentialManager } from '../credentials/provider-credential-manager';
 import { setupConfigHandlers } from './config-handlers';
 import { setupTestHandlers } from './test-handlers';
 import { setupRewindHandlers } from './rewind-handlers';
@@ -422,7 +423,21 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     deps.db,
     deps.mcpImportService
   );
-  registerCustomEndpointHandlers(deps.messageHub, deps.settingsManager, deps.internalEventBus);
+  registerCustomEndpointHandlers(
+    deps.messageHub,
+    deps.settingsManager,
+    deps.internalEventBus,
+    deps.db
+  );
+
+  // Provider registry handlers (unified CRUD over providers table)
+  const providerCredentialManager = ProviderCredentialManager.create(deps.db.getDatabase());
+  setupProviderHandlers({
+    messageHub: deps.messageHub,
+    providerRepo: deps.db.providers,
+    credentialManager: providerCredentialManager,
+  });
+
   setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);
   // Use reactiveDb.db so test-injected sdk_messages rows also invalidate LiveQuery.
   setupTestHandlers(deps.messageHub, deps.reactiveDb.db);

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -431,7 +431,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   );
 
   // Provider registry handlers (unified CRUD over providers table)
-  const providerCredentialManager = ProviderCredentialManager.create(deps.db.getDatabase());
+  const providerCredentialManager =
+    deps.credentialManager ?? ProviderCredentialManager.create(deps.db.getDatabase());
   setupProviderHandlers({
     messageHub: deps.messageHub,
     providerRepo: deps.db.providers,

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -168,9 +168,9 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
             updates.authType = 'api_key';
           } else if (data.credentials.oauthAccessToken) {
             await credentialManager.storeOAuthTokens(existing.providerId, {
-              oauthAccessToken: data.credentials.oauthAccessToken,
-              oauthRefreshToken: data.credentials.oauthRefreshToken,
-              oauthExpiresAt: data.credentials.oauthExpiresAt,
+              accessToken: data.credentials.oauthAccessToken,
+              refreshToken: data.credentials.oauthRefreshToken,
+              expiresAt: data.credentials.oauthExpiresAt,
             });
             updates.authType = 'oauth';
           }

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -1,0 +1,301 @@
+/**
+ * Provider RPC Handlers
+ *
+ * Unified CRUD for the providers table. Bridges persistence, credential storage,
+ * and the live ProviderRegistry so changes take effect immediately.
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type { CreateProviderParams, UpdateProviderParams } from '@neokai/shared';
+import type { ProviderRepository } from '../../storage/repositories/provider-repository';
+import type { ProviderCredentialManager } from '../credentials/provider-credential-manager';
+import { syncProviderToRegistry, removeProviderFromRegistry } from '../providers/provider-sync.js';
+import { getProviderRegistry } from '../providers/registry.js';
+
+const VALID_PROVIDER_KINDS = new Set(['built_in', 'custom_endpoint']);
+const VALID_AUTH_TYPES = new Set(['api_key', 'oauth', 'none']);
+
+function validateCreateParams(params: unknown): asserts params is CreateProviderParams {
+  if (!params || typeof params !== 'object') throw new Error('Invalid provider params');
+  const p = params as Record<string, unknown>;
+  if (!p.providerId || typeof p.providerId !== 'string') throw new Error('providerId is required');
+  if (!p.displayName || typeof p.displayName !== 'string')
+    throw new Error('displayName is required');
+  const kind = typeof p.kind === 'string' ? p.kind : '';
+  if (!VALID_PROVIDER_KINDS.has(kind))
+    throw new Error(`kind must be one of: ${[...VALID_PROVIDER_KINDS].join(', ')}`);
+  const authType = typeof p.authType === 'string' ? p.authType : '';
+  if (!VALID_AUTH_TYPES.has(authType))
+    throw new Error(`authType must be one of: ${[...VALID_AUTH_TYPES].join(', ')}`);
+}
+
+function validateUpdateParams(params: unknown): Partial<UpdateProviderParams> {
+  if (!params || typeof params !== 'object') throw new Error('Invalid provider update params');
+  const p = params as Record<string, unknown>;
+  const out: Partial<UpdateProviderParams> = {};
+  if (p.displayName !== undefined) {
+    if (typeof p.displayName !== 'string') throw new Error('displayName must be a string');
+    out.displayName = p.displayName;
+  }
+  if (p.authType !== undefined) {
+    const authType = typeof p.authType === 'string' ? p.authType : '';
+    if (!VALID_AUTH_TYPES.has(authType)) throw new Error('Invalid authType');
+    out.authType = authType as 'api_key' | 'oauth' | 'none';
+  }
+  if (p.isEnabled !== undefined) out.isEnabled = Boolean(p.isEnabled);
+  if (p.isDefault !== undefined) out.isDefault = Boolean(p.isDefault);
+  if (p.sortOrder !== undefined) out.sortOrder = Number(p.sortOrder);
+  if ('baseUrl' in p) out.baseUrl = p.baseUrl === undefined ? undefined : String(p.baseUrl);
+  if ('configJson' in p)
+    out.configJson = p.configJson === undefined ? undefined : String(p.configJson);
+  if ('customEndpointConfigJson' in p)
+    out.customEndpointConfigJson =
+      p.customEndpointConfigJson === undefined ? undefined : String(p.customEndpointConfigJson);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Mutation lock — serialises all provider mutations
+// ---------------------------------------------------------------------------
+
+let mutationQueue: Promise<unknown> = Promise.resolve();
+
+function withProviderLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = mutationQueue.then(fn, fn);
+  mutationQueue = run.catch(() => {});
+  return run;
+}
+
+// ---------------------------------------------------------------------------
+// Handler wiring
+// ---------------------------------------------------------------------------
+
+export interface ProviderHandlerDeps {
+  messageHub: MessageHub;
+  providerRepo: ProviderRepository;
+  credentialManager: ProviderCredentialManager;
+}
+
+export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
+  const { messageHub, providerRepo, credentialManager } = deps;
+
+  /** List all providers with live auth status from the registry. */
+  messageHub.onRequest('providers.list', async () => {
+    const records = providerRepo.listProviders();
+    const registry = getProviderRegistry();
+    const enriched = await Promise.all(
+      records.map(async (record) => {
+        const provider = registry.get(record.providerId);
+        const available = provider ? await provider.isAvailable() : false;
+        return {
+          ...record,
+          available,
+        };
+      })
+    );
+    return { providers: enriched };
+  });
+
+  /** Get a single provider by id. */
+  messageHub.onRequest('providers.get', async (data: { id: string }) => {
+    const record = providerRepo.getProvider(data.id);
+    if (!record) throw new Error(`Provider ${data.id} not found`);
+    const provider = getProviderRegistry().get(record.providerId);
+    const available = provider ? await provider.isAvailable() : false;
+    return { provider: { ...record, available } };
+  });
+
+  /** Create a provider, store credentials, and register it. */
+  messageHub.onRequest(
+    'providers.create',
+    async (data: {
+      params: CreateProviderParams;
+      credentials?: {
+        apiKey?: string;
+        baseUrl?: string;
+        oauthAccessToken?: string;
+        oauthRefreshToken?: string;
+        oauthExpiresAt?: number;
+      };
+    }) => {
+      return withProviderLock(async () => {
+        validateCreateParams(data.params);
+        const record = providerRepo.createProvider(data.params);
+
+        // Store credentials if provided.
+        if (data.credentials?.apiKey) {
+          await credentialManager.storeApiKey(record.providerId, data.credentials.apiKey);
+        } else if (data.credentials?.oauthAccessToken) {
+          await credentialManager.storeOAuthTokens(record.providerId, {
+            accessToken: data.credentials.oauthAccessToken,
+            refreshToken: data.credentials.oauthRefreshToken,
+            expiresAt: data.credentials.oauthExpiresAt,
+          });
+        }
+
+        // Sync to registry.
+        const creds = await credentialManager.getCredentials(record.providerId);
+        await syncProviderToRegistry(record, creds);
+
+        return { success: true, provider: record };
+      });
+    }
+  );
+
+  /** Update a provider. Re-registers if config changed. */
+  messageHub.onRequest(
+    'providers.update',
+    async (data: {
+      id: string;
+      params: Partial<UpdateProviderParams>;
+      credentials?: {
+        apiKey?: string;
+        baseUrl?: string;
+        oauthAccessToken?: string;
+        oauthRefreshToken?: string;
+        oauthExpiresAt?: number;
+      };
+    }) => {
+      return withProviderLock(async () => {
+        const updates = validateUpdateParams(data.params);
+        const existing = providerRepo.getProvider(data.id);
+        if (!existing) throw new Error(`Provider ${data.id} not found`);
+
+        // Handle credential updates.
+        if (data.credentials) {
+          if (data.credentials.apiKey) {
+            await credentialManager.storeApiKey(existing.providerId, data.credentials.apiKey);
+            updates.authType = 'api_key';
+          } else if (data.credentials.oauthAccessToken) {
+            await credentialManager.storeOAuthTokens(existing.providerId, {
+              oauthAccessToken: data.credentials.oauthAccessToken,
+              oauthRefreshToken: data.credentials.oauthRefreshToken,
+              oauthExpiresAt: data.credentials.oauthExpiresAt,
+            });
+            updates.authType = 'oauth';
+          }
+        }
+
+        const record = providerRepo.updateProvider(data.id, updates);
+        if (!record) throw new Error(`Provider ${data.id} not found`);
+
+        // Re-sync to registry if config or credentials changed.
+        const shouldResync =
+          data.credentials !== undefined ||
+          updates.baseUrl !== undefined ||
+          updates.customEndpointConfigJson !== undefined ||
+          updates.configJson !== undefined;
+
+        if (shouldResync) {
+          const creds = await credentialManager.getCredentials(record.providerId);
+          await syncProviderToRegistry(record, creds);
+        }
+
+        return { success: true, provider: record };
+      });
+    }
+  );
+
+  /** Delete a provider, remove credentials, and unregister. */
+  messageHub.onRequest('providers.delete', async (data: { id: string }) => {
+    return withProviderLock(async () => {
+      const record = providerRepo.getProvider(data.id);
+      if (!record) throw new Error(`Provider ${data.id} not found`);
+
+      await removeProviderFromRegistry(record.providerId);
+      await credentialManager.removeCredentials(record.providerId);
+      providerRepo.deleteProvider(data.id);
+
+      return { success: true };
+    });
+  });
+
+  /** Set a provider as the default. */
+  messageHub.onRequest('providers.setDefault', async (data: { id: string }) => {
+    return withProviderLock(async () => {
+      providerRepo.setDefaultProvider(data.id);
+      return { success: true };
+    });
+  });
+
+  /** Test a single provider and update its health_status. */
+  messageHub.onRequest('providers.test', async (data: { id: string }) => {
+    const record = providerRepo.getProvider(data.id);
+    if (!record) throw new Error(`Provider ${data.id} not found`);
+
+    const provider = getProviderRegistry().get(record.providerId);
+    if (!provider) {
+      providerRepo.updateProvider(data.id, {
+        healthStatus: 'unhealthy',
+        lastHealthCheckAt: Date.now(),
+      });
+      return { healthy: false, error: 'Provider not registered' };
+    }
+
+    try {
+      const available = await provider.isAvailable();
+      if (!available) {
+        providerRepo.updateProvider(data.id, {
+          healthStatus: 'unhealthy',
+          lastHealthCheckAt: Date.now(),
+        });
+        return { healthy: false, error: 'Provider not available' };
+      }
+      await provider.getModels();
+      providerRepo.updateProvider(data.id, {
+        healthStatus: 'healthy',
+        lastHealthCheckAt: Date.now(),
+      });
+      return { healthy: true };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      providerRepo.updateProvider(data.id, {
+        healthStatus: 'unhealthy',
+        lastHealthCheckAt: Date.now(),
+      });
+      return { healthy: false, error };
+    }
+  });
+
+  /** Batch health check for all enabled providers. */
+  messageHub.onRequest('providers.healthCheck', async () => {
+    const records = providerRepo.listEnabledProviders();
+    const registry = getProviderRegistry();
+    const results = await Promise.all(
+      records.map(async (record) => {
+        const provider = registry.get(record.providerId);
+        if (!provider) {
+          providerRepo.updateProvider(record.id, {
+            healthStatus: 'unhealthy',
+            lastHealthCheckAt: Date.now(),
+          });
+          return { providerId: record.providerId, healthy: false, error: 'Not registered' };
+        }
+        try {
+          const available = await provider.isAvailable();
+          if (!available) {
+            providerRepo.updateProvider(record.id, {
+              healthStatus: 'unhealthy',
+              lastHealthCheckAt: Date.now(),
+            });
+            return { providerId: record.providerId, healthy: false, error: 'Not available' };
+          }
+          await provider.getModels();
+          providerRepo.updateProvider(record.id, {
+            healthStatus: 'healthy',
+            lastHealthCheckAt: Date.now(),
+          });
+          return { providerId: record.providerId, healthy: true };
+        } catch (err) {
+          const error = err instanceof Error ? err.message : String(err);
+          providerRepo.updateProvider(record.id, {
+            healthStatus: 'unhealthy',
+            lastHealthCheckAt: Date.now(),
+          });
+          return { providerId: record.providerId, healthy: false, error };
+        }
+      })
+    );
+    return { results };
+  });
+}

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -11,22 +11,41 @@ import type { ProviderRepository } from '../../storage/repositories/provider-rep
 import type { ProviderCredentialManager } from '../credentials/provider-credential-manager';
 import { syncProviderToRegistry, removeProviderFromRegistry } from '../providers/provider-sync.js';
 import { getProviderRegistry } from '../providers/registry.js';
+import { withCustomEndpointsLock } from './custom-endpoint-handlers.js';
 
 const VALID_PROVIDER_KINDS = new Set(['built_in', 'custom_endpoint']);
 const VALID_AUTH_TYPES = new Set(['api_key', 'oauth', 'none']);
+
+const MAX_PROVIDER_ID_LEN = 128;
+const MAX_DISPLAY_NAME_LEN = 256;
+const MAX_BASE_URL_LEN = 2048;
+const MAX_JSON_FIELD_LEN = 64 * 1024;
 
 function validateCreateParams(params: unknown): asserts params is CreateProviderParams {
   if (!params || typeof params !== 'object') throw new Error('Invalid provider params');
   const p = params as Record<string, unknown>;
   if (!p.providerId || typeof p.providerId !== 'string') throw new Error('providerId is required');
+  if (p.providerId.length > MAX_PROVIDER_ID_LEN)
+    throw new Error(`providerId must be ≤ ${MAX_PROVIDER_ID_LEN} chars`);
   if (!p.displayName || typeof p.displayName !== 'string')
     throw new Error('displayName is required');
+  if (p.displayName.length > MAX_DISPLAY_NAME_LEN)
+    throw new Error(`displayName must be ≤ ${MAX_DISPLAY_NAME_LEN} chars`);
   const kind = typeof p.kind === 'string' ? p.kind : '';
   if (!VALID_PROVIDER_KINDS.has(kind))
     throw new Error(`kind must be one of: ${[...VALID_PROVIDER_KINDS].join(', ')}`);
   const authType = typeof p.authType === 'string' ? p.authType : '';
   if (!VALID_AUTH_TYPES.has(authType))
     throw new Error(`authType must be one of: ${[...VALID_AUTH_TYPES].join(', ')}`);
+  if (typeof p.baseUrl === 'string' && p.baseUrl.length > MAX_BASE_URL_LEN)
+    throw new Error(`baseUrl must be ≤ ${MAX_BASE_URL_LEN} chars`);
+  if (typeof p.configJson === 'string' && p.configJson.length > MAX_JSON_FIELD_LEN)
+    throw new Error(`configJson must be ≤ ${MAX_JSON_FIELD_LEN} chars`);
+  if (
+    typeof p.customEndpointConfigJson === 'string' &&
+    p.customEndpointConfigJson.length > MAX_JSON_FIELD_LEN
+  )
+    throw new Error(`customEndpointConfigJson must be ≤ ${MAX_JSON_FIELD_LEN} chars`);
 }
 
 function validateUpdateParams(params: unknown): Partial<UpdateProviderParams> {
@@ -35,6 +54,8 @@ function validateUpdateParams(params: unknown): Partial<UpdateProviderParams> {
   const out: Partial<UpdateProviderParams> = {};
   if (p.displayName !== undefined) {
     if (typeof p.displayName !== 'string') throw new Error('displayName must be a string');
+    if (p.displayName.length > MAX_DISPLAY_NAME_LEN)
+      throw new Error(`displayName must be ≤ ${MAX_DISPLAY_NAME_LEN} chars`);
     out.displayName = p.displayName;
   }
   if (p.authType !== undefined) {
@@ -45,12 +66,25 @@ function validateUpdateParams(params: unknown): Partial<UpdateProviderParams> {
   if (p.isEnabled !== undefined) out.isEnabled = Boolean(p.isEnabled);
   if (p.isDefault !== undefined) out.isDefault = Boolean(p.isDefault);
   if (p.sortOrder !== undefined) out.sortOrder = Number(p.sortOrder);
-  if ('baseUrl' in p) out.baseUrl = p.baseUrl === undefined ? undefined : String(p.baseUrl);
-  if ('configJson' in p)
-    out.configJson = p.configJson === undefined ? undefined : String(p.configJson);
-  if ('customEndpointConfigJson' in p)
-    out.customEndpointConfigJson =
+  if ('baseUrl' in p) {
+    const val = p.baseUrl === undefined ? undefined : String(p.baseUrl);
+    if (val !== undefined && val.length > MAX_BASE_URL_LEN)
+      throw new Error(`baseUrl must be ≤ ${MAX_BASE_URL_LEN} chars`);
+    out.baseUrl = val;
+  }
+  if ('configJson' in p) {
+    const val = p.configJson === undefined ? undefined : String(p.configJson);
+    if (val !== undefined && val.length > MAX_JSON_FIELD_LEN)
+      throw new Error(`configJson must be ≤ ${MAX_JSON_FIELD_LEN} chars`);
+    out.configJson = val;
+  }
+  if ('customEndpointConfigJson' in p) {
+    const val =
       p.customEndpointConfigJson === undefined ? undefined : String(p.customEndpointConfigJson);
+    if (val !== undefined && val.length > MAX_JSON_FIELD_LEN)
+      throw new Error(`customEndpointConfigJson must be ≤ ${MAX_JSON_FIELD_LEN} chars`);
+    out.customEndpointConfigJson = val;
+  }
   return out;
 }
 
@@ -118,24 +152,33 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
         oauthExpiresAt?: number;
       };
     }) => {
-      return withProviderLock(async () => {
+      const lock =
+        data.params.kind === 'custom_endpoint' ? withCustomEndpointsLock : withProviderLock;
+      return lock(async () => {
         validateCreateParams(data.params);
         const record = providerRepo.createProvider(data.params);
 
-        // Store credentials if provided.
-        if (data.credentials?.apiKey) {
-          await credentialManager.storeApiKey(record.providerId, data.credentials.apiKey);
-        } else if (data.credentials?.oauthAccessToken) {
-          await credentialManager.storeOAuthTokens(record.providerId, {
-            accessToken: data.credentials.oauthAccessToken,
-            refreshToken: data.credentials.oauthRefreshToken,
-            expiresAt: data.credentials.oauthExpiresAt,
-          });
-        }
+        try {
+          // Store credentials if provided.
+          if (data.credentials?.apiKey) {
+            await credentialManager.storeApiKey(record.providerId, data.credentials.apiKey);
+          } else if (data.credentials?.oauthAccessToken) {
+            await credentialManager.storeOAuthTokens(record.providerId, {
+              accessToken: data.credentials.oauthAccessToken,
+              refreshToken: data.credentials.oauthRefreshToken,
+              expiresAt: data.credentials.oauthExpiresAt,
+            });
+          }
 
-        // Sync to registry.
-        const creds = await credentialManager.getCredentials(record.providerId);
-        await syncProviderToRegistry(record, creds);
+          // Sync to registry.
+          const creds = await credentialManager.getCredentials(record.providerId);
+          await syncProviderToRegistry(record, creds);
+        } catch (err) {
+          // Compensating delete: remove the orphan DB record so retries don't fail
+          // with 'already exists'.
+          providerRepo.deleteProvider(record.id);
+          throw err;
+        }
 
         return { success: true, provider: record };
       });
@@ -160,51 +203,58 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
         const updates = validateUpdateParams(data.params);
         const existing = providerRepo.getProvider(data.id);
         if (!existing) throw new Error(`Provider ${data.id} not found`);
-
-        // Handle credential updates.
-        if (data.credentials) {
-          if (data.credentials.apiKey) {
-            await credentialManager.storeApiKey(existing.providerId, data.credentials.apiKey);
-            updates.authType = 'api_key';
-          } else if (data.credentials.oauthAccessToken) {
-            await credentialManager.storeOAuthTokens(existing.providerId, {
-              accessToken: data.credentials.oauthAccessToken,
-              refreshToken: data.credentials.oauthRefreshToken,
-              expiresAt: data.credentials.oauthExpiresAt,
-            });
-            updates.authType = 'oauth';
+        const lock =
+          existing.kind === 'custom_endpoint'
+            ? withCustomEndpointsLock
+            : (fn: () => Promise<unknown>) => fn();
+        return lock(async () => {
+          // Handle credential updates.
+          if (data.credentials) {
+            if (data.credentials.apiKey) {
+              await credentialManager.storeApiKey(existing.providerId, data.credentials.apiKey);
+              updates.authType = 'api_key';
+            } else if (data.credentials.oauthAccessToken) {
+              await credentialManager.storeOAuthTokens(existing.providerId, {
+                accessToken: data.credentials.oauthAccessToken,
+                refreshToken: data.credentials.oauthRefreshToken,
+                expiresAt: data.credentials.oauthExpiresAt,
+              });
+              updates.authType = 'oauth';
+            }
           }
-        }
 
-        const record = providerRepo.updateProvider(data.id, updates);
-        if (!record) throw new Error(`Provider ${data.id} not found`);
+          const record = providerRepo.updateProvider(data.id, updates);
+          if (!record) throw new Error(`Provider ${data.id} not found`);
 
-        // Re-sync to registry if config or credentials changed.
-        const shouldResync =
-          data.credentials !== undefined ||
-          updates.baseUrl !== undefined ||
-          updates.customEndpointConfigJson !== undefined ||
-          updates.configJson !== undefined;
+          // Re-sync to registry if config or credentials changed.
+          const shouldResync =
+            data.credentials !== undefined ||
+            updates.baseUrl !== undefined ||
+            updates.customEndpointConfigJson !== undefined ||
+            updates.configJson !== undefined;
 
-        if (shouldResync) {
-          const creds = await credentialManager.getCredentials(record.providerId);
-          await syncProviderToRegistry(record, creds);
-        }
+          if (shouldResync) {
+            const creds = await credentialManager.getCredentials(record.providerId);
+            await syncProviderToRegistry(record, creds);
+          }
 
-        return { success: true, provider: record };
+          return { success: true, provider: record };
+        });
       });
     }
   );
 
   /** Delete a provider, remove credentials, and unregister. */
   messageHub.onRequest('providers.delete', async (data: { id: string }) => {
-    return withProviderLock(async () => {
-      const record = providerRepo.getProvider(data.id);
-      if (!record) throw new Error(`Provider ${data.id} not found`);
-
+    const record = providerRepo.getProvider(data.id);
+    if (!record) throw new Error(`Provider ${data.id} not found`);
+    const lock = record.kind === 'custom_endpoint' ? withCustomEndpointsLock : withProviderLock;
+    return lock(async () => {
+      // DB-first: delete the row before touching the registry so a failure in
+      // credential removal doesn't leave a ghost record that resurrects on restart.
+      providerRepo.deleteProvider(data.id);
       await removeProviderFromRegistry(record.providerId);
       await credentialManager.removeCredentials(record.providerId);
-      providerRepo.deleteProvider(data.id);
 
       return { success: true };
     });

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -47,6 +47,7 @@ import { TransformersAgentMemoryEmbedder } from './repositories/agent-memory-tra
 import { AgentMemoryRepository } from './repositories/agent-memory-repository';
 import { EvolutionRepository } from './repositories/evolution-repository';
 import { GoalAutomationCursorRepository } from './repositories/goal-automation-cursor-repository';
+import { ProviderRepository } from './repositories/provider-repository';
 import type { ReactiveDatabase } from './reactive-database';
 
 export type { SendStatus } from './repositories/sdk-message-repository';
@@ -80,12 +81,18 @@ export { WorkspaceHistoryRepository } from './repositories/workspace-history-rep
 export { AgentMemoryRepository } from './repositories/agent-memory-repository';
 export { EvolutionRepository } from './repositories/evolution-repository';
 export { GoalAutomationCursorRepository } from './repositories/goal-automation-cursor-repository';
+export { ProviderRepository } from './repositories/provider-repository';
 export type { GoalAutomationCursor } from './repositories/goal-automation-cursor-repository';
 export type {
   AgentMemoryEntry,
   AgentMemorySearchResult,
 } from './repositories/agent-memory-repository';
 export type { WorkspaceHistoryRow } from './repositories/workspace-history-repository';
+export type {
+  ProviderRecord,
+  CreateProviderParams,
+  UpdateProviderParams,
+} from '@neokai/shared';
 
 /**
  * Database facade class that maintains backward compatibility with the original Database class.
@@ -112,6 +119,7 @@ export class Database {
   private agentMemoryRepo!: AgentMemoryRepository;
   private evolutionRepo!: EvolutionRepository;
   private goalAutomationCursorRepo!: GoalAutomationCursorRepository;
+  private providerRepo!: ProviderRepository;
   private shortIdAllocator!: ShortIdAllocator;
 
   constructor(dbPath: string) {
@@ -150,6 +158,7 @@ export class Database {
     );
     this.evolutionRepo = new EvolutionRepository(db);
     this.goalAutomationCursorRepo = new GoalAutomationCursorRepository(db);
+    this.providerRepo = new ProviderRepository(db, reactiveDb);
     this.agentMemoryRepo.backfillPendingEmbeddings();
   }
 
@@ -607,6 +616,10 @@ export class Database {
 
   get goalAutomationCursors(): GoalAutomationCursorRepository {
     return this.goalAutomationCursorRepo;
+  }
+
+  get providers(): ProviderRepository {
+    return this.providerRepo;
   }
 
   close(): void {

--- a/packages/daemon/src/storage/repositories/provider-repository.ts
+++ b/packages/daemon/src/storage/repositories/provider-repository.ts
@@ -180,7 +180,9 @@ export class ProviderRepository {
       );
 
     this.reactiveDb.notifyChange('providers');
-    return this.getProvider(id)!;
+    const result = this.getProvider(id);
+    if (!result) throw new Error(`Failed to read provider ${id} after write`);
+    return result;
   }
 
   /**
@@ -247,7 +249,9 @@ export class ProviderRepository {
     }
 
     this.reactiveDb.notifyChange('providers');
-    return this.getProvider(id)!;
+    const result = this.getProvider(id);
+    if (!result) throw new Error(`Failed to read provider ${id} after write`);
+    return result;
   }
 
   /**

--- a/packages/daemon/src/storage/repositories/provider-repository.ts
+++ b/packages/daemon/src/storage/repositories/provider-repository.ts
@@ -1,0 +1,290 @@
+/**
+ * ProviderRepository
+ *
+ * CRUD operations for the unified providers registry.
+ * Each write method calls reactiveDb.notifyChange('providers') so that
+ * LiveQueryEngine can invalidate frontend subscriptions on every change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type { ProviderRecord, CreateProviderParams, UpdateProviderParams } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+import type { SQLiteValue } from '../types';
+
+// ---------------------------------------------------------------------------
+// Internal row type (mirrors SQLite columns)
+// ---------------------------------------------------------------------------
+
+interface ProviderRow {
+  id: string;
+  provider_id: string;
+  display_name: string;
+  kind: string;
+  auth_type: string;
+  is_enabled: number;
+  is_default: number;
+  sort_order: number;
+  base_url: string | null;
+  config_json: string | null;
+  custom_endpoint_config_json: string | null;
+  health_status: string;
+  last_health_check_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rowToRecord(row: ProviderRow): ProviderRecord {
+  return {
+    id: row.id,
+    providerId: row.provider_id,
+    displayName: row.display_name,
+    kind: row.kind as 'built_in' | 'custom_endpoint',
+    authType: row.auth_type as 'api_key' | 'oauth' | 'none',
+    isEnabled: row.is_enabled === 1,
+    isDefault: row.is_default === 1,
+    sortOrder: row.sort_order,
+    baseUrl: row.base_url ?? undefined,
+    configJson: row.config_json ?? undefined,
+    customEndpointConfigJson: row.custom_endpoint_config_json ?? undefined,
+    healthStatus: row.health_status as 'unknown' | 'healthy' | 'unhealthy',
+    lastHealthCheckAt: row.last_health_check_at ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+const VALID_KINDS = new Set(['built_in', 'custom_endpoint']);
+const VALID_AUTH_TYPES = new Set(['api_key', 'oauth', 'none']);
+
+function validateKind(kind: string): void {
+  if (!VALID_KINDS.has(kind)) {
+    throw new Error(`Invalid kind "${kind}". Must be one of: ${[...VALID_KINDS].join(', ')}`);
+  }
+}
+
+function validateAuthType(authType: string): void {
+  if (!VALID_AUTH_TYPES.has(authType)) {
+    throw new Error(
+      `Invalid authType "${authType}". Must be one of: ${[...VALID_AUTH_TYPES].join(', ')}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class ProviderRepository {
+  constructor(
+    private db: BunDatabase,
+    private reactiveDb: ReactiveDatabase
+  ) {}
+
+  /**
+   * List all providers ordered by sort_order ASC.
+   */
+  listProviders(): ProviderRecord[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM providers ORDER BY sort_order ASC, created_at ASC`)
+      .all() as ProviderRow[];
+    return rows.map(rowToRecord);
+  }
+
+  /**
+   * List only enabled providers.
+   */
+  listEnabledProviders(): ProviderRecord[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM providers WHERE is_enabled = 1 ORDER BY sort_order ASC, created_at ASC`
+      )
+      .all() as ProviderRow[];
+    return rows.map(rowToRecord);
+  }
+
+  /**
+   * Get a provider by its UUID PK.
+   */
+  getProvider(id: string): ProviderRecord | null {
+    const row = this.db.prepare(`SELECT * FROM providers WHERE id = ?`).get(id) as
+      | ProviderRow
+      | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  /**
+   * Get a provider by its provider_id (e.g. 'anthropic').
+   */
+  getProviderByProviderId(providerId: string): ProviderRecord | null {
+    const row = this.db.prepare(`SELECT * FROM providers WHERE provider_id = ?`).get(providerId) as
+      | ProviderRow
+      | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  /**
+   * Check whether a provider_id is already taken.
+   */
+  isProviderIdTaken(providerId: string, excludeId?: string): boolean {
+    if (excludeId) {
+      const row = this.db
+        .prepare(`SELECT 1 FROM providers WHERE provider_id = ? AND id != ?`)
+        .get(providerId, excludeId);
+      return row !== null;
+    }
+    const row = this.db.prepare(`SELECT 1 FROM providers WHERE provider_id = ?`).get(providerId);
+    return row !== null;
+  }
+
+  /**
+   * Create a new provider record.
+   */
+  createProvider(params: CreateProviderParams): ProviderRecord {
+    validateKind(params.kind);
+    validateAuthType(params.authType);
+
+    if (this.isProviderIdTaken(params.providerId)) {
+      throw new Error(`Provider "${params.providerId}" already exists`);
+    }
+
+    const id = generateUUID();
+    const now = Date.now();
+
+    this.db
+      .prepare(
+        `INSERT INTO providers
+          (id, provider_id, display_name, kind, auth_type, is_enabled, is_default, sort_order,
+           base_url, config_json, custom_endpoint_config_json, health_status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        id,
+        params.providerId,
+        params.displayName,
+        params.kind,
+        params.authType,
+        (params.isEnabled ?? true) ? 1 : 0,
+        (params.isDefault ?? false) ? 1 : 0,
+        params.sortOrder ?? 0,
+        params.baseUrl ?? null,
+        params.configJson ?? null,
+        params.customEndpointConfigJson ?? null,
+        'unknown',
+        now,
+        now
+      );
+
+    this.reactiveDb.notifyChange('providers');
+    return this.getProvider(id)!;
+  }
+
+  /**
+   * Update an existing provider record. Returns the updated record or null if not found.
+   */
+  updateProvider(id: string, params: UpdateProviderParams): ProviderRecord | null {
+    const existing = this.getProvider(id);
+    if (!existing) return null;
+
+    if (params.authType !== undefined) {
+      validateAuthType(params.authType);
+    }
+
+    const now = Date.now();
+    const fields: string[] = [];
+    const values: SQLiteValue[] = [];
+
+    if (params.displayName !== undefined) {
+      fields.push('display_name = ?');
+      values.push(params.displayName);
+    }
+    if (params.authType !== undefined) {
+      fields.push('auth_type = ?');
+      values.push(params.authType);
+    }
+    if (params.isEnabled !== undefined) {
+      fields.push('is_enabled = ?');
+      values.push(params.isEnabled ? 1 : 0);
+    }
+    if (params.isDefault !== undefined) {
+      fields.push('is_default = ?');
+      values.push(params.isDefault ? 1 : 0);
+    }
+    if (params.sortOrder !== undefined) {
+      fields.push('sort_order = ?');
+      values.push(params.sortOrder);
+    }
+    if ('baseUrl' in params) {
+      fields.push('base_url = ?');
+      values.push(params.baseUrl ?? null);
+    }
+    if ('configJson' in params) {
+      fields.push('config_json = ?');
+      values.push(params.configJson ?? null);
+    }
+    if ('customEndpointConfigJson' in params) {
+      fields.push('custom_endpoint_config_json = ?');
+      values.push(params.customEndpointConfigJson ?? null);
+    }
+    if (params.healthStatus !== undefined) {
+      fields.push('health_status = ?');
+      values.push(params.healthStatus);
+    }
+    if (params.lastHealthCheckAt !== undefined) {
+      fields.push('last_health_check_at = ?');
+      values.push(params.lastHealthCheckAt);
+    }
+
+    if (fields.length > 0) {
+      fields.push('updated_at = ?');
+      values.push(now);
+      values.push(id);
+      this.db.prepare(`UPDATE providers SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+    }
+
+    this.reactiveDb.notifyChange('providers');
+    return this.getProvider(id)!;
+  }
+
+  /**
+   * Delete a provider record. Returns true if a row was deleted.
+   */
+  deleteProvider(id: string): boolean {
+    const result = this.db.prepare(`DELETE FROM providers WHERE id = ?`).run(id);
+    const deleted = result.changes > 0;
+    if (deleted) {
+      this.reactiveDb.notifyChange('providers');
+    }
+    return deleted;
+  }
+
+  /**
+   * Set a provider as the default, clearing is_default on all others.
+   */
+  setDefaultProvider(id: string): void {
+    const existing = this.getProvider(id);
+    if (!existing) throw new Error(`Provider ${id} not found`);
+
+    const tx = this.db.transaction(() => {
+      this.db.prepare(`UPDATE providers SET is_default = 0`).run();
+      this.db.prepare(`UPDATE providers SET is_default = 1 WHERE id = ?`).run(id);
+    });
+    tx();
+
+    this.reactiveDb.notifyChange('providers');
+  }
+
+  /**
+   * Count all provider rows.
+   */
+  countProviders(): number {
+    const row = this.db.prepare(`SELECT COUNT(*) as count FROM providers`).get() as {
+      count: number;
+    };
+    return row.count;
+  }
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -247,6 +247,29 @@ export function createTables(db: BunDatabase): void {
       VALUES (1, '${JSON.stringify(DEFAULT_GLOBAL_SETTINGS)}', datetime('now'))
     `);
 
+  // Providers table - unified provider registry
+  db.exec(`
+      CREATE TABLE IF NOT EXISTS providers (
+        id TEXT PRIMARY KEY,
+        provider_id TEXT UNIQUE NOT NULL,
+        display_name TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK(kind IN ('built_in', 'custom_endpoint')),
+        auth_type TEXT NOT NULL CHECK(auth_type IN ('api_key', 'oauth', 'none')),
+        is_enabled INTEGER NOT NULL DEFAULT 1,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        base_url TEXT,
+        config_json TEXT,
+        custom_endpoint_config_json TEXT,
+        health_status TEXT NOT NULL DEFAULT 'unknown' CHECK(health_status IN ('unknown', 'healthy', 'unhealthy')),
+        last_health_check_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_provider_id ON providers(provider_id)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_sort_order ON providers(sort_order)`);
+
   // Room tables - self-aware architecture foundation
 
   // Rooms table - conceptual workspaces

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -683,6 +683,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
   // Migration 149: Add encrypted provider credentials fallback table.
   runMigration149(db);
+
+  // Migration 150: Create providers table for unified provider registry.
+  runMigration150(db);
 }
 
 /**
@@ -10382,4 +10385,31 @@ export function runMigration149(db: BunDatabase): void {
       updated_at INTEGER NOT NULL
     )
   `);
+}
+
+/**
+ * Migration 150 — Create providers table for unified provider registry.
+ */
+function runMigration150(db: BunDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS providers (
+      id TEXT PRIMARY KEY,
+      provider_id TEXT UNIQUE NOT NULL,
+      display_name TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK(kind IN ('built_in', 'custom_endpoint')),
+      auth_type TEXT NOT NULL CHECK(auth_type IN ('api_key', 'oauth', 'none')),
+      is_enabled INTEGER NOT NULL DEFAULT 1,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      base_url TEXT,
+      config_json TEXT,
+      custom_endpoint_config_json TEXT,
+      health_status TEXT NOT NULL DEFAULT 'unknown' CHECK(health_status IN ('unknown', 'healthy', 'unhealthy')),
+      last_health_check_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_provider_id ON providers(provider_id)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_sort_order ON providers(sort_order)`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for Provider RPC handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import { setupProviderHandlers } from '../../../../src/lib/rpc-handlers/provider-handlers';
+import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
+import { resetProviderFactory } from '../../../../src/lib/providers/factory';
+import type { ProviderRepository } from '../../../../src/storage/repositories/provider-repository';
+import type { ProviderCredentialManager } from '../../../../src/lib/credentials/provider-credential-manager';
+import type { ProviderRecord, CreateProviderParams } from '@neokai/shared';
+import type { Provider } from '@neokai/shared/provider';
+
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockMessageHub(): { hub: MessageHub; handlers: Map<string, RequestHandler> } {
+  const handlers = new Map<string, RequestHandler>();
+  const hub = {
+    onRequest: mock((method: string, handler: RequestHandler) => {
+      handlers.set(method, handler);
+      return () => handlers.delete(method);
+    }),
+  } as unknown as MessageHub;
+  return { hub, handlers };
+}
+
+function createMockProviderRepo(): ProviderRepository {
+  const records = new Map<string, ProviderRecord>();
+  let nextId = 1;
+
+  return {
+    listProviders: () => Array.from(records.values()).sort((a, b) => a.sortOrder - b.sortOrder),
+    listEnabledProviders: () =>
+      Array.from(records.values())
+        .filter((r) => r.isEnabled)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+    getProvider: (id: string) => records.get(id) ?? null,
+    getProviderByProviderId: (providerId: string) =>
+      Array.from(records.values()).find((r) => r.providerId === providerId) ?? null,
+    isProviderIdTaken: (providerId: string) =>
+      Array.from(records.values()).some((r) => r.providerId === providerId),
+    createProvider: (params: CreateProviderParams) => {
+      const id = String(nextId++);
+      const now = Date.now();
+      const record: ProviderRecord = {
+        id,
+        providerId: params.providerId,
+        displayName: params.displayName,
+        kind: params.kind,
+        authType: params.authType,
+        isEnabled: params.isEnabled ?? true,
+        isDefault: params.isDefault ?? false,
+        sortOrder: params.sortOrder ?? 0,
+        baseUrl: params.baseUrl,
+        configJson: params.configJson,
+        customEndpointConfigJson: params.customEndpointConfigJson,
+        healthStatus: 'unknown',
+        createdAt: now,
+        updatedAt: now,
+      };
+      records.set(id, record);
+      return record;
+    },
+    updateProvider: (id: string, params) => {
+      const existing = records.get(id);
+      if (!existing) return null;
+      const updated = { ...existing, ...params, updatedAt: Date.now() };
+      records.set(id, updated);
+      return updated;
+    },
+    deleteProvider: (id: string) => {
+      return records.delete(id);
+    },
+    setDefaultProvider: (id: string) => {
+      for (const r of records.values()) {
+        r.isDefault = r.id === id;
+      }
+    },
+    countProviders: () => records.size,
+  } as unknown as ProviderRepository;
+}
+
+function createMockCredentialManager(): ProviderCredentialManager {
+  const store = new Map<string, string>();
+  return {
+    storeApiKey: mock(async (providerId: string, apiKey: string) => {
+      store.set(providerId, apiKey);
+    }),
+    storeOAuthTokens: mock(async (providerId: string, tokens: object) => {
+      store.set(providerId, JSON.stringify(tokens));
+    }),
+    getCredentials: mock(async (providerId: string) => {
+      const raw = store.get(providerId);
+      return raw ? { apiKey: raw } : null;
+    }),
+    removeCredentials: mock(async (providerId: string) => {
+      store.delete(providerId);
+    }),
+    migrateFromEnv: mock(async () => false),
+  } as unknown as ProviderCredentialManager;
+}
+
+describe('Provider RPC handlers', () => {
+  let hubData: ReturnType<typeof createMockMessageHub>;
+  let repo: ReturnType<typeof createMockProviderRepo>;
+  let creds: ReturnType<typeof createMockCredentialManager>;
+
+  beforeEach(() => {
+    hubData = createMockMessageHub();
+    repo = createMockProviderRepo();
+    creds = createMockCredentialManager();
+    resetProviderRegistry();
+    resetProviderFactory();
+  });
+
+  afterEach(() => {
+    resetProviderRegistry();
+    resetProviderFactory();
+  });
+
+  function setup(): Map<string, RequestHandler> {
+    setupProviderHandlers({
+      messageHub: hubData.hub,
+      providerRepo: repo,
+      credentialManager: creds,
+    });
+    return hubData.handlers;
+  }
+
+  describe('providers.list', () => {
+    it('returns empty array when no providers', async () => {
+      const handlers = setup();
+      const result = (await handlers.get('providers.list')!({}, {})) as {
+        providers: ProviderRecord[];
+      };
+      expect(result.providers).toEqual([]);
+    });
+
+    it('returns providers with availability', async () => {
+      repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.list')!({}, {})) as {
+        providers: Array<ProviderRecord & { available: boolean }>;
+      };
+      expect(result.providers.length).toBe(1);
+      expect(result.providers[0].providerId).toBe('anthropic');
+    });
+  });
+
+  describe('providers.create', () => {
+    it('creates a provider and stores credentials', async () => {
+      const handlers = setup();
+      const result = (await handlers.get('providers.create')!(
+        {
+          params: {
+            providerId: 'openrouter',
+            displayName: 'OpenRouter',
+            kind: 'built_in',
+            authType: 'api_key',
+          },
+          credentials: { apiKey: 'sk-or-test' },
+        },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(result.provider.providerId).toBe('openrouter');
+      expect(creds.storeApiKey).toHaveBeenCalledWith('openrouter', 'sk-or-test');
+    });
+
+    it('rejects invalid kind', async () => {
+      const handlers = setup();
+      await expect(
+        handlers.get('providers.create')!(
+          {
+            params: {
+              providerId: 'x',
+              displayName: 'X',
+              kind: 'invalid',
+              authType: 'api_key',
+            },
+          },
+          {}
+        )
+      ).rejects.toThrow('kind must be one of');
+    });
+  });
+
+  describe('providers.update', () => {
+    it('updates display name', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.update')!(
+        { id: created.id, params: { displayName: 'Anthropic Inc' } },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(result.provider.displayName).toBe('Anthropic Inc');
+    });
+  });
+
+  describe('providers.delete', () => {
+    it('deletes a provider', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.delete')!({ id: created.id }, {})) as {
+        success: boolean;
+      };
+
+      expect(result.success).toBe(true);
+      expect(repo.getProvider(created.id)).toBeNull();
+    });
+
+    it('throws when provider not found', async () => {
+      const handlers = setup();
+      await expect(handlers.get('providers.delete')!({ id: 'missing' }, {})).rejects.toThrow(
+        'not found'
+      );
+    });
+  });
+
+  describe('providers.setDefault', () => {
+    it('sets default provider', async () => {
+      const a = repo.createProvider({
+        providerId: 'a',
+        displayName: 'A',
+        kind: 'built_in',
+        authType: 'none',
+      });
+      const b = repo.createProvider({
+        providerId: 'b',
+        displayName: 'B',
+        kind: 'built_in',
+        authType: 'none',
+      });
+      const handlers = setup();
+
+      await handlers.get('providers.setDefault')!({ id: b.id }, {});
+      expect(repo.getProvider(a.id)?.isDefault).toBe(false);
+      expect(repo.getProvider(b.id)?.isDefault).toBe(true);
+    });
+  });
+
+  describe('providers.test', () => {
+    it('returns healthy for available provider', async () => {
+      repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'anthropic',
+        displayName: 'Anthropic',
+        capabilities: {
+          streaming: true,
+          extendedThinking: true,
+          thinkingModes: 'granular',
+          maxContextWindow: 200000,
+          functionCalling: true,
+          vision: true,
+        },
+        isAvailable: () => true,
+        getModels: async () => [],
+        ownsModel: () => true,
+        getModelForTier: () => 'sonnet',
+        buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+      } as Provider);
+
+      const handlers = setup();
+      const result = (await handlers.get('providers.test')!(
+        { id: repo.listProviders()[0].id },
+        {}
+      )) as {
+        healthy: boolean;
+      };
+
+      expect(result.healthy).toBe(true);
+    });
+
+    it('returns unhealthy for missing provider', async () => {
+      const created = repo.createProvider({
+        providerId: 'missing',
+        displayName: 'Missing',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.test')!({ id: created.id }, {})) as {
+        healthy: boolean;
+        error: string;
+      };
+
+      expect(result.healthy).toBe(false);
+    });
+  });
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
@@ -92,7 +92,16 @@ function createMockCredentialManager(): ProviderCredentialManager {
     }),
     getCredentials: mock(async (providerId: string) => {
       const raw = store.get(providerId);
-      return raw ? { apiKey: raw } : null;
+      if (!raw) return null;
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed.accessToken !== undefined) {
+          return { type: 'oauth' as const, accessToken: parsed.accessToken };
+        }
+      } catch {
+        // not JSON, treat as api key
+      }
+      return { type: 'api_key' as const, apiKey: raw };
     }),
     removeCredentials: mock(async (providerId: string) => {
       store.delete(providerId);
@@ -258,6 +267,193 @@ describe('Provider RPC handlers', () => {
     });
   });
 
+  describe('providers.create', () => {
+    it('creates a provider and stores apiKey credentials', async () => {
+      const handlers = setup();
+      const result = (await handlers.get('providers.create')!(
+        {
+          params: {
+            providerId: 'openrouter',
+            displayName: 'OpenRouter',
+            kind: 'built_in',
+            authType: 'api_key',
+          },
+          credentials: { apiKey: 'sk-or-test' },
+        },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(result.provider.providerId).toBe('openrouter');
+      expect(creds.storeApiKey).toHaveBeenCalledWith('openrouter', 'sk-or-test');
+    });
+
+    it('creates a provider and stores OAuth credentials', async () => {
+      const handlers = setup();
+      const result = (await handlers.get('providers.create')!(
+        {
+          params: {
+            providerId: 'anthropic-codex',
+            displayName: 'OpenAI (Codex)',
+            kind: 'built_in',
+            authType: 'oauth',
+          },
+          credentials: {
+            oauthAccessToken: 'tok-test',
+            oauthRefreshToken: 'ref-test',
+            oauthExpiresAt: 12345678,
+          },
+        },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(creds.storeOAuthTokens).toHaveBeenCalledWith('anthropic-codex', {
+        accessToken: 'tok-test',
+        refreshToken: 'ref-test',
+        expiresAt: 12345678,
+      });
+    });
+
+    it('rejects invalid kind', async () => {
+      const handlers = setup();
+      await expect(
+        handlers.get('providers.create')!(
+          {
+            params: {
+              providerId: 'x',
+              displayName: 'X',
+              kind: 'invalid',
+              authType: 'api_key',
+            },
+          },
+          {}
+        )
+      ).rejects.toThrow('kind must be one of');
+    });
+  });
+
+  describe('providers.get', () => {
+    it('returns a provider by id with availability', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.get')!({ id: created.id }, {})) as {
+        provider: ProviderRecord & { available: boolean };
+      };
+
+      expect(result.provider.providerId).toBe('anthropic');
+      expect(result.provider.available).toBe(false);
+    });
+
+    it('throws when provider not found', async () => {
+      const handlers = setup();
+      await expect(handlers.get('providers.get')!({ id: 'missing' }, {})).rejects.toThrow(
+        'not found'
+      );
+    });
+  });
+
+  describe('providers.update', () => {
+    it('updates display name', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.update')!(
+        { id: created.id, params: { displayName: 'Anthropic Inc' } },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(result.provider.displayName).toBe('Anthropic Inc');
+    });
+
+    it('updates OAuth credentials', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic-codex',
+        displayName: 'OpenAI (Codex)',
+        kind: 'built_in',
+        authType: 'none',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.update')!(
+        {
+          id: created.id,
+          params: {},
+          credentials: {
+            oauthAccessToken: 'new-tok',
+            oauthRefreshToken: 'new-ref',
+            oauthExpiresAt: 87654321,
+          },
+        },
+        {}
+      )) as { success: boolean; provider: ProviderRecord };
+
+      expect(result.success).toBe(true);
+      expect(result.provider.authType).toBe('oauth');
+      expect(creds.storeOAuthTokens).toHaveBeenCalledWith('anthropic-codex', {
+        accessToken: 'new-tok',
+        refreshToken: 'new-ref',
+        expiresAt: 87654321,
+      });
+    });
+  });
+
+  describe('providers.delete', () => {
+    it('deletes a provider', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      const result = (await handlers.get('providers.delete')!({ id: created.id }, {})) as {
+        success: boolean;
+      };
+
+      expect(result.success).toBe(true);
+      expect(repo.getProvider(created.id)).toBeNull();
+    });
+
+    it('throws when provider not found', async () => {
+      const handlers = setup();
+      await expect(handlers.get('providers.delete')!({ id: 'missing' }, {})).rejects.toThrow(
+        'not found'
+      );
+    });
+  });
+
+  describe('providers.setDefault', () => {
+    it('sets default provider', async () => {
+      const a = repo.createProvider({
+        providerId: 'a',
+        displayName: 'A',
+        kind: 'built_in',
+        authType: 'none',
+      });
+      const b = repo.createProvider({
+        providerId: 'b',
+        displayName: 'B',
+        kind: 'built_in',
+        authType: 'none',
+      });
+      const handlers = setup();
+
+      await handlers.get('providers.setDefault')!({ id: b.id }, {});
+      expect(repo.getProvider(a.id)?.isDefault).toBe(false);
+      expect(repo.getProvider(b.id)?.isDefault).toBe(true);
+    });
+  });
+
   describe('providers.test', () => {
     it('returns healthy for available provider', async () => {
       repo.createProvider({
@@ -310,6 +506,125 @@ describe('Provider RPC handlers', () => {
       };
 
       expect(result.healthy).toBe(false);
+    });
+  });
+
+  describe('providers.healthCheck', () => {
+    it('returns healthy results for available providers', async () => {
+      repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      repo.createProvider({
+        providerId: 'openrouter',
+        displayName: 'OpenRouter',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'anthropic',
+        displayName: 'Anthropic',
+        capabilities: {
+          streaming: true,
+          extendedThinking: true,
+          thinkingModes: 'granular',
+          maxContextWindow: 200000,
+          functionCalling: true,
+          vision: true,
+        },
+        isAvailable: () => true,
+        getModels: async () => [],
+        ownsModel: () => true,
+        getModelForTier: () => 'sonnet',
+        buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+      } as Provider);
+
+      const handlers = setup();
+      const result = (await handlers.get('providers.healthCheck')!({}, {})) as {
+        results: Array<{ providerId: string; healthy: boolean; error?: string }>;
+      };
+
+      expect(result.results.length).toBe(2);
+      const anthropic = result.results.find((r) => r.providerId === 'anthropic');
+      const openrouter = result.results.find((r) => r.providerId === 'openrouter');
+      expect(anthropic?.healthy).toBe(true);
+      expect(openrouter?.healthy).toBe(false);
+      expect(openrouter?.error).toBe('Not registered');
+    });
+
+    it('returns unhealthy when provider is not available', async () => {
+      repo.createProvider({
+        providerId: 'unavailable',
+        displayName: 'Unavailable',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'unavailable',
+        displayName: 'Unavailable',
+        capabilities: {
+          streaming: true,
+          extendedThinking: false,
+          thinkingModes: 'off',
+          maxContextWindow: 1000,
+          functionCalling: false,
+          vision: false,
+        },
+        isAvailable: () => false,
+        getModels: async () => [],
+        ownsModel: () => true,
+        getModelForTier: () => 'default',
+        buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+      } as Provider);
+
+      const handlers = setup();
+      const result = (await handlers.get('providers.healthCheck')!({}, {})) as {
+        results: Array<{ providerId: string; healthy: boolean; error?: string }>;
+      };
+
+      expect(result.results[0].healthy).toBe(false);
+      expect(result.results[0].error).toBe('Not available');
+    });
+
+    it('returns unhealthy when getModels throws', async () => {
+      repo.createProvider({
+        providerId: 'broken',
+        displayName: 'Broken',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const registry = getProviderRegistry();
+      registry.register({
+        id: 'broken',
+        displayName: 'Broken',
+        capabilities: {
+          streaming: true,
+          extendedThinking: false,
+          thinkingModes: 'off',
+          maxContextWindow: 1000,
+          functionCalling: false,
+          vision: false,
+        },
+        isAvailable: () => true,
+        getModels: async () => {
+          throw new Error('model fetch failed');
+        },
+        ownsModel: () => true,
+        getModelForTier: () => 'default',
+        buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+      } as Provider);
+
+      const handlers = setup();
+      const result = (await handlers.get('providers.healthCheck')!({}, {})) as {
+        results: Array<{ providerId: string; healthy: boolean; error?: string }>;
+      };
+
+      expect(result.results[0].healthy).toBe(false);
+      expect(result.results[0].error).toBe('model fetch failed');
     });
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/credential-store.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/credential-store.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Credential store tests
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { DatabaseCredentialStore } from '../../../src/lib/credentials/credential-store';
+
+describe('DatabaseCredentialStore', () => {
+  let db: Database;
+  let store: DatabaseCredentialStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    store = new DatabaseCredentialStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('round-trips a credential', async () => {
+    await store.set('test-service', 'test-account', 'secret-value');
+    const got = await store.get('test-service', 'test-account');
+    expect(got).toBe('secret-value');
+  });
+
+  it('returns null for missing credential', async () => {
+    const got = await store.get('test-service', 'missing');
+    expect(got).toBeNull();
+  });
+
+  it('deletes a credential', async () => {
+    await store.set('test-service', 'test-account', 'secret');
+    await store.delete('test-service', 'test-account');
+    const got = await store.get('test-service', 'test-account');
+    expect(got).toBeNull();
+  });
+
+  it('updates an existing credential', async () => {
+    await store.set('svc', 'acct', 'v1');
+    await store.set('svc', 'acct', 'v2');
+    const got = await store.get('svc', 'acct');
+    expect(got).toBe('v2');
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/provider-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/provider-repository.test.ts
@@ -1,0 +1,153 @@
+/**
+ * ProviderRepository tests
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createTables } from '../../../src/storage/schema/index';
+import { createReactiveDatabase } from '../../../src/storage/reactive-database';
+import { ProviderRepository } from '../../../src/storage/repositories/provider-repository';
+
+describe('ProviderRepository', () => {
+  let db: Database;
+  let reactiveDb: ReturnType<typeof createReactiveDatabase>;
+  let repo: ProviderRepository;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createTables(db);
+    reactiveDb = createReactiveDatabase({
+      getDatabase: () => db,
+    } as unknown as import('../../../src/storage/database').Database);
+    repo = new ProviderRepository(db, reactiveDb);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates a provider', () => {
+    const record = repo.createProvider({
+      providerId: 'anthropic',
+      displayName: 'Anthropic',
+      kind: 'built_in',
+      authType: 'api_key',
+    });
+
+    expect(record.providerId).toBe('anthropic');
+    expect(record.displayName).toBe('Anthropic');
+    expect(record.isEnabled).toBe(true);
+    expect(record.isDefault).toBe(false);
+    expect(record.healthStatus).toBe('unknown');
+  });
+
+  it('lists providers ordered by sort_order', () => {
+    repo.createProvider({
+      providerId: 'b',
+      displayName: 'B',
+      kind: 'built_in',
+      authType: 'none',
+      sortOrder: 2,
+    });
+    repo.createProvider({
+      providerId: 'a',
+      displayName: 'A',
+      kind: 'built_in',
+      authType: 'none',
+      sortOrder: 1,
+    });
+
+    const list = repo.listProviders();
+    expect(list.map((r) => r.providerId)).toEqual(['a', 'b']);
+  });
+
+  it('gets provider by id and by providerId', () => {
+    const created = repo.createProvider({
+      providerId: 'anthropic',
+      displayName: 'Anthropic',
+      kind: 'built_in',
+      authType: 'api_key',
+    });
+
+    expect(repo.getProvider(created.id)?.providerId).toBe('anthropic');
+    expect(repo.getProviderByProviderId('anthropic')?.id).toBe(created.id);
+    expect(repo.getProviderByProviderId('missing')).toBeNull();
+  });
+
+  it('updates a provider', () => {
+    const created = repo.createProvider({
+      providerId: 'anthropic',
+      displayName: 'Anthropic',
+      kind: 'built_in',
+      authType: 'api_key',
+    });
+
+    const updated = repo.updateProvider(created.id, {
+      displayName: 'Anthropic Inc',
+      healthStatus: 'healthy',
+    });
+    expect(updated?.displayName).toBe('Anthropic Inc');
+    expect(updated?.healthStatus).toBe('healthy');
+  });
+
+  it('update returns null for missing provider', () => {
+    expect(repo.updateProvider('missing', { displayName: 'X' })).toBeNull();
+  });
+
+  it('deletes a provider', () => {
+    const created = repo.createProvider({
+      providerId: 'anthropic',
+      displayName: 'Anthropic',
+      kind: 'built_in',
+      authType: 'api_key',
+    });
+
+    expect(repo.deleteProvider(created.id)).toBe(true);
+    expect(repo.getProvider(created.id)).toBeNull();
+    expect(repo.deleteProvider(created.id)).toBe(false);
+  });
+
+  it('setDefaultProvider clears others', () => {
+    const a = repo.createProvider({
+      providerId: 'a',
+      displayName: 'A',
+      kind: 'built_in',
+      authType: 'none',
+      isDefault: true,
+    });
+    const b = repo.createProvider({
+      providerId: 'b',
+      displayName: 'B',
+      kind: 'built_in',
+      authType: 'none',
+    });
+
+    expect(repo.getProvider(a.id)?.isDefault).toBe(true);
+    repo.setDefaultProvider(b.id);
+    expect(repo.getProvider(a.id)?.isDefault).toBe(false);
+    expect(repo.getProvider(b.id)?.isDefault).toBe(true);
+  });
+
+  it('rejects duplicate providerId', () => {
+    repo.createProvider({
+      providerId: 'anthropic',
+      displayName: 'Anthropic',
+      kind: 'built_in',
+      authType: 'api_key',
+    });
+    expect(() => {
+      repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic 2',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+    }).toThrow('already exists');
+  });
+
+  it('countProviders returns correct count', () => {
+    expect(repo.countProviders()).toBe(0);
+    repo.createProvider({ providerId: 'a', displayName: 'A', kind: 'built_in', authType: 'none' });
+    expect(repo.countProviders()).toBe(1);
+  });
+});

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -29,6 +29,7 @@ export * from './types/app-mcp-server.ts';
 export * from './types/mcp-enablement.ts';
 export * from './types/skills.ts';
 export * from './types/reference.ts';
+export * from './types/provider-record.ts';
 export * from './live-query-types.ts';
 export * from './validation/workspace-path.ts';
 export * from './lib/workflow-graph.ts';

--- a/packages/shared/src/provider/index.ts
+++ b/packages/shared/src/provider/index.ts
@@ -6,6 +6,7 @@ export type {
   Provider,
   ProviderCapabilities,
   ProviderContext,
+  ProviderCredentials,
   ProviderId,
   ProviderInfo,
   ProviderCredentials,

--- a/packages/shared/src/provider/index.ts
+++ b/packages/shared/src/provider/index.ts
@@ -9,7 +9,6 @@ export type {
   ProviderCredentials,
   ProviderId,
   ProviderInfo,
-  ProviderCredentials,
   ProviderSdkConfig,
   ProviderSessionConfig,
   ModelTier,

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -258,14 +258,6 @@ export interface Provider {
    * thinking for this model.
    */
   getModelThinkingMode?(modelId: string): 'off' | 'on' | 'granular' | undefined;
-
-  /**
-   * Optional: Inject credentials discovered from the providers table or
-   * keychain store. When set, `isAvailable()` should prefer these credentials
-   * over environment variables so the unified provider registry is the source
-   * of truth.
-   */
-  setCredentials?(credentials: ProviderCredentials): void;
 }
 
 /**

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -258,6 +258,26 @@ export interface Provider {
    * thinking for this model.
    */
   getModelThinkingMode?(modelId: string): 'off' | 'on' | 'granular' | undefined;
+
+  /**
+   * Optional: Inject credentials discovered from the providers table or
+   * keychain store. When set, `isAvailable()` should prefer these credentials
+   * over environment variables so the unified provider registry is the source
+   * of truth.
+   */
+  setCredentials?(credentials: ProviderCredentials): void;
+}
+
+/**
+ * Credentials passed to a provider via `setCredentials()`.
+ * Not all fields are used by every provider.
+ */
+export interface ProviderCredentials {
+  apiKey?: string;
+  baseUrl?: string;
+  oauthAccessToken?: string;
+  oauthRefreshToken?: string;
+  oauthExpiresAt?: number;
 }
 
 /**

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -269,18 +269,6 @@ export interface Provider {
 }
 
 /**
- * Credentials passed to a provider via `setCredentials()`.
- * Not all fields are used by every provider.
- */
-export interface ProviderCredentials {
-  apiKey?: string;
-  baseUrl?: string;
-  oauthAccessToken?: string;
-  oauthRefreshToken?: string;
-  oauthExpiresAt?: number;
-}
-
-/**
  * Provider context created for a session
  * Encapsulates provider-specific configuration for query building
  */

--- a/packages/shared/src/types/provider-record.ts
+++ b/packages/shared/src/types/provider-record.ts
@@ -1,0 +1,50 @@
+/**
+ * Provider record types for the unified providers table.
+ *
+ * Replaces the split between built-in providers (env-only) and custom endpoints
+ * (JSON blob in global_settings) with a single persisted registry.
+ */
+
+export interface ProviderRecord {
+  id: string;
+  providerId: string;
+  displayName: string;
+  kind: 'built_in' | 'custom_endpoint';
+  authType: 'api_key' | 'oauth' | 'none';
+  isEnabled: boolean;
+  isDefault: boolean;
+  sortOrder: number;
+  baseUrl?: string;
+  configJson?: string;
+  customEndpointConfigJson?: string;
+  healthStatus: 'unknown' | 'healthy' | 'unhealthy';
+  lastHealthCheckAt?: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreateProviderParams {
+  providerId: string;
+  displayName: string;
+  kind: 'built_in' | 'custom_endpoint';
+  authType: 'api_key' | 'oauth' | 'none';
+  isEnabled?: boolean;
+  isDefault?: boolean;
+  sortOrder?: number;
+  baseUrl?: string;
+  configJson?: string;
+  customEndpointConfigJson?: string;
+}
+
+export interface UpdateProviderParams {
+  displayName?: string;
+  authType?: 'api_key' | 'oauth' | 'none';
+  isEnabled?: boolean;
+  isDefault?: boolean;
+  sortOrder?: number;
+  baseUrl?: string;
+  configJson?: string;
+  customEndpointConfigJson?: string;
+  healthStatus?: 'unknown' | 'healthy' | 'unhealthy';
+  lastHealthCheckAt?: number;
+}


### PR DESCRIPTION
## Summary

Wires a unified `providers` table into the daemon with full CRUD RPCs, keychain-backed credential storage, one-time migration from env vars/auth files, and custom endpoint compat layer.

### What's new

- **Schema**: `providers` table (migration 148) + `provider_credentials` encrypted fallback table
- **Shared types**: `ProviderRecord`, `CreateProviderParams`, `UpdateProviderParams`, `ProviderCredentials`
- **Repository**: `ProviderRepository` with reactive DB notifications
- **Credential store**: `KeychainCredentialStore` (macOS) + `DatabaseCredentialStore` (AES-256-GCM fallback)
- **ProviderCredentialManager**: high-level storeApiKey / storeOAuthTokens / getCredentials / removeCredentials
- **Provider sync**: `syncProviderToRegistry`, `syncAllProviders`, `removeProviderFromRegistry`
- **RPC handlers**: `providers.list`, `.get`, `.create`, `.update`, `.delete`, `.setDefault`, `.test`, `.healthCheck`
- **Migration**: `migrateProvidersIfNeeded` scans env vars → `~/.neokai/auth.json` → `global_settings.customEndpoints`
- **Compat layer**: custom endpoint mutations also write to the `providers` table
- **Startup wiring**: app.ts calls migrate → sync custom endpoints → sync all providers

### Verification

- Fresh install with `ANTHROPIC_API_KEY` env: migration creates row, `providers.list` returns it
- Existing install with custom endpoints: migration creates records
- `providers.create` with API key: keychain stored, row inserted, provider registered
- `providers.delete`: unregistered, bridges stopped, keychain deleted
- `providers.update` changing base URL: provider re-registered
- `providers.test`: `{ healthy: true }` for valid creds, `{ healthy: false }` for invalid
- Old `customEndpoints.list` still works via compat layer
- All existing tests pass (auth-handlers pre-existing failures unchanged)