### PR TITLE
fix(web): prevent stale onInput from restoring draft after send

### DIFF
--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -447,27 +447,29 @@ export default function MessageInput({
         textareaInputRef.current.value = '';
       }
 
-      // Send message with images; a boolean false return signals failure
-      const result = await onSend(savedContent, outgoing.images, deliveryMode);
+      try {
+        // Send message with images; a boolean false return signals failure
+        const result = await onSend(savedContent, outgoing.images, deliveryMode);
 
-      submittingRef.current = false;
-
-      if (result === false) {
-        // Restore the draft and attachments so the user doesn't lose their work
-        setContent(savedContent);
-        if (savedAttachments.length > 0) {
-          restoreAttachments(savedAttachments);
+        if (result === false) {
+          // Restore the draft and attachments so the user doesn't lose their work
+          setContent(savedContent);
+          if (savedAttachments.length > 0) {
+            restoreAttachments(savedAttachments);
+          }
+          return;
         }
-        return;
-      }
 
-      if (
-        agentWorking ||
-        deliveryMode === 'defer' ||
-        queuedForCurrentTurn.length > 0 ||
-        queuedForNextTurn.length > 0
-      ) {
-        await refreshQueuedMessages();
+        if (
+          agentWorking ||
+          deliveryMode === 'defer' ||
+          queuedForCurrentTurn.length > 0 ||
+          queuedForNextTurn.length > 0
+        ) {
+          await refreshQueuedMessages();
+        }
+      } finally {
+        submittingRef.current = false;
       }
     },
     [

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -117,6 +117,9 @@ export default function MessageInput({
   // Textarea ref for programmatic focus after reference selection
   const textareaInputRef = useRef<HTMLTextAreaElement>(null);
 
+  // Guard against stale onInput events racing with submit/clear
+  const submittingRef = useRef(false);
+
   // Use shared hooks
   const { content, setContent, clear: clearDraft } = useInputDraft(sessionId);
   const {
@@ -195,6 +198,9 @@ export default function MessageInput({
   // Wrap setContent to detect @-mentions
   const handleContentChange = useCallback(
     (value: string) => {
+      // Drop stale onInput events that race with submit/clear
+      if (submittingRef.current) return;
+
       // Track cursor position via the textarea ref
       const cursor = textareaInputRef.current?.selectionStart ?? value.length;
       lastCursorRef.current = cursor;
@@ -429,12 +435,23 @@ export default function MessageInput({
       const savedContent = outgoing.content;
       const savedAttachments = attachments;
 
+      // Guard against stale onInput events racing with clear/useLayoutEffect
+      submittingRef.current = true;
+
       // Clear UI optimistically
       clearDraft();
       clearAttachments();
 
+      // Immediately clear textarea DOM — don't wait for batched useLayoutEffect
+      if (textareaInputRef.current) {
+        textareaInputRef.current.value = '';
+      }
+
       // Send message with images; a boolean false return signals failure
       const result = await onSend(savedContent, outgoing.images, deliveryMode);
+
+      submittingRef.current = false;
+
       if (result === false) {
         // Restore the draft and attachments so the user doesn't lose their work
         setContent(savedContent);

--- a/packages/web/src/components/__tests__/MessageInput.submit-race.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.submit-race.test.tsx
@@ -265,6 +265,40 @@ describe('MessageInput submit race condition', () => {
       // Void return = success; should NOT restore
       expect(mockSetContent).not.toHaveBeenCalledWith('hello world');
     });
+
+    it('resets submittingRef so textarea stays functional when onSend throws', async () => {
+      mockDraftContent = 'hello world';
+      const onSend = vi.fn(async () => {
+        throw new Error('network failure');
+      });
+
+      // Swallow unhandled rejection from fire-and-forget async submit
+      const unhandledHandler = (reason: unknown) => {
+        if (reason instanceof Error && reason.message === 'network failure') {
+          // swallowed
+        } else {
+          process.removeListener('unhandledRejection', unhandledHandler);
+          throw reason;
+        }
+      };
+      process.on('unhandledRejection', unhandledHandler);
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Give the unhandled rejection a tick to surface
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Textarea must remain functional — submittingRef should have reset
+      mockSetContent.mockClear();
+      fireEvent.input(textarea, { target: { value: 'typed after error' } });
+      expect(mockSetContent).toHaveBeenCalledWith('typed after error');
+
+      process.removeListener('unhandledRejection', unhandledHandler);
+    });
   });
 
   describe('send called with correct arguments', () => {

--- a/packages/web/src/components/__tests__/MessageInput.submit-race.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.submit-race.test.tsx
@@ -1,0 +1,292 @@
+// @ts-nocheck
+/**
+ * Tests for MessageInput submit/clear race condition fix.
+ *
+ * ROOT CAUSE:
+ * The textarea is uncontrolled (no value={content} prop). Content is synced to
+ * the DOM via useLayoutEffect in InputTextarea. When handleSubmit fires:
+ *
+ *   1. clearDraft() sets contentSignal.value = ''
+ *   2. textarea.value still has old content (useLayoutEffect hasn't flushed)
+ *   3. await onSend(...) yields; Preact flushes; useLayoutEffect syncs ''
+ *
+ * Between steps 1 and 3, a browser onInput event can read the stale
+ * textarea.value and call handleContentChange → setContent, restoring the old
+ * content into the signal. The "single letter" is the last keystroke already
+ * inserted into textarea.value before the keydown handler ran.
+ *
+ * FIX:
+ *   1. submittingRef guard — set true before clear, checked in
+ *      handleContentChange to ignore stale onInput events
+ *   2. Direct DOM clear — set textarea.value = '' immediately in handleSubmit
+ *      instead of waiting for batched useLayoutEffect
+ */
+
+import { signal } from '@preact/signals';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAgentWorking = signal(false);
+let mockDraftContent = '';
+
+const mockSetContent = vi.fn(() => {});
+const mockClearDraft = vi.fn(() => {});
+const mockClearAttachments = vi.fn(() => {});
+const mockRestoreAttachments = vi.fn(() => {});
+const mockGetImagesForSend = vi.fn(() => undefined);
+const mockRequest = vi.fn(async () => ({ messages: [] }));
+
+let mockReferenceShowAutocomplete = false;
+const mockReferenceHandleKeyDown = vi.fn(() => false);
+
+let mockCommandShowAutocomplete = false;
+const mockCommandHandleKeyDown = vi.fn(() => false);
+
+vi.mock('../../lib/state.ts', () => ({
+  get isAgentWorking() {
+    return {
+      get value() {
+        return mockAgentWorking.value;
+      },
+    };
+  },
+}));
+
+vi.mock('../../hooks', () => ({
+  useInputDraft: () => ({
+    content: mockDraftContent,
+    setContent: mockSetContent,
+    clear: mockClearDraft,
+  }),
+  useModelSwitcher: () => ({
+    currentModel: 'mock-model',
+    currentModelInfo: null,
+    availableModels: [],
+    switching: false,
+    loading: false,
+    switchModel: vi.fn(async () => {}),
+  }),
+  useModal: () => ({
+    isOpen: false,
+    toggle: vi.fn(() => {}),
+    close: vi.fn(() => {}),
+  }),
+  useCommandAutocomplete: () => ({
+    showAutocomplete: mockCommandShowAutocomplete,
+    filteredCommands: [],
+    selectedIndex: 0,
+    handleSelect: vi.fn(() => {}),
+    close: vi.fn(() => {}),
+    handleKeyDown: mockCommandHandleKeyDown,
+  }),
+  useReferenceAutocomplete: () => ({
+    showAutocomplete: mockReferenceShowAutocomplete,
+    results: [],
+    selectedIndex: 0,
+    searchQuery: '',
+    handleSelect: vi.fn(() => {}),
+    close: vi.fn(() => {}),
+    handleKeyDown: mockReferenceHandleKeyDown,
+  }),
+  extractActiveAtQuery: vi.fn(() => null),
+  useFileAttachments: () => ({
+    attachments: [],
+    fileInputRef: { current: null },
+    handleFileSelect: vi.fn(() => {}),
+    handleFileDrop: vi.fn(async () => {}),
+    handleRemove: vi.fn(() => {}),
+    clear: mockClearAttachments,
+    restore: mockRestoreAttachments,
+    openFilePicker: vi.fn(() => {}),
+    getImagesForSend: mockGetImagesForSend,
+    handlePaste: vi.fn(() => {}),
+  }),
+  useInterrupt: () => ({
+    interrupting: false,
+    handleInterrupt: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock('../../lib/connection-manager', () => ({
+  connectionManager: {
+    getHubIfConnected: () => ({ request: mockRequest }),
+  },
+}));
+
+import MessageInput from '../MessageInput';
+
+describe('MessageInput submit race condition', () => {
+  beforeEach(() => {
+    cleanup();
+    mockDraftContent = '';
+    mockAgentWorking.value = false;
+    mockSetContent.mockClear();
+    mockClearDraft.mockClear();
+    mockClearAttachments.mockClear();
+    mockRestoreAttachments.mockClear();
+    mockGetImagesForSend.mockClear();
+    mockGetImagesForSend.mockReturnValue(undefined);
+    mockRequest.mockClear();
+    mockReferenceShowAutocomplete = false;
+    mockReferenceHandleKeyDown.mockReturnValue(false);
+    mockReferenceHandleKeyDown.mockClear();
+    mockCommandShowAutocomplete = false;
+    mockCommandHandleKeyDown.mockReturnValue(false);
+    mockCommandHandleKeyDown.mockClear();
+    document.querySelectorAll('[data-messages-container]').forEach((node) => node.remove());
+    document.querySelectorAll('.chat-footer').forEach((node) => node.remove());
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn(() => ({ matches: false })),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.querySelectorAll('[data-messages-container]').forEach((node) => node.remove());
+    document.querySelectorAll('.chat-footer').forEach((node) => node.remove());
+  });
+
+  function renderInput(onSend = vi.fn(async () => {})) {
+    return render(<MessageInput sessionId="test-session" onSend={onSend} />);
+  }
+
+  describe('submittingRef guard', () => {
+    it('blocks stale onInput events while submit is in flight', async () => {
+      mockDraftContent = 'hello';
+
+      let resolveSend: (value: boolean | void) => void;
+      const onSend = vi.fn(async () => {
+        return new Promise((resolve) => {
+          resolveSend = resolve;
+        });
+      });
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      // Simulate pressing Enter to submit
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Simulate stale onInput firing while onSend is still pending
+      // (textarea.value still has old content because useLayoutEffect hasn't flushed)
+      fireEvent.input(textarea, { target: { value: 'hello' } });
+
+      // setContent should NOT have been called with the stale value
+      expect(mockSetContent).not.toHaveBeenCalledWith('hello');
+
+      // Resolve the pending send
+      resolveSend(true);
+      await waitFor(() => expect(onSend).toHaveReturned());
+
+      // Even after completion, the stale input should have been dropped
+      expect(mockSetContent).not.toHaveBeenCalledWith('hello');
+    });
+
+    it('allows new onInput events after submit completes', async () => {
+      mockDraftContent = 'hello';
+      const onSend = vi.fn(async () => {});
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // After submit completes, typing should work normally
+      fireEvent.input(textarea, { target: { value: 'new text' } });
+
+      expect(mockSetContent).toHaveBeenCalledWith('new text');
+    });
+  });
+
+  describe('direct DOM clear', () => {
+    it('clears textarea.value immediately on submit', async () => {
+      mockDraftContent = 'hello';
+      const onSend = vi.fn(async () => {});
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      // Before submit, textarea should reflect the draft content
+      expect(textarea.value).toBe('hello');
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+
+      // Textarea should be cleared immediately, not waiting for useLayoutEffect
+      expect(textarea.value).toBe('');
+
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+    });
+  });
+
+  describe('send failure restoration', () => {
+    it('restores draft and attachments when onSend returns false', async () => {
+      mockDraftContent = 'hello world';
+      const onSend = vi.fn(async () => false);
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Draft should be restored
+      expect(mockSetContent).toHaveBeenCalledWith('hello world');
+    });
+
+    it('does not restore draft when onSend succeeds', async () => {
+      mockDraftContent = 'hello world';
+      const onSend = vi.fn(async () => true);
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Should NOT restore the draft on success
+      expect(mockSetContent).not.toHaveBeenCalledWith('hello world');
+    });
+
+    it('does not restore draft when onSend returns void', async () => {
+      mockDraftContent = 'hello world';
+      const onSend = vi.fn(async () => {});
+
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Void return = success; should NOT restore
+      expect(mockSetContent).not.toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  describe('send called with correct arguments', () => {
+    it('calls onSend with trimmed content and images', async () => {
+      mockDraftContent = '  hello  ';
+      mockGetImagesForSend.mockReturnValue([
+        { data: 'base64data', media_type: 'image/png', name: 'test.png' },
+      ]);
+
+      const onSend = vi.fn(async () => {});
+      const { container } = renderInput(onSend);
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await waitFor(() => expect(onSend).toHaveBeenCalledOnce());
+
+      // Content should be trimmed
+      expect(onSend).toHaveBeenCalledWith(
+        'hello',
+        [{ data: 'base64data', media_type: 'image/png', name: 'test.png' }],
+        'immediate'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes race between `clearDraft()` and browser `onInput` in uncontrolled textarea.

When `handleSubmit` cleared the signal, `useLayoutEffect` hadn't flushed yet, so a stale `onInput` reading `textarea.value` could call `setContent` and restore the old content — leaving a single character in the composer.

Changes:
- `submittingRef` guard in `handleContentChange` drops `onInput` during submit
- Direct `textarea.value = ''` clear in `handleSubmit`, bypassing batch flush
- 7 unit tests covering guard behavior, DOM clear, failure restoration, and send args

Closes #502