### PR TITLE
fix(daemon): forward reasoning_content from OpenAI Chat Completions bridge

### DIFF
--- a/packages/daemon/src/lib/providers/custom-endpoint-provider.ts
+++ b/packages/daemon/src/lib/providers/custom-endpoint-provider.ts
@@ -36,6 +36,7 @@ import {
   CUSTOM_ENDPOINT_TYPE_CAPABILITY_DEFAULTS,
   DEFAULT_CUSTOM_ENDPOINT_CAPABILITIES,
   resolveCustomEndpointType,
+  THINKING_LEVEL_TOKENS,
   type CustomEndpointConfig,
   type CustomEndpointModel,
   type CustomEndpointModelCapabilities,
@@ -76,6 +77,10 @@ export function isCustomEndpointProviderId(providerId: string): boolean {
 interface CustomEndpointBridge {
   port: number;
   stop(): void;
+  setSessionThinkingConfig?(
+    sessionId: string,
+    thinking: { type: 'enabled'; budget_tokens: number } | undefined
+  ): void;
 }
 
 export interface CustomEndpointProviderOptions {
@@ -214,7 +219,7 @@ export class CustomEndpointProvider implements Provider {
     return {
       envVars: {
         ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridge.port}`,
-        ANTHROPIC_AUTH_TOKEN: 'custom-endpoint',
+        ANTHROPIC_AUTH_TOKEN: `custom-endpoint:${sessionConfig?.sessionId ?? 'default'}`,
         ANTHROPIC_API_KEY: '',
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
@@ -243,6 +248,27 @@ export class CustomEndpointProvider implements Provider {
     if (!model) return undefined;
     const caps = resolveModelCapabilities(model, this.type);
     return caps.thinking ? 'on' : 'off';
+  }
+
+  /**
+   * Propagate the session's thinking level to all chat bridges.
+   *
+   * The Claude Code CLI handles thinking internally and does not include the
+   * thinking field in Anthropic Messages API request bodies. Without this
+   * side-channel the bridge has no way to know that reasoning should be
+   * forwarded to the OpenAI Chat Completions API.
+   */
+  setSessionThinkingConfig(sessionId: string, thinkingLevel: string | undefined): void {
+    const tokens = THINKING_LEVEL_TOKENS[thinkingLevel as keyof typeof THINKING_LEVEL_TOKENS];
+    const thinking =
+      tokens !== undefined
+        ? ({ type: 'enabled' as const, budget_tokens: tokens } as const)
+        : undefined;
+    for (const bridge of this.bridges.values()) {
+      if (bridge.setSessionThinkingConfig) {
+        bridge.setSessionThinkingConfig(sessionId, thinking);
+      }
+    }
   }
 
   async getAuthStatus(): Promise<ProviderAuthStatusInfo> {

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -523,7 +523,8 @@ async function streamChatToAnthropic(params: {
   let thinkingOpen = false;
   let thinkingBlockIndex = -1;
   let nextBlockIndex = 0;
-  let heuristicOutputTokens = 0;
+  let heuristicOutputText = '';
+  let heuristicOutputThinking = '';
   let finalPromptTokens: number | undefined;
   let finalCompletionTokens: number | undefined;
   let finishReason: string | null = null;
@@ -576,6 +577,7 @@ async function streamChatToAnthropic(params: {
   const openToolCall = (call: PendingToolCall) => {
     if (call.opened) return;
     ensureStarted();
+    closeThinkingBlock();
     closeTextBlock();
     call.blockIndex = nextBlockIndex++;
     send(contentBlockStartToolUseSSE(call.blockIndex, call.id, call.name));
@@ -614,7 +616,7 @@ async function streamChatToAnthropic(params: {
       if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
         startThinkingBlock();
         send(thinkingDeltaSSE(thinkingBlockIndex, delta.reasoning_content));
-        heuristicOutputTokens += Math.max(1, Math.ceil(delta.reasoning_content.length / 4));
+        heuristicOutputThinking += delta.reasoning_content;
       }
 
       if (typeof delta.content === 'string' && delta.content.length > 0) {
@@ -626,7 +628,7 @@ async function streamChatToAnthropic(params: {
           textOpen = true;
         }
         send(textDeltaSSE(textBlockIndex, delta.content));
-        heuristicOutputTokens += Math.max(1, Math.ceil(delta.content.length / 4));
+        heuristicOutputText += delta.content;
       }
 
       if (delta.tool_calls) {
@@ -700,10 +702,14 @@ async function streamChatToAnthropic(params: {
           ? 'max_tokens'
           : 'end_turn';
 
+    const textTokens =
+      heuristicOutputText.length > 0 ? Math.ceil(heuristicOutputText.length / 4) : 0;
+    const thinkingTokens =
+      heuristicOutputThinking.length > 0 ? Math.ceil(heuristicOutputThinking.length / 4) : 0;
     send(
       messageDeltaSSE(stopReason, {
         inputTokens: finalPromptTokens ?? inputTokens,
-        outputTokens: finalCompletionTokens ?? Math.max(1, heuristicOutputTokens),
+        outputTokens: finalCompletionTokens ?? Math.max(1, textTokens + thinkingTokens),
         modelContextWindow,
       })
     );

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -25,6 +25,7 @@ import {
   type AnthropicContentBlockToolUse,
   type AnthropicRequest,
   contentBlockStartTextSSE,
+  contentBlockStartThinkingSSE,
   contentBlockStartToolUseSSE,
   contentBlockStopSSE,
   errorSSE,
@@ -33,6 +34,7 @@ import {
   messageStartSSE,
   messageStopSSE,
   textDeltaSSE,
+  thinkingDeltaSSE,
 } from '../provider-anthropic-compat/translator.js';
 import { estimateAnthropicInputTokens } from '../provider-anthropic-compat/token-estimator.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
@@ -132,6 +134,7 @@ type OpenAIChatStreamChoice = {
   delta?: {
     role?: string;
     content?: string | null;
+    reasoning_content?: string | null;
     tool_calls?: Array<{
       index?: number;
       id?: string;
@@ -172,10 +175,6 @@ function mapUpstreamStatus(status: number): AnthropicErrorType {
   if (status === 429) return 'rate_limit_error';
   if (status >= 500) return 'api_error';
   return 'invalid_request_error';
-}
-
-function estimateOutputTokens(text: string): number {
-  return Math.max(1, Math.ceil(text.length / 4));
 }
 
 function genMessageId(): string {
@@ -521,8 +520,10 @@ async function streamChatToAnthropic(params: {
   let started = false;
   let textOpen = false;
   let textBlockIndex = -1;
+  let thinkingOpen = false;
+  let thinkingBlockIndex = -1;
   let nextBlockIndex = 0;
-  let heuristicOutputText = '';
+  let heuristicOutputTokens = 0;
   let finalPromptTokens: number | undefined;
   let finalCompletionTokens: number | undefined;
   let finishReason: string | null = null;
@@ -554,6 +555,22 @@ async function streamChatToAnthropic(params: {
     if (!textOpen) return;
     send(contentBlockStopSSE(textBlockIndex));
     textOpen = false;
+  };
+
+  const startThinkingBlock = () => {
+    if (thinkingOpen) return;
+    ensureStarted();
+    closeTextBlock();
+    thinkingBlockIndex = nextBlockIndex++;
+    send(contentBlockStartThinkingSSE(thinkingBlockIndex));
+    thinkingOpen = true;
+  };
+
+  const closeThinkingBlock = () => {
+    if (!thinkingOpen) return;
+    send(contentBlockStopSSE(thinkingBlockIndex));
+    thinkingOpen = false;
+    thinkingBlockIndex = -1;
   };
 
   const openToolCall = (call: PendingToolCall) => {
@@ -594,15 +611,22 @@ async function streamChatToAnthropic(params: {
       const delta = choice.delta;
       if (!delta) continue;
 
+      if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
+        startThinkingBlock();
+        send(thinkingDeltaSSE(thinkingBlockIndex, delta.reasoning_content));
+        heuristicOutputTokens += Math.max(1, Math.ceil(delta.reasoning_content.length / 4));
+      }
+
       if (typeof delta.content === 'string' && delta.content.length > 0) {
         ensureStarted();
+        closeThinkingBlock();
         if (!textOpen) {
           textBlockIndex = nextBlockIndex++;
           send(contentBlockStartTextSSE(textBlockIndex));
           textOpen = true;
         }
         send(textDeltaSSE(textBlockIndex, delta.content));
-        heuristicOutputText += delta.content;
+        heuristicOutputTokens += Math.max(1, Math.ceil(delta.content.length / 4));
       }
 
       if (delta.tool_calls) {
@@ -666,6 +690,7 @@ async function streamChatToAnthropic(params: {
       if (call.opened && !emittedIds.has(call.id)) finishToolCall(call);
     }
 
+    closeThinkingBlock();
     closeTextBlock();
 
     const stopReason: 'tool_use' | 'max_tokens' | 'end_turn' =
@@ -678,7 +703,7 @@ async function streamChatToAnthropic(params: {
     send(
       messageDeltaSSE(stopReason, {
         inputTokens: finalPromptTokens ?? inputTokens,
-        outputTokens: finalCompletionTokens ?? estimateOutputTokens(heuristicOutputText),
+        outputTokens: finalCompletionTokens ?? Math.max(1, heuristicOutputTokens),
         modelContextWindow,
       })
     );

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -44,6 +44,8 @@ const logger = new Logger('openai-chat-bridge-server');
 
 export type OpenAIChatBridgeServer = {
   port: number;
+  /** Set per-session thinking config so the bridge can include reasoning even when the Anthropic SDK client omits the thinking field. */
+  setSessionThinkingConfig?(sessionId: string, thinking: AnthropicRequest['thinking']): void;
   stop(): void;
 };
 
@@ -741,6 +743,10 @@ export function createOpenAIChatBridgeServer(
   const streamUsageSupported = config.streamUsageSupported ?? false;
   const modelContextWindow = config.modelContextWindow;
 
+  // Per-session thinking config injected by the daemon when the Anthropic SDK client
+  // (Claude Code CLI) omits the thinking field from request bodies.
+  const sessionThinkingConfigs = new Map<string, { thinking: AnthropicRequest['thinking'] }>();
+
   const server = Bun.serve({
     // Bind to loopback so other local users cannot probe the ephemeral port
     // and reach this bridge with the configured upstream API key. The SDK
@@ -750,6 +756,10 @@ export function createOpenAIChatBridgeServer(
     idleTimeout: 0,
     async fetch(req: Request): Promise<Response> {
       const url = new URL(req.url);
+      const authHeader = req.headers.get('Authorization') ?? '';
+      const sessionId = authHeader.startsWith('Bearer custom-endpoint:')
+        ? authHeader.slice('Bearer custom-endpoint:'.length)
+        : 'default';
 
       if (url.pathname === '/health' || url.pathname === '/v1/health') return new Response('ok');
 
@@ -798,6 +808,14 @@ export function createOpenAIChatBridgeServer(
           'invalid_request_error',
           'Only streaming responses are supported'
         );
+      }
+
+      // The Claude Code CLI handles thinking internally and does not include the
+      // thinking field in Anthropic Messages API requests. Merge the per-session
+      // thinking config injected by the daemon so reasoning is forwarded to OpenAI.
+      const sessionThinkingEntry = sessionThinkingConfigs.get(sessionId);
+      if (sessionThinkingEntry?.thinking && !body.thinking) {
+        body = { ...body, thinking: sessionThinkingEntry.thinking };
       }
 
       const chatRequest = buildChatRequest(
@@ -866,7 +884,13 @@ export function createOpenAIChatBridgeServer(
 
   return {
     port,
-    stop: () => server.stop(true),
+    setSessionThinkingConfig: (sessionId: string, thinking: AnthropicRequest['thinking']) => {
+      sessionThinkingConfigs.set(sessionId, { thinking });
+    },
+    stop: () => {
+      sessionThinkingConfigs.clear();
+      server.stop(true);
+    },
   };
 }
 

--- a/packages/daemon/tests/unit/1-core/providers/custom-endpoint-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/custom-endpoint-provider.test.ts
@@ -20,19 +20,24 @@ function makeFakeBridge(): {
   factory: (config: OpenAIChatBridgeConfig) => OpenAIChatBridgeServer;
   configs: OpenAIChatBridgeConfig[];
   stoppedPorts: number[];
+  thinkingConfigs: Array<{ sessionId: string; thinking: unknown }>;
 } {
   const configs: OpenAIChatBridgeConfig[] = [];
   const stoppedPorts: number[] = [];
+  const thinkingConfigs: Array<{ sessionId: string; thinking: unknown }> = [];
   let nextPort = 40000;
   const factory = (config: OpenAIChatBridgeConfig): OpenAIChatBridgeServer => {
     configs.push(config);
     const port = nextPort++;
     return {
       port,
+      setSessionThinkingConfig: (sessionId: string, thinking: unknown) => {
+        thinkingConfigs.push({ sessionId, thinking });
+      },
       stop: () => stoppedPorts.push(port),
     };
   };
-  return { factory, configs, stoppedPorts };
+  return { factory, configs, stoppedPorts, thinkingConfigs };
 }
 
 const baseConfig: CustomEndpointConfig = {
@@ -495,6 +500,43 @@ describe('CustomEndpointProvider', () => {
       expect(anthropicCaps.caching).toBe(true);
       expect(anthropicCaps.thinking).toBe(true);
       expect(anthropicCaps.vision).toBe(true);
+    });
+  });
+
+  describe('setSessionThinkingConfig side-channel', () => {
+    it('embeds sessionId into ANTHROPIC_AUTH_TOKEN so the bridge can identify the session', () => {
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(baseConfig, { bridgeFactory: fake.factory });
+      const cfg = p.buildSdkConfig('qwen2.5-7b', { sessionId: 'sess-abc' });
+      expect(cfg.envVars.ANTHROPIC_AUTH_TOKEN).toBe('custom-endpoint:sess-abc');
+    });
+
+    it('forwards setSessionThinkingConfig to every chat bridge', () => {
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(baseConfig, { bridgeFactory: fake.factory });
+      p.buildSdkConfig('qwen2.5-7b');
+      p.buildSdkConfig('qwen2.5-vl-7b');
+      p.setSessionThinkingConfig('sess-1', 'think8k');
+      expect(fake.thinkingConfigs).toHaveLength(2);
+      expect(fake.thinkingConfigs[0]).toMatchObject({
+        sessionId: 'sess-1',
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      });
+      expect(fake.thinkingConfigs[1]).toMatchObject({
+        sessionId: 'sess-1',
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      });
+    });
+
+    it('sends undefined thinking when level is off or unknown', () => {
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(baseConfig, { bridgeFactory: fake.factory });
+      p.buildSdkConfig('qwen2.5-7b');
+      p.setSessionThinkingConfig('sess-1', 'off');
+      expect(fake.thinkingConfigs[0]).toMatchObject({
+        sessionId: 'sess-1',
+        thinking: undefined,
+      });
     });
   });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -1139,5 +1139,41 @@ describe('OpenAI Chat Completions bridge server', () => {
       // must not contain a text block
       expect(text).not.toContain('"type":"text"');
     });
+
+    it('merges side-channel thinking config into the request when SDK omits it', async () => {
+      let capturedRequest: Record<string, unknown> = {};
+      const fetchMock = mock(async (_url: string, init?: RequestInit) => {
+        capturedRequest = JSON.parse(String(init?.body));
+        return new Response(
+          sseBody([{ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }]),
+          { status: 200 }
+        );
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test',
+        fetchImpl: fetchMock as typeof fetch,
+        thinkingSupported: true,
+      });
+      servers.push(server);
+      server.setSessionThinkingConfig?.('sess-42', {
+        type: 'enabled',
+        budget_tokens: 8000,
+      });
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer custom-endpoint:sess-42',
+        },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      expect(response.status).toBe(200);
+      expect(capturedRequest.reasoning_effort).toBe('medium');
+    });
   });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -981,4 +981,76 @@ describe('OpenAI Chat Completions bridge server', () => {
       expect(text).not.toContain('non-SSE');
     });
   });
+
+  describe('reasoning_content translation', () => {
+    it('streams reasoning_content as Anthropic thinking blocks before text', async () => {
+      const fetchMock = mock(async () => {
+        const body = sseBody([
+          { choices: [{ index: 0, delta: { reasoning_content: 'Let' } }] },
+          { choices: [{ index: 0, delta: { reasoning_content: ' me think' } }] },
+          { choices: [{ index: 0, delta: { content: 'Hello' } }] },
+          { choices: [{ index: 0, delta: { content: ' world' } }] },
+          { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+        ]);
+        return new Response(body, { status: 200 });
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      const text = await response.text();
+      // thinking block opens first
+      expect(text).toContain('"type":"thinking"');
+      expect(text).toContain('"thinking":"Let"');
+      expect(text).toContain('"thinking":" me think"');
+      // text block follows
+      expect(text).toContain('"text":"Hello"');
+      expect(text).toContain('"text":" world"');
+      expect(text).toContain('"stop_reason":"end_turn"');
+      expect(text).toContain('event: message_stop');
+    });
+
+    it('counts reasoning tokens in heuristic output when no usage chunk', async () => {
+      const fetchMock = mock(async () => {
+        const body = sseBody([
+          { choices: [{ index: 0, delta: { reasoning_content: 'reasoning' } }] },
+          { choices: [{ index: 0, delta: { content: 'text' } }] },
+          { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+        ]);
+        return new Response(body, { status: 200 });
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      const text = await response.text();
+      const match = text.match(/event: message_delta\s*\ndata:.*?"output_tokens":(\d+)/);
+      expect(match).not.toBeNull();
+      const outputTokens = Number(match![1]);
+      // reasoning (9 chars) => ceil(9/4)=3, text (4 chars) => ceil(4/4)=1, total 4.
+      expect(outputTokens).toBe(4);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -1052,5 +1052,92 @@ describe('OpenAI Chat Completions bridge server', () => {
       // reasoning (9 chars) => ceil(9/4)=3, text (4 chars) => ceil(4/4)=1, total 4.
       expect(outputTokens).toBe(4);
     });
+
+    it('closes thinking block before tool_use when reasoning is followed by tool_calls', async () => {
+      const fetchMock = mock(async () => {
+        const body = sseBody([
+          { choices: [{ index: 0, delta: { reasoning_content: 'plan' } }] },
+          {
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_plan',
+                      type: 'function',
+                      function: { name: 'act', arguments: '{}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+        ]);
+        return new Response(body, { status: 200 });
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+          tools: [{ name: 'act', description: '', input_schema: { type: 'object' } }],
+        }),
+      });
+      const text = await response.text();
+      // thinking opens, then closes before tool_use
+      expect(text).toContain('"type":"thinking"');
+      expect(text).toContain('"type":"tool_use"');
+      expect(text).toContain('"name":"act"');
+      expect(text).toContain('"stop_reason":"tool_use"');
+      // ensure the thinking block is stopped before the tool_use block starts
+      const thinkingStopPos = text.indexOf('event: content_block_stop');
+      const toolUseStartPos = text.indexOf('"type":"tool_use"');
+      expect(thinkingStopPos).toBeGreaterThan(-1);
+      expect(toolUseStartPos).toBeGreaterThan(-1);
+      expect(thinkingStopPos).toBeLessThan(toolUseStartPos);
+    });
+
+    it('handles a reasoning-only stream with no content delta', async () => {
+      const fetchMock = mock(async () => {
+        const body = sseBody([
+          { choices: [{ index: 0, delta: { reasoning_content: 'Only reasoning' } }] },
+          { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+        ]);
+        return new Response(body, { status: 200 });
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      const text = await response.text();
+      expect(text).toContain('"type":"thinking"');
+      expect(text).toContain('"thinking":"Only reasoning"');
+      expect(text).toContain('"stop_reason":"end_turn"');
+      expect(text).toContain('event: message_stop');
+      // must not contain a text block
+      expect(text).not.toContain('"type":"text"');
+    });
   });
 });


### PR DESCRIPTION
Forwards `reasoning_content` deltas from OpenAI Chat Completions SSE streams as Anthropic `thinking` content blocks, so custom endpoints (DeepSeek R1, o-series, QwQ, etc.) no longer hide reasoning tokens.

Changes:
- Adds `reasoning_content` to the delta type and emits `thinking_delta` SSE events using existing translator helpers.
- Tracks thinking block open/close state during streaming (same pattern as the Responses bridge).
- Switches the fallback token estimator from text-only to a combined counter that includes both reasoning and content deltas.
- Adds unit tests for reasoning → thinking translation and heuristic token counting.