### PR TITLE
feat: refresh model list immediately when providers change

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -37,6 +37,7 @@ import { GitHubEventExtension } from './lib/external-events/github';
 import {
   initializeProviders,
   waitForOptionalProviderRegistration,
+  markBuiltInProviderDisabled,
 } from './lib/providers/factory.js';
 import { getProviderRegistry } from './lib/providers/registry.js';
 import { OAuthRefreshScheduler } from './lib/credentials/oauth-refresh-scheduler.js';
@@ -336,6 +337,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       await syncAllProviders(() => db.providers.listEnabledProviders(), credentialManager);
     } catch (err) {
       logError('[Daemon] Provider sync failed (non-fatal):', err);
+    }
+
+    // Seed disabled built-in state so initializeProviders() won't resurrect
+    // providers that were explicitly disabled or deleted in a prior run.
+    for (const record of db.providers.listProviders()) {
+      if (record.kind === 'built_in' && record.isEnabled === false) {
+        markBuiltInProviderDisabled(record.providerId);
+      }
     }
 
     // Check authentication status.

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -337,7 +337,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     // endpoint configs are logged and skipped rather than blocking daemon startup.
     {
       const { syncCustomEndpointProviders } = await import('./lib/providers/factory.js');
-      await syncCustomEndpointProviders(settingsManager.getGlobalSettings().customEndpoints);
+      const { filterDisabledCustomEndpoints } = await import(
+        './lib/rpc-handlers/custom-endpoint-handlers.js'
+      );
+      const endpoints = settingsManager.getGlobalSettings().customEndpoints ?? [];
+      const syncEndpoints = filterDisabledCustomEndpoints(endpoints, db);
+      await syncCustomEndpointProviders(syncEndpoints);
     }
 
     // Sync all enabled providers from the providers table into the registry.

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -309,6 +309,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     const settingsManager = new SettingsManager(db, process.env.NEOKAI_WORKSPACE_PATH ?? homedir());
     applyProviderModelAllowlistsToEnv(settingsManager.getGlobalSettings().providerModelAllowlists);
 
+    // Seed disabled built-in state so initializeProviders() won't register
+    // providers that were explicitly disabled or deleted in a prior run.
+    for (const record of db.providers.listProviders()) {
+      if (record.kind === 'built_in' && record.isEnabled === false) {
+        markBuiltInProviderDisabled(record.providerId);
+      }
+    }
+
     const providerRegistry = initializeProviders();
     await waitForOptionalProviderRegistration(providerRegistry);
     const credentialManager = ProviderCredentialManager.create(db.getDatabase());
@@ -337,14 +345,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       await syncAllProviders(() => db.providers.listEnabledProviders(), credentialManager);
     } catch (err) {
       logError('[Daemon] Provider sync failed (non-fatal):', err);
-    }
-
-    // Seed disabled built-in state so initializeProviders() won't resurrect
-    // providers that were explicitly disabled or deleted in a prior run.
-    for (const record of db.providers.listProviders()) {
-      if (record.kind === 'built_in' && record.isEnabled === false) {
-        markBuiltInProviderDisabled(record.providerId);
-      }
     }
 
     // Check authentication status.

--- a/packages/daemon/src/lib/client-event-bridge.ts
+++ b/packages/daemon/src/lib/client-event-bridge.ts
@@ -211,6 +211,11 @@ const SESSION_BRIDGE_MAPPINGS: BridgeMapping[] = [
       return p.contextInfo;
     },
   },
+  {
+    event: 'providers.changed',
+    clientEvent: 'providers.changed',
+    channel: () => Channels.global(),
+  },
 ];
 
 /**

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -703,6 +703,7 @@ interface ClientForwardingEvents {
     workflow: import('@neokai/shared').SpaceWorkflow;
   };
   'spaceWorkflow.deleted': { sessionId: string; spaceId: string; workflowId: string };
+  'providers.changed': { sessionId: string };
 }
 
 /**

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -343,8 +343,11 @@ export async function initializeModels(): Promise<void> {
       throw new Error('No models returned from providers');
     }
   } catch {
-    // Failed to load models - use well-known Anthropic models as fallback
-    modelsCache.set(cacheKey, FALLBACK_MODELS);
+    // Failed to load models - use well-known Anthropic models as fallback,
+    // but only for providers that are still registered.
+    const registry = getProviderRegistry();
+    const filteredFallbacks = FALLBACK_MODELS.filter((m) => registry.has(m.provider));
+    modelsCache.set(cacheKey, filteredFallbacks);
     cacheTimestamps.set(cacheKey, Date.now());
   }
 }
@@ -457,7 +460,9 @@ export async function refreshModels(): Promise<void> {
       } else if (!previousModels || previousModels.length === 0) {
         // Cache was cleared or was already empty — restore fallback models
         // so the UI and model resolution paths always have a baseline catalog.
-        modelsCache.set(cacheKey, FALLBACK_MODELS);
+        const registry = getProviderRegistry();
+        const filteredFallbacks = FALLBACK_MODELS.filter((m) => registry.has(m.provider));
+        modelsCache.set(cacheKey, filteredFallbacks);
         cacheTimestamps.set(cacheKey, Date.now());
       }
     } finally {

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -124,10 +124,14 @@ function mergeWithFallbackModels(providerModels: ModelInfo[]): ModelInfo[] {
   // Key by "provider:id" so same-id models from different providers
   // are preserved as distinct entries rather than last-writer-wins.
   const modelMap = new Map<string, ModelInfo>();
+  const registry = getProviderRegistry();
 
-  // Add fallback models first
+  // Add fallback models only when their provider is still registered.
+  // This prevents disabled/deleted providers from leaving ghost entries.
   for (const model of FALLBACK_MODELS) {
-    modelMap.set(`${model.provider}:${model.id}`, model);
+    if (registry.has(model.provider)) {
+      modelMap.set(`${model.provider}:${model.id}`, model);
+    }
   }
 
   // Provider models override fallbacks with same (provider, id)

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -209,6 +209,52 @@ export async function waitForOptionalProviderRegistration(
   await registerLoadedCopilotProvider(registry ?? initializeProviders());
 }
 
+/**
+ * Register a single built-in provider by ID if it is not already in the registry.
+ * This is the surgical re-registration path used when a provider is re-enabled
+ * after being disabled and removed from the registry.
+ *
+ * Unlike `initializeProviders()`, this only touches the requested provider so
+ * disabled built-ins are not accidentally recreated.
+ */
+export async function ensureBuiltInProviderRegistered(providerId: string): Promise<void> {
+  const registry = getProviderRegistry();
+  if (registry.has(providerId)) return;
+
+  switch (providerId) {
+    case 'anthropic':
+      registerIfMissing(registry, new AnthropicProvider());
+      break;
+    case 'glm':
+      registerIfMissing(registry, new GlmProvider());
+      break;
+    case 'kimi':
+      registerIfMissing(registry, new KimiProvider());
+      break;
+    case 'minimax':
+      registerIfMissing(registry, new MinimaxProvider());
+      break;
+    case 'openrouter':
+      registerIfMissing(registry, new OpenRouterProvider());
+      break;
+    case 'ollama':
+      registerIfMissing(registry, new OllamaProvider({ kind: 'local' }));
+      break;
+    case 'ollama-cloud':
+      registerIfMissing(registry, new OllamaProvider({ kind: 'cloud' }));
+      break;
+    case 'anthropic-codex':
+      registerIfMissing(registry, new AnthropicToCodexBridgeProvider());
+      break;
+    case 'anthropic-copilot':
+      registerCopilotProvider(registry);
+      await waitForOptionalProviderRegistration(registry);
+      break;
+    default:
+      break;
+  }
+}
+
 async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promise<void> {
   if (registry.has('anthropic-copilot')) return;
 

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -44,11 +44,12 @@ let initialized = false;
 export function initializeProviders(): ProviderRegistry {
   const registry = getProviderRegistry();
 
-  // If already initialized and the core providers are still present, return the
-  // existing registry. This handles the case where getProviderRegistry() was
-  // called but no providers were registered, and the case where the registry was
-  // reset without resetting the factory.
-  if (initialized && hasCoreProviders(registry)) {
+  // Once initialized, never re-register providers automatically. This prevents
+  // disabled built-ins from being resurrected when other callers (e.g.
+  // syncCustomEndpointProviders) trigger initialization. Explicit re-enablement
+  // must go through ensureBuiltInProviderRegistered().
+  // Tests that reset the registry should also call resetProviderFactory().
+  if (initialized) {
     return registry;
   }
 
@@ -185,10 +186,6 @@ function canonicalise(value: unknown): unknown {
   return out;
 }
 
-function hasCoreProviders(registry: ProviderRegistry): boolean {
-  return CORE_PROVIDER_IDS.every((id) => registry.has(id));
-}
-
 function registerIfMissing(registry: ProviderRegistry, provider: Provider): void {
   if (!registry.has(provider.id)) {
     registry.register(provider);
@@ -268,17 +265,6 @@ async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promis
 
 let copilotProviderModule: Promise<typeof import('./anthropic-copilot/index.js') | null> | null =
   null;
-
-const CORE_PROVIDER_IDS = [
-  'anthropic',
-  'glm',
-  'kimi',
-  'minimax',
-  'openrouter',
-  'ollama',
-  'ollama-cloud',
-  'anthropic-codex',
-];
 
 /** Tracks the last fingerprint we synced per provider so we can skip no-op rebuilds. */
 const lastSyncedConfigByProviderId = new Map<string, string>();

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -298,6 +298,7 @@ export async function ensureBuiltInProviderRegistered(providerId: string): Promi
 
 async function registerLoadedCopilotProvider(registry: ProviderRegistry): Promise<void> {
   if (registry.has('anthropic-copilot')) return;
+  if (disabledBuiltInProviderIds.has('anthropic-copilot')) return;
 
   // This dynamic import must remain a literal string: bun build --compile
   // discovers and embeds @github/copilot-sdk and vscode-jsonrpc through it.

--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -34,6 +34,32 @@ const logger = new Logger('providers:factory');
 let initialized = false;
 
 /**
+ * Built-in providers explicitly disabled via providers.update are tracked here
+ * so initializeProviders() does not resurrect them on subsequent calls.
+ */
+const disabledBuiltInProviderIds = new Set<string>();
+
+/**
+ * Mark a built-in provider as disabled so initializeProviders() skips it.
+ */
+export function markBuiltInProviderDisabled(providerId: string): void {
+  disabledBuiltInProviderIds.add(providerId);
+}
+
+/**
+ * Mark a built-in provider as enabled so initializeProviders() can register it.
+ */
+export function markBuiltInProviderEnabled(providerId: string): void {
+  disabledBuiltInProviderIds.delete(providerId);
+}
+
+const CORE_PROVIDER_IDS = ['anthropic'];
+
+function hasCoreProviders(registry: ProviderRegistry): boolean {
+  return CORE_PROVIDER_IDS.every((id) => registry.has(id));
+}
+
+/**
  * Initialize the provider system
  *
  * Registers all built-in providers with the global registry.
@@ -44,46 +70,63 @@ let initialized = false;
 export function initializeProviders(): ProviderRegistry {
   const registry = getProviderRegistry();
 
-  // Once initialized, never re-register providers automatically. This prevents
-  // disabled built-ins from being resurrected when other callers (e.g.
-  // syncCustomEndpointProviders) trigger initialization. Explicit re-enablement
-  // must go through ensureBuiltInProviderRegistered().
-  // Tests that reset the registry should also call resetProviderFactory().
-  if (initialized) {
+  // If already initialized and the core providers are still present, return the
+  // existing registry. This handles the case where getProviderRegistry() was
+  // called but no providers were registered, and the case where the registry was
+  // reset without resetting the factory.
+  if (initialized && hasCoreProviders(registry)) {
     return registry;
   }
 
   // Register Anthropic provider (always available)
-  registerIfMissing(registry, new AnthropicProvider());
+  if (!disabledBuiltInProviderIds.has('anthropic')) {
+    registerIfMissing(registry, new AnthropicProvider());
+  }
 
   // Register GLM provider (will be available if API key is set)
-  registerIfMissing(registry, new GlmProvider());
+  if (!disabledBuiltInProviderIds.has('glm')) {
+    registerIfMissing(registry, new GlmProvider());
+  }
 
   // Register Kimi provider (will be available if KIMI_API_KEY or MOONSHOT_API_KEY is set)
-  registerIfMissing(registry, new KimiProvider());
+  if (!disabledBuiltInProviderIds.has('kimi')) {
+    registerIfMissing(registry, new KimiProvider());
+  }
 
   // Register MiniMax provider (will be available if MINIMAX_API_KEY is set)
-  registerIfMissing(registry, new MinimaxProvider());
+  if (!disabledBuiltInProviderIds.has('minimax')) {
+    registerIfMissing(registry, new MinimaxProvider());
+  }
 
   // Register OpenRouter provider (will be available if OPENROUTER_API_KEY is set)
-  registerIfMissing(registry, new OpenRouterProvider());
+  if (!disabledBuiltInProviderIds.has('openrouter')) {
+    registerIfMissing(registry, new OpenRouterProvider());
+  }
 
   // Register Ollama providers. Local Ollama is available by default at localhost:11434;
   // Ollama Cloud requires OLLAMA_CLOUD_API_KEY.
-  registerIfMissing(registry, new OllamaProvider({ kind: 'local' }));
-  registerIfMissing(registry, new OllamaProvider({ kind: 'cloud' }));
+  if (!disabledBuiltInProviderIds.has('ollama')) {
+    registerIfMissing(registry, new OllamaProvider({ kind: 'local' }));
+  }
+  if (!disabledBuiltInProviderIds.has('ollama-cloud')) {
+    registerIfMissing(registry, new OllamaProvider({ kind: 'cloud' }));
+  }
 
   // Register Anthropic-to-Codex bridge provider for OpenAI/Codex-backed models.
   // Discovers credentials from env (OPENAI_API_KEY), ~/.neokai/auth.json,
   // and one-time import from ~/.codex/auth.json.
-  registerIfMissing(registry, new AnthropicToCodexBridgeProvider());
+  if (!disabledBuiltInProviderIds.has('anthropic-codex')) {
+    registerIfMissing(registry, new AnthropicToCodexBridgeProvider());
+  }
 
   // Register Anthropic Copilot provider (embedded Anthropic-compatible server).
   // process.cwd() is the fallback cwd; per-session workspace is threaded via
   // ANTHROPIC_AUTH_TOKEN (encoded by buildSdkConfig) and parsed per-request in server.ts.
   // Lazy registration keeps @github/copilot-sdk out of the startup import graph so
   // bun build --compile can tree-shake and bundle the SDK without crashing startup.
-  registerCopilotProvider(registry);
+  if (!disabledBuiltInProviderIds.has('anthropic-copilot')) {
+    registerCopilotProvider(registry);
+  }
 
   // Additional built-in providers can be registered here
   // Example:
@@ -217,6 +260,7 @@ export async function waitForOptionalProviderRegistration(
 export async function ensureBuiltInProviderRegistered(providerId: string): Promise<void> {
   const registry = getProviderRegistry();
   if (registry.has(providerId)) return;
+  markBuiltInProviderEnabled(providerId);
 
   switch (providerId) {
     case 'anthropic':
@@ -296,6 +340,7 @@ export function resetProviderFactory(): void {
   initialized = false;
   copilotProviderModule = null;
   lastSyncedConfigByProviderId.clear();
+  disabledBuiltInProviderIds.clear();
 }
 
 // Re-export types from shared package

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -228,6 +228,7 @@ export function setupAuthHandlers(
         if (credentialManager) {
           await credentialManager.removeCredentials(providerId);
         }
+        await clearCacheAndNotifyProvidersChanged(internalEventBus);
         log.error(`Logout failed for ${providerId}:`, error);
         return {
           success: false,

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -130,6 +130,7 @@ export function setupAuthHandlers(
             await credentialManager?.storeOAuthTokens(providerId, credentials);
           }
           unsubscribe?.();
+          await clearCacheAndNotifyProvidersChanged(internalEventBus);
         };
         unsubscribe = provider.onCredentialsChanged?.(persistCredentials);
         const flowData = await provider.startOAuthFlow();

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -21,8 +21,17 @@ import type {
 import type { AuthManager } from '../auth-manager';
 import type { ProviderCredentialManager } from '../credentials/provider-credential-manager';
 import { getProviderRegistry } from '../providers/registry';
+import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 const log = new Logger('auth-handlers');
+
+async function clearCacheAndNotifyProvidersChanged(
+  internalEventBus?: InternalEventBus<DaemonInternalEventMap>
+): Promise<void> {
+  const { clearModelsCache } = await import('../model-service.js');
+  clearModelsCache();
+  internalEventBus?.publishAsync('providers.changed', { sessionId: 'global' });
+}
 
 /**
  * Setup authentication-related RPC handlers
@@ -30,7 +39,8 @@ const log = new Logger('auth-handlers');
 export function setupAuthHandlers(
   messageHub: MessageHub,
   authManager: AuthManager,
-  credentialManager?: ProviderCredentialManager
+  credentialManager?: ProviderCredentialManager,
+  internalEventBus?: InternalEventBus<DaemonInternalEventMap>
 ): void {
   // NeoKai auth status (Anthropic)
   messageHub.onRequest('auth.status', async () => {
@@ -211,6 +221,7 @@ export function setupAuthHandlers(
             provider.setCredentials({ type: 'api_key', apiKey: '' });
           }
         }
+        await clearCacheAndNotifyProvidersChanged(internalEventBus);
         return { success: true };
       } catch (error) {
         if (credentialManager) {
@@ -259,6 +270,7 @@ export function setupAuthHandlers(
         if (credentials?.type === 'oauth') {
           await credentialManager?.storeOAuthTokens(providerId, credentials);
         }
+        await clearCacheAndNotifyProvidersChanged(internalEventBus);
         return { success: true };
       } catch (error) {
         log.error(`Token refresh failed for ${providerId}:`, error);

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -165,6 +165,9 @@ async function persistAndSync(
     namespaceId: 'global',
     settings: updated,
   });
+  internalEventBus.publishAsync('providers.changed', {
+    sessionId: 'global',
+  });
 
   // Compat: sync the full list to the providers table so the unified registry
   // stays in sync with the legacy customEndpoints JSON blob.

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -152,9 +152,22 @@ async function persistAndSync(
   endpoints: CustomEndpointConfig[],
   db?: Database
 ): Promise<void> {
+  // Filter out custom endpoints disabled in the providers table so legacy
+  // sync does not re-register them despite is_enabled = 0.
+  let syncEndpoints = endpoints;
+  if (db) {
+    const disabledIds = new Set(
+      db.providers
+        .listProviders()
+        .filter((p) => p.kind === 'custom_endpoint' && !p.isEnabled)
+        .map((p) => p.providerId)
+    );
+    syncEndpoints = endpoints.filter((e) => !disabledIds.has(customProviderIdFor(e.id)));
+  }
+
   const updated = settingsManager.updateGlobalSettings({ customEndpoints: endpoints });
   const { syncCustomEndpointProviders } = await import('../providers/factory.js');
-  await syncCustomEndpointProviders(endpoints);
+  await syncCustomEndpointProviders(syncEndpoints);
   // Invalidate the cached global model list so newly added/removed custom
   // models become discoverable immediately instead of waiting for the TTL
   // to expire. Without this, model resolution can keep using stale defaults

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -154,16 +154,7 @@ async function persistAndSync(
 ): Promise<void> {
   // Filter out custom endpoints disabled in the providers table so legacy
   // sync does not re-register them despite is_enabled = 0.
-  let syncEndpoints = endpoints;
-  if (db) {
-    const disabledIds = new Set(
-      db.providers
-        .listProviders()
-        .filter((p) => p.kind === 'custom_endpoint' && !p.isEnabled)
-        .map((p) => p.providerId)
-    );
-    syncEndpoints = endpoints.filter((e) => !disabledIds.has(customProviderIdFor(e.id)));
-  }
+  const syncEndpoints = db ? filterDisabledCustomEndpoints(endpoints, db) : endpoints;
 
   const updated = settingsManager.updateGlobalSettings({ customEndpoints: endpoints });
   const { syncCustomEndpointProviders } = await import('../providers/factory.js');
@@ -218,6 +209,25 @@ export function withCustomEndpointsLock<T>(fn: () => Promise<T>): Promise<T> {
   // Swallow errors on the queue tail so one failure doesn't poison the chain.
   mutationQueue = run.catch(() => {});
   return run;
+}
+
+/**
+ * Filter out custom endpoints that are disabled in the providers table.
+ * Used by both the legacy custom-endpoint handlers and the generic settings
+ * handlers so disabled endpoints are not re-registered by unrelated syncs.
+ */
+export function filterDisabledCustomEndpoints(
+  endpoints: CustomEndpointConfig[],
+  db: Database
+): CustomEndpointConfig[] {
+  if (!db?.providers?.listProviders) return endpoints;
+  const disabledIds = new Set(
+    db.providers
+      .listProviders()
+      .filter((p) => p.kind === 'custom_endpoint' && !p.isEnabled)
+      .map((p) => p.providerId)
+  );
+  return endpoints.filter((e) => !disabledIds.has(customProviderIdFor(e.id)));
 }
 
 export function registerCustomEndpointHandlers(

--- a/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/custom-endpoint-handlers.ts
@@ -146,6 +146,27 @@ function removeEndpointFromProviderTable(db: Database | undefined, endpointId: s
   }
 }
 
+/**
+ * Sync the full custom endpoint list to the providers table.
+ * Disabled endpoints are still updated so re-enablement uses the latest config.
+ */
+export function syncCustomEndpointsToProviderTable(
+  db: Database,
+  endpoints: CustomEndpointConfig[]
+): void {
+  if (!db?.providers?.listProviders) return;
+  const allProviderIds = new Set(endpoints.map((e) => customProviderIdFor(e.id)));
+  for (const endpoint of endpoints) {
+    syncEndpointToProviderTable(db, endpoint);
+  }
+  // Remove any provider records for endpoints that no longer exist.
+  for (const record of db.providers.listProviders()) {
+    if (record.kind === 'custom_endpoint' && !allProviderIds.has(record.providerId)) {
+      db.providers.deleteProvider(record.id);
+    }
+  }
+}
+
 async function persistAndSync(
   settingsManager: SettingsManager,
   internalEventBus: InternalEventBus<DaemonInternalEventMap>,
@@ -176,16 +197,7 @@ async function persistAndSync(
   // Compat: sync the full list to the providers table so the unified registry
   // stays in sync with the legacy customEndpoints JSON blob.
   if (db) {
-    const allProviderIds = new Set(endpoints.map((e) => customProviderIdFor(e.id)));
-    for (const endpoint of endpoints) {
-      syncEndpointToProviderTable(db, endpoint);
-    }
-    // Remove any provider records for endpoints that no longer exist.
-    for (const record of db.providers.listProviders()) {
-      if (record.kind === 'custom_endpoint' && !allProviderIds.has(record.providerId)) {
-        db.providers.deleteProvider(record.id);
-      }
-    }
+    syncCustomEndpointsToProviderTable(db, endpoints);
   }
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -414,7 +414,12 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   setupCommandHandlers(deps.messageHub, deps.sessionManager);
   setupFileHandlers(deps.messageHub, deps.sessionManager);
   setupSystemHandlers(deps.messageHub, deps.sessionManager, deps.authManager, deps.config);
-  setupAuthHandlers(deps.messageHub, deps.authManager, deps.credentialManager);
+  setupAuthHandlers(
+    deps.messageHub,
+    deps.authManager,
+    deps.credentialManager,
+    deps.internalEventBus
+  );
   registerMcpHandlers(deps.messageHub, deps.sessionManager, deps.appMcpManager);
   registerSettingsHandlers(
     deps.messageHub,
@@ -437,6 +442,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     messageHub: deps.messageHub,
     providerRepo: deps.db.providers,
     credentialManager: providerCredentialManager,
+    internalEventBus: deps.internalEventBus,
   });
 
   setupConfigHandlers(deps.messageHub, deps.sessionManager, deps.internalEventBus);

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -12,6 +12,7 @@ import type { ProviderCredentialManager } from '../credentials/provider-credenti
 import { syncProviderToRegistry, removeProviderFromRegistry } from '../providers/provider-sync.js';
 import { getProviderRegistry } from '../providers/registry.js';
 import { withCustomEndpointsLock } from './custom-endpoint-handlers.js';
+import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 
 const VALID_PROVIDER_KINDS = new Set(['built_in', 'custom_endpoint']);
 const VALID_AUTH_TYPES = new Set(['api_key', 'oauth', 'none']);
@@ -108,10 +109,19 @@ export interface ProviderHandlerDeps {
   messageHub: MessageHub;
   providerRepo: ProviderRepository;
   credentialManager: ProviderCredentialManager;
+  internalEventBus: InternalEventBus<DaemonInternalEventMap>;
+}
+
+async function clearCacheAndNotifyProvidersChanged(
+  internalEventBus: InternalEventBus<DaemonInternalEventMap>
+): Promise<void> {
+  const { clearModelsCache } = await import('../model-service.js');
+  clearModelsCache();
+  internalEventBus.publishAsync('providers.changed', { sessionId: 'global' });
 }
 
 export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
-  const { messageHub, providerRepo, credentialManager } = deps;
+  const { messageHub, providerRepo, credentialManager, internalEventBus } = deps;
 
   /** List all providers with live auth status from the registry. */
   messageHub.onRequest('providers.list', async () => {
@@ -180,6 +190,8 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
           throw err;
         }
 
+        await clearCacheAndNotifyProvidersChanged(internalEventBus);
+
         return { success: true, provider: record };
       });
     }
@@ -238,6 +250,8 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
             await syncProviderToRegistry(record, creds);
           }
 
+          await clearCacheAndNotifyProvidersChanged(internalEventBus);
+
           return { success: true, provider: record };
         });
       });
@@ -255,6 +269,8 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
       providerRepo.deleteProvider(data.id);
       await removeProviderFromRegistry(record.providerId);
       await credentialManager.removeCredentials(record.providerId);
+
+      await clearCacheAndNotifyProvidersChanged(internalEventBus);
 
       return { success: true };
     });

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -250,8 +250,8 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
             if (record.isEnabled === false) {
               await removeProviderFromRegistry(record.providerId);
             } else {
-              const { initializeProviders } = await import('../providers/factory.js');
-              initializeProviders();
+              const { ensureBuiltInProviderRegistered } = await import('../providers/factory.js');
+              await ensureBuiltInProviderRegistered(record.providerId);
               const creds = await credentialManager.getCredentials(record.providerId);
               await syncProviderToRegistry(record, creds);
             }

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -11,6 +11,7 @@ import type { ProviderRepository } from '../../storage/repositories/provider-rep
 import type { ProviderCredentialManager } from '../credentials/provider-credential-manager';
 import { syncProviderToRegistry, removeProviderFromRegistry } from '../providers/provider-sync.js';
 import { getProviderRegistry } from '../providers/registry.js';
+import { markBuiltInProviderDisabled } from '../providers/factory.js';
 import { withCustomEndpointsLock } from './custom-endpoint-handlers.js';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 
@@ -248,6 +249,9 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
 
           if (shouldResync) {
             if (record.isEnabled === false) {
+              if (record.kind === 'built_in') {
+                markBuiltInProviderDisabled(record.providerId);
+              }
               await removeProviderFromRegistry(record.providerId);
             } else {
               const { ensureBuiltInProviderRegistered } = await import('../providers/factory.js');
@@ -274,6 +278,9 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
       // DB-first: delete the row before touching the registry so a failure in
       // credential removal doesn't leave a ghost record that resurrects on restart.
       providerRepo.deleteProvider(data.id);
+      if (record.kind === 'built_in') {
+        markBuiltInProviderDisabled(record.providerId);
+      }
       await removeProviderFromRegistry(record.providerId);
       try {
         await credentialManager.removeCredentials(record.providerId);

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -279,11 +279,15 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
     if (!record) throw new Error(`Provider ${data.id} not found`);
     const lock = record.kind === 'custom_endpoint' ? withCustomEndpointsLock : withProviderLock;
     return lock(async () => {
-      // DB-first: delete the row before touching the registry so a failure in
-      // credential removal doesn't leave a ghost record that resurrects on restart.
-      providerRepo.deleteProvider(data.id);
       if (record.kind === 'built_in') {
+        // Built-ins cannot be truly deleted; keep the row disabled so the
+        // disabled state persists across daemon restarts.
+        providerRepo.updateProvider(data.id, { isEnabled: false });
         markBuiltInProviderDisabled(record.providerId);
+      } else {
+        // DB-first: delete the row before touching the registry so a failure in
+        // credential removal doesn't leave a ghost record that resurrects on restart.
+        providerRepo.deleteProvider(data.id);
       }
       await removeProviderFromRegistry(record.providerId);
       try {

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -238,16 +238,23 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
           const record = providerRepo.updateProvider(data.id, updates);
           if (!record) throw new Error(`Provider ${data.id} not found`);
 
-          // Re-sync to registry if config or credentials changed.
+          // Re-sync to registry if config, credentials, or enabled state changed.
           const shouldResync =
             data.credentials !== undefined ||
             updates.baseUrl !== undefined ||
             updates.customEndpointConfigJson !== undefined ||
-            updates.configJson !== undefined;
+            updates.configJson !== undefined ||
+            updates.isEnabled !== undefined;
 
           if (shouldResync) {
-            const creds = await credentialManager.getCredentials(record.providerId);
-            await syncProviderToRegistry(record, creds);
+            if (record.isEnabled === false) {
+              await removeProviderFromRegistry(record.providerId);
+            } else {
+              const { initializeProviders } = await import('../providers/factory.js');
+              initializeProviders();
+              const creds = await credentialManager.getCredentials(record.providerId);
+              await syncProviderToRegistry(record, creds);
+            }
           }
 
           await clearCacheAndNotifyProvidersChanged(internalEventBus);
@@ -268,10 +275,11 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
       // credential removal doesn't leave a ghost record that resurrects on restart.
       providerRepo.deleteProvider(data.id);
       await removeProviderFromRegistry(record.providerId);
-      await credentialManager.removeCredentials(record.providerId);
-
-      await clearCacheAndNotifyProvidersChanged(internalEventBus);
-
+      try {
+        await credentialManager.removeCredentials(record.providerId);
+      } finally {
+        await clearCacheAndNotifyProvidersChanged(internalEventBus);
+      }
       return { success: true };
     });
   });

--- a/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/provider-handlers.ts
@@ -182,6 +182,10 @@ export function setupProviderHandlers(deps: ProviderHandlerDeps): void {
           }
 
           // Sync to registry.
+          if (record.kind === 'built_in') {
+            const { ensureBuiltInProviderRegistered } = await import('../providers/factory.js');
+            await ensureBuiltInProviderRegistered(record.providerId);
+          }
           const creds = await credentialManager.getCredentials(record.providerId);
           await syncProviderToRegistry(record, creds);
         } catch (err) {

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -79,7 +79,11 @@ export function registerSettingsHandlers(
           await syncProviderModelAllowlists(data.updates.providerModelAllowlists);
         }
         if (touchesCustomEndpoints) {
-          const { filterDisabledCustomEndpoints } = await import('./custom-endpoint-handlers.js');
+          const { filterDisabledCustomEndpoints, syncCustomEndpointsToProviderTable } =
+            await import('./custom-endpoint-handlers.js');
+          // Update provider rows for ALL endpoints (including disabled) so
+          // re-enablement picks up the latest config instead of a stale one.
+          syncCustomEndpointsToProviderTable(db, data.updates.customEndpoints ?? []);
           const endpointsToSync = filterDisabledCustomEndpoints(
             data.updates.customEndpoints ?? [],
             db
@@ -143,7 +147,12 @@ export function registerSettingsHandlers(
         await syncProviderModelAllowlists(data.settings.providerModelAllowlists);
       }
       if (customEndpointsProvided) {
-        const { filterDisabledCustomEndpoints } = await import('./custom-endpoint-handlers.js');
+        const { filterDisabledCustomEndpoints, syncCustomEndpointsToProviderTable } = await import(
+          './custom-endpoint-handlers.js'
+        );
+        // Update provider rows for ALL endpoints (including disabled) so
+        // re-enablement picks up the latest config instead of a stale one.
+        syncCustomEndpointsToProviderTable(db, data.settings.customEndpoints ?? []);
         const endpointsToSync = filterDisabledCustomEndpoints(
           data.settings.customEndpoints ?? [],
           db

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -91,6 +91,9 @@ export function registerSettingsHandlers(
           namespaceId: 'global',
           settings: updated,
         });
+        if (touchesCustomEndpoints || data.updates.providerModelAllowlists !== undefined) {
+          internalEventBus.publishAsync('providers.changed', { sessionId: 'global' });
+        }
 
         // Note: showArchived filter is now handled client-side via LiveQuery (sessions.list)
 
@@ -145,6 +148,9 @@ export function registerSettingsHandlers(
         namespaceId: 'global',
         settings: settingsToPersist,
       });
+      if (customEndpointsProvided || data.settings.providerModelAllowlists !== undefined) {
+        internalEventBus.publishAsync('providers.changed', { sessionId: 'global' });
+      }
       return { success: true };
     };
     // Always serialise through the customEndpoints lock — even when the

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -79,8 +79,13 @@ export function registerSettingsHandlers(
           await syncProviderModelAllowlists(data.updates.providerModelAllowlists);
         }
         if (touchesCustomEndpoints) {
+          const { filterDisabledCustomEndpoints } = await import('./custom-endpoint-handlers.js');
+          const endpointsToSync = filterDisabledCustomEndpoints(
+            data.updates.customEndpoints ?? [],
+            db
+          );
           const { syncCustomEndpointProviders } = await import('../providers/factory.js');
-          await syncCustomEndpointProviders(data.updates.customEndpoints);
+          await syncCustomEndpointProviders(endpointsToSync);
           // Stale model cache would still list removed custom models and
           // miss newly added ones until the TTL expires.
           const { clearModelsCache } = await import('../model-service');
@@ -138,8 +143,13 @@ export function registerSettingsHandlers(
         await syncProviderModelAllowlists(data.settings.providerModelAllowlists);
       }
       if (customEndpointsProvided) {
+        const { filterDisabledCustomEndpoints } = await import('./custom-endpoint-handlers.js');
+        const endpointsToSync = filterDisabledCustomEndpoints(
+          data.settings.customEndpoints ?? [],
+          db
+        );
         const { syncCustomEndpointProviders } = await import('../providers/factory.js');
-        await syncCustomEndpointProviders(data.settings.customEndpoints);
+        await syncCustomEndpointProviders(endpointsToSync);
         const { clearModelsCache } = await import('../model-service');
         clearModelsCache();
       }

--- a/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
@@ -136,15 +136,23 @@ describe('ClientEventBridge', () => {
       expect(eventHandlers.has('session.errorClear')).toBe(true);
     });
 
+    it('should subscribe to provider bridge events', () => {
+      const { internalEventBus, gateway, eventHandlers } = buildFixture();
+      const bridge = new ClientEventBridge(internalEventBus, gateway);
+      bridge.start();
+
+      expect(eventHandlers.has('providers.changed')).toBe(true);
+    });
+
     it('should be idempotent', () => {
       const { internalEventBus, gateway, eventHandlers } = buildFixture();
       const bridge = new ClientEventBridge(internalEventBus, gateway);
       bridge.start();
       bridge.start();
 
-      // 20 space + 3 session + 2 conn/auth + 1 config + 2 error = 28 unique events
+      // 20 space + 4 session + 2 conn/auth + 1 config + 2 error = 29 unique events
       // (context.updated has 2 handlers but is 1 unique event key)
-      expect(eventHandlers.size).toBe(28);
+      expect(eventHandlers.size).toBe(29);
     });
   });
 
@@ -155,8 +163,8 @@ describe('ClientEventBridge', () => {
       bridge.start();
       bridge.stop();
 
-      // 29 internalEventBus.subscribe calls total (context.updated has 2 handlers)
-      expect(unsubscribers.length).toBe(29);
+      // 30 internalEventBus.subscribe calls total (context.updated has 2 handlers)
+      expect(unsubscribers.length).toBe(30);
     });
   });
 
@@ -467,6 +475,18 @@ describe('ClientEventBridge', () => {
       expect(published[0].method).toBe('context.updated');
       expect(published[0].data).toEqual(contextInfo);
       expect(published[0].channel).toEqual({ kind: 'session', sessionId: 'sess-1' });
+    });
+
+    it('forwards providers.changed to global channel', () => {
+      const { internalEventBus, gateway, eventHandlers, published } = buildFixture();
+      createClientEventBridge(internalEventBus, gateway).start();
+
+      const data = { sessionId: 'global' };
+      eventHandlers.get('providers.changed')![0](data);
+
+      expect(published[0].method).toBe('providers.changed');
+      expect(published[0].data).toEqual(data);
+      expect(published[0].channel).toEqual({ kind: 'global' });
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1079,12 +1079,18 @@ describe('Model Service', () => {
       type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
       const registry = getProviderRegistry();
       registry.register({
+        id: 'anthropic',
+        getModels: async () => [],
+        isAvailable: async () => true,
+      } as ProviderLike);
+      registry.register({
         id: 'empty-provider',
         getModels: async () => [],
         isAvailable: async () => true,
       } as ProviderLike);
 
-      // With no providers returning models, refreshModels should restore fallbacks.
+      // With no providers returning models, refreshModels should restore fallbacks
+      // for providers that are still registered.
       const { refreshModels } = await import('../../../../src/lib/model-service');
       await refreshModels();
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
@@ -277,7 +277,7 @@ describe('Provider RPC handlers', () => {
   });
 
   describe('providers.delete', () => {
-    it('deletes a provider', async () => {
+    it('disables a built-in provider instead of deleting the row', async () => {
       const created = repo.createProvider({
         providerId: 'anthropic',
         displayName: 'Anthropic',
@@ -290,7 +290,9 @@ describe('Provider RPC handlers', () => {
       };
 
       expect(result.success).toBe(true);
-      expect(repo.getProvider(created.id)).toBeNull();
+      const after = repo.getProvider(created.id);
+      expect(after).not.toBeNull();
+      expect(after?.isEnabled).toBe(false);
     });
 
     it('throws when provider not found', async () => {
@@ -478,7 +480,7 @@ describe('Provider RPC handlers', () => {
   });
 
   describe('providers.delete', () => {
-    it('deletes a provider', async () => {
+    it('disables a built-in provider instead of deleting the row', async () => {
       const created = repo.createProvider({
         providerId: 'anthropic',
         displayName: 'Anthropic',
@@ -491,7 +493,9 @@ describe('Provider RPC handlers', () => {
       };
 
       expect(result.success).toBe(true);
-      expect(repo.getProvider(created.id)).toBeNull();
+      const after = repo.getProvider(created.id);
+      expect(after).not.toBeNull();
+      expect(after?.isEnabled).toBe(false);
     });
 
     it('throws when provider not found', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/provider-handlers.test.ts
@@ -11,8 +11,25 @@ import type { ProviderRepository } from '../../../../src/storage/repositories/pr
 import type { ProviderCredentialManager } from '../../../../src/lib/credentials/provider-credential-manager';
 import type { ProviderRecord, CreateProviderParams } from '@neokai/shared';
 import type { Provider } from '@neokai/shared/provider';
+import type {
+  DaemonInternalEventMap,
+  InternalEventBus,
+} from '../../../../src/lib/internal-event-bus';
 
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+function createMockInternalEventBus(): InternalEventBus<DaemonInternalEventMap> {
+  return {
+    publishAsync: mock(() => {}),
+    publish: mock(async () => ({ delivered: 0, failures: [] })),
+    subscribe: mock(() => () => {}),
+    off: mock(() => {}),
+    clear: mock(() => {}),
+    getHandlerCount: mock(() => 0),
+    getHandlerCountForSession: mock(() => 0),
+    getHandlerCountForNamespace: mock(() => 0),
+  } as unknown as InternalEventBus<DaemonInternalEventMap>;
+}
 
 function createMockMessageHub(): { hub: MessageHub; handlers: Map<string, RequestHandler> } {
   const handlers = new Map<string, RequestHandler>();
@@ -114,11 +131,13 @@ describe('Provider RPC handlers', () => {
   let hubData: ReturnType<typeof createMockMessageHub>;
   let repo: ReturnType<typeof createMockProviderRepo>;
   let creds: ReturnType<typeof createMockCredentialManager>;
+  let eventBus: ReturnType<typeof createMockInternalEventBus>;
 
   beforeEach(() => {
     hubData = createMockMessageHub();
     repo = createMockProviderRepo();
     creds = createMockCredentialManager();
+    eventBus = createMockInternalEventBus();
     resetProviderRegistry();
     resetProviderFactory();
   });
@@ -133,6 +152,7 @@ describe('Provider RPC handlers', () => {
       messageHub: hubData.hub,
       providerRepo: repo,
       credentialManager: creds,
+      internalEventBus: eventBus,
     });
     return hubData.handlers;
   }
@@ -199,6 +219,25 @@ describe('Provider RPC handlers', () => {
         )
       ).rejects.toThrow('kind must be one of');
     });
+
+    it('emits providers.changed after creation', async () => {
+      const handlers = setup();
+      await handlers.get('providers.create')!(
+        {
+          params: {
+            providerId: 'openrouter',
+            displayName: 'OpenRouter',
+            kind: 'built_in',
+            authType: 'api_key',
+          },
+          credentials: { apiKey: 'sk-or-test' },
+        },
+        {}
+      );
+      expect(eventBus.publishAsync).toHaveBeenCalledWith('providers.changed', {
+        sessionId: 'global',
+      });
+    });
   });
 
   describe('providers.update', () => {
@@ -217,6 +256,23 @@ describe('Provider RPC handlers', () => {
 
       expect(result.success).toBe(true);
       expect(result.provider.displayName).toBe('Anthropic Inc');
+    });
+
+    it('emits providers.changed after update', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      await handlers.get('providers.update')!(
+        { id: created.id, params: { displayName: 'Anthropic Inc' } },
+        {}
+      );
+      expect(eventBus.publishAsync).toHaveBeenCalledWith('providers.changed', {
+        sessionId: 'global',
+      });
     });
   });
 
@@ -242,6 +298,20 @@ describe('Provider RPC handlers', () => {
       await expect(handlers.get('providers.delete')!({ id: 'missing' }, {})).rejects.toThrow(
         'not found'
       );
+    });
+
+    it('emits providers.changed after deletion', async () => {
+      const created = repo.createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        kind: 'built_in',
+        authType: 'api_key',
+      });
+      const handlers = setup();
+      await handlers.get('providers.delete')!({ id: created.id }, {});
+      expect(eventBus.publishAsync).toHaveBeenCalledWith('providers.changed', {
+        sessionId: 'global',
+      });
     });
   });
 

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -22,6 +22,7 @@ import {
   getThinkingOptionsForProvider,
 } from '@neokai/shared';
 import { connectionState, type ConnectionState } from '../lib/state.ts';
+import { connectionManager } from '../lib/connection-manager.ts';
 import ConnectionStatus from './ConnectionStatus.tsx';
 import ContextUsageBar from './ContextUsageBar.tsx';
 import { ContentContainer } from './ui/ContentContainer.tsx';
@@ -276,7 +277,7 @@ export default function SessionStatusBar({
   );
   const [modelSearchQuery, setModelSearchQuery] = useState('');
 
-  useEffect(() => {
+  const loadAuthStatuses = useCallback(() => {
     let cancelled = false;
     callIfConnected('auth.providers', {})
       .then((res) => {
@@ -295,6 +296,22 @@ export default function SessionStatusBar({
       cancelled = true;
     };
   }, [callIfConnected]);
+
+  useEffect(() => {
+    return loadAuthStatuses();
+  }, [loadAuthStatuses]);
+
+  // Refresh auth statuses when providers change so the picker filter stays current.
+  useEffect(() => {
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) return;
+    const unsub = hub.onEvent('providers.changed', () => {
+      loadAuthStatuses();
+    });
+    return () => {
+      unsub();
+    };
+  }, [loadAuthStatuses, connectionState.value]);
 
   // Dropdowns - only one can be open at a time
   const modelDropdown = useModal();

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -186,6 +186,7 @@ describe('useModelSwitcher', () => {
   describe('loadModelInfo with mocked hub', () => {
     it('should load current model and available models on mount', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -235,6 +236,7 @@ describe('useModelSwitcher', () => {
 
     it('should classify models by family correctly', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -267,6 +269,7 @@ describe('useModelSwitcher', () => {
 
     it('should set glm provider for glm models', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -294,6 +297,7 @@ describe('useModelSwitcher', () => {
 
     it('should detect kimi family and provider for Kimi models', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -326,6 +330,7 @@ describe('useModelSwitcher', () => {
 
     it('should detect gpt family and anthropic-copilot provider for Copilot GPT models', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -358,6 +363,7 @@ describe('useModelSwitcher', () => {
 
     it('should detect claude family via copilot provider', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -391,6 +397,7 @@ describe('useModelSwitcher', () => {
 
     it('should map OpenRouter models to OpenRouter provider and slash-based families', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -449,6 +456,7 @@ describe('useModelSwitcher', () => {
 
     it('should sort models by family order', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -479,6 +487,7 @@ describe('useModelSwitcher', () => {
 
     it('should handle error during load gracefully', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValue({ acknowledged: true })
@@ -512,6 +521,7 @@ describe('useModelSwitcher', () => {
   describe('switchModel', () => {
     it('should show info toast when switching to same model', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -537,6 +547,7 @@ describe('useModelSwitcher', () => {
 
     it('should switch model successfully', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -572,6 +583,7 @@ describe('useModelSwitcher', () => {
 
     it('should handle switch failure from server', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -601,6 +613,7 @@ describe('useModelSwitcher', () => {
 
     it('should handle switch failure with default error', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -629,6 +642,7 @@ describe('useModelSwitcher', () => {
 
     it('should handle switch error with no connection', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -657,6 +671,7 @@ describe('useModelSwitcher', () => {
 
     it('should handle switch exception', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValue({ acknowledged: true })
@@ -696,6 +711,7 @@ describe('useModelSwitcher', () => {
       const switchingStates: boolean[] = [];
 
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -738,6 +754,7 @@ describe('useModelSwitcher', () => {
 
     it('should update currentModelInfo after successful switch', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -776,6 +793,7 @@ describe('useModelSwitcher', () => {
       // Two providers both expose claude-sonnet-4-20250514; the post-switch find must
       // prefer the entry for the provider that was actually switched to.
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -828,6 +846,7 @@ describe('useModelSwitcher', () => {
   describe('switchModel - provider validation', () => {
     it('should show error when provider is missing from model', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -857,6 +876,7 @@ describe('useModelSwitcher', () => {
   describe('reload', () => {
     it('should reload model info', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           // First load (mount)
@@ -893,6 +913,7 @@ describe('useModelSwitcher', () => {
   describe('sessionId changes', () => {
     it('should reload when sessionId changes', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           // First load (session-1)
@@ -928,9 +949,63 @@ describe('useModelSwitcher', () => {
     });
   });
 
+  describe('providers.changed event', () => {
+    it('should reload model info when providers.changed event fires', async () => {
+      const mockHub = {
+        onEvent: vi.fn(() => () => {}),
+        request: vi
+          .fn()
+          // First load (mount)
+          .mockResolvedValueOnce({
+            currentModel: 'model-1',
+            modelInfo: null,
+          })
+          .mockResolvedValueOnce({
+            models: [{ id: 'model-1', display_name: 'Model 1', description: '' }],
+          })
+          // Second load (after providers.changed)
+          .mockResolvedValueOnce({
+            currentModel: 'model-1',
+            modelInfo: null,
+          })
+          .mockResolvedValueOnce({
+            models: [
+              { id: 'model-1', display_name: 'Model 1', description: '' },
+              { id: 'model-2', display_name: 'Model 2', description: '' },
+            ],
+          }),
+      };
+      mockGetHubIfConnected.mockReturnValue(mockHub);
+
+      const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.availableModels.length).toBe(1);
+
+      // Simulate providers.changed event by invoking the registered handler
+      const eventHandler = mockHub.onEvent.mock.results[0]?.value;
+      // onEvent returns an unsubscribe function; the handler is the second arg
+      const registeredHandler = mockHub.onEvent.mock.calls.find(
+        (call) => call[0] === 'providers.changed'
+      )?.[1];
+      expect(registeredHandler).toBeDefined();
+      await act(async () => {
+        registeredHandler();
+      });
+
+      await waitFor(() => {
+        expect(result.current.availableModels.length).toBe(2);
+      });
+    });
+  });
+
   describe('function stability', () => {
     it('should return stable reload function on same sessionId', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({
@@ -1030,6 +1105,7 @@ describe('useModelSwitcher', () => {
   describe('model alias extraction', () => {
     it('should extract alias from model ID', async () => {
       const mockHub = {
+        onEvent: vi.fn(() => () => {}),
         request: vi
           .fn()
           .mockResolvedValueOnce({

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -374,6 +374,18 @@ export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResu
     }
   }, [loadModelInfo, isConnected]);
 
+  // Reload model list when providers change (added/removed/updated)
+  useEffect(() => {
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) return;
+    const unsub = hub.onEvent('providers.changed', () => {
+      loadModelInfo();
+    });
+    return () => {
+      unsub();
+    };
+  }, [loadModelInfo]);
+
   const switchModel = useCallback(
     async (model: ModelInfo) => {
       if (!model.provider) {

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -374,7 +374,9 @@ export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResu
     }
   }, [loadModelInfo, isConnected]);
 
-  // Reload model list when providers change (added/removed/updated)
+  // Reload model list when providers change (added/removed/updated).
+  // Include connectionState so we re-subscribe after the WebSocket connects
+  // following a fresh page load where the hook rendered before the hub was ready.
   useEffect(() => {
     const hub = connectionManager.getHubIfConnected();
     if (!hub) return;
@@ -384,7 +386,7 @@ export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResu
     return () => {
       unsub();
     };
-  }, [loadModelInfo]);
+  }, [loadModelInfo, connectionState.value]);
 
   const switchModel = useCallback(
     async (model: ModelInfo) => {


### PR DESCRIPTION
## Summary

Model lists in open sessions now refresh immediately when providers change, without requiring daemon restart or page reload.

## Changes

**Backend**
- Add `providers.changed` event to `DaemonInternalEventMap`
- `provider-handlers.ts`: emit `providers.changed` + clear model cache after create/update/delete
- `custom-endpoint-handlers.ts`: emit `providers.changed` after endpoint mutations
- `settings-handlers.ts`: emit `providers.changed` when custom endpoints or model allowlists change
- `auth-handlers.ts`: emit `providers.changed` after logout/refresh
- Pass `internalEventBus` through `setupProviderHandlers` and `setupAuthHandlers`

**Frontend**
- `useModelSwitcher`: subscribe to `providers.changed` and reload model info on event

**Tests**
- Provider handlers: assert `providers.changed` is emitted on create/update/delete
- `useModelSwitcher`: assert models reload when `providers.changed` fires