### PR TITLE
Rehydrate long-horizon event subscriptions

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -536,12 +536,11 @@ const EXCLUDED_TABLE_NAMES: string[] = [
   'space_long_horizon_agent_forge_scopes',
   'space_long_horizon_agent_reminders',
   'space_long_horizon_agent_event_subscriptions',
-  // Space agent management tables — agent goal/scope assignments, reminders, event subscriptions;
+  // Space agent management tables — agent goal/scope assignments and reminders;
   // internal MCP tool state, not useful for ad-hoc agent queries.
   'space_agent_goal_assignments',
   'space_agent_forge_scope_assignments',
   'space_agent_reminders',
-  'space_agent_event_subscriptions',
 ];
 
 // ── Scope config registry ─────────────────────────────────────────────────────

--- a/packages/daemon/src/lib/external-events/external-event-store.ts
+++ b/packages/daemon/src/lib/external-events/external-event-store.ts
@@ -167,12 +167,19 @@ export class ExternalEventStore {
     return row ? rowToRecord(row) : null;
   }
 
+  markEventDelivered(eventId: string): void {
+    const event = this.getById(eventId);
+    if (!event || TERMINAL_EVENT_STATES.has(event.state)) return;
+    this.setEventState(eventId, 'delivered');
+  }
+
   /**
    * Mark the source event terminal `delivered` if **every** expected delivery
    * row is in state `delivered`. No-op if the source event is already
    * terminal, or if any delivery is non-terminal or terminal-failed.
    *
-   * This is the only path that can promote a source event to `delivered`.
+   * Workflow delivery rows use this path; sources without per-workflow delivery
+   * rows can call `markEventDelivered` after direct delivery succeeds.
    */
   markEventDeliveredIfAllDeliveriesDelivered(eventId: string): void {
     const event = this.getById(eventId);

--- a/packages/daemon/src/lib/external-events/topic-validator.ts
+++ b/packages/daemon/src/lib/external-events/topic-validator.ts
@@ -87,7 +87,7 @@ export function validateGlobPattern(pattern: string): ValidationResult {
  * their identifier here so unknown/typo'd sources fail loudly at publish time
  * rather than silently storing topics that no subscriber will ever match.
  */
-export const KNOWN_SOURCES: ReadonlySet<string> = new Set<string>(['github']);
+export const KNOWN_SOURCES: ReadonlySet<string> = new Set<string>(['github', 'space']);
 
 /**
  * Validate that a topic is a literal (no wildcards) suitable for storing

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -655,8 +655,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     deps.spaceManager,
     deps.db
   );
-  setupSpaceLongHorizonAgentHandlers(deps.messageHub, deps.spaceManager, longHorizonAgentRepo);
-
   setupSpaceWorkflowHandlers(
     deps.messageHub,
     deps.spaceManager,
@@ -846,6 +844,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     goalService: spaceGoalService,
     spaceManager: deps.spaceManager,
   });
+
+  setupSpaceLongHorizonAgentHandlers(
+    deps.messageHub,
+    deps.spaceManager,
+    longHorizonAgentRepo,
+    spaceRuntimeService
+  );
 
   // Register Space RPC handlers now that spaceRuntimeService exists.
   // spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -21,7 +21,10 @@ export function setupSpaceLongHorizonAgentHandlers(
   messageHub: MessageHub,
   spaceManager: SpaceManager,
   repo: SpaceLongHorizonAgentRepository,
-  runtimeService?: Pick<SpaceRuntimeService, 'refreshLongHorizonAgentSubscriptions'>
+  runtimeService?: Pick<
+    SpaceRuntimeService,
+    'refreshLongHorizonAgentSubscriptions' | 'removeLongHorizonAgentSubscriptions'
+  >
 ): void {
   messageHub.onRequest('spaceLongHorizonAgent.listBuiltInTemplates', async (data) => {
     const params = data as { spaceId: string };
@@ -110,6 +113,7 @@ export function setupSpaceLongHorizonAgentHandlers(
     if (!existing) throw new Error(`Agent not found: ${params.agentId}`);
     if (params.spaceId && existing.spaceId !== params.spaceId)
       throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    runtimeService?.removeLongHorizonAgentSubscriptions(existing.spaceId, existing.id);
     repo.delete(params.agentId);
     return { success: true };
   });

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -15,11 +15,13 @@ import type { MessageHub, SpaceLongHorizonAgent } from '@neokai/shared';
 import type { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
 import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
 import type { SpaceManager } from '../space/managers/space-manager';
+import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 
 export function setupSpaceLongHorizonAgentHandlers(
   messageHub: MessageHub,
   spaceManager: SpaceManager,
-  repo: SpaceLongHorizonAgentRepository
+  repo: SpaceLongHorizonAgentRepository,
+  runtimeService?: Pick<SpaceRuntimeService, 'refreshLongHorizonAgentSubscriptions'>
 ): void {
   messageHub.onRequest('spaceLongHorizonAgent.listBuiltInTemplates', async (data) => {
     const params = data as { spaceId: string };
@@ -94,6 +96,10 @@ export function setupSpaceLongHorizonAgentHandlers(
       status: params.status as 'active' | 'paused' | 'disabled' | 'archived' | undefined,
     });
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (runtimeService) {
+      const refresh = runtimeService.refreshLongHorizonAgentSubscriptions(agent.spaceId, agent.id);
+      if (!refresh.success) throw new Error(refresh.error ?? 'Failed to refresh subscriptions');
+    }
     return { agent };
   });
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1695,6 +1695,10 @@ export class SpaceRuntimeService {
     return this.runtime.refreshLongHorizonAgentSubscriptions(spaceId, agentId);
   }
 
+  removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void {
+    this.runtime.removeLongHorizonAgentSubscriptions(spaceId, agentId);
+  }
+
   /**
    * Release the runtime for a given space.
    *

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -292,6 +292,7 @@ export class SpaceRuntimeService {
           run,
         });
       },
+      deliverLongHorizonExternalEvent: (args) => this.deliverLongHorizonExternalEvent(args),
     });
   }
 
@@ -342,6 +343,22 @@ export class SpaceRuntimeService {
       },
       { spaceId, ...context }
     );
+  }
+
+  private async deliverLongHorizonExternalEvent(args: {
+    spaceId: string;
+    agentId: string;
+    message: string;
+    idempotencyKey: string;
+  }): Promise<{ delivered: boolean }> {
+    const agent = this.config.longHorizonAgentRepo?.getById(args.agentId);
+    if (!agent || agent.spaceId !== args.spaceId) return { delivered: false };
+    const session = await this.ensureLongHorizonAgentSession(args.spaceId, args.agentId);
+    if (session) {
+      await this.injectLongTermAgentMessage(session, args.message);
+      return { delivered: true };
+    }
+    return { delivered: false };
   }
 
   private async deliverToLongTermAgent(
@@ -462,6 +479,50 @@ export class SpaceRuntimeService {
     this.config.reactiveDb?.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
     await session.messageQueue.enqueueWithId(id, message);
     return id;
+  }
+
+  private async ensureLongHorizonAgentSession(spaceId: string, agentId: string) {
+    const sessionManager = this.config.sessionManager;
+    const repo = this.config.longHorizonAgentRepo;
+    if (!sessionManager || !repo) return null;
+    const agent = repo.getById(agentId);
+    if (!agent || agent.spaceId !== spaceId) return null;
+    const space = await this.config.spaceManager.getSpace(spaceId);
+    if (!space) return null;
+    const sessionId =
+      agent.sessionId ??
+      `space:long-horizon-agent:${encodeActorIdComponent(spaceId)}:${encodeActorIdComponent(agentId)}`;
+    let session = await sessionManager.getSessionAsync(sessionId);
+    if (!session) {
+      try {
+        await sessionManager.createSession({
+          sessionId,
+          workspacePath: space.workspacePath,
+          title: agent.displayName,
+          spaceId: space.id,
+          worktreeMode: 'direct',
+          config: {
+            model: agent.model ?? space.defaultModel,
+            thinkingLevel: agent.thinkingLevel ?? undefined,
+            systemPrompt: {
+              type: 'preset',
+              preset: 'claude_code',
+              append: agent.instructions,
+            },
+            features: LONG_TERM_AGENT_SESSION_FEATURES,
+            settingSources: space.settingSources,
+          },
+        });
+      } catch (err) {
+        session = await sessionManager.getSessionAsync(sessionId);
+        if (!session) throw err;
+      }
+      session = session ?? (await sessionManager.getSessionAsync(sessionId));
+      if (!session) return null;
+      if (!agent.sessionId) repo.update(agent.id, { sessionId });
+    }
+    this.attachLongTermAgentMcpServers(session, space, agent.displayName, sessionId, null);
+    return session;
   }
 
   private async ensureLongTermAgentSession(actor: ActorRef) {
@@ -655,6 +716,7 @@ export class SpaceRuntimeService {
     return createSpaceAgentMcpServer({
       spaceId: space.id,
       db: this.config.db,
+      longHorizonAgentRepo: this.config.longHorizonAgentRepo,
       runtime: this.runtime,
       workflowManager: this.config.spaceWorkflowManager,
       spaceManager: this.config.spaceManager,
@@ -1287,6 +1349,7 @@ export class SpaceRuntimeService {
     const mcpServer = createSpaceAgentMcpServer({
       spaceId: space.id,
       db: this.config.db,
+      longHorizonAgentRepo: this.config.longHorizonAgentRepo,
       runtime: this.runtime,
       workflowManager: this.config.spaceWorkflowManager,
       spaceManager: this.config.spaceManager,
@@ -1412,6 +1475,7 @@ export class SpaceRuntimeService {
     const mcpServer = createSpaceAgentMcpServer({
       spaceId: space.id,
       db: this.config.db,
+      longHorizonAgentRepo: this.config.longHorizonAgentRepo,
       runtime: this.runtime,
       workflowManager: spaceWorkflowManager,
       spaceManager: this.config.spaceManager,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -352,10 +352,12 @@ export class SpaceRuntimeService {
     idempotencyKey: string;
   }): Promise<{ delivered: boolean }> {
     const agent = this.config.longHorizonAgentRepo?.getById(args.agentId);
-    if (!agent || agent.spaceId !== args.spaceId) return { delivered: false };
+    if (!agent || agent.spaceId !== args.spaceId || agent.status !== 'active') {
+      return { delivered: false };
+    }
     const session = await this.ensureLongHorizonAgentSession(args.spaceId, args.agentId);
     if (session) {
-      await this.injectLongTermAgentMessage(session, args.message);
+      await this.injectLongTermAgentMessage(session, args.message, args.idempotencyKey);
       return { delivered: true };
     }
     return { delivered: false };
@@ -486,12 +488,10 @@ export class SpaceRuntimeService {
     const repo = this.config.longHorizonAgentRepo;
     if (!sessionManager || !repo) return null;
     const agent = repo.getById(agentId);
-    if (!agent || agent.spaceId !== spaceId) return null;
+    if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') return null;
     const space = await this.config.spaceManager.getSpace(spaceId);
     if (!space) return null;
-    const sessionId =
-      agent.sessionId ??
-      `space:long-horizon-agent:${encodeActorIdComponent(spaceId)}:${encodeActorIdComponent(agentId)}`;
+    const sessionId = longTermAgentSessionId(spaceId, agentId);
     let session = await sessionManager.getSessionAsync(sessionId);
     if (!session) {
       try {
@@ -519,8 +519,20 @@ export class SpaceRuntimeService {
       }
       session = session ?? (await sessionManager.getSessionAsync(sessionId));
       if (!session) return null;
-      if (!agent.sessionId) repo.update(agent.id, { sessionId });
     }
+    if (agent.sessionId !== sessionId) repo.update(agent.id, { sessionId });
+    const currentMetadata = session.getSessionData().metadata;
+    this.config.actorRegistryRepos?.sessionRepo.updateSession(sessionId, {
+      metadata: {
+        ...currentMetadata,
+        promptProvenance: {
+          source: agent.templateKey ?? 'long_horizon_agent',
+          hash: agent.id,
+          agentId: agent.id,
+          agentName: agent.displayName,
+        },
+      },
+    });
     this.attachLongTermAgentMcpServers(session, space, agent.displayName, sessionId, null);
     return session;
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1688,6 +1688,13 @@ export class SpaceRuntimeService {
     return this.runtime;
   }
 
+  refreshLongHorizonAgentSubscriptions(
+    spaceId: string,
+    agentId: string
+  ): { success: boolean; error?: string } {
+    return this.runtime.refreshLongHorizonAgentSubscriptions(spaceId, agentId);
+  }
+
   /**
    * Release the runtime for a given space.
    *

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -495,6 +495,14 @@ export class SpaceRuntimeService {
     let session = await sessionManager.getSessionAsync(sessionId);
     if (!session) {
       try {
+        const storedTools = Array.isArray(agent.toolPermissions.tools)
+          ? (agent.toolPermissions.tools.filter((tool) => typeof tool === 'string') as string[])
+          : [];
+        const customTools = storedTools.length > 0 ? storedTools : undefined;
+        const customDisallowedBuiltins = customTools
+          ? CLAUDE_CODE_BUILTIN_TOOLS.filter((tool) => !customTools.includes(tool))
+          : [];
+        const agentKey = sanitizeLongTermAgentKey(agent.displayName);
         await sessionManager.createSession({
           sessionId,
           workspacePath: space.workspacePath,
@@ -510,6 +518,24 @@ export class SpaceRuntimeService {
               append: agent.instructions,
             },
             features: LONG_TERM_AGENT_SESSION_FEATURES,
+            ...(customTools
+              ? {
+                  sdkToolsPreset: customTools,
+                  allowedTools: customTools,
+                  disallowedTools: customDisallowedBuiltins,
+                }
+              : {}),
+            agent: customTools ? agentKey : undefined,
+            agents: customTools
+              ? {
+                  [agentKey]: {
+                    description: `Long-horizon Space agent: ${agent.displayName}`,
+                    disallowedTools: customDisallowedBuiltins,
+                    model: 'inherit',
+                    prompt: agent.instructions,
+                  } satisfies AgentDefinition,
+                }
+              : undefined,
             settingSources: space.settingSources,
           },
         });

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -54,6 +54,7 @@ import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
+import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import { Logger } from '../../logger';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
@@ -98,6 +99,8 @@ import {
 } from './post-approval-router';
 
 import type { TaskAgentManager } from './task-agent-manager';
+import type { SpaceActorRegistryAdapter } from '../actor-registry';
+import type { SpaceAgentInboxRepository } from '../../../storage/repositories/space-agent-inbox-repository';
 import { TopicTrie } from '../../external-events/topic-trie';
 import { WorkflowExecutor } from './workflow-executor';
 import { isPermanentSpawnError } from './workflow-node-execution-validation';
@@ -130,6 +133,8 @@ export interface SpaceRuntimeConfig {
   spaceManager: SpaceManager;
   /** Agent manager for resolving agents */
   spaceAgentManager: SpaceAgentManager;
+  /** Long-horizon agent repository for durable external-event subscriptions. */
+  longHorizonAgentRepo?: SpaceLongHorizonAgentRepository;
   /** Workflow manager for loading workflow definitions */
   spaceWorkflowManager: SpaceWorkflowManager;
   /** Workflow run repository for run CRUD and status updates */
@@ -238,6 +243,17 @@ export interface SpaceRuntimeConfig {
   goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
   /** Optional Forge scope service for automatic terminal task evidence capture. */
   evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
+  /** Optional actor registry for long-horizon external-event delivery. */
+  actorRegistry?: SpaceActorRegistryAdapter;
+  /** Optional durable inbox for inactive long-horizon external-event delivery. */
+  spaceAgentInboxRepo?: SpaceAgentInboxRepository;
+  /** Optional direct long-horizon event delivery hook supplied by SpaceRuntimeService. */
+  deliverLongHorizonExternalEvent?: (args: {
+    spaceId: string;
+    agentId: string;
+    message: string;
+    idempotencyKey: string;
+  }) => Promise<{ delivered: boolean }>;
 }
 
 interface StartWorkflowRunOptions {
@@ -262,7 +278,8 @@ interface ExecutorMeta {
   workspacePath: string;
 }
 
-interface SubscriptionTarget {
+interface WorkflowSubscriptionTarget {
+  kind?: 'workflow';
   workflowRunId: string;
   taskId: string;
   nodeId: string;
@@ -270,6 +287,29 @@ interface SubscriptionTarget {
   topic?: string;
   subscriptionKind?: 'static' | 'dynamic';
   sessionId?: string;
+}
+
+interface LongHorizonSubscriptionTarget {
+  kind: 'long_horizon_agent';
+  spaceId: string;
+  agentId: string;
+  source: string;
+  topic: string;
+  subscriptionId: string;
+}
+
+type SubscriptionTarget = WorkflowSubscriptionTarget | LongHorizonSubscriptionTarget;
+
+function isWorkflowSubscriptionTarget(
+  target: SubscriptionTarget
+): target is WorkflowSubscriptionTarget {
+  return target.kind !== 'long_horizon_agent';
+}
+
+function isLongHorizonSubscriptionTarget(
+  target: SubscriptionTarget
+): target is LongHorizonSubscriptionTarget {
+  return target.kind === 'long_horizon_agent';
 }
 
 interface PendingExternalEvent {
@@ -280,7 +320,7 @@ interface PendingExternalEvent {
 }
 
 interface ExternalEventDigestItem {
-  target: SubscriptionTarget;
+  target: WorkflowSubscriptionTarget;
   event: ExternalEventPublishedPayload;
   deliveryKey: string;
   deliveryMode: 'immediate' | 'defer';
@@ -460,7 +500,7 @@ function isExternallyDeliverableRun(status: SpaceWorkflowRun['status']): boolean
 
 function parseSubscriptionQueueKey(
   key: string
-): Pick<SubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'> | null {
+): Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'> | null {
   try {
     const parsed = JSON.parse(key) as unknown;
     if (!Array.isArray(parsed) || parsed.length !== 4) return null;
@@ -803,7 +843,10 @@ export class SpaceRuntime {
     options: { clearQueuedDeliveries?: boolean } = {}
   ): void {
     this.topicTrie.remove(
-      (target) => target.workflowRunId === workflowRunId && target.subscriptionKind !== 'dynamic'
+      (target) =>
+        isWorkflowSubscriptionTarget(target) &&
+        target.workflowRunId === workflowRunId &&
+        target.subscriptionKind !== 'dynamic'
     );
     if (options.clearQueuedDeliveries) {
       this.clearQueuedDeliveriesForRun(workflowRunId, 'run_interests_rebuilt');
@@ -867,6 +910,7 @@ export class SpaceRuntime {
     const subscriptionKind = options.subscriptionKind ?? 'dynamic';
     this.topicTrie.remove(
       (target) =>
+        isWorkflowSubscriptionTarget(target) &&
         target.workflowRunId === workflowRunId &&
         target.taskId === taskId &&
         target.nodeId === nodeId &&
@@ -876,6 +920,7 @@ export class SpaceRuntime {
     );
     const existingInterests = this.topicTrie.count(
       (target) =>
+        isWorkflowSubscriptionTarget(target) &&
         target.workflowRunId === workflowRunId &&
         target.nodeId === nodeId &&
         target.agentName === agentName
@@ -913,6 +958,7 @@ export class SpaceRuntime {
     const normalized = trimmed.toLowerCase();
     this.topicTrie.remove(
       (target) =>
+        isWorkflowSubscriptionTarget(target) &&
         target.workflowRunId === workflowRunId &&
         target.taskId === taskId &&
         target.nodeId === nodeId &&
@@ -931,6 +977,7 @@ export class SpaceRuntime {
   ): void {
     this.topicTrie.remove(
       (target) =>
+        isWorkflowSubscriptionTarget(target) &&
         target.workflowRunId === workflowRunId &&
         target.taskId === taskId &&
         target.nodeId === nodeId &&
@@ -943,11 +990,13 @@ export class SpaceRuntime {
   }
 
   clearRunInterests(workflowRunId: string): void {
-    this.topicTrie.remove((target) => target.workflowRunId === workflowRunId);
+    this.topicTrie.remove(
+      (target) => isWorkflowSubscriptionTarget(target) && target.workflowRunId === workflowRunId
+    );
     this.clearQueuedDeliveriesForRun(workflowRunId, 'run_terminal_cleanup');
   }
 
-  flushPendingNodeQueue(target: SubscriptionTarget): void {
+  flushPendingNodeQueue(target: WorkflowSubscriptionTarget): void {
     if (!target.sessionId) return;
     const targetWithExecution = this.resolveSubscriptionTarget(target);
     const key = this.buildQueueKey(target);
@@ -976,6 +1025,7 @@ export class SpaceRuntime {
     const store = this.config.externalEventStore;
     if (!store) return;
     const matches = this.lookupSubscriptionTargets(payload.topic).filter((target) => {
+      if (isLongHorizonSubscriptionTarget(target)) return target.spaceId === payload.spaceId;
       const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
       if (!run || run.spaceId !== payload.spaceId) return false;
       if (run.status === 'blocked') return this.hasActiveExecutionForRun(run.id);
@@ -989,13 +1039,18 @@ export class SpaceRuntime {
       return;
     }
 
-    const deliveries = new Map<string, { target: SubscriptionTarget; deliveryKey: string }>();
+    const workflowDeliveries = new Map<
+      string,
+      { target: WorkflowSubscriptionTarget; deliveryKey: string }
+    >();
+    const longHorizonMatches = matches.filter(isLongHorizonSubscriptionTarget);
     for (const match of matches) {
+      if (isLongHorizonSubscriptionTarget(match)) continue;
       try {
         const target = this.resolveSubscriptionTarget(match);
         const deliveryKey = this.buildDeliveryKey(target, payload);
         store.registerExpectedDelivery(payload.eventId, deliveryKey, target);
-        deliveries.set(deliveryKey, { target, deliveryKey });
+        workflowDeliveries.set(deliveryKey, { target, deliveryKey });
       } catch (err) {
         log.warn(
           `SpaceRuntime: failed to register external event ${payload.eventId} for ` +
@@ -1004,7 +1059,11 @@ export class SpaceRuntime {
       }
     }
 
-    for (const { target, deliveryKey } of deliveries.values()) {
+    for (const match of longHorizonMatches) {
+      await this.deliverToLongHorizonAgent(match, payload, workflowDeliveries.size === 0);
+    }
+
+    for (const { target, deliveryKey } of workflowDeliveries.values()) {
       try {
         if (
           store.isDeliveryTerminal(payload.eventId, deliveryKey) ||
@@ -1040,8 +1099,37 @@ export class SpaceRuntime {
     }
   }
 
+  private async deliverToLongHorizonAgent(
+    target: LongHorizonSubscriptionTarget,
+    event: ExternalEventPublishedPayload,
+    markEventDeliveredOnSuccess: boolean
+  ): Promise<void> {
+    if (!this.config.deliverLongHorizonExternalEvent) {
+      log.warn(
+        `SpaceRuntime: long-horizon event delivery unavailable for ${target.spaceId}/${target.agentId}`
+      );
+      return;
+    }
+    try {
+      const result = await this.config.deliverLongHorizonExternalEvent({
+        spaceId: target.spaceId,
+        agentId: target.agentId,
+        message: this.formatExternalEventMessage(event),
+        idempotencyKey: this.buildLongHorizonDeliveryKey(target, event),
+      });
+      if (result.delivered && markEventDeliveredOnSuccess) {
+        this.config.externalEventStore?.markEventDelivered(event.eventId);
+      }
+    } catch (err) {
+      log.warn(
+        `SpaceRuntime: failed to deliver external event ${event.eventId} to long-horizon agent ` +
+          `${target.agentId}: ${formatCommandError(err)}`
+      );
+    }
+  }
+
   private async enqueueDeliverableExternalEvent(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
     deliveryMode: 'immediate' | 'defer',
@@ -1178,7 +1266,7 @@ export class SpaceRuntime {
     }
   }
 
-  private resolveDigestDeliveryTarget(item: ExternalEventDigestItem): SubscriptionTarget {
+  private resolveDigestDeliveryTarget(item: ExternalEventDigestItem): WorkflowSubscriptionTarget {
     const target = item.target;
     const resolved = this.resolveSubscriptionTarget({
       workflowRunId: target.workflowRunId,
@@ -1191,7 +1279,7 @@ export class SpaceRuntime {
   }
 
   private async deliverToSession(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
     deliveryMode: 'immediate' | 'defer'
@@ -1273,7 +1361,7 @@ export class SpaceRuntime {
   }
 
   private queueForRetry(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
     deliveryMode: 'immediate' | 'defer',
@@ -1292,7 +1380,7 @@ export class SpaceRuntime {
   }
 
   private scheduleExternalEventRetry(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
     deliveryMode: 'immediate' | 'defer',
@@ -1388,7 +1476,7 @@ export class SpaceRuntime {
   }
 
   private getQueuedDelivery(
-    target: Pick<SubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>,
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>,
     deliveryKey: string
   ): PendingExternalEvent | undefined {
     return this.pendingExternalEventQueue
@@ -1396,7 +1484,7 @@ export class SpaceRuntime {
       ?.find((item) => item.deliveryKey === deliveryKey);
   }
 
-  private clearQueuedDelivery(target: SubscriptionTarget, deliveryKey: string): void {
+  private clearQueuedDelivery(target: WorkflowSubscriptionTarget, deliveryKey: string): void {
     this.clearQueuedDeliveryByKey(this.buildQueueKey(target), deliveryKey);
   }
 
@@ -1425,7 +1513,7 @@ export class SpaceRuntime {
   }
 
   private queueForPendingNode(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
     deliveryMode: 'immediate' | 'defer' = 'immediate',
@@ -1476,7 +1564,7 @@ export class SpaceRuntime {
   }
 
   private failQueuedDeliveriesForTarget(
-    target: Omit<SubscriptionTarget, 'sessionId'>,
+    target: Omit<WorkflowSubscriptionTarget, 'sessionId'>,
     reason: string
   ): void {
     const key = this.buildQueueKey(target);
@@ -1510,12 +1598,14 @@ export class SpaceRuntime {
     }
   }
 
-  private resolveSubscriptionTarget(target: SubscriptionTarget): SubscriptionTarget {
+  private resolveSubscriptionTarget(
+    target: WorkflowSubscriptionTarget
+  ): WorkflowSubscriptionTarget {
     const current = this.getCurrentQueueableOrActiveExecution(target);
     return current?.agentSessionId ? { ...target, sessionId: current.agentSessionId } : target;
   }
 
-  private isPending(target: SubscriptionTarget): boolean {
+  private isPending(target: WorkflowSubscriptionTarget): boolean {
     const current = this.getCurrentQueueableOrActiveExecution(target);
     return current?.status === 'pending' || current?.status === 'waiting_rebind';
   }
@@ -1534,7 +1624,7 @@ export class SpaceRuntime {
   }
 
   private getCurrentQueueableOrActiveExecution(
-    target: SubscriptionTarget
+    target: WorkflowSubscriptionTarget
   ): NodeExecution | undefined {
     return this.config.nodeExecutionRepo
       .listByNode(target.workflowRunId, target.nodeId)
@@ -1559,7 +1649,7 @@ export class SpaceRuntime {
    * due to other nodes.
    */
   private hasTerminalExecutionForTarget(
-    target: Pick<SubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
   ): boolean {
     return this.config.nodeExecutionRepo
       .listByNode(target.workflowRunId, target.nodeId)
@@ -1571,7 +1661,7 @@ export class SpaceRuntime {
   }
 
   private buildQueueKey(
-    target: Pick<SubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
   ): string {
     return JSON.stringify([target.workflowRunId, target.taskId, target.nodeId, target.agentName]);
   }
@@ -1627,13 +1717,13 @@ export class SpaceRuntime {
     );
   }
 
-  private buildRateLimitKey(target: SubscriptionTarget): string {
+  private buildRateLimitKey(target: WorkflowSubscriptionTarget): string {
     const executionId = this.getCurrentQueueableOrActiveExecution(target)?.id;
     return executionId ?? `${target.workflowRunId}:${target.nodeId}:${target.agentName}`;
   }
 
   private buildDeliveryKey(
-    target: SubscriptionTarget,
+    target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload
   ): string {
     return JSON.stringify([
@@ -1643,6 +1733,20 @@ export class SpaceRuntime {
       target.nodeId,
       target.agentName,
       target.workflowRunId,
+    ]);
+  }
+
+  private buildLongHorizonDeliveryKey(
+    target: LongHorizonSubscriptionTarget,
+    event: ExternalEventPublishedPayload
+  ): string {
+    return JSON.stringify([
+      'long_horizon_agent',
+      event.source,
+      event.dedupeKey,
+      target.spaceId,
+      target.agentId,
+      target.subscriptionId,
     ]);
   }
 
@@ -3248,12 +3352,39 @@ export class SpaceRuntime {
     }
   }
 
+  private rehydrateLongHorizonSubscriptions(spaceId: string): void {
+    const repo = this.config.longHorizonAgentRepo;
+    if (!repo) return;
+    this.topicTrie.remove(
+      (target) => isLongHorizonSubscriptionTarget(target) && target.spaceId === spaceId
+    );
+    for (const subscription of repo.listActiveSubscriptionsBySpace(spaceId)) {
+      const validation = validateGlobPattern(subscription.topic);
+      if (!validation.valid) {
+        log.warn(
+          `SpaceRuntime: skipping invalid long-horizon subscription ${subscription.id}: ` +
+            (validation.reason ?? 'invalid pattern')
+        );
+        continue;
+      }
+      this.topicTrie.insert(subscription.topic, {
+        kind: 'long_horizon_agent',
+        spaceId: subscription.spaceId,
+        agentId: subscription.agentId,
+        source: subscription.source,
+        topic: subscription.topic,
+        subscriptionId: subscription.id,
+      });
+    }
+  }
+
   private isTargetStillSubscribed(
-    target: Pick<SubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>,
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>,
     topic: string
   ): boolean {
     return this.lookupSubscriptionTargets(topic).some(
       (match) =>
+        isWorkflowSubscriptionTarget(match) &&
         match.workflowRunId === target.workflowRunId &&
         match.taskId === target.taskId &&
         match.nodeId === target.nodeId &&
@@ -3319,6 +3450,7 @@ export class SpaceRuntime {
           await this.ensurePollsForRun(run, space);
         }
       }
+      this.rehydrateLongHorizonSubscriptions(space.id);
     }
 
     this.requeuePersistedPendingDeliveries();

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -942,6 +942,46 @@ export class SpaceRuntime {
     return { success: true };
   }
 
+  refreshLongHorizonSubscription(
+    spaceId: string,
+    subscriptionId: string
+  ): { success: boolean; error?: string } {
+    const repo = this.config.longHorizonAgentRepo;
+    if (!repo) return { success: false, error: 'Long-horizon agent repository unavailable.' };
+    this.topicTrie.remove(
+      (target) =>
+        isLongHorizonSubscriptionTarget(target) &&
+        target.spaceId === spaceId &&
+        target.subscriptionId === subscriptionId
+    );
+    const subscription = repo.getSubscription(subscriptionId);
+    if (!subscription || subscription.spaceId !== spaceId || subscription.status !== 'active') {
+      return { success: true };
+    }
+    const agent = repo.getById(subscription.agentId);
+    if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') return { success: true };
+    const validation = validateGlobPattern(subscription.topic);
+    if (!validation.valid) return { success: false, error: validation.reason ?? 'invalid pattern' };
+    this.topicTrie.insert(subscription.topic, {
+      kind: 'long_horizon_agent',
+      spaceId: subscription.spaceId,
+      agentId: subscription.agentId,
+      source: subscription.source,
+      topic: subscription.topic,
+      subscriptionId: subscription.id,
+    });
+    return { success: true };
+  }
+
+  removeLongHorizonSubscription(spaceId: string, subscriptionId: string): void {
+    this.topicTrie.remove(
+      (target) =>
+        isLongHorizonSubscriptionTarget(target) &&
+        target.spaceId === spaceId &&
+        target.subscriptionId === subscriptionId
+    );
+  }
+
   unregisterSubscription(
     workflowRunId: string,
     taskId: string,
@@ -1043,24 +1083,46 @@ export class SpaceRuntime {
       string,
       { target: WorkflowSubscriptionTarget; deliveryKey: string }
     >();
-    const longHorizonMatches = matches.filter(isLongHorizonSubscriptionTarget);
+    const longHorizonDeliveries = new Map<
+      string,
+      { target: LongHorizonSubscriptionTarget; deliveryKey: string }
+    >();
     for (const match of matches) {
-      if (isLongHorizonSubscriptionTarget(match)) continue;
       try {
+        if (isLongHorizonSubscriptionTarget(match)) {
+          const deliveryKey = this.buildLongHorizonDeliveryKey(match, payload);
+          store.registerExpectedDelivery(payload.eventId, deliveryKey, {
+            workflowRunId: `long_horizon:${match.spaceId}`,
+            taskId: match.subscriptionId,
+            nodeId: match.agentId,
+            agentName: match.agentId,
+          });
+          longHorizonDeliveries.set(deliveryKey, { target: match, deliveryKey });
+          continue;
+        }
         const target = this.resolveSubscriptionTarget(match);
         const deliveryKey = this.buildDeliveryKey(target, payload);
         store.registerExpectedDelivery(payload.eventId, deliveryKey, target);
         workflowDeliveries.set(deliveryKey, { target, deliveryKey });
       } catch (err) {
+        const targetDescription = isLongHorizonSubscriptionTarget(match)
+          ? `${match.spaceId}/${match.agentId}`
+          : `${match.workflowRunId}/${match.nodeId}/${match.agentName}`;
         log.warn(
           `SpaceRuntime: failed to register external event ${payload.eventId} for ` +
-            `${match.workflowRunId}/${match.nodeId}/${match.agentName}: ${formatCommandError(err)}`
+            `${targetDescription}: ${formatCommandError(err)}`
         );
       }
     }
 
-    for (const match of longHorizonMatches) {
-      await this.deliverToLongHorizonAgent(match, payload, workflowDeliveries.size === 0);
+    for (const { target, deliveryKey } of longHorizonDeliveries.values()) {
+      if (
+        store.isDeliveryTerminal(payload.eventId, deliveryKey) ||
+        this.externalEventDeliveriesInFlight.has(deliveryKey)
+      ) {
+        continue;
+      }
+      await this.deliverToLongHorizonAgent(target, payload, deliveryKey);
     }
 
     for (const { target, deliveryKey } of workflowDeliveries.values()) {
@@ -1102,30 +1164,73 @@ export class SpaceRuntime {
   private async deliverToLongHorizonAgent(
     target: LongHorizonSubscriptionTarget,
     event: ExternalEventPublishedPayload,
-    markEventDeliveredOnSuccess: boolean
+    deliveryKey: string
   ): Promise<void> {
-    if (!this.config.deliverLongHorizonExternalEvent) {
-      log.warn(
-        `SpaceRuntime: long-horizon event delivery unavailable for ${target.spaceId}/${target.agentId}`
-      );
-      return;
-    }
+    const store = this.config.externalEventStore;
+    if (!store) return;
+    this.externalEventDeliveriesInFlight.add(deliveryKey);
     try {
+      if (!this.config.deliverLongHorizonExternalEvent) {
+        throw new Error('long-horizon event delivery unavailable');
+      }
       const result = await this.config.deliverLongHorizonExternalEvent({
         spaceId: target.spaceId,
         agentId: target.agentId,
         message: this.formatExternalEventMessage(event),
-        idempotencyKey: this.buildLongHorizonDeliveryKey(target, event),
+        idempotencyKey: deliveryKey,
       });
-      if (result.delivered && markEventDeliveredOnSuccess) {
-        this.config.externalEventStore?.markEventDelivered(event.eventId);
-      }
+      if (!result.delivered) throw new Error('long-horizon agent unavailable');
+      this.clearExternalEventRetry(deliveryKey);
+      store.markDeliveryDelivered(event.eventId, deliveryKey);
+      store.markEventDeliveredIfAllDeliveriesDelivered(event.eventId);
+      store.markEventFailedIfAllDeliveriesTerminal(event.eventId);
     } catch (err) {
+      const failureReason = err instanceof Error ? err.message : String(err);
+      store.markDeliveryFailed(event.eventId, deliveryKey, {
+        terminal: false,
+        reason: failureReason,
+      });
+      this.scheduleLongHorizonEventRetry(target, event, deliveryKey, failureReason);
       log.warn(
         `SpaceRuntime: failed to deliver external event ${event.eventId} to long-horizon agent ` +
-          `${target.agentId}: ${formatCommandError(err)}`
+          `${target.agentId}: ${failureReason}`
       );
+    } finally {
+      this.externalEventDeliveriesInFlight.delete(deliveryKey);
     }
+  }
+
+  private scheduleLongHorizonEventRetry(
+    target: LongHorizonSubscriptionTarget,
+    event: ExternalEventPublishedPayload,
+    deliveryKey: string,
+    failureReason: string
+  ): void {
+    if (this.externalEventRetryTimers.has(deliveryKey)) return;
+    const attempts = (this.externalEventRetryCounts.get(deliveryKey) ?? 0) + 1;
+    this.externalEventRetryCounts.set(deliveryKey, attempts);
+    if (attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS) {
+      this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
+        terminal: true,
+        reason: failureReason,
+      });
+      this.config.externalEventStore?.markEventFailedIfAllDeliveriesTerminal(event.eventId);
+      this.clearExternalEventRetry(deliveryKey);
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.externalEventRetryTimers.delete(deliveryKey);
+      if (this.config.externalEventStore?.isDeliveryTerminal(event.eventId, deliveryKey)) {
+        this.clearExternalEventRetry(deliveryKey);
+        return;
+      }
+      if (this.externalEventDeliveriesInFlight.has(deliveryKey)) {
+        this.scheduleLongHorizonEventRetry(target, event, deliveryKey, failureReason);
+        return;
+      }
+      void this.deliverToLongHorizonAgent(target, event, deliveryKey);
+    }, EXTERNAL_EVENT_RETRY_DELAY_MS);
+    this.externalEventRetryTimers.set(deliveryKey, timer);
   }
 
   private async enqueueDeliverableExternalEvent(
@@ -3359,22 +3464,13 @@ export class SpaceRuntime {
       (target) => isLongHorizonSubscriptionTarget(target) && target.spaceId === spaceId
     );
     for (const subscription of repo.listActiveSubscriptionsBySpace(spaceId)) {
-      const validation = validateGlobPattern(subscription.topic);
-      if (!validation.valid) {
+      const result = this.refreshLongHorizonSubscription(spaceId, subscription.id);
+      if (!result.success) {
         log.warn(
           `SpaceRuntime: skipping invalid long-horizon subscription ${subscription.id}: ` +
-            (validation.reason ?? 'invalid pattern')
+            (result.error ?? 'invalid pattern')
         );
-        continue;
       }
-      this.topicTrie.insert(subscription.topic, {
-        kind: 'long_horizon_agent',
-        spaceId: subscription.spaceId,
-        agentId: subscription.agentId,
-        source: subscription.source,
-        topic: subscription.topic,
-        subscriptionId: subscription.id,
-      });
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -989,6 +989,22 @@ export class SpaceRuntime {
     return { success: true };
   }
 
+  refreshLongHorizonAgentSubscriptions(
+    spaceId: string,
+    agentId: string
+  ): { success: boolean; error?: string } {
+    const repo = this.config.longHorizonAgentRepo;
+    if (!repo) return { success: false, error: 'Long-horizon agent repository unavailable.' };
+    const subscriptions = repo
+      .listSubscriptions(agentId)
+      .filter((subscription) => subscription.spaceId === spaceId);
+    for (const subscription of subscriptions) {
+      const result = this.refreshLongHorizonSubscription(spaceId, subscription.id);
+      if (!result.success) return result;
+    }
+    return { success: true };
+  }
+
   removeLongHorizonSubscription(spaceId: string, subscriptionId: string): void {
     this.topicTrie.remove(
       (target) =>

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -494,6 +494,21 @@ function legacyGitHubTopic(topic: string): string | null {
   return `${source}/${owner}/${repo}/${resource}.${entityAction.slice(dotIndex + 1)}`;
 }
 
+function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
+  const trimmedSource = source.trim();
+  const trimmedTopic = topic.trim();
+  if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
+  if (trimmedSource === 'github' && !trimmedTopic.startsWith('*/*/')) {
+    return `${trimmedSource}/*/*/${trimmedTopic}`;
+  }
+  return `${trimmedSource}/${trimmedTopic}`;
+}
+
+function longHorizonSpaceIdFromWorkflowRunId(workflowRunId: string): string | null {
+  const prefix = 'long_horizon:';
+  return workflowRunId.startsWith(prefix) ? workflowRunId.slice(prefix.length) : null;
+}
+
 function isExternallyDeliverableRun(status: SpaceWorkflowRun['status']): boolean {
   return status === 'in_progress' || status === 'blocked';
 }
@@ -960,14 +975,15 @@ export class SpaceRuntime {
     }
     const agent = repo.getById(subscription.agentId);
     if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') return { success: true };
-    const validation = validateGlobPattern(subscription.topic);
+    const pattern = composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic);
+    const validation = validateGlobPattern(pattern);
     if (!validation.valid) return { success: false, error: validation.reason ?? 'invalid pattern' };
-    this.topicTrie.insert(subscription.topic, {
+    this.topicTrie.insert(pattern, {
       kind: 'long_horizon_agent',
       spaceId: subscription.spaceId,
       agentId: subscription.agentId,
       source: subscription.source,
-      topic: subscription.topic,
+      topic: pattern,
       subscriptionId: subscription.id,
     });
     return { success: true };
@@ -3382,9 +3398,52 @@ export class SpaceRuntime {
     if (!store) return;
 
     for (const delivery of store.listPendingDeliveries()) {
-      const run = this.config.workflowRunRepo.getRun(delivery.workflowRunId);
       const eventRecord = store.getById(delivery.eventId);
       if (!eventRecord || eventRecord.state !== 'published') continue;
+      const longHorizonSpaceId = longHorizonSpaceIdFromWorkflowRunId(delivery.workflowRunId);
+      if (longHorizonSpaceId) {
+        const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
+        const subscription = this.config.longHorizonAgentRepo?.getSubscription(delivery.taskId);
+        const agent = subscription
+          ? this.config.longHorizonAgentRepo?.getById(subscription.agentId)
+          : null;
+        const target = subscription
+          ? {
+              kind: 'long_horizon_agent' as const,
+              spaceId: longHorizonSpaceId,
+              agentId: subscription.agentId,
+              source: subscription.source,
+              topic: composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic),
+              subscriptionId: subscription.id,
+            }
+          : null;
+        if (
+          !subscription ||
+          subscription.spaceId !== longHorizonSpaceId ||
+          subscription.status !== 'active' ||
+          !agent ||
+          agent.spaceId !== longHorizonSpaceId ||
+          agent.status !== 'active' ||
+          !target ||
+          !this.lookupSubscriptionTargets(eventPayload.topic).some(
+            (match) =>
+              isLongHorizonSubscriptionTarget(match) &&
+              match.spaceId === target.spaceId &&
+              match.subscriptionId === target.subscriptionId
+          )
+        ) {
+          store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
+            terminal: true,
+            reason: 'subscription_no_longer_active',
+          });
+          store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+          continue;
+        }
+        void this.deliverToLongHorizonAgent(target, eventPayload, delivery.deliveryKey);
+        continue;
+      }
+
+      const run = this.config.workflowRunRepo.getRun(delivery.workflowRunId);
       const target = {
         workflowRunId: delivery.workflowRunId,
         taskId: delivery.taskId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1014,6 +1014,15 @@ export class SpaceRuntime {
     );
   }
 
+  removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void {
+    this.topicTrie.remove(
+      (target) =>
+        isLongHorizonSubscriptionTarget(target) &&
+        target.spaceId === spaceId &&
+        target.agentId === agentId
+    );
+  }
+
   unregisterSubscription(
     workflowRunId: string,
     taskId: string,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -476,6 +476,37 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     return existing?.spaceId === spaceId ? existing : null;
   }
 
+  function longHorizonStatusFromSpaceAgent(agent: SpaceAgent) {
+    return agent.status === 'archived'
+      ? 'archived'
+      : agent.status === 'paused'
+        ? 'paused'
+        : 'active';
+  }
+
+  function longHorizonToolPermissionsFromSpaceAgent(agent: SpaceAgent) {
+    return agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {};
+  }
+
+  function syncConvertedLongHorizonAgent(spaceAgent: SpaceAgent) {
+    const repo = requireLongHorizonAgentRepo();
+    const existing = repo.getById(spaceAgent.id);
+    if (!existing || existing.spaceId !== spaceId) return null;
+    return repo.update(spaceAgent.id, {
+      displayName: spaceAgent.name,
+      status: longHorizonStatusFromSpaceAgent(spaceAgent),
+      instructions: spaceAgent.customPrompt ?? '',
+      model: spaceAgent.model,
+      thinkingLevel: spaceAgent.thinkingLevel,
+      toolPermissions: longHorizonToolPermissionsFromSpaceAgent(spaceAgent),
+    });
+  }
+
+  function refreshConvertedLongHorizonSubscriptions(agentId: string) {
+    const refresh = runtime.refreshLongHorizonAgentSubscriptions(spaceId, agentId);
+    if (!refresh.success) throw new Error(refresh.error ?? 'Failed to refresh subscriptions');
+  }
+
   function ensureLongHorizonAgentInSpace(agentId: string) {
     const existing = getLongHorizonAgentInSpace(agentId);
     if (existing) return existing;
@@ -490,17 +521,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       spaceId,
       handle: spaceAgent.handle ?? spaceAgent.name,
       displayName: spaceAgent.name,
-      status:
-        spaceAgent.status === 'archived'
-          ? 'archived'
-          : spaceAgent.status === 'paused'
-            ? 'paused'
-            : 'active',
+      status: longHorizonStatusFromSpaceAgent(spaceAgent),
       instructions: spaceAgent.customPrompt ?? '',
       model: spaceAgent.model,
       thinkingLevel: spaceAgent.thinkingLevel,
-      toolPermissions:
-        spaceAgent.tools && spaceAgent.tools.length > 0 ? { tools: spaceAgent.tools } : undefined,
+      toolPermissions: longHorizonToolPermissionsFromSpaceAgent(spaceAgent),
     });
   }
 
@@ -691,6 +716,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
         normalizeSpaceAgentUpdateArgs(args)
       );
       if (!result.ok) return jsonResult({ success: false, error: result.error });
+      const synced = syncConvertedLongHorizonAgent(result.value);
+      if (synced) refreshConvertedLongHorizonSubscriptions(result.value.id);
       logAudit('update_agent', { agent_id: args.agent_id, status: args.status });
       emitSpaceAgentUpdated(result.value);
       return jsonResult({ success: true, agent: result.value });

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -488,6 +488,19 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     return agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {};
   }
 
+  function longHorizonHandleFromSpaceAgent(agent: SpaceAgent) {
+    const repo = requireLongHorizonAgentRepo();
+    const base = agent.handle ?? agent.name;
+    const candidates = [base, `${base}-${agent.id}`];
+    for (let suffix = 2; suffix <= 10; suffix += 1)
+      candidates.push(`${base}-${agent.id}-${suffix}`);
+    for (const candidate of candidates) {
+      const existing = repo.getByHandle(spaceId, candidate);
+      if (!existing || existing.id === agent.id) return candidate;
+    }
+    return `${base}-${agent.id}-${Date.now()}`;
+  }
+
   function syncConvertedLongHorizonAgent(spaceAgent: SpaceAgent) {
     const repo = requireLongHorizonAgentRepo();
     const existing = repo.getById(spaceAgent.id);
@@ -519,7 +532,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     return repo.create({
       id: spaceAgent.id,
       spaceId,
-      handle: spaceAgent.handle ?? spaceAgent.name,
+      handle: longHorizonHandleFromSpaceAgent(spaceAgent),
       displayName: spaceAgent.name,
       status: longHorizonStatusFromSpaceAgent(spaceAgent),
       instructions: spaceAgent.customPrompt ?? '',

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -48,6 +48,7 @@ import { z } from 'zod';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
+import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
@@ -69,6 +70,7 @@ import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
+import { validateGlobPattern } from '../../external-events/topic-validator';
 import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 
 const log = new Logger('space-agent-tools');
@@ -229,6 +231,8 @@ export interface SpaceAgentToolsConfig {
   spaceId: string;
   /** SQLite database for long-horizon agent assignment metadata. */
   db?: BunDatabase;
+  /** Long-horizon agent repository for durable agent event subscriptions. */
+  longHorizonAgentRepo?: SpaceLongHorizonAgentRepository;
   /** SpaceRuntime for starting and managing workflow runs. */
   runtime: SpaceRuntime;
   /** Workflow manager for listing available workflows. */
@@ -459,6 +463,23 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
   function requireLongHorizonAgentDb(): BunDatabase {
     if (!db) throw new Error('Long-horizon agent management not available');
     return db;
+  }
+
+  function requireLongHorizonAgentRepo(): SpaceLongHorizonAgentRepository {
+    if (!config.longHorizonAgentRepo)
+      throw new Error('Long-horizon agent management not available');
+    return config.longHorizonAgentRepo;
+  }
+
+  function requireLongHorizonAgentInSpace(agentId: string) {
+    const agent = requireLongHorizonAgentRepo().getById(agentId);
+    if (!agent || agent.spaceId !== spaceId)
+      throw new Error(`Long-horizon agent not found: ${agentId}`);
+    return agent;
+  }
+
+  function sourceFromTopicPattern(topicPattern: string): string {
+    return topicPattern.split('/')[0] ?? '';
   }
 
   function requireSpaceAgentInSpace(agentId: string): SpaceAgent {
@@ -797,16 +818,22 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       label?: string;
     }): Promise<ToolResult> {
       try {
-        requireSpaceAgentInSpace(args.agent_id);
-        requireLongHorizonAgentDb()
-          .prepare(
-            `INSERT INTO space_agent_event_subscriptions
-						 (space_id, agent_id, topic_pattern, label, created_at) VALUES (?, ?, ?, ?, ?)
-							 ON CONFLICT(agent_id, topic_pattern) DO UPDATE SET label = excluded.label`
-          )
-          .run(spaceId, args.agent_id, args.topic_pattern, args.label ?? null, Date.now());
+        requireLongHorizonAgentInSpace(args.agent_id);
+        const validation = validateGlobPattern(args.topic_pattern);
+        if (!validation.valid) {
+          return jsonResult({ success: false, error: validation.reason ?? 'invalid pattern' });
+        }
+        const repo = requireLongHorizonAgentRepo();
+        const subscription = repo.upsertSubscription({
+          spaceId,
+          agentId: args.agent_id,
+          source: sourceFromTopicPattern(args.topic_pattern),
+          topic: args.topic_pattern,
+          filter: args.label ? { label: args.label } : {},
+          status: 'active',
+        });
         logAudit('subscribe_agent_event', args);
-        return jsonResult({ success: true });
+        return jsonResult({ success: true, subscription });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ success: false, error: message });
@@ -818,13 +845,12 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       topic_pattern: string;
     }): Promise<ToolResult> {
       try {
-        requireSpaceAgentInSpace(args.agent_id);
-        requireLongHorizonAgentDb()
-          .prepare(
-            `DELETE FROM space_agent_event_subscriptions
-						 WHERE space_id = ? AND agent_id = ? AND topic_pattern = ?`
-          )
-          .run(spaceId, args.agent_id, args.topic_pattern);
+        requireLongHorizonAgentInSpace(args.agent_id);
+        requireLongHorizonAgentRepo().deleteSubscriptionByAgentTopic(
+          spaceId,
+          args.agent_id,
+          args.topic_pattern
+        );
         logAudit('unsubscribe_agent_event', args);
         return jsonResult({ success: true });
       } catch (err) {
@@ -835,13 +861,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
     async list_agent_event_subscriptions(args: { agent_id: string }): Promise<ToolResult> {
       try {
-        requireSpaceAgentInSpace(args.agent_id);
-        const subscriptions = requireLongHorizonAgentDb()
-          .prepare(
-            `SELECT * FROM space_agent_event_subscriptions
-						 WHERE space_id = ? AND agent_id = ? ORDER BY created_at ASC`
-          )
-          .all(spaceId, args.agent_id);
+        requireLongHorizonAgentInSpace(args.agent_id);
+        const subscriptions = requireLongHorizonAgentRepo().listSubscriptions(args.agent_id);
         return jsonResult({ success: true, subscriptions });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -490,11 +490,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       spaceId,
       handle: spaceAgent.handle ?? spaceAgent.name,
       displayName: spaceAgent.name,
-      status: 'active',
+      status:
+        spaceAgent.status === 'archived'
+          ? 'archived'
+          : spaceAgent.status === 'paused'
+            ? 'paused'
+            : 'active',
       instructions: spaceAgent.customPrompt ?? '',
       model: spaceAgent.model,
       thinkingLevel: spaceAgent.thinkingLevel,
-      toolPermissions: {},
+      toolPermissions:
+        spaceAgent.tools && spaceAgent.tools.length > 0 ? { tools: spaceAgent.tools } : undefined,
     });
   }
 

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -472,14 +472,37 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
   }
 
   function requireLongHorizonAgentInSpace(agentId: string) {
-    const agent = requireLongHorizonAgentRepo().getById(agentId);
-    if (!agent || agent.spaceId !== spaceId)
+    const repo = requireLongHorizonAgentRepo();
+    const existing = repo.getById(agentId);
+    if (existing) {
+      if (existing.spaceId !== spaceId) throw new Error(`Long-horizon agent not found: ${agentId}`);
+      return existing;
+    }
+
+    const spaceAgent = spaceAgentManager.getById(agentId);
+    if (!spaceAgent || spaceAgent.spaceId !== spaceId) {
       throw new Error(`Long-horizon agent not found: ${agentId}`);
-    return agent;
+    }
+
+    return repo.create({
+      id: spaceAgent.id,
+      spaceId,
+      handle: spaceAgent.handle ?? spaceAgent.name,
+      displayName: spaceAgent.name,
+      status: 'active',
+      instructions: spaceAgent.customPrompt ?? '',
+      model: spaceAgent.model,
+      thinkingLevel: spaceAgent.thinkingLevel,
+      toolPermissions: {},
+    });
   }
 
   function sourceFromTopicPattern(topicPattern: string): string {
     return topicPattern.split('/')[0] ?? '';
+  }
+
+  function filterJsonFromLabel(label?: string): string {
+    return JSON.stringify(label ? { label } : {});
   }
 
   function requireSpaceAgentInSpace(agentId: string): SpaceAgent {
@@ -832,6 +855,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
           filter: args.label ? { label: args.label } : {},
           status: 'active',
         });
+        const refresh = runtime.refreshLongHorizonSubscription(spaceId, subscription.id);
+        if (!refresh.success) {
+          return jsonResult({ success: false, error: refresh.error ?? 'invalid pattern' });
+        }
         logAudit('subscribe_agent_event', args);
         return jsonResult({ success: true, subscription });
       } catch (err) {
@@ -843,14 +870,28 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     async unsubscribe_agent_event(args: {
       agent_id: string;
       topic_pattern: string;
+      label?: string;
     }): Promise<ToolResult> {
       try {
         requireLongHorizonAgentInSpace(args.agent_id);
-        requireLongHorizonAgentRepo().deleteSubscriptionByAgentTopic(
+        const repo = requireLongHorizonAgentRepo();
+        const source = sourceFromTopicPattern(args.topic_pattern);
+        const filterJson = filterJsonFromLabel(args.label);
+        const subscription = repo.getSubscriptionByRoute(
           spaceId,
           args.agent_id,
-          args.topic_pattern
+          source,
+          args.topic_pattern,
+          filterJson
         );
+        repo.deleteSubscriptionByRoute(
+          spaceId,
+          args.agent_id,
+          source,
+          args.topic_pattern,
+          filterJson
+        );
+        if (subscription) runtime.removeLongHorizonSubscription(spaceId, subscription.id);
         logAudit('unsubscribe_agent_event', args);
         return jsonResult({ success: true });
       } catch (err) {
@@ -3428,7 +3469,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
         'subscribe_agent_event',
         'Record an external-event subscription for a long-horizon Space agent.',
         {
-          agent_id: z.string().describe('SpaceAgent ID'),
+          agent_id: z.string().describe('Long-horizon agent ID'),
           topic_pattern: z.string().describe('External event topic glob pattern'),
           label: z.string().optional().describe('Human-readable subscription label'),
         },
@@ -3438,15 +3479,16 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
         'unsubscribe_agent_event',
         'Remove an external-event subscription from a long-horizon Space agent.',
         {
-          agent_id: z.string().describe('SpaceAgent ID'),
+          agent_id: z.string().describe('Long-horizon agent ID'),
           topic_pattern: z.string().describe('External event topic glob pattern'),
+          label: z.string().optional().describe('Human-readable subscription label'),
         },
         (args) => handlers.unsubscribe_agent_event(args)
       ),
       tool(
         'list_agent_event_subscriptions',
         'List external-event subscriptions for a long-horizon Space agent.',
-        { agent_id: z.string().describe('SpaceAgent ID') },
+        { agent_id: z.string().describe('Long-horizon agent ID') },
         (args) => handlers.list_agent_event_subscriptions(args)
       )
     );

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -471,14 +471,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     return config.longHorizonAgentRepo;
   }
 
-  function requireLongHorizonAgentInSpace(agentId: string) {
-    const repo = requireLongHorizonAgentRepo();
-    const existing = repo.getById(agentId);
-    if (existing) {
-      if (existing.spaceId !== spaceId) throw new Error(`Long-horizon agent not found: ${agentId}`);
-      return existing;
-    }
+  function getLongHorizonAgentInSpace(agentId: string) {
+    const existing = requireLongHorizonAgentRepo().getById(agentId);
+    return existing?.spaceId === spaceId ? existing : null;
+  }
 
+  function ensureLongHorizonAgentInSpace(agentId: string) {
+    const existing = getLongHorizonAgentInSpace(agentId);
+    if (existing) return existing;
+    const repo = requireLongHorizonAgentRepo();
     const spaceAgent = spaceAgentManager.getById(agentId);
     if (!spaceAgent || spaceAgent.spaceId !== spaceId) {
       throw new Error(`Long-horizon agent not found: ${agentId}`);
@@ -499,10 +500,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
   function sourceFromTopicPattern(topicPattern: string): string {
     return topicPattern.split('/')[0] ?? '';
-  }
-
-  function filterJsonFromLabel(label?: string): string {
-    return JSON.stringify(label ? { label } : {});
   }
 
   function requireSpaceAgentInSpace(agentId: string): SpaceAgent {
@@ -841,7 +838,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       label?: string;
     }): Promise<ToolResult> {
       try {
-        requireLongHorizonAgentInSpace(args.agent_id);
+        ensureLongHorizonAgentInSpace(args.agent_id);
         const validation = validateGlobPattern(args.topic_pattern);
         if (!validation.valid) {
           return jsonResult({ success: false, error: validation.reason ?? 'invalid pattern' });
@@ -873,24 +870,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       label?: string;
     }): Promise<ToolResult> {
       try {
-        requireLongHorizonAgentInSpace(args.agent_id);
+        const agent = getLongHorizonAgentInSpace(args.agent_id);
+        if (!agent) return jsonResult({ success: true });
         const repo = requireLongHorizonAgentRepo();
         const source = sourceFromTopicPattern(args.topic_pattern);
-        const filterJson = filterJsonFromLabel(args.label);
         const subscription = repo.getSubscriptionByRoute(
           spaceId,
           args.agent_id,
           source,
-          args.topic_pattern,
-          filterJson
+          args.topic_pattern
         );
-        repo.deleteSubscriptionByRoute(
-          spaceId,
-          args.agent_id,
-          source,
-          args.topic_pattern,
-          filterJson
-        );
+        repo.deleteSubscriptionByRoute(spaceId, args.agent_id, source, args.topic_pattern);
         if (subscription) runtime.removeLongHorizonSubscription(spaceId, subscription.id);
         logAudit('unsubscribe_agent_event', args);
         return jsonResult({ success: true });
@@ -902,7 +892,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
     async list_agent_event_subscriptions(args: { agent_id: string }): Promise<ToolResult> {
       try {
-        requireLongHorizonAgentInSpace(args.agent_id);
+        const agent = getLongHorizonAgentInSpace(args.agent_id);
+        if (!agent) return jsonResult({ success: true, subscriptions: [] });
         const subscriptions = requireLongHorizonAgentRepo().listSubscriptions(args.agent_id);
         return jsonResult({ success: true, subscriptions });
       } catch (err) {

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -294,10 +294,62 @@ export class SpaceLongHorizonAgentRepository {
     return this.getSubscription(id) as SpaceLongHorizonAgentEventSubscription;
   }
 
+  upsertSubscription(
+    params: CreateSpaceLongHorizonAgentSubscriptionParams
+  ): SpaceLongHorizonAgentEventSubscription {
+    this.requireAgentInSpace(params.agentId, params.spaceId);
+    const id = generateUUID();
+    const now = Date.now();
+    const filterJson = JSON.stringify(params.filter ?? {});
+    this.db
+      .prepare(
+        `INSERT INTO space_long_horizon_agent_event_subscriptions (
+						id, space_id, agent_id, source, topic, filter_json, status, created_at, updated_at
+					) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+					ON CONFLICT(space_id, agent_id, source, topic, filter_json) DO UPDATE SET
+						status = excluded.status,
+						updated_at = excluded.updated_at`
+      )
+      .run(
+        id,
+        params.spaceId,
+        params.agentId,
+        params.source,
+        params.topic,
+        filterJson,
+        params.status ?? 'active',
+        now,
+        now
+      );
+    return this.getSubscriptionByRoute(
+      params.spaceId,
+      params.agentId,
+      params.source,
+      params.topic,
+      filterJson
+    ) as SpaceLongHorizonAgentEventSubscription;
+  }
+
   getSubscription(id: string): SpaceLongHorizonAgentEventSubscription | null {
     const row = this.db
       .prepare(`SELECT * FROM space_long_horizon_agent_event_subscriptions WHERE id = ?`)
       .get(id) as Record<string, unknown> | undefined;
+    return row ? rowToSubscription(row) : null;
+  }
+
+  getSubscriptionByRoute(
+    spaceId: string,
+    agentId: string,
+    source: string,
+    topic: string,
+    filterJson = '{}'
+  ): SpaceLongHorizonAgentEventSubscription | null {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM space_long_horizon_agent_event_subscriptions
+				 WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ? AND filter_json = ?`
+      )
+      .get(spaceId, agentId, source, topic, filterJson) as Record<string, unknown> | undefined;
     return row ? rowToSubscription(row) : null;
   }
 
@@ -312,6 +364,25 @@ export class SpaceLongHorizonAgentRepository {
       )
       .all(agentId) as Record<string, unknown>[];
     return rows.map(rowToSubscription);
+  }
+
+  listActiveSubscriptionsBySpace(spaceId: string): SpaceLongHorizonAgentEventSubscription[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM space_long_horizon_agent_event_subscriptions
+				 WHERE space_id = ? AND status = 'active' ORDER BY created_at ASC`
+      )
+      .all(spaceId) as Record<string, unknown>[];
+    return rows.map(rowToSubscription);
+  }
+
+  deleteSubscriptionByAgentTopic(spaceId: string, agentId: string, topic: string): void {
+    this.db
+      .prepare(
+        `DELETE FROM space_long_horizon_agent_event_subscriptions
+				 WHERE space_id = ? AND agent_id = ? AND topic = ?`
+      )
+      .run(spaceId, agentId, topic);
   }
 
   private requireAgent(agentId: string): SpaceLongHorizonAgent {

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -298,17 +298,30 @@ export class SpaceLongHorizonAgentRepository {
     params: CreateSpaceLongHorizonAgentSubscriptionParams
   ): SpaceLongHorizonAgentEventSubscription {
     this.requireAgentInSpace(params.agentId, params.spaceId);
-    const id = generateUUID();
     const now = Date.now();
     const filterJson = JSON.stringify(params.filter ?? {});
+    const existing = this.getSubscriptionByRoute(
+      params.spaceId,
+      params.agentId,
+      params.source,
+      params.topic
+    );
+    if (existing) {
+      this.db
+        .prepare(
+          `UPDATE space_long_horizon_agent_event_subscriptions
+             SET filter_json = ?, status = ?, updated_at = ?
+             WHERE id = ?`
+        )
+        .run(filterJson, params.status ?? 'active', now, existing.id);
+      return this.getSubscription(existing.id) as SpaceLongHorizonAgentEventSubscription;
+    }
+    const id = generateUUID();
     this.db
       .prepare(
         `INSERT INTO space_long_horizon_agent_event_subscriptions (
-						id, space_id, agent_id, source, topic, filter_json, status, created_at, updated_at
-					) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-					ON CONFLICT(space_id, agent_id, source, topic, filter_json) DO UPDATE SET
-						status = excluded.status,
-						updated_at = excluded.updated_at`
+              id, space_id, agent_id, source, topic, filter_json, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -321,13 +334,7 @@ export class SpaceLongHorizonAgentRepository {
         now,
         now
       );
-    return this.getSubscriptionByRoute(
-      params.spaceId,
-      params.agentId,
-      params.source,
-      params.topic,
-      filterJson
-    ) as SpaceLongHorizonAgentEventSubscription;
+    return this.getSubscription(id) as SpaceLongHorizonAgentEventSubscription;
   }
 
   getSubscription(id: string): SpaceLongHorizonAgentEventSubscription | null {
@@ -341,15 +348,16 @@ export class SpaceLongHorizonAgentRepository {
     spaceId: string,
     agentId: string,
     source: string,
-    topic: string,
-    filterJson = '{}'
+    topic: string
   ): SpaceLongHorizonAgentEventSubscription | null {
     const row = this.db
       .prepare(
         `SELECT * FROM space_long_horizon_agent_event_subscriptions
-				 WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ? AND filter_json = ?`
+           WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ?
+           ORDER BY created_at ASC
+           LIMIT 1`
       )
-      .get(spaceId, agentId, source, topic, filterJson) as Record<string, unknown> | undefined;
+      .get(spaceId, agentId, source, topic) as Record<string, unknown> | undefined;
     return row ? rowToSubscription(row) : null;
   }
 
@@ -376,19 +384,13 @@ export class SpaceLongHorizonAgentRepository {
     return rows.map(rowToSubscription);
   }
 
-  deleteSubscriptionByRoute(
-    spaceId: string,
-    agentId: string,
-    source: string,
-    topic: string,
-    filterJson = '{}'
-  ): void {
+  deleteSubscriptionByRoute(spaceId: string, agentId: string, source: string, topic: string): void {
     this.db
       .prepare(
         `DELETE FROM space_long_horizon_agent_event_subscriptions
-				 WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ? AND filter_json = ?`
+           WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ?`
       )
-      .run(spaceId, agentId, source, topic, filterJson);
+      .run(spaceId, agentId, source, topic);
   }
 
   private requireAgent(agentId: string): SpaceLongHorizonAgent {

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -376,13 +376,19 @@ export class SpaceLongHorizonAgentRepository {
     return rows.map(rowToSubscription);
   }
 
-  deleteSubscriptionByAgentTopic(spaceId: string, agentId: string, topic: string): void {
+  deleteSubscriptionByRoute(
+    spaceId: string,
+    agentId: string,
+    source: string,
+    topic: string,
+    filterJson = '{}'
+  ): void {
     this.db
       .prepare(
         `DELETE FROM space_long_horizon_agent_event_subscriptions
-				 WHERE space_id = ? AND agent_id = ? AND topic = ?`
+				 WHERE space_id = ? AND agent_id = ? AND source = ? AND topic = ? AND filter_json = ?`
       )
-      .run(spaceId, agentId, topic);
+      .run(spaceId, agentId, source, topic, filterJson);
   }
 
   private requireAgent(agentId: string): SpaceLongHorizonAgent {

--- a/packages/daemon/src/storage/schema/evolution.ts
+++ b/packages/daemon/src/storage/schema/evolution.ts
@@ -238,22 +238,6 @@ function createSpaceAgentLongHorizonTables(db: BunDatabase): void {
     `CREATE INDEX IF NOT EXISTS idx_space_agent_reminders_agent_status ` +
       `ON space_agent_reminders(space_id, agent_id, status, remind_at)`
   );
-  db.exec(`
-		CREATE TABLE IF NOT EXISTS space_agent_event_subscriptions (
-			space_id TEXT NOT NULL,
-			agent_id TEXT NOT NULL,
-			topic_pattern TEXT NOT NULL,
-			label TEXT,
-			created_at INTEGER NOT NULL,
-			PRIMARY KEY (agent_id, topic_pattern),
-			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-			FOREIGN KEY (agent_id) REFERENCES space_agents(id) ON DELETE CASCADE
-		)
-	`);
-  db.exec(
-    `CREATE INDEX IF NOT EXISTS idx_space_agent_event_subscriptions_space ` +
-      `ON space_agent_event_subscriptions(space_id, topic_pattern)`
-  );
 }
 
 function hasTable(db: BunDatabase, tableName: string): boolean {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -10429,6 +10429,15 @@ export function runMigration151(db: BunDatabase): void {
   if (!hasLegacy) return;
 
   const now = Date.now();
+  const hasSpaceAgentStatus = tableHasColumn(db, 'space_agents', 'status');
+  const hasSpaceAgentCustomPrompt = tableHasColumn(db, 'space_agents', 'custom_prompt');
+  const statusExpr = hasSpaceAgentStatus
+    ? `COALESCE(NULLIF(space_agents.status, ''), 'active')`
+    : `'active'`;
+  const instructionsExpr = hasSpaceAgentCustomPrompt
+    ? `COALESCE(space_agents.custom_prompt, space_agents.instructions, space_agents.system_prompt, '')`
+    : `COALESCE(space_agents.instructions, space_agents.system_prompt, '')`;
+
   db.prepare(
     `INSERT OR IGNORE INTO space_long_horizon_agents (
       id, space_id, handle, display_name, template_key, status, session_id,
@@ -10440,13 +10449,16 @@ export function runMigration151(db: BunDatabase): void {
       COALESCE(space_agents.handle, space_agents.name, legacy.agent_id),
       COALESCE(space_agents.name, space_agents.handle, legacy.agent_id),
       'migration.legacy_space_agent',
-      'active',
+      ${statusExpr},
       NULL,
-      COALESCE(space_agents.instructions, space_agents.system_prompt, ''),
+      ${instructionsExpr},
       NULL,
       space_agents.model,
       NULL,
-      COALESCE(space_agents.tools, '[]'),
+      CASE
+        WHEN space_agents.tools IS NULL OR space_agents.tools = '' OR space_agents.tools = '[]' THEN '{}'
+        ELSE json_object('tools', json(space_agents.tools))
+      END,
       COALESCE(space_agents.created_at, legacy.created_at, ?),
       ?
     FROM space_agent_event_subscriptions legacy

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -10446,7 +10446,17 @@ export function runMigration151(db: BunDatabase): void {
     SELECT
       legacy.agent_id,
       legacy.space_id,
-      COALESCE(space_agents.handle, space_agents.name, legacy.agent_id),
+      CASE
+        WHEN EXISTS (
+          SELECT 1
+          FROM space_long_horizon_agents existing
+          WHERE existing.space_id = legacy.space_id
+            AND existing.id != legacy.agent_id
+            AND existing.status != 'archived'
+            AND existing.handle = COALESCE(space_agents.handle, space_agents.name, legacy.agent_id)
+        ) THEN COALESCE(space_agents.handle, space_agents.name, legacy.agent_id) || '-' || legacy.agent_id
+        ELSE COALESCE(space_agents.handle, space_agents.name, legacy.agent_id)
+      END,
       COALESCE(space_agents.name, space_agents.handle, legacy.agent_id),
       'migration.legacy_space_agent',
       ${statusExpr},

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -686,6 +686,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
   // Migration 150: Create providers table for unified provider registry.
   runMigration150(db);
+
+  // Migration 151: Consolidate agent event subscriptions into long-horizon table.
+  runMigration151(db);
 }
 
 /**
@@ -10412,4 +10415,39 @@ function runMigration150(db: BunDatabase): void {
   `);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_provider_id ON providers(provider_id)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_providers_sort_order ON providers(sort_order)`);
+}
+
+/**
+ * Migration 151 — Consolidate legacy agent event subscriptions.
+ */
+export function runMigration151(db: BunDatabase): void {
+  const hasLegacy = db
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'space_agent_event_subscriptions'`
+    )
+    .get();
+  if (!hasLegacy) return;
+
+  const now = Date.now();
+  db.prepare(
+    `INSERT OR IGNORE INTO space_long_horizon_agent_event_subscriptions (
+      id, space_id, agent_id, source, topic, filter_json, status, created_at, updated_at
+    )
+    SELECT
+      'm151:' || legacy.space_id || ':' || legacy.agent_id || ':' || legacy.topic_pattern,
+      legacy.space_id,
+      legacy.agent_id,
+      substr(legacy.topic_pattern, 1, instr(legacy.topic_pattern || '/', '/') - 1),
+      legacy.topic_pattern,
+      CASE
+        WHEN legacy.label IS NULL OR legacy.label = '' THEN '{}'
+        ELSE json_object('label', legacy.label)
+      END,
+      'active',
+      legacy.created_at,
+      ?
+    FROM space_agent_event_subscriptions legacy
+    JOIN space_long_horizon_agents agents ON agents.id = legacy.agent_id AND agents.space_id = legacy.space_id`
+  ).run(now);
+  db.exec(`DROP TABLE IF EXISTS space_agent_event_subscriptions`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -10430,11 +10430,36 @@ export function runMigration151(db: BunDatabase): void {
 
   const now = Date.now();
   db.prepare(
+    `INSERT OR IGNORE INTO space_long_horizon_agents (
+      id, space_id, handle, display_name, template_key, status, session_id,
+      instructions, autonomy_level, model, thinking_level, tool_permissions_json, created_at, updated_at
+    )
+    SELECT
+      legacy.agent_id,
+      legacy.space_id,
+      COALESCE(space_agents.handle, space_agents.name, legacy.agent_id),
+      COALESCE(space_agents.name, space_agents.handle, legacy.agent_id),
+      'migration.legacy_space_agent',
+      'active',
+      NULL,
+      COALESCE(space_agents.instructions, space_agents.system_prompt, ''),
+      NULL,
+      space_agents.model,
+      NULL,
+      COALESCE(space_agents.tools, '[]'),
+      COALESCE(space_agents.created_at, legacy.created_at, ?),
+      ?
+    FROM space_agent_event_subscriptions legacy
+    LEFT JOIN space_agents ON space_agents.id = legacy.agent_id AND space_agents.space_id = legacy.space_id
+    GROUP BY legacy.space_id, legacy.agent_id`
+  ).run(now, now);
+
+  db.prepare(
     `INSERT OR IGNORE INTO space_long_horizon_agent_event_subscriptions (
       id, space_id, agent_id, source, topic, filter_json, status, created_at, updated_at
     )
     SELECT
-      'm151:' || legacy.space_id || ':' || legacy.agent_id || ':' || legacy.topic_pattern,
+      'm151:' || legacy.space_id || ':' || legacy.agent_id || ':' || legacy.topic_pattern || ':' || COALESCE(legacy.label, ''),
       legacy.space_id,
       legacy.agent_id,
       substr(legacy.topic_pattern, 1, instr(legacy.topic_pattern || '/', '/') - 1),

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -39,7 +39,10 @@ async function call<T>(
 describe('Space long-horizon agent handlers', () => {
   let hubData: ReturnType<typeof createMockMessageHub>;
   let repo: SpaceLongHorizonAgentRepository;
-  let runtimeService: { refreshLongHorizonAgentSubscriptions: ReturnType<typeof mock> };
+  let runtimeService: {
+    refreshLongHorizonAgentSubscriptions: ReturnType<typeof mock>;
+    removeLongHorizonAgentSubscriptions: ReturnType<typeof mock>;
+  };
 
   beforeEach(() => {
     hubData = createMockMessageHub();
@@ -56,6 +59,7 @@ describe('Space long-horizon agent handlers', () => {
     } as unknown as SpaceLongHorizonAgentRepository;
     runtimeService = {
       refreshLongHorizonAgentSubscriptions: mock(() => ({ success: true })),
+      removeLongHorizonAgentSubscriptions: mock(() => {}),
     };
     setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager(), repo, runtimeService);
   });
@@ -81,6 +85,26 @@ describe('Space long-horizon agent handlers', () => {
         'space-1',
         'agent-1'
       );
+    });
+  });
+
+  describe('spaceLongHorizonAgent.delete', () => {
+    it('removes runtime subscriptions before deleting the agent row', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.delete',
+        {
+          agentId: 'agent-1',
+          spaceId: 'space-1',
+        }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(runtimeService.removeLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
+        'space-1',
+        'agent-1'
+      );
+      expect(repo.delete).toHaveBeenCalledWith('agent-1');
     });
   });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { MessageHub } from '@neokai/shared';
 import { setupSpaceLongHorizonAgentHandlers } from '../../../../src/lib/rpc-handlers/space-long-horizon-agent-handlers';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
+import type { SpaceLongHorizonAgentRepository } from '../../../../src/storage/repositories/space-long-horizon-agent-repository';
 
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
 
@@ -37,10 +38,50 @@ async function call<T>(
 
 describe('Space long-horizon agent handlers', () => {
   let hubData: ReturnType<typeof createMockMessageHub>;
+  let repo: SpaceLongHorizonAgentRepository;
+  let runtimeService: { refreshLongHorizonAgentSubscriptions: ReturnType<typeof mock> };
 
   beforeEach(() => {
     hubData = createMockMessageHub();
-    setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager());
+    repo = {
+      ensureCoordinator: mock(() => {}),
+      listBySpaceId: mock(() => []),
+      create: mock((params) => ({ id: 'agent-new', ...params, spaceId: params.spaceId })),
+      getById: mock(() => ({ id: 'agent-1', spaceId: 'space-1' })),
+      update: mock((agentId, params) => ({ id: agentId, spaceId: 'space-1', ...params })),
+      delete: mock(() => {}),
+      listReminders: mock(() => []),
+      createReminder: mock(() => ({})),
+      deleteReminder: mock(() => {}),
+    } as unknown as SpaceLongHorizonAgentRepository;
+    runtimeService = {
+      refreshLongHorizonAgentSubscriptions: mock(() => ({ success: true })),
+    };
+    setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager(), repo, runtimeService);
+  });
+
+  describe('spaceLongHorizonAgent.update', () => {
+    it('refreshes durable subscriptions after status updates', async () => {
+      const result = await call<{ agent: { id: string; status: string } }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.update',
+        {
+          agentId: 'agent-1',
+          spaceId: 'space-1',
+          status: 'paused',
+        }
+      );
+
+      expect(result.agent).toEqual(expect.objectContaining({ id: 'agent-1', status: 'paused' }));
+      expect(repo.update).toHaveBeenCalledWith(
+        'agent-1',
+        expect.objectContaining({ status: 'paused' })
+      );
+      expect(runtimeService.refreshLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
+        'space-1',
+        'agent-1'
+      );
+    });
   });
 
   describe('spaceLongHorizonAgent.listBuiltInTemplates', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
@@ -19,6 +19,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         handle TEXT,
         instructions TEXT,
         system_prompt TEXT,
+        custom_prompt TEXT,
+        status TEXT,
         model TEXT,
         tools TEXT,
         created_at INTEGER
@@ -62,12 +64,24 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
     `);
     db.prepare(`INSERT INTO spaces (id) VALUES (?)`).run('space-1');
     db.prepare(
-      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, model, tools, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('lh-agent-1', 'space-1', 'Existing LH', 'existing-lh', '', '', null, '[]', 100);
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'lh-agent-1',
+      'space-1',
+      'Existing LH',
+      'existing-lh',
+      '',
+      '',
+      null,
+      'active',
+      null,
+      '[]',
+      100
+    );
     db.prepare(
-      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, model, tools, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       'legacy-agent-1',
       'space-1',
@@ -75,6 +89,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       'legacy-agent',
       'Legacy instructions',
       '',
+      'Canonical custom prompt',
+      'paused',
       'claude-sonnet-4',
       '["Read"]',
       101
@@ -142,7 +158,7 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
     expect(
       db
         .prepare(
-          `SELECT id, handle, display_name, template_key, instructions, model, tool_permissions_json
+          `SELECT id, handle, display_name, template_key, status, instructions, model, tool_permissions_json
            FROM space_long_horizon_agents
            WHERE id = ?`
         )
@@ -152,9 +168,10 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       handle: 'legacy-agent',
       display_name: 'Legacy Agent',
       template_key: 'migration.legacy_space_agent',
-      instructions: 'Legacy instructions',
+      status: 'paused',
+      instructions: 'Canonical custom prompt',
       model: 'claude-sonnet-4',
-      tool_permissions_json: '["Read"]',
+      tool_permissions_json: '{"tools":["Read"]}',
     });
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration151 } from '../../../../../src/storage/schema/migrations';
+
+describe('Migration 151: consolidate agent event subscriptions', () => {
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    db = new BunDatabase(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    db.exec(`
+      CREATE TABLE spaces (
+        id TEXT PRIMARY KEY
+      );
+      CREATE TABLE space_agents (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL
+      );
+      CREATE TABLE space_long_horizon_agents (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL
+      );
+      CREATE TABLE space_agent_event_subscriptions (
+        space_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        topic_pattern TEXT NOT NULL,
+        label TEXT,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, topic_pattern)
+      );
+      CREATE TABLE space_long_horizon_agent_event_subscriptions (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        topic TEXT NOT NULL,
+        filter_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(space_id, agent_id, source, topic, filter_json)
+      );
+    `);
+    db.prepare(`INSERT INTO spaces (id) VALUES (?)`).run('space-1');
+    db.prepare(`INSERT INTO space_agents (id, space_id) VALUES (?, ?)`).run(
+      'lh-agent-1',
+      'space-1'
+    );
+    db.prepare(`INSERT INTO space_agents (id, space_id) VALUES (?, ?)`).run(
+      'legacy-agent-1',
+      'space-1'
+    );
+    db.prepare(`INSERT INTO space_long_horizon_agents (id, space_id) VALUES (?, ?)`).run(
+      'lh-agent-1',
+      'space-1'
+    );
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  test('copies legacy rows for long-horizon agent ids and drops legacy table', () => {
+    db.prepare(
+      `INSERT INTO space_agent_event_subscriptions (space_id, agent_id, topic_pattern, label, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(
+      'space-1',
+      'lh-agent-1',
+      'github/lsm/neokai/pull_request/*.review_submitted',
+      'reviews',
+      123
+    );
+    db.prepare(
+      `INSERT INTO space_agent_event_subscriptions (space_id, agent_id, topic_pattern, label, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('space-1', 'legacy-agent-1', 'github/lsm/neokai/issues/*.opened', null, 123);
+
+    runMigration151(db);
+
+    expect(
+      db
+        .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+        .get('space_agent_event_subscriptions')
+    ).toBeNull();
+    expect(
+      db
+        .prepare(
+          `SELECT agent_id, source, topic, filter_json, status, created_at FROM space_long_horizon_agent_event_subscriptions`
+        )
+        .all()
+    ).toEqual([
+      {
+        agent_id: 'lh-agent-1',
+        source: 'github',
+        topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+        filter_json: '{"label":"reviews"}',
+        status: 'active',
+        created_at: 123,
+      },
+    ]);
+  });
+
+  test('is a no-op when legacy table is absent', () => {
+    db.exec(`DROP TABLE space_agent_event_subscriptions`);
+
+    expect(() => runMigration151(db)).not.toThrow();
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
@@ -14,11 +14,30 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       );
       CREATE TABLE space_agents (
         id TEXT PRIMARY KEY,
-        space_id TEXT NOT NULL
+        space_id TEXT NOT NULL,
+        name TEXT,
+        handle TEXT,
+        instructions TEXT,
+        system_prompt TEXT,
+        model TEXT,
+        tools TEXT,
+        created_at INTEGER
       );
       CREATE TABLE space_long_horizon_agents (
         id TEXT PRIMARY KEY,
-        space_id TEXT NOT NULL
+        space_id TEXT NOT NULL,
+        handle TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        template_key TEXT,
+        status TEXT NOT NULL DEFAULT 'active',
+        session_id TEXT,
+        instructions TEXT NOT NULL DEFAULT '',
+        autonomy_level INTEGER,
+        model TEXT,
+        thinking_level TEXT,
+        tool_permissions_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
       );
       CREATE TABLE space_agent_event_subscriptions (
         space_id TEXT NOT NULL,
@@ -42,25 +61,36 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       );
     `);
     db.prepare(`INSERT INTO spaces (id) VALUES (?)`).run('space-1');
-    db.prepare(`INSERT INTO space_agents (id, space_id) VALUES (?, ?)`).run(
-      'lh-agent-1',
-      'space-1'
-    );
-    db.prepare(`INSERT INTO space_agents (id, space_id) VALUES (?, ?)`).run(
+    db.prepare(
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, model, tools, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('lh-agent-1', 'space-1', 'Existing LH', 'existing-lh', '', '', null, '[]', 100);
+    db.prepare(
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, model, tools, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
       'legacy-agent-1',
-      'space-1'
+      'space-1',
+      'Legacy Agent',
+      'legacy-agent',
+      'Legacy instructions',
+      '',
+      'claude-sonnet-4',
+      '["Read"]',
+      101
     );
-    db.prepare(`INSERT INTO space_long_horizon_agents (id, space_id) VALUES (?, ?)`).run(
-      'lh-agent-1',
-      'space-1'
-    );
+    db.prepare(
+      `INSERT INTO space_long_horizon_agents (
+        id, space_id, handle, display_name, status, instructions, tool_permissions_json, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, 'active', '', '{}', ?, ?)`
+    ).run('lh-agent-1', 'space-1', 'existing-lh', 'Existing LH', 100, 100);
   });
 
   afterEach(() => {
     db.close();
   });
 
-  test('copies legacy rows for long-horizon agent ids and drops legacy table', () => {
+  test('maps legacy SpaceAgent subscription rows and drops legacy table', () => {
     db.prepare(
       `INSERT INTO space_agent_event_subscriptions (space_id, agent_id, topic_pattern, label, created_at)
        VALUES (?, ?, ?, ?, ?)`
@@ -86,10 +116,20 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
     expect(
       db
         .prepare(
-          `SELECT agent_id, source, topic, filter_json, status, created_at FROM space_long_horizon_agent_event_subscriptions`
+          `SELECT agent_id, source, topic, filter_json, status, created_at
+           FROM space_long_horizon_agent_event_subscriptions
+           ORDER BY agent_id`
         )
         .all()
     ).toEqual([
+      {
+        agent_id: 'legacy-agent-1',
+        source: 'github',
+        topic: 'github/lsm/neokai/issues/*.opened',
+        filter_json: '{}',
+        status: 'active',
+        created_at: 123,
+      },
       {
         agent_id: 'lh-agent-1',
         source: 'github',
@@ -99,6 +139,23 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         created_at: 123,
       },
     ]);
+    expect(
+      db
+        .prepare(
+          `SELECT id, handle, display_name, template_key, instructions, model, tool_permissions_json
+           FROM space_long_horizon_agents
+           WHERE id = ?`
+        )
+        .get('legacy-agent-1')
+    ).toEqual({
+      id: 'legacy-agent-1',
+      handle: 'legacy-agent',
+      display_name: 'Legacy Agent',
+      template_key: 'migration.legacy_space_agent',
+      instructions: 'Legacy instructions',
+      model: 'claude-sonnet-4',
+      tool_permissions_json: '["Read"]',
+    });
   });
 
   test('is a no-op when legacy table is absent', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
@@ -41,6 +41,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
+      CREATE UNIQUE INDEX idx_space_long_horizon_agents_handle
+        ON space_long_horizon_agents(space_id, handle) WHERE status != 'archived';
       CREATE TABLE space_agent_event_subscriptions (
         space_id TEXT NOT NULL,
         agent_id TEXT NOT NULL,
@@ -96,6 +98,22 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       101
     );
     db.prepare(
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'conflict-agent-1',
+      'space-1',
+      'Conflicting Agent',
+      'existing-lh',
+      '',
+      '',
+      'Conflict prompt',
+      'active',
+      null,
+      '[]',
+      102
+    );
+    db.prepare(
       `INSERT INTO space_long_horizon_agents (
         id, space_id, handle, display_name, status, instructions, tool_permissions_json, created_at, updated_at
        ) VALUES (?, ?, ?, ?, 'active', '', '{}', ?, ?)`
@@ -121,6 +139,10 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       `INSERT INTO space_agent_event_subscriptions (space_id, agent_id, topic_pattern, label, created_at)
        VALUES (?, ?, ?, ?, ?)`
     ).run('space-1', 'legacy-agent-1', 'github/lsm/neokai/issues/*.opened', null, 123);
+    db.prepare(
+      `INSERT INTO space_agent_event_subscriptions (space_id, agent_id, topic_pattern, label, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run('space-1', 'conflict-agent-1', 'github/lsm/neokai/issues/*.closed', null, 124);
 
     runMigration151(db);
 
@@ -138,6 +160,14 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         )
         .all()
     ).toEqual([
+      {
+        agent_id: 'conflict-agent-1',
+        source: 'github',
+        topic: 'github/lsm/neokai/issues/*.closed',
+        filter_json: '{}',
+        status: 'active',
+        created_at: 124,
+      },
       {
         agent_id: 'legacy-agent-1',
         source: 'github',
@@ -172,6 +202,19 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       instructions: 'Canonical custom prompt',
       model: 'claude-sonnet-4',
       tool_permissions_json: '{"tools":["Read"]}',
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT id, handle, instructions
+           FROM space_long_horizon_agents
+           WHERE id = ?`
+        )
+        .get('conflict-agent-1')
+    ).toEqual({
+      id: 'conflict-agent-1',
+      handle: 'existing-lh-conflict-agent-1',
+      instructions: 'Conflict prompt',
     });
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -242,6 +242,14 @@ describe('SpaceLongHorizonAgentRepository', () => {
       filter: { label: 'reviews' },
       status: 'active',
     });
+    repo.upsertSubscription({
+      spaceId: 'space-1',
+      agentId: agent.id,
+      source: 'github',
+      topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+      filter: { label: 'triage' },
+      status: 'active',
+    });
     expect(repo.listActiveSubscriptionsBySpace('space-1')).toEqual([
       expect.objectContaining({
         id: created.id,
@@ -249,13 +257,21 @@ describe('SpaceLongHorizonAgentRepository', () => {
         topic: 'github/lsm/neokai/pull_request/*.review_submitted',
         status: 'active',
       }),
+      expect.objectContaining({
+        agentId: agent.id,
+        filter: { label: 'triage' },
+      }),
     ]);
 
-    repo.deleteSubscriptionByAgentTopic(
+    repo.deleteSubscriptionByRoute(
       'space-1',
       agent.id,
-      'github/lsm/neokai/pull_request/*.review_submitted'
+      'github',
+      'github/lsm/neokai/pull_request/*.review_submitted',
+      JSON.stringify({ label: 'reviews' })
     );
-    expect(repo.listSubscriptions(agent.id)).toHaveLength(0);
+    expect(repo.listSubscriptions(agent.id)).toEqual([
+      expect.objectContaining({ filter: { label: 'triage' } }),
+    ]);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -255,11 +255,8 @@ describe('SpaceLongHorizonAgentRepository', () => {
         id: created.id,
         agentId: agent.id,
         topic: 'github/lsm/neokai/pull_request/*.review_submitted',
-        status: 'active',
-      }),
-      expect.objectContaining({
-        agentId: agent.id,
         filter: { label: 'triage' },
+        status: 'active',
       }),
     ]);
 
@@ -267,11 +264,8 @@ describe('SpaceLongHorizonAgentRepository', () => {
       'space-1',
       agent.id,
       'github',
-      'github/lsm/neokai/pull_request/*.review_submitted',
-      JSON.stringify({ label: 'reviews' })
+      'github/lsm/neokai/pull_request/*.review_submitted'
     );
-    expect(repo.listSubscriptions(agent.id)).toEqual([
-      expect.objectContaining({ filter: { label: 'triage' } }),
-    ]);
+    expect(repo.listSubscriptions(agent.id)).toEqual([]);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -209,4 +209,53 @@ describe('SpaceLongHorizonAgentRepository', () => {
       status: 'active',
     });
   });
+
+  test('upserts, lists active, and deletes event subscriptions by route', () => {
+    const agent = repo.ensureCoordinator('space-1');
+
+    const created = repo.upsertSubscription({
+      spaceId: 'space-1',
+      agentId: agent.id,
+      source: 'github',
+      topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+      filter: { label: 'reviews' },
+      status: 'active',
+    });
+    const updated = repo.upsertSubscription({
+      spaceId: 'space-1',
+      agentId: agent.id,
+      source: 'github',
+      topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+      filter: { label: 'reviews' },
+      status: 'paused',
+    });
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.status).toBe('paused');
+    expect(repo.listActiveSubscriptionsBySpace('space-1')).toHaveLength(0);
+
+    repo.upsertSubscription({
+      spaceId: 'space-1',
+      agentId: agent.id,
+      source: 'github',
+      topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+      filter: { label: 'reviews' },
+      status: 'active',
+    });
+    expect(repo.listActiveSubscriptionsBySpace('space-1')).toEqual([
+      expect.objectContaining({
+        id: created.id,
+        agentId: agent.id,
+        topic: 'github/lsm/neokai/pull_request/*.review_submitted',
+        status: 'active',
+      }),
+    ]);
+
+    repo.deleteSubscriptionByAgentTopic(
+      'space-1',
+      agent.id,
+      'github/lsm/neokai/pull_request/*.review_submitted'
+    );
+    expect(repo.listSubscriptions(agent.id)).toHaveLength(0);
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -658,6 +658,31 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
         toolPermissions: { tools: ['Read', 'Edit'] },
       })
     );
+    const updatedConvertedLegacy = JSON.parse(
+      (
+        await handlers.update_agent({
+          agent_id: legacyAgent.id,
+          status: 'active',
+          custom_prompt: 'Updated converted prompt',
+          tools: ['Read'],
+        })
+      ).content[0].text
+    );
+    expect(updatedConvertedLegacy.success).toBe(true);
+    expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toEqual(
+      expect.objectContaining({
+        status: 'active',
+        instructions: 'Updated converted prompt',
+        toolPermissions: { tools: ['Read'] },
+      })
+    );
+    const pausedConvertedLegacy = JSON.parse(
+      (await handlers.pause_agent({ agent_id: legacyAgent.id })).content[0].text
+    );
+    expect(pausedConvertedLegacy.success).toBe(true);
+    expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toEqual(
+      expect.objectContaining({ status: 'paused' })
+    );
     expect(
       JSON.parse(
         (await handlers.unassign_agent_from_goal({ agent_id: agent.id, goal_id: goal.id }))

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -606,6 +606,12 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     const legacyAgent = JSON.parse(
       (await handlers.create_agent({ name: 'Legacy list-only agent' })).content[0].text
     ).agent;
+    ctx.longHorizonAgentRepo.create({
+      id: 'existing-lh-handle-conflict',
+      spaceId: ctx.spaceId,
+      handle: legacyAgent.handle ?? legacyAgent.name,
+      displayName: 'Existing handle conflict',
+    });
     const listedLegacy = JSON.parse(
       (await handlers.list_agent_event_subscriptions({ agent_id: legacyAgent.id })).content[0].text
     );
@@ -653,6 +659,7 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     expect(resubscribedLegacy.success).toBe(true);
     expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toEqual(
       expect.objectContaining({
+        handle: `${legacyAgent.handle ?? legacyAgent.name}-${legacyAgent.id}`,
         status: 'paused',
         instructions: 'Converted agent prompt',
         toolPermissions: { tools: ['Read', 'Edit'] },

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -25,6 +25,7 @@ import { JobQueueRepository } from '../../../../src/storage/repositories/job-que
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceLongHorizonAgentRepository } from '../../../../src/storage/repositories/space-long-horizon-agent-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
@@ -132,6 +133,7 @@ interface TestCtx {
   runtime: SpaceRuntime;
   nodeExecutionRepo: NodeExecutionRepository;
   spaceManager: SpaceManager;
+  longHorizonAgentRepo: SpaceLongHorizonAgentRepository;
   goalService: SpaceGoalService;
   evolutionRepo: EvolutionRepository;
   evolutionScopeService: EvolutionScopeService;
@@ -158,6 +160,7 @@ function makeCtx(): TestCtx {
   const nodeExecutionRepo = new NodeExecutionRepository(db);
   const taskRepo = new SpaceTaskRepository(db);
   const spaceManager = new SpaceManager(db);
+  const longHorizonAgentRepo = new SpaceLongHorizonAgentRepository(db);
 
   const runtime = new SpaceRuntime({
     db,
@@ -245,6 +248,7 @@ function makeCtx(): TestCtx {
     runtime,
     nodeExecutionRepo,
     spaceManager,
+    longHorizonAgentRepo,
     goalService,
     evolutionRepo,
     evolutionScopeService,
@@ -264,6 +268,7 @@ function makeHandlers(ctx: TestCtx) {
     spaceAgentManager: ctx.agentManager,
     nodeExecutionRepo: ctx.nodeExecutionRepo,
     spaceManager: ctx.spaceManager,
+    longHorizonAgentRepo: ctx.longHorizonAgentRepo,
     goalService: ctx.goalService,
     evolutionScopeService: ctx.evolutionScopeService,
     evolutionEpisodeService: ctx.evolutionEpisodeService,
@@ -541,11 +546,17 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     );
     expect(reminders.reminders).toHaveLength(1);
 
+    const longHorizonAgent = ctx.longHorizonAgentRepo.create({
+      id: 'lh-tools-agent',
+      spaceId: ctx.spaceId,
+      handle: '@tools-agent',
+      displayName: 'Tools Agent',
+    });
     expect(
       JSON.parse(
         (
           await handlers.subscribe_agent_event({
-            agent_id: agent.id,
+            agent_id: longHorizonAgent.id,
             topic_pattern: 'github/*/*/pull_request/*',
             label: 'PR activity',
           })
@@ -553,9 +564,11 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
       ).success
     ).toBe(true);
     const subscriptions = JSON.parse(
-      (await handlers.list_agent_event_subscriptions({ agent_id: agent.id })).content[0].text
+      (await handlers.list_agent_event_subscriptions({ agent_id: longHorizonAgent.id })).content[0]
+        .text
     );
-    expect(subscriptions.subscriptions[0].topic_pattern).toBe('github/*/*/pull_request/*');
+    expect(subscriptions.subscriptions[0].topic).toBe('github/*/*/pull_request/*');
+    expect(subscriptions.subscriptions[0].filter).toEqual({ label: 'PR activity' });
 
     expect(
       JSON.parse(

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -571,12 +571,28 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     expect(subscriptions.subscriptions[0].topic).toBe('github/*/*/pull_request/*');
     expect(subscriptions.subscriptions[0].filter).toEqual({ label: 'PR activity' });
 
+    const relabeled = JSON.parse(
+      (
+        await handlers.subscribe_agent_event({
+          agent_id: longHorizonAgent.id,
+          topic_pattern: 'github/*/*/pull_request/*',
+          label: 'PR triage',
+        })
+      ).content[0].text
+    );
+    expect(relabeled.success).toBe(true);
+    const afterRelabel = JSON.parse(
+      (await handlers.list_agent_event_subscriptions({ agent_id: longHorizonAgent.id })).content[0]
+        .text
+    );
+    expect(afterRelabel.subscriptions).toHaveLength(1);
+    expect(afterRelabel.subscriptions[0].filter).toEqual({ label: 'PR triage' });
+
     const removed = JSON.parse(
       (
         await handlers.unsubscribe_agent_event({
           agent_id: longHorizonAgent.id,
           topic_pattern: 'github/*/*/pull_request/*',
-          label: 'PR activity',
         })
       ).content[0].text
     );
@@ -586,6 +602,25 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
         .text
     );
     expect(afterUnsubscribe.subscriptions).toEqual([]);
+
+    const legacyAgent = JSON.parse(
+      (await handlers.create_agent({ name: 'Legacy list-only agent' })).content[0].text
+    ).agent;
+    const listedLegacy = JSON.parse(
+      (await handlers.list_agent_event_subscriptions({ agent_id: legacyAgent.id })).content[0].text
+    );
+    expect(listedLegacy).toEqual({ success: true, subscriptions: [] });
+    expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toBeNull();
+    const unsubscribedLegacy = JSON.parse(
+      (
+        await handlers.unsubscribe_agent_event({
+          agent_id: legacyAgent.id,
+          topic_pattern: 'github/*/*/pull_request/*',
+        })
+      ).content[0].text
+    );
+    expect(unsubscribedLegacy.success).toBe(true);
+    expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toBeNull();
 
     expect(
       JSON.parse(

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -170,6 +170,7 @@ function makeCtx(): TestCtx {
     workflowRunRepo,
     taskRepo,
     nodeExecutionRepo,
+    longHorizonAgentRepo,
   });
 
   const taskManager = new SpaceTaskManager(db, spaceId);
@@ -569,6 +570,22 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     );
     expect(subscriptions.subscriptions[0].topic).toBe('github/*/*/pull_request/*');
     expect(subscriptions.subscriptions[0].filter).toEqual({ label: 'PR activity' });
+
+    const removed = JSON.parse(
+      (
+        await handlers.unsubscribe_agent_event({
+          agent_id: longHorizonAgent.id,
+          topic_pattern: 'github/*/*/pull_request/*',
+          label: 'PR activity',
+        })
+      ).content[0].text
+    );
+    expect(removed.success).toBe(true);
+    const afterUnsubscribe = JSON.parse(
+      (await handlers.list_agent_event_subscriptions({ agent_id: longHorizonAgent.id })).content[0]
+        .text
+    );
+    expect(afterUnsubscribe.subscriptions).toEqual([]);
 
     expect(
       JSON.parse(

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -611,7 +611,7 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
     );
     expect(listedLegacy).toEqual({ success: true, subscriptions: [] });
     expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toBeNull();
-    const unsubscribedLegacy = JSON.parse(
+    const unsubscribedUnconvertedLegacy = JSON.parse(
       (
         await handlers.unsubscribe_agent_event({
           agent_id: legacyAgent.id,
@@ -619,9 +619,45 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
         })
       ).content[0].text
     );
-    expect(unsubscribedLegacy.success).toBe(true);
+    expect(unsubscribedUnconvertedLegacy.success).toBe(true);
     expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toBeNull();
-
+    const subscribedLegacy = JSON.parse(
+      (
+        await handlers.subscribe_agent_event({
+          agent_id: legacyAgent.id,
+          topic_pattern: 'github/*/*/pull_request/*',
+        })
+      ).content[0].text
+    );
+    expect(subscribedLegacy.success).toBe(true);
+    ctx.agentManager.update(legacyAgent.id, {
+      status: 'paused',
+      customPrompt: 'Converted agent prompt',
+      tools: ['Read', 'Edit'],
+    });
+    ctx.longHorizonAgentRepo.deleteSubscriptionByRoute(
+      ctx.spaceId,
+      legacyAgent.id,
+      'github',
+      'github/*/*/pull_request/*'
+    );
+    ctx.db.prepare(`DELETE FROM space_long_horizon_agents WHERE id = ?`).run(legacyAgent.id);
+    const resubscribedLegacy = JSON.parse(
+      (
+        await handlers.subscribe_agent_event({
+          agent_id: legacyAgent.id,
+          topic_pattern: 'github/*/*/issues/*',
+        })
+      ).content[0].text
+    );
+    expect(resubscribedLegacy.success).toBe(true);
+    expect(ctx.longHorizonAgentRepo.getById(legacyAgent.id)).toEqual(
+      expect.objectContaining({
+        status: 'paused',
+        instructions: 'Converted agent prompt',
+        toolPermissions: { tools: ['Read', 'Edit'] },
+      })
+    );
     expect(
       JSON.parse(
         (await handlers.unassign_agent_from_goal({ agent_id: agent.id, goal_id: goal.id }))

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../src/lib/space/runtime/space-runtime';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
+import { SpaceLongHorizonAgentRepository } from '../../../../src/storage/repositories/space-long-horizon-agent-repository';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
@@ -128,6 +129,7 @@ describe('SpaceRuntime external event subscriptions', () => {
   let eventStore: ExternalEventStore;
   let eventService: ExternalEventService;
   let injected: Array<{ sessionId: string; message: string; deliveryMode?: string }>;
+  let longHorizonMessages: Array<{ agentId: string; message: string }>;
   let tam: MockTaskAgentManager;
   let bus: ReturnType<typeof createDaemonInternalEventBus>;
 
@@ -195,6 +197,7 @@ describe('SpaceRuntime external event subscriptions', () => {
     eventStore = new ExternalEventStore(db);
     eventService = new ExternalEventService(eventStore, bus);
     injected = [];
+    longHorizonMessages = [];
     commandBus.register('agent.message.inject', async (command) => {
       injected.push({
         sessionId: command.sessionId,
@@ -216,7 +219,54 @@ describe('SpaceRuntime external event subscriptions', () => {
       commandBus,
       externalEventStore: eventStore,
       taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message }) => {
+        longHorizonMessages.push({ agentId, message });
+        return { delivered: true };
+      },
     });
+  });
+
+  test('rehydrates long-horizon agent subscriptions and delivers matching events', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-events',
+      spaceId: SPACE_ID,
+      handle: 'watcher',
+      displayName: 'Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message }) => {
+        longHorizonMessages.push({ agentId, message });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(longHorizonMessages).toHaveLength(1);
+    expect(longHorizonMessages[0]!.agentId).toBe(agent.id);
+    expect(JSON.parse(longHorizonMessages[0]!.message).eventId).toBe(event.id);
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+    expect(eventStore.listDeliveries(event.id)).toHaveLength(0);
   });
 
   test('delivers matching events to a live node-agent session and marks delivery complete', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -354,6 +354,58 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('published');
   });
 
+  test('refreshes trie entries after long-horizon agent status changes', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-status-refresh',
+      spaceId: SPACE_ID,
+      handle: 'status-refresh-watcher',
+      displayName: 'Status Refresh Watcher',
+      status: 'disabled',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    await eventService.publish(makeEvent({ id: 'evt-before-reactivate' }));
+    expect(longHorizonMessages).toHaveLength(0);
+
+    repo.update(agent.id, { status: 'active' });
+    expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
+      success: true,
+    });
+    await eventService.publish(makeEvent({ id: 'evt-after-reactivate' }));
+    expect(longHorizonMessages).toHaveLength(1);
+
+    repo.update(agent.id, { status: 'paused' });
+    expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
+      success: true,
+    });
+    await eventService.publish(makeEvent({ id: 'evt-after-pause' }));
+    expect(longHorizonMessages).toHaveLength(1);
+  });
+
   test('keeps long-horizon events pending until every matched delivery succeeds', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const first = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -406,6 +406,47 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(longHorizonMessages).toHaveLength(1);
   });
 
+  test('removes trie entries after long-horizon agent deletion', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-delete-refresh',
+      spaceId: SPACE_ID,
+      handle: 'delete-refresh-watcher',
+      displayName: 'Delete Refresh Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    runtime.removeLongHorizonAgentSubscriptions(SPACE_ID, agent.id);
+    repo.delete(agent.id);
+    await eventService.publish(makeEvent({ id: 'evt-after-delete' }));
+
+    expect(longHorizonMessages).toHaveLength(0);
+    expect(eventStore.getById('evt-after-delete')?.state).toBe('published');
+  });
+
   test('keeps long-horizon events pending until every matched delivery succeeds', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const first = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -129,7 +129,7 @@ describe('SpaceRuntime external event subscriptions', () => {
   let eventStore: ExternalEventStore;
   let eventService: ExternalEventService;
   let injected: Array<{ sessionId: string; message: string; deliveryMode?: string }>;
-  let longHorizonMessages: Array<{ agentId: string; message: string }>;
+  let longHorizonMessages: Array<{ agentId: string; message: string; idempotencyKey?: string }>;
   let tam: MockTaskAgentManager;
   let bus: ReturnType<typeof createDaemonInternalEventBus>;
 
@@ -219,8 +219,8 @@ describe('SpaceRuntime external event subscriptions', () => {
       commandBus,
       externalEventStore: eventStore,
       taskAgentManager: tam as never,
-      deliverLongHorizonExternalEvent: async ({ agentId, message }) => {
-        longHorizonMessages.push({ agentId, message });
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
         return { delivered: true };
       },
     });
@@ -252,8 +252,8 @@ describe('SpaceRuntime external event subscriptions', () => {
       internalEventBus: bus,
       externalEventStore: eventStore,
       taskAgentManager: tam as never,
-      deliverLongHorizonExternalEvent: async ({ agentId, message }) => {
-        longHorizonMessages.push({ agentId, message });
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
         return { delivered: true };
       },
     });
@@ -266,7 +266,107 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(longHorizonMessages[0]!.agentId).toBe(agent.id);
     expect(JSON.parse(longHorizonMessages[0]!.message).eventId).toBe(event.id);
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
-    expect(eventStore.listDeliveries(event.id)).toHaveLength(0);
+    const deliveries = eventStore.listDeliveries(event.id);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]!.state).toBe('delivered');
+    expect(longHorizonMessages[0]!.idempotencyKey).toBe(deliveries[0]!.deliveryKey);
+  });
+
+  test('skips inactive long-horizon agent subscriptions during rehydration', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-paused',
+      spaceId: SPACE_ID,
+      handle: 'paused-watcher',
+      displayName: 'Paused Watcher',
+      status: 'disabled',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(longHorizonMessages).toHaveLength(0);
+    expect(eventStore.getById(event.id)?.state).toBe('published');
+  });
+
+  test('keeps long-horizon events pending until every matched delivery succeeds', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const first = repo.create({
+      id: 'lh-agent-first',
+      spaceId: SPACE_ID,
+      handle: 'first-watcher',
+      displayName: 'First Watcher',
+    });
+    const second = repo.create({
+      id: 'lh-agent-second',
+      spaceId: SPACE_ID,
+      handle: 'second-watcher',
+      displayName: 'Second Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: first.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: second.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: agentId === first.id };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(longHorizonMessages).toHaveLength(2);
+    expect(eventStore.getById(event.id)?.state).toBe('published');
+    const deliveries = eventStore.listDeliveries(event.id);
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries.map((delivery) => delivery.state).sort()).toEqual(['delivered', 'pending']);
+    await runtime.stop();
   });
 
   test('delivers matching events to a live node-agent session and marks delivery complete', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -272,6 +272,47 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(longHorizonMessages[0]!.idempotencyKey).toBe(deliveries[0]!.deliveryKey);
   });
 
+  test('rehydrates relative long-horizon agent subscriptions and matches full event topics', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-relative-events',
+      spaceId: SPACE_ID,
+      handle: 'relative-watcher',
+      displayName: 'Relative Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: 'pull_request/*.review_*',
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(longHorizonMessages).toHaveLength(1);
+    expect(longHorizonMessages[0]!.agentId).toBe(agent.id);
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
+
   test('skips inactive long-horizon agent subscriptions during rehydration', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({
@@ -1829,6 +1870,61 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById('evt-arrived-while-stopped')?.state).toBe('delivered');
     expect(injected).toHaveLength(1);
     expect(injected[0]!.sessionId).toBe('session-stop-start-sweep');
+  });
+
+  test('requeues persisted pending long-horizon deliveries during runtime rehydrate', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-pending-retry',
+      spaceId: SPACE_ID,
+      handle: 'pending-retry',
+      displayName: 'Pending Retry',
+    });
+    const subscription = repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    const event = makeEvent({ id: 'evt-lh-pending-retry' });
+    eventStore.store(event);
+    const deliveryKey = `lh:${subscription.id}:${event.id}`;
+    eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+      workflowRunId: `long_horizon:${SPACE_ID}`,
+      taskId: subscription.id,
+      nodeId: agent.id,
+      agentName: agent.id,
+    });
+    eventStore.markDeliveryFailed(event.id, deliveryKey, {
+      terminal: false,
+      reason: 'long-horizon agent unavailable',
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(longHorizonMessages).toHaveLength(1);
+    expect(longHorizonMessages[0]!.agentId).toBe(agent.id);
+    expect(longHorizonMessages[0]!.idempotencyKey).toBe(deliveryKey);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
 
   test('requeues persisted pending deliveries during runtime rehydrate', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -755,6 +755,88 @@ describe('SpaceRuntimeService', () => {
       );
     });
 
+    test('long-horizon event sessions preserve converted agent tool restrictions', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({
+          id: sessionId,
+          metadata: {},
+          config: {},
+        })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'restricted-agent',
+          displayName: 'Restricted Agent',
+          templateKey: 'migration.legacy_space_agent',
+          status: 'active',
+          sessionId: null,
+          instructions: 'Use limited tools.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          toolPermissions: { tools: ['Read', 'Edit'] },
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        longHorizonAgentRepo,
+      });
+
+      const result = await (
+        svc as unknown as {
+          deliverLongHorizonExternalEvent(args: {
+            spaceId: string;
+            agentId: string;
+            message: string;
+            idempotencyKey: string;
+          }): Promise<{ delivered: boolean }>;
+        }
+      ).deliverLongHorizonExternalEvent({
+        spaceId: mockSpace.id,
+        agentId: 'lh-agent-1',
+        message: 'event payload',
+        idempotencyKey: 'delivery-1',
+      });
+
+      expect(result).toEqual({ delivered: true });
+      expect(sessionManager.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            sdkToolsPreset: ['Read', 'Edit'],
+            allowedTools: ['Read', 'Edit'],
+            disallowedTools: expect.arrayContaining(['Bash']),
+            agent: 'restricted-agent',
+            agents: {
+              'restricted-agent': expect.objectContaining({
+                disallowedTools: expect.arrayContaining(['Bash']),
+                prompt: 'Use limited tools.',
+              }),
+            },
+          }),
+        })
+      );
+      expect(createdSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
+        'delivery-1',
+        'event payload'
+      );
+    });
+
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {
       const agentSession = makeSession();
       const sessionManager = makeSessionManager(agentSession);

--- a/scripts/check-db-schema-parity.ts
+++ b/scripts/check-db-schema-parity.ts
@@ -58,7 +58,6 @@ export const HELPER_SCHEMA_TABLES = [
   'pending_agent_messages',
   'sdk_messages',
   'sessions',
-  'space_agent_event_subscriptions',
   'space_agent_forge_scope_assignments',
   'space_agent_goal_assignments',
   'space_agent_core_memory',


### PR DESCRIPTION
Consolidates agent event subscriptions onto the long-horizon subscription table and rehydrates active subscriptions into the SpaceRuntime TopicTrie on startup.

Also updates MCP subscription tools to use long-horizon agent IDs, migrates legacy rows, and covers repository/runtime/migration paths with unit tests.

Tests:
- bun run check
- bun test tests/unit/5-space/runtime/space-runtime-external-events.test.ts tests/unit/5-space/runtime/space-agent-tools.test.ts tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts