### PR TITLE
fix(web): space ad-hoc session refresh spinning on slug URLs

### DIFF
--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -685,16 +685,25 @@ export default function ChatContainer({
   // Effects
   // ========================================
 
+  // Track whether this is a fresh mount (or remount) so we can force
+  // re-selection even when activeSessionId already matches. This prevents
+  // a race where the previous instance's cleanup deselects the session
+  // after the new instance has already started rendering.
+  const isNewMountRef = useRef(true);
+
   // Select session on mount or when sessionId changes
   // This is needed when ChatContainer is used outside the main navigation flow
   // (e.g., space agent overlays).
   // Skip when in pending-agent mode — no real session exists yet.
   useEffect(() => {
     if (pendingAgent) return;
-    // Only select if this sessionId is different from the current active session
-    if (sessionId && sessionId !== sessionStore.activeSessionId.value) {
+    // On a fresh mount/remount, always select so we claim ownership even
+    // if a previous instance left activeSessionId set to the same value.
+    // On re-renders, only select when the sessionId actually changed.
+    if (sessionId && (sessionId !== sessionStore.activeSessionId.value || isNewMountRef.current)) {
       sessionStore.select(sessionId);
     }
+    isNewMountRef.current = false;
     // Cleanup: deselect session when component unmounts
     return () => {
       const pendingChecks = pendingMessageVisibilityChecksRef.current;
@@ -702,12 +711,9 @@ export default function ChatContainer({
         clearTimeout(timer);
       }
       pendingChecks.clear();
-      // Defer cleanup so a newly-mounted ChatContainer can claim selection first.
-      setTimeout(() => {
-        if (sessionStore.activeSessionId.value === sessionId) {
-          sessionStore.select(null);
-        }
-      }, 0);
+      if (sessionStore.activeSessionId.value === sessionId) {
+        sessionStore.select(null);
+      }
     };
   }, [sessionId]);
 

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -340,9 +340,11 @@ export default function MainContent() {
 
   // Compute a stable key that changes when the major content view changes.
   // This drives the animate-fadeIn-200 transition wrapper below.
+  // Use spaceRouteId (the URL-facing identifier) rather than the canonical UUID
+  // so slug resolution doesn't trigger an unnecessary remount.
   let contentKey: string;
-  if (spaceId) {
-    contentKey = `space-${spaceId}-${spaceViewMode}`;
+  if (spaceRouteId) {
+    contentKey = `space-${spaceRouteId}-${spaceViewMode}`;
   } else if (navSection === 'spaces') {
     contentKey = 'spaces';
   } else if (sessionExists) {


### PR DESCRIPTION
## Problem
Refreshing `/space/{slug}/session/space:chat:{uuid}` left the page stuck on a spinning circle. The session never loaded.

## Root cause
Two issues combined:
1. `MainContent` used the canonical UUID in `contentKey`. When `spaceStore` resolved a slug → UUID, `SpaceIsland`/`ChatContainer` remounted.
2. `ChatContainer`'s deferred cleanup (`setTimeout`) ran *after* the new mount effect. Because the new mount saw `activeSessionId` already matched the same `space:chat:{id}` session, it didn't re-select — then the old cleanup deselected it, leaving the session store empty.

## Fix
- `MainContent`: use `spaceRouteId` (URL-facing slug/UUID) in `contentKey` instead of `spaceId` (canonical UUID), preventing the unnecessary remount on slug resolution.
- `ChatContainer`: remove the `setTimeout` deferral in the unmount cleanup. React/Preact cleanup runs before new mount effects during commit, so a remounted `ChatContainer` re-selects correctly without the race.

## Verification
- Empirically tested with Playwright: created a space, navigated to its slug-based chat session URL, refreshed — session loads correctly.
- All web tests pass (218 files, 6090 tests).
- `bun run check` passes (lint, typecheck, knip, guards).