### PR TITLE
Add agent event subscription UI

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -648,13 +648,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   };
 
   // Space agent handlers
-  setupSpaceAgentHandlers(
-    deps.messageHub,
-    deps.internalEventBus,
-    deps.spaceAgentManager,
-    deps.spaceManager,
-    deps.db
-  );
   setupSpaceWorkflowHandlers(
     deps.messageHub,
     deps.spaceManager,
@@ -807,6 +800,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     }
     spaceRuntimeService.recoverStalledWorkflowRunsAfterSpaceResume(spaceId);
   });
+
+  setupSpaceAgentHandlers(
+    deps.messageHub,
+    deps.internalEventBus,
+    deps.spaceAgentManager,
+    deps.spaceManager,
+    deps.db,
+    spaceRuntimeService
+  );
 
   // Session handlers — registered here (after spaceRuntimeService is built) so
   // session.create can synchronously call attachSpaceToolsToMemberSession for

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -22,6 +22,7 @@ import type {
 } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { Database } from '../../storage';
+import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -64,6 +65,20 @@ function extractTools(session: Session): string[] | undefined {
 
   const disallowed = new Set(disallowedTools);
   return KNOWN_TOOLS.filter((tool) => !disallowed.has(tool));
+}
+
+function archiveMatchingLongHorizonAgent(
+  db: Database,
+  runtimeService: {
+    removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void;
+  },
+  agent: SpaceAgent
+): void {
+  const repo = new SpaceLongHorizonAgentRepository(db.getDatabase());
+  const longHorizonAgent = repo.getByHandle(agent.spaceId, agent.handle);
+  if (!longHorizonAgent) return;
+  runtimeService.removeLongHorizonAgentSubscriptions(agent.spaceId, longHorizonAgent.id);
+  repo.update(longHorizonAgent.id, { status: 'archived' });
 }
 
 function extractSettingSources(session: Session): SettingSource[] | undefined {
@@ -143,7 +158,10 @@ export function setupSpaceAgentHandlers(
   internalEventBus: InternalEventBus<DaemonInternalEventMap>,
   spaceAgentManager: SpaceAgentManager,
   spaceManager: SpaceManager,
-  db: Database
+  db: Database,
+  runtimeService?: {
+    removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void;
+  }
 ): void {
   // spaceAgent.listBuiltInTemplates — return built-in templates from seeding source
   messageHub.onRequest('spaceAgent.listBuiltInTemplates', async (data) => {
@@ -399,6 +417,7 @@ export function setupSpaceAgentHandlers(
       const detailsMsg = result.details?.length ? `\n${result.details.join('\n')}` : '';
       throw new Error(`${result.error}${detailsMsg}`);
     }
+    if (runtimeService) archiveMatchingLongHorizonAgent(db, runtimeService, existing);
 
     // Await the event so subscribers (e.g. StateManager) see it before the
     // handler returns — consistent with how room.delete emits room.deleted.

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -18,6 +18,7 @@ import type {
   SettingSource,
   SpaceAgent,
   SpaceAgentPromotionDraft,
+  SpaceLongHorizonAgent,
   ThinkingLevel,
 } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
@@ -67,6 +68,15 @@ function extractTools(session: Session): string[] | undefined {
   return KNOWN_TOOLS.filter((tool) => !disallowed.has(tool));
 }
 
+function findMatchingLongHorizonAgent(
+  repo: SpaceLongHorizonAgentRepository,
+  agent: SpaceAgent
+): SpaceLongHorizonAgent | null {
+  const byId = repo.getById(agent.id);
+  if (byId?.spaceId === agent.spaceId) return byId;
+  return repo.getByHandle(agent.spaceId, agent.handle);
+}
+
 function archiveMatchingLongHorizonAgent(
   db: Database,
   runtimeService: {
@@ -75,10 +85,24 @@ function archiveMatchingLongHorizonAgent(
   agent: SpaceAgent
 ): void {
   const repo = new SpaceLongHorizonAgentRepository(db.getDatabase());
-  const longHorizonAgent = repo.getByHandle(agent.spaceId, agent.handle);
+  const longHorizonAgent = findMatchingLongHorizonAgent(repo, agent);
   if (!longHorizonAgent) return;
   runtimeService.removeLongHorizonAgentSubscriptions(agent.spaceId, longHorizonAgent.id);
   repo.update(longHorizonAgent.id, { status: 'archived' });
+}
+
+function syncMatchingLongHorizonAgent(db: Database, agent: SpaceAgent): void {
+  const repo = new SpaceLongHorizonAgentRepository(db.getDatabase());
+  const longHorizonAgent = findMatchingLongHorizonAgent(repo, agent);
+  if (!longHorizonAgent) return;
+  repo.update(longHorizonAgent.id, {
+    handle: agent.handle,
+    displayName: agent.name,
+    instructions: agent.customPrompt ?? agent.description ?? '',
+    model: agent.model ?? null,
+    thinkingLevel: agent.thinkingLevel ?? null,
+    toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
+  });
 }
 
 function extractSettingSources(session: Session): SettingSource[] | undefined {
@@ -332,6 +356,7 @@ export function setupSpaceAgentHandlers(
     });
 
     if (!result.ok) throw new Error(result.error);
+    syncMatchingLongHorizonAgent(db, result.value);
 
     internalEventBus
       .publish('spaceAgent.updated', {

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -23,7 +23,10 @@ import type {
 } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { Database } from '../../storage';
-import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
+import {
+  coordinatorLongHorizonAgentId,
+  SpaceLongHorizonAgentRepository,
+} from '../../storage/repositories/space-long-horizon-agent-repository';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -68,13 +71,25 @@ function extractTools(session: Session): string[] | undefined {
   return KNOWN_TOOLS.filter((tool) => !disallowed.has(tool));
 }
 
+function isCoordinatorAgent(agent: SpaceAgent): boolean {
+  return agent.name.toLowerCase() === 'coordinator' || agent.templateName === 'Coordinator';
+}
+
+function getLongHorizonAgentHandle(agent: SpaceAgent): string {
+  return isCoordinatorAgent(agent) ? 'coordinator' : agent.handle;
+}
+
 function findMatchingLongHorizonAgent(
   repo: SpaceLongHorizonAgentRepository,
   agent: SpaceAgent
 ): SpaceLongHorizonAgent | null {
   const byId = repo.getById(agent.id);
   if (byId?.spaceId === agent.spaceId) return byId;
-  return repo.getByHandle(agent.spaceId, agent.handle);
+  if (isCoordinatorAgent(agent)) {
+    const coordinator = repo.getById(coordinatorLongHorizonAgentId(agent.spaceId));
+    if (coordinator) return coordinator;
+  }
+  return repo.getByHandle(agent.spaceId, getLongHorizonAgentHandle(agent));
 }
 
 function archiveMatchingLongHorizonAgent(
@@ -96,7 +111,7 @@ function syncMatchingLongHorizonAgent(db: Database, agent: SpaceAgent): void {
   const longHorizonAgent = findMatchingLongHorizonAgent(repo, agent);
   if (!longHorizonAgent) return;
   repo.update(longHorizonAgent.id, {
-    handle: agent.handle,
+    handle: getLongHorizonAgentHandle(agent),
     displayName: agent.name,
     instructions: agent.customPrompt ?? agent.description ?? '',
     model: agent.model ?? null,

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -109,9 +109,15 @@ function archiveMatchingLongHorizonAgent(
   repo.update(longHorizonAgent.id, { status: 'archived' });
 }
 
-function syncMatchingLongHorizonAgent(db: Database, agent: SpaceAgent): void {
+function syncMatchingLongHorizonAgent(
+  db: Database,
+  agent: SpaceAgent,
+  previousAgent?: SpaceAgent | null
+): void {
   const repo = new SpaceLongHorizonAgentRepository(db.getDatabase());
-  const longHorizonAgent = findMatchingLongHorizonAgent(repo, agent);
+  const longHorizonAgent =
+    findMatchingLongHorizonAgent(repo, agent) ??
+    (previousAgent ? findMatchingLongHorizonAgent(repo, previousAgent) : null);
   if (!longHorizonAgent) return;
   repo.update(longHorizonAgent.id, {
     handle: getLongHorizonAgentHandle(agent),
@@ -119,6 +125,8 @@ function syncMatchingLongHorizonAgent(db: Database, agent: SpaceAgent): void {
     instructions: agent.customPrompt ?? agent.description ?? '',
     model: agent.model ?? null,
     thinkingLevel: agent.thinkingLevel ?? null,
+    provider: agent.provider ?? null,
+    settingSources: agent.settingSources ?? null,
     toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
   });
 }
@@ -360,6 +368,7 @@ export function setupSpaceAgentHandlers(
 
     if (!params.id) throw new Error('id is required');
 
+    const previousAgent = spaceAgentManager.getById(params.id);
     const { id, ...updateFields } = params;
     const result = await spaceAgentManager.update(id, {
       name: updateFields.name,
@@ -374,7 +383,7 @@ export function setupSpaceAgentHandlers(
     });
 
     if (!result.ok) throw new Error(result.error);
-    syncMatchingLongHorizonAgent(db, result.value);
+    syncMatchingLongHorizonAgent(db, result.value, previousAgent);
 
     internalEventBus
       .publish('spaceAgent.updated', {

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -89,7 +89,7 @@ function findMatchingLongHorizonAgent(
     const coordinator = repo.getById(coordinatorLongHorizonAgentId(agent.spaceId));
     if (coordinator) return coordinator;
   }
-  return repo.getByHandle(agent.spaceId, getLongHorizonAgentHandle(agent));
+  return null;
 }
 
 function archiveMatchingLongHorizonAgent(

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -103,6 +103,9 @@ function archiveMatchingLongHorizonAgent(
   const longHorizonAgent = findMatchingLongHorizonAgent(repo, agent);
   if (!longHorizonAgent) return;
   runtimeService.removeLongHorizonAgentSubscriptions(agent.spaceId, longHorizonAgent.id);
+  for (const subscription of repo.listSubscriptions(longHorizonAgent.id)) {
+    repo.updateSubscription(subscription.id, { status: 'disabled' });
+  }
   repo.update(longHorizonAgent.id, { status: 'archived' });
 }
 
@@ -426,6 +429,7 @@ export function setupSpaceAgentHandlers(
 
     const result = await spaceAgentManager.syncFromTemplate(params.agentId);
     if (!result.ok) throw new Error(result.error);
+    syncMatchingLongHorizonAgent(db, result.value);
 
     internalEventBus
       .publish('spaceAgent.updated', {

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -109,6 +109,23 @@ function archiveMatchingLongHorizonAgent(
   repo.update(longHorizonAgent.id, { status: 'archived' });
 }
 
+function assertCanSyncMatchingLongHorizonAgent(
+  db: Database,
+  previousAgent: SpaceAgent,
+  nextHandle: string
+): void {
+  const repo = new SpaceLongHorizonAgentRepository(db.getDatabase());
+  const longHorizonAgent = findMatchingLongHorizonAgent(repo, previousAgent);
+  if (!longHorizonAgent) return;
+  const targetHandle = isCoordinatorAgent(previousAgent) ? 'coordinator' : nextHandle;
+  const handleOwner = repo.getByHandle(previousAgent.spaceId, targetHandle);
+  if (handleOwner && handleOwner.id !== longHorizonAgent.id) {
+    throw new Error(
+      `Long-horizon agent handle "${targetHandle}" is already used by ${handleOwner.id}`
+    );
+  }
+}
+
 function syncMatchingLongHorizonAgent(
   db: Database,
   agent: SpaceAgent,
@@ -122,7 +139,7 @@ function syncMatchingLongHorizonAgent(
   repo.update(longHorizonAgent.id, {
     handle: getLongHorizonAgentHandle(agent),
     displayName: agent.name,
-    instructions: agent.customPrompt ?? agent.description ?? '',
+    instructions: agent.customPrompt ?? '',
     model: agent.model ?? null,
     thinkingLevel: agent.thinkingLevel ?? null,
     provider: agent.provider ?? null,
@@ -370,6 +387,9 @@ export function setupSpaceAgentHandlers(
 
     const previousAgent = spaceAgentManager.getById(params.id);
     const { id, ...updateFields } = params;
+    if (previousAgent && updateFields.handle !== undefined) {
+      assertCanSyncMatchingLongHorizonAgent(db, previousAgent, updateFields.handle);
+    }
     const result = await spaceAgentManager.update(id, {
       name: updateFields.name,
       handle: updateFields.handle,

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -28,6 +28,9 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
   if (topicSource === trimmedSource) return trimmedTopic;
+  if (topicSource.toLowerCase() === trimmedSource.toLowerCase()) {
+    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
+  }
   if (validateSource(topicSource).valid) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -58,7 +58,9 @@ function rejectGitHubEntityPatternWithoutAction(topic: string): never {
 }
 
 function ensureGitHubEntityAction(topic: string, entityAction: string): void {
-  if (entityAction !== '*' && !entityAction.includes('.')) {
+  if (entityAction === '*') return;
+  const dotIndex = entityAction.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === entityAction.length - 1) {
     rejectGitHubEntityPatternWithoutAction(topic);
   }
 }
@@ -102,6 +104,9 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   }
   if (resourceSegments.length === 2) {
     const [resource, entityAction] = resourceSegments;
+    if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
+      return `${source}/${source}/${resource}/${entityAction}/*`;
+    }
     if (!isGitHubEventResource(resource ?? '')) {
       throw new Error(
         `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
@@ -127,7 +132,9 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (trimmedSource === 'github') {
     const segments = trimmedTopic.split('/');
     const isOwnerRepoShorthand =
-      segments.length === 4 || (segments[0] === trimmedSource && segments.length === 4);
+      segments.length === 3 ||
+      segments.length === 4 ||
+      (segments[0] === trimmedSource && (segments.length === 3 || segments.length === 4));
     if (isOwnerRepoShorthand || topicSource === trimmedSource) {
       return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
     }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -26,12 +26,44 @@ import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 
+function rejectSlashSeparatedGitHubAction(topic: string): never {
+  throw new Error(
+    `GitHub topic "${topic}" must use dotted entity actions like "pull_request/42.closed"`
+  );
+}
+
+function composeGitHubSubscriptionPattern(source: string, topic: string): string {
+  const segments = topic.split('/');
+  if (segments[0] === source) {
+    const unqualifiedSegments = segments.slice(1);
+    if (unqualifiedSegments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+    if (unqualifiedSegments.length === 4) return topic;
+    if (unqualifiedSegments.length === 3) return `${source}/${topic}`;
+  }
+  if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (topic.startsWith('*/*/') || segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 1 && topic.includes('.')) {
+    const dotIndex = topic.indexOf('.');
+    return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
+  }
+  return `${source}/*/*/${topic}`;
+}
+
 function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
-  if (topicSource === trimmedSource) return trimmedTopic;
+  if (trimmedSource === 'github') {
+    const segments = trimmedTopic.split('/');
+    const isOwnerRepoShorthand =
+      segments.length === 4 || (segments[0] === trimmedSource && segments.length === 4);
+    if (isOwnerRepoShorthand || topicSource === trimmedSource) {
+      return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
+    }
+  } else if (topicSource === trimmedSource) {
+    return trimmedTopic;
+  }
   const normalizedTopicSource = topicSource.toLowerCase();
   if (
     normalizedTopicSource === trimmedSource.toLowerCase() ||
@@ -39,16 +71,8 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   ) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }
-  if (trimmedSource === 'github') {
-    const segments = trimmedTopic.split('/');
-    if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
-      return `${trimmedSource}/${trimmedTopic}`;
-    if (segments.length === 1 && trimmedTopic.includes('.')) {
-      const dotIndex = trimmedTopic.indexOf('.');
-      return `${trimmedSource}/*/*/${trimmedTopic.slice(0, dotIndex)}/*.${trimmedTopic.slice(dotIndex + 1)}`;
-    }
-    return `${trimmedSource}/*/*/${trimmedTopic}`;
-  }
+  if (trimmedSource === 'github')
+    return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
   return `${trimmedSource}/${trimmedTopic}`;
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -25,6 +25,7 @@ import {
 import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import { slugifyWithinLimit } from '../space/slug';
 
 function rejectSlashSeparatedGitHubAction(topic: string): never {
   throw new Error(
@@ -187,6 +188,20 @@ function validateLongHorizonSubscriptionPattern(
   return pattern;
 }
 
+function resolveLongHorizonAgentCreateHandle(
+  repo: SpaceLongHorizonAgentRepository,
+  spaceId: string,
+  agentId: string,
+  handle: string
+): string {
+  const owner = repo.getByHandle(spaceId, handle);
+  if (!owner || owner.id === agentId) return handle;
+  return slugifyWithinLimit(
+    `${handle}-events`,
+    repo.listBySpaceId(spaceId).map((agent) => agent.handle)
+  );
+}
+
 function assertNoDuplicateLongHorizonSubscriptionPattern(
   repo: SpaceLongHorizonAgentRepository,
   agentId: string,
@@ -265,10 +280,16 @@ export function setupSpaceLongHorizonAgentHandlers(
     if (!params.handle) throw new Error('handle is required');
     const space = await spaceManager.getSpace(params.spaceId);
     if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+    const handle = resolveLongHorizonAgentCreateHandle(
+      repo,
+      params.spaceId,
+      params.id ?? '',
+      params.handle
+    );
     const agent = repo.create({
       id: params.id,
       spaceId: params.spaceId,
-      handle: params.handle,
+      handle,
       displayName: params.displayName,
       templateKey: params.templateKey,
       instructions: params.instructions,

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -38,11 +38,26 @@ function splitDottedGitHubResource(segment: string): { resource: string; action:
   return { resource: segment.slice(0, dotIndex), action: segment.slice(dotIndex + 1) };
 }
 
+function rejectGitHubEntityPatternWithoutAction(topic: string): never {
+  throw new Error(
+    `GitHub topic "${topic}" must use dotted entity actions like "pull_request/42.opened"`
+  );
+}
+
+function ensureGitHubEntityAction(topic: string, entityAction: string): void {
+  if (entityAction !== '*' && !entityAction.includes('.')) {
+    rejectGitHubEntityPatternWithoutAction(topic);
+  }
+}
+
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
   if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
-  if (segments[0] === source && segments.length === 5) return topic;
-  if (segments[0] === source && segments.length === 4) {
+  if (segments[0] === source && segments.length === 5) {
+    ensureGitHubEntityAction(topic, segments[4] ?? '');
+    return topic;
+  }
+  if (segments[0] === source && segments.length === 4 && segments[2] !== 'pull_request') {
     const dotted = splitDottedGitHubResource(segments[3] ?? '');
     if (dotted)
       return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
@@ -55,7 +70,10 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
     return `${source}/*/*/${resource}/*`;
   }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 4) {
+    ensureGitHubEntityAction(topic, segments[3] ?? '');
+    return `${source}/${topic}`;
+  }
   if (segments.length === 3) {
     const dotted = splitDottedGitHubResource(segments[2] ?? '');
     if (dotted)
@@ -124,7 +142,10 @@ function assertNoDuplicateLongHorizonSubscriptionPattern(
     if (subscription.id === currentSubscriptionId) return false;
     try {
       return (
-        composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic) === pattern
+        composeLongHorizonSubscriptionPattern(
+          subscription.source,
+          subscription.topic
+        ).toLowerCase() === pattern.toLowerCase()
       );
     } catch {
       return false;

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -17,7 +17,11 @@ import type {
   SpaceLongHorizonAgentEventSubscriptionStatus,
 } from '@neokai/shared';
 import type { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
-import { validateGlobPattern, validateSource } from '../external-events/topic-validator';
+import {
+  KNOWN_SOURCES,
+  validateGlobPattern,
+  validateSource,
+} from '../external-events/topic-validator';
 import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
@@ -28,10 +32,11 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
   if (topicSource === trimmedSource) return trimmedTopic;
-  if (topicSource.toLowerCase() === trimmedSource.toLowerCase()) {
-    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
-  }
-  if (validateSource(topicSource).valid) {
+  const normalizedTopicSource = topicSource.toLowerCase();
+  if (
+    normalizedTopicSource === trimmedSource.toLowerCase() ||
+    KNOWN_SOURCES.has(normalizedTopicSource)
+  ) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }
   if (trimmedSource === 'github') {

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -32,18 +32,35 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
   );
 }
 
+function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
+  const dotIndex = segment.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
+  return { resource: segment.slice(0, dotIndex), action: segment.slice(dotIndex + 1) };
+}
+
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source && segments.length === 5) return topic;
   if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
+  if (segments[0] === source && segments.length === 5) return topic;
+  if (segments[0] === source && segments.length === 4) {
+    const dotted = splitDottedGitHubResource(segments[3] ?? '');
+    if (dotted)
+      return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
+    return `${topic}/*`;
+  }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 4) return `${source}/${topic}`;
-  if (segments.length === 3) return `${source}/${topic}/*`;
-  if (segments.length === 1 && topic.includes('.')) {
-    const dotIndex = topic.indexOf('.');
-    return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
+  if (segments.length === 3) {
+    const dotted = splitDottedGitHubResource(segments[2] ?? '');
+    if (dotted)
+      return `${source}/${segments[0]}/${segments[1]}/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/${topic}/*`;
   }
-  if (segments.length === 1) return `${source}/*/*/${topic}/*`;
+  if (segments.length === 1) {
+    const dotted = splitDottedGitHubResource(topic);
+    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/*/*/${topic}/*`;
+  }
   return `${source}/*/*/${topic}`;
 }
 
@@ -93,9 +110,13 @@ function assertNoDuplicateLongHorizonSubscriptionPattern(
 ): void {
   const duplicate = repo.listSubscriptions(agentId).find((subscription) => {
     if (subscription.id === currentSubscriptionId) return false;
-    return (
-      composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic) === pattern
-    );
+    try {
+      return (
+        composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic) === pattern
+      );
+    } catch {
+      return false;
+    }
   });
   if (duplicate) {
     throw new Error(

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -74,6 +74,11 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
 
   if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (resourceSegments.length > 4) {
+    throw new Error(
+      `GitHub topic "${topic}" must match supported shape "owner/repo/pull_request/<id>.<action>"`
+    );
+  }
   if (isSourcePrefixed && segments.length === 5) {
     ensureGitHubEventResource(topic, segments[3] ?? '');
     ensureGitHubEntityAction(topic, segments[4] ?? '');
@@ -98,16 +103,24 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   if (resourceSegments.length === 3) {
     const [owner, repo, resource] = resourceSegments;
     const dotted = splitDottedGitHubResource(resource ?? '');
-    if (dotted) return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    if (dotted) {
+      ensureGitHubEventResource(topic, dotted.resource);
+      return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    }
     if (!isGitHubEventResource(resource ?? '')) rejectSlashSeparatedGitHubAction(topic);
     return `${source}/${owner}/${repo}/${resource}/*`;
   }
   if (resourceSegments.length === 2) {
     const [resource, entityAction] = resourceSegments;
-    if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
-      return `${source}/${source}/${resource}/${entityAction}/*`;
-    }
     if (!isGitHubEventResource(resource ?? '')) {
+      const dottedEntityAction = splitDottedGitHubResource(entityAction ?? '');
+      if (isSourcePrefixed && dottedEntityAction) {
+        ensureGitHubEventResource(topic, dottedEntityAction.resource);
+        return `${source}/${source}/${resource}/${dottedEntityAction.resource}/*.${dottedEntityAction.action}`;
+      }
+      if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
+        return `${source}/${source}/${resource}/${entityAction}/*`;
+      }
       throw new Error(
         `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
       );

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -40,11 +40,35 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   return `${trimmedSource}/${trimmedTopic}`;
 }
 
-function validateLongHorizonSubscriptionPattern(source: string, topic: string): void {
+function validateLongHorizonSubscriptionPattern(source: string, topic: string): string {
   const sourceValidation = validateSource(source);
   if (!sourceValidation.valid) throw new Error(sourceValidation.reason ?? 'invalid source');
-  const validation = validateGlobPattern(composeLongHorizonSubscriptionPattern(source, topic));
+  const pattern = composeLongHorizonSubscriptionPattern(source, topic);
+  const validation = validateGlobPattern(pattern);
   if (!validation.valid) throw new Error(validation.reason ?? 'invalid pattern');
+  return pattern;
+}
+
+function assertNoDuplicateLongHorizonSubscriptionPattern(
+  repo: SpaceLongHorizonAgentRepository,
+  agentId: string,
+  source: string,
+  topic: string,
+  pattern: string,
+  currentSubscriptionId?: string
+): void {
+  const duplicate = repo.listSubscriptions(agentId).find((subscription) => {
+    if (subscription.id === currentSubscriptionId) return false;
+    if (subscription.source === source && subscription.topic === topic) return false;
+    return (
+      composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic) === pattern
+    );
+  });
+  if (duplicate) {
+    throw new Error(
+      `Subscription pattern duplicates existing subscription ${duplicate.id}: ${pattern}`
+    );
+  }
 }
 
 export function setupSpaceLongHorizonAgentHandlers(
@@ -224,7 +248,8 @@ export function setupSpaceLongHorizonAgentHandlers(
     if (!params.topic?.trim()) throw new Error('topic is required');
     const source = params.source.trim();
     const topic = params.topic.trim();
-    validateLongHorizonSubscriptionPattern(source, topic);
+    const pattern = validateLongHorizonSubscriptionPattern(source, topic);
+    assertNoDuplicateLongHorizonSubscriptionPattern(repo, params.agentId, source, topic, pattern);
     const subscription = repo.createSubscription({
       spaceId: params.spaceId,
       agentId: params.agentId,
@@ -263,7 +288,15 @@ export function setupSpaceLongHorizonAgentHandlers(
     }
     const source = params.source?.trim() ?? existing.source;
     const topic = params.topic?.trim() ?? existing.topic;
-    validateLongHorizonSubscriptionPattern(source, topic);
+    const pattern = validateLongHorizonSubscriptionPattern(source, topic);
+    assertNoDuplicateLongHorizonSubscriptionPattern(
+      repo,
+      existing.agentId,
+      source,
+      topic,
+      pattern,
+      existing.id
+    );
     const subscription = repo.updateSubscription(params.subscriptionId, {
       ...(params.source !== undefined ? { source } : {}),
       ...(params.topic !== undefined ? { topic } : {}),

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -26,7 +26,10 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
   if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
-  if (trimmedSource === 'github' && !trimmedTopic.startsWith('*/*/')) {
+  if (trimmedSource === 'github') {
+    const segments = trimmedTopic.split('/');
+    if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
+      return `${trimmedSource}/${trimmedTopic}`;
     return `${trimmedSource}/*/*/${trimmedTopic}`;
   }
   return `${trimmedSource}/${trimmedTopic}`;

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -115,6 +115,8 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel?: number | null;
       model?: string | null;
       thinkingLevel?: string | null;
+      provider?: string | null;
+      settingSources?: SpaceLongHorizonAgent['settingSources'];
       toolPermissions?: Record<string, unknown>;
     };
     if (!params.spaceId) throw new Error('spaceId is required');
@@ -131,6 +133,8 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel: params.autonomyLevel as 1 | 2 | 3 | 4 | 5 | null | undefined,
       model: params.model,
       thinkingLevel: params.thinkingLevel as SpaceLongHorizonAgent['thinkingLevel'],
+      provider: params.provider,
+      settingSources: params.settingSources,
       toolPermissions: params.toolPermissions,
     });
     return { agent };

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -48,6 +48,12 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
       return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
     return `${topic}/*`;
   }
+  if (segments[0] === source && segments.length === 2) {
+    const resource = segments[1] ?? '';
+    const dotted = splitDottedGitHubResource(resource);
+    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/*/*/${resource}/*`;
+  }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 4) return `${source}/${topic}`;
   if (segments.length === 3) {
@@ -91,9 +97,15 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   return `${trimmedSource}/${trimmedTopic}`;
 }
 
-function validateLongHorizonSubscriptionPattern(source: string, topic: string): string {
-  const sourceValidation = validateSource(source);
-  if (!sourceValidation.valid) throw new Error(sourceValidation.reason ?? 'invalid source');
+function validateLongHorizonSubscriptionPattern(
+  source: string,
+  topic: string,
+  options: { allowWildcardSource?: boolean } = {}
+): string {
+  if (source !== '*' || !options.allowWildcardSource) {
+    const sourceValidation = validateSource(source);
+    if (!sourceValidation.valid) throw new Error(sourceValidation.reason ?? 'invalid source');
+  }
   const pattern = composeLongHorizonSubscriptionPattern(source, topic);
   const validation = validateGlobPattern(pattern);
   if (!validation.valid) throw new Error(validation.reason ?? 'invalid pattern');
@@ -195,6 +207,7 @@ export function setupSpaceLongHorizonAgentHandlers(
     const params = data as {
       agentId: string;
       spaceId?: string;
+      handle?: string;
       displayName?: string;
       instructions?: string;
       autonomyLevel?: number | null;
@@ -213,6 +226,7 @@ export function setupSpaceLongHorizonAgentHandlers(
         throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
     }
     const agent = repo.update(params.agentId, {
+      handle: params.handle,
       displayName: params.displayName,
       instructions: params.instructions,
       autonomyLevel: params.autonomyLevel as 1 | 2 | 3 | 4 | 5 | null | undefined,
@@ -352,7 +366,9 @@ export function setupSpaceLongHorizonAgentHandlers(
     }
     const source = params.source?.trim() ?? existing.source;
     const topic = params.topic?.trim() ?? existing.topic;
-    const pattern = validateLongHorizonSubscriptionPattern(source, topic);
+    const pattern = validateLongHorizonSubscriptionPattern(source, topic, {
+      allowWildcardSource: params.source === undefined && params.topic === undefined,
+    });
     assertNoDuplicateLongHorizonSubscriptionPattern(
       repo,
       existing.agentId,

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -17,7 +17,7 @@ import type {
   SpaceLongHorizonAgentEventSubscriptionStatus,
 } from '@neokai/shared';
 import type { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
-import { validateGlobPattern } from '../external-events/topic-validator';
+import { validateGlobPattern, validateSource } from '../external-events/topic-validator';
 import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
@@ -36,6 +36,8 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
 }
 
 function validateLongHorizonSubscriptionPattern(source: string, topic: string): void {
+  const sourceValidation = validateSource(source);
+  if (!sourceValidation.valid) throw new Error(sourceValidation.reason ?? 'invalid source');
   const validation = validateGlobPattern(composeLongHorizonSubscriptionPattern(source, topic));
   if (!validation.valid) throw new Error(validation.reason ?? 'invalid pattern');
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -25,7 +25,12 @@ import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service
 function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
-  if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
+  if (!trimmedSource) return trimmedTopic;
+  const topicSource = trimmedTopic.split('/')[0] ?? '';
+  if (topicSource === trimmedSource) return trimmedTopic;
+  if (validateSource(topicSource).valid) {
+    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
+  }
   if (trimmedSource === 'github') {
     const segments = trimmedTopic.split('/');
     if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
@@ -74,6 +79,7 @@ export function setupSpaceLongHorizonAgentHandlers(
 
   messageHub.onRequest('spaceLongHorizonAgent.create', async (data) => {
     const params = data as {
+      id?: string;
       spaceId: string;
       handle: string;
       displayName?: string;
@@ -82,12 +88,14 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel?: number | null;
       model?: string | null;
       thinkingLevel?: string | null;
+      toolPermissions?: Record<string, unknown>;
     };
     if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.handle) throw new Error('handle is required');
     const space = await spaceManager.getSpace(params.spaceId);
     if (!space) throw new Error(`Space not found: ${params.spaceId}`);
     const agent = repo.create({
+      id: params.id,
       spaceId: params.spaceId,
       handle: params.handle,
       displayName: params.displayName,
@@ -96,6 +104,7 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel: params.autonomyLevel as 1 | 2 | 3 | 4 | 5 | null | undefined,
       model: params.model,
       thinkingLevel: params.thinkingLevel as SpaceLongHorizonAgent['thinkingLevel'],
+      toolPermissions: params.toolPermissions,
     });
     return { agent };
   });

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -93,7 +93,6 @@ function assertNoDuplicateLongHorizonSubscriptionPattern(
 ): void {
   const duplicate = repo.listSubscriptions(agentId).find((subscription) => {
     if (subscription.id === currentSubscriptionId) return false;
-    if (subscription.source === source && subscription.topic === topic) return false;
     return (
       composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic) === pattern
     );

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -38,6 +38,10 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
     const segments = trimmedTopic.split('/');
     if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
       return `${trimmedSource}/${trimmedTopic}`;
+    if (segments.length === 1 && trimmedTopic.includes('.')) {
+      const dotIndex = trimmedTopic.indexOf('.');
+      return `${trimmedSource}/*/*/${trimmedTopic.slice(0, dotIndex)}/*.${trimmedTopic.slice(dotIndex + 1)}`;
+    }
     return `${trimmedSource}/*/*/${trimmedTopic}`;
   }
   return `${trimmedSource}/${trimmedTopic}`;
@@ -149,6 +153,9 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel?: number | null;
       model?: string | null;
       thinkingLevel?: string | null;
+      provider?: string | null;
+      settingSources?: SpaceLongHorizonAgent['settingSources'];
+      toolPermissions?: Record<string, unknown> | null;
       status?: string;
     };
     if (!params.agentId) throw new Error('agentId is required');
@@ -164,6 +171,9 @@ export function setupSpaceLongHorizonAgentHandlers(
       autonomyLevel: params.autonomyLevel as 1 | 2 | 3 | 4 | 5 | null | undefined,
       model: params.model,
       thinkingLevel: params.thinkingLevel as SpaceLongHorizonAgent['thinkingLevel'],
+      provider: params.provider,
+      settingSources: params.settingSources,
+      toolPermissions: params.toolPermissions,
       status: params.status as 'active' | 'paused' | 'disabled' | 'archived' | undefined,
     });
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -60,7 +60,11 @@ function rejectGitHubEntityPatternWithoutAction(topic: string): never {
 function ensureGitHubEntityAction(topic: string, entityAction: string): void {
   if (entityAction === '*') return;
   const dotIndex = entityAction.indexOf('.');
-  if (dotIndex <= 0 || dotIndex === entityAction.length - 1) {
+  if (
+    dotIndex <= 0 ||
+    dotIndex === entityAction.length - 1 ||
+    entityAction.indexOf('.', dotIndex + 1) !== -1
+  ) {
     rejectGitHubEntityPatternWithoutAction(topic);
   }
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -32,6 +32,12 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
   );
 }
 
+const GITHUB_EVENT_RESOURCES = new Set(['pull_request']);
+
+function isGitHubEventResource(resource: string): boolean {
+  return GITHUB_EVENT_RESOURCES.has(resource);
+}
+
 function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
   const dotIndex = segment.indexOf('.');
   if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
@@ -52,38 +58,54 @@ function ensureGitHubEntityAction(topic: string, entityAction: string): void {
 
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
-  if (segments[0] === source && segments.length === 5) {
+  const isSourcePrefixed = segments[0] === source;
+  const resourceSegments = isSourcePrefixed ? segments.slice(1) : segments;
+  const firstResourceSegment = resourceSegments[0] ?? '';
+  const firstDottedResource = splitDottedGitHubResource(firstResourceSegment);
+
+  if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
+  if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (isSourcePrefixed && segments.length === 5) {
     ensureGitHubEntityAction(topic, segments[4] ?? '');
     return topic;
   }
-  if (segments[0] === source && segments.length === 4 && segments[2] !== 'pull_request') {
-    const dotted = splitDottedGitHubResource(segments[3] ?? '');
-    if (dotted)
-      return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
-    return `${topic}/*`;
+  if (resourceSegments.length === 4) {
+    ensureGitHubEntityAction(topic, resourceSegments[3] ?? '');
+    return `${source}/${resourceSegments.join('/')}`;
   }
-  if (segments[0] === source && segments.length === 2) {
-    const resource = segments[1] ?? '';
-    const dotted = splitDottedGitHubResource(resource);
-    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/*/*/${resource}/*`;
+  if (isSourcePrefixed && resourceSegments.length === 3) {
+    const [first, second, third] = resourceSegments;
+    if (isGitHubEventResource(first ?? '')) {
+      ensureGitHubEntityAction(topic, `${second}.${third}`);
+      return `${source}/*/*/${first}/${second}.${third}`;
+    }
+    if (isGitHubEventResource(second ?? '')) {
+      ensureGitHubEntityAction(topic, third ?? '');
+      return `${source}/${source}/${first}/${second}/${third}`;
+    }
   }
-  if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (segments.length === 4) {
-    ensureGitHubEntityAction(topic, segments[3] ?? '');
-    return `${source}/${topic}`;
+  if (resourceSegments.length === 3) {
+    const [owner, repo, resource] = resourceSegments;
+    const dotted = splitDottedGitHubResource(resource ?? '');
+    if (dotted) return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    if (!isGitHubEventResource(resource ?? '')) rejectSlashSeparatedGitHubAction(topic);
+    return `${source}/${owner}/${repo}/${resource}/*`;
   }
-  if (segments.length === 3) {
-    const dotted = splitDottedGitHubResource(segments[2] ?? '');
-    if (dotted)
-      return `${source}/${segments[0]}/${segments[1]}/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/${topic}/*`;
+  if (resourceSegments.length === 2) {
+    const [resource, entityAction] = resourceSegments;
+    if (!isGitHubEventResource(resource ?? '')) {
+      throw new Error(
+        `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
+      );
+    }
+    ensureGitHubEntityAction(topic, entityAction ?? '');
+    return `${source}/*/*/${resource}/${entityAction}`;
   }
-  if (segments.length === 1) {
-    const dotted = splitDottedGitHubResource(topic);
-    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/*/*/${topic}/*`;
+  if (resourceSegments.length === 1) {
+    if (firstDottedResource) {
+      return `${source}/*/*/${firstDottedResource.resource}/*.${firstDottedResource.action}`;
+    }
+    return `${source}/*/*/${firstResourceSegment}/*`;
   }
   return `${source}/*/*/${topic}`;
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -34,18 +34,16 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
 
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source) {
-    const unqualifiedSegments = segments.slice(1);
-    if (unqualifiedSegments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-    if (unqualifiedSegments.length === 4) return topic;
-    if (unqualifiedSegments.length === 3) return `${source}/${topic}`;
-  }
+  if (segments[0] === source && segments.length === 5) return topic;
+  if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (topic.startsWith('*/*/') || segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 3) return `${source}/${topic}/*`;
   if (segments.length === 1 && topic.includes('.')) {
     const dotIndex = topic.indexOf('.');
     return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
   }
+  if (segments.length === 1) return `${source}/*/*/${topic}/*`;
   return `${source}/*/*/${topic}`;
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -211,7 +211,7 @@ export function setupSpaceLongHorizonAgentHandlers(
     const source = params.source.trim();
     const topic = params.topic.trim();
     validateLongHorizonSubscriptionPattern(source, topic);
-    const subscription = repo.upsertSubscription({
+    const subscription = repo.createSubscription({
       spaceId: params.spaceId,
       agentId: params.agentId,
       source,

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -117,8 +117,10 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   }
   if (resourceSegments.length === 1) {
     if (firstDottedResource) {
+      ensureGitHubEventResource(topic, firstDottedResource.resource);
       return `${source}/*/*/${firstDottedResource.resource}/*.${firstDottedResource.action}`;
     }
+    ensureGitHubEventResource(topic, firstResourceSegment);
     return `${source}/*/*/${firstResourceSegment}/*`;
   }
   return `${source}/*/*/${topic}`;
@@ -240,6 +242,7 @@ export function setupSpaceLongHorizonAgentHandlers(
       provider?: string | null;
       settingSources?: SpaceLongHorizonAgent['settingSources'];
       toolPermissions?: Record<string, unknown>;
+      status?: string;
     };
     if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.handle) throw new Error('handle is required');
@@ -258,6 +261,7 @@ export function setupSpaceLongHorizonAgentHandlers(
       provider: params.provider,
       settingSources: params.settingSources,
       toolPermissions: params.toolPermissions,
+      status: params.status as 'active' | 'paused' | 'disabled' | 'archived' | undefined,
     });
     return { agent };
   });

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -11,11 +11,31 @@
  * - spaceLongHorizonAgent.deleteReminder
  */
 
-import type { MessageHub, SpaceLongHorizonAgent } from '@neokai/shared';
+import type {
+  MessageHub,
+  SpaceLongHorizonAgent,
+  SpaceLongHorizonAgentEventSubscriptionStatus,
+} from '@neokai/shared';
 import type { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
+import { validateGlobPattern } from '../external-events/topic-validator';
 import { getLongHorizonAgentTemplates } from '../space/agents/long-horizon-agent-templates';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+
+function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
+  const trimmedSource = source.trim();
+  const trimmedTopic = topic.trim();
+  if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
+  if (trimmedSource === 'github' && !trimmedTopic.startsWith('*/*/')) {
+    return `${trimmedSource}/*/*/${trimmedTopic}`;
+  }
+  return `${trimmedSource}/${trimmedTopic}`;
+}
+
+function validateLongHorizonSubscriptionPattern(source: string, topic: string): void {
+  const validation = validateGlobPattern(composeLongHorizonSubscriptionPattern(source, topic));
+  if (!validation.valid) throw new Error(validation.reason ?? 'invalid pattern');
+}
 
 export function setupSpaceLongHorizonAgentHandlers(
   messageHub: MessageHub,
@@ -23,7 +43,10 @@ export function setupSpaceLongHorizonAgentHandlers(
   repo: SpaceLongHorizonAgentRepository,
   runtimeService?: Pick<
     SpaceRuntimeService,
-    'refreshLongHorizonAgentSubscriptions' | 'removeLongHorizonAgentSubscriptions'
+    | 'refreshLongHorizonAgentSubscriptions'
+    | 'removeLongHorizonAgentSubscriptions'
+    | 'refreshLongHorizonSubscription'
+    | 'removeLongHorizonSubscription'
   >
 ): void {
   messageHub.onRequest('spaceLongHorizonAgent.listBuiltInTemplates', async (data) => {
@@ -158,6 +181,103 @@ export function setupSpaceLongHorizonAgentHandlers(
     const existing = repo.getReminder(params.reminderId);
     if (!existing) throw new Error(`Reminder not found: ${params.reminderId}`);
     repo.deleteReminder(params.reminderId);
+    return { success: true };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.listSubscriptions', async (data) => {
+    const params = data as { agentId: string; spaceId?: string };
+    if (!params.agentId) throw new Error('agentId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    return { subscriptions: repo.listSubscriptions(params.agentId) };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.createSubscription', async (data) => {
+    const params = data as {
+      spaceId: string;
+      agentId: string;
+      source: string;
+      topic: string;
+      filter?: Record<string, unknown>;
+      status?: SpaceLongHorizonAgentEventSubscriptionStatus;
+    };
+    if (!params.spaceId) throw new Error('spaceId is required');
+    if (!params.agentId) throw new Error('agentId is required');
+    if (!params.source?.trim()) throw new Error('source is required');
+    if (!params.topic?.trim()) throw new Error('topic is required');
+    const source = params.source.trim();
+    const topic = params.topic.trim();
+    validateLongHorizonSubscriptionPattern(source, topic);
+    const subscription = repo.upsertSubscription({
+      spaceId: params.spaceId,
+      agentId: params.agentId,
+      source,
+      topic,
+      filter: params.filter,
+      status: params.status,
+    });
+    const refresh = runtimeService?.refreshLongHorizonSubscription(
+      subscription.spaceId,
+      subscription.id
+    );
+    if (refresh && !refresh.success)
+      throw new Error(refresh.error ?? 'Failed to refresh subscription');
+    return { subscription };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.updateSubscription', async (data) => {
+    const params = data as {
+      subscriptionId: string;
+      spaceId?: string;
+      source?: string;
+      topic?: string;
+      filter?: Record<string, unknown>;
+      status?: SpaceLongHorizonAgentEventSubscriptionStatus;
+    };
+    if (!params.subscriptionId) throw new Error('subscriptionId is required');
+    if (params.source !== undefined && !params.source.trim()) throw new Error('source is required');
+    if (params.topic !== undefined && !params.topic.trim()) throw new Error('topic is required');
+    const existing = repo.getSubscription(params.subscriptionId);
+    if (!existing) throw new Error(`Subscription not found: ${params.subscriptionId}`);
+    if (params.spaceId && existing.spaceId !== params.spaceId) {
+      throw new Error(
+        `Subscription ${params.subscriptionId} does not belong to space ${params.spaceId}`
+      );
+    }
+    const source = params.source?.trim() ?? existing.source;
+    const topic = params.topic?.trim() ?? existing.topic;
+    validateLongHorizonSubscriptionPattern(source, topic);
+    const subscription = repo.updateSubscription(params.subscriptionId, {
+      ...(params.source !== undefined ? { source } : {}),
+      ...(params.topic !== undefined ? { topic } : {}),
+      ...(params.filter !== undefined ? { filter: params.filter } : {}),
+      ...(params.status !== undefined ? { status: params.status } : {}),
+    });
+    if (!subscription) throw new Error(`Subscription not found: ${params.subscriptionId}`);
+    const refresh = runtimeService?.refreshLongHorizonSubscription(
+      subscription.spaceId,
+      subscription.id
+    );
+    if (refresh && !refresh.success)
+      throw new Error(refresh.error ?? 'Failed to refresh subscription');
+    return { subscription };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.deleteSubscription', async (data) => {
+    const params = data as { subscriptionId: string; spaceId?: string };
+    if (!params.subscriptionId) throw new Error('subscriptionId is required');
+    const existing = repo.getSubscription(params.subscriptionId);
+    if (!existing) throw new Error(`Subscription not found: ${params.subscriptionId}`);
+    if (params.spaceId && existing.spaceId !== params.spaceId) {
+      throw new Error(
+        `Subscription ${params.subscriptionId} does not belong to space ${params.spaceId}`
+      );
+    }
+    runtimeService?.removeLongHorizonSubscription(existing.spaceId, existing.id);
+    repo.deleteSubscription(params.subscriptionId);
     return { success: true };
   });
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -38,6 +38,13 @@ function isGitHubEventResource(resource: string): boolean {
   return GITHUB_EVENT_RESOURCES.has(resource);
 }
 
+function ensureGitHubEventResource(topic: string, resource: string): void {
+  if (resource === '*' || isGitHubEventResource(resource)) return;
+  throw new Error(
+    `GitHub topic "${topic}" uses unsupported resource "${resource}"; supported resources: pull_request`
+  );
+}
+
 function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
   const dotIndex = segment.indexOf('.');
   if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
@@ -66,10 +73,12 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (isSourcePrefixed && segments.length === 5) {
+    ensureGitHubEventResource(topic, segments[3] ?? '');
     ensureGitHubEntityAction(topic, segments[4] ?? '');
     return topic;
   }
   if (resourceSegments.length === 4) {
+    ensureGitHubEventResource(topic, resourceSegments[2] ?? '');
     ensureGitHubEntityAction(topic, resourceSegments[3] ?? '');
     return `${source}/${resourceSegments.join('/')}`;
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1695,6 +1695,17 @@ export class SpaceRuntimeService {
     return this.runtime.refreshLongHorizonAgentSubscriptions(spaceId, agentId);
   }
 
+  refreshLongHorizonSubscription(
+    spaceId: string,
+    subscriptionId: string
+  ): { success: boolean; error?: string } {
+    return this.runtime.refreshLongHorizonSubscription(spaceId, subscriptionId);
+  }
+
+  removeLongHorizonSubscription(spaceId: string, subscriptionId: string): void {
+    this.runtime.removeLongHorizonSubscription(spaceId, subscriptionId);
+  }
+
   removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void {
     this.runtime.removeLongHorizonAgentSubscriptions(spaceId, agentId);
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -501,7 +501,10 @@ export class SpaceRuntimeService {
     const agentKey = sanitizeLongTermAgentKey(agent.displayName);
 
     return {
-      model: agent.model ?? space.defaultModel ?? DEFAULT_LONG_HORIZON_AGENT_MODEL,
+      model:
+        agent.model ??
+        space.defaultModel ??
+        (agent.provider ? undefined : DEFAULT_LONG_HORIZON_AGENT_MODEL),
       provider: (agent.provider ?? undefined) as Session['config']['provider'],
       thinkingLevel: agent.thinkingLevel ?? undefined,
       systemPrompt: {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -16,6 +16,7 @@ import type {
   Session,
   Space,
   SpaceAgent,
+  SpaceLongHorizonAgent,
   SpaceTask,
   SpaceWorkflowRun,
   UpdateSpaceTaskParams,
@@ -44,6 +45,7 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
+import type { AgentSession } from '../../agent/agent-session';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
@@ -82,6 +84,8 @@ const LONG_TERM_AGENT_SESSION_FEATURES = {
   archive: false,
   sessionInfo: false,
 } as const;
+
+const DEFAULT_LONG_HORIZON_AGENT_MODEL = 'claude-sonnet-4-6';
 
 const CLAUDE_CODE_BUILTIN_TOOLS = [
   ...KNOWN_TOOLS,
@@ -483,6 +487,75 @@ export class SpaceRuntimeService {
     return id;
   }
 
+  private buildLongHorizonAgentSessionConfig(
+    space: Space,
+    agent: SpaceLongHorizonAgent
+  ): Partial<Session['config']> {
+    const storedTools = Array.isArray(agent.toolPermissions.tools)
+      ? (agent.toolPermissions.tools.filter((tool) => typeof tool === 'string') as string[])
+      : [];
+    const customTools = storedTools.length > 0 ? storedTools : undefined;
+    const customDisallowedBuiltins = customTools
+      ? CLAUDE_CODE_BUILTIN_TOOLS.filter((tool) => !customTools.includes(tool))
+      : [];
+    const agentKey = sanitizeLongTermAgentKey(agent.displayName);
+
+    return {
+      model: agent.model ?? space.defaultModel ?? DEFAULT_LONG_HORIZON_AGENT_MODEL,
+      thinkingLevel: agent.thinkingLevel ?? undefined,
+      systemPrompt: {
+        type: 'preset',
+        preset: 'claude_code',
+        append: agent.instructions,
+      },
+      features: LONG_TERM_AGENT_SESSION_FEATURES,
+      sdkToolsPreset: customTools,
+      allowedTools: customTools,
+      disallowedTools: customTools ? customDisallowedBuiltins : undefined,
+      agent: customTools ? agentKey : undefined,
+      agents: customTools
+        ? {
+            [agentKey]: {
+              description: `Long-horizon Space agent: ${agent.displayName}`,
+              disallowedTools: customDisallowedBuiltins,
+              model: 'inherit',
+              prompt: agent.instructions,
+            } satisfies AgentDefinition,
+          }
+        : undefined,
+      settingSources: space.settingSources,
+    };
+  }
+
+  private async refreshLongHorizonAgentSessionConfig(
+    session: AgentSession,
+    config: Partial<Session['config']>
+  ): Promise<void> {
+    const currentConfig = session.getSessionData().config;
+    const updates: Partial<Session['config']> = {
+      model: config.model,
+      thinkingLevel: config.thinkingLevel,
+      systemPrompt: config.systemPrompt,
+      features: config.features,
+      sdkToolsPreset: config.sdkToolsPreset,
+      allowedTools: config.allowedTools,
+      disallowedTools: config.disallowedTools,
+      agent: config.agent,
+      agents: config.agents,
+      settingSources: config.settingSources,
+    };
+    const changed = Object.entries(updates).some(
+      ([key, value]) =>
+        JSON.stringify(currentConfig[key as keyof Session['config']]) !== JSON.stringify(value)
+    );
+    if (!changed) return;
+    await session.updateConfig(updates);
+    const result = await session.resetQuery({ restartQuery: true });
+    if (!result.success) {
+      throw new Error(result.error ?? 'Failed to refresh long-horizon agent session');
+    }
+  }
+
   private async ensureLongHorizonAgentSession(spaceId: string, agentId: string) {
     const sessionManager = this.config.sessionManager;
     const repo = this.config.longHorizonAgentRepo;
@@ -492,52 +565,17 @@ export class SpaceRuntimeService {
     const space = await this.config.spaceManager.getSpace(spaceId);
     if (!space) return null;
     const sessionId = longTermAgentSessionId(spaceId, agentId);
+    const config = this.buildLongHorizonAgentSessionConfig(space, agent);
     let session = await sessionManager.getSessionAsync(sessionId);
     if (!session) {
       try {
-        const storedTools = Array.isArray(agent.toolPermissions.tools)
-          ? (agent.toolPermissions.tools.filter((tool) => typeof tool === 'string') as string[])
-          : [];
-        const customTools = storedTools.length > 0 ? storedTools : undefined;
-        const customDisallowedBuiltins = customTools
-          ? CLAUDE_CODE_BUILTIN_TOOLS.filter((tool) => !customTools.includes(tool))
-          : [];
-        const agentKey = sanitizeLongTermAgentKey(agent.displayName);
         await sessionManager.createSession({
           sessionId,
           workspacePath: space.workspacePath,
           title: agent.displayName,
           spaceId: space.id,
           worktreeMode: 'direct',
-          config: {
-            model: agent.model ?? space.defaultModel,
-            thinkingLevel: agent.thinkingLevel ?? undefined,
-            systemPrompt: {
-              type: 'preset',
-              preset: 'claude_code',
-              append: agent.instructions,
-            },
-            features: LONG_TERM_AGENT_SESSION_FEATURES,
-            ...(customTools
-              ? {
-                  sdkToolsPreset: customTools,
-                  allowedTools: customTools,
-                  disallowedTools: customDisallowedBuiltins,
-                }
-              : {}),
-            agent: customTools ? agentKey : undefined,
-            agents: customTools
-              ? {
-                  [agentKey]: {
-                    description: `Long-horizon Space agent: ${agent.displayName}`,
-                    disallowedTools: customDisallowedBuiltins,
-                    model: 'inherit',
-                    prompt: agent.instructions,
-                  } satisfies AgentDefinition,
-                }
-              : undefined,
-            settingSources: space.settingSources,
-          },
+          config,
         });
       } catch (err) {
         session = await sessionManager.getSessionAsync(sessionId);
@@ -545,6 +583,8 @@ export class SpaceRuntimeService {
       }
       session = session ?? (await sessionManager.getSessionAsync(sessionId));
       if (!session) return null;
+    } else {
+      await this.refreshLongHorizonAgentSessionConfig(session, config);
     }
     if (agent.sessionId !== sessionId) repo.update(agent.id, { sessionId });
     const currentMetadata = session.getSessionData().metadata;

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -502,6 +502,7 @@ export class SpaceRuntimeService {
 
     return {
       model: agent.model ?? space.defaultModel ?? DEFAULT_LONG_HORIZON_AGENT_MODEL,
+      provider: (agent.provider ?? undefined) as Session['config']['provider'],
       thinkingLevel: agent.thinkingLevel ?? undefined,
       systemPrompt: {
         type: 'preset',
@@ -523,7 +524,7 @@ export class SpaceRuntimeService {
             } satisfies AgentDefinition,
           }
         : undefined,
-      settingSources: space.settingSources,
+      settingSources: agent.settingSources ?? space.settingSources,
     };
   }
 
@@ -534,6 +535,7 @@ export class SpaceRuntimeService {
     const currentConfig = session.getSessionData().config;
     const updates: Partial<Session['config']> = {
       model: config.model,
+      provider: config.provider,
       thinkingLevel: config.thinkingLevel,
       systemPrompt: config.systemPrompt,
       features: config.features,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -506,11 +506,26 @@ function splitDottedGitHubResource(segment: string): { resource: string; action:
   return { resource: segment.slice(0, dotIndex), action: segment.slice(dotIndex + 1) };
 }
 
+function rejectGitHubEntityPatternWithoutAction(topic: string): never {
+  throw new Error(
+    `GitHub topic "${topic}" must use dotted entity actions like "pull_request/42.opened"`
+  );
+}
+
+function ensureGitHubEntityAction(topic: string, entityAction: string): void {
+  if (entityAction !== '*' && !entityAction.includes('.')) {
+    rejectGitHubEntityPatternWithoutAction(topic);
+  }
+}
+
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
   if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
-  if (segments[0] === source && segments.length === 5) return topic;
-  if (segments[0] === source && segments.length === 4) {
+  if (segments[0] === source && segments.length === 5) {
+    ensureGitHubEntityAction(topic, segments[4] ?? '');
+    return topic;
+  }
+  if (segments[0] === source && segments.length === 4 && segments[2] !== 'pull_request') {
     const dotted = splitDottedGitHubResource(segments[3] ?? '');
     if (dotted)
       return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
@@ -523,7 +538,10 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
     return `${source}/*/*/${resource}/*`;
   }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 4) {
+    ensureGitHubEntityAction(topic, segments[3] ?? '');
+    return `${source}/${topic}`;
+  }
   if (segments.length === 3) {
     const dotted = splitDottedGitHubResource(segments[2] ?? '');
     if (dotted)

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -44,7 +44,7 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { ExternalEventPublishedPayload } from '../../external-events/external-event-service';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
 import type { ExternalEvent } from '../../external-events/types';
-import { validateGlobPattern, validateSource } from '../../external-events/topic-validator';
+import { KNOWN_SOURCES, validateGlobPattern } from '../../external-events/topic-validator';
 import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
@@ -500,10 +500,11 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
   if (topicSource === trimmedSource) return trimmedTopic;
-  if (topicSource.toLowerCase() === trimmedSource.toLowerCase()) {
-    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
-  }
-  if (validateSource(topicSource).valid) {
+  const normalizedTopicSource = topicSource.toLowerCase();
+  if (
+    normalizedTopicSource === trimmedSource.toLowerCase() ||
+    KNOWN_SOURCES.has(normalizedTopicSource)
+  ) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }
   if (trimmedSource === 'github') {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -516,6 +516,12 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
       return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
     return `${topic}/*`;
   }
+  if (segments[0] === source && segments.length === 2) {
+    const resource = segments[1] ?? '';
+    const dotted = splitDottedGitHubResource(resource);
+    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/*/*/${resource}/*`;
+  }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 4) return `${source}/${topic}`;
   if (segments.length === 3) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -526,7 +526,9 @@ function rejectGitHubEntityPatternWithoutAction(topic: string): never {
 }
 
 function ensureGitHubEntityAction(topic: string, entityAction: string): void {
-  if (entityAction !== '*' && !entityAction.includes('.')) {
+  if (entityAction === '*') return;
+  const dotIndex = entityAction.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === entityAction.length - 1) {
     rejectGitHubEntityPatternWithoutAction(topic);
   }
 }
@@ -570,6 +572,9 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   }
   if (resourceSegments.length === 2) {
     const [resource, entityAction] = resourceSegments;
+    if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
+      return `${source}/${source}/${resource}/${entityAction}/*`;
+    }
     if (!isGitHubEventResource(resource ?? '')) {
       throw new Error(
         `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
@@ -595,7 +600,9 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (trimmedSource === 'github') {
     const segments = trimmedTopic.split('/');
     const isOwnerRepoShorthand =
-      segments.length === 4 || (segments[0] === trimmedSource && segments.length === 4);
+      segments.length === 3 ||
+      segments.length === 4 ||
+      (segments[0] === trimmedSource && (segments.length === 3 || segments.length === 4));
     if (isOwnerRepoShorthand || topicSource === trimmedSource) {
       return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
     }
@@ -877,6 +884,7 @@ export class SpaceRuntime {
   private readonly externalEventRetryTimers = new Map<string, Timer>();
   private readonly externalEventRetryCounts = new Map<string, number>();
   private readonly externalEventDeliveriesInFlight = new Set<string>();
+  private readonly cancelledLongHorizonDeliveries = new Set<string>();
   private readonly externalEventRateLimits = new Map<string, ExternalEventRateLimitState>();
   private unsubscribeExternalEventPublished?: () => void;
   private unsubscribeSdkToolUseCreated?: () => void;
@@ -1357,12 +1365,14 @@ export class SpaceRuntime {
         message: this.formatExternalEventMessage(event),
         idempotencyKey: deliveryKey,
       });
+      if (this.cancelledLongHorizonDeliveries.has(deliveryKey)) return;
       if (!result.delivered) throw new Error('long-horizon agent unavailable');
       this.clearExternalEventRetry(deliveryKey);
       store.markDeliveryDelivered(event.eventId, deliveryKey);
       store.markEventDeliveredIfAllDeliveriesDelivered(event.eventId);
       store.markEventFailedIfAllDeliveriesTerminal(event.eventId);
     } catch (err) {
+      if (this.cancelledLongHorizonDeliveries.has(deliveryKey)) return;
       const failureReason = err instanceof Error ? err.message : String(err);
       store.markDeliveryFailed(event.eventId, deliveryKey, {
         terminal: false,
@@ -1375,6 +1385,7 @@ export class SpaceRuntime {
       );
     } finally {
       this.externalEventDeliveriesInFlight.delete(deliveryKey);
+      this.cancelledLongHorizonDeliveries.delete(deliveryKey);
     }
   }
 
@@ -1386,6 +1397,12 @@ export class SpaceRuntime {
       if (!target || !predicate(target)) continue;
       this.markLongHorizonRetryCancelled(deliveryKey);
       this.clearExternalEventRetry(deliveryKey);
+    }
+    for (const deliveryKey of Array.from(this.externalEventDeliveriesInFlight)) {
+      const target = this.parseLongHorizonDeliveryKey(deliveryKey);
+      if (!target || !predicate(target)) continue;
+      this.cancelledLongHorizonDeliveries.add(deliveryKey);
+      this.markLongHorizonRetryCancelled(deliveryKey);
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -510,6 +510,10 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
     const segments = trimmedTopic.split('/');
     if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
       return `${trimmedSource}/${trimmedTopic}`;
+    if (segments.length === 1 && trimmedTopic.includes('.')) {
+      const dotIndex = trimmedTopic.indexOf('.');
+      return `${trimmedSource}/*/*/${trimmedTopic.slice(0, dotIndex)}/*.${trimmedTopic.slice(dotIndex + 1)}`;
+    }
     return `${trimmedSource}/*/*/${trimmedTopic}`;
   }
   return `${trimmedSource}/${trimmedTopic}`;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -502,18 +502,16 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
 
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source) {
-    const unqualifiedSegments = segments.slice(1);
-    if (unqualifiedSegments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-    if (unqualifiedSegments.length === 4) return topic;
-    if (unqualifiedSegments.length === 3) return `${source}/${topic}`;
-  }
+  if (segments[0] === source && segments.length === 5) return topic;
+  if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (topic.startsWith('*/*/') || segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 3) return `${source}/${topic}/*`;
   if (segments.length === 1 && topic.includes('.')) {
     const dotIndex = topic.indexOf('.');
     return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
   }
+  if (segments.length === 1) return `${source}/*/*/${topic}/*`;
   return `${source}/*/*/${topic}`;
 }
 
@@ -1023,7 +1021,12 @@ export class SpaceRuntime {
       );
       return { success: true };
     }
-    const pattern = composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic);
+    let pattern: string;
+    try {
+      pattern = composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic);
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
     const validation = validateGlobPattern(pattern);
     if (!validation.valid) return { success: false, error: validation.reason ?? 'invalid pattern' };
     this.topicTrie.insert(pattern, {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -498,7 +498,10 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
   if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
-  if (trimmedSource === 'github' && !trimmedTopic.startsWith('*/*/')) {
+  if (trimmedSource === 'github') {
+    const segments = trimmedTopic.split('/');
+    if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
+      return `${trimmedSource}/${trimmedTopic}`;
     return `${trimmedSource}/*/*/${trimmedTopic}`;
   }
   return `${trimmedSource}/${trimmedTopic}`;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -500,18 +500,35 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
   );
 }
 
+function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
+  const dotIndex = segment.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
+  return { resource: segment.slice(0, dotIndex), action: segment.slice(dotIndex + 1) };
+}
+
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source && segments.length === 5) return topic;
   if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
+  if (segments[0] === source && segments.length === 5) return topic;
+  if (segments[0] === source && segments.length === 4) {
+    const dotted = splitDottedGitHubResource(segments[3] ?? '');
+    if (dotted)
+      return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
+    return `${topic}/*`;
+  }
   if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (segments.length === 4) return `${source}/${topic}`;
-  if (segments.length === 3) return `${source}/${topic}/*`;
-  if (segments.length === 1 && topic.includes('.')) {
-    const dotIndex = topic.indexOf('.');
-    return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
+  if (segments.length === 3) {
+    const dotted = splitDottedGitHubResource(segments[2] ?? '');
+    if (dotted)
+      return `${source}/${segments[0]}/${segments[1]}/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/${topic}/*`;
   }
-  if (segments.length === 1) return `${source}/*/*/${topic}/*`;
+  if (segments.length === 1) {
+    const dotted = splitDottedGitHubResource(topic);
+    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
+    return `${source}/*/*/${topic}/*`;
+  }
   return `${source}/*/*/${topic}`;
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -985,7 +985,12 @@ export class SpaceRuntime {
       return { success: true };
     }
     const agent = repo.getById(subscription.agentId);
-    if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') return { success: true };
+    if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') {
+      this.clearLongHorizonRetries(
+        (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
+      );
+      return { success: true };
+    }
     const pattern = composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic);
     const validation = validateGlobPattern(pattern);
     if (!validation.valid) return { success: false, error: validation.reason ?? 'invalid pattern' };

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3543,16 +3543,26 @@ export class SpaceRuntime {
         const agent = subscription
           ? this.config.longHorizonAgentRepo?.getById(subscription.agentId)
           : null;
-        const target = subscription
-          ? {
-              kind: 'long_horizon_agent' as const,
+        let target: LongHorizonSubscriptionTarget | null = null;
+        if (subscription) {
+          try {
+            target = {
+              kind: 'long_horizon_agent',
               spaceId: longHorizonSpaceId,
               agentId: subscription.agentId,
               source: subscription.source,
               topic: composeLongHorizonSubscriptionPattern(subscription.source, subscription.topic),
               subscriptionId: subscription.id,
-            }
-          : null;
+            };
+          } catch (err) {
+            store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
+              terminal: true,
+              reason: err instanceof Error ? err.message : String(err),
+            });
+            store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+            continue;
+          }
+        }
         if (
           !subscription ||
           subscription.spaceId !== longHorizonSpaceId ||

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -542,6 +542,11 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
 
   if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (resourceSegments.length > 4) {
+    throw new Error(
+      `GitHub topic "${topic}" must match supported shape "owner/repo/pull_request/<id>.<action>"`
+    );
+  }
   if (isSourcePrefixed && segments.length === 5) {
     ensureGitHubEventResource(topic, segments[3] ?? '');
     ensureGitHubEntityAction(topic, segments[4] ?? '');
@@ -566,16 +571,24 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   if (resourceSegments.length === 3) {
     const [owner, repo, resource] = resourceSegments;
     const dotted = splitDottedGitHubResource(resource ?? '');
-    if (dotted) return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    if (dotted) {
+      ensureGitHubEventResource(topic, dotted.resource);
+      return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    }
     if (!isGitHubEventResource(resource ?? '')) rejectSlashSeparatedGitHubAction(topic);
     return `${source}/${owner}/${repo}/${resource}/*`;
   }
   if (resourceSegments.length === 2) {
     const [resource, entityAction] = resourceSegments;
-    if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
-      return `${source}/${source}/${resource}/${entityAction}/*`;
-    }
     if (!isGitHubEventResource(resource ?? '')) {
+      const dottedEntityAction = splitDottedGitHubResource(entityAction ?? '');
+      if (isSourcePrefixed && dottedEntityAction) {
+        ensureGitHubEventResource(topic, dottedEntityAction.resource);
+        return `${source}/${source}/${resource}/${dottedEntityAction.resource}/*.${dottedEntityAction.action}`;
+      }
+      if (isSourcePrefixed && isGitHubEventResource(entityAction ?? '')) {
+        return `${source}/${source}/${resource}/${entityAction}/*`;
+      }
       throw new Error(
         `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
       );

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -500,6 +500,9 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
   if (topicSource === trimmedSource) return trimmedTopic;
+  if (topicSource.toLowerCase() === trimmedSource.toLowerCase()) {
+    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
+  }
   if (validateSource(topicSource).valid) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -500,6 +500,12 @@ function rejectSlashSeparatedGitHubAction(topic: string): never {
   );
 }
 
+const GITHUB_EVENT_RESOURCES = new Set(['pull_request']);
+
+function isGitHubEventResource(resource: string): boolean {
+  return GITHUB_EVENT_RESOURCES.has(resource);
+}
+
 function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
   const dotIndex = segment.indexOf('.');
   if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
@@ -520,38 +526,54 @@ function ensureGitHubEntityAction(topic: string, entityAction: string): void {
 
 function composeGitHubSubscriptionPattern(source: string, topic: string): string {
   const segments = topic.split('/');
-  if (segments[0] === source && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
-  if (segments[0] === source && segments.length === 5) {
+  const isSourcePrefixed = segments[0] === source;
+  const resourceSegments = isSourcePrefixed ? segments.slice(1) : segments;
+  const firstResourceSegment = resourceSegments[0] ?? '';
+  const firstDottedResource = splitDottedGitHubResource(firstResourceSegment);
+
+  if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
+  if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (isSourcePrefixed && segments.length === 5) {
     ensureGitHubEntityAction(topic, segments[4] ?? '');
     return topic;
   }
-  if (segments[0] === source && segments.length === 4 && segments[2] !== 'pull_request') {
-    const dotted = splitDottedGitHubResource(segments[3] ?? '');
-    if (dotted)
-      return `${source}/${segments[1]}/${segments[2]}/${dotted.resource}/*.${dotted.action}`;
-    return `${topic}/*`;
+  if (resourceSegments.length === 4) {
+    ensureGitHubEntityAction(topic, resourceSegments[3] ?? '');
+    return `${source}/${resourceSegments.join('/')}`;
   }
-  if (segments[0] === source && segments.length === 2) {
-    const resource = segments[1] ?? '';
-    const dotted = splitDottedGitHubResource(resource);
-    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/*/*/${resource}/*`;
+  if (isSourcePrefixed && resourceSegments.length === 3) {
+    const [first, second, third] = resourceSegments;
+    if (isGitHubEventResource(first ?? '')) {
+      ensureGitHubEntityAction(topic, `${second}.${third}`);
+      return `${source}/*/*/${first}/${second}.${third}`;
+    }
+    if (isGitHubEventResource(second ?? '')) {
+      ensureGitHubEntityAction(topic, third ?? '');
+      return `${source}/${source}/${first}/${second}/${third}`;
+    }
   }
-  if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
-  if (segments.length === 4) {
-    ensureGitHubEntityAction(topic, segments[3] ?? '');
-    return `${source}/${topic}`;
+  if (resourceSegments.length === 3) {
+    const [owner, repo, resource] = resourceSegments;
+    const dotted = splitDottedGitHubResource(resource ?? '');
+    if (dotted) return `${source}/${owner}/${repo}/${dotted.resource}/*.${dotted.action}`;
+    if (!isGitHubEventResource(resource ?? '')) rejectSlashSeparatedGitHubAction(topic);
+    return `${source}/${owner}/${repo}/${resource}/*`;
   }
-  if (segments.length === 3) {
-    const dotted = splitDottedGitHubResource(segments[2] ?? '');
-    if (dotted)
-      return `${source}/${segments[0]}/${segments[1]}/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/${topic}/*`;
+  if (resourceSegments.length === 2) {
+    const [resource, entityAction] = resourceSegments;
+    if (!isGitHubEventResource(resource ?? '')) {
+      throw new Error(
+        `GitHub topic "${topic}" must include a resource segment like "owner/repo/pull_request"`
+      );
+    }
+    ensureGitHubEntityAction(topic, entityAction ?? '');
+    return `${source}/*/*/${resource}/${entityAction}`;
   }
-  if (segments.length === 1) {
-    const dotted = splitDottedGitHubResource(topic);
-    if (dotted) return `${source}/*/*/${dotted.resource}/*.${dotted.action}`;
-    return `${source}/*/*/${topic}/*`;
+  if (resourceSegments.length === 1) {
+    if (firstDottedResource) {
+      return `${source}/*/*/${firstDottedResource.resource}/*.${firstDottedResource.action}`;
+    }
+    return `${source}/*/*/${firstResourceSegment}/*`;
   }
   return `${source}/*/*/${topic}`;
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -506,6 +506,13 @@ function isGitHubEventResource(resource: string): boolean {
   return GITHUB_EVENT_RESOURCES.has(resource);
 }
 
+function ensureGitHubEventResource(topic: string, resource: string): void {
+  if (resource === '*' || isGitHubEventResource(resource)) return;
+  throw new Error(
+    `GitHub topic "${topic}" uses unsupported resource "${resource}"; supported resources: pull_request`
+  );
+}
+
 function splitDottedGitHubResource(segment: string): { resource: string; action: string } | null {
   const dotIndex = segment.indexOf('.');
   if (dotIndex <= 0 || dotIndex === segment.length - 1) return null;
@@ -534,10 +541,12 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   if (isSourcePrefixed && segments.length === 6) rejectSlashSeparatedGitHubAction(topic);
   if (!isSourcePrefixed && segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
   if (isSourcePrefixed && segments.length === 5) {
+    ensureGitHubEventResource(topic, segments[3] ?? '');
     ensureGitHubEntityAction(topic, segments[4] ?? '');
     return topic;
   }
   if (resourceSegments.length === 4) {
+    ensureGitHubEventResource(topic, resourceSegments[2] ?? '');
     ensureGitHubEntityAction(topic, resourceSegments[3] ?? '');
     return `${source}/${resourceSegments.join('/')}`;
   }
@@ -1374,7 +1383,24 @@ export class SpaceRuntime {
   ): void {
     for (const deliveryKey of Array.from(this.externalEventRetryTimers.keys())) {
       const target = this.parseLongHorizonDeliveryKey(deliveryKey);
-      if (target && predicate(target)) this.clearExternalEventRetry(deliveryKey);
+      if (!target || !predicate(target)) continue;
+      this.markLongHorizonRetryCancelled(deliveryKey);
+      this.clearExternalEventRetry(deliveryKey);
+    }
+  }
+
+  private markLongHorizonRetryCancelled(deliveryKey: string): void {
+    const store = this.config.externalEventStore;
+    if (!store) return;
+    try {
+      const eventId = store.getEventIdForDeliveryKey(deliveryKey);
+      store.markDeliveryFailed(eventId, deliveryKey, {
+        terminal: true,
+        reason: 'subscription_no_longer_active',
+      });
+      store.markEventFailedIfAllDeliveriesTerminal(eventId);
+    } catch {
+      return;
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -494,12 +494,44 @@ function legacyGitHubTopic(topic: string): string | null {
   return `${source}/${owner}/${repo}/${resource}.${entityAction.slice(dotIndex + 1)}`;
 }
 
+function rejectSlashSeparatedGitHubAction(topic: string): never {
+  throw new Error(
+    `GitHub topic "${topic}" must use dotted entity actions like "pull_request/42.closed"`
+  );
+}
+
+function composeGitHubSubscriptionPattern(source: string, topic: string): string {
+  const segments = topic.split('/');
+  if (segments[0] === source) {
+    const unqualifiedSegments = segments.slice(1);
+    if (unqualifiedSegments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+    if (unqualifiedSegments.length === 4) return topic;
+    if (unqualifiedSegments.length === 3) return `${source}/${topic}`;
+  }
+  if (segments.length === 5) rejectSlashSeparatedGitHubAction(topic);
+  if (topic.startsWith('*/*/') || segments.length === 4) return `${source}/${topic}`;
+  if (segments.length === 1 && topic.includes('.')) {
+    const dotIndex = topic.indexOf('.');
+    return `${source}/*/*/${topic.slice(0, dotIndex)}/*.${topic.slice(dotIndex + 1)}`;
+  }
+  return `${source}/*/*/${topic}`;
+}
+
 function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
   if (!trimmedSource) return trimmedTopic;
   const topicSource = trimmedTopic.split('/')[0] ?? '';
-  if (topicSource === trimmedSource) return trimmedTopic;
+  if (trimmedSource === 'github') {
+    const segments = trimmedTopic.split('/');
+    const isOwnerRepoShorthand =
+      segments.length === 4 || (segments[0] === trimmedSource && segments.length === 4);
+    if (isOwnerRepoShorthand || topicSource === trimmedSource) {
+      return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
+    }
+  } else if (topicSource === trimmedSource) {
+    return trimmedTopic;
+  }
   const normalizedTopicSource = topicSource.toLowerCase();
   if (
     normalizedTopicSource === trimmedSource.toLowerCase() ||
@@ -507,16 +539,8 @@ function composeLongHorizonSubscriptionPattern(source: string, topic: string): s
   ) {
     throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
   }
-  if (trimmedSource === 'github') {
-    const segments = trimmedTopic.split('/');
-    if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
-      return `${trimmedSource}/${trimmedTopic}`;
-    if (segments.length === 1 && trimmedTopic.includes('.')) {
-      const dotIndex = trimmedTopic.indexOf('.');
-      return `${trimmedSource}/*/*/${trimmedTopic.slice(0, dotIndex)}/*.${trimmedTopic.slice(dotIndex + 1)}`;
-    }
-    return `${trimmedSource}/*/*/${trimmedTopic}`;
-  }
+  if (trimmedSource === 'github')
+    return composeGitHubSubscriptionPattern(trimmedSource, trimmedTopic);
   return `${trimmedSource}/${trimmedTopic}`;
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -585,8 +585,10 @@ function composeGitHubSubscriptionPattern(source: string, topic: string): string
   }
   if (resourceSegments.length === 1) {
     if (firstDottedResource) {
+      ensureGitHubEventResource(topic, firstDottedResource.resource);
       return `${source}/*/*/${firstDottedResource.resource}/*.${firstDottedResource.action}`;
     }
+    ensureGitHubEventResource(topic, firstResourceSegment);
     return `${source}/*/*/${firstResourceSegment}/*`;
   }
   return `${source}/*/*/${topic}`;
@@ -885,6 +887,7 @@ export class SpaceRuntime {
   private readonly externalEventRetryCounts = new Map<string, number>();
   private readonly externalEventDeliveriesInFlight = new Set<string>();
   private readonly cancelledLongHorizonDeliveries = new Set<string>();
+  private readonly longHorizonSubscriptionPatterns = new Map<string, string>();
   private readonly externalEventRateLimits = new Map<string, ExternalEventRateLimitState>();
   private unsubscribeExternalEventPublished?: () => void;
   private unsubscribeSdkToolUseCreated?: () => void;
@@ -1087,8 +1090,10 @@ export class SpaceRuntime {
         target.spaceId === spaceId &&
         target.subscriptionId === subscriptionId
     );
+    const previousPattern = this.longHorizonSubscriptionPatterns.get(subscriptionId);
     const subscription = repo.getSubscription(subscriptionId);
     if (!subscription || subscription.spaceId !== spaceId || subscription.status !== 'active') {
+      this.longHorizonSubscriptionPatterns.delete(subscriptionId);
       this.clearLongHorizonRetries(
         (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
       );
@@ -1096,6 +1101,7 @@ export class SpaceRuntime {
     }
     const agent = repo.getById(subscription.agentId);
     if (!agent || agent.spaceId !== spaceId || agent.status !== 'active') {
+      this.longHorizonSubscriptionPatterns.delete(subscriptionId);
       this.clearLongHorizonRetries(
         (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
       );
@@ -1109,6 +1115,12 @@ export class SpaceRuntime {
     }
     const validation = validateGlobPattern(pattern);
     if (!validation.valid) return { success: false, error: validation.reason ?? 'invalid pattern' };
+    if (previousPattern && previousPattern.toLowerCase() !== pattern.toLowerCase()) {
+      this.clearLongHorizonRetries(
+        (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
+      );
+    }
+    this.longHorizonSubscriptionPatterns.set(subscriptionId, pattern);
     this.topicTrie.insert(pattern, {
       kind: 'long_horizon_agent',
       spaceId: subscription.spaceId,
@@ -1151,18 +1163,21 @@ export class SpaceRuntime {
         target.spaceId === spaceId &&
         target.subscriptionId === subscriptionId
     );
+    this.longHorizonSubscriptionPatterns.delete(subscriptionId);
     this.clearLongHorizonRetries(
       (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
     );
   }
 
   removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void {
-    this.topicTrie.remove(
-      (target) =>
+    this.topicTrie.remove((target) => {
+      const matches =
         isLongHorizonSubscriptionTarget(target) &&
         target.spaceId === spaceId &&
-        target.agentId === agentId
-    );
+        target.agentId === agentId;
+      if (matches) this.longHorizonSubscriptionPatterns.delete(target.subscriptionId);
+      return matches;
+    });
     this.clearLongHorizonRetries(
       (target) => target.spaceId === spaceId && target.agentId === agentId
     );

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -528,7 +528,11 @@ function rejectGitHubEntityPatternWithoutAction(topic: string): never {
 function ensureGitHubEntityAction(topic: string, entityAction: string): void {
   if (entityAction === '*') return;
   const dotIndex = entityAction.indexOf('.');
-  if (dotIndex <= 0 || dotIndex === entityAction.length - 1) {
+  if (
+    dotIndex <= 0 ||
+    dotIndex === entityAction.length - 1 ||
+    entityAction.indexOf('.', dotIndex + 1) !== -1
+  ) {
     rejectGitHubEntityPatternWithoutAction(topic);
   }
 }
@@ -1163,8 +1167,7 @@ export class SpaceRuntime {
       .listSubscriptions(agentId)
       .filter((subscription) => subscription.spaceId === spaceId);
     for (const subscription of subscriptions) {
-      const result = this.refreshLongHorizonSubscription(spaceId, subscription.id);
-      if (!result.success) return result;
+      this.refreshLongHorizonSubscription(spaceId, subscription.id);
     }
     return { success: true };
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1081,6 +1081,14 @@ export class SpaceRuntime {
     return { success: true };
   }
 
+  hasPendingRetriesForAgent(spaceId: string, agentId: string): boolean {
+    for (const deliveryKey of this.externalEventRetryTimers.keys()) {
+      const target = this.parseLongHorizonDeliveryKey(deliveryKey);
+      if (target?.spaceId === spaceId && target.agentId === agentId) return true;
+    }
+    return false;
+  }
+
   refreshLongHorizonAgentSubscriptions(
     spaceId: string,
     agentId: string

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -44,7 +44,7 @@ import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { ExternalEventPublishedPayload } from '../../external-events/external-event-service';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
 import type { ExternalEvent } from '../../external-events/types';
-import { validateGlobPattern } from '../../external-events/topic-validator';
+import { validateGlobPattern, validateSource } from '../../external-events/topic-validator';
 import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
@@ -497,7 +497,12 @@ function legacyGitHubTopic(topic: string): string | null {
 function composeLongHorizonSubscriptionPattern(source: string, topic: string): string {
   const trimmedSource = source.trim();
   const trimmedTopic = topic.trim();
-  if (!trimmedSource || trimmedTopic.startsWith(`${trimmedSource}/`)) return trimmedTopic;
+  if (!trimmedSource) return trimmedTopic;
+  const topicSource = trimmedTopic.split('/')[0] ?? '';
+  if (topicSource === trimmedSource) return trimmedTopic;
+  if (validateSource(topicSource).valid) {
+    throw new Error(`Topic source "${topicSource}" does not match source "${trimmedSource}"`);
+  }
   if (trimmedSource === 'github') {
     const segments = trimmedTopic.split('/');
     if (trimmedTopic.startsWith('*/*/') || segments.length >= 4)
@@ -974,6 +979,9 @@ export class SpaceRuntime {
     );
     const subscription = repo.getSubscription(subscriptionId);
     if (!subscription || subscription.spaceId !== spaceId || subscription.status !== 'active') {
+      this.clearLongHorizonRetries(
+        (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
+      );
       return { success: true };
     }
     const agent = repo.getById(subscription.agentId);
@@ -1015,6 +1023,9 @@ export class SpaceRuntime {
         target.spaceId === spaceId &&
         target.subscriptionId === subscriptionId
     );
+    this.clearLongHorizonRetries(
+      (target) => target.spaceId === spaceId && target.subscriptionId === subscriptionId
+    );
   }
 
   removeLongHorizonAgentSubscriptions(spaceId: string, agentId: string): void {
@@ -1023,6 +1034,9 @@ export class SpaceRuntime {
         isLongHorizonSubscriptionTarget(target) &&
         target.spaceId === spaceId &&
         target.agentId === agentId
+    );
+    this.clearLongHorizonRetries(
+      (target) => target.spaceId === spaceId && target.agentId === agentId
     );
   }
 
@@ -1241,6 +1255,15 @@ export class SpaceRuntime {
       );
     } finally {
       this.externalEventDeliveriesInFlight.delete(deliveryKey);
+    }
+  }
+
+  private clearLongHorizonRetries(
+    predicate: (target: LongHorizonSubscriptionTarget) => boolean
+  ): void {
+    for (const deliveryKey of Array.from(this.externalEventRetryTimers.keys())) {
+      const target = this.parseLongHorizonDeliveryKey(deliveryKey);
+      if (target && predicate(target)) this.clearExternalEventRetry(deliveryKey);
     }
   }
 
@@ -1897,6 +1920,33 @@ export class SpaceRuntime {
       target.agentId,
       target.subscriptionId,
     ]);
+  }
+
+  private parseLongHorizonDeliveryKey(deliveryKey: string): LongHorizonSubscriptionTarget | null {
+    try {
+      const parsed = JSON.parse(deliveryKey) as unknown;
+      if (!Array.isArray(parsed) || parsed.length !== 6 || parsed[0] !== 'long_horizon_agent') {
+        return null;
+      }
+      const [, , , spaceId, agentId, subscriptionId] = parsed;
+      if (
+        typeof spaceId !== 'string' ||
+        typeof agentId !== 'string' ||
+        typeof subscriptionId !== 'string'
+      ) {
+        return null;
+      }
+      return {
+        kind: 'long_horizon_agent',
+        spaceId,
+        agentId,
+        source: '',
+        topic: '',
+        subscriptionId,
+      };
+    } catch {
+      return null;
+    }
   }
 
   private formatExternalEventMessage(event: ExternalEventPublishedPayload): string {

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -4,6 +4,7 @@ import type {
   CreateSpaceLongHorizonAgentParams,
   CreateSpaceLongHorizonAgentReminderParams,
   CreateSpaceLongHorizonAgentSubscriptionParams,
+  UpdateSpaceLongHorizonAgentSubscriptionParams,
   SpaceAgentAutonomyLevel,
   SpaceLongHorizonAgent,
   SpaceLongHorizonAgentEventSubscription,
@@ -372,6 +373,39 @@ export class SpaceLongHorizonAgentRepository {
       )
       .all(agentId) as Record<string, unknown>[];
     return rows.map(rowToSubscription);
+  }
+
+  updateSubscription(
+    subscriptionId: string,
+    params: UpdateSpaceLongHorizonAgentSubscriptionParams
+  ): SpaceLongHorizonAgentEventSubscription | null {
+    const existing = this.getSubscription(subscriptionId);
+    if (!existing) return null;
+    const nextSource = params.source ?? existing.source;
+    const nextTopic = params.topic ?? existing.topic;
+    const nextFilter = params.filter ?? existing.filter;
+    const nextStatus = params.status ?? existing.status;
+    this.db
+      .prepare(
+        `UPDATE space_long_horizon_agent_event_subscriptions
+           SET source = ?, topic = ?, filter_json = ?, status = ?, updated_at = ?
+           WHERE id = ?`
+      )
+      .run(
+        nextSource,
+        nextTopic,
+        JSON.stringify(nextFilter),
+        nextStatus,
+        Date.now(),
+        subscriptionId
+      );
+    return this.getSubscription(subscriptionId);
+  }
+
+  deleteSubscription(subscriptionId: string): void {
+    this.db
+      .prepare(`DELETE FROM space_long_horizon_agent_event_subscriptions WHERE id = ?`)
+      .run(subscriptionId);
   }
 
   listActiveSubscriptionsBySpace(spaceId: string): SpaceLongHorizonAgentEventSubscription[] {

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -31,8 +31,9 @@ export class SpaceLongHorizonAgentRepository {
       .prepare(
         `INSERT INTO space_long_horizon_agents (
 					id, space_id, handle, display_name, template_key, status, session_id,
-					instructions, autonomy_level, model, thinking_level, tool_permissions_json, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					instructions, autonomy_level, model, thinking_level, provider, setting_sources,
+					tool_permissions_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -46,6 +47,8 @@ export class SpaceLongHorizonAgentRepository {
         params.autonomyLevel ?? null,
         params.model ?? null,
         params.thinkingLevel ?? null,
+        params.provider ?? null,
+        params.settingSources === undefined ? null : JSON.stringify(params.settingSources),
         JSON.stringify(params.toolPermissions ?? DEFAULT_TOOL_PERMISSIONS),
         now,
         now
@@ -150,6 +153,14 @@ export class SpaceLongHorizonAgentRepository {
     if (params.thinkingLevel !== undefined) {
       fields.push('thinking_level = ?');
       values.push(params.thinkingLevel ?? null);
+    }
+    if (params.provider !== undefined) {
+      fields.push('provider = ?');
+      values.push(params.provider ?? null);
+    }
+    if (params.settingSources !== undefined) {
+      fields.push('setting_sources = ?');
+      values.push(params.settingSources === null ? null : JSON.stringify(params.settingSources));
     }
     if (params.toolPermissions !== undefined) {
       fields.push('tool_permissions_json = ?');
@@ -478,6 +489,10 @@ function rowToAgent(row: Record<string, unknown>): SpaceLongHorizonAgent {
     autonomyLevel: (row.autonomy_level as SpaceAgentAutonomyLevel | null) ?? null,
     model: (row.model as string | null) ?? null,
     thinkingLevel: (row.thinking_level as SpaceLongHorizonAgent['thinkingLevel']) ?? null,
+    provider: (row.provider as string | null) ?? null,
+    settingSources: row.setting_sources
+      ? (JSON.parse(row.setting_sources as string) as SpaceLongHorizonAgent['settingSources'])
+      : null,
     toolPermissions: parseObject(row.tool_permissions_json),
     createdAt: row.created_at as number,
     updatedAt: row.updated_at as number,

--- a/packages/daemon/src/storage/schema/long-horizon-agents.ts
+++ b/packages/daemon/src/storage/schema/long-horizon-agents.ts
@@ -16,6 +16,8 @@ export function createLongHorizonAgentTables(db: BunDatabase): void {
 				CHECK(autonomy_level IS NULL OR autonomy_level BETWEEN 1 AND 5),
 			model TEXT DEFAULT NULL,
 			thinking_level TEXT DEFAULT NULL,
+			provider TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			tool_permissions_json TEXT NOT NULL DEFAULT '{}',
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -689,6 +689,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
   // Migration 151: Consolidate agent event subscriptions into long-horizon table.
   runMigration151(db);
+
+  // Migration 152: Preserve provider and setting sources on long-horizon agents.
+  runMigration152(db);
 }
 
 /**
@@ -10428,20 +10431,27 @@ export function runMigration151(db: BunDatabase): void {
     .get();
   if (!hasLegacy) return;
 
+  runMigration152(db);
+
   const now = Date.now();
   const hasSpaceAgentStatus = tableHasColumn(db, 'space_agents', 'status');
   const hasSpaceAgentCustomPrompt = tableHasColumn(db, 'space_agents', 'custom_prompt');
+  const hasSpaceAgentProvider = tableHasColumn(db, 'space_agents', 'provider');
+  const hasSpaceAgentSettingSources = tableHasColumn(db, 'space_agents', 'setting_sources');
   const statusExpr = hasSpaceAgentStatus
     ? `COALESCE(NULLIF(space_agents.status, ''), 'active')`
     : `'active'`;
   const instructionsExpr = hasSpaceAgentCustomPrompt
     ? `COALESCE(space_agents.custom_prompt, space_agents.instructions, space_agents.system_prompt, '')`
     : `COALESCE(space_agents.instructions, space_agents.system_prompt, '')`;
+  const providerExpr = hasSpaceAgentProvider ? `space_agents.provider` : `NULL`;
+  const settingSourcesExpr = hasSpaceAgentSettingSources ? `space_agents.setting_sources` : `NULL`;
 
   db.prepare(
     `INSERT OR IGNORE INTO space_long_horizon_agents (
       id, space_id, handle, display_name, template_key, status, session_id,
-      instructions, autonomy_level, model, thinking_level, tool_permissions_json, created_at, updated_at
+      instructions, autonomy_level, model, thinking_level, provider, setting_sources,
+      tool_permissions_json, created_at, updated_at
     )
     SELECT
       legacy.agent_id,
@@ -10465,6 +10475,8 @@ export function runMigration151(db: BunDatabase): void {
       NULL,
       space_agents.model,
       NULL,
+      ${providerExpr},
+      ${settingSourcesExpr},
       CASE
         WHEN space_agents.tools IS NULL OR space_agents.tools = '' OR space_agents.tools = '[]' THEN '{}'
         ELSE json_object('tools', json(space_agents.tools))
@@ -10497,4 +10509,17 @@ export function runMigration151(db: BunDatabase): void {
     JOIN space_long_horizon_agents agents ON agents.id = legacy.agent_id AND agents.space_id = legacy.space_id`
   ).run(now);
   db.exec(`DROP TABLE IF EXISTS space_agent_event_subscriptions`);
+}
+
+/**
+ * Migration 152 — Preserve provider and setting source policy on long-horizon agents.
+ */
+function runMigration152(db: BunDatabase): void {
+  if (!tableExists(db, 'space_long_horizon_agents')) return;
+  if (!tableHasColumn(db, 'space_long_horizon_agents', 'provider')) {
+    db.exec(`ALTER TABLE space_long_horizon_agents ADD COLUMN provider TEXT DEFAULT NULL`);
+  }
+  if (!tableHasColumn(db, 'space_long_horizon_agents', 'setting_sources')) {
+    db.exec(`ALTER TABLE space_long_horizon_agents ADD COLUMN setting_sources TEXT DEFAULT NULL`);
+  }
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -808,10 +808,17 @@ describe('Space Agent RPC Handlers', () => {
       });
       const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
       const coordinator = longHorizonRepo.ensureCoordinator('space-1');
+      const subscription = longHorizonRepo.createSubscription({
+        spaceId: 'space-1',
+        agentId: coordinator.id,
+        source: 'github',
+        topic: 'github/*/*/pull_request/*',
+      });
 
       await call(hubData.handlers, 'spaceAgent.delete', { id: created.agent.id });
 
       expect(longHorizonRepo.getById(coordinator.id)?.status).toBe('archived');
+      expect(longHorizonRepo.getSubscription(subscription.id)?.status).toBe('disabled');
       expect(removeLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-1', coordinator.id);
     });
 
@@ -986,6 +993,40 @@ describe('Space Agent RPC Handlers', () => {
           agentId: created.value.id,
         })
       ).rejects.toThrow('Agent not found');
+    });
+
+    it('syncs matching long-horizon event agents after template sync', async () => {
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        description: 'old',
+        tools: ['Read'],
+        customPrompt: 'old',
+        templateName: 'Coder',
+        templateHash: 'stale',
+      });
+      if (!created.ok) throw new Error('create failed');
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const longHorizonAgent = longHorizonRepo.create({
+        id: created.value.id,
+        spaceId: 'space-1',
+        handle: created.value.handle,
+        displayName: created.value.name,
+        instructions: 'old',
+        toolPermissions: { tools: ['Read'] },
+      });
+
+      await call(hubData.handlers, 'spaceAgent.syncFromTemplate', {
+        spaceId: 'space-1',
+        agentId: created.value.id,
+      });
+
+      expect(longHorizonRepo.getById(longHorizonAgent.id)).toEqual(
+        expect.objectContaining({
+          instructions: expect.stringContaining('expert software engineer'),
+          toolPermissions: expect.objectContaining({ tools: expect.arrayContaining(['Edit']) }),
+        })
+      );
     });
 
     it('returns the updated agent and emits spaceAgent.updated', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -17,7 +17,10 @@ import { Database } from 'bun:sqlite';
 import type { MessageHub, SDKMessage, Session } from '@neokai/shared';
 import { setupSpaceAgentHandlers } from '../../../../src/lib/rpc-handlers/space-agent-handlers';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
-import { SpaceLongHorizonAgentRepository } from '../../../../src/storage/repositories/space-long-horizon-agent-repository';
+import {
+  coordinatorLongHorizonAgentId,
+  SpaceLongHorizonAgentRepository,
+} from '../../../../src/storage/repositories/space-long-horizon-agent-repository';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
 import { SessionRepository } from '../../../../src/storage/repositories/session-repository';
 import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
@@ -670,6 +673,30 @@ describe('Space Agent RPC Handlers', () => {
       );
     });
 
+    it('syncs seeded coordinator long-horizon rows using normalized handle', async () => {
+      const created = await call<{ agent: { id: string } }>(hubData.handlers, 'spaceAgent.create', {
+        spaceId: 'space-1',
+        name: 'Coordinator',
+        handle: 'space-coordinator',
+      });
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const coordinator = longHorizonRepo.ensureCoordinator('space-1');
+
+      await call(hubData.handlers, 'spaceAgent.update', {
+        id: created.agent.id,
+        customPrompt: 'Updated coordinator prompt',
+        tools: ['Read'],
+      });
+
+      expect(longHorizonRepo.getById(coordinator.id)).toEqual(
+        expect.objectContaining({
+          handle: 'coordinator',
+          instructions: 'Updated coordinator prompt',
+          toolPermissions: { tools: ['Read'] },
+        })
+      );
+    });
+
     it('emits spaceAgent.updated event', async () => {
       await call(hubData.handlers, 'spaceAgent.update', { id: agentId, name: 'Updated' });
       await new Promise((r) => setTimeout(r, 0));
@@ -762,6 +789,30 @@ describe('Space Agent RPC Handlers', () => {
       await call(hubData.handlers, 'spaceAgent.delete', { id: agentId });
 
       expect(longHorizonRepo.getById(longHorizonAgent.id)?.status).toBe('archived');
+    });
+
+    it('archives seeded coordinator long-horizon rows using normalized handle', async () => {
+      const removeLongHorizonAgentSubscriptions = mock(() => {});
+      setupSpaceAgentHandlers(
+        hubData.hub,
+        daemonData.internalEventBus,
+        manager,
+        spaceManagerData.spaceManager,
+        createTestDatabaseFacade(db),
+        { removeLongHorizonAgentSubscriptions }
+      );
+      const created = await call<{ agent: { id: string } }>(hubData.handlers, 'spaceAgent.create', {
+        spaceId: 'space-1',
+        name: 'Coordinator',
+        handle: 'space-coordinator',
+      });
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const coordinator = longHorizonRepo.ensureCoordinator('space-1');
+
+      await call(hubData.handlers, 'spaceAgent.delete', { id: created.agent.id });
+
+      expect(longHorizonRepo.getById(coordinator.id)?.status).toBe('archived');
+      expect(removeLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-1', coordinator.id);
     });
 
     it('emits spaceAgent.deleted event', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -714,27 +714,28 @@ describe('Space Agent RPC Handlers', () => {
       expect(daemonData.publishMock).not.toHaveBeenCalled();
     });
 
-    it('syncs legacy long-horizon rows matched by the previous handle', async () => {
+    it('does not sync standalone long-horizon rows matched only by handle', async () => {
       const visibleAgent = manager.getById(agentId);
       expect(visibleAgent).not.toBeNull();
       const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
-      const legacyAgent = longHorizonRepo.create({
-        id: 'legacy-lh-agent',
+      const standaloneAgent = longHorizonRepo.create({
+        id: 'standalone-lh-agent',
         spaceId: 'space-1',
         handle: visibleAgent?.handle ?? 'original',
-        displayName: 'Legacy Agent',
+        displayName: 'Standalone Agent',
+        instructions: 'Standalone prompt',
       });
 
       await call(hubData.handlers, 'spaceAgent.update', {
         id: agentId,
-        handle: 'renamed-legacy',
-        customPrompt: 'Updated legacy prompt',
+        handle: 'renamed-visible',
+        customPrompt: 'Updated visible prompt',
       });
 
-      expect(longHorizonRepo.getById(legacyAgent.id)).toEqual(
+      expect(longHorizonRepo.getById(standaloneAgent.id)).toEqual(
         expect.objectContaining({
-          handle: 'renamed-legacy',
-          instructions: 'Updated legacy prompt',
+          handle: visibleAgent?.handle,
+          instructions: 'Standalone prompt',
         })
       );
     });
@@ -855,6 +856,30 @@ describe('Space Agent RPC Handlers', () => {
       await call(hubData.handlers, 'spaceAgent.delete', { id: agentId });
 
       expect(longHorizonRepo.getById(longHorizonAgent.id)?.status).toBe('archived');
+    });
+
+    it('does not archive standalone long-horizon rows matched only by handle', async () => {
+      setupSpaceAgentHandlers(
+        hubData.hub,
+        daemonData.internalEventBus,
+        manager,
+        spaceManagerData.spaceManager,
+        createTestDatabaseFacade(db),
+        { removeLongHorizonAgentSubscriptions: mock(() => {}) }
+      );
+      const visibleAgent = manager.getById(agentId);
+      expect(visibleAgent).not.toBeNull();
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const standaloneAgent = longHorizonRepo.create({
+        id: 'standalone-lh-agent-delete',
+        spaceId: 'space-1',
+        handle: visibleAgent?.handle ?? 'todelete',
+        displayName: 'Standalone To Keep',
+      });
+
+      await call(hubData.handlers, 'spaceAgent.delete', { id: agentId });
+
+      expect(longHorizonRepo.getById(standaloneAgent.id)?.status).toBe('active');
     });
 
     it('archives seeded coordinator long-horizon rows using normalized handle', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -651,7 +651,7 @@ describe('Space Agent RPC Handlers', () => {
       expect(result.agent.customPrompt).toBe('New prompt');
     });
 
-    it('syncs matching long-horizon agent rows when handle and tools change', async () => {
+    it('syncs matching long-horizon agent rows when handle and policy change', async () => {
       const visibleAgent = manager.getById(agentId);
       expect(visibleAgent).not.toBeNull();
       const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
@@ -665,11 +665,43 @@ describe('Space Agent RPC Handlers', () => {
       await call(hubData.handlers, 'spaceAgent.update', {
         id: agentId,
         handle: 'renamed',
+        provider: 'openrouter',
+        settingSources: ['project'],
         tools: ['Read', 'Edit'],
       });
 
       expect(longHorizonRepo.getById(longHorizonAgent.id)).toEqual(
-        expect.objectContaining({ handle: 'renamed', toolPermissions: { tools: ['Read', 'Edit'] } })
+        expect.objectContaining({
+          handle: 'renamed',
+          provider: 'openrouter',
+          settingSources: ['project'],
+          toolPermissions: { tools: ['Read', 'Edit'] },
+        })
+      );
+    });
+
+    it('syncs legacy long-horizon rows matched by the previous handle', async () => {
+      const visibleAgent = manager.getById(agentId);
+      expect(visibleAgent).not.toBeNull();
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const legacyAgent = longHorizonRepo.create({
+        id: 'legacy-lh-agent',
+        spaceId: 'space-1',
+        handle: visibleAgent?.handle ?? 'original',
+        displayName: 'Legacy Agent',
+      });
+
+      await call(hubData.handlers, 'spaceAgent.update', {
+        id: agentId,
+        handle: 'renamed-legacy',
+        customPrompt: 'Updated legacy prompt',
+      });
+
+      expect(longHorizonRepo.getById(legacyAgent.id)).toEqual(
+        expect.objectContaining({
+          handle: 'renamed-legacy',
+          instructions: 'Updated legacy prompt',
+        })
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -17,6 +17,7 @@ import { Database } from 'bun:sqlite';
 import type { MessageHub, SDKMessage, Session } from '@neokai/shared';
 import { setupSpaceAgentHandlers } from '../../../../src/lib/rpc-handlers/space-agent-handlers';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
+import { SpaceLongHorizonAgentRepository } from '../../../../src/storage/repositories/space-long-horizon-agent-repository';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
 import { SessionRepository } from '../../../../src/storage/repositories/session-repository';
 import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
@@ -98,6 +99,7 @@ function createTestDatabaseFacade(db: Database) {
   const sessionRepo = new SessionRepository(db as any);
   const sdkMessageRepo = new SDKMessageRepository(db as any);
   return {
+    getDatabase: () => db,
     getSession: (id: string) => sessionRepo.getSession(id),
     getRenderableTextMessages: (sessionId: string, limit?: number) =>
       sdkMessageRepo.getRenderableTextMessages(sessionId, limit),
@@ -714,6 +716,29 @@ describe('Space Agent RPC Handlers', () => {
         id: agentId,
       });
       expect(result.success).toBe(true);
+    });
+
+    it('archives matching long-horizon agent rows before deleting specialists', async () => {
+      setupSpaceAgentHandlers(
+        hubData.hub,
+        daemonData.internalEventBus,
+        manager,
+        spaceManagerData.spaceManager,
+        createTestDatabaseFacade(db),
+        { removeLongHorizonAgentSubscriptions: mock(() => {}) }
+      );
+      const visibleAgent = manager.getById(agentId);
+      expect(visibleAgent).not.toBeNull();
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const longHorizonAgent = longHorizonRepo.create({
+        spaceId: 'space-1',
+        handle: visibleAgent?.handle ?? 'todelete',
+        displayName: 'ToDelete',
+      });
+
+      await call(hubData.handlers, 'spaceAgent.delete', { id: agentId });
+
+      expect(longHorizonRepo.getById(longHorizonAgent.id)?.status).toBe('archived');
     });
 
     it('emits spaceAgent.deleted event', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -648,6 +648,28 @@ describe('Space Agent RPC Handlers', () => {
       expect(result.agent.customPrompt).toBe('New prompt');
     });
 
+    it('syncs matching long-horizon agent rows when handle and tools change', async () => {
+      const visibleAgent = manager.getById(agentId);
+      expect(visibleAgent).not.toBeNull();
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      const longHorizonAgent = longHorizonRepo.create({
+        id: agentId,
+        spaceId: 'space-1',
+        handle: visibleAgent?.handle ?? 'original',
+        displayName: 'Original',
+      });
+
+      await call(hubData.handlers, 'spaceAgent.update', {
+        id: agentId,
+        handle: 'renamed',
+        tools: ['Read', 'Edit'],
+      });
+
+      expect(longHorizonRepo.getById(longHorizonAgent.id)).toEqual(
+        expect.objectContaining({ handle: 'renamed', toolPermissions: { tools: ['Read', 'Edit'] } })
+      );
+    });
+
     it('emits spaceAgent.updated event', async () => {
       await call(hubData.handlers, 'spaceAgent.update', { id: agentId, name: 'Updated' });
       await new Promise((r) => setTimeout(r, 0));
@@ -731,6 +753,7 @@ describe('Space Agent RPC Handlers', () => {
       expect(visibleAgent).not.toBeNull();
       const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
       const longHorizonAgent = longHorizonRepo.create({
+        id: agentId,
         spaceId: 'space-1',
         handle: visibleAgent?.handle ?? 'todelete',
         displayName: 'ToDelete',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -665,6 +665,7 @@ describe('Space Agent RPC Handlers', () => {
       await call(hubData.handlers, 'spaceAgent.update', {
         id: agentId,
         handle: 'renamed',
+        description: 'Short UI summary only',
         provider: 'openrouter',
         settingSources: ['project'],
         tools: ['Read', 'Edit'],
@@ -673,11 +674,44 @@ describe('Space Agent RPC Handlers', () => {
       expect(longHorizonRepo.getById(longHorizonAgent.id)).toEqual(
         expect.objectContaining({
           handle: 'renamed',
+          instructions: '',
           provider: 'openrouter',
           settingSources: ['project'],
           toolPermissions: { tools: ['Read', 'Edit'] },
         })
       );
+    });
+
+    it('rejects handle changes that would break event-agent sync before mutating the agent', async () => {
+      const visibleAgent = manager.getById(agentId);
+      expect(visibleAgent).not.toBeNull();
+      const longHorizonRepo = new SpaceLongHorizonAgentRepository(db as any);
+      longHorizonRepo.create({
+        id: agentId,
+        spaceId: 'space-1',
+        handle: visibleAgent?.handle ?? 'original',
+        displayName: 'Original',
+      });
+      longHorizonRepo.create({
+        id: 'standalone-lh-agent',
+        spaceId: 'space-1',
+        handle: 'taken-handle',
+        displayName: 'Standalone Agent',
+      });
+
+      await expect(
+        call(hubData.handlers, 'spaceAgent.update', {
+          id: agentId,
+          handle: 'taken-handle',
+        })
+      ).rejects.toThrow(
+        'Long-horizon agent handle "taken-handle" is already used by standalone-lh-agent'
+      );
+
+      expect(manager.getById(agentId)).toEqual(
+        expect.objectContaining({ handle: visibleAgent?.handle })
+      );
+      expect(daemonData.publishMock).not.toHaveBeenCalled();
     });
 
     it('syncs legacy long-horizon rows matched by the previous handle', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -300,6 +300,29 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('rejects unsupported GitHub resources in exact patterns', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/issue/42.opened',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/issue/42.opened" uses unsupported resource "issue"; supported resources: pull_request'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/issue/42.opened',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "github/owner/repo/issue/42.opened" uses unsupported resource "issue"; supported resources: pull_request'
+      );
+    });
+
     it('expands GitHub resource shorthands with entity wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -106,6 +106,7 @@ describe('Space long-horizon agent handlers', () => {
           agentId: 'agent-1',
           spaceId: 'space-1',
           status: 'paused',
+          handle: 'coder',
           provider: 'openrouter',
           settingSources: ['project'],
           toolPermissions: { tools: ['Read'] },
@@ -117,6 +118,7 @@ describe('Space long-horizon agent handlers', () => {
         'agent-1',
         expect.objectContaining({
           status: 'paused',
+          handle: 'coder',
           provider: 'openrouter',
           settingSources: ['project'],
           toolPermissions: { tools: ['Read'] },
@@ -296,6 +298,18 @@ describe('Space long-horizon agent handlers', () => {
         source: 'github',
         topic: 'owner/repo/pull_request.closed',
       });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/pull_request.closed',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/pull_request',
+      });
 
       repo.listSubscriptions = mock(() => [
         {
@@ -329,6 +343,56 @@ describe('Space long-horizon agent handlers', () => {
           agentId: 'agent-1',
           source: 'github',
           topic: 'pull_request',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/pull_request.closed',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*.closed',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*.closed'
+      );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/pull_request',
           filter: {},
           status: 'active',
           createdAt: 1,
@@ -505,6 +569,61 @@ describe('Space long-horizon agent handlers', () => {
         'space-1',
         'sub-1'
       );
+    });
+
+    it('allows status-only updates for wildcard-source subscriptions', async () => {
+      repo.getSubscription = mock(() => ({
+        id: 'sub-wildcard',
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: '*',
+        topic: '*/space/task.updated',
+        filter: {},
+        status: 'active',
+        createdAt: 1,
+        updatedAt: 1,
+      })) as unknown as SpaceLongHorizonAgentRepository['getSubscription'];
+      repo.updateSubscription = mock((subscriptionId, params) => ({
+        id: subscriptionId,
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: '*',
+        topic: '*/space/task.updated',
+        filter: {},
+        status: params.status ?? 'active',
+        createdAt: 1,
+        updatedAt: 2,
+      })) as unknown as SpaceLongHorizonAgentRepository['updateSubscription'];
+
+      await call(hubData.handlers, 'spaceLongHorizonAgent.updateSubscription', {
+        subscriptionId: 'sub-wildcard',
+        spaceId: 'space-1',
+        status: 'paused',
+      });
+
+      expect(repo.updateSubscription).toHaveBeenCalledWith('sub-wildcard', { status: 'paused' });
+    });
+
+    it('rejects topic edits for wildcard-source subscriptions', async () => {
+      repo.getSubscription = mock(() => ({
+        id: 'sub-wildcard',
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: '*',
+        topic: '*/space/task.updated',
+        filter: {},
+        status: 'active',
+        createdAt: 1,
+        updatedAt: 1,
+      })) as unknown as SpaceLongHorizonAgentRepository['getSubscription'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.updateSubscription', {
+          subscriptionId: 'sub-wildcard',
+          spaceId: 'space-1',
+          topic: '*/space/task.done',
+        })
+      ).rejects.toThrow('Source "*" must be lowercase');
     });
 
     it('deletes subscriptions and removes runtime target before deleting row', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -386,6 +386,17 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow(
         'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
       );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*',
+          filter: { label: 'Duplicate label' },
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
     });
 
     it('updates subscriptions and refreshes runtime target', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -265,12 +265,24 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
-    it('expands GitHub dotted resource shorthands with an entity wildcard', async () => {
+    it('expands GitHub resource shorthands with entity wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',
         agentId: 'agent-1',
         source: 'github',
         topic: 'pull_request.closed',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'pull_request',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'owner/repo/pull_request',
       });
 
       repo.listSubscriptions = mock(() => [
@@ -296,6 +308,56 @@ describe('Space long-horizon agent handlers', () => {
         })
       ).rejects.toThrow(
         'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*.closed'
+      );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'pull_request',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/owner/repo/pull_request/*'
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -98,7 +98,7 @@ describe('Space long-horizon agent handlers', () => {
   });
 
   describe('spaceLongHorizonAgent.update', () => {
-    it('refreshes durable subscriptions after status updates', async () => {
+    it('refreshes durable subscriptions after policy updates', async () => {
       const result = await call<{ agent: { id: string; status: string } }>(
         hubData.handlers,
         'spaceLongHorizonAgent.update',
@@ -106,13 +106,21 @@ describe('Space long-horizon agent handlers', () => {
           agentId: 'agent-1',
           spaceId: 'space-1',
           status: 'paused',
+          provider: 'openrouter',
+          settingSources: ['project'],
+          toolPermissions: { tools: ['Read'] },
         }
       );
 
       expect(result.agent).toEqual(expect.objectContaining({ id: 'agent-1', status: 'paused' }));
       expect(repo.update).toHaveBeenCalledWith(
         'agent-1',
-        expect.objectContaining({ status: 'paused' })
+        expect.objectContaining({
+          status: 'paused',
+          provider: 'openrouter',
+          settingSources: ['project'],
+          toolPermissions: { tools: ['Read'] },
+        })
       );
       expect(runtimeService.refreshLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
         'space-1',
@@ -224,6 +232,40 @@ describe('Space long-horizon agent handlers', () => {
 
       expect(repo.createSubscription).toHaveBeenCalledWith(
         expect.objectContaining({ topic: 'lsm/neokai/pull_request/*' })
+      );
+    });
+
+    it('expands GitHub dotted resource shorthands with an entity wildcard', async () => {
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'pull_request.closed',
+      });
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'pull_request.closed',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*.closed',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*.closed'
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -379,6 +379,16 @@ describe('Space long-horizon agent handlers', () => {
           spaceId: 'space-1',
           agentId: 'agent-1',
           source: 'github',
+          topic: 'owner/repo/pull_request/42.opened.extra',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/42.opened.extra" must use dotted entity actions like "pull_request/42.opened"'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
           topic: 'owner/repo/pull_request/42.opened/extra/x',
         })
       ).rejects.toThrow(

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -181,6 +181,19 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'lsm/neokai/pull_request/*',
+      });
+
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'lsm/neokai/pull_request/*' })
+      );
+    });
+
     it('updates subscriptions and refreshes runtime target', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.updateSubscription', {
         subscriptionId: 'sub-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -300,7 +300,7 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
-    it('rejects unsupported GitHub resources in exact patterns', async () => {
+    it('rejects unsupported GitHub resources in exact and bare patterns', async () => {
       await expect(
         call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
           spaceId: 'space-1',
@@ -320,6 +320,26 @@ describe('Space long-horizon agent handlers', () => {
         })
       ).rejects.toThrow(
         'GitHub topic "github/owner/repo/issue/42.opened" uses unsupported resource "issue"; supported resources: pull_request'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'issue',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "issue" uses unsupported resource "issue"; supported resources: pull_request'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'issue.opened',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "issue.opened" uses unsupported resource "issue"; supported resources: pull_request'
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -216,6 +216,33 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('rejects duplicate canonical subscription patterns', async () => {
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: '*/*/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
+    });
+
     it('updates subscriptions and refreshes runtime target', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.updateSubscription', {
         subscriptionId: 'sub-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -192,6 +192,17 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow('Source "gihub" is not registered');
     });
 
+    it('rejects full topics whose source differs from the source field', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'space/task.done',
+        })
+      ).rejects.toThrow('Topic source "space" does not match source "github"');
+    });
+
     it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -323,6 +323,29 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('rejects malformed GitHub entity actions', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/.opened',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/.opened" must use dotted entity actions like "pull_request/42.opened"'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/42.',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/42." must use dotted entity actions like "pull_request/42.opened"'
+      );
+    });
+
     it('expands GitHub resource shorthands with entity wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',
@@ -384,9 +407,18 @@ describe('Space long-horizon agent handlers', () => {
         source: 'github',
         topic: 'github/neokai/pull_request/*',
       });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'space/neokai/pull_request',
+      });
 
       expect(repo.createSubscription).toHaveBeenCalledWith(
         expect.objectContaining({ topic: 'github/neokai/pull_request/*' })
+      );
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'space/neokai/pull_request' })
       );
 
       repo.listSubscriptions = mock(() => [

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -41,6 +41,8 @@ describe('Space long-horizon agent handlers', () => {
   let repo: SpaceLongHorizonAgentRepository;
   let runtimeService: {
     refreshLongHorizonAgentSubscriptions: ReturnType<typeof mock>;
+    refreshLongHorizonSubscription: ReturnType<typeof mock>;
+    removeLongHorizonSubscription: ReturnType<typeof mock>;
     removeLongHorizonAgentSubscriptions: ReturnType<typeof mock>;
   };
 
@@ -56,9 +58,40 @@ describe('Space long-horizon agent handlers', () => {
       listReminders: mock(() => []),
       createReminder: mock(() => ({})),
       deleteReminder: mock(() => {}),
+      listSubscriptions: mock(() => []),
+      upsertSubscription: mock((params) => ({
+        id: 'sub-1',
+        ...params,
+        status: params.status ?? 'active',
+      })),
+      getSubscription: mock(() => ({
+        id: 'sub-1',
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/*/*/pull_request/*',
+        filter: {},
+        status: 'active',
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+      updateSubscription: mock((subscriptionId, params) => ({
+        id: subscriptionId,
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: params.source ?? 'github',
+        topic: params.topic ?? 'github/*/*/pull_request/*',
+        filter: params.filter ?? {},
+        status: params.status ?? 'active',
+        createdAt: 1,
+        updatedAt: 2,
+      })),
+      deleteSubscription: mock(() => {}),
     } as unknown as SpaceLongHorizonAgentRepository;
     runtimeService = {
       refreshLongHorizonAgentSubscriptions: mock(() => ({ success: true })),
+      refreshLongHorizonSubscription: mock(() => ({ success: true })),
+      removeLongHorizonSubscription: mock(() => {}),
       removeLongHorizonAgentSubscriptions: mock(() => {}),
     };
     setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager(), repo, runtimeService);
@@ -105,6 +138,73 @@ describe('Space long-horizon agent handlers', () => {
         'agent-1'
       );
       expect(repo.delete).toHaveBeenCalledWith('agent-1');
+    });
+  });
+
+  describe('spaceLongHorizonAgent.subscriptions', () => {
+    it('lists subscriptions for an agent', async () => {
+      const result = await call<{ subscriptions: unknown[] }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.listSubscriptions',
+        { agentId: 'agent-1', spaceId: 'space-1' }
+      );
+
+      expect(result.subscriptions).toEqual([]);
+      expect(repo.listSubscriptions).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('creates subscriptions and refreshes runtime target', async () => {
+      const result = await call<{ subscription: { id: string; topic: string } }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.createSubscription',
+        {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/*/*/pull_request/*',
+          filter: { label: 'PRs' },
+        }
+      );
+
+      expect(result.subscription.id).toBe('sub-1');
+      expect(repo.upsertSubscription).toHaveBeenCalledWith({
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/*/*/pull_request/*',
+        filter: { label: 'PRs' },
+        status: undefined,
+      });
+      expect(runtimeService.refreshLongHorizonSubscription).toHaveBeenCalledWith(
+        'space-1',
+        'sub-1'
+      );
+    });
+
+    it('updates subscriptions and refreshes runtime target', async () => {
+      await call(hubData.handlers, 'spaceLongHorizonAgent.updateSubscription', {
+        subscriptionId: 'sub-1',
+        spaceId: 'space-1',
+        status: 'paused',
+      });
+
+      expect(repo.updateSubscription).toHaveBeenCalledWith('sub-1', { status: 'paused' });
+      expect(runtimeService.refreshLongHorizonSubscription).toHaveBeenCalledWith(
+        'space-1',
+        'sub-1'
+      );
+    });
+
+    it('deletes subscriptions and removes runtime target before deleting row', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.deleteSubscription',
+        { subscriptionId: 'sub-1', spaceId: 'space-1' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(runtimeService.removeLongHorizonSubscription).toHaveBeenCalledWith('space-1', 'sub-1');
+      expect(repo.deleteSubscription).toHaveBeenCalledWith('sub-1');
     });
   });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -181,6 +181,17 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('rejects unregistered subscription sources', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'gihub',
+          topic: 'lsm/neokai/pull_request/*',
+        })
+      ).rejects.toThrow('Source "gihub" is not registered');
+    });
+
     it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -59,7 +59,7 @@ describe('Space long-horizon agent handlers', () => {
       createReminder: mock(() => ({})),
       deleteReminder: mock(() => {}),
       listSubscriptions: mock(() => []),
-      upsertSubscription: mock((params) => ({
+      createSubscription: mock((params) => ({
         id: 'sub-1',
         ...params,
         status: params.status ?? 'active',
@@ -167,7 +167,7 @@ describe('Space long-horizon agent handlers', () => {
       );
 
       expect(result.subscription.id).toBe('sub-1');
-      expect(repo.upsertSubscription).toHaveBeenCalledWith({
+      expect(repo.createSubscription).toHaveBeenCalledWith({
         spaceId: 'space-1',
         agentId: 'agent-1',
         source: 'github',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -284,6 +284,18 @@ describe('Space long-horizon agent handlers', () => {
         source: 'github',
         topic: 'owner/repo/pull_request',
       });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/owner/repo/pull_request',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'owner/repo/pull_request.closed',
+      });
 
       repo.listSubscriptions = mock(() => [
         {
@@ -359,6 +371,56 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow(
         'Subscription pattern duplicates existing subscription sub-existing: github/owner/repo/pull_request/*'
       );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/pull_request',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/owner/repo/pull_request/*'
+      );
+
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request.closed',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/pull_request/*.closed',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/owner/repo/pull_request/*.closed'
+      );
     });
 
     it('rejects duplicate canonical subscription patterns', async () => {
@@ -396,6 +458,38 @@ describe('Space long-horizon agent handlers', () => {
         })
       ).rejects.toThrow(
         'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
+    });
+
+    it('skips invalid existing subscriptions during duplicate checks', async () => {
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-invalid',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'space/task.done',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      const result = await call<{ subscription: { id: string } }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.createSubscription',
+        {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'pull_request',
+        }
+      );
+
+      expect(result.subscription.id).toBe('sub-1');
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'pull_request' })
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -267,6 +267,29 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('rejects GitHub entity patterns without dotted actions', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/42',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/42" must use dotted entity actions like "pull_request/42.opened"'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'github/owner/repo/pull_request/42',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "github/owner/repo/pull_request/42" must use dotted entity actions like "pull_request/42.opened"'
+      );
+    });
+
     it('expands GitHub resource shorthands with entity wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',
@@ -310,6 +333,16 @@ describe('Space long-horizon agent handlers', () => {
         source: 'github',
         topic: 'github/pull_request',
       });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/neokai/pull_request/*',
+      });
+
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'github/neokai/pull_request/*' })
+      );
 
       repo.listSubscriptions = mock(() => [
         {
@@ -522,6 +555,33 @@ describe('Space long-horizon agent handlers', () => {
         })
       ).rejects.toThrow(
         'Subscription pattern duplicates existing subscription sub-existing: github/*/*/pull_request/*'
+      );
+    });
+
+    it('rejects case-only duplicate event patterns', async () => {
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/*',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'Owner/Repo/pull_request/*',
+        })
+      ).rejects.toThrow(
+        'Subscription pattern duplicates existing subscription sub-existing: github/Owner/Repo/pull_request/*'
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -220,6 +220,14 @@ describe('Space long-horizon agent handlers', () => {
           topic: 'GitHub/lsm/neokai/pull_request/*',
         })
       ).rejects.toThrow('Topic source "GitHub" does not match source "github"');
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'Space/task.done',
+        })
+      ).rejects.toThrow('Topic source "Space" does not match source "github"');
     });
 
     it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -585,6 +585,33 @@ describe('Space long-horizon agent handlers', () => {
       );
     });
 
+    it('allows non-duplicate subscription patterns for the same agent', async () => {
+      repo.listSubscriptions = mock(() => [
+        {
+          id: 'sub-existing',
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/*',
+          filter: {},
+          status: 'active',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]) as unknown as SpaceLongHorizonAgentRepository['listSubscriptions'];
+
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'owner/repo/pull_request/*.closed',
+      });
+
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'owner/repo/pull_request/*.closed' })
+      );
+    });
+
     it('skips invalid existing subscriptions during duplicate checks', async () => {
       repo.listSubscriptions = mock(() => [
         {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -203,6 +203,17 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow('Topic source "space" does not match source "github"');
     });
 
+    it('rejects full topics whose source casing differs from the source field', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'GitHub/lsm/neokai/pull_request/*',
+        })
+      ).rejects.toThrow('Topic source "GitHub" does not match source "github"');
+    });
+
     it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -341,9 +341,19 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow(
         'GitHub topic "issue.opened" uses unsupported resource "issue"; supported resources: pull_request'
       );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/issue.opened',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/issue.opened" uses unsupported resource "issue"; supported resources: pull_request'
+      );
     });
 
-    it('rejects malformed GitHub entity actions', async () => {
+    it('rejects malformed GitHub entity actions and overlong shapes', async () => {
       await expect(
         call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
           spaceId: 'space-1',
@@ -363,6 +373,16 @@ describe('Space long-horizon agent handlers', () => {
         })
       ).rejects.toThrow(
         'GitHub topic "owner/repo/pull_request/42." must use dotted entity actions like "pull_request/42.opened"'
+      );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/42.opened/extra/x',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/42.opened/extra/x" must match supported shape "owner/repo/pull_request/<id>.<action>"'
       );
     });
 
@@ -433,12 +453,21 @@ describe('Space long-horizon agent handlers', () => {
         source: 'github',
         topic: 'space/neokai/pull_request',
       });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/neokai/pull_request.closed',
+      });
 
       expect(repo.createSubscription).toHaveBeenCalledWith(
         expect.objectContaining({ topic: 'github/neokai/pull_request/*' })
       );
       expect(repo.createSubscription).toHaveBeenCalledWith(
         expect.objectContaining({ topic: 'space/neokai/pull_request' })
+      );
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'github/neokai/pull_request.closed' })
       );
 
       repo.listSubscriptions = mock(() => [

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -230,16 +230,38 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow('Topic source "Space" does not match source "github"');
     });
 
-    it('accepts GitHub owner/repo topic shorthands without injecting owner/repo wildcards', async () => {
+    it('accepts GitHub owner/repo topic shorthands before known-source prefix checks', async () => {
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',
         agentId: 'agent-1',
         source: 'github',
-        topic: 'lsm/neokai/pull_request/*',
+        topic: 'space/neokai/pull_request/*',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/neokai/pull_request/*',
       });
 
       expect(repo.createSubscription).toHaveBeenCalledWith(
-        expect.objectContaining({ topic: 'lsm/neokai/pull_request/*' })
+        expect.objectContaining({ topic: 'space/neokai/pull_request/*' })
+      );
+      expect(repo.createSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'github/neokai/pull_request/*' })
+      );
+    });
+
+    it('rejects slash-separated GitHub entity actions', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'owner/repo/pull_request/42/closed',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "owner/repo/pull_request/42/closed" must use dotted entity actions like "pull_request/42.closed"'
       );
     });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -288,6 +288,16 @@ describe('Space long-horizon agent handlers', () => {
       ).rejects.toThrow(
         'GitHub topic "github/owner/repo/pull_request/42" must use dotted entity actions like "pull_request/42.opened"'
       );
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          source: 'github',
+          topic: 'pull_request/42',
+        })
+      ).rejects.toThrow(
+        'GitHub topic "pull_request/42" must use dotted entity actions like "pull_request/42.opened"'
+      );
     });
 
     it('expands GitHub resource shorthands with entity wildcards', async () => {
@@ -332,6 +342,18 @@ describe('Space long-horizon agent handlers', () => {
         agentId: 'agent-1',
         source: 'github',
         topic: 'github/pull_request',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/pull_request/*.closed',
+      });
+      await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        source: 'github',
+        topic: 'github/pull_request/42.closed',
       });
       await call(hubData.handlers, 'spaceLongHorizonAgent.createSubscription', {
         spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -51,8 +51,13 @@ describe('Space long-horizon agent handlers', () => {
     repo = {
       ensureCoordinator: mock(() => {}),
       listBySpaceId: mock(() => []),
-      create: mock((params) => ({ id: 'agent-new', ...params, spaceId: params.spaceId })),
+      create: mock((params) => ({
+        id: params.id ?? 'agent-new',
+        ...params,
+        spaceId: params.spaceId,
+      })),
       getById: mock(() => ({ id: 'agent-1', spaceId: 'space-1' })),
+      getByHandle: mock(() => null),
       update: mock((agentId, params) => ({ id: agentId, spaceId: 'space-1', ...params })),
       delete: mock(() => {}),
       listReminders: mock(() => []),
@@ -95,6 +100,38 @@ describe('Space long-horizon agent handlers', () => {
       removeLongHorizonAgentSubscriptions: mock(() => {}),
     };
     setupSpaceLongHorizonAgentHandlers(hubData.hub, createMockSpaceManager(), repo, runtimeService);
+  });
+
+  describe('spaceLongHorizonAgent.create', () => {
+    it('uses a non-conflicting mirror handle when requested handle belongs to another row', async () => {
+      repo.getByHandle = mock(() => ({
+        id: 'standalone-agent',
+        spaceId: 'space-1',
+        handle: 'researcher',
+      })) as SpaceLongHorizonAgentRepository['getByHandle'];
+      repo.listBySpaceId = mock(() => [
+        { id: 'standalone-agent', spaceId: 'space-1', handle: 'researcher' },
+        { id: 'existing-events-agent', spaceId: 'space-1', handle: 'researcher-events' },
+      ]) as SpaceLongHorizonAgentRepository['listBySpaceId'];
+
+      const result = await call<{ agent: { id: string; handle: string } }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.create',
+        {
+          id: 'visible-agent',
+          spaceId: 'space-1',
+          handle: 'researcher',
+          displayName: 'Researcher',
+        }
+      );
+
+      expect(result.agent).toEqual(
+        expect.objectContaining({ id: 'visible-agent', handle: 'researcher-events-2' })
+      );
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'visible-agent', handle: 'researcher-events-2' })
+      );
+    });
   });
 
   describe('spaceLongHorizonAgent.update', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-151-agent-event-subscriptions.test.ts
@@ -23,6 +23,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         status TEXT,
         model TEXT,
         tools TEXT,
+        provider TEXT,
+        setting_sources TEXT,
         created_at INTEGER
       );
       CREATE TABLE space_long_horizon_agents (
@@ -37,6 +39,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
         autonomy_level INTEGER,
         model TEXT,
         thinking_level TEXT,
+        provider TEXT,
+        setting_sources TEXT,
         tool_permissions_json TEXT NOT NULL DEFAULT '{}',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
@@ -66,8 +70,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
     `);
     db.prepare(`INSERT INTO spaces (id) VALUES (?)`).run('space-1');
     db.prepare(
-      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, provider, setting_sources, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       'lh-agent-1',
       'space-1',
@@ -79,11 +83,13 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       'active',
       null,
       '[]',
+      null,
+      null,
       100
     );
     db.prepare(
-      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, provider, setting_sources, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       'legacy-agent-1',
       'space-1',
@@ -95,11 +101,13 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       'paused',
       'claude-sonnet-4',
       '["Read"]',
+      'openrouter',
+      '["project"]',
       101
     );
     db.prepare(
-      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO space_agents (id, space_id, name, handle, instructions, system_prompt, custom_prompt, status, model, tools, provider, setting_sources, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       'conflict-agent-1',
       'space-1',
@@ -111,6 +119,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       'active',
       null,
       '[]',
+      null,
+      null,
       102
     );
     db.prepare(
@@ -188,7 +198,7 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
     expect(
       db
         .prepare(
-          `SELECT id, handle, display_name, template_key, status, instructions, model, tool_permissions_json
+          `SELECT id, handle, display_name, template_key, status, instructions, model, provider, setting_sources, tool_permissions_json
            FROM space_long_horizon_agents
            WHERE id = ?`
         )
@@ -201,6 +211,8 @@ describe('Migration 151: consolidate agent event subscriptions', () => {
       status: 'paused',
       instructions: 'Canonical custom prompt',
       model: 'claude-sonnet-4',
+      provider: 'openrouter',
+      setting_sources: '["project"]',
       tool_permissions_json: '{"tools":["Read"]}',
     });
     expect(

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -83,6 +83,8 @@ describe('SpaceLongHorizonAgentRepository', () => {
       sessionId: 'space:lh:forge-steward',
       instructions: 'Watch Forge scopes.',
       autonomyLevel: 3,
+      provider: 'openrouter',
+      settingSources: ['project'],
       toolPermissions: { forge: { write: true } },
     });
 
@@ -94,6 +96,8 @@ describe('SpaceLongHorizonAgentRepository', () => {
       sessionId: 'space:lh:forge-steward',
       instructions: 'Watch Forge scopes.',
       autonomyLevel: 3,
+      provider: 'openrouter',
+      settingSources: ['project'],
       toolPermissions: { forge: { write: true } },
     });
 
@@ -101,11 +105,15 @@ describe('SpaceLongHorizonAgentRepository', () => {
       repo.update(agent.id, {
         status: 'active',
         autonomyLevel: null,
+        provider: null,
+        settingSources: null,
         toolPermissions: null,
       })
     ).toMatchObject({
       status: 'active',
       autonomyLevel: null,
+      provider: null,
+      settingSources: null,
       toolPermissions: {},
     });
   });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -652,7 +652,7 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
       (
         await handlers.subscribe_agent_event({
           agent_id: legacyAgent.id,
-          topic_pattern: 'github/*/*/issues/*',
+          topic_pattern: 'github/*/*/pull_request/*.opened',
         })
       ).content[0].text
     );

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -406,6 +406,52 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(longHorizonMessages).toHaveLength(1);
   });
 
+  test('clears pending long-horizon retries after agent pause', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-paused-retry',
+      spaceId: SPACE_ID,
+      handle: 'paused-retry-watcher',
+      displayName: 'Paused Retry Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: false, error: 'temporary failure' };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    await eventService.publish(makeEvent({ id: 'evt-paused-retry' }));
+    expect(longHorizonMessages).toHaveLength(1);
+
+    repo.update(agent.id, { status: 'paused' });
+    expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
+      success: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    expect(longHorizonMessages).toHaveLength(1);
+    await runtime.stop();
+  });
+
   test('removes trie entries after long-horizon agent deletion', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2105,6 +2105,58 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
 
+  test('marks invalid persisted pending long-horizon deliveries failed during rehydrate', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-invalid-pending',
+      spaceId: SPACE_ID,
+      handle: 'invalid-pending',
+      displayName: 'Invalid Pending',
+    });
+    const subscription = repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: 'space/task.done',
+    });
+    const event = makeEvent({ id: 'evt-lh-invalid-pending' });
+    eventStore.store(event);
+    const deliveryKey = `lh:${subscription.id}:${event.id}`;
+    eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+      workflowRunId: `long_horizon:${SPACE_ID}`,
+      taskId: subscription.id,
+      nodeId: agent.id,
+      agentName: agent.id,
+    });
+    eventStore.markDeliveryFailed(event.id, deliveryKey, {
+      terminal: false,
+      reason: 'long-horizon agent unavailable',
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await expect(runtime.rehydrateExecutors()).resolves.toBeUndefined();
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('Topic source "space" does not match source "github"');
+    expect(longHorizonMessages).toHaveLength(0);
+  });
+
   test('requeues persisted pending deliveries during runtime rehydrate', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const event = makeEvent();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -480,13 +480,14 @@ describe('SpaceRuntime external event subscriptions', () => {
     await runtime.rehydrateExecutors();
     await eventService.publish(makeEvent({ id: 'evt-paused-retry' }));
     expect(longHorizonMessages).toHaveLength(1);
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(true);
 
     repo.update(agent.id, { status: 'paused' });
     expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
       success: true,
     });
-    await new Promise((resolve) => setTimeout(resolve, 1100));
 
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(false);
     expect(longHorizonMessages).toHaveLength(1);
     await runtime.stop();
   });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -488,6 +488,10 @@ describe('SpaceRuntime external event subscriptions', () => {
     });
 
     expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(false);
+    const delivery = eventStore.listDeliveries('evt-paused-retry')[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('subscription_no_longer_active');
+    expect(eventStore.getById('evt-paused-retry')?.state).toBe('failed');
     expect(longHorizonMessages).toHaveLength(1);
     await runtime.stop();
   });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -496,6 +496,69 @@ describe('SpaceRuntime external event subscriptions', () => {
     await runtime.stop();
   });
 
+  test('cancels in-flight long-horizon delivery after agent pause', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-inflight-pause',
+      spaceId: SPACE_ID,
+      handle: 'inflight-pause-watcher',
+      displayName: 'Inflight Pause Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    let resolveDelivery!: (value: { delivered: boolean }) => void;
+    let resolveStarted!: () => void;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        resolveStarted();
+        return new Promise<{ delivered: boolean }>((resolve) => {
+          resolveDelivery = resolve;
+        });
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    const publishPromise = eventService.publish(makeEvent({ id: 'evt-inflight-pause' }));
+    await deliveryStarted;
+
+    repo.update(agent.id, { status: 'paused' });
+    expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
+      success: true,
+    });
+
+    const delivery = eventStore.listDeliveries('evt-inflight-pause')[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('subscription_no_longer_active');
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(false);
+
+    resolveDelivery({ delivered: false });
+    await publishPromise;
+
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(false);
+    expect(longHorizonMessages).toHaveLength(1);
+    expect(eventStore.getById('evt-inflight-pause')?.state).toBe('failed');
+    await runtime.stop();
+  });
+
   test('removes trie entries after long-horizon agent deletion', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -393,6 +393,51 @@ describe('SpaceRuntime external event subscriptions', () => {
     });
   });
 
+  test('skips invalid existing long-horizon subscriptions during agent refresh', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-invalid-refresh',
+      spaceId: SPACE_ID,
+      handle: 'invalid-refresh-watcher',
+      displayName: 'Invalid Refresh Watcher',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: 'space/task.done',
+    });
+    repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    expect(runtime.refreshLongHorizonAgentSubscriptions(SPACE_ID, agent.id)).toEqual({
+      success: true,
+    });
+    await eventService.publish(makeEvent({ id: 'evt-after-invalid-refresh' }));
+    expect(longHorizonMessages).toHaveLength(1);
+  });
+
   test('refreshes trie entries after long-horizon agent status changes', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -354,6 +354,45 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('published');
   });
 
+  test('skips invalid persisted long-horizon subscriptions during rehydration', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-invalid-pattern',
+      spaceId: SPACE_ID,
+      handle: 'invalid-pattern-watcher',
+      displayName: 'Invalid Pattern Watcher',
+    });
+    const subscription = repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: 'space/task.done',
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: true };
+      },
+    });
+
+    await expect(runtime.rehydrateExecutors()).resolves.toBeUndefined();
+    expect(runtime.refreshLongHorizonSubscription(SPACE_ID, subscription.id)).toEqual({
+      success: false,
+      error: 'Topic source "space" does not match source "github"',
+    });
+  });
+
   test('refreshes trie entries after long-horizon agent status changes', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -496,6 +496,55 @@ describe('SpaceRuntime external event subscriptions', () => {
     await runtime.stop();
   });
 
+  test('cancels long-horizon retry after subscription route changes', async () => {
+    const repo = new SpaceLongHorizonAgentRepository(db);
+    const agent = repo.create({
+      id: 'lh-agent-route-change',
+      spaceId: SPACE_ID,
+      handle: 'route-change-watcher',
+      displayName: 'Route Change Watcher',
+    });
+    const subscription = repo.createSubscription({
+      spaceId: SPACE_ID,
+      agentId: agent.id,
+      source: 'github',
+      topic: DEFAULT_TOPIC,
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      longHorizonAgentRepo: repo,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+      deliverLongHorizonExternalEvent: async ({ agentId, message, idempotencyKey }) => {
+        longHorizonMessages.push({ agentId, message, idempotencyKey });
+        return { delivered: false };
+      },
+    });
+
+    await runtime.rehydrateExecutors();
+    await eventService.publish(makeEvent({ id: 'evt-route-change' }));
+    expect(longHorizonMessages).toHaveLength(1);
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(true);
+
+    repo.updateSubscription(subscription.id, { topic: 'github/*/*/pull_request/*.closed' });
+    expect(runtime.refreshLongHorizonSubscription(SPACE_ID, subscription.id)).toEqual({
+      success: true,
+    });
+
+    const delivery = eventStore.listDeliveries('evt-route-change')[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('subscription_no_longer_active');
+    expect(runtime.hasPendingRetriesForAgent(SPACE_ID, agent.id)).toBe(false);
+    await runtime.stop();
+  });
+
   test('cancels in-flight long-horizon delivery after agent pause', async () => {
     const repo = new SpaceLongHorizonAgentRepository(db);
     const agent = repo.create({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -790,6 +790,8 @@ describe('SpaceRuntimeService', () => {
           autonomyLevel: null,
           model: null,
           thinkingLevel: null,
+          provider: 'openrouter',
+          settingSources: ['project'],
           toolPermissions: { tools: ['Read', 'Edit'] },
           createdAt: NOW,
           updatedAt: NOW,
@@ -821,6 +823,8 @@ describe('SpaceRuntimeService', () => {
       expect(sessionManager.createSession).toHaveBeenCalledWith(
         expect.objectContaining({
           config: expect.objectContaining({
+            provider: 'openrouter',
+            settingSources: ['project'],
             sdkToolsPreset: ['Read', 'Edit'],
             allowedTools: ['Read', 'Edit'],
             disallowedTools: expect.arrayContaining(['Bash']),
@@ -877,6 +881,8 @@ describe('SpaceRuntimeService', () => {
           autonomyLevel: null,
           model: 'claude-new',
           thinkingLevel: null,
+          provider: 'openrouter',
+          settingSources: ['project'],
           toolPermissions: { tools: ['Read', 'Edit'] },
           createdAt: NOW,
           updatedAt: NOW,
@@ -908,6 +914,8 @@ describe('SpaceRuntimeService', () => {
       expect(existingSession.updateConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'claude-new',
+          provider: 'openrouter',
+          settingSources: ['project'],
           systemPrompt: expect.objectContaining({ append: 'Use updated tools.' }),
           sdkToolsPreset: ['Read', 'Edit'],
           allowedTools: ['Read', 'Edit'],

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -462,6 +462,9 @@ describe('SpaceRuntimeService', () => {
         setRuntimeMcpServers: mock(() => {}),
         mergeRuntimeMcpServers: mock(() => {}),
         setRuntimeSystemPrompt: mock(() => {}),
+        updateConfig: mock(async () => {}),
+        resetQuery: mock(async () => ({ success: true })),
+        getSessionData: mock(() => ({ id: 'session-1', metadata: {}, config: {} }) as Session),
       } as unknown as AgentSession;
     }
 
@@ -832,6 +835,91 @@ describe('SpaceRuntimeService', () => {
         })
       );
       expect(createdSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
+        'delivery-1',
+        'event payload'
+      );
+    });
+
+    test('long-horizon event sessions refresh existing config before delivery', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const sessionData = {
+        id: sessionId,
+        metadata: {},
+        config: {
+          model: 'claude-old',
+          systemPrompt: {
+            type: 'preset' as const,
+            preset: 'claude_code' as const,
+            append: 'Old instructions.',
+          },
+          sdkToolsPreset: ['Read'],
+          allowedTools: ['Read'],
+          disallowedTools: ['Edit'],
+        },
+      } as Session;
+      const existingSession = {
+        ...makeSession(),
+        getSessionData: mock(() => sessionData),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(existingSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'restricted-agent',
+          displayName: 'Restricted Agent',
+          templateKey: 'migration.legacy_space_agent',
+          status: 'active',
+          sessionId,
+          instructions: 'Use updated tools.',
+          autonomyLevel: null,
+          model: 'claude-new',
+          thinkingLevel: null,
+          toolPermissions: { tools: ['Read', 'Edit'] },
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        longHorizonAgentRepo,
+      });
+
+      const result = await (
+        svc as unknown as {
+          deliverLongHorizonExternalEvent(args: {
+            spaceId: string;
+            agentId: string;
+            message: string;
+            idempotencyKey: string;
+          }): Promise<{ delivered: boolean }>;
+        }
+      ).deliverLongHorizonExternalEvent({
+        spaceId: mockSpace.id,
+        agentId: 'lh-agent-1',
+        message: 'event payload',
+        idempotencyKey: 'delivery-1',
+      });
+
+      expect(result).toEqual({ delivered: true });
+      expect(existingSession.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-new',
+          systemPrompt: expect.objectContaining({ append: 'Use updated tools.' }),
+          sdkToolsPreset: ['Read', 'Edit'],
+          allowedTools: ['Read', 'Edit'],
+          disallowedTools: expect.arrayContaining(['Bash']),
+          agent: 'restricted-agent',
+          agents: {
+            'restricted-agent': expect.objectContaining({ prompt: 'Use updated tools.' }),
+          },
+        })
+      );
+      expect(existingSession.resetQuery).toHaveBeenCalledWith({ restartQuery: true });
+      expect(existingSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
         'delivery-1',
         'event payload'
       );

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -844,6 +844,74 @@ describe('SpaceRuntimeService', () => {
       );
     });
 
+    test('long-horizon event sessions leave model unset for custom provider defaults', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({
+          id: sessionId,
+          metadata: {},
+          config: {},
+        })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'provider-default-agent',
+          displayName: 'Provider Default Agent',
+          templateKey: 'migration.legacy_space_agent',
+          status: 'active',
+          sessionId: null,
+          instructions: 'Use provider defaults.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          provider: 'openrouter',
+          settingSources: null,
+          toolPermissions: {},
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        longHorizonAgentRepo,
+      });
+
+      await (
+        svc as unknown as {
+          deliverLongHorizonExternalEvent(args: {
+            spaceId: string;
+            agentId: string;
+            message: string;
+            idempotencyKey: string;
+          }): Promise<{ delivered: boolean }>;
+        }
+      ).deliverLongHorizonExternalEvent({
+        spaceId: mockSpace.id,
+        agentId: 'lh-agent-1',
+        message: 'event payload',
+        idempotencyKey: 'delivery-1',
+      });
+
+      const createSessionArg = (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mock.calls[0]![0] as { config: Partial<Session['config']> };
+      expect(createSessionArg.config.provider).toBe('openrouter');
+      expect(createSessionArg.config.model).toBeUndefined();
+    });
+
     test('long-horizon event sessions refresh existing config before delivery', async () => {
       const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
       const sessionData = {

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -66,6 +66,48 @@ export function createSpaceAgentSchema(db: Database): void {
   `);
 
   db.exec(`
+		CREATE TABLE space_long_horizon_agents (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			handle TEXT NOT NULL,
+			display_name TEXT NOT NULL,
+			template_key TEXT DEFAULT NULL,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'disabled', 'archived')),
+			session_id TEXT DEFAULT NULL,
+			instructions TEXT NOT NULL DEFAULT '',
+			autonomy_level INTEGER DEFAULT NULL
+				CHECK(autonomy_level IS NULL OR autonomy_level BETWEEN 1 AND 5),
+			model TEXT DEFAULT NULL,
+			thinking_level TEXT DEFAULT NULL,
+			tool_permissions_json TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+  db.exec(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_space_long_horizon_agents_handle ` +
+      `ON space_long_horizon_agents(space_id, handle) WHERE status != 'archived'`
+  );
+  db.exec(`
+		CREATE TABLE space_long_horizon_agent_event_subscriptions (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			source TEXT NOT NULL,
+			topic TEXT NOT NULL,
+			filter_json TEXT NOT NULL DEFAULT '{}',
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'disabled')),
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (agent_id) REFERENCES space_long_horizon_agents(id) ON DELETE CASCADE
+		)
+	`);
+
+  db.exec(`
 		CREATE TABLE sessions (
 			id TEXT PRIMARY KEY,
 			title TEXT NOT NULL,

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -49,6 +49,8 @@ export function createSpaceAgentSchema(db: Database): void {
 			tools TEXT NOT NULL DEFAULT '[]',
 			thinking_level TEXT DEFAULT NULL,
 			custom_prompt TEXT,
+			system_prompt TEXT NOT NULL DEFAULT '',
+			instructions TEXT,
 			provider TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
@@ -105,7 +107,8 @@ export function createSpaceAgentSchema(db: Database): void {
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-			FOREIGN KEY (agent_id) REFERENCES space_long_horizon_agents(id) ON DELETE CASCADE
+			FOREIGN KEY (agent_id) REFERENCES space_long_horizon_agents(id) ON DELETE CASCADE,
+			UNIQUE(space_id, agent_id, source, topic, filter_json)
 		)
 	`);
 

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -80,6 +80,8 @@ export function createSpaceAgentSchema(db: Database): void {
 				CHECK(autonomy_level IS NULL OR autonomy_level BETWEEN 1 AND 5),
 			model TEXT DEFAULT NULL,
 			thinking_level TEXT DEFAULT NULL,
+			provider TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			tool_permissions_json TEXT NOT NULL DEFAULT '{}',
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -185,6 +185,13 @@ export interface CreateSpaceLongHorizonAgentSubscriptionParams {
   status?: SpaceLongHorizonAgentEventSubscriptionStatus;
 }
 
+export interface UpdateSpaceLongHorizonAgentSubscriptionParams {
+  source?: string;
+  topic?: string;
+  filter?: Record<string, unknown>;
+  status?: SpaceLongHorizonAgentEventSubscriptionStatus;
+}
+
 export const MIN_SPACE_CONCURRENT_TASKS = 1;
 export const MAX_SPACE_CONCURRENT_TASKS = 10;
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -82,6 +82,8 @@ export interface SpaceLongHorizonAgent {
   autonomyLevel: SpaceAgentAutonomyLevel | null;
   model: string | null;
   thinkingLevel: ThinkingLevel | null;
+  provider: string | null;
+  settingSources: SettingSource[] | null;
   toolPermissions: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
@@ -99,6 +101,8 @@ export interface CreateSpaceLongHorizonAgentParams {
   autonomyLevel?: SpaceAgentAutonomyLevel | null;
   model?: string | null;
   thinkingLevel?: ThinkingLevel | null;
+  provider?: string | null;
+  settingSources?: SettingSource[] | null;
   toolPermissions?: Record<string, unknown>;
 }
 
@@ -112,6 +116,8 @@ export interface UpdateSpaceLongHorizonAgentParams {
   autonomyLevel?: SpaceAgentAutonomyLevel | null;
   model?: string | null;
   thinkingLevel?: ThinkingLevel | null;
+  provider?: string | null;
+  settingSources?: SettingSource[] | null;
   toolPermissions?: Record<string, unknown> | null;
 }
 

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -6,8 +6,13 @@
  * reminders, and event subscriptions.
  */
 
-import { useEffect, useState } from 'preact/hooks';
-import type { AgentDriftReport, SpaceAgent } from '@neokai/shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import type {
+  AgentDriftReport,
+  SpaceAgent,
+  SpaceLongHorizonAgent,
+  SpaceLongHorizonAgentEventSubscription,
+} from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
 import { navigateToSpaceAgent, navigateToSpaceForge, navigateToSpaceGoals } from '../../lib/router';
 import { spaceStore } from '../../lib/space-store';
@@ -22,10 +27,13 @@ interface AgentCardProps {
   syncing: boolean;
   managedGoalCount: number;
   reminderCount: number;
+  subscriptionCount: number;
+  subscriptionTopics: Array<{ id: string; topic: string }>;
   onEdit: (agent: SpaceAgent) => void;
   onDelete: (agent: SpaceAgent) => void;
   onSync: (agent: SpaceAgent) => void;
   onOpenDetail: (agent: SpaceAgent) => void;
+  onEditSubscriptions: (agent: SpaceAgent) => void;
 }
 
 function isCoordinatorAgent(agent: SpaceAgent): boolean {
@@ -44,16 +52,229 @@ function AgentStat({ label, value }: { label: string; value: string | number }) 
   );
 }
 
+function formatFilter(filter: Record<string, unknown>): string {
+  return Object.keys(filter).length === 0 ? 'No filter' : JSON.stringify(filter);
+}
+
+interface SubscriptionEditorProps {
+  agent: SpaceAgent;
+  longHorizonAgent: SpaceLongHorizonAgent;
+  subscriptions: SpaceLongHorizonAgentEventSubscription[];
+  onClose: () => void;
+  onChanged: (agentId: string) => Promise<void>;
+}
+
+function SubscriptionEditor({
+  agent,
+  longHorizonAgent,
+  subscriptions,
+  onClose,
+  onChanged,
+}: SubscriptionEditorProps) {
+  const [source, setSource] = useState('github');
+  const [topic, setTopic] = useState('github/*/*/pull_request/*');
+  const [label, setLabel] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    const trimmedSource = source.trim();
+    const trimmedTopic = topic.trim();
+    if (!trimmedSource) {
+      setError('Source is required');
+      return;
+    }
+    if (!trimmedTopic) {
+      setError('Topic pattern is required');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const filter = label.trim() ? { label: label.trim() } : {};
+      await spaceStore.createLongHorizonAgentSubscription({
+        agentId: longHorizonAgent.id,
+        source: trimmedSource,
+        topic: trimmedTopic,
+        filter,
+        status: 'active',
+      });
+      setTopic('github/*/*/pull_request/*');
+      setLabel('');
+      await onChanged(longHorizonAgent.id);
+      toast.success('Subscription added');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add subscription');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (subscription: SpaceLongHorizonAgentEventSubscription) => {
+    const nextStatus = subscription.status === 'active' ? 'paused' : 'active';
+    setBusyId(subscription.id);
+    setError(null);
+    try {
+      await spaceStore.updateLongHorizonAgentSubscription(subscription.id, { status: nextStatus });
+      await onChanged(longHorizonAgent.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update subscription');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (subscription: SpaceLongHorizonAgentEventSubscription) => {
+    setBusyId(subscription.id);
+    setError(null);
+    try {
+      await spaceStore.deleteLongHorizonAgentSubscription(subscription.id);
+      await onChanged(longHorizonAgent.id);
+      toast.success('Subscription deleted');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete subscription');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div class="fixed inset-0 z-50 flex items-center justify-end bg-black/50" onClick={onClose}>
+      <div
+        class="h-full w-full max-w-xl overflow-y-auto border-l border-white/10 bg-dark-900 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div class="border-b border-white/10 px-4 py-3">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-wider text-purple-300">
+                Event subscriptions
+              </p>
+              <h2 class="mt-1 text-sm font-semibold text-gray-100">{agent.name}</h2>
+              <p class="mt-0.5 font-mono text-xs text-gray-500">@{agent.handle}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              class="rounded-md px-2 py-1 text-xs text-gray-400 hover:bg-white/5 hover:text-gray-200"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+
+        <div class="space-y-4 px-4 py-4">
+          <section class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
+            <p class="text-xs font-medium text-gray-200">Add subscription</p>
+            <label class="mt-3 block text-xs text-gray-400">
+              Source
+              <input
+                value={source}
+                onInput={(event) => setSource(event.currentTarget.value)}
+                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 font-mono text-xs text-gray-100 outline-none focus:border-blue-500/60"
+                placeholder="github"
+              />
+            </label>
+            <label class="mt-3 block text-xs text-gray-400">
+              Topic pattern
+              <input
+                value={topic}
+                onInput={(event) => setTopic(event.currentTarget.value)}
+                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 font-mono text-xs text-gray-100 outline-none focus:border-blue-500/60"
+                placeholder="github/owner/repo/pull_request/*.review_*"
+              />
+            </label>
+            <label class="mt-3 block text-xs text-gray-400">
+              Label (optional)
+              <input
+                value={label}
+                onInput={(event) => setLabel(event.currentTarget.value)}
+                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 outline-none focus:border-blue-500/60"
+                placeholder="PR review comments"
+              />
+            </label>
+            <div class="mt-3 flex justify-end">
+              <Button size="sm" onClick={handleCreate} disabled={saving}>
+                {saving ? 'Adding…' : 'Add subscription'}
+              </Button>
+            </div>
+          </section>
+
+          {error && <p class="text-xs text-red-400">{error}</p>}
+
+          <section class="space-y-2">
+            <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
+              Current · {subscriptions.length}
+            </p>
+            {subscriptions.length === 0 ? (
+              <div class="rounded border border-white/10 bg-dark-800 px-3 py-4 text-xs text-gray-500">
+                No event subscriptions configured.
+              </div>
+            ) : (
+              subscriptions.map((subscription) => (
+                <div
+                  key={subscription.id}
+                  class="rounded-lg border border-white/10 bg-white/[0.025] p-3"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="break-all font-mono text-xs text-gray-100">{subscription.topic}</p>
+                      <p class="mt-1 text-xs text-gray-500">
+                        Source: {subscription.source} · Filter: {formatFilter(subscription.filter)}
+                      </p>
+                    </div>
+                    <span
+                      class={`rounded px-1.5 py-0.5 text-xs ${
+                        subscription.status === 'active'
+                          ? 'bg-green-500/10 text-green-300'
+                          : 'bg-amber-500/10 text-amber-300'
+                      }`}
+                    >
+                      {subscription.status}
+                    </span>
+                  </div>
+                  <div class="mt-3 flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(subscription)}
+                      disabled={busyId === subscription.id}
+                      class="rounded-md px-2 py-1 text-xs text-blue-300 hover:bg-white/5 hover:text-blue-200 disabled:opacity-50"
+                    >
+                      {subscription.status === 'active' ? 'Pause' : 'Resume'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(subscription)}
+                      disabled={busyId === subscription.id}
+                      class="rounded-md px-2 py-1 text-xs text-red-300 hover:bg-white/5 hover:text-red-200 disabled:opacity-50"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function AgentCard({
   agent,
   drifted,
   syncing,
   managedGoalCount,
   reminderCount,
+  subscriptionCount,
+  subscriptionTopics,
   onEdit,
   onDelete,
   onSync,
   onOpenDetail,
+  onEditSubscriptions,
 }: AgentCardProps) {
   const toolCount = agent.tools?.length ?? 0;
   const isCoordinator = isCoordinatorAgent(agent);
@@ -104,6 +325,19 @@ function AgentCard({
               </span>
             ))}
           </div>
+          {subscriptionTopics.length > 0 && (
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              {subscriptionTopics.slice(0, 3).map((subscription) => (
+                <span
+                  key={subscription.id}
+                  class="max-w-full truncate rounded border border-blue-400/20 bg-blue-500/10 px-1.5 py-0.5 font-mono text-xs text-blue-200"
+                  title={subscription.topic}
+                >
+                  {subscription.topic}
+                </span>
+              ))}
+            </div>
+          )}
           {isCoordinator && (
             <div class="mt-3 grid gap-2 rounded-lg border border-purple-400/15 bg-black/10 p-3 sm:grid-cols-2">
               <div>
@@ -117,7 +351,7 @@ function AgentCard({
                 <p class="text-xs font-medium text-purple-100">Automation</p>
                 <div class="mt-2 flex flex-wrap gap-1.5">
                   <AgentStat label="reminders" value={reminderCount} />
-                  <AgentStat label="event subscriptions" value="Coming soon" />
+                  <AgentStat label="event subscriptions" value={subscriptionCount} />
                 </div>
               </div>
             </div>
@@ -135,6 +369,14 @@ function AgentCard({
               {syncing ? 'Syncing…' : 'Sync'}
             </button>
           )}
+          <button
+            type="button"
+            onClick={() => onEditSubscriptions(agent)}
+            class="rounded-md px-2 py-1 text-xs text-blue-300 transition-colors hover:bg-white/5 hover:text-blue-200"
+            aria-label={`Edit event subscriptions for ${agent.name}`}
+          >
+            Events
+          </button>
           <button
             type="button"
             onClick={() => onEdit(agent)}
@@ -200,12 +442,18 @@ export function SpaceAgentList() {
   const goals = spaceStore.goals.value;
   const schedules = spaceStore.schedules.value;
   const workflows = spaceStore.workflows.value;
+  const longHorizonAgents = spaceStore.longHorizonAgents.value;
 
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<SpaceAgent | null>(null);
   const [deletingAgent, setDeletingAgent] = useState<SpaceAgent | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+
+  const [subscriptionEditorAgent, setSubscriptionEditorAgent] = useState<SpaceAgent | null>(null);
+  const [subscriptionsByAgentId, setSubscriptionsByAgentId] = useState<
+    Record<string, SpaceLongHorizonAgentEventSubscription[]>
+  >({});
 
   const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
   const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
@@ -214,6 +462,49 @@ export function SpaceAgentList() {
     .map((a) => `${a.id}:${a.updatedAt}`)
     .sort()
     .join('|');
+  const longHorizonAgentById = useMemo(() => {
+    const map = new Map<string, SpaceLongHorizonAgent>();
+    for (const agent of longHorizonAgents) map.set(agent.id, agent);
+    return map;
+  }, [longHorizonAgents]);
+  const longHorizonAgentIds = longHorizonAgents
+    .map((agent) => agent.id)
+    .sort()
+    .join('|');
+
+  const loadSubscriptions = async (agentId: string) => {
+    const subscriptions = await spaceStore.listLongHorizonAgentSubscriptions(agentId);
+    setSubscriptionsByAgentId((current) => ({ ...current, [agentId]: subscriptions }));
+  };
+
+  useEffect(() => {
+    if (!spaceId || longHorizonAgents.length === 0) {
+      setSubscriptionsByAgentId({});
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      const entries = await Promise.all(
+        longHorizonAgents.map(
+          async (agent) =>
+            [agent.id, await spaceStore.listLongHorizonAgentSubscriptions(agent.id)] as const
+        )
+      );
+      if (!cancelled) setSubscriptionsByAgentId(Object.fromEntries(entries));
+    };
+    load().catch((err) => {
+      if (!cancelled) {
+        toast.error(
+          `Failed to load event subscriptions: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceId, longHorizonAgentIds]);
 
   useEffect(() => {
     if (!spaceId) return;
@@ -296,6 +587,16 @@ export function SpaceAgentList() {
     navigateToSpaceAgent(spaceUrlId, agent.handle);
   };
 
+  const handleEditSubscriptions = (agent: SpaceAgent) => {
+    const longHorizonAgent = longHorizonAgentById.get(agent.id);
+    if (!longHorizonAgent) {
+      toast.error('No long-horizon agent row found for this agent.');
+      return;
+    }
+    setSubscriptionEditorAgent(agent);
+    loadSubscriptions(longHorizonAgent.id).catch(() => {});
+  };
+
   const handleCreate = () => {
     setEditingAgent(null);
     setEditorOpen(true);
@@ -336,6 +637,13 @@ export function SpaceAgentList() {
   };
 
   const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
+  const selectedLongHorizonAgent = subscriptionEditorAgent
+    ? longHorizonAgentById.get(subscriptionEditorAgent.id)
+    : null;
+  const totalEventSubscriptions = Object.values(subscriptionsByAgentId).reduce(
+    (total, subscriptions) => total + subscriptions.filter((s) => s.status === 'active').length,
+    0
+  );
   const coordinator = agents.find(isCoordinatorAgent);
   const otherAgents = agents.filter((agent) => agent.id !== coordinator?.id);
   const visibleAgents = coordinator ? [coordinator, ...otherAgents] : agents;
@@ -417,11 +725,12 @@ export function SpaceAgentList() {
               <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
                 Reminders and events
               </p>
-              <div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-500">
-                Event subscriptions coming soon.
+              <div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-300">
+                {totalEventSubscriptions} active event subscriptions
               </div>
               <p class="mt-1 text-xs text-gray-500">
-                {activeSchedules.length} active reminders · event subscriptions not yet configured
+                {activeSchedules.length} active reminders · event subscriptions configurable per
+                agent
               </p>
             </div>
           </div>
@@ -441,20 +750,33 @@ export function SpaceAgentList() {
             </div>
           ) : (
             <div class="space-y-2">
-              {visibleAgents.map((agent) => (
-                <AgentCard
-                  key={agent.id}
-                  agent={agent}
-                  drifted={driftedAgentIds.has(agent.id)}
-                  syncing={syncingAgentId === agent.id}
-                  managedGoalCount={activeGoals.length}
-                  reminderCount={activeSchedules.length}
-                  onEdit={handleEdit}
-                  onDelete={handleDeleteClick}
-                  onSync={handleSync}
-                  onOpenDetail={handleOpenDetail}
-                />
-              ))}
+              {visibleAgents.map((agent) => {
+                const longHorizonAgent = longHorizonAgentById.get(agent.id);
+                const subscriptions = longHorizonAgent
+                  ? (subscriptionsByAgentId[longHorizonAgent.id] ?? [])
+                  : [];
+                const activeSubscriptions = subscriptions.filter((s) => s.status === 'active');
+                return (
+                  <AgentCard
+                    key={agent.id}
+                    agent={agent}
+                    drifted={driftedAgentIds.has(agent.id)}
+                    syncing={syncingAgentId === agent.id}
+                    managedGoalCount={activeGoals.length}
+                    reminderCount={activeSchedules.length}
+                    subscriptionCount={activeSubscriptions.length}
+                    subscriptionTopics={activeSubscriptions.map((s) => ({
+                      id: s.id,
+                      topic: s.topic,
+                    }))}
+                    onEdit={handleEdit}
+                    onDelete={handleDeleteClick}
+                    onSync={handleSync}
+                    onOpenDetail={handleOpenDetail}
+                    onEditSubscriptions={handleEditSubscriptions}
+                  />
+                );
+              })}
             </div>
           )}
 
@@ -476,6 +798,16 @@ export function SpaceAgentList() {
           existingAgentNames={existingAgentNames}
           onSave={handleEditorClose}
           onCancel={handleEditorClose}
+        />
+      )}
+
+      {subscriptionEditorAgent && selectedLongHorizonAgent && (
+        <SubscriptionEditor
+          agent={subscriptionEditorAgent}
+          longHorizonAgent={selectedLongHorizonAgent}
+          subscriptions={subscriptionsByAgentId[selectedLongHorizonAgent.id] ?? []}
+          onClose={() => setSubscriptionEditorAgent(null)}
+          onChanged={loadSubscriptions}
         />
       )}
 

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -608,6 +608,8 @@ export function SpaceAgentList() {
           instructions: agent.customPrompt ?? agent.description ?? '',
           model: agent.model ?? null,
           thinkingLevel: agent.thinkingLevel ?? null,
+          provider: agent.provider ?? null,
+          settingSources: agent.settingSources ?? null,
           toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
         });
       } catch (err) {

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -605,7 +605,7 @@ export function SpaceAgentList() {
           id: agent.id,
           handle: agent.handle,
           displayName: agent.name,
-          instructions: agent.customPrompt ?? agent.description ?? '',
+          instructions: agent.customPrompt ?? '',
           model: agent.model ?? null,
           thinkingLevel: agent.thinkingLevel ?? null,
           provider: agent.provider ?? null,

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -468,6 +468,7 @@ export function SpaceAgentList() {
     const byId = new Map<string, SpaceLongHorizonAgent>();
     const byHandle = new Map<string, SpaceLongHorizonAgent>();
     for (const agent of longHorizonAgents) {
+      if (agent.status !== 'active') continue;
       byId.set(agent.id, agent);
       byHandle.set(agent.handle, agent);
     }

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -466,25 +466,23 @@ export function SpaceAgentList() {
     .join('|');
   const longHorizonAgentResolver = useMemo(() => {
     const activeById = new Map<string, SpaceLongHorizonAgent>();
-    const activeByHandle = new Map<string, SpaceLongHorizonAgent>();
     const inactiveById = new Map<string, SpaceLongHorizonAgent>();
-    const inactiveByHandle = new Map<string, SpaceLongHorizonAgent>();
     for (const agent of longHorizonAgents) {
       if (agent.status === 'active') {
         activeById.set(agent.id, agent);
-        activeByHandle.set(agent.handle, agent);
       } else {
         inactiveById.set(agent.id, agent);
-        inactiveByHandle.set(agent.handle, agent);
       }
     }
     return (agent: SpaceAgent) => {
-      const handle = isCoordinatorAgent(agent) ? 'coordinator' : agent.handle;
+      const coordinatorId = isCoordinatorAgent(agent)
+        ? `space-lh-agent:coordinator:${agent.spaceId}`
+        : null;
       return (
         activeById.get(agent.id) ??
-        activeByHandle.get(handle) ??
+        (coordinatorId ? activeById.get(coordinatorId) : null) ??
         inactiveById.get(agent.id) ??
-        inactiveByHandle.get(handle) ??
+        (coordinatorId ? inactiveById.get(coordinatorId) : null) ??
         null
       );
     };
@@ -612,6 +610,7 @@ export function SpaceAgentList() {
   const handleEditSubscriptions = async (agent: SpaceAgent) => {
     let longHorizonAgent = longHorizonAgentResolver(agent);
     try {
+      const agentStatus = agent.status ?? 'active';
       const agentConfig = {
         handle: isCoordinatorAgent(agent) ? 'coordinator' : agent.handle,
         displayName: agent.name,
@@ -625,12 +624,13 @@ export function SpaceAgentList() {
       if (longHorizonAgent) {
         longHorizonAgent = await spaceStore.updateLongHorizonAgent(longHorizonAgent.id, {
           ...agentConfig,
-          status: 'active',
+          status: agentStatus,
         });
       } else {
         longHorizonAgent = await spaceStore.createLongHorizonAgent({
           id: agent.id,
           ...agentConfig,
+          status: agentStatus,
         });
       }
     } catch (err) {

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -451,6 +451,8 @@ export function SpaceAgentList() {
   const [deleting, setDeleting] = useState(false);
 
   const [subscriptionEditorAgent, setSubscriptionEditorAgent] = useState<SpaceAgent | null>(null);
+  const [subscriptionEditorLongHorizonAgent, setSubscriptionEditorLongHorizonAgent] =
+    useState<SpaceLongHorizonAgent | null>(null);
   const [subscriptionsByAgentId, setSubscriptionsByAgentId] = useState<
     Record<string, SpaceLongHorizonAgentEventSubscription[]>
   >({});
@@ -594,13 +596,26 @@ export function SpaceAgentList() {
     navigateToSpaceAgent(spaceUrlId, agent.handle);
   };
 
-  const handleEditSubscriptions = (agent: SpaceAgent) => {
-    const longHorizonAgent = longHorizonAgentResolver(agent);
+  const handleEditSubscriptions = async (agent: SpaceAgent) => {
+    let longHorizonAgent = longHorizonAgentResolver(agent);
     if (!longHorizonAgent) {
-      toast.error('No long-horizon agent row found for this agent.');
-      return;
+      try {
+        longHorizonAgent = await spaceStore.createLongHorizonAgent({
+          handle: agent.handle,
+          displayName: agent.name,
+          instructions: agent.customPrompt ?? agent.description ?? '',
+          model: agent.model ?? null,
+          thinkingLevel: agent.thinkingLevel ?? null,
+        });
+      } catch (err) {
+        toast.error(
+          `Failed to create long-horizon agent row: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return;
+      }
     }
     setSubscriptionEditorAgent(agent);
+    setSubscriptionEditorLongHorizonAgent(longHorizonAgent);
     loadSubscriptions(longHorizonAgent.id).catch(() => {});
   };
 
@@ -645,7 +660,7 @@ export function SpaceAgentList() {
 
   const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
   const selectedLongHorizonAgent = subscriptionEditorAgent
-    ? longHorizonAgentResolver(subscriptionEditorAgent)
+    ? (longHorizonAgentResolver(subscriptionEditorAgent) ?? subscriptionEditorLongHorizonAgent)
     : null;
   const totalEventSubscriptions = Object.values(subscriptionsByAgentId).reduce(
     (total, subscriptions) => total + subscriptions.filter((s) => s.status === 'active').length,
@@ -813,7 +828,10 @@ export function SpaceAgentList() {
           agent={subscriptionEditorAgent}
           longHorizonAgent={selectedLongHorizonAgent}
           subscriptions={subscriptionsByAgentId[selectedLongHorizonAgent.id] ?? []}
-          onClose={() => setSubscriptionEditorAgent(null)}
+          onClose={() => {
+            setSubscriptionEditorAgent(null);
+            setSubscriptionEditorLongHorizonAgent(null);
+          }}
           onChanged={loadSubscriptions}
         />
       )}

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -623,12 +623,10 @@ export function SpaceAgentList() {
         toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
       };
       if (longHorizonAgent) {
-        if (longHorizonAgent.status !== 'active') {
-          longHorizonAgent = await spaceStore.updateLongHorizonAgent(longHorizonAgent.id, {
-            ...agentConfig,
-            status: 'active',
-          });
-        }
+        longHorizonAgent = await spaceStore.updateLongHorizonAgent(longHorizonAgent.id, {
+          ...agentConfig,
+          status: 'active',
+        });
       } else {
         longHorizonAgent = await spaceStore.createLongHorizonAgent({
           id: agent.id,

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -602,11 +602,13 @@ export function SpaceAgentList() {
     if (!longHorizonAgent) {
       try {
         longHorizonAgent = await spaceStore.createLongHorizonAgent({
+          id: agent.id,
           handle: agent.handle,
           displayName: agent.name,
           instructions: agent.customPrompt ?? agent.description ?? '',
           model: agent.model ?? null,
           thinkingLevel: agent.thinkingLevel ?? null,
+          toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
         });
       } catch (err) {
         toast.error(

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -465,16 +465,28 @@ export function SpaceAgentList() {
     .sort()
     .join('|');
   const longHorizonAgentResolver = useMemo(() => {
-    const byId = new Map<string, SpaceLongHorizonAgent>();
-    const byHandle = new Map<string, SpaceLongHorizonAgent>();
+    const activeById = new Map<string, SpaceLongHorizonAgent>();
+    const activeByHandle = new Map<string, SpaceLongHorizonAgent>();
+    const inactiveById = new Map<string, SpaceLongHorizonAgent>();
+    const inactiveByHandle = new Map<string, SpaceLongHorizonAgent>();
     for (const agent of longHorizonAgents) {
-      if (agent.status !== 'active') continue;
-      byId.set(agent.id, agent);
-      byHandle.set(agent.handle, agent);
+      if (agent.status === 'active') {
+        activeById.set(agent.id, agent);
+        activeByHandle.set(agent.handle, agent);
+      } else {
+        inactiveById.set(agent.id, agent);
+        inactiveByHandle.set(agent.handle, agent);
+      }
     }
     return (agent: SpaceAgent) => {
       const handle = isCoordinatorAgent(agent) ? 'coordinator' : agent.handle;
-      return byId.get(agent.id) ?? byHandle.get(handle) ?? null;
+      return (
+        activeById.get(agent.id) ??
+        activeByHandle.get(handle) ??
+        inactiveById.get(agent.id) ??
+        inactiveByHandle.get(handle) ??
+        null
+      );
     };
   }, [longHorizonAgents]);
   const longHorizonAgentIds = longHorizonAgents
@@ -599,25 +611,35 @@ export function SpaceAgentList() {
 
   const handleEditSubscriptions = async (agent: SpaceAgent) => {
     let longHorizonAgent = longHorizonAgentResolver(agent);
-    if (!longHorizonAgent) {
-      try {
+    try {
+      const agentConfig = {
+        handle: isCoordinatorAgent(agent) ? 'coordinator' : agent.handle,
+        displayName: agent.name,
+        instructions: agent.customPrompt ?? '',
+        model: agent.model ?? null,
+        thinkingLevel: agent.thinkingLevel ?? null,
+        provider: agent.provider ?? null,
+        settingSources: agent.settingSources ?? null,
+        toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
+      };
+      if (longHorizonAgent) {
+        if (longHorizonAgent.status !== 'active') {
+          longHorizonAgent = await spaceStore.updateLongHorizonAgent(longHorizonAgent.id, {
+            ...agentConfig,
+            status: 'active',
+          });
+        }
+      } else {
         longHorizonAgent = await spaceStore.createLongHorizonAgent({
           id: agent.id,
-          handle: agent.handle,
-          displayName: agent.name,
-          instructions: agent.customPrompt ?? '',
-          model: agent.model ?? null,
-          thinkingLevel: agent.thinkingLevel ?? null,
-          provider: agent.provider ?? null,
-          settingSources: agent.settingSources ?? null,
-          toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
+          ...agentConfig,
         });
-      } catch (err) {
-        toast.error(
-          `Failed to create long-horizon agent row: ${err instanceof Error ? err.message : String(err)}`
-        );
-        return;
       }
+    } catch (err) {
+      toast.error(
+        `Failed to prepare long-horizon agent row: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return;
     }
     setSubscriptionEditorAgent(agent);
     setSubscriptionEditorLongHorizonAgent(longHorizonAgent);

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -462,10 +462,17 @@ export function SpaceAgentList() {
     .map((a) => `${a.id}:${a.updatedAt}`)
     .sort()
     .join('|');
-  const longHorizonAgentById = useMemo(() => {
-    const map = new Map<string, SpaceLongHorizonAgent>();
-    for (const agent of longHorizonAgents) map.set(agent.id, agent);
-    return map;
+  const longHorizonAgentResolver = useMemo(() => {
+    const byId = new Map<string, SpaceLongHorizonAgent>();
+    const byHandle = new Map<string, SpaceLongHorizonAgent>();
+    for (const agent of longHorizonAgents) {
+      byId.set(agent.id, agent);
+      byHandle.set(agent.handle, agent);
+    }
+    return (agent: SpaceAgent) => {
+      const handle = isCoordinatorAgent(agent) ? 'coordinator' : agent.handle;
+      return byId.get(agent.id) ?? byHandle.get(handle) ?? null;
+    };
   }, [longHorizonAgents]);
   const longHorizonAgentIds = longHorizonAgents
     .map((agent) => agent.id)
@@ -588,7 +595,7 @@ export function SpaceAgentList() {
   };
 
   const handleEditSubscriptions = (agent: SpaceAgent) => {
-    const longHorizonAgent = longHorizonAgentById.get(agent.id);
+    const longHorizonAgent = longHorizonAgentResolver(agent);
     if (!longHorizonAgent) {
       toast.error('No long-horizon agent row found for this agent.');
       return;
@@ -638,7 +645,7 @@ export function SpaceAgentList() {
 
   const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
   const selectedLongHorizonAgent = subscriptionEditorAgent
-    ? longHorizonAgentById.get(subscriptionEditorAgent.id)
+    ? longHorizonAgentResolver(subscriptionEditorAgent)
     : null;
   const totalEventSubscriptions = Object.values(subscriptionsByAgentId).reduce(
     (total, subscriptions) => total + subscriptions.filter((s) => s.status === 'active').length,
@@ -751,7 +758,7 @@ export function SpaceAgentList() {
           ) : (
             <div class="space-y-2">
               {visibleAgents.map((agent) => {
-                const longHorizonAgent = longHorizonAgentById.get(agent.id);
+                const longHorizonAgent = longHorizonAgentResolver(agent);
                 const subscriptions = longHorizonAgent
                   ? (subscriptionsByAgentId[longHorizonAgent.id] ?? [])
                   : [];

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -19,11 +19,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, waitFor, cleanup, screen } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
+import type { SpaceAgent, SpaceLongHorizonAgent, SpaceWorkflow } from '@neokai/shared';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
+let mockLongHorizonAgents: ReturnType<typeof signal<SpaceLongHorizonAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockGoals: ReturnType<typeof signal<any[]>>;
 let mockSchedules: ReturnType<typeof signal<any[]>>;
@@ -36,6 +37,10 @@ const {
   mockCreateAgent,
   mockUpdateAgent,
   mockListSchedules,
+  mockListLongHorizonAgentSubscriptions,
+  mockCreateLongHorizonAgentSubscription,
+  mockUpdateLongHorizonAgentSubscription,
+  mockDeleteLongHorizonAgentSubscription,
   mockOnceConnected,
   mockNavigateToSpaceGoals,
   mockNavigateToSpaceForge,
@@ -44,6 +49,10 @@ const {
   mockCreateAgent: vi.fn(),
   mockUpdateAgent: vi.fn(),
   mockListSchedules: vi.fn(),
+  mockListLongHorizonAgentSubscriptions: vi.fn(),
+  mockCreateLongHorizonAgentSubscription: vi.fn(),
+  mockUpdateLongHorizonAgentSubscription: vi.fn(),
+  mockDeleteLongHorizonAgentSubscription: vi.fn(),
   mockOnceConnected: vi.fn(),
   mockNavigateToSpaceGoals: vi.fn(),
   mockNavigateToSpaceForge: vi.fn(),
@@ -58,6 +67,7 @@ vi.mock('../../../lib/space-store', () => ({
   get spaceStore() {
     return {
       agents: mockAgents,
+      longHorizonAgents: mockLongHorizonAgents,
       workflows: mockWorkflows,
       goals: mockGoals,
       schedules: mockSchedules,
@@ -68,6 +78,10 @@ vi.mock('../../../lib/space-store', () => ({
       createAgent: mockCreateAgent,
       updateAgent: mockUpdateAgent,
       listSchedules: mockListSchedules,
+      listLongHorizonAgentSubscriptions: mockListLongHorizonAgentSubscriptions,
+      createLongHorizonAgentSubscription: mockCreateLongHorizonAgentSubscription,
+      updateLongHorizonAgentSubscription: mockUpdateLongHorizonAgentSubscription,
+      deleteLongHorizonAgentSubscription: mockDeleteLongHorizonAgentSubscription,
     };
   },
 }));
@@ -217,6 +231,7 @@ vi.mock('../../ui/Modal', () => ({
 
 // Initialize signals before import
 mockAgents = signal<SpaceAgent[]>([]);
+mockLongHorizonAgents = signal<SpaceLongHorizonAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockGoals = signal<any[]>([]);
 mockSchedules = signal<any[]>([]);
@@ -248,6 +263,28 @@ function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
   };
 }
 
+function makeLongHorizonAgent(
+  overrides: Partial<SpaceLongHorizonAgent> = {}
+): SpaceLongHorizonAgent {
+  return {
+    id: 'lh-agent-1',
+    spaceId: 'space-1',
+    handle: 'my-coder',
+    displayName: 'My Coder',
+    templateKey: null,
+    status: 'active',
+    sessionId: null,
+    instructions: '',
+    autonomyLevel: null,
+    model: null,
+    thinkingLevel: null,
+    toolPermissions: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
 function makeWorkflow(agentId: string): SpaceWorkflow {
   return {
     id: 'wf-1',
@@ -269,6 +306,7 @@ describe('SpaceAgentList', () => {
   beforeEach(() => {
     cleanup();
     mockAgents.value = [];
+    mockLongHorizonAgents.value = [];
     mockWorkflows.value = [];
     mockGoals.value = [];
     mockSchedules.value = [];
@@ -279,6 +317,11 @@ describe('SpaceAgentList', () => {
     mockUpdateAgent.mockReset();
     mockListSchedules.mockReset();
     mockListSchedules.mockResolvedValue([]);
+    mockListLongHorizonAgentSubscriptions.mockReset();
+    mockListLongHorizonAgentSubscriptions.mockResolvedValue([]);
+    mockCreateLongHorizonAgentSubscription.mockReset();
+    mockUpdateLongHorizonAgentSubscription.mockReset();
+    mockDeleteLongHorizonAgentSubscription.mockReset();
     mockOnceConnected.mockReset();
     mockOnceConnected.mockReturnValue(() => {});
     mockNavigateToSpaceGoals.mockReset();
@@ -451,7 +494,7 @@ describe('SpaceAgentList', () => {
     expect(container.textContent).toContain('reminders');
     expect(container.textContent).toContain('event subscriptions');
     expect(container.textContent).toContain('Per-Agent Forge scope policy coming soon.');
-    expect(container.textContent).toContain('Event subscriptions coming soon.');
+    expect(container.textContent).toContain('0 active event subscriptions');
     expect(queryByLabelText('Forge scope filter')).toBeNull();
     expect(queryByLabelText('Event subscription pattern')).toBeNull();
   });
@@ -472,6 +515,33 @@ describe('SpaceAgentList', () => {
     fireEvent.click(getByLabelText('Edit Coder'));
     expect(getByTestId('editor-mode').textContent).toBe('edit');
     expect(getByTestId('editor-agent-name').textContent).toBe('Coder');
+  });
+
+  it('opens event subscriptions using the matching long-horizon agent handle', async () => {
+    mockAgents.value = [
+      makeAgent({
+        id: 'space-agent-coordinator',
+        name: 'Coordinator',
+        handle: 'coordinator',
+        templateName: 'Coordinator',
+      }),
+    ];
+    mockLongHorizonAgents.value = [
+      makeLongHorizonAgent({
+        id: 'space-lh-agent:coordinator:space-1',
+        handle: 'coordinator',
+        displayName: 'Coordinator',
+        templateKey: 'coordinator.default',
+      }),
+    ];
+
+    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+    fireEvent.click(getByLabelText('Edit event subscriptions for Coordinator'));
+
+    expect(await findByText('Event subscriptions')).toBeTruthy();
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
+      'space-lh-agent:coordinator:space-1'
+    );
   });
 
   it('closes editor when cancel is clicked', () => {

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -281,6 +281,8 @@ function makeLongHorizonAgent(
     autonomyLevel: null,
     model: null,
     thinkingLevel: null,
+    provider: null,
+    settingSources: null,
     toolPermissions: {},
     createdAt: Date.now(),
     updatedAt: Date.now(),
@@ -572,6 +574,8 @@ describe('SpaceAgentList', () => {
         name: 'Coder',
         handle: 'coder',
         tools: ['Read', 'Edit'],
+        provider: 'openrouter',
+        settingSources: ['project'],
       }),
     ];
     mockCreateLongHorizonAgent.mockResolvedValue(
@@ -587,6 +591,8 @@ describe('SpaceAgentList', () => {
         id: 'space-agent-coder',
         handle: 'coder',
         displayName: 'Coder',
+        provider: 'openrouter',
+        settingSources: ['project'],
         toolPermissions: { tools: ['Read', 'Edit'] },
       })
     );

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -549,6 +549,22 @@ describe('SpaceAgentList', () => {
     );
   });
 
+  it('ignores archived long-horizon rows when opening subscriptions', async () => {
+    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
+    mockLongHorizonAgents.value = [
+      makeLongHorizonAgent({ id: 'archived-coder', handle: 'coder', status: 'archived' }),
+    ];
+    mockCreateLongHorizonAgent.mockResolvedValue(
+      makeLongHorizonAgent({ id: 'active-coder', handle: 'coder', displayName: 'Coder' })
+    );
+
+    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
+
+    expect(await findByText('Event subscriptions')).toBeTruthy();
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('active-coder');
+  });
+
   it('creates a long-horizon row before opening subscriptions for new specialists', async () => {
     mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
     mockCreateLongHorizonAgent.mockResolvedValue(

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -39,6 +39,7 @@ const {
   mockListSchedules,
   mockListLongHorizonAgentSubscriptions,
   mockCreateLongHorizonAgent,
+  mockUpdateLongHorizonAgent,
   mockCreateLongHorizonAgentSubscription,
   mockUpdateLongHorizonAgentSubscription,
   mockDeleteLongHorizonAgentSubscription,
@@ -52,6 +53,7 @@ const {
   mockListSchedules: vi.fn(),
   mockListLongHorizonAgentSubscriptions: vi.fn(),
   mockCreateLongHorizonAgent: vi.fn(),
+  mockUpdateLongHorizonAgent: vi.fn(),
   mockCreateLongHorizonAgentSubscription: vi.fn(),
   mockUpdateLongHorizonAgentSubscription: vi.fn(),
   mockDeleteLongHorizonAgentSubscription: vi.fn(),
@@ -81,6 +83,7 @@ vi.mock('../../../lib/space-store', () => ({
       updateAgent: mockUpdateAgent,
       listSchedules: mockListSchedules,
       createLongHorizonAgent: mockCreateLongHorizonAgent,
+      updateLongHorizonAgent: mockUpdateLongHorizonAgent,
       listLongHorizonAgentSubscriptions: mockListLongHorizonAgentSubscriptions,
       createLongHorizonAgentSubscription: mockCreateLongHorizonAgentSubscription,
       updateLongHorizonAgentSubscription: mockUpdateLongHorizonAgentSubscription,
@@ -326,6 +329,10 @@ describe('SpaceAgentList', () => {
     mockListLongHorizonAgentSubscriptions.mockResolvedValue([]);
     mockCreateLongHorizonAgent.mockReset();
     mockCreateLongHorizonAgent.mockImplementation(async (params) => makeLongHorizonAgent(params));
+    mockUpdateLongHorizonAgent.mockReset();
+    mockUpdateLongHorizonAgent.mockImplementation(async (id, params) =>
+      makeLongHorizonAgent({ id, ...params })
+    );
     mockCreateLongHorizonAgentSubscription.mockReset();
     mockUpdateLongHorizonAgentSubscription.mockReset();
     mockDeleteLongHorizonAgentSubscription.mockReset();
@@ -551,20 +558,25 @@ describe('SpaceAgentList', () => {
     );
   });
 
-  it('ignores archived long-horizon rows when opening subscriptions', async () => {
+  it('reactivates inactive long-horizon rows when opening subscriptions', async () => {
     mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
     mockLongHorizonAgents.value = [
-      makeLongHorizonAgent({ id: 'archived-coder', handle: 'coder', status: 'archived' }),
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' }),
     ];
-    mockCreateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'active-coder', handle: 'coder', displayName: 'Coder' })
+    mockUpdateLongHorizonAgent.mockResolvedValue(
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' })
     );
 
     const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
     fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
 
     expect(await findByText('Event subscriptions')).toBeTruthy();
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('active-coder');
+    expect(mockCreateLongHorizonAgent).not.toHaveBeenCalled();
+    expect(mockUpdateLongHorizonAgent).toHaveBeenCalledWith(
+      'space-agent-coder',
+      expect.objectContaining({ status: 'active' })
+    );
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
   });
 
   it('creates a long-horizon row before opening subscriptions for new specialists', async () => {

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -531,7 +531,7 @@ describe('SpaceAgentList', () => {
     expect(getByTestId('editor-agent-name').textContent).toBe('Coder');
   });
 
-  it('opens event subscriptions using the matching long-horizon agent handle', async () => {
+  it('opens event subscriptions using the seeded coordinator long-horizon agent id', async () => {
     mockAgents.value = [
       makeAgent({
         id: 'space-agent-coordinator',
@@ -578,12 +578,13 @@ describe('SpaceAgentList', () => {
     expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
   });
 
-  it('reactivates inactive long-horizon rows when opening subscriptions', async () => {
+  it('preserves inactive long-horizon rows when opening subscriptions for paused agents', async () => {
     mockAgents.value = [
       makeAgent({
         id: 'space-agent-coder',
         name: 'Coder',
         handle: 'coder',
+        status: 'paused',
         customPrompt: 'Use Coder prompt.',
         model: 'claude-sonnet-4-6',
         thinkingLevel: 'medium',
@@ -596,7 +597,7 @@ describe('SpaceAgentList', () => {
       makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' }),
     ];
     mockUpdateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' })
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' })
     );
 
     const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
@@ -615,7 +616,7 @@ describe('SpaceAgentList', () => {
         provider: 'openrouter',
         settingSources: ['project'],
         toolPermissions: { tools: ['Read', 'Edit'] },
-        status: 'active',
+        status: 'paused',
       })
     );
     expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
@@ -627,6 +628,7 @@ describe('SpaceAgentList', () => {
         id: 'space-agent-coder',
         name: 'Coder',
         handle: 'coder',
+        status: 'paused',
         tools: ['Read', 'Edit'],
         provider: 'openrouter',
         settingSources: ['project'],
@@ -635,7 +637,12 @@ describe('SpaceAgentList', () => {
       }),
     ];
     mockCreateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', displayName: 'Coder' })
+      makeLongHorizonAgent({
+        id: 'space-agent-coder',
+        handle: 'coder',
+        displayName: 'Coder',
+        status: 'paused',
+      })
     );
 
     const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
@@ -651,6 +658,7 @@ describe('SpaceAgentList', () => {
         provider: 'openrouter',
         settingSources: ['project'],
         toolPermissions: { tools: ['Read', 'Edit'] },
+        status: 'paused',
       })
     );
     expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -38,6 +38,7 @@ const {
   mockUpdateAgent,
   mockListSchedules,
   mockListLongHorizonAgentSubscriptions,
+  mockCreateLongHorizonAgent,
   mockCreateLongHorizonAgentSubscription,
   mockUpdateLongHorizonAgentSubscription,
   mockDeleteLongHorizonAgentSubscription,
@@ -50,6 +51,7 @@ const {
   mockUpdateAgent: vi.fn(),
   mockListSchedules: vi.fn(),
   mockListLongHorizonAgentSubscriptions: vi.fn(),
+  mockCreateLongHorizonAgent: vi.fn(),
   mockCreateLongHorizonAgentSubscription: vi.fn(),
   mockUpdateLongHorizonAgentSubscription: vi.fn(),
   mockDeleteLongHorizonAgentSubscription: vi.fn(),
@@ -78,6 +80,7 @@ vi.mock('../../../lib/space-store', () => ({
       createAgent: mockCreateAgent,
       updateAgent: mockUpdateAgent,
       listSchedules: mockListSchedules,
+      createLongHorizonAgent: mockCreateLongHorizonAgent,
       listLongHorizonAgentSubscriptions: mockListLongHorizonAgentSubscriptions,
       createLongHorizonAgentSubscription: mockCreateLongHorizonAgentSubscription,
       updateLongHorizonAgentSubscription: mockUpdateLongHorizonAgentSubscription,
@@ -319,6 +322,8 @@ describe('SpaceAgentList', () => {
     mockListSchedules.mockResolvedValue([]);
     mockListLongHorizonAgentSubscriptions.mockReset();
     mockListLongHorizonAgentSubscriptions.mockResolvedValue([]);
+    mockCreateLongHorizonAgent.mockReset();
+    mockCreateLongHorizonAgent.mockImplementation(async (params) => makeLongHorizonAgent(params));
     mockCreateLongHorizonAgentSubscription.mockReset();
     mockUpdateLongHorizonAgentSubscription.mockReset();
     mockDeleteLongHorizonAgentSubscription.mockReset();
@@ -542,6 +547,22 @@ describe('SpaceAgentList', () => {
     expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
       'space-lh-agent:coordinator:space-1'
     );
+  });
+
+  it('creates a long-horizon row before opening subscriptions for new specialists', async () => {
+    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
+    mockCreateLongHorizonAgent.mockResolvedValue(
+      makeLongHorizonAgent({ id: 'lh-coder', handle: 'coder', displayName: 'Coder' })
+    );
+
+    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
+
+    expect(await findByText('Event subscriptions')).toBeTruthy();
+    expect(mockCreateLongHorizonAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ handle: 'coder', displayName: 'Coder' })
+    );
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('lh-coder');
   });
 
   it('closes editor when cancel is clicked', () => {

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -576,6 +576,8 @@ describe('SpaceAgentList', () => {
         tools: ['Read', 'Edit'],
         provider: 'openrouter',
         settingSources: ['project'],
+        description: 'Short UI summary only',
+        customPrompt: 'Use Coder prompt.',
       }),
     ];
     mockCreateLongHorizonAgent.mockResolvedValue(
@@ -591,6 +593,7 @@ describe('SpaceAgentList', () => {
         id: 'space-agent-coder',
         handle: 'coder',
         displayName: 'Coder',
+        instructions: 'Use Coder prompt.',
         provider: 'openrouter',
         settingSources: ['project'],
         toolPermissions: { tools: ['Read', 'Edit'] },

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -558,6 +558,26 @@ describe('SpaceAgentList', () => {
     );
   });
 
+  it('refreshes active long-horizon rows when opening subscriptions', async () => {
+    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
+    mockLongHorizonAgents.value = [
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' }),
+    ];
+    mockUpdateLongHorizonAgent.mockResolvedValue(
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' })
+    );
+
+    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
+
+    expect(await findByText('Event subscriptions')).toBeTruthy();
+    expect(mockUpdateLongHorizonAgent).toHaveBeenCalledWith(
+      'space-agent-coder',
+      expect.objectContaining({ status: 'active' })
+    );
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
+  });
+
   it('reactivates inactive long-horizon rows when opening subscriptions', async () => {
     mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
     mockLongHorizonAgents.value = [

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -579,7 +579,19 @@ describe('SpaceAgentList', () => {
   });
 
   it('reactivates inactive long-horizon rows when opening subscriptions', async () => {
-    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
+    mockAgents.value = [
+      makeAgent({
+        id: 'space-agent-coder',
+        name: 'Coder',
+        handle: 'coder',
+        customPrompt: 'Use Coder prompt.',
+        model: 'claude-sonnet-4-6',
+        thinkingLevel: 'medium',
+        provider: 'openrouter',
+        settingSources: ['project'],
+        tools: ['Read', 'Edit'],
+      }),
+    ];
     mockLongHorizonAgents.value = [
       makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' }),
     ];
@@ -594,7 +606,17 @@ describe('SpaceAgentList', () => {
     expect(mockCreateLongHorizonAgent).not.toHaveBeenCalled();
     expect(mockUpdateLongHorizonAgent).toHaveBeenCalledWith(
       'space-agent-coder',
-      expect.objectContaining({ status: 'active' })
+      expect.objectContaining({
+        handle: 'coder',
+        displayName: 'Coder',
+        instructions: 'Use Coder prompt.',
+        model: 'claude-sonnet-4-6',
+        thinkingLevel: 'medium',
+        provider: 'openrouter',
+        settingSources: ['project'],
+        toolPermissions: { tools: ['Read', 'Edit'] },
+        status: 'active',
+      })
     );
     expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
   });

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -566,9 +566,16 @@ describe('SpaceAgentList', () => {
   });
 
   it('creates a long-horizon row before opening subscriptions for new specialists', async () => {
-    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
+    mockAgents.value = [
+      makeAgent({
+        id: 'space-agent-coder',
+        name: 'Coder',
+        handle: 'coder',
+        tools: ['Read', 'Edit'],
+      }),
+    ];
     mockCreateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'lh-coder', handle: 'coder', displayName: 'Coder' })
+      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', displayName: 'Coder' })
     );
 
     const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
@@ -576,9 +583,14 @@ describe('SpaceAgentList', () => {
 
     expect(await findByText('Event subscriptions')).toBeTruthy();
     expect(mockCreateLongHorizonAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ handle: 'coder', displayName: 'Coder' })
+      expect.objectContaining({
+        id: 'space-agent-coder',
+        handle: 'coder',
+        displayName: 'Coder',
+        toolPermissions: { tools: ['Read', 'Edit'] },
+      })
     );
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('lh-coder');
+    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
   });
 
   it('closes editor when cancel is clicked', () => {

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -270,6 +270,39 @@ function makeMockHub() {
       }
       if (method === 'spaceAgent.promoteSession') return { agent: makeAgent('promoted-agent') };
       if (method === 'spaceAgent.update') return { agent: makeAgent('a1') };
+      if (method === 'spaceLongHorizonAgent.list') return { agents: [] };
+      if (method === 'spaceLongHorizonAgent.listBuiltInTemplates') return { templates: [] };
+      if (method === 'spaceLongHorizonAgent.listSubscriptions') return { subscriptions: [] };
+      if (method === 'spaceLongHorizonAgent.createSubscription') {
+        return {
+          subscription: {
+            id: 'sub-1',
+            spaceId: params?.spaceId,
+            agentId: params?.agentId,
+            source: params?.source,
+            topic: params?.topic,
+            filter: params?.filter ?? {},
+            status: params?.status ?? 'active',
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        };
+      }
+      if (method === 'spaceLongHorizonAgent.updateSubscription') {
+        return {
+          subscription: {
+            id: params?.subscriptionId,
+            spaceId: params?.spaceId,
+            agentId: 'lh-1',
+            source: 'github',
+            topic: 'github/*/*/pull_request/*',
+            filter: {},
+            status: params?.status ?? 'active',
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        };
+      }
       // spaceWorkflow handlers return wrapped { workflow }
       if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
       if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
@@ -1335,6 +1368,41 @@ describe('SpaceStore — CRUD methods', () => {
 
     expect(mockHub.request).toHaveBeenCalledWith('spaceAgent.delete', {
       id: 'a1',
+      spaceId: 'space-1',
+    });
+  });
+
+  it('long-horizon subscription methods call RPC with current space', async () => {
+    await spaceStore.selectSpace('space-1');
+
+    await spaceStore.listLongHorizonAgentSubscriptions('lh-1');
+    await spaceStore.createLongHorizonAgentSubscription({
+      agentId: 'lh-1',
+      source: 'github',
+      topic: 'github/*/*/pull_request/*',
+      filter: { label: 'PRs' },
+    });
+    await spaceStore.updateLongHorizonAgentSubscription('sub-1', { status: 'paused' });
+    await spaceStore.deleteLongHorizonAgentSubscription('sub-1');
+
+    expect(mockHub.request).toHaveBeenCalledWith('spaceLongHorizonAgent.listSubscriptions', {
+      agentId: 'lh-1',
+      spaceId: 'space-1',
+    });
+    expect(mockHub.request).toHaveBeenCalledWith('spaceLongHorizonAgent.createSubscription', {
+      agentId: 'lh-1',
+      source: 'github',
+      topic: 'github/*/*/pull_request/*',
+      filter: { label: 'PRs' },
+      spaceId: 'space-1',
+    });
+    expect(mockHub.request).toHaveBeenCalledWith('spaceLongHorizonAgent.updateSubscription', {
+      subscriptionId: 'sub-1',
+      spaceId: 'space-1',
+      status: 'paused',
+    });
+    expect(mockHub.request).toHaveBeenCalledWith('spaceLongHorizonAgent.deleteSubscription', {
+      subscriptionId: 'sub-1',
       spaceId: 'space-1',
     });
   });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2144,6 +2144,7 @@ class SpaceStore {
   // ========================================
 
   async createLongHorizonAgent(params: {
+    id?: string;
     handle: string;
     displayName?: string;
     templateKey?: string | null;
@@ -2151,6 +2152,7 @@ class SpaceStore {
     autonomyLevel?: number | null;
     model?: string | null;
     thinkingLevel?: string | null;
+    toolPermissions?: Record<string, unknown>;
   }): Promise<SpaceLongHorizonAgent> {
     const spaceId = this.spaceId.value;
     if (!spaceId) throw new Error('No space selected');

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -29,6 +29,7 @@ import type {
   CreateSpaceTaskParams,
   CreateSpaceWorkflowParams,
   CreateSpaceLongHorizonAgentReminderParams,
+  CreateSpaceLongHorizonAgentSubscriptionParams,
   LiveQueryDeltaEvent,
   LiveQuerySnapshotEvent,
   MessageImage,
@@ -43,6 +44,7 @@ import type {
   SpaceGoalEvent,
   SpaceGoalListParams,
   SpaceLongHorizonAgent,
+  SpaceLongHorizonAgentEventSubscription,
   SpaceLongHorizonAgentReminder,
   SpaceLongHorizonAgentTemplate,
   SpaceTask,
@@ -57,6 +59,7 @@ import type {
   TaskScheduleTriggerType,
   UpdateSpaceAgentParams,
   UpdateSpaceLongHorizonAgentParams,
+  UpdateSpaceLongHorizonAgentSubscriptionParams,
   UpdateSpaceGoalParams,
   UpdateSpaceParams,
   UpdateSpaceTaskParams,
@@ -2216,6 +2219,54 @@ class SpaceStore {
     const hub = connectionManager.getHubIfConnected();
     if (!hub) throw new Error('Not connected');
     await hub.request('spaceLongHorizonAgent.deleteReminder', { reminderId });
+  }
+
+  async listLongHorizonAgentSubscriptions(
+    agentId: string
+  ): Promise<SpaceLongHorizonAgentEventSubscription[]> {
+    const spaceId = this.spaceId.value;
+    if (!spaceId) throw new Error('No space selected');
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) throw new Error('Not connected');
+    const { subscriptions } = await hub.request<{
+      subscriptions: SpaceLongHorizonAgentEventSubscription[];
+    }>('spaceLongHorizonAgent.listSubscriptions', { agentId, spaceId });
+    return subscriptions ?? [];
+  }
+
+  async createLongHorizonAgentSubscription(
+    params: Omit<CreateSpaceLongHorizonAgentSubscriptionParams, 'spaceId'>
+  ): Promise<SpaceLongHorizonAgentEventSubscription> {
+    const spaceId = this.spaceId.value;
+    if (!spaceId) throw new Error('No space selected');
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) throw new Error('Not connected');
+    const { subscription } = await hub.request<{
+      subscription: SpaceLongHorizonAgentEventSubscription;
+    }>('spaceLongHorizonAgent.createSubscription', { spaceId, ...params });
+    return subscription;
+  }
+
+  async updateLongHorizonAgentSubscription(
+    subscriptionId: string,
+    params: UpdateSpaceLongHorizonAgentSubscriptionParams
+  ): Promise<SpaceLongHorizonAgentEventSubscription> {
+    const spaceId = this.spaceId.value;
+    if (!spaceId) throw new Error('No space selected');
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) throw new Error('Not connected');
+    const { subscription } = await hub.request<{
+      subscription: SpaceLongHorizonAgentEventSubscription;
+    }>('spaceLongHorizonAgent.updateSubscription', { subscriptionId, spaceId, ...params });
+    return subscription;
+  }
+
+  async deleteLongHorizonAgentSubscription(subscriptionId: string): Promise<void> {
+    const spaceId = this.spaceId.value;
+    if (!spaceId) throw new Error('No space selected');
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) throw new Error('Not connected');
+    await hub.request('spaceLongHorizonAgent.deleteSubscription', { subscriptionId, spaceId });
   }
 
   // ========================================

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2152,6 +2152,8 @@ class SpaceStore {
     autonomyLevel?: number | null;
     model?: string | null;
     thinkingLevel?: string | null;
+    provider?: string | null;
+    settingSources?: SpaceLongHorizonAgent['settingSources'];
     toolPermissions?: Record<string, unknown>;
   }): Promise<SpaceLongHorizonAgent> {
     const spaceId = this.spaceId.value;

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2155,6 +2155,7 @@ class SpaceStore {
     provider?: string | null;
     settingSources?: SpaceLongHorizonAgent['settingSources'];
     toolPermissions?: Record<string, unknown>;
+    status?: SpaceLongHorizonAgent['status'];
   }): Promise<SpaceLongHorizonAgent> {
     const spaceId = this.spaceId.value;
     if (!spaceId) throw new Error('No space selected');


### PR DESCRIPTION
Adds per-agent event subscription management from the Space agents page.

Summary:
- Adds long-horizon agent subscription RPC CRUD wired to runtime refresh/removal.
- Shows subscription counts/topics on agent cards and adds a drawer for add/pause/resume/delete.
- Adds store and handler tests for subscription RPC flows.

Tested:
- bun test tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
- bunx vitest run src/lib/__tests__/space-store.test.ts
- bun run check