### PR TITLE
Fix task thread loading after reconnect

### DIFF
--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -13,7 +13,7 @@
  * renderer that genuinely needs the unbounded history (e.g. the verbose feed).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, renderHook } from '@testing-library/preact';
 
 // ---------------------------------------------------------------------------
@@ -75,6 +75,7 @@ import { useSpaceTaskMessages } from '../useSpaceTaskMessages';
 
 describe('useSpaceTaskMessages', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     mockRequest.mockReset();
     mockOnEvent.mockReset();
     mockGetHub.mockReset();
@@ -89,6 +90,10 @@ describe('useSpaceTaskMessages', () => {
         eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
       };
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('subscribes to compact messages and active-turn queries by default', () => {
@@ -294,6 +299,61 @@ describe('useSpaceTaskMessages', () => {
         });
       });
       expect(result.current.isLoading).toBe(false);
+    });
+
+    it('retries a reconnect subscribe when the server acks without a snapshot', async () => {
+      vi.useFakeTimers();
+      let connectionHandler: ((state: string) => void) | null = null;
+      mockGetHub.mockReturnValue({
+        request: mockRequest,
+        onConnection: vi.fn((handler: (state: string) => void) => {
+          connectionHandler = handler;
+          return () => {};
+        }),
+      });
+
+      const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+      const firstSubId = lastMessageSubscribeSubId();
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: firstSubId,
+          rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+          version: 1,
+        });
+      });
+
+      act(() => {
+        connectionHandler?.('connected');
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(subscribeCalls()).toHaveLength(4);
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+        await Promise.resolve();
+      });
+
+      expect(subscribeCalls()).toHaveLength(6);
+
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: firstSubId,
+          rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+          version: 2,
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+        await Promise.resolve();
+      });
+
+      expect(subscribeCalls()).toHaveLength(6);
     });
   });
 });

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -355,5 +355,54 @@ describe('useSpaceTaskMessages', () => {
 
       expect(subscribeCalls()).toHaveLength(6);
     });
+
+    it('releases loading after reconnect snapshot retries are exhausted', async () => {
+      vi.useFakeTimers();
+      let connectionHandler: ((state: string) => void) | null = null;
+      mockGetHub.mockReturnValue({
+        request: mockRequest,
+        onConnection: vi.fn((handler: (state: string) => void) => {
+          connectionHandler = handler;
+          return () => {};
+        }),
+      });
+
+      const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+      const firstSubId = lastMessageSubscribeSubId();
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: firstSubId,
+          rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+          version: 1,
+        });
+      });
+
+      act(() => {
+        connectionHandler?.('connected');
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      for (let i = 0; i < 5; i += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          vi.advanceTimersByTime(2000);
+          await Promise.resolve();
+        });
+      }
+
+      expect(subscribeCalls()).toHaveLength(12);
+      expect(result.current.isLoading).toBe(false);
+
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+        await Promise.resolve();
+      });
+
+      expect(subscribeCalls()).toHaveLength(12);
+    });
   });
 });

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -75,6 +75,7 @@ function nextActiveTurnSubId(taskId: string): string {
 }
 
 const SNAPSHOT_RETRY_DELAY_MS = 2000;
+const MAX_SNAPSHOT_RETRIES = 5;
 
 function sortRows(rows: SpaceTaskThreadMessageRow[]): SpaceTaskThreadMessageRow[] {
   return [...rows].sort((a, b) => {
@@ -179,6 +180,7 @@ export function useSpaceTaskMessages(
     activeTurnSubIdRef.current = shouldSubscribeActiveTurn ? activeTurnSubscriptionId : null;
     const snapshotRetryTimers = new Set<ReturnType<typeof setTimeout>>();
     let sawSnapshot = false;
+    let snapshotRetries = 0;
     let subscribeGeneration = 0;
     // Clear stale rows from a previous subscription synchronously. The
     // empty-state UI is still suppressed because `loadedForTaskId` is now
@@ -209,10 +211,13 @@ export function useSpaceTaskMessages(
       }
     });
 
-    const subscribe = () => {
+    const subscribe = (resetRetryCount = false) => {
       const hub = getHub();
       if (!hub) return;
       sawSnapshot = false;
+      if (resetRetryCount) {
+        snapshotRetries = 0;
+      }
       subscribeGeneration += 1;
       const generation = subscribeGeneration;
       hub
@@ -222,6 +227,13 @@ export function useSpaceTaskMessages(
           subscriptionId,
         })
         .then(() => {
+          if (snapshotRetries >= MAX_SNAPSHOT_RETRIES) {
+            if (activeSubIdRef.current === subscriptionId && !sawSnapshot) {
+              setLoadedForTaskId(taskId);
+            }
+            return;
+          }
+          snapshotRetries += 1;
           const retryTimer = setTimeout(() => {
             snapshotRetryTimers.delete(retryTimer);
             if (
@@ -261,10 +273,10 @@ export function useSpaceTaskMessages(
       if (state !== 'connected') return;
       if (activeSubIdRef.current !== subscriptionId) return;
       setLoadedForTaskId(null);
-      subscribe();
+      subscribe(true);
     });
 
-    subscribe();
+    subscribe(true);
 
     return () => {
       for (const timer of snapshotRetryTimers) clearTimeout(timer);

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -74,6 +74,8 @@ function nextActiveTurnSubId(taskId: string): string {
   return `space-task-active-turn-${taskId}-${_activeTurnSubCounter}`;
 }
 
+const SNAPSHOT_RETRY_DELAY_MS = 2000;
+
 function sortRows(rows: SpaceTaskThreadMessageRow[]): SpaceTaskThreadMessageRow[] {
   return [...rows].sort((a, b) => {
     if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
@@ -175,6 +177,9 @@ export function useSpaceTaskMessages(
     const shouldSubscribeActiveTurn = variant === 'compact';
     activeSubIdRef.current = subscriptionId;
     activeTurnSubIdRef.current = shouldSubscribeActiveTurn ? activeTurnSubscriptionId : null;
+    const snapshotRetryTimers = new Set<ReturnType<typeof setTimeout>>();
+    let sawSnapshot = false;
+    let subscribeGeneration = 0;
     // Clear stale rows from a previous subscription synchronously. The
     // empty-state UI is still suppressed because `loadedForTaskId` is now
     // out of sync with `taskId`, so consumers see the loading state.
@@ -184,6 +189,7 @@ export function useSpaceTaskMessages(
 
     const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
       if (event.subscriptionId === activeSubIdRef.current) {
+        sawSnapshot = true;
         setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
         setLoadedForTaskId(taskId);
         return;
@@ -206,11 +212,27 @@ export function useSpaceTaskMessages(
     const subscribe = () => {
       const hub = getHub();
       if (!hub) return;
+      sawSnapshot = false;
+      subscribeGeneration += 1;
+      const generation = subscribeGeneration;
       hub
         .request('liveQuery.subscribe', {
           queryName,
           params: [taskId],
           subscriptionId,
+        })
+        .then(() => {
+          const retryTimer = setTimeout(() => {
+            snapshotRetryTimers.delete(retryTimer);
+            if (
+              activeSubIdRef.current === subscriptionId &&
+              generation === subscribeGeneration &&
+              !sawSnapshot
+            ) {
+              subscribe();
+            }
+          }, SNAPSHOT_RETRY_DELAY_MS);
+          snapshotRetryTimers.add(retryTimer);
         })
         .catch(() => {
           // Release the loading gate on subscribe failure so consumers can
@@ -245,6 +267,8 @@ export function useSpaceTaskMessages(
     subscribe();
 
     return () => {
+      for (const timer of snapshotRetryTimers) clearTimeout(timer);
+      snapshotRetryTimers.clear();
       unsubSnapshot();
       unsubDelta();
       unsubReconnect?.();


### PR DESCRIPTION
Fix Space task thread recovery when a reconnect subscribe is acknowledged but no LiveQuery snapshot arrives.

Changes:
- Retry task thread LiveQuery subscription while waiting for the post-reconnect snapshot.
- Keep existing rows visible under the loading gate until the fresh snapshot lands.
- Add regression coverage for the ack-without-snapshot reconnect path.

Tests:
- cd packages/web && bunx vitest run src/hooks/__tests__/useSpaceTaskMessages.test.ts
- bun run check