### PR TITLE
fix(agent): disable SDK auto-compaction for non-Anthropic models

### DIFF
--- a/packages/daemon/src/lib/agent/context-tracker.ts
+++ b/packages/daemon/src/lib/agent/context-tracker.ts
@@ -9,12 +9,30 @@
 
 import type { ContextInfo } from '@neokai/shared';
 
+/**
+ * Default cooldown between NeoKai-triggered compactions (ms).
+ * Prevents rapid-fire /compact commands when context stays near the limit.
+ */
+const DEFAULT_COMPACTION_COOLDOWN_MS = 60_000;
+
+/**
+ * Fraction of the model's actual context window at which NeoKai triggers
+ * compaction for non-native providers.
+ */
+export const COMPACTION_THRESHOLD = 0.85;
+
 export class ContextTracker {
   /**
    * Current context info - the latest snapshot of context window usage.
    * Updated by SDKMessageHandler via `updateWithDetailedBreakdown()`.
    */
   private currentContextInfo: ContextInfo | null = null;
+
+  /**
+   * Timestamp of the last compaction trigger (ms since epoch).
+   * Used for cooldown gating.
+   */
+  private lastCompactionTriggerAt = 0;
 
   constructor(
     private sessionId: string,
@@ -48,5 +66,41 @@ export class ContextTracker {
    */
   setModel(_model: string): void {
     // Model is extracted from SDK getContextUsage() output, not tracked here.
+  }
+
+  /**
+   * Check whether the context window is full enough that NeoKai should
+   * trigger compaction for a non-native provider.
+   *
+   * Uses the *actual* model context window (from model metadata), NOT the
+   * SDK-reported capacity which may be `Number.MAX_SAFE_INTEGER` after we
+   * disabled SDK auto-compaction.
+   *
+   * Gated by a cooldown so we don't enqueue `/compact` repeatedly while the
+   * SDK is still processing a previous compaction.
+   */
+  shouldCompact(actualContextWindow: number, cooldownMs = DEFAULT_COMPACTION_COOLDOWN_MS): boolean {
+    const info = this.currentContextInfo;
+    if (!info || actualContextWindow <= 0) {
+      return false;
+    }
+
+    const threshold = Math.floor(actualContextWindow * COMPACTION_THRESHOLD);
+    if (info.totalUsed < threshold) {
+      return false;
+    }
+
+    if (Date.now() - this.lastCompactionTriggerAt < cooldownMs) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Record that a compaction was triggered. Resets the cooldown clock.
+   */
+  markCompactionTriggered(): void {
+    this.lastCompactionTriggerAt = Date.now();
   }
 }

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -48,8 +48,6 @@ import type { Database } from '../../storage/database';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { McpEnablementRepository } from '../../storage/repositories/mcp-enablement-repository';
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
-import { getSessionModelInfo } from '../model-service.js';
-import { requireModelContextWindow } from '../providers/codex-models';
 import {
   getProviderContextManager,
   getProviderRegistry,
@@ -191,43 +189,33 @@ export function ensureAgentTools(
  * anthropic        — native Anthropic API, SDK knows all model context windows.
  * anthropic-copilot — Copilot bridge still routes to Anthropic API.
  */
-const NATIVE_CONTEXT_WINDOW_PROVIDERS = ['anthropic', 'anthropic-copilot'];
+export const NATIVE_CONTEXT_WINDOW_PROVIDER_IDS = ['anthropic', 'anthropic-copilot'];
 
 /**
  * Provider-specific SDK settings overrides.
  *
- * For the Codex bridge, looks up the model's actual context window so the
- * SDK auto-compacts at the right threshold.
- * For other non-native providers, the caller should supply the model's
- * actual contextWindow so the SDK auto-compacts at the right threshold.
+ * For native Anthropic providers the SDK already knows the correct context
+ * window and auto-compact behaviour — no override needed.
+ *
+ * For non-native providers (OpenRouter, Ollama, GLM, Codex bridge, etc.) the
+ * SDK assumes Claude's 200 k context window and auto-compacts prematurely.
+ * We disable SDK auto-compaction entirely here and let NeoKai trigger
+ * compaction at the correct threshold (see ContextTracker / SDKMessageHandler).
  */
-export function buildProviderSettings(
-  providerId: string,
-  modelId?: string,
-  contextWindow?: number
-): Options['settings'] {
-  if (providerId === 'anthropic-codex') {
-    if (!modelId) {
-      throw new Error(`Unknown Codex model auto-compact window: ${modelId ?? 'missing model'}`);
-    }
-    try {
-      const actualContextWindow = requireModelContextWindow(modelId);
-      return {
-        autoCompactWindow: actualContextWindow,
-      };
-    } catch {
-      throw new Error(`Unknown Codex model auto-compact window: ${modelId}`);
-    }
+export function buildProviderSettings(providerId: string): Options['settings'] {
+  if (NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId)) {
+    return undefined;
   }
 
-  // For non-native providers where the SDK can't discover the actual context
-  // window (OpenRouter, Ollama, GLM, etc.), pass the model's contextWindow
-  // so auto-compact triggers at the right percentage of actual capacity.
-  if (!NATIVE_CONTEXT_WINDOW_PROVIDERS.includes(providerId) && contextWindow) {
-    return { autoCompactWindow: contextWindow };
-  }
-
-  return undefined;
+  // Disable SDK auto-compaction for all non-native providers.
+  // The SDK's internal 200 k assumption causes premature compaction on
+  // models with larger context windows (1 M, 272 k, etc.).
+  // NeoKai monitors getContextUsage() and enqueues /compact when the
+  // real context window approaches its limit.
+  return {
+    autoCompactEnabled: false,
+    autoCompactWindow: Number.MAX_SAFE_INTEGER,
+  };
 }
 
 /**
@@ -367,12 +355,6 @@ export class QueryOptionsBuilder {
     // here is the effective set for this session.
     const mergedMcpServers = this.mergeMcpServers(mcpServers, mcpServersFromSkills);
 
-    // Resolve model metadata so non-native providers get the correct
-    // autoCompactWindow (the SDK defaults to 200k when it can't discover
-    // the real context window, causing premature compaction on 1M models).
-    const modelInfo = await getSessionModelInfo(this.ctx.session);
-    const autoCompactWindow = modelInfo?.contextWindow;
-
     // Build final query options
     const queryOptions: Options = {
       // ============ Model & Execution ============
@@ -457,7 +439,7 @@ export class QueryOptionsBuilder {
       // output style, CLAUDE.md content, etc.).
       settingSources:
         config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
-      settings: buildProviderSettings(providerId, config.model, autoCompactWindow),
+      settings: buildProviderSettings(providerId),
 
       // ============ Streaming ============
       includePartialMessages: config.includePartialMessages,

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -897,6 +897,9 @@ export class SDKMessageHandler {
         // providers because the SDK assumes a 200 k Claude context window.
         // We monitor usage and enqueue /compact when the real limit is approached.
         const providerId = session.config.provider;
+        if (!providerId) {
+          return;
+        }
         const isNativeProvider = NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId);
         if (
           !isNativeProvider &&

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -890,6 +890,25 @@ export class SDKMessageHandler {
           sessionId: session.id,
           contextInfo,
         });
+
+        // NeoKai-level compaction trigger for non-native providers.
+        // SDK auto-compaction is disabled in buildProviderSettings() for these
+        // providers because the SDK assumes a 200 k Claude context window.
+        // We monitor usage and enqueue /compact when the real limit is approached.
+        const providerId = session.config.provider;
+        const isNativeProvider = providerId === 'anthropic' || providerId === 'anthropic-copilot';
+        if (
+          !isNativeProvider &&
+          modelInfo?.contextWindow &&
+          contextTracker.shouldCompact(modelInfo.contextWindow)
+        ) {
+          contextTracker.markCompactionTriggered();
+          this.logger.info(
+            `Triggering compaction for session ${session.id} ` +
+              `(${contextInfo.totalUsed} / ${modelInfo.contextWindow} tokens)`
+          );
+          void this.ctx.messageQueue.enqueue('/compact', /* internal */ true);
+        }
       } catch (error) {
         this.logger.warn(`context refresh (${reason}) failed:`, error);
       } finally {

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -44,6 +44,7 @@ import { ApiErrorCircuitBreaker } from './api-error-circuit-breaker';
 import type { MessageQueue } from './message-queue';
 import type { QueryLifecycleManager } from './query-lifecycle-manager';
 import { getSessionModelInfo } from '../model-service';
+import { NATIVE_CONTEXT_WINDOW_PROVIDER_IDS } from './query-options-builder.js';
 
 /**
  * Number of SDK stream events between automatic context-usage refreshes.
@@ -896,7 +897,7 @@ export class SDKMessageHandler {
         // providers because the SDK assumes a 200 k Claude context window.
         // We monitor usage and enqueue /compact when the real limit is approached.
         const providerId = session.config.provider;
-        const isNativeProvider = providerId === 'anthropic' || providerId === 'anthropic-copilot';
+        const isNativeProvider = NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId);
         if (
           !isNativeProvider &&
           modelInfo?.contextWindow &&

--- a/packages/daemon/src/lib/providers/codex-models.ts
+++ b/packages/daemon/src/lib/providers/codex-models.ts
@@ -69,14 +69,6 @@ export function getModelContextWindow(modelId: string): number | undefined {
   return resolved ? MODEL_CONTEXT_WINDOWS[resolved] : undefined;
 }
 
-export function requireModelContextWindow(modelId: string): number {
-  const contextWindow = getModelContextWindow(modelId);
-  if (!contextWindow) {
-    throw new Error(`Unknown Codex model context window: ${modelId}`);
-  }
-  return contextWindow;
-}
-
 export function getCodexBridgeModelInfos(): ModelInfo[] {
   return (Object.keys(MODEL_CONTEXT_WINDOWS) as CodexBridgeModelId[]).map((id) => {
     const details = CODEX_MODEL_DETAILS[id];

--- a/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
@@ -98,4 +98,68 @@ describe('ContextTracker', () => {
       expect(() => tracker.setModel('claude-opus-4-6')).not.toThrow();
     });
   });
+
+  describe('shouldCompact', () => {
+    it('returns false when no context info exists', () => {
+      expect(tracker.shouldCompact(200_000)).toBe(false);
+    });
+
+    it('returns false when usage is below 85% threshold', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'gpt-4',
+        totalUsed: 100_000,
+        totalCapacity: 128_000,
+        percentUsed: 78,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompact(128_000)).toBe(false);
+    });
+
+    it('returns true when usage is at or above 85% threshold', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'gpt-4',
+        totalUsed: 109_000,
+        totalCapacity: 128_000,
+        percentUsed: 85,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompact(128_000)).toBe(true);
+    });
+
+    it('returns false when cooldown has not elapsed', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'gpt-4',
+        totalUsed: 109_000,
+        totalCapacity: 128_000,
+        percentUsed: 85,
+        breakdown: {},
+      });
+      tracker.markCompactionTriggered();
+      expect(tracker.shouldCompact(128_000, 60_000)).toBe(false);
+    });
+
+    it('returns true after cooldown elapses', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'gpt-4',
+        totalUsed: 109_000,
+        totalCapacity: 128_000,
+        percentUsed: 85,
+        breakdown: {},
+      });
+      tracker.markCompactionTriggered();
+      expect(tracker.shouldCompact(128_000, 0)).toBe(true);
+    });
+
+    it('returns false for invalid context window', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'gpt-4',
+        totalUsed: 109_000,
+        totalCapacity: 128_000,
+        percentUsed: 85,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompact(0)).toBe(false);
+      expect(tracker.shouldCompact(-1)).toBe(false);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -168,69 +168,42 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('provider settings', () => {
-    it('should use the actual context window for full-size Codex models', () => {
-      expect(buildProviderSettings('anthropic-codex', 'gpt-5.5')).toEqual({
-        autoCompactWindow: 272_000,
+    it('should disable SDK auto-compaction for Codex bridge (non-Anthropic)', () => {
+      expect(buildProviderSettings('anthropic-codex')).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
       });
-      expect(buildProviderSettings('anthropic-codex', 'gpt-5.4')).toEqual({
-        autoCompactWindow: 272_000,
-      });
-    });
-
-    it('should use the actual context window for mini Codex models', () => {
-      expect(buildProviderSettings('anthropic-codex', 'gpt-5.4-mini')).toEqual({
-        autoCompactWindow: 128_000,
-      });
-      expect(buildProviderSettings('anthropic-codex', 'gpt-5.1-codex-mini')).toEqual({
-        autoCompactWindow: 128_000,
-      });
-    });
-
-    it('should resolve Codex aliases before applying SDK auto-compaction settings', () => {
-      expect(buildProviderSettings('anthropic-codex', 'codex-latest')).toEqual({
-        autoCompactWindow: 272_000,
-      });
-      expect(buildProviderSettings('anthropic-codex', 'codex-mini')).toEqual({
-        autoCompactWindow: 128_000,
-      });
-    });
-
-    it('should fail explicitly when Codex model metadata is unknown', () => {
-      expect(() => buildProviderSettings('anthropic-codex', 'gpt-unknown')).toThrow(
-        'Unknown Codex model auto-compact window: gpt-unknown'
-      );
     });
 
     it('should not override SDK auto-compaction settings for native anthropic provider', () => {
       expect(buildProviderSettings('anthropic')).toBeUndefined();
     });
 
-    it('should not override SDK auto-compaction settings when no contextWindow is known', () => {
-      expect(buildProviderSettings('glm', 'glm-5')).toBeUndefined();
-      expect(buildProviderSettings('openrouter', 'deepseek-v4')).toBeUndefined();
-    });
-
-    it('should set autoCompactWindow for non-native providers when contextWindow is known', () => {
-      expect(buildProviderSettings('openrouter', 'deepseek-v4', 1_000_000)).toEqual({
-        autoCompactWindow: 1_000_000,
+    it('should disable SDK auto-compaction for all non-native providers', () => {
+      expect(buildProviderSettings('openrouter')).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
       });
-      expect(buildProviderSettings('glm', 'glm-5', 128_000)).toEqual({
-        autoCompactWindow: 128_000,
+      expect(buildProviderSettings('glm')).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
       });
-      expect(buildProviderSettings('ollama', 'llama3', 128_000)).toEqual({
-        autoCompactWindow: 128_000,
+      expect(buildProviderSettings('ollama')).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
+      });
+      expect(buildProviderSettings('kimi')).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
       });
     });
 
     it('should still return undefined for anthropic-copilot (native Anthropic API)', () => {
-      // anthropic-copilot routes to Anthropic API — SDK knows the context window
-      expect(
-        buildProviderSettings('anthropic-copilot', 'claude-sonnet-4.6', 200_000)
-      ).toBeUndefined();
+      expect(buildProviderSettings('anthropic-copilot')).toBeUndefined();
     });
   });
 
-  describe('auto-compact window via build()', () => {
+  describe('auto-compact settings via build()', () => {
     function registerOpenRouterProvider(): void {
       resetProviderRegistry();
       const registry = getProviderRegistry();
@@ -256,7 +229,7 @@ describe('QueryOptionsBuilder', () => {
       resetProviderRegistry();
     });
 
-    it('should set autoCompactWindow for OpenRouter 1M context model', async () => {
+    it('should disable SDK auto-compaction for OpenRouter models', async () => {
       registerOpenRouterProvider();
       setModelsCache(
         new Map([
@@ -277,45 +250,27 @@ describe('QueryOptionsBuilder', () => {
       mockSession.config.provider = 'openrouter';
       mockSession.config.model = 'deepseek-v4';
       const options = await builder.build();
-      expect(options.settings).toEqual({ autoCompactWindow: 1_000_000 });
+      expect(options.settings).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
+      });
     });
 
-    it('should set autoCompactWindow for OpenRouter model with 128k context window', async () => {
-      registerOpenRouterProvider();
-      setModelsCache(
-        new Map([
-          [
-            'global',
-            [
-              {
-                id: 'qwen-2.5-72b',
-                name: 'Qwen 2.5 72B',
-                provider: 'openrouter',
-                contextWindow: 128_000,
-                available: true,
-              },
-            ],
-          ],
-        ])
-      );
-      mockSession.config.provider = 'openrouter';
-      mockSession.config.model = 'qwen-2.5-72b';
-      const options = await builder.build();
-      expect(options.settings).toEqual({ autoCompactWindow: 128_000 });
-    });
-
-    it('should leave settings undefined for native anthropic provider', async () => {
-      // Default mockSession uses anthropic provider
-      const options = await builder.build();
-      expect(options.settings).toBeUndefined();
-    });
-
-    it('should leave settings undefined when model context window is unknown', async () => {
+    it('should disable SDK auto-compaction for OpenRouter even when model is unknown', async () => {
       registerOpenRouterProvider();
       // Empty cache — model not found
       setModelsCache(new Map());
       mockSession.config.provider = 'openrouter';
       mockSession.config.model = 'unknown-model';
+      const options = await builder.build();
+      expect(options.settings).toEqual({
+        autoCompactEnabled: false,
+        autoCompactWindow: Number.MAX_SAFE_INTEGER,
+      });
+    });
+
+    it('should leave settings undefined for native anthropic provider', async () => {
+      // Default mockSession uses anthropic provider
       const options = await builder.build();
       expect(options.settings).toBeUndefined();
     });

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -4,7 +4,7 @@
  * Tests for processing incoming SDK messages.
  */
 
-import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
 import {
   SDKMessageHandler,
   type SDKMessageHandlerContext,
@@ -19,6 +19,7 @@ import type { ContextTracker } from '../../../../src/lib/agent/context-tracker';
 import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
 import type { ErrorManager } from '../../../../src/lib/error-manager';
 import type { QueryLifecycleManager } from '../../../../src/lib/agent/query-lifecycle-manager';
+import { setModelsCache } from '../../../../src/lib/model-service';
 
 describe('SDKMessageHandler', () => {
   let handler: SDKMessageHandler;
@@ -132,6 +133,8 @@ describe('SDKMessageHandler', () => {
     mockContextTracker = {
       getContextInfo: getContextInfoSpy,
       updateWithDetailedBreakdown: updateWithDetailedBreakdownSpy,
+      shouldCompact: mock(() => false),
+      markCompactionTriggered: mock(() => {}),
     } as unknown as ContextTracker;
 
     // MessageQueue spies
@@ -1331,6 +1334,176 @@ describe('SDKMessageHandler', () => {
 
       expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
       expect(updateWithDetailedBreakdownSpy).not.toHaveBeenCalled();
+    });
+
+    describe('NeoKai-level compaction trigger', () => {
+      afterEach(() => {
+        setModelsCache(new Map());
+      });
+
+      it('enqueues /compact when non-native provider exceeds 85% threshold', async () => {
+        setModelsCache(
+          new Map([
+            [
+              'global',
+              [
+                {
+                  id: 'deepseek-v4',
+                  name: 'DeepSeek V4',
+                  provider: 'openrouter',
+                  contextWindow: 1_000_000,
+                  available: true,
+                },
+              ],
+            ],
+          ])
+        );
+
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 860_000 }],
+          totalTokens: 860_000,
+          maxTokens: Number.MAX_SAFE_INTEGER,
+          rawMaxTokens: Number.MAX_SAFE_INTEGER,
+          percentage: 0,
+          gridRows: [],
+          model: 'deepseek-v4',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: false,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'openrouter';
+        mockContext.session.config.model = 'deepseek-v4';
+        mockContextTracker.shouldCompact = mock(() => true);
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
+        expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
+      });
+
+      it('does not enqueue /compact for native Anthropic providers', async () => {
+        setModelsCache(
+          new Map([
+            [
+              'global',
+              [
+                {
+                  id: 'sonnet',
+                  name: 'Claude Sonnet',
+                  provider: 'anthropic',
+                  contextWindow: 200_000,
+                  available: true,
+                },
+              ],
+            ],
+          ])
+        );
+
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 180_000 }],
+          totalTokens: 180_000,
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          percentage: 90,
+          gridRows: [],
+          model: 'claude-sonnet-4-6',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: true,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'anthropic';
+        mockContext.session.config.model = 'sonnet';
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
+        expect(enqueueMessageSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not enqueue /compact when model info is missing', async () => {
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 860_000 }],
+          totalTokens: 860_000,
+          maxTokens: Number.MAX_SAFE_INTEGER,
+          rawMaxTokens: Number.MAX_SAFE_INTEGER,
+          percentage: 0,
+          gridRows: [],
+          model: 'unknown',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: false,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'openrouter';
+        mockContext.session.config.model = 'unknown-model';
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
+        expect(enqueueMessageSpy).not.toHaveBeenCalled();
+      });
     });
 
     it('never injects /context into the message queue', async () => {


### PR DESCRIPTION
Disables the Claude Agent SDK's built-in auto-compaction for non-native providers and replaces it with a NeoKai-level trigger based on each model's actual context window.

**Problem:** The SDK uses an internal 200k-token assumption for auto-compaction. For non-Anthropic models (OpenRouter, Codex bridge, GLM, Kimi, MiniMax, Ollama, custom endpoints), this causes compaction far earlier than necessary, losing conversation context.

**Fix:**
- `buildProviderSettings()` now returns `autoCompactEnabled: false` + `autoCompactWindow: Number.MAX_SAFE_INTEGER` for non-native providers.
- `ContextTracker.shouldCompact()` checks `getContextUsage()` against an 85% threshold of the real model context window, with a 60s cooldown.
- `SDKMessageHandler.refreshContextUsage()` enqueues `/compact` internally when the threshold is breached.
- Verified with unit tests covering threshold, cooldown, and handler integration.