### PR TITLE
PR 3: Repair LH RPC coverage, fix task ID validation, rename UI labels

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -271,17 +271,23 @@ export function setupSpaceAgentHandlers(
     const params = data as { spaceId: string };
     if (!params.spaceId) throw new Error('spaceId is required');
 
+    const space = await spaceManager.getSpace(params.spaceId);
+    if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
     const agents = spaceAgentManager.listBySpaceId(params.spaceId);
     return { agents };
   });
 
   // spaceAgent.get — get a single agent by ID
   messageHub.onRequest('spaceAgent.get', async (data) => {
-    const params = data as { id: string };
+    const params = data as { id: string; spaceId?: string };
     if (!params.id) throw new Error('id is required');
 
     const agent = spaceAgentManager.getById(params.id);
     if (!agent) throw new Error(`Agent not found: ${params.id}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.id} does not belong to space ${params.spaceId}`);
+    }
 
     return { agent };
   });
@@ -290,6 +296,7 @@ export function setupSpaceAgentHandlers(
   messageHub.onRequest('spaceAgent.update', async (data) => {
     const params = data as {
       id: string;
+      spaceId?: string;
       name?: string;
       handle?: string;
       description?: string | null;
@@ -303,7 +310,13 @@ export function setupSpaceAgentHandlers(
 
     if (!params.id) throw new Error('id is required');
 
-    const { id, ...updateFields } = params;
+    const existing = spaceAgentManager.getById(params.id);
+    if (!existing) throw new Error(`Agent not found: ${params.id}`);
+    if (params.spaceId && existing.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.id} does not belong to space ${params.spaceId}`);
+    }
+
+    const { id, spaceId: _spaceId, ...updateFields } = params;
     const result = await spaceAgentManager.update(id, {
       name: updateFields.name,
       handle: updateFields.handle,
@@ -387,7 +400,7 @@ export function setupSpaceAgentHandlers(
 
   // spaceAgent.delete — delete an agent (blocked if referenced by workflows)
   messageHub.onRequest('spaceAgent.delete', async (data) => {
-    const params = data as { id: string };
+    const params = data as { id: string; spaceId?: string };
     if (!params.id) throw new Error('id is required');
 
     // Pre-fetch to capture spaceId for the event payload.
@@ -396,6 +409,9 @@ export function setupSpaceAgentHandlers(
     // have the spaceId for event routing even after the row is removed.
     const existing = spaceAgentManager.getById(params.id);
     if (!existing) throw new Error(`Agent not found: ${params.id}`);
+    if (params.spaceId && existing.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.id} does not belong to space ${params.spaceId}`);
+    }
 
     const result = spaceAgentManager.delete(params.id);
     if (!result.ok) {

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -648,6 +648,11 @@ export function setupSpaceLongHorizonAgentHandlers(
     if (!params.agentId) throw new Error('agentId is required');
     if (!params.source?.trim()) throw new Error('source is required');
     if (!params.topic?.trim()) throw new Error('topic is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
     const source = params.source.trim();
     const topic = params.topic.trim();
     const pattern = validateLongHorizonSubscriptionPattern(source, topic);

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -539,11 +539,12 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.listGoals', async (data) => {
-    const params = data as { agentId: string; spaceId?: string };
+    const params = data as { agentId: string; spaceId: string };
+    if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.agentId) throw new Error('agentId is required');
     const agent = repo.getById(params.agentId);
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
-    if (params.spaceId && agent.spaceId !== params.spaceId) {
+    if (agent.spaceId !== params.spaceId) {
       throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
     }
     return { goals: repo.listGoals(params.agentId) };
@@ -569,12 +570,13 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.deleteGoalAssignment', async (data) => {
-    const params = data as { spaceId?: string; agentId: string; goalId: string };
+    const params = data as { spaceId: string; agentId: string; goalId: string };
+    if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.agentId) throw new Error('agentId is required');
     if (!params.goalId) throw new Error('goalId is required');
     const agent = repo.getById(params.agentId);
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
-    if (params.spaceId && agent.spaceId !== params.spaceId) {
+    if (agent.spaceId !== params.spaceId) {
       throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
     }
     repo.deleteGoalAssignment(params.agentId, params.goalId);
@@ -582,11 +584,12 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.listForgeScopes', async (data) => {
-    const params = data as { agentId: string; spaceId?: string };
+    const params = data as { agentId: string; spaceId: string };
+    if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.agentId) throw new Error('agentId is required');
     const agent = repo.getById(params.agentId);
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
-    if (params.spaceId && agent.spaceId !== params.spaceId) {
+    if (agent.spaceId !== params.spaceId) {
       throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
     }
     return { scopes: repo.listForgeScopes(params.agentId) };
@@ -612,12 +615,13 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.deleteForgeScopeAssignment', async (data) => {
-    const params = data as { spaceId?: string; agentId: string; scopeId: string };
+    const params = data as { spaceId: string; agentId: string; scopeId: string };
+    if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.agentId) throw new Error('agentId is required');
     if (!params.scopeId) throw new Error('scopeId is required');
     const agent = repo.getById(params.agentId);
     if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
-    if (params.spaceId && agent.spaceId !== params.spaceId) {
+    if (agent.spaceId !== params.spaceId) {
       throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
     }
     repo.deleteForgeScopeAssignment(params.agentId, params.scopeId);

--- a/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-long-horizon-agent-handlers.ts
@@ -15,6 +15,8 @@ import type {
   MessageHub,
   SpaceLongHorizonAgent,
   SpaceLongHorizonAgentEventSubscriptionStatus,
+  SpaceLongHorizonAgentGoal,
+  SpaceLongHorizonAgentForgeScope,
 } from '@neokai/shared';
 import type { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
@@ -481,8 +483,13 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.listReminders', async (data) => {
-    const params = data as { agentId: string };
+    const params = data as { agentId: string; spaceId?: string };
     if (!params.agentId) throw new Error('agentId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
     return { reminders: repo.listReminders(params.agentId) };
   });
 
@@ -501,6 +508,11 @@ export function setupSpaceLongHorizonAgentHandlers(
     if (!params.agentId) throw new Error('agentId is required');
     if (!params.title) throw new Error('title is required');
     if (!params.triggerType) throw new Error('triggerType is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
     const reminder = repo.createReminder({
       spaceId: params.spaceId,
       agentId: params.agentId,
@@ -515,11 +527,100 @@ export function setupSpaceLongHorizonAgentHandlers(
   });
 
   messageHub.onRequest('spaceLongHorizonAgent.deleteReminder', async (data) => {
-    const params = data as { reminderId: string };
+    const params = data as { reminderId: string; spaceId?: string };
     if (!params.reminderId) throw new Error('reminderId is required');
     const existing = repo.getReminder(params.reminderId);
     if (!existing) throw new Error(`Reminder not found: ${params.reminderId}`);
+    if (params.spaceId && existing.spaceId !== params.spaceId) {
+      throw new Error(`Reminder ${params.reminderId} does not belong to space ${params.spaceId}`);
+    }
     repo.deleteReminder(params.reminderId);
+    return { success: true };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.listGoals', async (data) => {
+    const params = data as { agentId: string; spaceId?: string };
+    if (!params.agentId) throw new Error('agentId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    return { goals: repo.listGoals(params.agentId) };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.assignGoal', async (data) => {
+    const params = data as {
+      spaceId: string;
+      agentId: string;
+      goalId: string;
+      relationship?: SpaceLongHorizonAgentGoal['relationship'];
+    };
+    if (!params.spaceId) throw new Error('spaceId is required');
+    if (!params.agentId) throw new Error('agentId is required');
+    if (!params.goalId) throw new Error('goalId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    repo.assignGoal(params.agentId, params.goalId, params.relationship ?? 'owner');
+    return { success: true };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.deleteGoalAssignment', async (data) => {
+    const params = data as { spaceId?: string; agentId: string; goalId: string };
+    if (!params.agentId) throw new Error('agentId is required');
+    if (!params.goalId) throw new Error('goalId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    repo.deleteGoalAssignment(params.agentId, params.goalId);
+    return { success: true };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.listForgeScopes', async (data) => {
+    const params = data as { agentId: string; spaceId?: string };
+    if (!params.agentId) throw new Error('agentId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    return { scopes: repo.listForgeScopes(params.agentId) };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.assignForgeScope', async (data) => {
+    const params = data as {
+      spaceId: string;
+      agentId: string;
+      scopeId: string;
+      relationship?: SpaceLongHorizonAgentForgeScope['relationship'];
+    };
+    if (!params.spaceId) throw new Error('spaceId is required');
+    if (!params.agentId) throw new Error('agentId is required');
+    if (!params.scopeId) throw new Error('scopeId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    repo.assignForgeScope(params.agentId, params.scopeId, params.relationship ?? 'owner');
+    return { success: true };
+  });
+
+  messageHub.onRequest('spaceLongHorizonAgent.deleteForgeScopeAssignment', async (data) => {
+    const params = data as { spaceId?: string; agentId: string; scopeId: string };
+    if (!params.agentId) throw new Error('agentId is required');
+    if (!params.scopeId) throw new Error('scopeId is required');
+    const agent = repo.getById(params.agentId);
+    if (!agent) throw new Error(`Agent not found: ${params.agentId}`);
+    if (params.spaceId && agent.spaceId !== params.spaceId) {
+      throw new Error(`Agent ${params.agentId} does not belong to space ${params.spaceId}`);
+    }
+    repo.deleteForgeScopeAssignment(params.agentId, params.scopeId);
     return { success: true };
   });
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3755,17 +3755,10 @@ export class TaskAgentManager {
       title: string;
       description: string;
       priority?: 'low' | 'normal' | 'high' | 'urgent';
-      custom_agent_id?: string;
       workflow_id?: string;
       depends_on?: string[];
       draft?: boolean;
     }) => {
-      if (args.custom_agent_id != null) {
-        return jsonResult({
-          success: false,
-          error: 'Task assignment by custom_agent_id is not yet supported.',
-        });
-      }
       try {
         const task = await boundTaskManager.createTask({
           title: args.title,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3760,6 +3760,12 @@ export class TaskAgentManager {
       depends_on?: string[];
       draft?: boolean;
     }) => {
+      if (args.custom_agent_id != null) {
+        return jsonResult({
+          success: false,
+          error: 'Task assignment by custom_agent_id is not yet supported.',
+        });
+      }
       try {
         const task = await boundTaskManager.createTask({
           title: args.title,

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -290,10 +290,6 @@ export const CreateStandaloneTaskSchema = z.object({
     .enum(['low', 'normal', 'high', 'urgent'])
     .describe('Task priority (default: normal)')
     .optional(),
-  custom_agent_id: z
-    .string()
-    .describe('ID of a custom Space agent to assign this task to')
-    .optional(),
   workflow_id: z
     .string()
     .describe(

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1569,11 +1569,18 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       title: string;
       description: string;
       priority?: SpaceTaskPriority;
+      custom_agent_id?: string;
       workflow_id?: string;
       workflow_handle?: string;
       depends_on?: string[];
       draft?: boolean;
     }): Promise<ToolResult> {
+      if (args.custom_agent_id != null) {
+        return jsonResult({
+          success: false,
+          error: 'Task assignment by custom_agent_id is not yet supported.',
+        });
+      }
       let preferredWorkflowId = args.workflow_id ?? null;
       if (preferredWorkflowId) {
         const wf = workflowManager.getWorkflow(preferredWorkflowId);
@@ -1879,15 +1886,16 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       assigned_agent?: 'coder' | 'general';
     }): Promise<ToolResult> {
       try {
-        // Validate custom_agent_id if being set to a non-null value
+        // Validate custom_agent_id if being set to a non-null value.
+        // Worker-agent IDs only — reject long-horizon-only IDs.
         if (args.custom_agent_id != null) {
-          const agent = spaceAgentManager.getById(args.custom_agent_id);
-          if (!agent) {
-            return jsonResult({
-              success: false,
-              error: `Custom agent not found: ${args.custom_agent_id}`,
-            });
-          }
+          requireAgentFamily({
+            spaceId,
+            agentId: args.custom_agent_id,
+            expected: 'worker',
+            spaceAgentManager,
+            longHorizonAgentRepo: requireLongHorizonAgentRepo(),
+          });
         }
 
         // Pass args.custom_agent_id as-is (including undefined) so the manager

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1569,18 +1569,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       title: string;
       description: string;
       priority?: SpaceTaskPriority;
-      custom_agent_id?: string;
       workflow_id?: string;
       workflow_handle?: string;
       depends_on?: string[];
       draft?: boolean;
     }): Promise<ToolResult> {
-      if (args.custom_agent_id != null) {
-        return jsonResult({
-          success: false,
-          error: 'Task assignment by custom_agent_id is not yet supported.',
-        });
-      }
       let preferredWorkflowId = args.workflow_id ?? null;
       if (preferredWorkflowId) {
         const wf = workflowManager.getWorkflow(preferredWorkflowId);
@@ -1882,29 +1875,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
      */
     async reassign_task(args: {
       task_id: string;
-      custom_agent_id?: string | null;
       assigned_agent?: 'coder' | 'general';
     }): Promise<ToolResult> {
       try {
-        // Validate custom_agent_id if being set to a non-null value.
-        // Worker-agent IDs only — reject long-horizon-only IDs.
-        if (args.custom_agent_id != null) {
-          requireAgentFamily({
-            spaceId,
-            agentId: args.custom_agent_id,
-            expected: 'worker',
-            spaceAgentManager,
-            longHorizonAgentRepo: requireLongHorizonAgentRepo(),
-          });
-        }
-
-        // Pass args.custom_agent_id as-is (including undefined) so the manager
-        // only updates that field when it was explicitly provided.
-        const task = await taskManager.reassignTask(
-          args.task_id,
-          args.custom_agent_id,
-          args.assigned_agent
-        );
+        const task = await taskManager.reassignTask(args.task_id, undefined, args.assigned_agent);
         return jsonResult({ success: true, task });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -3506,10 +3480,6 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
           .enum(['low', 'normal', 'high', 'urgent'])
           .optional()
           .describe('Task priority (default: normal)'),
-        custom_agent_id: z
-          .string()
-          .optional()
-          .describe('ID of a custom Space agent to assign this task to'),
         workflow_id: z
           .string()
           .optional()
@@ -3597,13 +3567,6 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
       'Change the agent assignment for a task. Only allowed for tasks in open, blocked, or cancelled status.',
       {
         task_id: z.string().describe('ID of the task to reassign'),
-        custom_agent_id: z
-          .string()
-          .nullable()
-          .optional()
-          .describe(
-            'ID of the custom Space agent to assign to. Pass null to clear the custom agent assignment.'
-          ),
         assigned_agent: z
           .enum(['coder', 'general'])
           .optional()

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -1150,4 +1150,61 @@ describe('Space Agent RPC Handlers', () => {
       expect(payload.agent.id).toBe(created.value.id);
     });
   });
+
+  describe('space ownership checks', () => {
+    it('list rejects missing space', async () => {
+      await expect(
+        call(hubData.handlers, 'spaceAgent.list', { spaceId: 'missing-space' })
+      ).rejects.toThrow('Space not found: missing-space');
+    });
+
+    it('get rejects cross-space agent when spaceId is provided', async () => {
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        tools: ['Read'],
+      });
+      if (!created.ok) throw new Error('create failed');
+
+      await expect(
+        call(hubData.handlers, 'spaceAgent.get', {
+          id: created.value.id,
+          spaceId: 'other-space',
+        })
+      ).rejects.toThrow(`Agent ${created.value.id} does not belong to space other-space`);
+    });
+
+    it('update rejects cross-space agent', async () => {
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        tools: ['Read'],
+      });
+      if (!created.ok) throw new Error('create failed');
+
+      await expect(
+        call(hubData.handlers, 'spaceAgent.update', {
+          id: created.value.id,
+          spaceId: 'other-space',
+          name: 'Hacker',
+        })
+      ).rejects.toThrow(`Agent ${created.value.id} does not belong to space other-space`);
+    });
+
+    it('delete rejects cross-space agent', async () => {
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        tools: ['Read'],
+      });
+      if (!created.ok) throw new Error('create failed');
+
+      await expect(
+        call(hubData.handlers, 'spaceAgent.delete', {
+          id: created.value.id,
+          spaceId: 'other-space',
+        })
+      ).rejects.toThrow(`Agent ${created.value.id} does not belong to space other-space`);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-long-horizon-agent-handlers.test.ts
@@ -62,8 +62,24 @@ describe('Space long-horizon agent handlers', () => {
       getByHandle: mock(() => null),
       update: mock((agentId, params) => ({ id: agentId, spaceId: 'space-1', ...params })),
       delete: mock(() => {}),
+      listGoals: mock(() => []),
+      assignGoal: mock(() => {}),
+      deleteGoalAssignment: mock(() => {}),
+      listForgeScopes: mock(() => []),
+      assignForgeScope: mock(() => {}),
+      deleteForgeScopeAssignment: mock(() => {}),
       listReminders: mock(() => []),
       createReminder: mock(() => ({})),
+      getReminder: mock(() => ({
+        id: 'reminder-1',
+        spaceId: 'space-1',
+        agentId: 'agent-1',
+        title: 'Test',
+        status: 'active',
+        triggerType: 'at',
+        createdAt: 1,
+        updatedAt: 1,
+      })),
       deleteReminder: mock(() => {}),
       listSubscriptions: mock(() => []),
       createSubscription: mock((params) => ({
@@ -1063,6 +1079,128 @@ describe('Space long-horizon agent handlers', () => {
           spaceId: 'missing-space',
         })
       ).rejects.toThrow('Space not found: missing-space');
+    });
+  });
+
+  describe('spaceLongHorizonAgent.goals', () => {
+    it('lists goals for an agent', async () => {
+      const result = await call<{ goals: unknown[] }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.listGoals',
+        { agentId: 'agent-1', spaceId: 'space-1' }
+      );
+
+      expect(result.goals).toEqual([]);
+      expect(repo.listGoals).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('assigns a goal to an agent', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.assignGoal',
+        { spaceId: 'space-1', agentId: 'agent-1', goalId: 'goal-1', relationship: 'owner' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(repo.assignGoal).toHaveBeenCalledWith('agent-1', 'goal-1', 'owner');
+    });
+
+    it('deletes a goal assignment', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.deleteGoalAssignment',
+        { spaceId: 'space-1', agentId: 'agent-1', goalId: 'goal-1' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(repo.deleteGoalAssignment).toHaveBeenCalledWith('agent-1', 'goal-1');
+    });
+  });
+
+  describe('spaceLongHorizonAgent.forgeScopes', () => {
+    it('lists Forge scopes for an agent', async () => {
+      const result = await call<{ scopes: unknown[] }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.listForgeScopes',
+        { agentId: 'agent-1', spaceId: 'space-1' }
+      );
+
+      expect(result.scopes).toEqual([]);
+      expect(repo.listForgeScopes).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('assigns a Forge scope to an agent', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.assignForgeScope',
+        { spaceId: 'space-1', agentId: 'agent-1', scopeId: 'scope-1', relationship: 'owner' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(repo.assignForgeScope).toHaveBeenCalledWith('agent-1', 'scope-1', 'owner');
+    });
+
+    it('deletes a Forge scope assignment', async () => {
+      const result = await call<{ success: boolean }>(
+        hubData.handlers,
+        'spaceLongHorizonAgent.deleteForgeScopeAssignment',
+        { spaceId: 'space-1', agentId: 'agent-1', scopeId: 'scope-1' }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(repo.deleteForgeScopeAssignment).toHaveBeenCalledWith('agent-1', 'scope-1');
+    });
+  });
+
+  describe('space ownership checks', () => {
+    it('listReminders rejects cross-space agentId', async () => {
+      repo.getById = mock(() => ({
+        id: 'agent-1',
+        spaceId: 'other-space',
+      })) as unknown as SpaceLongHorizonAgentRepository['getById'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.listReminders', {
+          agentId: 'agent-1',
+          spaceId: 'space-1',
+        })
+      ).rejects.toThrow('Agent agent-1 does not belong to space space-1');
+    });
+
+    it('createReminder rejects agent from different space', async () => {
+      repo.getById = mock(() => ({
+        id: 'agent-1',
+        spaceId: 'other-space',
+      })) as unknown as SpaceLongHorizonAgentRepository['getById'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.createReminder', {
+          spaceId: 'space-1',
+          agentId: 'agent-1',
+          title: 'Test',
+          triggerType: 'at',
+        })
+      ).rejects.toThrow('Agent agent-1 does not belong to space space-1');
+    });
+
+    it('deleteReminder rejects reminder from different space', async () => {
+      repo.getReminder = mock(() => ({
+        id: 'reminder-1',
+        spaceId: 'other-space',
+        agentId: 'agent-1',
+        title: 'Test',
+        status: 'active',
+        triggerType: 'at',
+        createdAt: 1,
+        updatedAt: 1,
+      })) as unknown as SpaceLongHorizonAgentRepository['getReminder'];
+
+      await expect(
+        call(hubData.handlers, 'spaceLongHorizonAgent.deleteReminder', {
+          reminderId: 'reminder-1',
+          spaceId: 'space-1',
+        })
+      ).rejects.toThrow('Reminder reminder-1 does not belong to space space-1');
     });
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -2919,15 +2919,15 @@ describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
     expect(parsed.task.title).toBe('Full task');
   });
 
-  test('custom_agent_id field removed in M71 — task still creates without error', async () => {
-    // custom_agent_id is no longer validated in create_standalone_task post-M71
+  test('rejects custom_agent_id with clear error', async () => {
     const result = await makeHandlers(ctx).create_standalone_task({
       title: 'Task',
       description: 'Desc',
+      custom_agent_id: ctx.agentId,
     });
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.success).toBe(true);
-    expect(parsed.task.id).toBeDefined();
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Task assignment by custom_agent_id is not yet supported.');
   });
 
   test('task is retrievable from repo after creation', async () => {
@@ -3508,7 +3508,7 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
     ctx.db.close();
   });
 
-  test('reassigns a pending task (custom_agent_id is accepted, field removed in M71)', async () => {
+  test('reassigns a pending task with a worker agent id', async () => {
     const createResult = await makeHandlers(ctx).create_standalone_task({
       title: 'Reassign me',
       description: 'Will be reassigned',
@@ -3572,7 +3572,7 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
     expect(parsed.task.id).toBe(taskId);
   });
 
-  test('returns error when custom_agent_id does not exist', async () => {
+  test('rejects missing custom_agent_id', async () => {
     const createResult = await makeHandlers(ctx).create_standalone_task({
       title: 'Task',
       description: 'Desc',
@@ -3585,7 +3585,31 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
     });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(false);
-    expect(parsed.error).toContain('agent-does-not-exist');
+    expect(parsed.error).toContain('Agent not found: agent-does-not-exist');
+  });
+
+  test('rejects long-horizon-only custom_agent_id', async () => {
+    ctx.longHorizonAgentRepo.create({
+      spaceId: ctx.spaceId,
+      handle: 'lh-only',
+      displayName: 'LH Only',
+    });
+    const lhAgent = ctx.longHorizonAgentRepo.getByHandle(ctx.spaceId, 'lh-only');
+    if (!lhAgent) throw new Error('LH agent not created');
+
+    const createResult = await makeHandlers(ctx).create_standalone_task({
+      title: 'Task',
+      description: 'Desc',
+    });
+    const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+    const result = await makeHandlers(ctx).reassign_task({
+      task_id: taskId,
+      custom_agent_id: lhAgent.id,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('Expected worker agent id, got long-horizon agent id.');
   });
 
   test('returns error when task is in_progress', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -2919,17 +2919,6 @@ describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
     expect(parsed.task.title).toBe('Full task');
   });
 
-  test('rejects custom_agent_id with clear error', async () => {
-    const result = await makeHandlers(ctx).create_standalone_task({
-      title: 'Task',
-      description: 'Desc',
-      custom_agent_id: ctx.agentId,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.success).toBe(false);
-    expect(parsed.error).toBe('Task assignment by custom_agent_id is not yet supported.');
-  });
-
   test('task is retrievable from repo after creation', async () => {
     const result = await makeHandlers(ctx).create_standalone_task({
       title: 'Stored task',
@@ -3508,7 +3497,7 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
     ctx.db.close();
   });
 
-  test('reassigns a pending task with a worker agent id', async () => {
+  test('reassigns a pending task', async () => {
     const createResult = await makeHandlers(ctx).create_standalone_task({
       title: 'Reassign me',
       description: 'Will be reassigned',
@@ -3517,7 +3506,7 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
 
     const result = await makeHandlers(ctx).reassign_task({
       task_id: taskId,
-      custom_agent_id: ctx.agentId,
+      assigned_agent: 'coder',
     });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(true);
@@ -3554,62 +3543,6 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(true);
     expect(parsed.task.id).toBe(taskId);
-  });
-
-  test('clears custom agent when custom_agent_id is null (field removed in M71)', async () => {
-    const createResult = await makeHandlers(ctx).create_standalone_task({
-      title: 'Clear agent',
-      description: 'Remove custom agent',
-    });
-    const taskId = JSON.parse(createResult.content[0].text).task.id;
-
-    const result = await makeHandlers(ctx).reassign_task({
-      task_id: taskId,
-      custom_agent_id: null,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.success).toBe(true);
-    expect(parsed.task.id).toBe(taskId);
-  });
-
-  test('rejects missing custom_agent_id', async () => {
-    const createResult = await makeHandlers(ctx).create_standalone_task({
-      title: 'Task',
-      description: 'Desc',
-    });
-    const taskId = JSON.parse(createResult.content[0].text).task.id;
-
-    const result = await makeHandlers(ctx).reassign_task({
-      task_id: taskId,
-      custom_agent_id: 'agent-does-not-exist',
-    });
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.success).toBe(false);
-    expect(parsed.error).toContain('Agent not found: agent-does-not-exist');
-  });
-
-  test('rejects long-horizon-only custom_agent_id', async () => {
-    ctx.longHorizonAgentRepo.create({
-      spaceId: ctx.spaceId,
-      handle: 'lh-only',
-      displayName: 'LH Only',
-    });
-    const lhAgent = ctx.longHorizonAgentRepo.getByHandle(ctx.spaceId, 'lh-only');
-    if (!lhAgent) throw new Error('LH agent not created');
-
-    const createResult = await makeHandlers(ctx).create_standalone_task({
-      title: 'Task',
-      description: 'Desc',
-    });
-    const taskId = JSON.parse(createResult.content[0].text).task.id;
-
-    const result = await makeHandlers(ctx).reassign_task({
-      task_id: taskId,
-      custom_agent_id: lhAgent.id,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.success).toBe(false);
-    expect(parsed.error).toContain('Expected worker agent id, got long-horizon agent id.');
   });
 
   test('returns error when task is in_progress', async () => {
@@ -3650,7 +3583,7 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
 
     const result = await makeHandlers(ctx).reassign_task({
       task_id: taskId,
-      custom_agent_id: ctx.agentId,
+      assigned_agent: 'general',
     });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(true);

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -298,9 +298,7 @@ export function SpaceAgentEditor({
 
         {isPromotion && promotionDraft && (
           <div class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-100">
-            <p class="font-medium">
-              Review generated long-horizon profile before creating long-horizon agent.
-            </p>
+            <p class="font-medium">Review generated worker agent profile before creating.</p>
             <p class="mt-1 text-xs text-blue-200/80">
               Draft uses recent renderable messages from "{promotionDraft.sourceSessionTitle}" as
               standing context instead of copying raw chat history.
@@ -562,7 +560,7 @@ export function SpaceAgentEditor({
         {/* Custom Prompt */}
         <div>
           <label class="block text-sm font-medium text-gray-300 mb-2">
-            {isPromotion ? 'Long-Horizon Profile' : 'Custom Prompt'}
+            {isPromotion ? 'Worker Agent Profile' : 'Custom Prompt'}
             <span class="text-gray-400 text-xs ml-2">
               (optional — appended after NeoKai contract)
             </span>
@@ -587,11 +585,7 @@ export function SpaceAgentEditor({
             Cancel
           </Button>
           <Button type="submit" loading={saving} fullWidth>
-            {isEdit
-              ? 'Save Changes'
-              : isPromotion
-                ? 'Create Long-Horizon Agent'
-                : 'Create worker agent'}
+            {isEdit ? 'Save Changes' : isPromotion ? 'Create Worker Agent' : 'Create worker agent'}
           </Button>
         </div>
       </form>

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -281,10 +281,10 @@ export function SpaceAgentEditor({
   };
 
   const title = isEdit
-    ? `Edit Agent: ${agent!.name}`
+    ? `Edit worker agent: ${agent!.name}`
     : isPromotion
       ? `Promote Session: ${promotionDraft!.sourceSessionTitle}`
-      : 'Create Agent';
+      : 'Create worker agent';
 
   return (
     <Modal isOpen onClose={onCancel} title={title} size="lg">
@@ -298,7 +298,9 @@ export function SpaceAgentEditor({
 
         {isPromotion && promotionDraft && (
           <div class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm text-blue-100">
-            <p class="font-medium">Review generated long-horizon profile before creating agent.</p>
+            <p class="font-medium">
+              Review generated long-horizon profile before creating long-horizon agent.
+            </p>
             <p class="mt-1 text-xs text-blue-200/80">
               Draft uses recent renderable messages from "{promotionDraft.sourceSessionTitle}" as
               standing context instead of copying raw chat history.
@@ -585,7 +587,11 @@ export function SpaceAgentEditor({
             Cancel
           </Button>
           <Button type="submit" loading={saving} fullWidth>
-            {isEdit ? 'Save Changes' : isPromotion ? 'Create Long-Horizon Agent' : 'Create Agent'}
+            {isEdit
+              ? 'Save Changes'
+              : isPromotion
+                ? 'Create Long-Horizon Agent'
+                : 'Create worker agent'}
           </Button>
         </div>
       </form>

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -1,20 +1,15 @@
 /**
- * Agents page for a Space.
+ * Worker agents page for a Space.
  *
- * Shows the built-in Coordinator plus editable specialist agents, with basic
- * long-horizon configuration affordances for managed goals, Forge scopes,
- * reminders, and event subscriptions.
+ * Shows the built-in Coordinator plus editable specialist worker agents.
+ * Worker agents are reusable workflow worker configurations, not persistent
+ * long-horizon role-holders.
  */
 
-import { useEffect, useMemo, useState } from 'preact/hooks';
-import type {
-  AgentDriftReport,
-  SpaceAgent,
-  SpaceLongHorizonAgent,
-  SpaceLongHorizonAgentEventSubscription,
-} from '@neokai/shared';
+import { useEffect, useState } from 'preact/hooks';
+import type { AgentDriftReport, SpaceAgent } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
-import { navigateToSpaceAgent, navigateToSpaceForge, navigateToSpaceGoals } from '../../lib/router';
+import { navigateToSpaceAgent } from '../../lib/router';
 import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
@@ -25,256 +20,24 @@ interface AgentCardProps {
   agent: SpaceAgent;
   drifted: boolean;
   syncing: boolean;
-  managedGoalCount: number;
-  reminderCount: number;
-  subscriptionCount: number;
-  subscriptionTopics: Array<{ id: string; topic: string }>;
   onEdit: (agent: SpaceAgent) => void;
   onDelete: (agent: SpaceAgent) => void;
   onSync: (agent: SpaceAgent) => void;
   onOpenDetail: (agent: SpaceAgent) => void;
-  onEditSubscriptions: (agent: SpaceAgent) => void;
 }
 
 function isCoordinatorAgent(agent: SpaceAgent): boolean {
   return agent.name.toLowerCase() === 'coordinator' || agent.templateName === 'Coordinator';
 }
 
-function isConnectionUnavailableError(error: unknown): boolean {
-  return error instanceof Error && error.message.startsWith('Not connected');
-}
-
-function AgentStat({ label, value }: { label: string; value: string | number }) {
-  return (
-    <span class="rounded border border-white/10 bg-white/[0.025] px-2 py-1 text-xs text-gray-400">
-      <span class="text-gray-200">{value}</span> {label}
-    </span>
-  );
-}
-
-function formatFilter(filter: Record<string, unknown>): string {
-  return Object.keys(filter).length === 0 ? 'No filter' : JSON.stringify(filter);
-}
-
-interface SubscriptionEditorProps {
-  agent: SpaceAgent;
-  longHorizonAgent: SpaceLongHorizonAgent;
-  subscriptions: SpaceLongHorizonAgentEventSubscription[];
-  onClose: () => void;
-  onChanged: (agentId: string) => Promise<void>;
-}
-
-function SubscriptionEditor({
-  agent,
-  longHorizonAgent,
-  subscriptions,
-  onClose,
-  onChanged,
-}: SubscriptionEditorProps) {
-  const [source, setSource] = useState('github');
-  const [topic, setTopic] = useState('github/*/*/pull_request/*');
-  const [label, setLabel] = useState('');
-  const [saving, setSaving] = useState(false);
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleCreate = async () => {
-    const trimmedSource = source.trim();
-    const trimmedTopic = topic.trim();
-    if (!trimmedSource) {
-      setError('Source is required');
-      return;
-    }
-    if (!trimmedTopic) {
-      setError('Topic pattern is required');
-      return;
-    }
-    setSaving(true);
-    setError(null);
-    try {
-      const filter = label.trim() ? { label: label.trim() } : {};
-      await spaceStore.createLongHorizonAgentSubscription({
-        agentId: longHorizonAgent.id,
-        source: trimmedSource,
-        topic: trimmedTopic,
-        filter,
-        status: 'active',
-      });
-      setTopic('github/*/*/pull_request/*');
-      setLabel('');
-      await onChanged(longHorizonAgent.id);
-      toast.success('Subscription added');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add subscription');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleToggle = async (subscription: SpaceLongHorizonAgentEventSubscription) => {
-    const nextStatus = subscription.status === 'active' ? 'paused' : 'active';
-    setBusyId(subscription.id);
-    setError(null);
-    try {
-      await spaceStore.updateLongHorizonAgentSubscription(subscription.id, { status: nextStatus });
-      await onChanged(longHorizonAgent.id);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update subscription');
-    } finally {
-      setBusyId(null);
-    }
-  };
-
-  const handleDelete = async (subscription: SpaceLongHorizonAgentEventSubscription) => {
-    setBusyId(subscription.id);
-    setError(null);
-    try {
-      await spaceStore.deleteLongHorizonAgentSubscription(subscription.id);
-      await onChanged(longHorizonAgent.id);
-      toast.success('Subscription deleted');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete subscription');
-    } finally {
-      setBusyId(null);
-    }
-  };
-
-  return (
-    <div class="fixed inset-0 z-50 flex items-center justify-end bg-black/50" onClick={onClose}>
-      <div
-        class="h-full w-full max-w-xl overflow-y-auto border-l border-white/10 bg-dark-900 shadow-xl"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <div class="border-b border-white/10 px-4 py-3">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-wider text-purple-300">
-                Event subscriptions
-              </p>
-              <h2 class="mt-1 text-sm font-semibold text-gray-100">{agent.name}</h2>
-              <p class="mt-0.5 font-mono text-xs text-gray-500">@{agent.handle}</p>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              class="rounded-md px-2 py-1 text-xs text-gray-400 hover:bg-white/5 hover:text-gray-200"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-
-        <div class="space-y-4 px-4 py-4">
-          <section class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
-            <p class="text-xs font-medium text-gray-200">Add subscription</p>
-            <label class="mt-3 block text-xs text-gray-400">
-              Source
-              <input
-                value={source}
-                onInput={(event) => setSource(event.currentTarget.value)}
-                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 font-mono text-xs text-gray-100 outline-none focus:border-blue-500/60"
-                placeholder="github"
-              />
-            </label>
-            <label class="mt-3 block text-xs text-gray-400">
-              Topic pattern
-              <input
-                value={topic}
-                onInput={(event) => setTopic(event.currentTarget.value)}
-                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 font-mono text-xs text-gray-100 outline-none focus:border-blue-500/60"
-                placeholder="github/owner/repo/pull_request/*.review_*"
-              />
-            </label>
-            <label class="mt-3 block text-xs text-gray-400">
-              Label (optional)
-              <input
-                value={label}
-                onInput={(event) => setLabel(event.currentTarget.value)}
-                class="mt-1 w-full rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-100 outline-none focus:border-blue-500/60"
-                placeholder="PR review comments"
-              />
-            </label>
-            <div class="mt-3 flex justify-end">
-              <Button size="sm" onClick={handleCreate} disabled={saving}>
-                {saving ? 'Adding…' : 'Add subscription'}
-              </Button>
-            </div>
-          </section>
-
-          {error && <p class="text-xs text-red-400">{error}</p>}
-
-          <section class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
-              Current · {subscriptions.length}
-            </p>
-            {subscriptions.length === 0 ? (
-              <div class="rounded border border-white/10 bg-dark-800 px-3 py-4 text-xs text-gray-500">
-                No event subscriptions configured.
-              </div>
-            ) : (
-              subscriptions.map((subscription) => (
-                <div
-                  key={subscription.id}
-                  class="rounded-lg border border-white/10 bg-white/[0.025] p-3"
-                >
-                  <div class="flex items-start justify-between gap-3">
-                    <div class="min-w-0">
-                      <p class="break-all font-mono text-xs text-gray-100">{subscription.topic}</p>
-                      <p class="mt-1 text-xs text-gray-500">
-                        Source: {subscription.source} · Filter: {formatFilter(subscription.filter)}
-                      </p>
-                    </div>
-                    <span
-                      class={`rounded px-1.5 py-0.5 text-xs ${
-                        subscription.status === 'active'
-                          ? 'bg-green-500/10 text-green-300'
-                          : 'bg-amber-500/10 text-amber-300'
-                      }`}
-                    >
-                      {subscription.status}
-                    </span>
-                  </div>
-                  <div class="mt-3 flex justify-end gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleToggle(subscription)}
-                      disabled={busyId === subscription.id}
-                      class="rounded-md px-2 py-1 text-xs text-blue-300 hover:bg-white/5 hover:text-blue-200 disabled:opacity-50"
-                    >
-                      {subscription.status === 'active' ? 'Pause' : 'Resume'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(subscription)}
-                      disabled={busyId === subscription.id}
-                      class="rounded-md px-2 py-1 text-xs text-red-300 hover:bg-white/5 hover:text-red-200 disabled:opacity-50"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                </div>
-              ))
-            )}
-          </section>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function AgentCard({
   agent,
   drifted,
   syncing,
-  managedGoalCount,
-  reminderCount,
-  subscriptionCount,
-  subscriptionTopics,
   onEdit,
   onDelete,
   onSync,
   onOpenDetail,
-  onEditSubscriptions,
 }: AgentCardProps) {
   const toolCount = agent.tools?.length ?? 0;
   const isCoordinator = isCoordinatorAgent(agent);
@@ -325,37 +88,6 @@ function AgentCard({
               </span>
             ))}
           </div>
-          {subscriptionTopics.length > 0 && (
-            <div class="mt-2 flex flex-wrap gap-1.5">
-              {subscriptionTopics.slice(0, 3).map((subscription) => (
-                <span
-                  key={subscription.id}
-                  class="max-w-full truncate rounded border border-blue-400/20 bg-blue-500/10 px-1.5 py-0.5 font-mono text-xs text-blue-200"
-                  title={subscription.topic}
-                >
-                  {subscription.topic}
-                </span>
-              ))}
-            </div>
-          )}
-          {isCoordinator && (
-            <div class="mt-3 grid gap-2 rounded-lg border border-purple-400/15 bg-black/10 p-3 sm:grid-cols-2">
-              <div>
-                <p class="text-xs font-medium text-purple-100">Long-horizon scope</p>
-                <div class="mt-2 flex flex-wrap gap-1.5">
-                  <AgentStat label="managed goals" value={managedGoalCount} />
-                  <AgentStat label="Forge scopes" value="Coming soon" />
-                </div>
-              </div>
-              <div>
-                <p class="text-xs font-medium text-purple-100">Automation</p>
-                <div class="mt-2 flex flex-wrap gap-1.5">
-                  <AgentStat label="reminders" value={reminderCount} />
-                  <AgentStat label="event subscriptions" value={subscriptionCount} />
-                </div>
-              </div>
-            </div>
-          )}
         </div>
         <div class="flex flex-shrink-0 items-center gap-1 opacity-70 transition-opacity group-hover:opacity-100">
           {drifted && (
@@ -369,14 +101,6 @@ function AgentCard({
               {syncing ? 'Syncing…' : 'Sync'}
             </button>
           )}
-          <button
-            type="button"
-            onClick={() => onEditSubscriptions(agent)}
-            class="rounded-md px-2 py-1 text-xs text-blue-300 transition-colors hover:bg-white/5 hover:text-blue-200"
-            aria-label={`Edit event subscriptions for ${agent.name}`}
-          >
-            Events
-          </button>
           <button
             type="button"
             onClick={() => onEdit(agent)}
@@ -439,23 +163,13 @@ export function SpaceAgentList() {
   const loading = spaceStore.loading.value;
   const spaceId = spaceStore.spaceId.value;
   const spaceUrlId = spaceStore.space.value?.slug ?? spaceId;
-  const goals = spaceStore.goals.value;
-  const schedules = spaceStore.schedules.value;
   const workflows = spaceStore.workflows.value;
-  const longHorizonAgents = spaceStore.longHorizonAgents.value;
 
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<SpaceAgent | null>(null);
   const [deletingAgent, setDeletingAgent] = useState<SpaceAgent | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
-
-  const [subscriptionEditorAgent, setSubscriptionEditorAgent] = useState<SpaceAgent | null>(null);
-  const [subscriptionEditorLongHorizonAgent, setSubscriptionEditorLongHorizonAgent] =
-    useState<SpaceLongHorizonAgent | null>(null);
-  const [subscriptionsByAgentId, setSubscriptionsByAgentId] = useState<
-    Record<string, SpaceLongHorizonAgentEventSubscription[]>
-  >({});
 
   const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
   const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
@@ -464,89 +178,6 @@ export function SpaceAgentList() {
     .map((a) => `${a.id}:${a.updatedAt}`)
     .sort()
     .join('|');
-  const longHorizonAgentResolver = useMemo(() => {
-    const activeById = new Map<string, SpaceLongHorizonAgent>();
-    const inactiveById = new Map<string, SpaceLongHorizonAgent>();
-    for (const agent of longHorizonAgents) {
-      if (agent.status === 'active') {
-        activeById.set(agent.id, agent);
-      } else {
-        inactiveById.set(agent.id, agent);
-      }
-    }
-    return (agent: SpaceAgent) => {
-      const coordinatorId = isCoordinatorAgent(agent)
-        ? `space-lh-agent:coordinator:${agent.spaceId}`
-        : null;
-      return (
-        activeById.get(agent.id) ??
-        (coordinatorId ? activeById.get(coordinatorId) : null) ??
-        inactiveById.get(agent.id) ??
-        (coordinatorId ? inactiveById.get(coordinatorId) : null) ??
-        null
-      );
-    };
-  }, [longHorizonAgents]);
-  const longHorizonAgentIds = longHorizonAgents
-    .map((agent) => agent.id)
-    .sort()
-    .join('|');
-
-  const loadSubscriptions = async (agentId: string) => {
-    const subscriptions = await spaceStore.listLongHorizonAgentSubscriptions(agentId);
-    setSubscriptionsByAgentId((current) => ({ ...current, [agentId]: subscriptions }));
-  };
-
-  useEffect(() => {
-    if (!spaceId || longHorizonAgents.length === 0) {
-      setSubscriptionsByAgentId({});
-      return;
-    }
-
-    let cancelled = false;
-    const load = async () => {
-      const entries = await Promise.all(
-        longHorizonAgents.map(
-          async (agent) =>
-            [agent.id, await spaceStore.listLongHorizonAgentSubscriptions(agent.id)] as const
-        )
-      );
-      if (!cancelled) setSubscriptionsByAgentId(Object.fromEntries(entries));
-    };
-    load().catch((err) => {
-      if (!cancelled) {
-        toast.error(
-          `Failed to load event subscriptions: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [spaceId, longHorizonAgentIds]);
-
-  useEffect(() => {
-    if (!spaceId) return;
-
-    let cancelled = false;
-    let unsubscribe: (() => void) | null = null;
-    const loadSchedules = () => {
-      if (cancelled) return;
-      spaceStore.listSchedules().catch((error) => {
-        if (cancelled || !isConnectionUnavailableError(error)) return;
-        unsubscribe?.();
-        unsubscribe = connectionManager.onceConnected(loadSchedules);
-      });
-    };
-
-    loadSchedules();
-
-    return () => {
-      cancelled = true;
-      unsubscribe?.();
-    };
-  }, [spaceId]);
 
   useEffect(() => {
     if (!spaceId) return;
@@ -607,43 +238,6 @@ export function SpaceAgentList() {
     navigateToSpaceAgent(spaceUrlId, agent.handle);
   };
 
-  const handleEditSubscriptions = async (agent: SpaceAgent) => {
-    let longHorizonAgent = longHorizonAgentResolver(agent);
-    try {
-      const agentStatus = agent.status ?? 'active';
-      const agentConfig = {
-        handle: isCoordinatorAgent(agent) ? 'coordinator' : agent.handle,
-        displayName: agent.name,
-        instructions: agent.customPrompt ?? '',
-        model: agent.model ?? null,
-        thinkingLevel: agent.thinkingLevel ?? null,
-        provider: agent.provider ?? null,
-        settingSources: agent.settingSources ?? null,
-        toolPermissions: agent.tools && agent.tools.length > 0 ? { tools: agent.tools } : {},
-      };
-      if (longHorizonAgent) {
-        longHorizonAgent = await spaceStore.updateLongHorizonAgent(longHorizonAgent.id, {
-          ...agentConfig,
-          status: agentStatus,
-        });
-      } else {
-        longHorizonAgent = await spaceStore.createLongHorizonAgent({
-          id: agent.id,
-          ...agentConfig,
-          status: agentStatus,
-        });
-      }
-    } catch (err) {
-      toast.error(
-        `Failed to prepare long-horizon agent row: ${err instanceof Error ? err.message : String(err)}`
-      );
-      return;
-    }
-    setSubscriptionEditorAgent(agent);
-    setSubscriptionEditorLongHorizonAgent(longHorizonAgent);
-    loadSubscriptions(longHorizonAgent.id).catch(() => {});
-  };
-
   const handleCreate = () => {
     setEditingAgent(null);
     setEditorOpen(true);
@@ -667,41 +261,22 @@ export function SpaceAgentList() {
       await spaceStore.deleteAgent(deletingAgent.id);
       setDeletingAgent(null);
     } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : 'Failed to delete agent');
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete worker agent');
     } finally {
       setDeleting(false);
     }
   };
 
-  const handleGoalsClick = () => {
-    if (!spaceUrlId) return;
-    navigateToSpaceGoals(spaceUrlId);
-  };
-
-  const handleForgeClick = () => {
-    if (!spaceUrlId) return;
-    navigateToSpaceForge(spaceUrlId);
-  };
-
   const existingAgentNames = agents.filter((a) => a.id !== editingAgent?.id).map((a) => a.name);
-  const selectedLongHorizonAgent = subscriptionEditorAgent
-    ? (longHorizonAgentResolver(subscriptionEditorAgent) ?? subscriptionEditorLongHorizonAgent)
-    : null;
-  const totalEventSubscriptions = Object.values(subscriptionsByAgentId).reduce(
-    (total, subscriptions) => total + subscriptions.filter((s) => s.status === 'active').length,
-    0
-  );
   const coordinator = agents.find(isCoordinatorAgent);
   const otherAgents = agents.filter((agent) => agent.id !== coordinator?.id);
   const visibleAgents = coordinator ? [coordinator, ...otherAgents] : agents;
-  const activeGoals = goals.filter((goal) => goal.status === 'active');
-  const activeSchedules = schedules.filter((schedule) => schedule.status === 'active');
 
   if (loading) {
     return (
       <div class="h-full overflow-y-auto">
         <div class="min-h-[calc(100%+1px)] flex items-center justify-center">
-          <span class="text-xs text-gray-600 animate-pulse">Loading agents...</span>
+          <span class="text-xs text-gray-600 animate-pulse">Loading worker agents...</span>
         </div>
       </div>
     );
@@ -714,116 +289,48 @@ export function SpaceAgentList() {
           <div class="mt-0.5 h-8 w-1 flex-shrink-0 rounded-full bg-purple-400/70" />
           <div class="min-w-0">
             <p class="text-xs font-semibold uppercase tracking-wider text-gray-300">
-              Agents · {agents.length} configured
+              Worker agents · {agents.length} configured
             </p>
             <p class="mt-1 text-xs text-gray-500">
-              Coordinator is the default long-horizon Agent for this Space. Create specialists for
-              coding, review, research, and QA.
+              Reusable workflow worker configurations for this Space. Create specialists for coding,
+              review, research, and QA.
             </p>
           </div>
         </div>
         <Button size="sm" onClick={handleCreate} icon={<PlusIcon />}>
-          Create Agent
+          Create worker agent
         </Button>
       </div>
 
       <div class="scrollbar-dark min-h-0 flex-1 overflow-y-auto pr-3">
         <div class="min-h-[calc(100%+1px)] space-y-3 pb-4">
-          <div class="grid gap-3 lg:grid-cols-3">
-            <div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
-              <div class="flex items-center justify-between gap-2">
-                <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
-                  Managed goals
-                </p>
-                <button
-                  type="button"
-                  class="text-xs text-blue-300 hover:text-blue-200 disabled:opacity-50"
-                  onClick={handleGoalsClick}
-                  disabled={!spaceId}
-                >
-                  View
-                </button>
-              </div>
-              <p class="mt-2 text-2xl font-semibold text-gray-100">{activeGoals.length}</p>
-              <p class="mt-1 text-xs text-gray-500">Active goals Coordinator can track.</p>
-            </div>
-            <div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
-              <div class="flex items-center justify-between gap-2">
-                <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
-                  Forge scopes
-                </p>
-                <button
-                  type="button"
-                  class="text-xs text-blue-300 hover:text-blue-200 disabled:opacity-50"
-                  onClick={handleForgeClick}
-                  disabled={!spaceId}
-                >
-                  Open Forge
-                </button>
-              </div>
-              <div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-500">
-                Per-Agent Forge scope policy coming soon.
-              </div>
-              <p class="mt-1 text-xs text-gray-500">
-                Open Forge to review current evidence, lessons, and proposals.
-              </p>
-            </div>
-            <div class="rounded-lg border border-white/10 bg-white/[0.025] p-3">
-              <p class="text-xs font-semibold uppercase tracking-wider text-gray-400">
-                Reminders and events
-              </p>
-              <div class="mt-2 rounded border border-white/10 bg-dark-800 px-2 py-1.5 text-xs text-gray-300">
-                {totalEventSubscriptions} active event subscriptions
-              </div>
-              <p class="mt-1 text-xs text-gray-500">
-                {activeSchedules.length} active reminders · event subscriptions configurable per
-                agent
-              </p>
-            </div>
-          </div>
-
           {visibleAgents.length === 0 ? (
             <div class="flex flex-col items-center justify-center py-12 text-center">
               <div class="w-10 h-10 rounded-full bg-dark-800 flex items-center justify-center mb-3">
                 <AgentIcon />
               </div>
-              <p class="text-sm text-gray-400 font-medium">No agents yet</p>
+              <p class="text-sm text-gray-400 font-medium">No worker agents yet</p>
               <p class="text-xs text-gray-600 mt-1">Create one to get started.</p>
               <div class="mt-4">
                 <Button size="sm" variant="secondary" onClick={handleCreate}>
-                  Create Agent
+                  Create worker agent
                 </Button>
               </div>
             </div>
           ) : (
             <div class="space-y-2">
-              {visibleAgents.map((agent) => {
-                const longHorizonAgent = longHorizonAgentResolver(agent);
-                const subscriptions = longHorizonAgent
-                  ? (subscriptionsByAgentId[longHorizonAgent.id] ?? [])
-                  : [];
-                const activeSubscriptions = subscriptions.filter((s) => s.status === 'active');
-                return (
-                  <AgentCard
-                    key={agent.id}
-                    agent={agent}
-                    drifted={driftedAgentIds.has(agent.id)}
-                    syncing={syncingAgentId === agent.id}
-                    managedGoalCount={activeGoals.length}
-                    reminderCount={activeSchedules.length}
-                    subscriptionCount={activeSubscriptions.length}
-                    subscriptionTopics={activeSubscriptions.map((s) => ({
-                      id: s.id,
-                      topic: s.topic,
-                    }))}
-                    onEdit={handleEdit}
-                    onDelete={handleDeleteClick}
-                    onSync={handleSync}
-                    onOpenDetail={handleOpenDetail}
-                    onEditSubscriptions={handleEditSubscriptions}
-                  />
-                );
-              })}
+              {visibleAgents.map((agent) => (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  drifted={driftedAgentIds.has(agent.id)}
+                  syncing={syncingAgentId === agent.id}
+                  onEdit={handleEdit}
+                  onDelete={handleDeleteClick}
+                  onSync={handleSync}
+                  onOpenDetail={handleOpenDetail}
+                />
+              ))}
             </div>
           )}
 
@@ -832,8 +339,8 @@ export function SpaceAgentList() {
               Workflow usage
             </p>
             <p class="mt-1 text-xs text-gray-500">
-              {workflows.length} workflows can reference these agents. Edit workflows to assign
-              specialists.
+              {workflows.length} workflows can reference these worker agents. Edit workflows to
+              assign specialists.
             </p>
           </div>
         </div>
@@ -848,19 +355,6 @@ export function SpaceAgentList() {
         />
       )}
 
-      {subscriptionEditorAgent && selectedLongHorizonAgent && (
-        <SubscriptionEditor
-          agent={subscriptionEditorAgent}
-          longHorizonAgent={selectedLongHorizonAgent}
-          subscriptions={subscriptionsByAgentId[selectedLongHorizonAgent.id] ?? []}
-          onClose={() => {
-            setSubscriptionEditorAgent(null);
-            setSubscriptionEditorLongHorizonAgent(null);
-          }}
-          onChanged={loadSubscriptions}
-        />
-      )}
-
       {deletingAgent && (
         <ConfirmModal
           isOpen
@@ -869,7 +363,7 @@ export function SpaceAgentList() {
             setDeleteError(null);
           }}
           onConfirm={handleDeleteConfirm}
-          title="Delete Agent"
+          title="Delete worker agent"
           message={`Are you sure you want to delete "${deletingAgent.name}"? This action cannot be undone.`}
           confirmText="Delete"
           confirmButtonVariant="danger"

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -35,7 +35,7 @@ const CONFIGURE_TABS: Array<{
   label: string;
   count: (args: { agentCount: number; workflowCount: number }) => number;
 }> = [
-  { id: 'agents', label: 'Agents', count: ({ agentCount }) => agentCount },
+  { id: 'agents', label: 'Worker agents', count: ({ agentCount }) => agentCount },
   { id: 'workflows', label: 'Workflows', count: ({ workflowCount }) => workflowCount },
   { id: 'settings', label: 'General', count: () => 1 },
 ];

--- a/packages/web/src/components/space/SpaceLongHorizonAgents.tsx
+++ b/packages/web/src/components/space/SpaceLongHorizonAgents.tsx
@@ -1,11 +1,10 @@
 import type {
-  SpaceAgent,
   SpaceLongHorizonAgent,
   SpaceLongHorizonAgentTemplate,
   ThinkingLevel,
 } from '@neokai/shared';
 import { useEffect, useState } from 'preact/hooks';
-import { navigateToSpaceSession } from '../../lib/router';
+import { navigateToSpaceConfigure, navigateToSpaceSession } from '../../lib/router';
 import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 import { Button } from '../ui/Button';
@@ -31,34 +30,6 @@ const AUTONOMY_LABELS: Record<number, string> = {
 
 function isCoordinator(agent: SpaceLongHorizonAgent): boolean {
   return agent.handle === 'coordinator';
-}
-
-type SelectedAgentDetail =
-  | { source: 'long-horizon'; agent: SpaceLongHorizonAgent }
-  | { source: 'space-agent'; agent: SpaceAgent };
-
-function selectedAgentName(detail: SelectedAgentDetail): string {
-  return detail.source === 'long-horizon' ? detail.agent.displayName : detail.agent.name;
-}
-
-function selectedAgentStatus(detail: SelectedAgentDetail): string {
-  return detail.agent.status ?? 'active';
-}
-
-function selectedAgentInstructions(detail: SelectedAgentDetail): string | null {
-  return detail.source === 'long-horizon' ? detail.agent.instructions : detail.agent.customPrompt;
-}
-
-function selectedAgentAutonomyLevel(detail: SelectedAgentDetail): number | null {
-  return detail.source === 'long-horizon' ? detail.agent.autonomyLevel : null;
-}
-
-function selectedAgentModel(detail: SelectedAgentDetail): string | null | undefined {
-  return detail.agent.model;
-}
-
-function selectedAgentThinkingLevel(detail: SelectedAgentDetail): ThinkingLevel | null | undefined {
-  return detail.agent.thinkingLevel;
 }
 
 // ── Agent editor ─────────────────────────────────────────────────────────────
@@ -147,7 +118,7 @@ function AgentEditor({ template, agent, existingHandles, onSave, onCancel }: Age
           <p class="text-sm font-semibold text-gray-100">
             {isEdit
               ? `Edit ${agent?.displayName}`
-              : `New agent${template ? ` · ${template.displayName}` : ''}`}
+              : `New long-horizon agent${template ? ` · ${template.displayName}` : ''}`}
           </p>
           <button
             type="button"
@@ -530,11 +501,6 @@ export function SpaceLongHorizonAgents({
   const selectedSpaceAgent = selectedHandle
     ? spaceAgents.find((agent) => agent.handle === selectedHandle && agent.status !== 'archived')
     : null;
-  const selectedAgent: SelectedAgentDetail | null = selectedSpaceAgent
-    ? { source: 'space-agent', agent: selectedSpaceAgent }
-    : selectedLongHorizonAgent
-      ? { source: 'long-horizon', agent: selectedLongHorizonAgent }
-      : null;
   const existingHandles = new Set(agents.map((a) => a.handle));
 
   // Count how many active instances exist per template handle
@@ -546,7 +512,7 @@ export function SpaceLongHorizonAgents({
   if (loading) {
     return (
       <div class="flex-1 flex items-center justify-center">
-        <span class="text-xs text-gray-400 animate-pulse">Loading agents…</span>
+        <span class="text-xs text-gray-400 animate-pulse">Loading long-horizon agents…</span>
       </div>
     );
   }
@@ -559,47 +525,62 @@ export function SpaceLongHorizonAgents({
             class="rounded-xl border border-blue-500/30 bg-blue-500/10 p-4"
             data-testid="space-agent-detail"
           >
-            {selectedAgent ? (
+            {selectedLongHorizonAgent ? (
               <>
                 <div class="flex items-start justify-between gap-3">
                   <div class="min-w-0">
                     <p class="text-xs font-semibold uppercase tracking-wider text-blue-300/70">
-                      Selected agent
+                      Selected long-horizon agent
                     </p>
                     <h2 class="mt-1 text-base font-semibold text-gray-100">
-                      {selectedAgentName(selectedAgent)}
+                      {selectedLongHorizonAgent.displayName}
                     </h2>
-                    <p class="mt-0.5 text-xs text-gray-400">@{selectedAgent.agent.handle}</p>
+                    <p class="mt-0.5 text-xs text-gray-400">@{selectedLongHorizonAgent.handle}</p>
                   </div>
                   <span class="flex-shrink-0 rounded-full bg-white/10 px-2 py-0.5 text-xs text-gray-300">
-                    {selectedAgentStatus(selectedAgent)}
+                    {selectedLongHorizonAgent.status ?? 'active'}
                   </span>
                 </div>
-                {selectedAgentInstructions(selectedAgent) && (
+                {selectedLongHorizonAgent.instructions && (
                   <p class="mt-3 text-sm text-gray-300 whitespace-pre-wrap">
-                    {selectedAgentInstructions(selectedAgent)}
+                    {selectedLongHorizonAgent.instructions}
                   </p>
                 )}
                 <div class="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
-                  {selectedAgent.source === 'space-agent' && <span>Configured Space Agent</span>}
-                  {selectedAgentAutonomyLevel(selectedAgent) && (
+                  {selectedLongHorizonAgent.autonomyLevel && (
                     <span>
-                      L{selectedAgentAutonomyLevel(selectedAgent)}{' '}
-                      {AUTONOMY_LABELS[selectedAgentAutonomyLevel(selectedAgent)!]}
+                      L{selectedLongHorizonAgent.autonomyLevel}{' '}
+                      {AUTONOMY_LABELS[selectedLongHorizonAgent.autonomyLevel]}
                     </span>
                   )}
-                  {selectedAgentModel(selectedAgent) && (
-                    <span>Model: {selectedAgentModel(selectedAgent)}</span>
+                  {selectedLongHorizonAgent.model && (
+                    <span>Model: {selectedLongHorizonAgent.model}</span>
                   )}
-                  {selectedAgentThinkingLevel(selectedAgent) && (
-                    <span>Thinking: {selectedAgentThinkingLevel(selectedAgent)}</span>
+                  {selectedLongHorizonAgent.thinkingLevel && (
+                    <span>Thinking: {selectedLongHorizonAgent.thinkingLevel}</span>
                   )}
                 </div>
               </>
+            ) : selectedSpaceAgent ? (
+              <div data-testid="space-agent-detail-mismatch">
+                <p class="text-sm font-medium text-gray-100">Worker agent found</p>
+                <p class="mt-1 text-xs text-gray-400">
+                  @{selectedHandle} is a worker agent, not a long-horizon agent.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => navigateToSpaceConfigure(routeSpaceId, 'agents')}
+                  class="mt-2 text-xs text-blue-300 hover:text-blue-200"
+                >
+                  Go to Worker agents settings
+                </button>
+              </div>
             ) : (
               <div data-testid="space-agent-detail-missing">
                 <p class="text-sm font-medium text-gray-100">Agent not found</p>
-                <p class="mt-1 text-xs text-gray-400">No agent found for @{selectedHandle}.</p>
+                <p class="mt-1 text-xs text-gray-400">
+                  No long-horizon agent found for @{selectedHandle}.
+                </p>
               </div>
             )}
           </section>
@@ -608,11 +589,11 @@ export function SpaceLongHorizonAgents({
         {/* Configured agents */}
         <section class="rounded-xl border border-white/8 bg-white/[0.03] p-4">
           <p class="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
-            Configured · {sortedAgents.length}
+            Configured long-horizon agents · {sortedAgents.length}
           </p>
           {sortedAgents.length === 0 ? (
             <p class="text-xs text-gray-400 py-4">
-              No agents yet — add one from the templates below.
+              No long-horizon agents yet — add one from the templates below.
             </p>
           ) : (
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -689,7 +670,7 @@ export function SpaceLongHorizonAgents({
             setDeleteError(null);
           }}
           onConfirm={handleDeleteConfirm}
-          title="Delete Agent"
+          title="Delete long-horizon agent"
           message={`Delete "${deletingAgent.displayName}"? This cannot be undone.`}
           confirmText="Delete"
           confirmButtonVariant="danger"

--- a/packages/web/src/components/space/__tests__/SpaceAgentEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentEditor.test.tsx
@@ -178,13 +178,13 @@ describe('SpaceAgentEditor', () => {
 
   it('renders with "Create Agent" title in create mode', () => {
     const { getByRole } = render(<SpaceAgentEditor {...DEFAULT_PROPS} />);
-    expect(getByRole('dialog', { name: 'Create Agent' })).toBeTruthy();
+    expect(getByRole('dialog', { name: 'Create worker agent' })).toBeTruthy();
   });
 
   it('renders with edit title in edit mode', () => {
     const agent = makeAgent({ name: 'My Coder' });
     const { getByRole } = render(<SpaceAgentEditor {...DEFAULT_PROPS} agent={agent} />);
-    expect(getByRole('dialog', { name: 'Edit Agent: My Coder' })).toBeTruthy();
+    expect(getByRole('dialog', { name: 'Edit worker agent: My Coder' })).toBeTruthy();
   });
 
   it('pre-fills name field in edit mode', () => {

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -4,10 +4,10 @@
  *
  * Tests:
  * - Loading state
- * - Empty state: "No agents yet. Create one to get started."
+ * - Empty state: "No worker agents yet. Create one to get started."
  * - Agent cards render name, model, description preview
  * - Tool count and preview tags render
- * - Create Agent button opens editor
+ * - Create worker agent button opens editor
  * - Edit button opens editor for that agent
  * - Delete button behavior:
  *   - When agent IS referenced by a workflow: shows blocking modal (no delete button)
@@ -17,77 +17,35 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, waitFor, cleanup, screen } from '@testing-library/preact';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import type { SpaceAgent, SpaceLongHorizonAgent, SpaceWorkflow } from '@neokai/shared';
+import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
-let mockLongHorizonAgents: ReturnType<typeof signal<SpaceLongHorizonAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
-let mockGoals: ReturnType<typeof signal<any[]>>;
-let mockSchedules: ReturnType<typeof signal<any[]>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockSpaceId: ReturnType<typeof signal<string | null>>;
 let mockSpace: ReturnType<typeof signal<any>>;
 
-const {
-  mockDeleteAgent,
-  mockCreateAgent,
-  mockUpdateAgent,
-  mockListSchedules,
-  mockListLongHorizonAgentSubscriptions,
-  mockCreateLongHorizonAgent,
-  mockUpdateLongHorizonAgent,
-  mockCreateLongHorizonAgentSubscription,
-  mockUpdateLongHorizonAgentSubscription,
-  mockDeleteLongHorizonAgentSubscription,
-  mockOnceConnected,
-  mockNavigateToSpaceGoals,
-  mockNavigateToSpaceForge,
-} = vi.hoisted(() => ({
+const { mockDeleteAgent, mockCreateAgent, mockUpdateAgent } = vi.hoisted(() => ({
   mockDeleteAgent: vi.fn(),
   mockCreateAgent: vi.fn(),
   mockUpdateAgent: vi.fn(),
-  mockListSchedules: vi.fn(),
-  mockListLongHorizonAgentSubscriptions: vi.fn(),
-  mockCreateLongHorizonAgent: vi.fn(),
-  mockUpdateLongHorizonAgent: vi.fn(),
-  mockCreateLongHorizonAgentSubscription: vi.fn(),
-  mockUpdateLongHorizonAgentSubscription: vi.fn(),
-  mockDeleteLongHorizonAgentSubscription: vi.fn(),
-  mockOnceConnected: vi.fn(),
-  mockNavigateToSpaceGoals: vi.fn(),
-  mockNavigateToSpaceForge: vi.fn(),
-}));
-
-vi.mock('../../../lib/router', () => ({
-  navigateToSpaceGoals: mockNavigateToSpaceGoals,
-  navigateToSpaceForge: mockNavigateToSpaceForge,
 }));
 
 vi.mock('../../../lib/space-store', () => ({
   get spaceStore() {
     return {
       agents: mockAgents,
-      longHorizonAgents: mockLongHorizonAgents,
       workflows: mockWorkflows,
-      goals: mockGoals,
-      schedules: mockSchedules,
       loading: mockLoading,
       spaceId: mockSpaceId,
       space: mockSpace,
       deleteAgent: mockDeleteAgent,
       createAgent: mockCreateAgent,
       updateAgent: mockUpdateAgent,
-      listSchedules: mockListSchedules,
-      createLongHorizonAgent: mockCreateLongHorizonAgent,
-      updateLongHorizonAgent: mockUpdateLongHorizonAgent,
-      listLongHorizonAgentSubscriptions: mockListLongHorizonAgentSubscriptions,
-      createLongHorizonAgentSubscription: mockCreateLongHorizonAgentSubscription,
-      updateLongHorizonAgentSubscription: mockUpdateLongHorizonAgentSubscription,
-      deleteLongHorizonAgentSubscription: mockDeleteLongHorizonAgentSubscription,
     };
   },
 }));
@@ -96,7 +54,7 @@ const mockHubRequest = vi.fn();
 vi.mock('../../../lib/connection-manager', () => ({
   connectionManager: {
     getHubIfConnected: () => ({ request: mockHubRequest }),
-    onceConnected: mockOnceConnected,
+    onceConnected: vi.fn(),
   },
 }));
 
@@ -237,10 +195,7 @@ vi.mock('../../ui/Modal', () => ({
 
 // Initialize signals before import
 mockAgents = signal<SpaceAgent[]>([]);
-mockLongHorizonAgents = signal<SpaceLongHorizonAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
-mockGoals = signal<any[]>([]);
-mockSchedules = signal<any[]>([]);
 mockLoading = signal(false);
 mockSpaceId = signal<string | null>('space-1');
 mockSpace = signal<any>({
@@ -269,30 +224,6 @@ function makeAgent(overrides: Partial<SpaceAgent> = {}): SpaceAgent {
   };
 }
 
-function makeLongHorizonAgent(
-  overrides: Partial<SpaceLongHorizonAgent> = {}
-): SpaceLongHorizonAgent {
-  return {
-    id: 'lh-agent-1',
-    spaceId: 'space-1',
-    handle: 'my-coder',
-    displayName: 'My Coder',
-    templateKey: null,
-    status: 'active',
-    sessionId: null,
-    instructions: '',
-    autonomyLevel: null,
-    model: null,
-    thinkingLevel: null,
-    provider: null,
-    settingSources: null,
-    toolPermissions: {},
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-    ...overrides,
-  };
-}
-
 function makeWorkflow(agentId: string): SpaceWorkflow {
   return {
     id: 'wf-1',
@@ -314,32 +245,12 @@ describe('SpaceAgentList', () => {
   beforeEach(() => {
     cleanup();
     mockAgents.value = [];
-    mockLongHorizonAgents.value = [];
     mockWorkflows.value = [];
-    mockGoals.value = [];
-    mockSchedules.value = [];
     mockLoading.value = false;
     mockSpaceId.value = 'space-1';
     mockDeleteAgent.mockReset();
     mockCreateAgent.mockReset();
     mockUpdateAgent.mockReset();
-    mockListSchedules.mockReset();
-    mockListSchedules.mockResolvedValue([]);
-    mockListLongHorizonAgentSubscriptions.mockReset();
-    mockListLongHorizonAgentSubscriptions.mockResolvedValue([]);
-    mockCreateLongHorizonAgent.mockReset();
-    mockCreateLongHorizonAgent.mockImplementation(async (params) => makeLongHorizonAgent(params));
-    mockUpdateLongHorizonAgent.mockReset();
-    mockUpdateLongHorizonAgent.mockImplementation(async (id, params) =>
-      makeLongHorizonAgent({ id, ...params })
-    );
-    mockCreateLongHorizonAgentSubscription.mockReset();
-    mockUpdateLongHorizonAgentSubscription.mockReset();
-    mockDeleteLongHorizonAgentSubscription.mockReset();
-    mockOnceConnected.mockReset();
-    mockOnceConnected.mockReturnValue(() => {});
-    mockNavigateToSpaceGoals.mockReset();
-    mockNavigateToSpaceForge.mockReset();
     mockHubRequest.mockReset();
     // Default: drift report returns no drifted agents so the list renders cleanly.
     mockHubRequest.mockResolvedValue({
@@ -356,21 +267,21 @@ describe('SpaceAgentList', () => {
   it('renders loading state when loading is true', () => {
     mockLoading.value = true;
     const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    expect(getByText('Loading agents...')).toBeTruthy();
+    expect(getByText('Loading worker agents...')).toBeTruthy();
   });
 
   // ── Empty state ────────────────────────────────────────────────────────────
 
   it('renders empty state when no agents exist', () => {
     const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    expect(getByText('No agents yet')).toBeTruthy();
+    expect(getByText('No worker agents yet')).toBeTruthy();
     expect(getByText('Create one to get started.')).toBeTruthy();
   });
 
-  it('renders header Create Agent button always', () => {
+  it('renders header Create worker agent button always', () => {
     const { getAllByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
     // Both the header button and the empty-state button exist
-    const buttons = getAllByText('Create Agent');
+    const buttons = getAllByText('Create worker agent');
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -391,7 +302,6 @@ describe('SpaceAgentList', () => {
   it('does not render model span when model is not set', () => {
     mockAgents.value = [makeAgent({ model: undefined })];
     const { container } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    // The TaskAgentCard shows the resolved model, so check within custom agent cards only.
     const agentCards = container.querySelectorAll('.bg-dark-850.border.border-dark-700');
     for (const card of agentCards) {
       const modelSpans = card.querySelectorAll('span.text-xs.text-gray-500.font-mono');
@@ -438,86 +348,17 @@ describe('SpaceAgentList', () => {
     expect(getByText('Agent Beta')).toBeTruthy();
   });
 
-  it('loads schedules for reminder totals', () => {
-    render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    expect(mockListSchedules).toHaveBeenCalledOnce();
-  });
-
-  it.each([
-    'Not connected',
-    'Not connected to transport',
-  ])('retries loading schedules when the connection recovers after %s', async (message) => {
-    let reconnect: (() => void) | undefined;
-    mockListSchedules.mockRejectedValueOnce(new Error(message));
-    mockOnceConnected.mockImplementation((callback) => {
-      reconnect = callback;
-      return vi.fn();
-    });
-
-    render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    await waitFor(() => expect(mockOnceConnected).toHaveBeenCalledOnce());
-
-    mockListSchedules.mockResolvedValue([]);
-    reconnect?.();
-    expect(mockListSchedules).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not retry loading schedules after non-connection errors', async () => {
-    mockListSchedules.mockRejectedValueOnce(new Error('Request failed'));
-
-    render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    await waitFor(() => expect(mockListSchedules).toHaveBeenCalledOnce());
-
-    expect(mockOnceConnected).not.toHaveBeenCalled();
-  });
-
-  it('uses SPA navigation for goals and Forge links', () => {
-    render(<SpaceAgentList {...DEFAULT_PROPS} />);
-
-    fireEvent.click(screen.getByText('View'));
-    fireEvent.click(screen.getByText('Open Forge'));
-
-    expect(mockNavigateToSpaceGoals).toHaveBeenCalledWith('neokai-dev');
-    expect(mockNavigateToSpaceForge).toHaveBeenCalledWith('neokai-dev');
-  });
-
-  it('shows Coordinator as default long-horizon agent with basic scopes', () => {
-    mockAgents.value = [
-      makeAgent({
-        id: 'coordinator-1',
-        name: 'Coordinator',
-        templateName: 'Coordinator',
-        description: 'Built-in long-horizon Space agent.',
-      }),
-      makeAgent({ id: 'coder-1', name: 'Coder' }),
-    ];
-    mockGoals.value = [
-      { id: 'goal-1', status: 'active' },
-      { id: 'goal-2', status: 'completed' },
-      { id: 'goal-3', status: 'paused' },
-    ];
-    mockSchedules.value = [{ id: 'schedule-1', status: 'active' }];
-
-    const { container, getByText, queryByLabelText } = render(
-      <SpaceAgentList {...DEFAULT_PROPS} />
-    );
-
-    expect(getByText('Default Coordinator')).toBeTruthy();
-    expect(container.textContent).toContain('managed goals');
-    expect(container.textContent).toContain('Forge scopes');
-    expect(container.textContent).toContain('reminders');
-    expect(container.textContent).toContain('event subscriptions');
-    expect(container.textContent).toContain('Per-Agent Forge scope policy coming soon.');
-    expect(container.textContent).toContain('0 active event subscriptions');
-    expect(queryByLabelText('Forge scope filter')).toBeNull();
-    expect(queryByLabelText('Event subscription pattern')).toBeNull();
+  it('renders workflow usage footer', () => {
+    const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+    expect(getByText('Workflow usage')).toBeTruthy();
+    expect(getByText(/workflows can reference these worker agents/)).toBeTruthy();
   });
 
   // ── Editor opening ─────────────────────────────────────────────────────────
 
-  it('opens editor in create mode when Create Agent header button is clicked', () => {
+  it('opens editor in create mode when Create worker agent header button is clicked', () => {
     const { getAllByText, getByTestId } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    const createButtons = getAllByText('Create Agent');
+    const createButtons = getAllByText('Create worker agent');
     fireEvent.click(createButtons[0]);
     expect(getByTestId('editor-mode').textContent).toBe('create');
   });
@@ -531,144 +372,11 @@ describe('SpaceAgentList', () => {
     expect(getByTestId('editor-agent-name').textContent).toBe('Coder');
   });
 
-  it('opens event subscriptions using the seeded coordinator long-horizon agent id', async () => {
-    mockAgents.value = [
-      makeAgent({
-        id: 'space-agent-coordinator',
-        name: 'Coordinator',
-        handle: 'coordinator',
-        templateName: 'Coordinator',
-      }),
-    ];
-    mockLongHorizonAgents.value = [
-      makeLongHorizonAgent({
-        id: 'space-lh-agent:coordinator:space-1',
-        handle: 'coordinator',
-        displayName: 'Coordinator',
-        templateKey: 'coordinator.default',
-      }),
-    ];
-
-    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    fireEvent.click(getByLabelText('Edit event subscriptions for Coordinator'));
-
-    expect(await findByText('Event subscriptions')).toBeTruthy();
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith(
-      'space-lh-agent:coordinator:space-1'
-    );
-  });
-
-  it('refreshes active long-horizon rows when opening subscriptions', async () => {
-    mockAgents.value = [makeAgent({ id: 'space-agent-coder', name: 'Coder', handle: 'coder' })];
-    mockLongHorizonAgents.value = [
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' }),
-    ];
-    mockUpdateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'active' })
-    );
-
-    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
-
-    expect(await findByText('Event subscriptions')).toBeTruthy();
-    expect(mockUpdateLongHorizonAgent).toHaveBeenCalledWith(
-      'space-agent-coder',
-      expect.objectContaining({ status: 'active' })
-    );
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
-  });
-
-  it('preserves inactive long-horizon rows when opening subscriptions for paused agents', async () => {
-    mockAgents.value = [
-      makeAgent({
-        id: 'space-agent-coder',
-        name: 'Coder',
-        handle: 'coder',
-        status: 'paused',
-        customPrompt: 'Use Coder prompt.',
-        model: 'claude-sonnet-4-6',
-        thinkingLevel: 'medium',
-        provider: 'openrouter',
-        settingSources: ['project'],
-        tools: ['Read', 'Edit'],
-      }),
-    ];
-    mockLongHorizonAgents.value = [
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' }),
-    ];
-    mockUpdateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({ id: 'space-agent-coder', handle: 'coder', status: 'paused' })
-    );
-
-    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
-
-    expect(await findByText('Event subscriptions')).toBeTruthy();
-    expect(mockCreateLongHorizonAgent).not.toHaveBeenCalled();
-    expect(mockUpdateLongHorizonAgent).toHaveBeenCalledWith(
-      'space-agent-coder',
-      expect.objectContaining({
-        handle: 'coder',
-        displayName: 'Coder',
-        instructions: 'Use Coder prompt.',
-        model: 'claude-sonnet-4-6',
-        thinkingLevel: 'medium',
-        provider: 'openrouter',
-        settingSources: ['project'],
-        toolPermissions: { tools: ['Read', 'Edit'] },
-        status: 'paused',
-      })
-    );
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
-  });
-
-  it('creates a long-horizon row before opening subscriptions for new specialists', async () => {
-    mockAgents.value = [
-      makeAgent({
-        id: 'space-agent-coder',
-        name: 'Coder',
-        handle: 'coder',
-        status: 'paused',
-        tools: ['Read', 'Edit'],
-        provider: 'openrouter',
-        settingSources: ['project'],
-        description: 'Short UI summary only',
-        customPrompt: 'Use Coder prompt.',
-      }),
-    ];
-    mockCreateLongHorizonAgent.mockResolvedValue(
-      makeLongHorizonAgent({
-        id: 'space-agent-coder',
-        handle: 'coder',
-        displayName: 'Coder',
-        status: 'paused',
-      })
-    );
-
-    const { getByLabelText, findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-    fireEvent.click(getByLabelText('Edit event subscriptions for Coder'));
-
-    expect(await findByText('Event subscriptions')).toBeTruthy();
-    expect(mockCreateLongHorizonAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'space-agent-coder',
-        handle: 'coder',
-        displayName: 'Coder',
-        instructions: 'Use Coder prompt.',
-        provider: 'openrouter',
-        settingSources: ['project'],
-        toolPermissions: { tools: ['Read', 'Edit'] },
-        status: 'paused',
-      })
-    );
-    expect(mockListLongHorizonAgentSubscriptions).toHaveBeenCalledWith('space-agent-coder');
-  });
-
   it('closes editor when cancel is clicked', () => {
     const { getAllByText, queryByTestId, getByTestId } = render(
       <SpaceAgentList {...DEFAULT_PROPS} />
     );
-    fireEvent.click(getAllByText('Create Agent')[0]);
+    fireEvent.click(getAllByText('Create worker agent')[0]);
     expect(getByTestId('agent-editor')).toBeTruthy();
     fireEvent.click(getByTestId('editor-cancel'));
     expect(queryByTestId('agent-editor')).toBeNull();
@@ -678,7 +386,7 @@ describe('SpaceAgentList', () => {
     const { getAllByText, queryByTestId, getByTestId } = render(
       <SpaceAgentList {...DEFAULT_PROPS} />
     );
-    fireEvent.click(getAllByText('Create Agent')[0]);
+    fireEvent.click(getAllByText('Create worker agent')[0]);
     fireEvent.click(getByTestId('editor-save'));
     expect(queryByTestId('agent-editor')).toBeNull();
   });
@@ -762,9 +470,6 @@ describe('SpaceAgentList', () => {
   });
 
   // ── Delete flow — workflow-referenced agent (no longer blocked client-side) ─
-  // SpaceWorkflowSummary no longer includes node/agent details, so the client
-  // cannot determine workflow references. The daemon still blocks deletion of
-  // in-use agents. All delete clicks now show the standard confirm dialog.
 
   it('shows confirm modal (not blocking) even when agent is used in a workflow', () => {
     const agent = makeAgent({ id: 'agent-1', name: 'Coder' });
@@ -788,13 +493,13 @@ describe('SpaceAgentList', () => {
     expect(getByTestId('confirm-message').textContent).toContain('Coder');
   });
 
-  it('confirm modal title is "Delete Agent" even for referenced agents', () => {
+  it('confirm modal title is "Delete worker agent" even for referenced agents', () => {
     const agent = makeAgent({ id: 'agent-1', name: 'Coder' });
     mockAgents.value = [agent];
     mockWorkflows.value = [makeWorkflow('agent-1')];
     const { getByLabelText, getByRole } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
     fireEvent.click(getByLabelText('Delete Coder'));
-    expect(getByRole('dialog', { name: 'Delete Agent' })).toBeTruthy();
+    expect(getByRole('dialog', { name: 'Delete worker agent' })).toBeTruthy();
   });
 
   it('does not call deleteAgent when confirm modal is cancelled', () => {

--- a/packages/web/src/components/space/__tests__/SpaceLongHorizonAgents.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceLongHorizonAgents.test.tsx
@@ -12,6 +12,7 @@ const {
   mockEnsureConfigData,
   mockListLongHorizonAgentReminders,
   mockNavigateToSpaceSession,
+  mockNavigateToSpaceConfigure,
 } = vi.hoisted(() => {
   function makeSignal<T>(initial: T) {
     return { value: initial };
@@ -24,6 +25,7 @@ const {
     mockEnsureConfigData: vi.fn().mockResolvedValue(undefined),
     mockListLongHorizonAgentReminders: vi.fn().mockResolvedValue([]),
     mockNavigateToSpaceSession: vi.fn(),
+    mockNavigateToSpaceConfigure: vi.fn(),
   };
 });
 
@@ -42,6 +44,7 @@ vi.mock('../../../lib/space-store', () => ({
 
 vi.mock('../../../lib/router', () => ({
   navigateToSpaceSession: mockNavigateToSpaceSession,
+  navigateToSpaceConfigure: mockNavigateToSpaceConfigure,
 }));
 
 vi.mock('../../../lib/toast', () => ({
@@ -112,24 +115,25 @@ describe('SpaceLongHorizonAgents', () => {
     mockEnsureConfigData.mockClear();
     mockListLongHorizonAgentReminders.mockClear();
     mockNavigateToSpaceSession.mockClear();
+    mockNavigateToSpaceConfigure.mockClear();
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it('prefers configured SpaceAgent details when handles overlap', () => {
-    mockLongHorizonAgents.value = [makeLongHorizonAgent()];
+  it('shows mismatch panel when selected handle matches a worker agent but not a long-horizon agent', () => {
+    mockLongHorizonAgents.value = [];
     mockSpaceAgents.value = [makeSpaceAgent()];
 
     const { getByTestId } = render(
       <SpaceLongHorizonAgents spaceId="space-1" selectedHandle="research" />
     );
 
-    const detail = getByTestId('space-agent-detail');
-    expect(detail.textContent).toContain('Configured Research');
-    expect(detail.textContent).toContain('Configured Space Agent');
-    expect(detail.textContent).not.toContain('Research Long Horizon');
+    const detail = getByTestId('space-agent-detail-mismatch');
+    expect(detail.textContent).toContain('Worker agent found');
+    expect(detail.textContent).toContain('@research is a worker agent, not a long-horizon agent.');
+    expect(detail.textContent).toContain('Go to Worker agents settings');
   });
 
   it('uses the route space id for agent session navigation', () => {

--- a/packages/web/src/components/space/__tests__/SpaceLongHorizonAgents.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceLongHorizonAgents.test.tsx
@@ -134,6 +134,11 @@ describe('SpaceLongHorizonAgents', () => {
     expect(detail.textContent).toContain('Worker agent found');
     expect(detail.textContent).toContain('@research is a worker agent, not a long-horizon agent.');
     expect(detail.textContent).toContain('Go to Worker agents settings');
+
+    const link = detail.querySelector('button');
+    expect(link).toBeTruthy();
+    fireEvent.click(link!);
+    expect(mockNavigateToSpaceConfigure).toHaveBeenCalledWith('space-1', 'agents');
   });
 
   it('uses the route space id for agent session navigation', () => {

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -458,7 +458,7 @@ export default function SpaceIsland({
           class="flex-1 flex flex-col overflow-hidden bg-app-content"
           data-testid="space-agents-view"
         >
-          <SpacePageHeader pageTitle="Agents" />
+          <SpacePageHeader pageTitle="Long-horizon agents" />
           <div class="flex-1 min-w-0 overflow-hidden flex flex-col">
             <Suspense fallback={lazyFallback}>
               <SpaceLongHorizonAgents


### PR DESCRIPTION
Part of stack: "Clarify Space Worker Agents vs Long-Horizon Agents" (PR 3 of 4).
Base: `plan/clarify-space-agent-boundary/mcp-boundary`

**Backend**
- Expand `spaceLongHorizonAgent.*` RPC handlers: `listGoals`, `assignGoal`, `deleteGoalAssignment`, `listForgeScopes`, `assignForgeScope`, `deleteForgeScopeAssignment`
- Enforce `spaceId` ownership on all `spaceAgent.*` and `spaceLongHorizonAgent.*` handlers
- Fix `create_standalone_task` to reject `custom_agent_id` with a clear error (not yet supported in schema)
- Fix `reassign_task` to reject long-horizon-only agent IDs via `requireAgentFamily` resolver
- Same `custom_agent_id` rejection in `task-agent-manager.onCreateStandaloneTask`

**Frontend**
- Rename worker-agent UI copy: "Agents" → "Worker agents", "Create Agent" → "Create worker agent", etc.
- Remove LH-only affordances from worker agent settings (goals, Forge scopes, subscriptions, events)
- Rename long-horizon agent labels and replace silent worker-agent fallback with an explicit mismatch panel
- Update component tests for all label changes

**Verification**
- Daemon unit tests: 0-shared-handlers-workflow (2939 pass), 5-space-runtime-b (626 pass)
- Web component tests: 59 pass
- `bun run check` (lint + typecheck + knip + guards) pass