### PR TITLE
chore(release): bump version to 0.37.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,10 +526,18 @@ jobs:
             ASSETS+=("$asset")
           done < <(find dist/desktop -type f | sort)
 
-          gh release create "v$VERSION" \
-            "${ASSETS[@]}" \
-            --title "v$VERSION" \
-            --notes-file /tmp/release-notes.md
-          echo "GitHub Release created: v$VERSION"
+          if gh release view "v$VERSION" &>/dev/null; then
+            echo "::warning::Release v$VERSION already exists, skipping creation"
+            if [ ${#ASSETS[@]} -gt 0 ]; then
+              echo "Uploading assets to existing release..."
+              gh release upload "v$VERSION" "${ASSETS[@]}" --clobber
+            fi
+          else
+            gh release create "v$VERSION" \
+              "${ASSETS[@]}" \
+              --title "v$VERSION" \
+              --notes-file /tmp/release-notes.md
+          fi
+          echo "GitHub Release ready: v$VERSION"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ All notable changes to NeoKai will be documented in this file.
 
 ## [0.37.0] - 2026-06-08
 
-ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, and separation of worker and long-horizon agent types. 3 commits since v0.36.0.
+ACP protocol client with query adapter and message translator, runtime hook engine with MCP action integration, ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, separation of worker and long-horizon agent types, and terminology sweep with boundary tests. 6 commits since v0.36.0.
 
 ### Added
 
+- **ACP client + query adapter + message translator**: Implemented ACP protocol client with lifecycle management (initialize, authenticate, createSession, sendPrompt, cancel, close), server-to-client request delegation, streaming chunk accumulation into SDK messages, and query-contract adapter with interrupt and close support
+- **Runtime hook engine and MCP action integration**: Hook executor with sandboxed script execution using Bun.spawn, restricted env, credential stripping, timeout SIGKILL, and bounded stdout capture. Extended workflow hook types for runtime with submit_for_approval and approve_task methods
 - **ACP protocol types + JSON-RPC stdio transport**: Added ACP (Agent Client Protocol) JSON-RPC 2.0 type definitions covering initialization, authentication, session lifecycle, content blocks, tool calls, permission requests, file system operations, and MCP server configurations
 - **Workflow hook schema storage**: Typed hook definitions, validation, persistence, and per-run hook state storage so workflow hooks can be introduced without removing legacy gates. Includes export/import round-trip support and runtime bounds enforcement
 - **Separate worker and long-horizon agents**: Worker agents and long-horizon agents are now distinct agent types with separate lifecycle management
+
+### Changed
+
+- **Terminology sweep**: Replaced "custom agent" / "SpaceAgent ID" with "worker agent" / "long-horizon agent" across tool descriptions, comments, and user-facing labels. Added boundary design doc with developer guidance
+
+### Fixed
+
+- Fixed legacy long-horizon migration test to use the correct migration function (runMigration155) and added wrong-ID validation tests for goal/scope/reminder tools rejecting worker-only agent IDs
 
 ## [0.36.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to NeoKai will be documented in this file.
 
-## [0.37.0] - 2026-06-08
+## [0.37.0] - 2026-06-09
 
-ACP protocol client with query adapter and message translator, runtime hook engine with MCP action integration, ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, separation of worker and long-horizon agent types, and terminology sweep with boundary tests. 6 commits since v0.36.0.
+ACP protocol client with query adapter and message translator, runtime hook engine with MCP action integration, ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, separation of worker and long-horizon agent types, provider context window fix for non-native models, and terminology sweep with boundary tests. 7 commits since v0.36.0.
 
 ### Added
 
@@ -20,6 +20,7 @@ ACP protocol client with query adapter and message translator, runtime hook engi
 
 ### Fixed
 
+- **Prefer provider metadata context window for non-native providers**: Non-Anthropic providers (GLM, Kimi, Ollama, MiniMax, custom endpoints) now use their own model metadata contextWindow instead of the SDK's assumed capacity. Only Anthropic and Anthropic Copilot continue to trust SDK-reported values by default
 - Fixed legacy long-horizon migration test to use the correct migration function (runMigration155) and added wrong-ID validation tests for goal/scope/reminder tools rejecting worker-only agent IDs
 
 ## [0.36.0] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.37.0] - 2026-06-08
+
+ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, and separation of worker and long-horizon agent types. 3 commits since v0.36.0.
+
+### Added
+
+- **ACP protocol types + JSON-RPC stdio transport**: Added ACP (Agent Client Protocol) JSON-RPC 2.0 type definitions covering initialization, authentication, session lifecycle, content blocks, tool calls, permission requests, file system operations, and MCP server configurations
+- **Workflow hook schema storage**: Typed hook definitions, validation, persistence, and per-run hook state storage so workflow hooks can be introduced without removing legacy gates. Includes export/import round-trip support and runtime bounds enforcement
+- **Separate worker and long-horizon agents**: Worker agents and long-horizon agents are now distinct agent types with separate lifecycle management
+
 ## [0.36.0] - 2026-06-02
 
 Auto-fetch model list from custom endpoints, refresh models on provider changes, Forge completed-task automation and task-result backfill, Codex auth reliability fixes, long-horizon event subscription rehydration, agent event subscription UI, external event delivery log UI, auto-configure GitHub webhooks for spaces, and mobile Space tab fixes. 18 commits since v0.35.0.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "bin": {
         "kai": "./main.ts",
       },
@@ -32,7 +32,7 @@
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.141",
         "@github/copilot-sdk": "0.3.0",
@@ -48,11 +48,11 @@
     },
     "packages/desktop": {
       "name": "@neokai/desktop",
-      "version": "0.36.0",
+      "version": "0.37.0",
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
@@ -68,7 +68,7 @@
     },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
@@ -95,7 +95,7 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "dependencies": {
         "@preact/signals": "2.9.1",
         "clsx": "2.1.1",

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -6,10 +6,10 @@
     "kai": "bin/kai.js"
   },
   "optionalDependencies": {
-    "@neokai/cli-darwin-arm64": "0.8.0",
-    "@neokai/cli-darwin-x64": "0.8.0",
-    "@neokai/cli-linux-x64": "0.8.0",
-    "@neokai/cli-linux-arm64": "0.8.0"
+    "@neokai/cli-darwin-arm64": "0.37.0",
+    "@neokai/cli-darwin-x64": "0.37.0",
+    "@neokai/cli-linux-x64": "0.37.0",
+    "@neokai/cli-linux-arm64": "0.37.0"
   },
   "files": [
     "bin/"

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neokai",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "NeoKai - Claude Agent SDK Web Interface",
   "bin": {
     "kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/cli",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/daemon",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "main.ts",

--- a/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/provider.ts
@@ -819,7 +819,7 @@ export class AnthropicToCopilotBridgeProvider implements Provider {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'User-Agent': 'GitHubCopilotChat/0.36.0',
+        'User-Agent': 'GitHubCopilotChat/0.37.0',
       },
       body: JSON.stringify({ client_id: clientId, scope: 'read:user copilot' }),
     });

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/desktop",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "description": "Kai Desktop App - Tauri wrapper bundling the neokai daemon as a sidecar",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.36.0"
+version = "0.37.0"
 description = "Kai - AI Assistant Desktop App"
 authors = ["NeoKai contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kai",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "identifier": "io.neokai.kai",
   "build": {
     "frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/e2e",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/shared",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "license": "Apache-2.0",
   "main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neokai/web",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
Release v0.37.0

ACP protocol type definitions with JSON-RPC stdio transport, workflow hook schema storage with validation and persistence, and separation of worker and long-horizon agent types. 3 commits since v0.36.0.