### PR TITLE
refactor: replace channel gate evaluation with hook-driven message validation

### DIFF
--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -129,6 +129,7 @@ const exportedWorkflowChannelSchema = z.object({
   maxCycles: z.number().int().positive().optional(),
   label: z.string().optional(),
   gateId: z.string().optional(),
+  hookIds: z.array(z.string().min(1)).optional(),
 });
 
 const workflowHookValidatorSchema = z.union([
@@ -425,6 +426,7 @@ export function exportWorkflow(
       if (ch.maxCycles !== undefined) exported.maxCycles = ch.maxCycles;
       if (ch.label !== undefined) exported.label = ch.label;
       if (ch.gateId !== undefined) exported.gateId = ch.gateId;
+      if (ch.hookIds !== undefined) exported.hookIds = ch.hookIds;
       return exported;
     });
     result.channels = exportedChannels;

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -516,7 +516,9 @@ export class ChannelRouter {
       return { allowed: true };
     }
     const { channel, index } = match;
+    this.validateChannelExclusivity(channel);
     const gateSourceName = this.getChannelSourceName(workflow, channel, fromRole);
+    const hookManaged = this.isHookManagedChannel(channel);
 
     const channelIsCyclic = this.isChannelCyclicByIndex(index, workflow);
 
@@ -532,12 +534,15 @@ export class ChannelRouter {
     }
 
     // ── Gate condition evaluation ────────────────────────────────────────
+    // Hook-managed channels skip legacy gate evaluation; the hook engine
+    // validates the MCP action as the single authorization decision.
+    //
     // Cache optimization: skip re-evaluation when the gate was previously
     // opened (by a prior deliverMessage or onGateDataChanged), unless cyclic
     // with `resetOnCycle`. canDeliver does NOT write to the cache — it is a
     // non-mutating probe and must remain side-effect free so that a UI
     // readiness check cannot permanently cache a gate as open.
-    if (channel.gateId) {
+    if (channel.gateId && !hookManaged) {
       const skipEval =
         this.isGateCachedOpen(runId, channel.gateId, workflow) &&
         !this.mustReevaluateGate(channel.gateId, channelIsCyclic, workflow, gateSourceName);
@@ -644,11 +649,15 @@ export class ChannelRouter {
 
     const match = this.findMatchingWorkflowChannel(workflow, fromRole, toTarget);
     const channel = match?.channel;
+    if (channel) {
+      this.validateChannelExclusivity(channel);
+    }
     const channelIndex = match?.index ?? -1;
     const gateSourceName = channel
       ? this.getChannelSourceName(workflow, channel, fromRole)
       : undefined;
     const channelIsCyclic = match ? this.isChannelCyclicByIndex(channelIndex, workflow) : false;
+    const hookManaged = channel ? this.isHookManagedChannel(channel) : false;
 
     // ── 2. Target resolution: agent name → DM, node name → fan-out ────────
     // Target resolution itself is non-mutating — only `activateNode` below
@@ -695,7 +704,9 @@ export class ChannelRouter {
     // re-evaluation on subsequent messages. Exception: cyclic channels
     // whose gate has `resetOnCycle: true` must always re-evaluate because
     // their gate data is reset on each cycle traversal.
-    if (channel?.gateId) {
+    // Hook-managed channels skip legacy gate evaluation entirely; the hook
+    // engine has already validated the MCP action before this method is called.
+    if (channel?.gateId && !hookManaged) {
       const skipEval =
         this.isGateCachedOpen(runId, channel.gateId, workflow) &&
         !this.mustReevaluateGate(channel.gateId, channelIsCyclic, workflow, gateSourceName);
@@ -742,9 +753,12 @@ export class ChannelRouter {
     // the common case without creating pending executions; this second
     // check is the correctness backstop.
     //
+    // Hook-managed channels skip this legacy gate re-check; the hook
+    // engine's validation is the single authorization decision.
+    //
     // Cache optimization: same as step 3 — skip re-evaluation when the gate
     // was previously opened, unless cyclic with `resetOnCycle`.
-    if (channel?.gateId) {
+    if (channel?.gateId && !hookManaged) {
       const skipEval =
         this.isGateCachedOpen(runId, channel.gateId, workflow) &&
         !this.mustReevaluateGate(channel.gateId, channelIsCyclic, workflow, gateSourceName);
@@ -810,16 +824,18 @@ export class ChannelRouter {
     const run = this.config.workflowRunRepo.getRun(runId);
     if (!run) return [];
 
-    // Archive is the only tombstone. Done / cancelled runs are reopened
-    // below when the gate re-evaluation opens a channel requiring activation.
+    // Archive is the only tombstone.
     if (this.isParentTaskArchived(runId)) {
       this.evictRunCache(runId);
       return [];
     }
 
-    // Evict gate-open cache for terminal runs. Same rationale as deliverMessage.
+    // Terminal runs are not reopened by gate-data changes. Allowed
+    // reactivation paths are explicit cyclic send_message re-entry and
+    // manual human resume/retry only.
     if (run.status === 'done' || run.status === 'cancelled' || run.status === 'blocked') {
       this.evictRunCache(runId);
+      return [];
     }
 
     const workflow = this.config.workflowManager.getWorkflow(run.workflowId);
@@ -827,8 +843,12 @@ export class ChannelRouter {
 
     if (!this.config.gateDataRepo) return [];
 
-    // Find all channels in this workflow that reference this gate
-    const channels = (workflow.channels ?? []).filter((ch) => ch.gateId === gateId);
+    // Find all channels in this workflow that reference this gate.
+    // Skip hook-managed channels — they are evaluated by the hook engine
+    // at MCP action time, not by gate data writes.
+    const channels = (workflow.channels ?? []).filter(
+      (ch) => ch.gateId === gateId && !this.isHookManagedChannel(ch)
+    );
     if (channels.length === 0) return [];
 
     // --- Auto-approval: pre-write approval data when the space's autonomy level meets or
@@ -929,9 +949,12 @@ export class ChannelRouter {
         }
         if (!targetNode) continue;
 
-        // Only activate if no active tasks for this node
-        const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
-        if (activeTasks.length === 0) {
+        // Only activate nodes that have never been activated. Completed node
+        // executions must not be reactivated via onGateDataChanged — allowed
+        // reactivation paths are explicit cyclic send_message re-entry and
+        // manual human resume/retry only.
+        const allExecutions = this.config.nodeExecutionRepo.listByNode(runId, targetNode.id);
+        if (allExecutions.length === 0) {
           nodeIdsToActivate.add(targetNode.id);
         }
       }
@@ -1418,6 +1441,28 @@ export class ChannelRouter {
       return false;
     });
     return index >= 0 ? { channel: channels[index], index } : undefined;
+  }
+
+  /**
+   * Returns true when a channel is managed by hooks instead of legacy gates.
+   * A channel is hook-managed when it has a non-empty `hookIds` array.
+   */
+  private isHookManagedChannel(channel: WorkflowChannel): boolean {
+    return Array.isArray(channel.hookIds) && channel.hookIds.length > 0;
+  }
+
+  /**
+   * Validates that a channel does not reference both legacy `gateId` and `hookIds`.
+   * If both appear in persisted JSON the runtime fails closed with a workflow
+   * validation error until the workflow is migrated.
+   */
+  private validateChannelExclusivity(channel: WorkflowChannel): void {
+    if (channel.gateId && this.isHookManagedChannel(channel)) {
+      throw new ActivationError(
+        `Channel "${channel.id ?? 'unknown'}" references both gateId "${channel.gateId}" and hookIds [${channel.hookIds!.join(', ')}]. ` +
+          `A channel may reference either legacy gateId or hookIds, never both. Migrate the workflow to resolve.`
+      );
+    }
   }
 
   /**

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -832,8 +832,9 @@ export class ChannelRouter {
 
     // Terminal runs are not reopened by gate-data changes. Allowed
     // reactivation paths are explicit cyclic send_message re-entry and
-    // manual human resume/retry only.
-    if (run.status === 'done' || run.status === 'cancelled' || run.status === 'blocked') {
+    // manual human resume/retry only. Blocked runs are still evaluated so
+    // gate writes can unblock them.
+    if (run.status === 'done' || run.status === 'cancelled') {
       this.evictRunCache(runId);
       return [];
     }

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -200,6 +200,8 @@ function buildHookRestrictedEnv(
 
   if (context.prUrl) {
     env['NEOKAI_PR_URL'] = context.prUrl;
+    // Also expose as PR_URL for backward compatibility with converted gate scripts
+    env['PR_URL'] = context.prUrl;
   }
 
   if (context.gateDataJson) {

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -46,6 +46,10 @@ export interface HookExecutorContext {
   templateData?: Record<string, unknown>;
   /** Optional ISO8601 timestamp of workflowRun.createdAt for time-window checks. */
   workflowStartIso?: string;
+  /** Optional resolved PR URL for this workflow run. */
+  prUrl?: string;
+  /** Optional JSON-serialized gate data for this run, keyed by gateId. */
+  gateDataJson?: string;
 }
 
 /** Result of executing a single hook validator. */
@@ -192,6 +196,14 @@ function buildHookRestrictedEnv(
 
   if (context.workflowStartIso) {
     env['NEOKAI_WORKFLOW_START_ISO'] = context.workflowStartIso;
+  }
+
+  if (context.prUrl) {
+    env['NEOKAI_PR_URL'] = context.prUrl;
+  }
+
+  if (context.gateDataJson) {
+    env['NEOKAI_GATE_DATA_JSON'] = context.gateDataJson;
   }
 
   if (context.targetNode) {

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -18,7 +18,7 @@ import {
   MAX_BUFFER_BYTES,
   parseJsonStdout,
 } from './gate-script-executor';
-import { mkdtempSync } from 'fs';
+import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { validateWorkflowHookResult } from '../workflow-hook-validation';
@@ -301,127 +301,139 @@ export async function executeHookScript(
   const hookHome = mkdtempSync(join(tmpdir(), 'neokai-hook-'));
   restrictedEnv['HOME'] = hookHome;
 
-  let proc;
-  try {
-    proc = Bun.spawn(args, {
-      cwd: context.workspacePath,
-      env: restrictedEnv,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      detached: true,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      result: {
-        type: 'block',
-        reason: `Failed to spawn ${validator.interpreter}: ${message}`,
-      },
-    };
-  }
+  const runScript = async (): Promise<HookExecutorResult> => {
+    let proc;
+    try {
+      proc = Bun.spawn(args, {
+        cwd: context.workspacePath,
+        env: restrictedEnv,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        detached: true,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        result: {
+          type: 'block',
+          reason: `Failed to spawn ${validator.interpreter}: ${message}`,
+        },
+      };
+    }
 
-  const controller = new AbortController();
-  let killed = false;
+    const controller = new AbortController();
+    let killed = false;
 
-  const [stdoutResult, stderrResult, exitCode] = await Promise.all([
-    collectWithMaxBuffer(proc.stdout, MAX_BUFFER_BYTES, controller.signal),
-    collectWithMaxBuffer(proc.stderr, MAX_BUFFER_BYTES, controller.signal),
-    (async () => {
-      const killTimer = setTimeout(() => {
-        killed = true;
-        // Kill the entire process group so background children are reaped.
+    const [stdoutResult, stderrResult, exitCode] = await Promise.all([
+      collectWithMaxBuffer(proc.stdout, MAX_BUFFER_BYTES, controller.signal),
+      collectWithMaxBuffer(proc.stderr, MAX_BUFFER_BYTES, controller.signal),
+      (async () => {
+        const killTimer = setTimeout(() => {
+          killed = true;
+          // Kill the entire process group so background children are reaped.
+          try {
+            if (proc.pid) {
+              process.kill(-proc.pid, 'SIGKILL');
+            } else {
+              proc.kill('SIGKILL');
+            }
+          } catch {
+            proc.kill('SIGKILL');
+          }
+          controller.abort();
+        }, timeoutMs);
+
+        const code = await proc.exited;
+        clearTimeout(killTimer);
+
+        // Reap any background children in the process group after the main
+        // script exits (success, failure, or timeout).
         try {
           if (proc.pid) {
             process.kill(-proc.pid, 'SIGKILL');
-          } else {
-            proc.kill('SIGKILL');
           }
         } catch {
-          proc.kill('SIGKILL');
+          // process group already gone
         }
-        controller.abort();
-      }, timeoutMs);
 
-      const code = await proc.exited;
-      clearTimeout(killTimer);
+        return { code, timedOut: killed };
+      })(),
+    ]);
 
-      // Reap any background children in the process group after the main
-      // script exits (success, failure, or timeout).
-      try {
-        if (proc.pid) {
-          process.kill(-proc.pid, 'SIGKILL');
-        }
-      } catch {
-        // process group already gone
-      }
+    if (exitCode.timedOut) {
+      return {
+        result: {
+          type: 'block',
+          reason: `Hook script timed out after ${timeoutMs}ms`,
+        },
+      };
+    }
 
-      return { code, timedOut: killed };
-    })(),
-  ]);
+    if (exitCode.code !== 0) {
+      const stderrText = stderrResult.text.trim();
+      return {
+        result: {
+          type: 'block',
+          reason: stderrText || `Hook script exited with code ${exitCode.code}`,
+        },
+      };
+    }
 
-  if (exitCode.timedOut) {
-    return {
-      result: {
-        type: 'block',
-        reason: `Hook script timed out after ${timeoutMs}ms`,
-      },
-    };
+    // Exit 0 — parse JSON stdout as WorkflowHookResult
+    const parsed = parseJsonStdout(stdoutResult.text);
+    if (!parsed) {
+      return {
+        result: {
+          type: 'block',
+          reason: 'Hook script produced empty or non-JSON stdout',
+        },
+      };
+    }
+
+    // Validate that parsed result has a recognized type
+    const validTypes = new Set([
+      'allow',
+      'block',
+      'retryable_block',
+      'patch_params',
+      'emit_follow_up',
+      'record_state',
+    ]);
+    if (typeof parsed.type !== 'string' || !validTypes.has(parsed.type)) {
+      return {
+        result: {
+          type: 'block',
+          reason: `Hook script returned unrecognized result type: ${JSON.stringify(parsed.type)}`,
+        },
+      };
+    }
+
+    // Validate required fields for the specific result type
+    const validationErrors = validateWorkflowHookResult(parsed);
+    if (validationErrors.length > 0) {
+      return {
+        result: {
+          type: 'block',
+          reason: `Hook script returned malformed result: ${validationErrors.join('; ')}`,
+        },
+      };
+    }
+
+    // Merge parsed data into the result shape
+    const result = deepMergeWithDepthLimit({}, parsed) as unknown as WorkflowHookResult;
+
+    return { result };
+  };
+
+  try {
+    return await runScript();
+  } finally {
+    try {
+      rmSync(hookHome, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
   }
-
-  if (exitCode.code !== 0) {
-    const stderrText = stderrResult.text.trim();
-    return {
-      result: {
-        type: 'block',
-        reason: stderrText || `Hook script exited with code ${exitCode.code}`,
-      },
-    };
-  }
-
-  // Exit 0 — parse JSON stdout as WorkflowHookResult
-  const parsed = parseJsonStdout(stdoutResult.text);
-  if (!parsed) {
-    return {
-      result: {
-        type: 'block',
-        reason: 'Hook script produced empty or non-JSON stdout',
-      },
-    };
-  }
-
-  // Validate that parsed result has a recognized type
-  const validTypes = new Set([
-    'allow',
-    'block',
-    'retryable_block',
-    'patch_params',
-    'emit_follow_up',
-    'record_state',
-  ]);
-  if (typeof parsed.type !== 'string' || !validTypes.has(parsed.type)) {
-    return {
-      result: {
-        type: 'block',
-        reason: `Hook script returned unrecognized result type: ${JSON.stringify(parsed.type)}`,
-      },
-    };
-  }
-
-  // Validate required fields for the specific result type
-  const validationErrors = validateWorkflowHookResult(parsed);
-  if (validationErrors.length > 0) {
-    return {
-      result: {
-        type: 'block',
-        reason: `Hook script returned malformed result: ${validationErrors.join('; ')}`,
-      },
-    };
-  }
-
-  // Merge parsed data into the result shape
-  const result = deepMergeWithDepthLimit({}, parsed) as unknown as WorkflowHookResult;
-
-  return { result };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -44,6 +44,8 @@ export interface HookExecutorContext {
   permittedExternalLookups: string[];
   /** Optional bounded template data from the hook definition. */
   templateData?: Record<string, unknown>;
+  /** Optional ISO8601 timestamp of workflowRun.createdAt for time-window checks. */
+  workflowStartIso?: string;
 }
 
 /** Result of executing a single hook validator. */
@@ -187,6 +189,10 @@ function buildHookRestrictedEnv(
   env['NEOKAI_NODE_NAME'] = context.nodeName;
   env['NEOKAI_SESSION_ID'] = context.sessionId;
   env['NEOKAI_TASK_ID'] = context.taskId;
+
+  if (context.workflowStartIso) {
+    env['NEOKAI_WORKFLOW_START_ISO'] = context.workflowStartIso;
+  }
 
   if (context.targetNode) {
     env['NEOKAI_TARGET_NODE'] = context.targetNode;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3838,22 +3838,6 @@ export class TaskAgentManager {
     if (workflow && ((workflow.hooks && workflow.hooks.length > 0) || hasHookManagedChannels)) {
       const hookExecutor = new HookExecutor({ workspacePath });
 
-      // Build gate data JSON for hook script environments so converted gate
-      // scripts can read the same context they had in the legacy gate path.
-      let gateDataJson: string | undefined;
-      if (this.config.gateDataRepo) {
-        try {
-          const records = this.config.gateDataRepo.listByRun(workflowRunId);
-          const gateData: Record<string, unknown> = {};
-          for (const record of records) {
-            gateData[record.gateId] = record.data;
-          }
-          gateDataJson = JSON.stringify(gateData);
-        } catch {
-          // best effort — hook scripts that depend on gate data will fail closed
-        }
-      }
-
       hookEngine = new WorkflowHookEngine({
         workflow,
         workflowRunId,
@@ -3864,7 +3848,7 @@ export class TaskAgentManager {
         hookExecutor,
         workspacePath,
         prUrl: this.resolvePrUrlForRun(workflowRunId) || undefined,
-        gateDataJson,
+        gateDataRepo: this.config.gateDataRepo,
       });
     }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3836,6 +3836,7 @@ export class TaskAgentManager {
         workflow,
         workflowRunId,
         nodeExecutionRepo: this.config.nodeExecutionRepo,
+        workflowRunRepo: this.config.workflowRunRepo,
         artifactRepo: this.config.artifactRepo,
         hookStateRepo: new WorkflowHookStateRepository(this.config.db.getDatabase()),
         hookExecutor,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3828,10 +3828,32 @@ export class TaskAgentManager {
       }
     };
 
-    // Build workflow hook engine when the workflow defines hooks.
+    // Build workflow hook engine when the workflow defines hooks OR when any
+    // channel declares hookIds (so missing-hook fail-closed checks run even
+    // when the hooks array is empty or omitted).
+    const hasHookManagedChannels = (workflow?.channels ?? []).some(
+      (ch) => ch.hookIds && ch.hookIds.length > 0
+    );
     let hookEngine: WorkflowHookEngine | undefined;
-    if (workflow?.hooks && workflow.hooks.length > 0) {
+    if (workflow && ((workflow.hooks && workflow.hooks.length > 0) || hasHookManagedChannels)) {
       const hookExecutor = new HookExecutor({ workspacePath });
+
+      // Build gate data JSON for hook script environments so converted gate
+      // scripts can read the same context they had in the legacy gate path.
+      let gateDataJson: string | undefined;
+      if (this.config.gateDataRepo) {
+        try {
+          const records = this.config.gateDataRepo.listByRun(workflowRunId);
+          const gateData: Record<string, unknown> = {};
+          for (const record of records) {
+            gateData[record.gateId] = record.data;
+          }
+          gateDataJson = JSON.stringify(gateData);
+        } catch {
+          // best effort — hook scripts that depend on gate data will fail closed
+        }
+      }
+
       hookEngine = new WorkflowHookEngine({
         workflow,
         workflowRunId,
@@ -3841,6 +3863,8 @@ export class TaskAgentManager {
         hookStateRepo: new WorkflowHookStateRepository(this.config.db.getDatabase()),
         hookExecutor,
         workspacePath,
+        prUrl: this.resolvePrUrlForRun(workflowRunId) || undefined,
+        gateDataJson,
       });
     }
 

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -182,10 +182,31 @@ export class WorkflowHookEngine {
     params: Record<string, unknown>,
     meta: HookActionMeta
   ): Promise<HookActionOutcome> {
-    const { hooks, missingChannelHooks } = this.resolveMatchingHooks(methodName, params, meta);
+    const { hooks, missingChannelHooks, mixedGateHookChannel } = this.resolveMatchingHooks(
+      methodName,
+      params,
+      meta
+    );
 
-    // Fail closed when a hook-managed channel declares hookIds but no matching
-    // hooks resolve (disabled, missing, or misconfigured).
+    // Reject mixed gate/hook channels before any hooks run.
+    if (mixedGateHookChannel) {
+      return {
+        decision: 'block',
+        finalParams: params,
+        followUpRequests: [],
+        stateUpdates: [],
+        userState: {
+          status: 'blocked_by_hook',
+          reason:
+            'Channel references both gateId and hookIds. Action blocked (mixed configuration).',
+        },
+        executionLog: [],
+      };
+    }
+
+    // Fail closed when a hook-managed channel declares hookIds but one or more
+    // declared hooks do not resolve (disabled, missing, misconfigured, or wrong
+    // source/target).
     if (missingChannelHooks) {
       return {
         decision: 'block',
@@ -195,7 +216,7 @@ export class WorkflowHookEngine {
         userState: {
           status: 'blocked_by_hook',
           reason:
-            'Channel declares hookIds but no matching hooks were found. Action blocked (fail closed).',
+            'Channel declares hookIds but not all declared hooks resolve. Action blocked (fail closed).',
         },
         executionLog: [],
       };
@@ -498,9 +519,10 @@ export class WorkflowHookEngine {
     methodName: string,
     params: Record<string, unknown>,
     meta: HookActionMeta
-  ): { hooks: WorkflowHook[]; missingChannelHooks: boolean } {
+  ): { hooks: WorkflowHook[]; missingChannelHooks: boolean; mixedGateHookChannel: boolean } {
     const workflow = this.config.workflow;
-    if (!workflow?.hooks) return { hooks: [], missingChannelHooks: false };
+    if (!workflow?.hooks)
+      return { hooks: [], missingChannelHooks: false, mixedGateHookChannel: false };
 
     const nodeName = workflow.nodes.find((n) => n.id === meta.nodeId)?.name ?? meta.agentName;
 
@@ -521,8 +543,12 @@ export class WorkflowHookEngine {
     const nodeNames = new Set(workflow.nodes.map((n) => n.name));
     const resolver = new ChannelResolver(workflow.channels ?? []);
 
-    // Resolve action target(s) for send_message
+    // Resolve action target(s) for send_message.
+    // Keep both raw targets (slot names, node IDs, bare strings) and resolved
+    // node names so channel matching works for slot-addressed channels like
+    // { from: 'coder', to: 'reviewer', hookIds: [...] }.
     const actionTargets = new Set<string>();
+    const rawActionTargets = new Set<string>();
     if (methodName === 'send_message') {
       const target = params.target;
       if (typeof target === 'string') {
@@ -536,6 +562,7 @@ export class WorkflowHookEngine {
             }
           } else {
             for (const t of permitted) {
+              rawActionTargets.add(t);
               for (const resolved of this.resolveTargetEntries(
                 t,
                 nodeIdToName,
@@ -547,6 +574,7 @@ export class WorkflowHookEngine {
             }
           }
         } else {
+          rawActionTargets.add(target);
           for (const resolved of this.resolveTargetEntries(
             target,
             nodeIdToName,
@@ -569,6 +597,7 @@ export class WorkflowHookEngine {
               }
             } else {
               for (const pt of permitted) {
+                rawActionTargets.add(pt);
                 for (const resolved of this.resolveTargetEntries(
                   pt,
                   nodeIdToName,
@@ -580,6 +609,7 @@ export class WorkflowHookEngine {
               }
             }
           } else {
+            rawActionTargets.add(t);
             for (const resolved of this.resolveTargetEntries(
               t,
               nodeIdToName,
@@ -598,13 +628,23 @@ export class WorkflowHookEngine {
     // hooks in that set are authoritative for this action.
     const channelHookIds = new Set<string>();
     let hasChannelHookIds = false;
-    if (methodName === 'send_message' && actionTargets.size > 0) {
+    let mixedGateHookChannel = false;
+    if (methodName === 'send_message' && (actionTargets.size > 0 || rawActionTargets.size > 0)) {
       for (const ch of workflow.channels ?? []) {
         const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
         if (!fromMatches) continue;
         const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
-        const toMatches = toList.some((t) => t === '*' || actionTargets.has(t));
+        const toMatches = toList.some(
+          (t) => t === '*' || actionTargets.has(t) || rawActionTargets.has(t)
+        );
         if (!toMatches) continue;
+
+        // Reject mixed gate/hook channels before any hooks run
+        if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
+          mixedGateHookChannel = true;
+          break;
+        }
+
         if (ch.hookIds && ch.hookIds.length > 0) {
           hasChannelHookIds = true;
           for (const hid of ch.hookIds) {
@@ -642,8 +682,12 @@ export class WorkflowHookEngine {
       });
     });
 
-    const missingChannelHooks = hasChannelHookIds && matchedHooks.length === 0;
-    return { hooks: matchedHooks, missingChannelHooks };
+    // Fail closed when any declared channel hookId does not resolve to a
+    // runnable hook (deleted, disabled, wrong source/target, missing auth).
+    const resolvedHookIds = new Set(matchedHooks.map((h) => h.id));
+    const missingChannelHooks =
+      hasChannelHookIds && [...channelHookIds].some((hid) => !resolvedHookIds.has(hid));
+    return { hooks: matchedHooks, missingChannelHooks, mixedGateHookChannel };
   }
 
   private sortHooks(hooks: WorkflowHook[]): WorkflowHook[] {

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -15,16 +15,18 @@
  *   - `record_state` persists hook-local state
  */
 
-import type {
-  WorkflowHook,
-  WorkflowHookResult,
-  WorkflowHookUserState,
-  SpaceWorkflow,
-  WorkflowRunArtifact,
+import {
+  resolveNodeAgents,
+  type WorkflowHook,
+  type WorkflowHookResult,
+  type WorkflowHookUserState,
+  type SpaceWorkflow,
+  type WorkflowRunArtifact,
 } from '@neokai/shared';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { WorkflowHookStateRepository } from '../../../storage/repositories/workflow-hook-state-repository';
+import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { HookExecutor, HookExecutorContext } from './hook-executor';
 import { ChannelResolver } from './channel-resolver';
@@ -98,8 +100,8 @@ export interface WorkflowHookEngineConfig {
   workspacePath?: string;
   /** Optional resolved PR URL for this workflow run (injected into hook script env). */
   prUrl?: string;
-  /** Optional JSON-serialized gate data for this run, keyed by gateId (injected into hook script env). */
-  gateDataJson?: string;
+  /** Optional gate data repository for building fresh NEOKAI_GATE_DATA_JSON per action. */
+  gateDataRepo?: GateDataRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -638,31 +640,52 @@ export class WorkflowHookEngine {
     }
 
     // For send_message, intersect resolved hooks with the hookIds declared on
-    // the matching workflow channels. If any matched channel has hookIds, only
-    // hooks in that set are authoritative for this action.
+    // the matching workflow channels. Use first-match semantics (same as
+    // ChannelRouter.findMatchingWorkflowChannel) for single-string targets so
+    // overlapping routes don't pull in unrelated hooks.
     const channelHookIds = new Set<string>();
     let hasChannelHookIds = false;
     let mixedGateHookChannel = false;
     if (methodName === 'send_message' && (actionTargets.size > 0 || rawActionTargets.size > 0)) {
-      for (const ch of workflow?.channels ?? []) {
-        const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
-        if (!fromMatches) continue;
-        const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
-        const toMatches = toList.some(
-          (t) => t === '*' || actionTargets.has(t) || rawActionTargets.has(t)
-        );
-        if (!toMatches) continue;
+      const target = params.target;
+      const isSingleString = typeof target === 'string' && target.trim() !== '*';
 
-        // Reject mixed gate/hook channels before any hooks run
-        if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
-          mixedGateHookChannel = true;
-          break;
+      if (isSingleString) {
+        // First-match semantics: only the first matching channel governs delivery.
+        const firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, target.trim());
+        if (firstCh) {
+          if (firstCh.gateId && firstCh.hookIds && firstCh.hookIds.length > 0) {
+            mixedGateHookChannel = true;
+          } else if (firstCh.hookIds && firstCh.hookIds.length > 0) {
+            hasChannelHookIds = true;
+            for (const hid of firstCh.hookIds) {
+              channelHookIds.add(hid);
+            }
+          }
         }
+      } else {
+        // Broadcast (*) or array targets: multiple deliveries may use different
+        // channels, so collect hookIds from all matching channels (fail-closed).
+        for (const ch of workflow?.channels ?? []) {
+          const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
+          if (!fromMatches) continue;
+          const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
+          const toMatches = toList.some(
+            (t) => t === '*' || actionTargets.has(t) || rawActionTargets.has(t)
+          );
+          if (!toMatches) continue;
 
-        if (ch.hookIds && ch.hookIds.length > 0) {
-          hasChannelHookIds = true;
-          for (const hid of ch.hookIds) {
-            channelHookIds.add(hid);
+          // Reject mixed gate/hook channels before any hooks run
+          if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
+            mixedGateHookChannel = true;
+            break;
+          }
+
+          if (ch.hookIds && ch.hookIds.length > 0) {
+            hasChannelHookIds = true;
+            for (const hid of ch.hookIds) {
+              channelHookIds.add(hid);
+            }
           }
         }
       }
@@ -795,6 +818,22 @@ export class WorkflowHookEngine {
     const run = this.config.workflowRunRepo.getRun(this.config.workflowRunId);
     const workflowStartIso = run ? new Date(run.createdAt).toISOString() : undefined;
 
+    // Build fresh gate data JSON per action so long-lived sessions don't
+    // validate against stale gate data or missing PR URLs.
+    let gateDataJson: string | undefined;
+    if (this.config.gateDataRepo) {
+      try {
+        const records = this.config.gateDataRepo.listByRun(this.config.workflowRunId);
+        const gateData: Record<string, unknown> = {};
+        for (const record of records) {
+          gateData[record.gateId] = record.data;
+        }
+        gateDataJson = JSON.stringify(gateData);
+      } catch {
+        // best effort — hook scripts that depend on gate data will fail closed
+      }
+    }
+
     return {
       workspacePath: this.config.workspacePath ?? '',
       runId: this.config.workflowRunId,
@@ -812,7 +851,7 @@ export class WorkflowHookEngine {
       templateData: hook.templateData,
       workflowStartIso,
       prUrl: this.config.prUrl,
-      gateDataJson: this.config.gateDataJson,
+      gateDataJson,
     };
   }
 
@@ -1108,6 +1147,50 @@ export class WorkflowHookEngine {
     }
 
     return decoded;
+  }
+
+  /**
+   * Find the first matching workflow channel for a given fromRole → toTarget pair,
+   * using the same semantics as ChannelRouter.findMatchingWorkflowChannel.
+   *
+   * Returns undefined when no channel matches (open topology).
+   */
+  private findFirstMatchingChannel(
+    workflow: SpaceWorkflow | undefined,
+    fromRole: string,
+    toTarget: string
+  ): import('@neokai/shared').WorkflowChannel | undefined {
+    if (!workflow) return undefined;
+
+    const fromNodeName = workflow.nodes.find((n) => {
+      try {
+        return resolveNodeAgents(n).some((a) => a.name === fromRole);
+      } catch {
+        return false;
+      }
+    })?.name;
+
+    const toNodeName =
+      workflow.nodes.find((n) => {
+        try {
+          return resolveNodeAgents(n).some((a) => a.name === toTarget);
+        } catch {
+          return false;
+        }
+      })?.name ?? workflow.nodes.find((n) => n.name === toTarget)?.name;
+
+    for (const ch of workflow.channels ?? []) {
+      if (ch.from !== '*' && ch.from !== fromRole && ch.from !== fromNodeName) continue;
+      const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
+      if (
+        toList.includes('*') ||
+        toList.includes(toTarget) ||
+        (toNodeName && toList.includes(toNodeName))
+      ) {
+        return ch;
+      }
+    }
+    return undefined;
   }
 
   private shallowEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -652,7 +652,15 @@ export class WorkflowHookEngine {
 
       if (isSingleString) {
         // First-match semantics: only the first matching channel governs delivery.
-        const firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, target.trim());
+        // Try raw target first, then decoded slot names from @worker:/@role: forms.
+        const trimmedTarget = target.trim();
+        let firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, trimmedTarget);
+        if (!firstCh) {
+          for (const decoded of this.decodeTargetSlotNames(trimmedTarget)) {
+            firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, decoded);
+            if (firstCh) break;
+          }
+        }
         if (firstCh) {
           if (firstCh.gateId && firstCh.hookIds && firstCh.hookIds.length > 0) {
             mixedGateHookChannel = true;
@@ -720,8 +728,13 @@ export class WorkflowHookEngine {
     });
 
     // Fail closed when any declared channel hookId does not resolve to a
-    // runnable hook (deleted, disabled, wrong source/target, missing auth).
-    const resolvedHookIds = new Set(matchedHooks.map((h) => h.id));
+    // runnable validation hook. Side_effect hooks cannot block delivery, so
+    // they do not count as resolved validators for a channel.
+    const resolvedHookIds = new Set(
+      matchedHooks
+        .filter((h) => (h.classification ?? 'validation') === 'validation')
+        .map((h) => h.id)
+    );
     const missingChannelHooks =
       hasChannelHookIds && [...channelHookIds].some((hid) => !resolvedHookIds.has(hid));
     return { hooks: matchedHooks, missingChannelHooks, mixedGateHookChannel };

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -96,6 +96,10 @@ export interface WorkflowHookEngineConfig {
   hookStateRepo: WorkflowHookStateRepository;
   hookExecutor: HookExecutor;
   workspacePath?: string;
+  /** Optional resolved PR URL for this workflow run (injected into hook script env). */
+  prUrl?: string;
+  /** Optional JSON-serialized gate data for this run, keyed by gateId (injected into hook script env). */
+  gateDataJson?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -521,14 +525,11 @@ export class WorkflowHookEngine {
     meta: HookActionMeta
   ): { hooks: WorkflowHook[]; missingChannelHooks: boolean; mixedGateHookChannel: boolean } {
     const workflow = this.config.workflow;
-    if (!workflow?.hooks)
-      return { hooks: [], missingChannelHooks: false, mixedGateHookChannel: false };
-
-    const nodeName = workflow.nodes.find((n) => n.id === meta.nodeId)?.name ?? meta.agentName;
+    const nodeName = workflow?.nodes.find((n) => n.id === meta.nodeId)?.name ?? meta.agentName;
 
     // Build slot-to-nodes map so duplicate slot names across nodes are preserved
     const slotToNodes = new Map<string, string[]>();
-    for (const node of workflow.nodes) {
+    for (const node of workflow?.nodes ?? []) {
       for (const agent of node.agents ?? []) {
         const arr = slotToNodes.get(agent.name) ?? [];
         if (!arr.includes(node.name)) {
@@ -539,9 +540,9 @@ export class WorkflowHookEngine {
     }
 
     const fromNode = nodeName;
-    const nodeIdToName = new Map(workflow.nodes.map((n) => [n.id, n.name]));
-    const nodeNames = new Set(workflow.nodes.map((n) => n.name));
-    const resolver = new ChannelResolver(workflow.channels ?? []);
+    const nodeIdToName = new Map((workflow?.nodes ?? []).map((n) => [n.id, n.name]));
+    const nodeNames = new Set((workflow?.nodes ?? []).map((n) => n.name));
+    const resolver = new ChannelResolver(workflow?.channels ?? []);
 
     // Resolve action target(s) for send_message.
     // Keep both raw targets (slot names, node IDs, bare strings) and resolved
@@ -557,8 +558,12 @@ export class WorkflowHookEngine {
           const permittedSlot = resolver.getPermittedTargets(meta.agentName);
           const permitted = [...new Set([...permittedNode, ...permittedSlot])];
           if (permitted.includes('*')) {
-            for (const node of workflow.nodes) {
+            for (const node of workflow?.nodes ?? []) {
               actionTargets.add(node.name);
+            }
+            // Also add permitted slot/node names so slot-addressed channels match
+            for (const t of permitted) {
+              if (t !== '*') rawActionTargets.add(t);
             }
           } else {
             for (const t of permitted) {
@@ -575,6 +580,9 @@ export class WorkflowHookEngine {
           }
         } else {
           rawActionTargets.add(target);
+          for (const decoded of this.decodeTargetSlotNames(target)) {
+            rawActionTargets.add(decoded);
+          }
           for (const resolved of this.resolveTargetEntries(
             target,
             nodeIdToName,
@@ -592,8 +600,11 @@ export class WorkflowHookEngine {
             const permittedSlot = resolver.getPermittedTargets(meta.agentName);
             const permitted = [...new Set([...permittedNode, ...permittedSlot])];
             if (permitted.includes('*')) {
-              for (const node of workflow.nodes) {
+              for (const node of workflow?.nodes ?? []) {
                 actionTargets.add(node.name);
+              }
+              for (const pt of permitted) {
+                if (pt !== '*') rawActionTargets.add(pt);
               }
             } else {
               for (const pt of permitted) {
@@ -610,6 +621,9 @@ export class WorkflowHookEngine {
             }
           } else {
             rawActionTargets.add(t);
+            for (const decoded of this.decodeTargetSlotNames(t)) {
+              rawActionTargets.add(decoded);
+            }
             for (const resolved of this.resolveTargetEntries(
               t,
               nodeIdToName,
@@ -630,7 +644,7 @@ export class WorkflowHookEngine {
     let hasChannelHookIds = false;
     let mixedGateHookChannel = false;
     if (methodName === 'send_message' && (actionTargets.size > 0 || rawActionTargets.size > 0)) {
-      for (const ch of workflow.channels ?? []) {
+      for (const ch of workflow?.channels ?? []) {
         const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
         if (!fromMatches) continue;
         const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
@@ -654,7 +668,7 @@ export class WorkflowHookEngine {
       }
     }
 
-    const matchedHooks = workflow.hooks.filter((hook) => {
+    const matchedHooks = (workflow?.hooks ?? []).filter((hook) => {
       if (!hook.enabled) return false;
       if (hook.method !== methodName) return false;
 
@@ -797,6 +811,8 @@ export class WorkflowHookEngine {
       permittedExternalLookups,
       templateData: hook.templateData,
       workflowStartIso,
+      prUrl: this.config.prUrl,
+      gateDataJson: this.config.gateDataJson,
     };
   }
 
@@ -1058,6 +1074,40 @@ export class WorkflowHookEngine {
       return [role];
     }
     return [trimmed];
+  }
+
+  /**
+   * Extract decoded slot/agent names from generic target strings so that
+   * slot-addressed channels (e.g. to: 'reviewer') match even when the agent
+   * uses the explicit address form (@worker:.../reviewer or @role:reviewer).
+   */
+  private decodeTargetSlotNames(target: string): string[] {
+    const decoded: string[] = [];
+    const trimmed = target.trim();
+
+    if (trimmed.startsWith('@worker:')) {
+      try {
+        const addr = parseAddress(trimmed);
+        if (addr.kind === 'worker' && addr.agentName) {
+          decoded.push(addr.agentName);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    if (trimmed.startsWith('@role:')) {
+      const role = trimmed.slice(6);
+      const actorRolePrefix = 'actor-role:';
+      if (role.startsWith(actorRolePrefix)) {
+        const actorRoleValue = decodeURIComponent(role.slice(actorRolePrefix.length));
+        decoded.push(actorRoleValue);
+      } else {
+        decoded.push(role);
+      }
+    }
+
+    return decoded;
   }
 
   private shallowEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -25,6 +25,7 @@ import type {
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { WorkflowHookStateRepository } from '../../../storage/repositories/workflow-hook-state-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { HookExecutor, HookExecutorContext } from './hook-executor';
 import { ChannelResolver } from './channel-resolver';
 import { Logger } from '../../logger';
@@ -90,6 +91,7 @@ export interface WorkflowHookEngineConfig {
   workflow: SpaceWorkflow;
   workflowRunId: string;
   nodeExecutionRepo: NodeExecutionRepository;
+  workflowRunRepo?: SpaceWorkflowRunRepository;
   artifactRepo?: WorkflowRunArtifactRepository;
   hookStateRepo: WorkflowHookStateRepository;
   hookExecutor: HookExecutor;
@@ -688,6 +690,9 @@ export class WorkflowHookEngine {
       mappedArtifacts.push(item);
     }
 
+    const run = this.config.workflowRunRepo?.getRun(this.config.workflowRunId);
+    const workflowStartIso = run ? new Date(run.createdAt).toISOString() : undefined;
+
     return {
       workspacePath: this.config.workspacePath ?? '',
       runId: this.config.workflowRunId,
@@ -703,6 +708,7 @@ export class WorkflowHookEngine {
       currentArtifacts: mappedArtifacts,
       permittedExternalLookups,
       templateData: hook.templateData,
+      workflowStartIso,
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -641,54 +641,99 @@ export class WorkflowHookEngine {
 
     // For send_message, intersect resolved hooks with the hookIds declared on
     // the matching workflow channels. Use first-match semantics (same as
-    // ChannelRouter.findMatchingWorkflowChannel) for single-string targets so
-    // overlapping routes don't pull in unrelated hooks.
+    // ChannelRouter.findMatchingWorkflowChannel) so overlapping routes don't
+    // pull in unrelated hooks.
     const channelHookIds = new Set<string>();
     let hasChannelHookIds = false;
     let mixedGateHookChannel = false;
     if (methodName === 'send_message' && (actionTargets.size > 0 || rawActionTargets.size > 0)) {
       const target = params.target;
-      const isSingleString = typeof target === 'string' && target.trim() !== '*';
 
-      if (isSingleString) {
-        // First-match semantics: only the first matching channel governs delivery.
-        // Try raw target first, then decoded slot names from @worker:/@role: forms.
-        const trimmedTarget = target.trim();
-        let firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, trimmedTarget);
+      // Skip built-in escalation targets — they route outside channel topology.
+      const isEscalationTarget = (t: string) => t === 'space-agent' || t.startsWith('@coordinator');
+
+      const processFirstMatch = (rawTarget: string): boolean => {
+        const trimmed = rawTarget.trim();
+        if (isEscalationTarget(trimmed)) return false;
+
+        // Try raw target, then decoded slot names, then resolved node names.
+        let firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, trimmed);
         if (!firstCh) {
-          for (const decoded of this.decodeTargetSlotNames(trimmedTarget)) {
+          for (const decoded of this.decodeTargetSlotNames(trimmed)) {
             firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, decoded);
             if (firstCh) break;
           }
         }
-        if (firstCh) {
-          if (firstCh.gateId && firstCh.hookIds && firstCh.hookIds.length > 0) {
-            mixedGateHookChannel = true;
-          } else if (firstCh.hookIds && firstCh.hookIds.length > 0) {
-            hasChannelHookIds = true;
-            for (const hid of firstCh.hookIds) {
-              channelHookIds.add(hid);
-            }
+        if (!firstCh) {
+          for (const resolved of actionTargets) {
+            firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, resolved);
+            if (firstCh) break;
           }
         }
-      } else {
-        // Broadcast (*) or array targets: multiple deliveries may use different
-        // channels, so collect hookIds from all matching channels (fail-closed).
+
+        if (!firstCh) return false;
+
+        if (firstCh.gateId && firstCh.hookIds && firstCh.hookIds.length > 0) {
+          mixedGateHookChannel = true;
+          return true;
+        }
+        if (firstCh.hookIds && firstCh.hookIds.length > 0) {
+          hasChannelHookIds = true;
+          for (const hid of firstCh.hookIds) {
+            channelHookIds.add(hid);
+          }
+        }
+        return true;
+      };
+
+      if (typeof target === 'string' && target.trim() !== '*') {
+        processFirstMatch(target);
+      } else if (Array.isArray(target)) {
+        // First-match per array element so a specific channel governs each target.
+        const seenChannels = new Set<string>();
+        for (const t of target) {
+          if (typeof t !== 'string') continue;
+          if (t.trim() === '*') {
+            // Broadcast: fall back to union over all matching non-escalation channels.
+            for (const ch of workflow?.channels ?? []) {
+              const fromMatches =
+                ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
+              if (!fromMatches) continue;
+              const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
+              const toMatches = toList.some(
+                (to) => to === '*' || actionTargets.has(to) || rawActionTargets.has(to)
+              );
+              if (!toMatches) continue;
+              if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
+                mixedGateHookChannel = true;
+                break;
+              }
+              if (ch.hookIds && ch.hookIds.length > 0) {
+                hasChannelHookIds = true;
+                for (const hid of ch.hookIds) {
+                  channelHookIds.add(hid);
+                }
+              }
+            }
+          } else if (!seenChannels.has(t)) {
+            seenChannels.add(t);
+            processFirstMatch(t);
+          }
+        }
+      } else if (target === '*' || (typeof target === 'string' && target.trim() === '*')) {
+        // Broadcast: union over all matching non-escalation channels.
         for (const ch of workflow?.channels ?? []) {
           const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
           if (!fromMatches) continue;
           const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
           const toMatches = toList.some(
-            (t) => t === '*' || actionTargets.has(t) || rawActionTargets.has(t)
+            (to) => to === '*' || actionTargets.has(to) || rawActionTargets.has(to)
           );
           if (!toMatches) continue;
-
-          // Reject mixed gate/hook channels before any hooks run
           if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
             mixedGateHookChannel = true;
             break;
           }
-
           if (ch.hookIds && ch.hookIds.length > 0) {
             hasChannelHookIds = true;
             for (const hid of ch.hookIds) {
@@ -833,15 +878,17 @@ export class WorkflowHookEngine {
 
     // Build fresh gate data JSON per action so long-lived sessions don't
     // validate against stale gate data or missing PR URLs.
+    // Flat-merge all gate data objects for backward compatibility with
+    // converted gate scripts that expect a single flat object shape.
     let gateDataJson: string | undefined;
     if (this.config.gateDataRepo) {
       try {
         const records = this.config.gateDataRepo.listByRun(this.config.workflowRunId);
-        const gateData: Record<string, unknown> = {};
+        const flatGateData: Record<string, unknown> = {};
         for (const record of records) {
-          gateData[record.gateId] = record.data;
+          Object.assign(flatGateData, record.data);
         }
-        gateDataJson = JSON.stringify(gateData);
+        gateDataJson = JSON.stringify(flatGateData);
       } catch {
         // best effort — hook scripts that depend on gate data will fail closed
       }

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -91,7 +91,7 @@ export interface WorkflowHookEngineConfig {
   workflow: SpaceWorkflow;
   workflowRunId: string;
   nodeExecutionRepo: NodeExecutionRepository;
-  workflowRunRepo?: SpaceWorkflowRunRepository;
+  workflowRunRepo: SpaceWorkflowRunRepository;
   artifactRepo?: WorkflowRunArtifactRepository;
   hookStateRepo: WorkflowHookStateRepository;
   hookExecutor: HookExecutor;
@@ -690,7 +690,7 @@ export class WorkflowHookEngine {
       mappedArtifacts.push(item);
     }
 
-    const run = this.config.workflowRunRepo?.getRun(this.config.workflowRunId);
+    const run = this.config.workflowRunRepo.getRun(this.config.workflowRunId);
     const workflowStartIso = run ? new Date(run.createdAt).toISOString() : undefined;
 
     return {

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -649,17 +649,29 @@ export class WorkflowHookEngine {
     if (methodName === 'send_message' && (actionTargets.size > 0 || rawActionTargets.size > 0)) {
       const target = params.target;
 
-      // Skip built-in escalation targets — they route outside channel topology.
-      // Also skip @session: reply-session targets — AgentMessageRouter handles
-      // these as direct Space Agent reply routes that bypass channel topology.
-      const isEscalationTarget = (t: string) =>
-        t === 'space-agent' || t.startsWith('@coordinator') || t.startsWith('@session:');
+      // Skip targets that route outside workflow channel topology:
+      // - space-agent: built-in escalation
+      // - @session: reply-session targets (direct Space Agent reply routes)
+      // - Generic handles (@some-agent): routed through SpaceDeliveryFacade,
+      //   not channelRouter.deliverMessage, so channel hooks cannot govern them
+      // Only @worker: and @role: addresses map to workflow node agents.
+      const isOutsideChannelTopology = (t: string) => {
+        if (t === 'space-agent') return true;
+        if (t.startsWith('@session:')) return true;
+        if (t.startsWith('@') && !t.startsWith('@worker:') && !t.startsWith('@role:')) {
+          // Generic handle — routes through SpaceDeliveryFacade, not channels.
+          return true;
+        }
+        return false;
+      };
 
       const processFirstMatch = (rawTarget: string): boolean => {
         const trimmed = rawTarget.trim();
-        if (isEscalationTarget(trimmed)) return false;
+        if (isOutsideChannelTopology(trimmed)) return false;
 
-        // Try raw target, then decoded slot names, then resolved node names.
+        // Try raw target, then decoded slot names, then per-element resolved
+        // node names (NOT the global actionTargets set — each array element
+        // must first-match its own channel, not a sibling's channel).
         let firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, trimmed);
         if (!firstCh) {
           for (const decoded of this.decodeTargetSlotNames(trimmed)) {
@@ -668,7 +680,12 @@ export class WorkflowHookEngine {
           }
         }
         if (!firstCh) {
-          for (const resolved of actionTargets) {
+          for (const resolved of this.resolveTargetEntries(
+            trimmed,
+            nodeIdToName,
+            slotToNodes,
+            nodeNames
+          )) {
             firstCh = this.findFirstMatchingChannel(workflow, meta.agentName, resolved);
             if (firstCh) break;
           }
@@ -1213,7 +1230,9 @@ export class WorkflowHookEngine {
       try {
         const addr = parseAddress(trimmed);
         if (addr.kind === 'worker' && addr.agentName) {
-          decoded.push(addr.agentName);
+          // Decode URL-encoded agent names (e.g. reviewer%2Flead → reviewer/lead)
+          // so slot-addressed channels with special characters match correctly.
+          decoded.push(decodeURIComponent(addr.agentName));
         }
       } catch {
         // ignore parse errors

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -182,7 +182,24 @@ export class WorkflowHookEngine {
     params: Record<string, unknown>,
     meta: HookActionMeta
   ): Promise<HookActionOutcome> {
-    const hooks = this.resolveMatchingHooks(methodName, params, meta);
+    const { hooks, missingChannelHooks } = this.resolveMatchingHooks(methodName, params, meta);
+
+    // Fail closed when a hook-managed channel declares hookIds but no matching
+    // hooks resolve (disabled, missing, or misconfigured).
+    if (missingChannelHooks) {
+      return {
+        decision: 'block',
+        finalParams: params,
+        followUpRequests: [],
+        stateUpdates: [],
+        userState: {
+          status: 'blocked_by_hook',
+          reason:
+            'Channel declares hookIds but no matching hooks were found. Action blocked (fail closed).',
+        },
+        executionLog: [],
+      };
+    }
 
     if (hooks.length === 0) {
       return {
@@ -481,9 +498,9 @@ export class WorkflowHookEngine {
     methodName: string,
     params: Record<string, unknown>,
     meta: HookActionMeta
-  ): WorkflowHook[] {
+  ): { hooks: WorkflowHook[]; missingChannelHooks: boolean } {
     const workflow = this.config.workflow;
-    if (!workflow?.hooks) return [];
+    if (!workflow?.hooks) return { hooks: [], missingChannelHooks: false };
 
     const nodeName = workflow.nodes.find((n) => n.id === meta.nodeId)?.name ?? meta.agentName;
 
@@ -576,7 +593,28 @@ export class WorkflowHookEngine {
       }
     }
 
-    return workflow.hooks.filter((hook) => {
+    // For send_message, intersect resolved hooks with the hookIds declared on
+    // the matching workflow channels. If any matched channel has hookIds, only
+    // hooks in that set are authoritative for this action.
+    const channelHookIds = new Set<string>();
+    let hasChannelHookIds = false;
+    if (methodName === 'send_message' && actionTargets.size > 0) {
+      for (const ch of workflow.channels ?? []) {
+        const fromMatches = ch.from === fromNode || ch.from === meta.agentName || ch.from === '*';
+        if (!fromMatches) continue;
+        const toList = Array.isArray(ch.to) ? ch.to : [ch.to];
+        const toMatches = toList.some((t) => t === '*' || actionTargets.has(t));
+        if (!toMatches) continue;
+        if (ch.hookIds && ch.hookIds.length > 0) {
+          hasChannelHookIds = true;
+          for (const hid of ch.hookIds) {
+            channelHookIds.add(hid);
+          }
+        }
+      }
+    }
+
+    const matchedHooks = workflow.hooks.filter((hook) => {
       if (!hook.enabled) return false;
       if (hook.method !== methodName) return false;
 
@@ -594,12 +632,18 @@ export class WorkflowHookEngine {
       if (hook.humanOnly) return false; // agent MCP sessions cannot trigger human-only hooks
       if (!hook.authorizedCallers || hook.authorizedCallers.length === 0) return false;
 
+      // Channel hookIds are the authoritative binding when present
+      if (hasChannelHookIds && !channelHookIds.has(hook.id)) return false;
+
       return hook.authorizedCallers.some((caller) => {
         if (caller.sourceNode !== nodeName) return false;
         if (!caller.agentSlots || caller.agentSlots.length === 0) return true;
         return caller.agentSlots.includes(meta.agentName);
       });
     });
+
+    const missingChannelHooks = hasChannelHookIds && matchedHooks.length === 0;
+    return { hooks: matchedHooks, missingChannelHooks };
   }
 
   private sortHooks(hooks: WorkflowHook[]): WorkflowHook[] {
@@ -1140,14 +1184,19 @@ export function wrapHandlerWithHooks<T extends Record<string, unknown>>(
           message: req.message,
         } as unknown as Record<string, unknown>);
 
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(
+          timeoutHandle = setTimeout(
             () => reject(new Error('Follow-up dispatch timed out')),
             DEFAULT_FOLLOW_UP_TIMEOUT_MS
           );
         });
 
-        return Promise.race([dispatchPromise, timeoutPromise]);
+        return Promise.race([dispatchPromise, timeoutPromise]).finally(() => {
+          if (timeoutHandle !== undefined) {
+            clearTimeout(timeoutHandle);
+          }
+        });
       });
 
       try {

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -650,7 +650,10 @@ export class WorkflowHookEngine {
       const target = params.target;
 
       // Skip built-in escalation targets — they route outside channel topology.
-      const isEscalationTarget = (t: string) => t === 'space-agent' || t.startsWith('@coordinator');
+      // Also skip @session: reply-session targets — AgentMessageRouter handles
+      // these as direct Space Agent reply routes that bypass channel topology.
+      const isEscalationTarget = (t: string) =>
+        t === 'space-agent' || t.startsWith('@coordinator') || t.startsWith('@session:');
 
       const processFirstMatch = (rawTarget: string): boolean => {
         const trimmed = rawTarget.trim();
@@ -880,13 +883,35 @@ export class WorkflowHookEngine {
     // validate against stale gate data or missing PR URLs.
     // Flat-merge all gate data objects for backward compatibility with
     // converted gate scripts that expect a single flat object shape.
+    // Also merge the current `params.data` (from send_message's `data` arg)
+    // so that converted gate scripts see the in-flight payload without
+    // requiring a separate gate data write first — matching legacy behavior
+    // where the gate write happened before evaluation.
     let gateDataJson: string | undefined;
-    if (this.config.gateDataRepo) {
+    {
       try {
-        const records = this.config.gateDataRepo.listByRun(this.config.workflowRunId);
+        const records = this.config.gateDataRepo?.listByRun(this.config.workflowRunId) ?? [];
         const flatGateData: Record<string, unknown> = {};
         for (const record of records) {
           Object.assign(flatGateData, record.data);
+        }
+        // Merge current action data so hooks evaluating in the same MCP call
+        // see the payload the agent is sending (e.g. { pr_url }) without
+        // needing a prior gate data write.
+        if (
+          methodName === 'send_message' &&
+          params.data &&
+          typeof params.data === 'object' &&
+          !Array.isArray(params.data)
+        ) {
+          try {
+            const dataBytes = new TextEncoder().encode(JSON.stringify(params.data)).length;
+            if (dataBytes <= MAX_PARAM_DATA_BYTES) {
+              Object.assign(flatGateData, params.data as Record<string, unknown>);
+            }
+          } catch {
+            // non-serializable data — skip merge
+          }
         }
         gateDataJson = JSON.stringify(flatGateData);
       } catch {

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -218,7 +218,8 @@ export async function evaluateTerminalGateFeatures(
       });
       const includeIncoming = incomingChannels.length === 1;
       for (const ch of workflow.channels) {
-        if (!ch.gateId) continue;
+        // Skip hook-managed channels — terminal gate features only apply to legacy gates
+        if (!ch.gateId || (ch.hookIds && ch.hookIds.length > 0)) continue;
         const isOutgoing =
           ch.from === currentNodeName || ch.from === '*' || currentNodeAgentNames.has(ch.from);
         let isIncoming = false;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -218,6 +218,15 @@ export async function evaluateTerminalGateFeatures(
       });
       const includeIncoming = incomingChannels.length === 1;
       for (const ch of workflow.channels) {
+        // Fail closed on mixed gate/hook channels — a channel referencing
+        // both gateId and hookIds is an invalid configuration that must not
+        // silently bypass terminal gate validation.
+        if (ch.gateId && ch.hookIds && ch.hookIds.length > 0) {
+          return jsonResult({
+            success: false,
+            error: `Channel "${ch.id ?? 'unknown'}" references both gateId "${ch.gateId}" and hookIds [${ch.hookIds.join(', ')}]. Terminal gate validation cannot proceed with mixed configuration.`,
+          });
+        }
         // Skip hook-managed channels — terminal gate features only apply to legacy gates
         if (!ch.gateId || (ch.hookIds && ch.hookIds.length > 0)) continue;
         const isOutgoing =

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -853,6 +853,9 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 
           const gatedChannel = (workflow.channels ?? []).find((ch) => {
             if (!ch.gateId) return false;
+            // Skip hook-managed channels — hooks validate at MCP action time;
+            // no legacy gate data write or evaluation is performed.
+            if (ch.hookIds && ch.hookIds.length > 0) return false;
             if (ch.from !== '*' && !fromRefs.has(ch.from)) return false;
             const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
             const candidateTargets = uniqueTargetRefs([

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -2870,6 +2870,63 @@ describe('node-agent-tools: async gate evaluation', () => {
     expect(data.gateWrite.gateOpen).toBe(true);
   });
 
+  test('evaluateTerminalGateFeatures rejects mixed gateId+hookIds channel', async () => {
+    const gate: Gate = {
+      id: 'mixed-gate',
+      fields: [
+        { name: 'approved', type: 'boolean', writers: [], check: { op: '==', value: true } },
+      ],
+      resetOnCycle: false,
+    };
+    const workflow = makeWorkflowWithGate(gate, ctx.spaceId, {
+      nodes: [
+        {
+          id: 'node-coder',
+          name: 'Coding',
+          agents: [{ agentId: 'agent-coder', name: 'coder' }],
+        },
+        {
+          id: 'node-planner',
+          name: 'Planning',
+          agents: [{ agentId: 'agent-planner', name: 'planner' }],
+        },
+      ],
+      channels: [
+        {
+          id: 'ch-mixed',
+          from: 'coder',
+          to: 'planner',
+          gateId: 'mixed-gate',
+          hookIds: ['some-hook'],
+        },
+      ],
+    });
+
+    const gateDataRepo = new GateDataRepository(ctx.db);
+    gateDataRepo.set(ctx.workflowRunId, gate.id, { approved: true });
+    const mockExecutor = async () => ({ success: true, data: {}, error: null });
+
+    const result = await evaluateTerminalGateFeatures(
+      workflow,
+      gateDataRepo,
+      ctx.workflowRunId,
+      mockExecutor,
+      {
+        workspacePath: '/tmp',
+        runId: ctx.workflowRunId,
+        gateId: gate.id,
+      },
+      'node-coder',
+      ctx.artifactRepo
+    );
+
+    expect(result).not.toBeNull();
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('references both gateId');
+    expect(data.error).toContain('hookIds');
+  });
+
   test('scriptExecutor receives correct context with gateId via send_message', async () => {
     const gate: Gate = {
       id: 'gate-context-check',

--- a/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
@@ -338,7 +338,7 @@ describe('ChannelRouter — reopen on inbound activity (archive tombstone)', () 
   // -------------------------------------------------------------------------
 
   describe('onGateDataChanged', () => {
-    test('re-activates target nodes on a done run when parent task is not archived', async () => {
+    test('does NOT re-activate target nodes on a done run (terminal runs closed)', async () => {
       const gate: Gate = {
         id: 'ok-gate',
         fields: [{ name: 'done', type: 'string', writers: ['*'], check: { op: 'exists' } }],
@@ -365,13 +365,10 @@ describe('ChannelRouter — reopen on inbound activity (archive tombstone)', () 
 
       gateDataRepo.set(run.id, 'ok-gate', { done: true });
       const activated = await router.onGateDataChanged(run.id, 'ok-gate');
-      expect(activated.length).toBeGreaterThan(0);
-
-      expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
-      const reopens = collector.reopens();
-      expect(reopens).toHaveLength(1);
-      expect(reopens[0].by).toBe('gate:ok-gate');
-      expect(reopens[0].fromStatus).toBe('done');
+      // Terminal runs are no longer reopened by onGateDataChanged.
+      expect(activated).toHaveLength(0);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+      expect(collector.reopens()).toHaveLength(0);
     });
 
     test('returns [] and emits no reopen when parent task is archived', async () => {

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -4437,7 +4437,7 @@ describe('ChannelRouter', () => {
       expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
     });
 
-    test('does not reactivate terminal runs (blocked)', async () => {
+    test('still evaluates and activates blocked runs via gate data changes', async () => {
       const gate: Gate = {
         id: 'blocked-gate',
         fields: [{ name: 'blocked', type: 'string', writers: ['*'], check: { op: 'exists' } }],
@@ -4464,13 +4464,16 @@ describe('ChannelRouter', () => {
       const run = workflowRunRepo.createRun({
         spaceId: SPACE_ID,
         workflowId: workflow.id,
-        title: 'Terminal Blocked Run',
+        title: 'Blocked Run',
       });
       workflowRunRepo.updateStatusUnchecked(run.id, 'blocked');
 
       gateDataRepo.set(run.id, 'blocked-gate', { blocked: true });
       const activated = await router.onGateDataChanged(run.id, 'blocked-gate');
-      expect(activated).toHaveLength(0);
+      // Gate is open (field exists) → target node should be activated even though
+      // the run is blocked, so gate writes can unblock recoverable blocked runs.
+      expect(activated.length).toBeGreaterThan(0);
+      // Run stays blocked — activateNode does not auto-reopen blocked runs.
       expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
     });
 

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1810,7 +1810,7 @@ describe('ChannelRouter', () => {
       expect(activated).toHaveLength(0);
     });
 
-    test('onGateDataChanged: re-activates target node when run is done but parent task is not archived', async () => {
+    test('onGateDataChanged: does NOT re-activate target node when run is done (terminal runs closed)', async () => {
       const gate: Gate = {
         id: 'done-gate',
         fields: [{ name: 'done', type: 'string', writers: ['*'], check: { op: 'exists' } }],
@@ -1843,9 +1843,10 @@ describe('ChannelRouter', () => {
 
       gateDataRepo.set(run.id, 'done-gate', { done: true });
       const activated = await router.onGateDataChanged(run.id, 'done-gate');
-      expect(activated.length).toBeGreaterThan(0);
-      // The run was auto-reopened back to in_progress.
-      expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+      // Terminal runs are no longer reopened by onGateDataChanged.
+      // Allowed paths are explicit cyclic send_message re-entry and manual resume only.
+      expect(activated).toHaveLength(0);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
     });
 
     // -----------------------------------------------------------------------
@@ -4151,6 +4152,416 @@ describe('ChannelRouter', () => {
         const result = await router.canDeliver(run.id, 'coder', 'planner');
         expect(result.allowed).toBe(false);
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Hook-managed channels (WI-3)
+  // -------------------------------------------------------------------------
+
+  describe('hook-managed channels', () => {
+    test('exclusivity: both gateId and hookIds fails closed in deliverMessage', async () => {
+      const channels: WorkflowChannel[] = [
+        {
+          id: 'ch-1',
+          from: 'Sender',
+          to: 'Receiver',
+          gateId: 'legacy-gate',
+          hookIds: ['hook-1'],
+        },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels,
+        []
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Exclusivity Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      await expect(
+        router.deliverMessage(run.id, 'coder', 'planner', 'hello')
+      ).rejects.toBeInstanceOf(ActivationError);
+      await expect(router.deliverMessage(run.id, 'coder', 'planner', 'hello')).rejects.toThrow(
+        /both gateId.*and hookIds/
+      );
+    });
+
+    test('exclusivity: both gateId and hookIds fails closed in canDeliver', async () => {
+      const channels: WorkflowChannel[] = [
+        {
+          id: 'ch-1',
+          from: 'Sender',
+          to: 'Receiver',
+          gateId: 'legacy-gate',
+          hookIds: ['hook-1'],
+        },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels,
+        []
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Exclusivity canDeliver Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      await expect(router.canDeliver(run.id, 'coder', 'planner')).rejects.toBeInstanceOf(
+        ActivationError
+      );
+      await expect(router.canDeliver(run.id, 'coder', 'planner')).rejects.toThrow(
+        /both gateId.*and hookIds/
+      );
+    });
+
+    test('hook-managed channel skips gate evaluation in deliverMessage', async () => {
+      const gate: Gate = {
+        id: 'blocked-gate',
+        fields: [
+          { name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+        ],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        {
+          id: 'ch-1',
+          from: 'Sender',
+          to: 'Receiver',
+          hookIds: ['hook-1'],
+        },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Hook Skip Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // Gate data says blocked, but channel is hook-managed so gate is skipped
+      gateDataRepo.set(run.id, 'blocked-gate', { approved: false });
+
+      const result = await router.deliverMessage(run.id, 'coder', 'planner', 'hello');
+      expect(result.fromRole).toBe('coder');
+      expect(result.toRole).toBe('planner');
+      expect(result.activatedTasks).toBeDefined();
+    });
+
+    test('hook-managed channel skips gate evaluation in canDeliver', async () => {
+      const gate: Gate = {
+        id: 'blocked-gate',
+        fields: [
+          { name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+        ],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        {
+          id: 'ch-1',
+          from: 'Sender',
+          to: 'Receiver',
+          hookIds: ['hook-1'],
+        },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Hook Skip canDeliver Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      gateDataRepo.set(run.id, 'blocked-gate', { approved: false });
+
+      const result = await router.canDeliver(run.id, 'coder', 'planner');
+      expect(result.allowed).toBe(true);
+    });
+
+    test('onGateDataChanged skips hook-managed channels', async () => {
+      const gate: Gate = {
+        id: 'legacy-gate',
+        fields: [
+          { name: 'approved', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+        ],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        {
+          id: 'ch-1',
+          from: 'Sender',
+          to: 'Receiver',
+          hookIds: ['hook-1'],
+        },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Hook Skip onGateDataChanged Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      gateDataRepo.set(run.id, 'legacy-gate', { approved: true });
+
+      // onGateDataChanged should not activate the target because the channel
+      // is hook-managed — gate data changes do not drive activation for hooks.
+      const activated = await router.onGateDataChanged(run.id, 'legacy-gate');
+      expect(activated).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onGateDataChanged reactivation guards (WI-3)
+  // -------------------------------------------------------------------------
+
+  describe('onGateDataChanged reactivation guards', () => {
+    test('does not reactivate terminal runs (done)', async () => {
+      const gate: Gate = {
+        id: 'done-gate',
+        fields: [{ name: 'done', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-1', from: 'coder', to: 'planner', gateId: 'done-gate' },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          {
+            id: NODE_A,
+            name: 'Planner Node',
+            agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+          },
+          { id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Terminal Done Run',
+      });
+      workflowRunRepo.updateStatusUnchecked(run.id, 'done');
+
+      gateDataRepo.set(run.id, 'done-gate', { done: true });
+      const activated = await router.onGateDataChanged(run.id, 'done-gate');
+      expect(activated).toHaveLength(0);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+    });
+
+    test('does not reactivate terminal runs (cancelled)', async () => {
+      const gate: Gate = {
+        id: 'cancel-gate',
+        fields: [{ name: 'cancelled', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-1', from: 'coder', to: 'planner', gateId: 'cancel-gate' },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          {
+            id: NODE_A,
+            name: 'Planner Node',
+            agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+          },
+          { id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Terminal Cancelled Run',
+      });
+      workflowRunRepo.updateStatusUnchecked(run.id, 'cancelled');
+
+      gateDataRepo.set(run.id, 'cancel-gate', { cancelled: true });
+      const activated = await router.onGateDataChanged(run.id, 'cancel-gate');
+      expect(activated).toHaveLength(0);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
+    });
+
+    test('does not reactivate terminal runs (blocked)', async () => {
+      const gate: Gate = {
+        id: 'blocked-gate',
+        fields: [{ name: 'blocked', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-1', from: 'coder', to: 'planner', gateId: 'blocked-gate' },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          {
+            id: NODE_A,
+            name: 'Planner Node',
+            agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+          },
+          { id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Terminal Blocked Run',
+      });
+      workflowRunRepo.updateStatusUnchecked(run.id, 'blocked');
+
+      gateDataRepo.set(run.id, 'blocked-gate', { blocked: true });
+      const activated = await router.onGateDataChanged(run.id, 'blocked-gate');
+      expect(activated).toHaveLength(0);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+    });
+
+    test('does not reactivate nodes with completed executions', async () => {
+      const gate: Gate = {
+        id: 'reopen-gate',
+        fields: [
+          { name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+        ],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-1', from: 'coder', to: 'planner', gateId: 'reopen-gate' },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          {
+            id: NODE_A,
+            name: 'Planner Node',
+            agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+          },
+          { id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Completed Execution Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // Pre-activate planner node and then mark its execution as done
+      await router.activateNode(run.id, NODE_A);
+      const nodeExecutionRepo = new NodeExecutionRepository(db);
+      const executions = nodeExecutionRepo.listByNode(run.id, NODE_A);
+      expect(executions.length).toBeGreaterThan(0);
+      for (const e of executions) {
+        nodeExecutionRepo.update(e.id, { status: 'done', completedAt: Date.now() });
+      }
+
+      gateDataRepo.set(run.id, 'reopen-gate', { ready: true });
+      const activated = await router.onGateDataChanged(run.id, 'reopen-gate');
+      expect(activated).toHaveLength(0);
+    });
+
+    test('still activates never-activated nodes via onGateDataChanged', async () => {
+      const gate: Gate = {
+        id: 'first-activation-gate',
+        fields: [
+          { name: 'ready', type: 'boolean', writers: ['*'], check: { op: '==', value: true } },
+        ],
+        resetOnCycle: false,
+      };
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-1', from: 'coder', to: 'planner', gateId: 'first-activation-gate' },
+      ];
+      const workflow = buildWorkflowWithGates(
+        SPACE_ID,
+        workflowManager,
+        [
+          {
+            id: NODE_A,
+            name: 'Planner Node',
+            agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+          },
+          { id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+        ],
+        channels,
+        [gate]
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'First Activation Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // Node A has never been activated
+      const nodeExecutionRepo = new NodeExecutionRepository(db);
+      expect(nodeExecutionRepo.listByNode(run.id, NODE_A)).toHaveLength(0);
+
+      gateDataRepo.set(run.id, 'first-activation-gate', { ready: true });
+      const activated = await router.onGateDataChanged(run.id, 'first-activation-gate');
+      expect(activated.length).toBeGreaterThan(0);
+      expect(activated[0].workflowRunId).toBe(run.id);
     });
   });
 });

--- a/packages/daemon/tests/unit/5-space/other/export-format.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/export-format.test.ts
@@ -1642,6 +1642,85 @@ describe('ExportedWorkflowChannel — export and validation', () => {
     expect(ch.maxCycles).toBe(3);
   });
 
+  test('exportWorkflow preserves hookIds on channel', () => {
+    const workflow: SpaceWorkflow = {
+      id: 'wf-hook',
+      spaceId: 'space-1',
+      name: 'Hook Workflow',
+      nodes: [
+        {
+          id: 'node-1',
+          name: 'Work',
+          agents: [
+            { agentId: 'agent-uuid-1', name: 'coder' },
+            { agentId: 'agent-uuid-3', name: 'reviewer' },
+          ],
+        },
+      ],
+      transitions: [],
+      startNodeId: 'node-1',
+      rules: [],
+      tags: [],
+      channels: [
+        {
+          id: 'ch-hook-uuid',
+          from: 'coder',
+          to: 'reviewer',
+          hookIds: ['review-gate', 'pr-check'],
+        },
+      ],
+      createdAt: 1000,
+      updatedAt: 2000,
+    };
+    const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+
+    const ch = exported.channels![0] as Record<string, unknown>;
+    expect('id' in ch).toBe(false);
+    expect(ch.hookIds).toEqual(['review-gate', 'pr-check']);
+  });
+
+  test('round-trip: export preserves hookIds, validate passes', () => {
+    const workflow: SpaceWorkflow = {
+      id: 'wf-hook',
+      spaceId: 'space-1',
+      name: 'Hook Workflow',
+      nodes: [
+        {
+          id: 'node-1',
+          name: 'Work',
+          agents: [
+            { agentId: 'agent-uuid-1', name: 'coder' },
+            { agentId: 'agent-uuid-3', name: 'reviewer' },
+          ],
+        },
+      ],
+      transitions: [],
+      startNodeId: 'node-1',
+      rules: [],
+      tags: [],
+      channels: [
+        {
+          id: 'ch-hook-uuid',
+          from: 'coder',
+          to: 'reviewer',
+          hookIds: ['review-gate'],
+        },
+      ],
+      createdAt: 1000,
+      updatedAt: 2000,
+    };
+    const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);
+    const json = JSON.stringify(exported);
+    const parsed = JSON.parse(json) as unknown;
+    const result = validateExportedWorkflow(parsed);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const ch = result.value.channels![0] as Record<string, unknown>;
+      expect(ch.hookIds).toEqual(['review-gate']);
+    }
+  });
+
   test('channel id does not appear in exported JSON', () => {
     const workflow = makeWorkflowWithChannelId();
     const exported = exportWorkflow(workflow, [makeAgent(), makeReviewerAgent()]);

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1314,6 +1314,117 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.decision).toBe('block');
     expect(outcome.userState.reason).toContain('Patched params invalid');
   });
+
+  test('slot-addressed channel with hookIds resolves when target is agent slot name', async () => {
+    // Channel uses agent slot name 'reviewer' as to-address instead of node name 'Review'
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'reviewer', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'reviewer', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
+
+  test('missing one of multiple declared hookIds fails closed', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'hook-a',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [
+      { id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['hook-a', 'hook-b'] },
+    ];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('hook-a', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('block');
+    expect(outcome.userState.status).toBe('blocked_by_hook');
+    expect(outcome.userState.reason).toContain('not all declared hooks resolve');
+  });
+
+  test('mixed gateId and hookIds channel fails closed before hooks run', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [
+      { id: 'ch-1', from: 'Coding', to: 'Review', gateId: 'legacy-gate', hookIds: ['review-gate'] },
+    ];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('block');
+    expect(outcome.userState.status).toBe('blocked_by_hook');
+    expect(outcome.userState.reason).toContain('mixed configuration');
+    expect(outcome.executionLog).toHaveLength(0);
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -18,6 +18,7 @@ import type { WorkflowHook, WorkflowHookResult, SpaceWorkflow } from '@neokai/sh
 import type { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
 import type { WorkflowHookStateRepository } from '../../../../src/storage/repositories/workflow-hook-state-repository';
 import type { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository';
+import type { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
 import type { ToolResult } from '../../../../src/lib/space/tools/tool-result';
 
 // ---------------------------------------------------------------------------
@@ -168,6 +169,16 @@ function makeMockArtifactRepo(): WorkflowRunArtifactRepository {
   } as unknown as WorkflowRunArtifactRepository;
 }
 
+function makeMockWorkflowRunRepo(): SpaceWorkflowRunRepository {
+  return {
+    getRun: () =>
+      ({
+        id: 'run-1',
+        createdAt: Date.now(),
+      }) as unknown as import('@neokai/shared').SpaceWorkflowRun,
+  } as unknown as SpaceWorkflowRunRepository;
+}
+
 function makeWorkflow(hooks: WorkflowHook[]): SpaceWorkflow {
   return {
     id: 'wf-1',
@@ -210,6 +221,7 @@ function makeEngine(hooks: WorkflowHook[]): {
     workflow: makeWorkflow(hooks),
     workflowRunId: 'run-1',
     nodeExecutionRepo: makeMockNodeExecutionRepo(),
+    workflowRunRepo: makeMockWorkflowRunRepo(),
     artifactRepo: makeMockArtifactRepo(),
     hookStateRepo: makeMockHookStateRepo(),
     hookExecutor: mockExecutor,
@@ -524,6 +536,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -566,6 +579,7 @@ describe('WorkflowHookEngine', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -729,6 +743,7 @@ describe('WorkflowHookEngine', () => {
       workflow,
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo: makeMockHookStateRepo(),
       hookExecutor: mockExecutor,
@@ -758,6 +773,7 @@ describe('WorkflowHookEngine', () => {
       workflow,
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo: makeMockHookStateRepo(),
       hookExecutor: mockExecutor,
@@ -803,6 +819,7 @@ describe('WorkflowHookEngine', () => {
       workflow,
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo: makeMockHookStateRepo(),
       hookExecutor: mockExecutor,
@@ -828,6 +845,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -858,6 +876,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -889,6 +908,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -922,6 +942,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -958,6 +979,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1003,6 +1025,7 @@ describe('WorkflowHookEngine', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1054,6 +1077,7 @@ describe('WorkflowHookEngine', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1135,6 +1159,7 @@ describe('WorkflowHookEngine', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1170,6 +1195,7 @@ describe('WorkflowHookEngine', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1207,6 +1233,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo,
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1251,6 +1278,7 @@ describe('WorkflowHookEngine', () => {
       workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo,
       hookStateRepo,
       hookExecutor: mockExecutor,
@@ -1354,6 +1382,7 @@ describe('wrapHandlerWithHooks', () => {
       ]),
       workflowRunId: 'run-1',
       nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
       artifactRepo: makeMockArtifactRepo(),
       hookStateRepo,
       hookExecutor: mockExecutor,

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1425,6 +1425,139 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.userState.reason).toContain('mixed configuration');
     expect(outcome.executionLog).toHaveLength(0);
   });
+
+  test('empty hooks array with hook-managed channel fails closed', async () => {
+    const workflow = makeWorkflow([]);
+    workflow.hooks = [];
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['missing-hook'] }];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('block');
+    expect(outcome.userState.status).toBe('blocked_by_hook');
+    expect(outcome.userState.reason).toContain('not all declared hooks resolve');
+  });
+
+  test('@worker address with agent slot matches slot-addressed channel', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'reviewer', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '@worker:run-1/Review/reviewer', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
+
+  test('@role address with agent slot matches slot-addressed channel', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'reviewer', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '@role:reviewer', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
+
+  test('broadcast * matches slot-addressed channels', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    // Channel uses agent slot name 'reviewer' and wildcard permits all
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'reviewer', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '*', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1746,6 +1746,114 @@ describe('WorkflowHookEngine', () => {
     const ctx = capturedContext as { prUrl?: string };
     expect(ctx.prUrl).toBe('https://github.com/lsm/neokai/pull/42');
   });
+
+  test('node-id target first-matches channel by resolved node name', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'node-review', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
+
+  test('array target uses first-match per element', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'specific-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+      makeHook({
+        id: 'wildcard-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [
+      { id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['specific-gate'] },
+      { id: 'ch-2', from: 'Coding', to: '*', hookIds: ['wildcard-gate'] },
+    ];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('specific-gate', { type: 'allow' });
+    // wildcard-gate not set — would block if union behavior still applied
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: ['Review'], message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('specific-gate');
+  });
+
+  test('space-agent target skips channel hook binding', async () => {
+    // No hooks in workflow.hooks — channel only references a missing hook.
+    const workflow = makeWorkflow([]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: '*', hookIds: ['missing-gate'] }];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'space-agent', message: 'escalate' },
+      defaultMeta
+    );
+
+    // Channel hook binding is skipped for space-agent, so missing-gate
+    // does not trigger fail-closed.
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(0);
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1647,6 +1647,105 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.executionLog).toHaveLength(1);
     expect(outcome.executionLog[0].hookId).toBe('workflow-hook');
   });
+
+  test('@worker address first-matches slot-addressed channel', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'review-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'reviewer', hookIds: ['review-gate'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('review-gate', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '@worker:run-1/Review/reviewer', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('review-gate');
+  });
+
+  test('side_effect channel-bound hook fails closed', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'side-hook',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        classification: 'side_effect',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['side-hook'] }];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('side-hook', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('block');
+    expect(outcome.userState.status).toBe('blocked_by_hook');
+    expect(outcome.userState.reason).toContain('not all declared hooks resolve');
+  });
+
+  test('PR_URL env var injected alongside NEOKAI_PR_URL', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'side_effect' })]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+      prUrl: 'https://github.com/lsm/neokai/pull/42',
+    });
+
+    let capturedContext: unknown;
+    mockExecutor.execute = async (hook, context) => {
+      capturedContext = context;
+      return { result: { type: 'allow' } };
+    };
+
+    await engine.executeAction('send_message', { target: 'Review' }, defaultMeta);
+
+    const ctx = capturedContext as { prUrl?: string };
+    expect(ctx.prUrl).toBe('https://github.com/lsm/neokai/pull/42');
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1558,6 +1558,95 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.executionLog).toHaveLength(1);
     expect(outcome.executionLog[0].hookId).toBe('review-gate');
   });
+
+  test('first-match channel semantics: specific channel governs over later wildcard', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'specific-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+      makeHook({
+        id: 'wildcard-gate',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    // Specific channel first, then wildcard — router would use the specific one
+    workflow.channels = [
+      { id: 'ch-1', from: 'Coding', to: 'Review', hookIds: ['specific-gate'] },
+      { id: 'ch-2', from: 'Coding', to: '*', hookIds: ['wildcard-gate'] },
+    ];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('specific-gate', { type: 'allow' });
+    // wildcard-gate is NOT set — if first-match fails, it would block
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    // Only specific-gate should run because the specific channel matches first
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('specific-gate');
+  });
+
+  test('first-match channel with no hookIds allows action without channel-bound hooks', async () => {
+    const workflow = makeWorkflow([
+      makeHook({
+        id: 'workflow-hook',
+        sourceNode: 'Coding',
+        method: 'send_message',
+        authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      }),
+    ]);
+    // Open channel first, then wildcard hook-managed — router uses the open one
+    workflow.channels = [
+      { id: 'ch-1', from: 'Coding', to: 'Review' },
+      { id: 'ch-2', from: 'Coding', to: '*', hookIds: ['wildcard-gate'] },
+    ];
+
+    const mockExecutor = new MockHookExecutor();
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+    mockExecutor.setResult('workflow-hook', { type: 'allow' });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi' },
+      defaultMeta
+    );
+
+    // workflow-hook runs because it's not channel-bound and matches on its own
+    // criteria. The wildcard channel's hookIds are ignored because the first
+    // matching channel (ch-1) has no hookIds.
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('workflow-hook');
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1941,6 +1941,145 @@ describe('WorkflowHookEngine', () => {
     expect(gateData.existing_field).toBe(true);
     expect(gateData.pr_url).toBe('https://github.com/pull/1');
   });
+
+  test('generic handle target skips channel hook binding', async () => {
+    // @some-agent is a generic handle — routes through SpaceDeliveryFacade,
+    // not channelRouter.deliverMessage, so channel hooks must not bind.
+    const workflow = makeWorkflow([]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: '*', hookIds: ['missing-gate'] }];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '@some-agent', message: 'hello' },
+      defaultMeta
+    );
+
+    // Generic handle bypasses channel topology — no channel hook binding.
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(0);
+  });
+
+  test('@worker address with URL-encoded agent name decodes for channel matching', async () => {
+    // Agent slot name contains '/' which is URL-encoded in @worker addresses.
+    const hook: WorkflowHook = {
+      id: 'encoded-hook',
+      method: 'send_message',
+      sourceNode: 'Coding',
+      enabled: true,
+      classification: 'validation',
+      authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      validator: { kind: 'built_in', id: 'pr_open' as const },
+    };
+
+    const workflow = makeWorkflow([hook]);
+    workflow.nodes = [
+      { id: 'node-coding', name: 'Coding', agents: [{ name: 'coder', agentId: 'agent-coder' }] },
+      {
+        id: 'node-review',
+        name: 'Review',
+        agents: [{ name: 'reviewer/lead', agentId: 'agent-reviewer' }],
+      },
+    ];
+    // Channel targets the decoded agent slot name
+    workflow.channels = [
+      { id: 'ch-encoded', from: 'Coding', to: 'reviewer/lead', hookIds: ['encoded-hook'] },
+    ];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      // @worker:Review/reviewer%2Flead — encoded form of reviewer/lead
+      { target: '@worker:Review/reviewer%2Flead', message: 'review please' },
+      defaultMeta
+    );
+
+    // URL-encoded agent name is decoded to match the channel's to: 'reviewer/lead'
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(1);
+    expect(outcome.executionLog[0].hookId).toBe('encoded-hook');
+  });
+
+  test('array targets each resolve their own channel independently', async () => {
+    // Two channels with different hookIds — each array element must match
+    // its own channel, not the sibling's.
+    const hookReview: WorkflowHook = {
+      id: 'review-hook',
+      method: 'send_message',
+      sourceNode: 'Coding',
+      enabled: true,
+      classification: 'validation',
+      authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      validator: { kind: 'built_in', id: 'pr_open' as const },
+    };
+    const hookQa: WorkflowHook = {
+      id: 'qa-hook',
+      method: 'send_message',
+      sourceNode: 'Coding',
+      enabled: true,
+      classification: 'validation',
+      authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      validator: { kind: 'built_in', id: 'pr_open' as const },
+    };
+
+    const workflow = makeWorkflow([hookReview, hookQa]);
+    workflow.nodes = [
+      { id: 'node-coding', name: 'Coding', agents: [{ name: 'coder', agentId: 'agent-coder' }] },
+      {
+        id: 'node-review',
+        name: 'Review',
+        agents: [{ name: 'reviewer', agentId: 'agent-reviewer' }],
+      },
+      { id: 'node-qa', name: 'QA', agents: [{ name: 'qa', agentId: 'agent-qa' }] },
+    ];
+    workflow.channels = [
+      { id: 'ch-coder-reviewer', from: 'Coding', to: 'Review', hookIds: ['review-hook'] },
+      { id: 'ch-coder-qa', from: 'Coding', to: 'QA', hookIds: ['qa-hook'] },
+    ];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      // Node-id targets — each should resolve to its own node name
+      { target: ['node-review', 'node-qa'], message: 'check both' },
+      defaultMeta
+    );
+
+    // Both channels' hooks should be collected (not just Review's)
+    expect(outcome.decision).toBe('allow');
+    const hookIds = outcome.executionLog.map((r) => r.hookId).sort();
+    expect(hookIds).toEqual(['qa-hook', 'review-hook']);
+  });
 });
 
 describe('wrapHandlerWithHooks', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -13,7 +13,10 @@ import {
   type HookActionMeta,
   type HookActionOutcome,
 } from '../../../../src/lib/space/runtime/workflow-hook-engine';
-import { HookExecutor } from '../../../../src/lib/space/runtime/hook-executor';
+import {
+  HookExecutor,
+  type HookExecutorContext,
+} from '../../../../src/lib/space/runtime/hook-executor';
 import type { WorkflowHook, WorkflowHookResult, SpaceWorkflow } from '@neokai/shared';
 import type { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
 import type { WorkflowHookStateRepository } from '../../../../src/storage/repositories/workflow-hook-state-repository';
@@ -1853,6 +1856,90 @@ describe('WorkflowHookEngine', () => {
     // does not trigger fail-closed.
     expect(outcome.decision).toBe('allow');
     expect(outcome.executionLog).toHaveLength(0);
+  });
+
+  test('@session: reply target skips channel hook binding', async () => {
+    // Wildcard hook-managed channel should not bind @session: targets.
+    const workflow = makeWorkflow([]);
+    workflow.channels = [{ id: 'ch-1', from: 'Coding', to: '*', hookIds: ['missing-gate'] }];
+
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: new MockHookExecutor(),
+      workspacePath: '/tmp',
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: '@session:abc-123', message: 'reply to human' },
+      defaultMeta
+    );
+
+    // @session: targets route outside channel topology — no channel hook binding.
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(0);
+  });
+
+  test('send_message data is merged into gate data context', async () => {
+    const capturedContexts: HookExecutorContext[] = [];
+    const capturingExecutor = new (class extends HookExecutor {
+      constructor() {
+        super({ workspacePath: '/tmp' });
+      }
+      override async execute(
+        hook: WorkflowHook,
+        context: HookExecutorContext
+      ): Promise<{ result: WorkflowHookResult }> {
+        capturedContexts.push(context);
+        return { result: { type: 'allow' } };
+      }
+    })();
+
+    const mockGateDataRepo = {
+      listByRun: () => [{ gateId: 'g1', data: { existing_field: true }, runId: 'run-1' }],
+      get: () => null,
+    };
+
+    const hook: WorkflowHook = {
+      id: 'test-hook',
+      method: 'send_message',
+      sourceNode: 'Coding',
+      enabled: true,
+      classification: 'validation',
+      authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+      validator: { kind: 'built_in', id: 'pr_open' as const },
+    };
+
+    const workflow = makeWorkflow([hook]);
+    const engine = new WorkflowHookEngine({
+      workflow,
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      workflowRunRepo: makeMockWorkflowRunRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo: makeMockHookStateRepo(),
+      hookExecutor: capturingExecutor,
+      workspacePath: '/tmp',
+      gateDataRepo: mockGateDataRepo as any,
+    });
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'done', data: { pr_url: 'https://github.com/pull/1' } },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(capturedContexts).toHaveLength(1);
+    const gateData = JSON.parse(capturedContexts[0].gateDataJson ?? '{}');
+    // Both persisted gate data and in-flight params.data should be present
+    expect(gateData.existing_field).toBe(true);
+    expect(gateData.pr_url).toBe('https://github.com/pull/1');
   });
 });
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -2390,6 +2390,8 @@ export interface ExportedWorkflowChannel {
   maxCycles?: number;
   label?: string;
   gateId?: string;
+  /** Hook IDs that validate MCP actions on this channel */
+  hookIds?: string[];
 }
 
 /**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1934,6 +1934,17 @@ export interface WorkflowChannel {
    * Each gate belongs to exactly one channel.
    */
   gateId?: string;
+  /**
+   * Optional references to WorkflowHook entities in `SpaceWorkflow.hooks`.
+   * When set, the referenced hooks validate the originating MCP action
+   * (e.g. `send_message`) before delivery is permitted. Hooks replace
+   * gate evaluation for guarded handoffs on this channel.
+   *
+   * A channel may reference either `gateId` or `hookIds`, never both.
+   * If both appear in persisted JSON the runtime fails closed with a
+   * workflow validation error until the workflow is migrated.
+   */
+  hookIds?: string[];
 }
 
 /**


### PR DESCRIPTION
Refactor message delivery so `send_message` hooks replace gate data writes and gate evaluation for guarded handoffs.

## Changes
- Add `hookIds` to `WorkflowChannel` type (shared)
- `ChannelRouter`: enforce hook/gate exclusivity per channel; skip legacy gate checks entirely for hook-managed channels (both pre-activation and post-activation)
- `ChannelRouter`: `onGateDataChanged` returns early for terminal runs (`done`/`cancelled`/`blocked`) and skips hook-managed channels; does not reactivate nodes that already have any executions
- `send_message` handler: skip auto gate-write for hook-managed channels
- `WorkflowHookEngine`: accept `workflowRunRepo` and inject `NEOKAI_WORKFLOW_START_ISO` into hook script environment to enable reuse of existing gate bash scripts as hook validators
- Update existing tests for new terminal-run behavior; add exclusivity, gate-skip, and reactivation-guard tests

Part of stack: Redesign workflow gates as MCP action hooks. PR 3 of 10.