### PR TITLE
WI-5: Migrate review-approval-gate and plan approval voting to hooks

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -124,6 +124,7 @@ function buildTemplateUpdateParams(
     ? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
     : null;
   const newGates = template.gates ? [...template.gates] : null;
+  const newHooks = template.hooks ? [...template.hooks] : null;
   const templateHash = computeWorkflowHash(template);
 
   return {
@@ -135,6 +136,7 @@ function buildTemplateUpdateParams(
     endNodeId: newEndNodeId ?? null,
     channels: newChannels,
     gates: newGates,
+    hooks: newHooks,
     tags: [...template.tags],
     completionAutonomyLevel: template.completionAutonomyLevel,
     templateName: template.name,

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -130,6 +130,15 @@ function floorToGithubSecond(ms: number): number {
   return Math.floor(ms / 1000) * 1000;
 }
 
+type GithubReaction = { content?: string; createdAt?: string; user?: { login?: string } };
+type GithubReactable = {
+  id?: string;
+  reactions?: {
+    nodes?: GithubReaction[];
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+  };
+};
+
 async function githubGraphql(
   host: string,
   query: string,
@@ -185,6 +194,48 @@ async function githubGraphql(
   }
 }
 
+async function hasFreshCodexReaction(
+  host: string,
+  reactable: GithubReactable | undefined,
+  isFreshCodexPlusOne: (reaction: GithubReaction) => boolean
+): Promise<boolean> {
+  if (!reactable) return false;
+  if (reactable.reactions?.nodes?.some(isFreshCodexPlusOne)) return true;
+
+  let reactionCursor = reactable.reactions?.pageInfo?.hasNextPage
+    ? reactable.reactions.pageInfo.endCursor
+    : undefined;
+  while (reactable.id && reactionCursor) {
+    const result = await githubGraphql(
+      host,
+      `
+        query($nodeId:ID!,$reactionCursor:String) {
+          node(id:$nodeId) {
+            ... on Reactable {
+              reactions(first:100, after:$reactionCursor) {
+                nodes { content createdAt user { login } }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      `,
+      { nodeId: reactable.id, reactionCursor }
+    );
+    if (!result.ok) return false;
+    const json = result.json as {
+      data?: { node?: GithubReactable };
+      errors?: unknown[];
+    };
+    if (json.errors) return false;
+    const reactions = json.data?.node?.reactions;
+    if (reactions?.nodes?.some(isFreshCodexPlusOne)) return true;
+    reactionCursor = reactions?.pageInfo?.hasNextPage ? reactions.pageInfo.endCursor : undefined;
+  }
+
+  return false;
+}
+
 /**
  * Check GitHub for a codex[bot] +1 reaction on the PR body, issue comments,
  * or review comments. Uses the GraphQL API to query all reaction locations
@@ -213,13 +264,17 @@ async function checkCodexApproval(
           pullRequest(number:$number) {
             headRefOid
             updatedAt
+            id
             reactions(first:100) {
               nodes { content createdAt user { login } }
+              pageInfo { hasNextPage endCursor }
             }
             comments(first:100, after:$commentsCursor) @include(if:$includeComments) {
               nodes {
+                id
                 reactions(first:100) {
                   nodes { content createdAt user { login } }
+                  pageInfo { hasNextPage endCursor }
                 }
               }
               pageInfo { hasNextPage endCursor }
@@ -229,8 +284,10 @@ async function checkCodexApproval(
                 id
                 comments(first:100) {
                   nodes {
+                    id
                     reactions(first:100) {
                       nodes { content createdAt user { login } }
+                      pageInfo { hasNextPage endCursor }
                     }
                   }
                   pageInfo { hasNextPage endCursor }
@@ -260,34 +317,17 @@ async function checkCodexApproval(
           pullRequest?: {
             headRefOid?: string;
             updatedAt?: string;
-            reactions?: {
-              nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
-            };
+            id?: string;
+            reactions?: GithubReactable['reactions'];
             comments?: {
-              nodes?: Array<{
-                reactions?: {
-                  nodes?: Array<{
-                    content?: string;
-                    createdAt?: string;
-                    user?: { login?: string };
-                  }>;
-                };
-              }>;
+              nodes?: GithubReactable[];
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             reviewThreads?: {
               nodes?: Array<{
                 id?: string;
                 comments?: {
-                  nodes?: Array<{
-                    reactions?: {
-                      nodes?: Array<{
-                        content?: string;
-                        createdAt?: string;
-                        user?: { login?: string };
-                      }>;
-                    };
-                  }>;
+                  nodes?: GithubReactable[];
                   pageInfo?: { hasNextPage?: boolean; endCursor?: string };
                 };
               }>;
@@ -330,11 +370,13 @@ async function checkCodexApproval(
     };
 
     // PR body reactions
-    if (pr.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
+    if (await hasFreshCodexReaction(parsed.host, pr, isFreshCodexPlusOne)) {
+      return { status: 'approved', headSha };
+    }
 
     // Issue comments
     for (const comment of pr.comments?.nodes ?? []) {
-      if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
+      if (await hasFreshCodexReaction(parsed.host, comment, isFreshCodexPlusOne)) {
         return { status: 'approved', headSha };
       }
     }
@@ -342,7 +384,7 @@ async function checkCodexApproval(
     // Review comments. Fetch replies beyond GraphQL's first 100 comments with per-thread calls.
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       for (const comment of thread.comments?.nodes ?? []) {
-        if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
+        if (await hasFreshCodexReaction(parsed.host, comment, isFreshCodexPlusOne)) {
           return { status: 'approved', headSha };
         }
       }
@@ -358,8 +400,10 @@ async function checkCodexApproval(
                 ... on PullRequestReviewThread {
                   comments(first:100, after:$commentsCursor) {
                     nodes {
+                      id
                       reactions(first:100) {
                         nodes { content createdAt user { login } }
+                        pageInfo { hasNextPage endCursor }
                       }
                     }
                     pageInfo { hasNextPage endCursor }
@@ -375,15 +419,7 @@ async function checkCodexApproval(
           data?: {
             node?: {
               comments?: {
-                nodes?: Array<{
-                  reactions?: {
-                    nodes?: Array<{
-                      content?: string;
-                      createdAt?: string;
-                      user?: { login?: string };
-                    }>;
-                  };
-                }>;
+                nodes?: GithubReactable[];
                 pageInfo?: { hasNextPage?: boolean; endCursor?: string };
               };
             };
@@ -393,7 +429,7 @@ async function checkCodexApproval(
         if (threadJson.errors) return { status: 'error', headSha };
         const comments = threadJson.data?.node?.comments;
         for (const comment of comments?.nodes ?? []) {
-          if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
+          if (await hasFreshCodexReaction(parsed.host, comment, isFreshCodexPlusOne)) {
             return { status: 'approved', headSha };
           }
         }
@@ -493,7 +529,15 @@ export async function reviewApprovalValidator(
         codexStartedAt ?? (storedHeadSha ? undefined : 'head')
       );
 
-      // New revision pushed — reset codex timer so stale approvals don't release
+      if (codexResult.status === 'approved') {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
+        };
+      }
+
+      // New revision pushed — reset codex timer so stale approvals don't release.
+      // Check approval first so a fresh pre-existing Codex +1 on the new head can release.
       if (codexResult.headSha && storedHeadSha && storedHeadSha !== codexResult.headSha) {
         return {
           type: 'retryable_block',
@@ -505,13 +549,6 @@ export async function reviewApprovalValidator(
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },
-        };
-      }
-
-      if (codexResult.status === 'approved') {
-        return {
-          type: 'allow',
-          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
         };
       }
 
@@ -546,7 +583,7 @@ export async function reviewApprovalValidator(
         retryAfterMs: 60_000,
         state: {
           ...nextState,
-          _codex_started_at: codexStartedAt ?? now,
+          _codex_started_at: codexStartedAt ?? githubNow,
           _codex_head_sha: codexResult.headSha ?? storedHeadSha,
           _pr_url: prUrl,
         },

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -72,6 +72,19 @@ function getVotes(state: Record<string, unknown>, voteKey: string): Record<strin
   return {};
 }
 
+function findPrUrl(ctx: HookExecutorContext): string | undefined {
+  const data = ctx.params.data as Record<string, unknown> | undefined;
+  if (typeof data?.pr_url === 'string') return data.pr_url;
+  if (typeof ctx.hookLocalState._pr_url === 'string') return ctx.hookLocalState._pr_url as string;
+
+  for (const artifact of ctx.currentArtifacts) {
+    const artifactData = artifact.data as Record<string, unknown> | undefined;
+    if (typeof artifactData?.pr_url === 'string') return artifactData.pr_url;
+  }
+
+  return undefined;
+}
+
 function parsePrUrl(url: string): { owner: string; repo: string; number: number } | null {
   const m = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
   if (!m) return null;
@@ -180,7 +193,7 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
 
     const isCodexPlusOne = (r: { content?: string; user?: { login?: string } }): boolean =>
       (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
-      r.content === '+1';
+      r.content === 'THUMBS_UP';
 
     // PR body reactions
     if (pr.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
@@ -254,12 +267,19 @@ export async function reviewApprovalValidator(
 
   // Threshold met → check codex if required
   if (template.requireCodex) {
-    const prUrl =
-      typeof data?.pr_url === 'string'
-        ? data.pr_url
-        : typeof state._pr_url === 'string'
-          ? (state._pr_url as string)
-          : undefined;
+    const prUrl = findPrUrl(ctx);
+    const timeoutMs =
+      typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
+    const codexStartedAt = state._codex_started_at as number | undefined;
+    const now = Date.now();
+
+    // Timeout already elapsed — allow regardless of API state
+    if (codexStartedAt !== undefined && now - codexStartedAt > timeoutMs) {
+      return {
+        type: 'allow',
+        message: `Threshold met (${approvalCount}/${threshold}). Codex approval timed out after ${timeoutMs}ms; allowing.`,
+      };
+    }
 
     if (prUrl) {
       const codexResult = await checkCodexApproval(prUrl);
@@ -269,47 +289,14 @@ export async function reviewApprovalValidator(
           message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
         };
       }
-      if (codexResult === 'error') {
-        // Fail closed on GitHub error — retryable so the agent can retry
-        return {
-          type: 'retryable_block',
-          reason: 'Threshold met. Unable to verify codex[bot] status (GitHub API error). Retrying.',
-          retryAfterMs: 60_000,
-          state: nextState,
-        };
-      }
     }
 
-    // Codex not yet approved → retryable block with timeout
-    const timeoutMs =
-      typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
-    const codexStartedAt = state._codex_started_at as number | undefined;
-    const now = Date.now();
-
-    if (codexStartedAt === undefined) {
-      // First time we hit threshold — start the codex clock
-      return {
-        type: 'retryable_block',
-        reason: 'Threshold met. Waiting for codex[bot] approval.',
-        retryAfterMs: 60_000,
-        state: { ...nextState, _codex_started_at: now, _pr_url: prUrl },
-      };
-    }
-
-    if (now - codexStartedAt > timeoutMs) {
-      // Codex timeout elapsed — allow through
-      return {
-        type: 'allow',
-        message: `Threshold met (${approvalCount}/${threshold}). Codex approval timed out after ${timeoutMs}ms; allowing.`,
-      };
-    }
-
-    // Still within timeout window
+    // Not yet approved (or API error / no prUrl). Start or continue timeout.
     return {
       type: 'retryable_block',
       reason: 'Threshold met. Waiting for codex[bot] approval.',
       retryAfterMs: 60_000,
-      state: nextState,
+      state: { ...nextState, _codex_started_at: codexStartedAt ?? now, _pr_url: prUrl },
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -187,7 +187,7 @@ async function githubGraphql(
  */
 async function checkCodexApproval(
   prUrl: string,
-  sinceMs: number | undefined
+  sinceMs: number | 'head' | undefined
 ): Promise<{ status: 'approved' | 'waiting' | 'error'; headSha?: string }> {
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return { status: 'error' };
@@ -197,6 +197,7 @@ async function checkCodexApproval(
       repository(owner:$owner,name:$name) {
         pullRequest(number:$number) {
           headRefOid
+          commits(last:1) { nodes { commit { committedDate } } }
           reactions(first:100) {
             nodes { content createdAt user { login } }
           }
@@ -235,6 +236,7 @@ async function checkCodexApproval(
       repository?: {
         pullRequest?: {
           headRefOid?: string;
+          commits?: { nodes?: Array<{ commit?: { committedDate?: string } }> };
           reactions?: {
             nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
           };
@@ -276,7 +278,14 @@ async function checkCodexApproval(
   if (!pr) return { status: 'error' };
 
   const headSha = pr.headRefOid;
-  const since = sinceMs ?? Number.POSITIVE_INFINITY;
+  const headCommittedAt = pr.commits?.nodes?.[0]?.commit?.committedDate;
+  const headCommittedMs = headCommittedAt ? Date.parse(headCommittedAt) : Number.NaN;
+  const since =
+    sinceMs === 'head'
+      ? Number.isFinite(headCommittedMs)
+        ? headCommittedMs
+        : Number.POSITIVE_INFINITY
+      : (sinceMs ?? Number.POSITIVE_INFINITY);
 
   const isFreshCodexPlusOne = (r: {
     content?: string;
@@ -378,7 +387,7 @@ export async function reviewApprovalValidator(
     if (prUrl) {
       const codexResult = await checkCodexApproval(
         prUrl,
-        codexStartedAt ?? (storedHeadSha || resetPending ? undefined : 0)
+        codexStartedAt ?? (storedHeadSha || resetPending ? undefined : 'head')
       );
 
       // New revision pushed — reset codex timer so stale approvals don't release

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -77,14 +77,16 @@ function findPrUrl(ctx: HookExecutorContext): string | undefined {
   if (typeof data?.pr_url === 'string') return data.pr_url;
   if (typeof ctx.hookLocalState._pr_url === 'string') return ctx.hookLocalState._pr_url as string;
 
-  for (const artifact of ctx.currentArtifacts) {
-    const artifactData = artifact.data as Record<string, unknown> | undefined;
-    if (typeof artifactData?.pr_url === 'string') return artifactData.pr_url;
-  }
-
+  // Gate data is the canonical source for the active PR URL
   for (const gate of ctx.gateData ?? []) {
     const gateData = gate.data as Record<string, unknown> | undefined;
     if (typeof gateData?.pr_url === 'string') return gateData.pr_url;
+  }
+
+  // Fall back to artifacts (may contain stale URLs from prior cycles)
+  for (const artifact of ctx.currentArtifacts) {
+    const artifactData = artifact.data as Record<string, unknown> | undefined;
+    if (typeof artifactData?.pr_url === 'string') return artifactData.pr_url;
   }
 
   return undefined;
@@ -114,6 +116,19 @@ async function checkCodexApproval(
 
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) return { status: 'error' };
+
+  // Only send credentials to trusted hosts
+  const trustedHosts = new Set(['github.com']);
+  const ghHost = process.env.GH_HOST;
+  if (ghHost) trustedHosts.add(ghHost);
+  const extraHosts = process.env.NEOKAI_TRUSTED_GITHUB_HOSTS;
+  if (extraHosts) {
+    for (const h of extraHosts.split(',')) {
+      const trimmed = h.trim();
+      if (trimmed) trustedHosts.add(trimmed);
+    }
+  }
+  if (!trustedHosts.has(parsed.host)) return { status: 'error' };
 
   const endpoint =
     parsed.host === 'github.com'
@@ -305,6 +320,22 @@ export async function reviewApprovalValidator(
           state: {
             ...nextState,
             _codex_started_at: now,
+            _codex_head_sha: codexResult.headSha,
+            _pr_url: prUrl,
+          },
+        };
+      }
+
+      // After a reset, storedHeadSha is null. Record the current head and wait
+      // for a fresh codex approval instead of accepting historical thumbs-ups.
+      if (codexResult.headSha && !storedHeadSha) {
+        return {
+          type: 'retryable_block',
+          reason: 'Recording PR head SHA after reset. Waiting for fresh codex approval.',
+          retryAfterMs: 60_000,
+          state: {
+            ...nextState,
+            _codex_started_at: codexStartedAt ?? now,
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -275,7 +275,7 @@ async function checkCodexApproval(
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
             headRefOid
-            updatedAt
+            headRef { target { ... on Commit { committedDate } } }
             id
             reactions(first:100) {
               nodes { content createdAt user { login } }
@@ -328,7 +328,7 @@ async function checkCodexApproval(
         repository?: {
           pullRequest?: {
             headRefOid?: string;
-            updatedAt?: string;
+            headRef?: { target?: { committedDate?: string } };
             id?: string;
             reactions?: GithubReactable['reactions'];
             comments?: {
@@ -357,11 +357,13 @@ async function checkCodexApproval(
     if (!pr) return { status: 'error', headSha };
 
     headSha = pr.headRefOid;
-    const prUpdatedMs = pr.updatedAt ? Date.parse(pr.updatedAt) : Number.NaN;
+    const headCommittedMs = pr.headRef?.target?.committedDate
+      ? Date.parse(pr.headRef.target.committedDate)
+      : Number.NaN;
     const since =
       sinceMs === 'head'
-        ? Number.isFinite(prUpdatedMs)
-          ? floorToGithubSecond(prUpdatedMs)
+        ? Number.isFinite(headCommittedMs)
+          ? floorToGithubSecond(headCommittedMs)
           : Number.POSITIVE_INFINITY
         : sinceMs !== undefined
           ? floorToGithubSecond(sinceMs)
@@ -541,16 +543,14 @@ export async function reviewApprovalValidator(
         codexStartedAt ?? (storedHeadSha ? undefined : 'head')
       );
 
-      if (codexResult.status === 'approved') {
-        return {
-          type: 'allow',
-          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
-        };
-      }
-
-      // New revision pushed — reset codex timer so stale approvals don't release.
-      // Check approval first so a fresh pre-existing Codex +1 on the new head can release.
       if (codexResult.headSha && storedHeadSha && storedHeadSha !== codexResult.headSha) {
+        const headCodexResult = await checkCodexApproval(prUrl, 'head');
+        if (headCodexResult.status === 'approved') {
+          return {
+            type: 'allow',
+            message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
+          };
+        }
         return {
           type: 'retryable_block',
           reason: 'New PR revision detected. Resetting codex timer.',
@@ -561,6 +561,13 @@ export async function reviewApprovalValidator(
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },
+        };
+      }
+
+      if (codexResult.status === 'approved') {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
         };
       }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -368,12 +368,18 @@ export async function reviewApprovalValidator(
     const prUrl = findPrUrl(ctx);
     const timeoutMs =
       typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
-    const codexStartedAt = state._codex_started_at as number | undefined;
-    const storedHeadSha = state._codex_head_sha as string | undefined;
+    const codexStartedAt =
+      typeof state._codex_started_at === 'number' ? state._codex_started_at : undefined;
+    const storedHeadSha =
+      typeof state._codex_head_sha === 'string' ? state._codex_head_sha : undefined;
+    const resetPending = state._codex_started_at === null || state._codex_head_sha === null;
     const now = Date.now();
 
     if (prUrl) {
-      const codexResult = await checkCodexApproval(prUrl, codexStartedAt);
+      const codexResult = await checkCodexApproval(
+        prUrl,
+        codexStartedAt ?? (storedHeadSha || resetPending ? undefined : 0)
+      );
 
       // New revision pushed — reset codex timer so stale approvals don't release
       if (codexResult.headSha && storedHeadSha && storedHeadSha !== codexResult.headSha) {
@@ -392,7 +398,7 @@ export async function reviewApprovalValidator(
 
       // After a reset, storedHeadSha is null. Record the current head and wait
       // for a fresh codex approval instead of accepting historical thumbs-ups.
-      if (codexResult.headSha && !storedHeadSha) {
+      if (codexResult.headSha && resetPending && !storedHeadSha) {
         return {
           type: 'retryable_block',
           reason: 'Recording PR head SHA after reset. Waiting for fresh codex approval.',

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -85,10 +85,12 @@ function findPrUrl(ctx: HookExecutorContext): string | undefined {
   return undefined;
 }
 
-function parsePrUrl(url: string): { owner: string; repo: string; number: number } | null {
-  const m = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+function parsePrUrl(
+  url: string
+): { owner: string; repo: string; number: number; host: string } | null {
+  const m = url.match(/https?:\/\/([^/]+)\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
   if (!m) return null;
-  return { owner: m[1], repo: m[2], number: Number(m[3]) };
+  return { host: m[1], owner: m[2], repo: m[3], number: Number(m[4]) };
 }
 
 /**
@@ -96,25 +98,34 @@ function parsePrUrl(url: string): { owner: string; repo: string; number: number 
  * or review comments. Uses the GraphQL API to query all reaction locations
  * in a single request.
  *
- * Returns 'approved' if found, 'waiting' if not, 'error' on failure.
+ * Returns status 'approved' if found, 'waiting' if not, 'error' on failure,
+ * plus the current PR head SHA when available.
  */
-async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting' | 'error'> {
+async function checkCodexApproval(
+  prUrl: string
+): Promise<{ status: 'approved' | 'waiting' | 'error'; headSha?: string }> {
   const parsed = parsePrUrl(prUrl);
-  if (!parsed) return 'error';
+  if (!parsed) return { status: 'error' };
 
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  if (!token) return 'error';
+  if (!token) return { status: 'error' };
+
+  const endpoint =
+    parsed.host === 'github.com'
+      ? 'https://api.github.com/graphql'
+      : `https://${parsed.host}/api/graphql`;
 
   const query = `
     query($owner:String!,$name:String!,$number:Int!) {
       repository(owner:$owner,name:$name) {
         pullRequest(number:$number) {
-          reactions(first:10) {
+          headRefOid
+          reactions(first:100) {
             nodes { content user { login } }
           }
           comments(first:100) {
             nodes {
-              reactions(first:10) {
+              reactions(first:100) {
                 nodes { content user { login } }
               }
             }
@@ -123,7 +134,7 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
             nodes {
               comments(first:100) {
                 nodes {
-                  reactions(first:10) {
+                  reactions(first:100) {
                     nodes { content user { login } }
                   }
                 }
@@ -139,7 +150,7 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
   const timeout = setTimeout(() => controller.abort(), 10_000);
 
   try {
-    const res = await fetch('https://api.github.com/graphql', {
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -153,12 +164,13 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
     });
     clearTimeout(timeout);
 
-    if (!res.ok) return 'error';
+    if (!res.ok) return { status: 'error' };
 
     const json = (await res.json()) as {
       data?: {
         repository?: {
           pullRequest?: {
+            headRefOid?: string;
             reactions?: {
               nodes?: Array<{ content?: string; user?: { login?: string } }>;
             };
@@ -186,33 +198,35 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
       errors?: unknown[];
     };
 
-    if (json.errors) return 'error';
+    if (json.errors) return { status: 'error' };
 
     const pr = json.data?.repository?.pullRequest;
-    if (!pr) return 'error';
+    if (!pr) return { status: 'error' };
+
+    const headSha = pr.headRefOid;
 
     const isCodexPlusOne = (r: { content?: string; user?: { login?: string } }): boolean =>
       (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
       r.content === 'THUMBS_UP';
 
     // PR body reactions
-    if (pr.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+    if (pr.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
 
     // Issue comments
     for (const comment of pr.comments?.nodes ?? []) {
-      if (comment.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+      if (comment.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
     }
 
     // Review comments
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       for (const comment of thread.comments?.nodes ?? []) {
-        if (comment.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+        if (comment.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
       }
     }
 
-    return 'waiting';
+    return { status: 'waiting', headSha };
   } catch {
-    return 'error';
+    return { status: 'error' };
   } finally {
     clearTimeout(timeout);
   }
@@ -271,9 +285,57 @@ export async function reviewApprovalValidator(
     const timeoutMs =
       typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
     const codexStartedAt = state._codex_started_at as number | undefined;
+    const storedHeadSha = state._codex_head_sha as string | undefined;
     const now = Date.now();
 
-    // Timeout already elapsed — allow regardless of API state
+    if (prUrl) {
+      const codexResult = await checkCodexApproval(prUrl);
+
+      // New revision pushed — reset codex timer so stale approvals don't release
+      if (codexResult.headSha && storedHeadSha && storedHeadSha !== codexResult.headSha) {
+        return {
+          type: 'retryable_block',
+          reason: 'New PR revision detected. Resetting codex timer.',
+          retryAfterMs: 60_000,
+          state: {
+            ...nextState,
+            _codex_started_at: now,
+            _codex_head_sha: codexResult.headSha,
+            _pr_url: prUrl,
+          },
+        };
+      }
+
+      // Timeout already elapsed — allow regardless of API state
+      if (codexStartedAt !== undefined && now - codexStartedAt > timeoutMs) {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}). Codex approval timed out after ${timeoutMs}ms; allowing.`,
+        };
+      }
+
+      if (codexResult.status === 'approved') {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
+        };
+      }
+
+      // Not yet approved (or API error). Start or continue timeout.
+      return {
+        type: 'retryable_block',
+        reason: 'Threshold met. Waiting for codex[bot] approval.',
+        retryAfterMs: 60_000,
+        state: {
+          ...nextState,
+          _codex_started_at: codexStartedAt ?? now,
+          _codex_head_sha: codexResult.headSha ?? storedHeadSha,
+          _pr_url: prUrl,
+        },
+      };
+    }
+
+    // No PR URL available — rely on timeout only
     if (codexStartedAt !== undefined && now - codexStartedAt > timeoutMs) {
       return {
         type: 'allow',
@@ -281,17 +343,6 @@ export async function reviewApprovalValidator(
       };
     }
 
-    if (prUrl) {
-      const codexResult = await checkCodexApproval(prUrl);
-      if (codexResult === 'approved') {
-        return {
-          type: 'allow',
-          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
-        };
-      }
-    }
-
-    // Not yet approved (or API error / no prUrl). Start or continue timeout.
     return {
       type: 'retryable_block',
       reason: 'Threshold met. Waiting for codex[bot] approval.',

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -100,24 +100,7 @@ function parsePrUrl(
   return { host: m[1], owner: m[2], repo: m[3], number: Number(m[4]) };
 }
 
-/**
- * Check GitHub for a codex[bot] +1 reaction on the PR body, issue comments,
- * or review comments. Uses the GraphQL API to query all reaction locations
- * in a single request.
- *
- * Returns status 'approved' if found, 'waiting' if not, 'error' on failure,
- * plus the current PR head SHA when available.
- */
-async function checkCodexApproval(
-  prUrl: string
-): Promise<{ status: 'approved' | 'waiting' | 'error'; headSha?: string }> {
-  const parsed = parsePrUrl(prUrl);
-  if (!parsed) return { status: 'error' };
-
-  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  if (!token) return { status: 'error' };
-
-  // Only send credentials to trusted hosts
+function trustedGithubHosts(): Set<string> {
   const trustedHosts = new Set(['github.com']);
   const ghHost = process.env.GH_HOST;
   if (ghHost) trustedHosts.add(ghHost);
@@ -128,12 +111,86 @@ async function checkCodexApproval(
       if (trimmed) trustedHosts.add(trimmed);
     }
   }
-  if (!trustedHosts.has(parsed.host)) return { status: 'error' };
+  return trustedHosts;
+}
 
-  const endpoint =
-    parsed.host === 'github.com'
-      ? 'https://api.github.com/graphql'
-      : `https://${parsed.host}/api/graphql`;
+function githubTokenForHost(host: string): string | undefined {
+  if (host !== 'github.com') {
+    return (
+      process.env.GH_ENTERPRISE_TOKEN ||
+      process.env.GITHUB_ENTERPRISE_TOKEN ||
+      process.env.GITHUB_TOKEN ||
+      process.env.GH_TOKEN
+    );
+  }
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+}
+
+async function githubGraphql(
+  host: string,
+  query: string,
+  variables: Record<string, string | number>
+): Promise<{ ok: true; json: unknown } | { ok: false }> {
+  if (!trustedGithubHosts().has(host)) return { ok: false };
+
+  const token = githubTokenForHost(host);
+  if (token) {
+    const endpoint =
+      host === 'github.com' ? 'https://api.github.com/graphql' : `https://${host}/api/graphql`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+      if (!res.ok) return { ok: false };
+      return { ok: true, json: await res.json() };
+    } catch {
+      return { ok: false };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  try {
+    const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
+    for (const [key, value] of Object.entries(variables)) {
+      args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+    }
+    const proc = Bun.spawn(['gh', ...args], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: process.env,
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return { ok: false };
+    return { ok: true, json: JSON.parse(output) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * Check GitHub for a codex[bot] +1 reaction on the PR body, issue comments,
+ * or review comments. Uses the GraphQL API to query all reaction locations
+ * in a single request.
+ *
+ * Returns status 'approved' if found, 'waiting' if not, 'error' on failure,
+ * plus the current PR head SHA when available.
+ */
+async function checkCodexApproval(
+  prUrl: string,
+  sinceMs: number | undefined
+): Promise<{ status: 'approved' | 'waiting' | 'error'; headSha?: string }> {
+  const parsed = parsePrUrl(prUrl);
+  if (!parsed) return { status: 'error' };
 
   const query = `
     query($owner:String!,$name:String!,$number:Int!) {
@@ -141,12 +198,12 @@ async function checkCodexApproval(
         pullRequest(number:$number) {
           headRefOid
           reactions(first:100) {
-            nodes { content user { login } }
+            nodes { content createdAt user { login } }
           }
           comments(first:100) {
             nodes {
               reactions(first:100) {
-                nodes { content user { login } }
+                nodes { content createdAt user { login } }
               }
             }
           }
@@ -155,7 +212,7 @@ async function checkCodexApproval(
               comments(first:100) {
                 nodes {
                   reactions(first:100) {
-                    nodes { content user { login } }
+                    nodes { content createdAt user { login } }
                   }
                 }
               }
@@ -166,90 +223,92 @@ async function checkCodexApproval(
     }
   `;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
+  const result = await githubGraphql(parsed.host, query, {
+    owner: parsed.owner,
+    name: parsed.repo,
+    number: parsed.number,
+  });
+  if (!result.ok) return { status: 'error' };
 
-  try {
-    const res = await fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        query,
-        variables: { owner: parsed.owner, name: parsed.repo, number: parsed.number },
-      }),
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (!res.ok) return { status: 'error' };
-
-    const json = (await res.json()) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            headRefOid?: string;
-            reactions?: {
-              nodes?: Array<{ content?: string; user?: { login?: string } }>;
-            };
-            comments?: {
-              nodes?: Array<{
-                reactions?: {
-                  nodes?: Array<{ content?: string; user?: { login?: string } }>;
-                };
-              }>;
-            };
-            reviewThreads?: {
-              nodes?: Array<{
-                comments?: {
-                  nodes?: Array<{
-                    reactions?: {
-                      nodes?: Array<{ content?: string; user?: { login?: string } }>;
-                    };
-                  }>;
-                };
-              }>;
-            };
+  const json = result.json as {
+    data?: {
+      repository?: {
+        pullRequest?: {
+          headRefOid?: string;
+          reactions?: {
+            nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
+          };
+          comments?: {
+            nodes?: Array<{
+              reactions?: {
+                nodes?: Array<{
+                  content?: string;
+                  createdAt?: string;
+                  user?: { login?: string };
+                }>;
+              };
+            }>;
+          };
+          reviewThreads?: {
+            nodes?: Array<{
+              comments?: {
+                nodes?: Array<{
+                  reactions?: {
+                    nodes?: Array<{
+                      content?: string;
+                      createdAt?: string;
+                      user?: { login?: string };
+                    }>;
+                  };
+                }>;
+              };
+            }>;
           };
         };
       };
-      errors?: unknown[];
     };
+    errors?: unknown[];
+  };
 
-    if (json.errors) return { status: 'error' };
+  if (json.errors) return { status: 'error' };
 
-    const pr = json.data?.repository?.pullRequest;
-    if (!pr) return { status: 'error' };
+  const pr = json.data?.repository?.pullRequest;
+  if (!pr) return { status: 'error' };
 
-    const headSha = pr.headRefOid;
+  const headSha = pr.headRefOid;
+  const since = sinceMs ?? Number.POSITIVE_INFINITY;
 
-    const isCodexPlusOne = (r: { content?: string; user?: { login?: string } }): boolean =>
+  const isFreshCodexPlusOne = (r: {
+    content?: string;
+    createdAt?: string;
+    user?: { login?: string };
+  }): boolean => {
+    const createdAt = r.createdAt ? Date.parse(r.createdAt) : Number.NaN;
+    return (
       (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
-      r.content === 'THUMBS_UP';
+      r.content === 'THUMBS_UP' &&
+      Number.isFinite(createdAt) &&
+      createdAt >= since
+    );
+  };
 
-    // PR body reactions
-    if (pr.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
+  // PR body reactions
+  if (pr.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
 
-    // Issue comments
-    for (const comment of pr.comments?.nodes ?? []) {
-      if (comment.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
-    }
-
-    // Review comments
-    for (const thread of pr.reviewThreads?.nodes ?? []) {
-      for (const comment of thread.comments?.nodes ?? []) {
-        if (comment.reactions?.nodes?.some(isCodexPlusOne)) return { status: 'approved', headSha };
-      }
-    }
-
-    return { status: 'waiting', headSha };
-  } catch {
-    return { status: 'error' };
-  } finally {
-    clearTimeout(timeout);
+  // Issue comments
+  for (const comment of pr.comments?.nodes ?? []) {
+    if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
   }
+
+  // Review comments
+  for (const thread of pr.reviewThreads?.nodes ?? []) {
+    for (const comment of thread.comments?.nodes ?? []) {
+      if (comment.reactions?.nodes?.some(isFreshCodexPlusOne))
+        return { status: 'approved', headSha };
+    }
+  }
+
+  return { status: 'waiting', headSha };
 }
 
 /**
@@ -309,7 +368,7 @@ export async function reviewApprovalValidator(
     const now = Date.now();
 
     if (prUrl) {
-      const codexResult = await checkCodexApproval(prUrl);
+      const codexResult = await checkCodexApproval(prUrl, codexStartedAt);
 
       // New revision pushed — reset codex timer so stale approvals don't release
       if (codexResult.headSha && storedHeadSha && storedHeadSha !== codexResult.headSha) {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -34,7 +34,8 @@ function getTemplateData(ctx: HookExecutorContext): ReviewApprovalTemplateData {
 
 function extractIncomingVotes(
   data: Record<string, unknown> | undefined,
-  voteKey: string
+  voteKey: string,
+  agentName: string
 ): Record<string, unknown> | undefined {
   if (!data) return undefined;
 
@@ -45,8 +46,9 @@ function extractIncomingVotes(
   }
 
   // Boolean-style vote: { approved: true }
+  // Use agentName as key so multiple reviewers don't collide.
   if (data.approved === true) {
-    return { _approved: 'approved' };
+    return { [agentName]: 'approved' };
   }
 
   return undefined;
@@ -60,6 +62,61 @@ function hasRejection(votes: Record<string, unknown>): boolean {
   return Object.values(votes).some(
     (v) => v === 'rejected' || v === 'reject' || v === 'denied' || v === 'deny'
   );
+}
+
+function getVotes(state: Record<string, unknown>, voteKey: string): Record<string, unknown> {
+  const raw = state[voteKey];
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+function parsePrUrl(url: string): { owner: string; repo: string; number: number } | null {
+  const m = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!m) return null;
+  return { owner: m[1], repo: m[2], number: Number(m[3]) };
+}
+
+/**
+ * Check GitHub for a codex[bot] +1 reaction on the PR.
+ * Returns 'approved' if found, 'waiting' if not, 'error' on failure.
+ */
+async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting' | 'error'> {
+  const parsed = parsePrUrl(prUrl);
+  if (!parsed) return 'error';
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) return 'error';
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/reactions?per_page=100`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      }
+    );
+    if (!res.ok) return 'error';
+
+    const reactions = (await res.json()) as Array<{
+      user?: { login?: string };
+      content?: string;
+    }>;
+
+    const approved = reactions.some(
+      (r) =>
+        (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
+        r.content === '+1'
+    );
+
+    return approved ? 'approved' : 'waiting';
+  } catch {
+    return 'error';
+  }
 }
 
 /**
@@ -78,8 +135,8 @@ export async function reviewApprovalValidator(
   const state = ctx.hookLocalState;
 
   // Merge incoming votes into existing state
-  const currentVotes = (state[voteKey] as Record<string, unknown> | undefined) ?? {};
-  const incoming = extractIncomingVotes(data, voteKey);
+  const currentVotes = getVotes(state, voteKey);
+  const incoming = extractIncomingVotes(data, voteKey, ctx.agentName);
 
   let mergedVotes = { ...currentVotes };
   if (incoming) {
@@ -88,12 +145,12 @@ export async function reviewApprovalValidator(
     }
   }
 
-  // Handle rejection reset
+  // Handle rejection reset — use null so deepMerge overwrites instead of merging
   if (resetOnRejection && hasRejection(mergedVotes)) {
     return {
       type: 'block',
       reason: 'Approval rejected. Resetting vote state and requesting revision.',
-      state: { [voteKey]: {} },
+      state: { [voteKey]: null },
     };
   }
 
@@ -111,17 +168,33 @@ export async function reviewApprovalValidator(
 
   // Threshold met → check codex if required
   if (template.requireCodex) {
-    const codexKey = '_codex_status';
-    const codexStatus = mergedVotes[codexKey];
+    const prUrl =
+      typeof data?.pr_url === 'string'
+        ? data.pr_url
+        : typeof state._pr_url === 'string'
+          ? (state._pr_url as string)
+          : undefined;
 
-    if (codexStatus === 'approved') {
-      return {
-        type: 'allow',
-        message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
-      };
+    if (prUrl) {
+      const codexResult = await checkCodexApproval(prUrl);
+      if (codexResult === 'approved') {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
+        };
+      }
+      if (codexResult === 'error') {
+        // Fail closed on GitHub error — retryable so the agent can retry
+        return {
+          type: 'retryable_block',
+          reason: 'Threshold met. Unable to verify codex[bot] status (GitHub API error). Retrying.',
+          retryAfterMs: 60_000,
+          state: nextState,
+        };
+      }
     }
 
-    // Codex not yet approved → retryable block
+    // Codex not yet approved → retryable block with timeout
     const timeoutMs =
       typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
     const codexStartedAt = state._codex_started_at as number | undefined;
@@ -133,7 +206,7 @@ export async function reviewApprovalValidator(
         type: 'retryable_block',
         reason: 'Threshold met. Waiting for codex[bot] approval.',
         retryAfterMs: 60_000,
-        state: { ...nextState, _codex_started_at: now },
+        state: { ...nextState, _codex_started_at: now, _pr_url: prUrl },
       };
     }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -26,29 +26,41 @@ export interface ReviewApprovalTemplateData {
   requireCodex?: boolean;
   /** Timeout window for codex approval in ms (default 10 min). */
   codexTimeoutMs?: number;
+  /** Optional vote binding mode for multi-reviewer hooks. */
+  voteBinding?: 'agent_lens';
 }
 
 function getTemplateData(ctx: HookExecutorContext): ReviewApprovalTemplateData {
   return (ctx.templateData ?? {}) as ReviewApprovalTemplateData;
 }
 
+function lensKeyForAgent(agentName: string): string {
+  return agentName.endsWith('-reviewer') ? agentName.slice(0, -'-reviewer'.length) : agentName;
+}
+
 function extractIncomingVotes(
   data: Record<string, unknown> | undefined,
   voteKey: string,
-  agentName: string
+  agentName: string,
+  voteBinding?: ReviewApprovalTemplateData['voteBinding']
 ): Record<string, unknown> | undefined {
   if (!data) return undefined;
 
   // Map-style votes: { approvals: { architecture: "approved" } }
   const mapVotes = data[voteKey];
   if (mapVotes && typeof mapVotes === 'object' && !Array.isArray(mapVotes)) {
-    return mapVotes as Record<string, unknown>;
+    const votes = mapVotes as Record<string, unknown>;
+    if (voteBinding === 'agent_lens') {
+      const lensKey = lensKeyForAgent(agentName);
+      return Object.hasOwn(votes, lensKey) ? { [lensKey]: votes[lensKey] } : undefined;
+    }
+    return votes;
   }
 
   // Boolean-style vote: { approved: true }
   // Use agentName as key so multiple reviewers don't collide.
   if (data.approved === true) {
-    return { [agentName]: 'approved' };
+    return { [voteBinding === 'agent_lens' ? lensKeyForAgent(agentName) : agentName]: 'approved' };
   }
 
   return undefined;
@@ -472,7 +484,7 @@ export async function reviewApprovalValidator(
 
   // Merge incoming votes into existing state
   const currentVotes = getVotes(state, voteKey);
-  const incoming = extractIncomingVotes(data, voteKey, ctx.agentName);
+  const incoming = extractIncomingVotes(data, voteKey, ctx.agentName, template.voteBinding);
 
   let mergedVotes = { ...currentVotes };
   if (incoming) {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -129,7 +129,7 @@ function githubTokenForHost(host: string): string | undefined {
 async function githubGraphql(
   host: string,
   query: string,
-  variables: Record<string, string | number | null | undefined>
+  variables: Record<string, string | number | boolean | null | undefined>
 ): Promise<{ ok: true; json: unknown } | { ok: false }> {
   if (!trustedGithubHosts().has(host)) return { ok: false };
 
@@ -162,7 +162,10 @@ async function githubGraphql(
     const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
     for (const [key, value] of Object.entries(variables)) {
       if (value === null || value === undefined) continue;
-      args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+      args.push(
+        typeof value === 'number' || typeof value === 'boolean' ? '-F' : '-f',
+        `${key}=${value}`
+      );
     }
     const proc = Bun.spawn(['gh', ...args], {
       stdout: 'pipe',
@@ -196,10 +199,12 @@ async function checkCodexApproval(
   let commentsCursor: string | undefined;
   let threadsCursor: string | undefined;
   let headSha: string | undefined;
+  let commentsDone = false;
+  let threadsDone = false;
 
   for (;;) {
     const query = `
-      query($owner:String!,$name:String!,$number:Int!,$commentsCursor:String,$threadsCursor:String) {
+      query($owner:String!,$name:String!,$number:Int!,$commentsCursor:String,$threadsCursor:String,$includeComments:Boolean!,$includeThreads:Boolean!) {
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
             headRefOid
@@ -207,7 +212,7 @@ async function checkCodexApproval(
             reactions(first:100) {
               nodes { content createdAt user { login } }
             }
-            comments(first:100, after:$commentsCursor) {
+            comments(first:100, after:$commentsCursor) @include(if:$includeComments) {
               nodes {
                 reactions(first:100) {
                   nodes { content createdAt user { login } }
@@ -215,14 +220,16 @@ async function checkCodexApproval(
               }
               pageInfo { hasNextPage endCursor }
             }
-            reviewThreads(first:100, after:$threadsCursor) {
+            reviewThreads(first:100, after:$threadsCursor) @include(if:$includeThreads) {
               nodes {
+                id
                 comments(first:100) {
                   nodes {
                     reactions(first:100) {
                       nodes { content createdAt user { login } }
                     }
                   }
+                  pageInfo { hasNextPage endCursor }
                 }
               }
               pageInfo { hasNextPage endCursor }
@@ -238,6 +245,8 @@ async function checkCodexApproval(
       number: parsed.number,
       commentsCursor,
       threadsCursor,
+      includeComments: !commentsDone,
+      includeThreads: !threadsDone,
     });
     if (!result.ok) return { status: 'error', headSha };
 
@@ -264,6 +273,7 @@ async function checkCodexApproval(
             };
             reviewThreads?: {
               nodes?: Array<{
+                id?: string;
                 comments?: {
                   nodes?: Array<{
                     reactions?: {
@@ -274,6 +284,7 @@ async function checkCodexApproval(
                       }>;
                     };
                   }>;
+                  pageInfo?: { hasNextPage?: boolean; endCursor?: string };
                 };
               }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
@@ -323,24 +334,83 @@ async function checkCodexApproval(
       }
     }
 
-    // Review comments
+    // Review comments. Fetch replies beyond GraphQL's first 100 comments with per-thread calls.
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       for (const comment of thread.comments?.nodes ?? []) {
         if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
           return { status: 'approved', headSha };
         }
       }
+      let threadCommentsCursor = thread.comments?.pageInfo?.hasNextPage
+        ? thread.comments.pageInfo.endCursor
+        : undefined;
+      while (thread.id && threadCommentsCursor) {
+        const threadResult = await githubGraphql(
+          parsed.host,
+          `
+            query($threadId:ID!,$commentsCursor:String) {
+              node(id:$threadId) {
+                ... on PullRequestReviewThread {
+                  comments(first:100, after:$commentsCursor) {
+                    nodes {
+                      reactions(first:100) {
+                        nodes { content createdAt user { login } }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }
+          `,
+          { threadId: thread.id, commentsCursor: threadCommentsCursor }
+        );
+        if (!threadResult.ok) return { status: 'error', headSha };
+        const threadJson = threadResult.json as {
+          data?: {
+            node?: {
+              comments?: {
+                nodes?: Array<{
+                  reactions?: {
+                    nodes?: Array<{
+                      content?: string;
+                      createdAt?: string;
+                      user?: { login?: string };
+                    }>;
+                  };
+                }>;
+                pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+              };
+            };
+          };
+          errors?: unknown[];
+        };
+        if (threadJson.errors) return { status: 'error', headSha };
+        const comments = threadJson.data?.node?.comments;
+        for (const comment of comments?.nodes ?? []) {
+          if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
+            return { status: 'approved', headSha };
+          }
+        }
+        threadCommentsCursor = comments?.pageInfo?.hasNextPage
+          ? comments.pageInfo.endCursor
+          : undefined;
+      }
     }
 
-    const nextCommentsCursor = pr.comments?.pageInfo?.hasNextPage
-      ? pr.comments.pageInfo.endCursor
-      : undefined;
-    const nextThreadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
-      ? pr.reviewThreads.pageInfo.endCursor
-      : undefined;
-    if (!nextCommentsCursor && !nextThreadsCursor) return { status: 'waiting', headSha };
-    commentsCursor = nextCommentsCursor;
-    threadsCursor = nextThreadsCursor;
+    if (!commentsDone) {
+      commentsCursor = pr.comments?.pageInfo?.hasNextPage
+        ? pr.comments.pageInfo.endCursor
+        : undefined;
+      commentsDone = !commentsCursor;
+    }
+    if (!threadsDone) {
+      threadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
+        ? pr.reviewThreads.pageInfo.endCursor
+        : undefined;
+      threadsDone = !threadsCursor;
+    }
+    if (commentsDone && threadsDone) return { status: 'waiting', headSha };
   }
 }
 
@@ -414,7 +484,7 @@ export async function reviewApprovalValidator(
     if (prUrl) {
       const codexResult = await checkCodexApproval(
         prUrl,
-        codexStartedAt ?? (storedHeadSha || resetPending ? undefined : 'head')
+        codexStartedAt ?? (storedHeadSha ? undefined : 'head')
       );
 
       // New revision pushed — reset codex timer so stale approvals don't release
@@ -429,6 +499,13 @@ export async function reviewApprovalValidator(
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },
+        };
+      }
+
+      if (codexResult.status === 'approved') {
+        return {
+          type: 'allow',
+          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
         };
       }
 
@@ -453,13 +530,6 @@ export async function reviewApprovalValidator(
         return {
           type: 'allow',
           message: `Threshold met (${approvalCount}/${threshold}). Codex approval timed out after ${timeoutMs}ms; allowing.`,
-        };
-      }
-
-      if (codexResult.status === 'approved') {
-        return {
-          type: 'allow',
-          message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
         };
       }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -129,7 +129,7 @@ function githubTokenForHost(host: string): string | undefined {
 async function githubGraphql(
   host: string,
   query: string,
-  variables: Record<string, string | number>
+  variables: Record<string, string | number | null | undefined>
 ): Promise<{ ok: true; json: unknown } | { ok: false }> {
   if (!trustedGithubHosts().has(host)) return { ok: false };
 
@@ -161,6 +161,7 @@ async function githubGraphql(
   try {
     const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
     for (const [key, value] of Object.entries(variables)) {
+      if (value === null || value === undefined) continue;
       args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
     }
     const proc = Bun.spawn(['gh', ...args], {
@@ -192,132 +193,155 @@ async function checkCodexApproval(
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return { status: 'error' };
 
-  const query = `
-    query($owner:String!,$name:String!,$number:Int!) {
-      repository(owner:$owner,name:$name) {
-        pullRequest(number:$number) {
-          headRefOid
-          commits(last:1) { nodes { commit { committedDate } } }
-          reactions(first:100) {
-            nodes { content createdAt user { login } }
-          }
-          comments(first:100) {
-            nodes {
-              reactions(first:100) {
-                nodes { content createdAt user { login } }
-              }
+  let commentsCursor: string | undefined;
+  let threadsCursor: string | undefined;
+  let headSha: string | undefined;
+
+  for (;;) {
+    const query = `
+      query($owner:String!,$name:String!,$number:Int!,$commentsCursor:String,$threadsCursor:String) {
+        repository(owner:$owner,name:$name) {
+          pullRequest(number:$number) {
+            headRefOid
+            commits(last:1) { nodes { commit { committedDate } } }
+            reactions(first:100) {
+              nodes { content createdAt user { login } }
             }
-          }
-          reviewThreads(first:100) {
-            nodes {
-              comments(first:100) {
-                nodes {
-                  reactions(first:100) {
-                    nodes { content createdAt user { login } }
+            comments(first:100, after:$commentsCursor) {
+              nodes {
+                reactions(first:100) {
+                  nodes { content createdAt user { login } }
+                }
+              }
+              pageInfo { hasNextPage endCursor }
+            }
+            reviewThreads(first:100, after:$threadsCursor) {
+              nodes {
+                comments(first:100) {
+                  nodes {
+                    reactions(first:100) {
+                      nodes { content createdAt user { login } }
+                    }
                   }
                 }
               }
+              pageInfo { hasNextPage endCursor }
             }
           }
         }
       }
-    }
-  `;
+    `;
 
-  const result = await githubGraphql(parsed.host, query, {
-    owner: parsed.owner,
-    name: parsed.repo,
-    number: parsed.number,
-  });
-  if (!result.ok) return { status: 'error' };
+    const result = await githubGraphql(parsed.host, query, {
+      owner: parsed.owner,
+      name: parsed.repo,
+      number: parsed.number,
+      commentsCursor,
+      threadsCursor,
+    });
+    if (!result.ok) return { status: 'error', headSha };
 
-  const json = result.json as {
-    data?: {
-      repository?: {
-        pullRequest?: {
-          headRefOid?: string;
-          commits?: { nodes?: Array<{ commit?: { committedDate?: string } }> };
-          reactions?: {
-            nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
-          };
-          comments?: {
-            nodes?: Array<{
-              reactions?: {
-                nodes?: Array<{
-                  content?: string;
-                  createdAt?: string;
-                  user?: { login?: string };
-                }>;
-              };
-            }>;
-          };
-          reviewThreads?: {
-            nodes?: Array<{
-              comments?: {
-                nodes?: Array<{
-                  reactions?: {
-                    nodes?: Array<{
-                      content?: string;
-                      createdAt?: string;
-                      user?: { login?: string };
-                    }>;
-                  };
-                }>;
-              };
-            }>;
+    const json = result.json as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            headRefOid?: string;
+            commits?: { nodes?: Array<{ commit?: { committedDate?: string } }> };
+            reactions?: {
+              nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
+            };
+            comments?: {
+              nodes?: Array<{
+                reactions?: {
+                  nodes?: Array<{
+                    content?: string;
+                    createdAt?: string;
+                    user?: { login?: string };
+                  }>;
+                };
+              }>;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+            };
+            reviewThreads?: {
+              nodes?: Array<{
+                comments?: {
+                  nodes?: Array<{
+                    reactions?: {
+                      nodes?: Array<{
+                        content?: string;
+                        createdAt?: string;
+                        user?: { login?: string };
+                      }>;
+                    };
+                  }>;
+                };
+              }>;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+            };
           };
         };
       };
+      errors?: unknown[];
     };
-    errors?: unknown[];
-  };
 
-  if (json.errors) return { status: 'error' };
+    if (json.errors) return { status: 'error', headSha };
 
-  const pr = json.data?.repository?.pullRequest;
-  if (!pr) return { status: 'error' };
+    const pr = json.data?.repository?.pullRequest;
+    if (!pr) return { status: 'error', headSha };
 
-  const headSha = pr.headRefOid;
-  const headCommittedAt = pr.commits?.nodes?.[0]?.commit?.committedDate;
-  const headCommittedMs = headCommittedAt ? Date.parse(headCommittedAt) : Number.NaN;
-  const since =
-    sinceMs === 'head'
-      ? Number.isFinite(headCommittedMs)
-        ? headCommittedMs
-        : Number.POSITIVE_INFINITY
-      : (sinceMs ?? Number.POSITIVE_INFINITY);
+    headSha = pr.headRefOid;
+    const headCommittedAt = pr.commits?.nodes?.[0]?.commit?.committedDate;
+    const headCommittedMs = headCommittedAt ? Date.parse(headCommittedAt) : Number.NaN;
+    const since =
+      sinceMs === 'head'
+        ? Number.isFinite(headCommittedMs)
+          ? headCommittedMs
+          : Number.POSITIVE_INFINITY
+        : (sinceMs ?? Number.POSITIVE_INFINITY);
 
-  const isFreshCodexPlusOne = (r: {
-    content?: string;
-    createdAt?: string;
-    user?: { login?: string };
-  }): boolean => {
-    const createdAt = r.createdAt ? Date.parse(r.createdAt) : Number.NaN;
-    return (
-      (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
-      r.content === 'THUMBS_UP' &&
-      Number.isFinite(createdAt) &&
-      createdAt >= since
-    );
-  };
+    const isFreshCodexPlusOne = (r: {
+      content?: string;
+      createdAt?: string;
+      user?: { login?: string };
+    }): boolean => {
+      const createdAt = r.createdAt ? Date.parse(r.createdAt) : Number.NaN;
+      return (
+        (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
+        r.content === 'THUMBS_UP' &&
+        Number.isFinite(createdAt) &&
+        createdAt >= since
+      );
+    };
 
-  // PR body reactions
-  if (pr.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
+    // PR body reactions
+    if (pr.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
 
-  // Issue comments
-  for (const comment of pr.comments?.nodes ?? []) {
-    if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) return { status: 'approved', headSha };
-  }
-
-  // Review comments
-  for (const thread of pr.reviewThreads?.nodes ?? []) {
-    for (const comment of thread.comments?.nodes ?? []) {
-      if (comment.reactions?.nodes?.some(isFreshCodexPlusOne))
+    // Issue comments
+    for (const comment of pr.comments?.nodes ?? []) {
+      if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
         return { status: 'approved', headSha };
+      }
     }
-  }
 
-  return { status: 'waiting', headSha };
+    // Review comments
+    for (const thread of pr.reviewThreads?.nodes ?? []) {
+      for (const comment of thread.comments?.nodes ?? []) {
+        if (comment.reactions?.nodes?.some(isFreshCodexPlusOne)) {
+          return { status: 'approved', headSha };
+        }
+      }
+    }
+
+    const nextCommentsCursor = pr.comments?.pageInfo?.hasNextPage
+      ? pr.comments.pageInfo.endCursor
+      : undefined;
+    const nextThreadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
+      ? pr.reviewThreads.pageInfo.endCursor
+      : undefined;
+    if (!nextCommentsCursor && !nextThreadsCursor) return { status: 'waiting', headSha };
+    commentsCursor = nextCommentsCursor;
+    threadsCursor = nextThreadsCursor;
+  }
 }
 
 /**

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -363,11 +363,14 @@ export async function reviewApprovalValidator(
   const approvalCount = countApprovals(mergedVotes, voteMatch);
   const nextState: Record<string, unknown> = { [voteKey]: mergedVotes };
 
-  // Threshold not yet met → block and persist the partial vote
+  // Threshold not yet met → persist the partial vote and ask caller to retry.
+  // A retry re-reads persisted hook state, so concurrent final votes that deep-merge
+  // to the threshold get a chance to release without another human message.
   if (approvalCount < threshold) {
     return {
-      type: 'block',
-      reason: `Waiting for approvals (${approvalCount}/${threshold}). Vote recorded.`,
+      type: 'retryable_block',
+      reason: `Waiting for approvals (${approvalCount}/${threshold}). Vote recorded; retry after state merge.`,
+      retryAfterMs: 1_000,
       state: nextState,
     };
   }

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -126,6 +126,10 @@ function githubTokenForHost(host: string): string | undefined {
   return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 }
 
+function floorToGithubSecond(ms: number): number {
+  return Math.floor(ms / 1000) * 1000;
+}
+
 async function githubGraphql(
   host: string,
   query: string,
@@ -208,7 +212,7 @@ async function checkCodexApproval(
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
             headRefOid
-            commits(last:1) { nodes { commit { committedDate } } }
+            updatedAt
             reactions(first:100) {
               nodes { content createdAt user { login } }
             }
@@ -255,7 +259,7 @@ async function checkCodexApproval(
         repository?: {
           pullRequest?: {
             headRefOid?: string;
-            commits?: { nodes?: Array<{ commit?: { committedDate?: string } }> };
+            updatedAt?: string;
             reactions?: {
               nodes?: Array<{ content?: string; createdAt?: string; user?: { login?: string } }>;
             };
@@ -301,14 +305,15 @@ async function checkCodexApproval(
     if (!pr) return { status: 'error', headSha };
 
     headSha = pr.headRefOid;
-    const headCommittedAt = pr.commits?.nodes?.[0]?.commit?.committedDate;
-    const headCommittedMs = headCommittedAt ? Date.parse(headCommittedAt) : Number.NaN;
+    const prUpdatedMs = pr.updatedAt ? Date.parse(pr.updatedAt) : Number.NaN;
     const since =
       sinceMs === 'head'
-        ? Number.isFinite(headCommittedMs)
-          ? headCommittedMs
+        ? Number.isFinite(prUpdatedMs)
+          ? floorToGithubSecond(prUpdatedMs)
           : Number.POSITIVE_INFINITY
-        : (sinceMs ?? Number.POSITIVE_INFINITY);
+        : sinceMs !== undefined
+          ? floorToGithubSecond(sinceMs)
+          : Number.POSITIVE_INFINITY;
 
     const isFreshCodexPlusOne = (r: {
       content?: string;
@@ -480,6 +485,7 @@ export async function reviewApprovalValidator(
       typeof state._codex_head_sha === 'string' ? state._codex_head_sha : undefined;
     const resetPending = state._codex_started_at === null || state._codex_head_sha === null;
     const now = Date.now();
+    const githubNow = floorToGithubSecond(now);
 
     if (prUrl) {
       const codexResult = await checkCodexApproval(
@@ -495,7 +501,7 @@ export async function reviewApprovalValidator(
           retryAfterMs: 60_000,
           state: {
             ...nextState,
-            _codex_started_at: now,
+            _codex_started_at: githubNow,
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },
@@ -518,7 +524,7 @@ export async function reviewApprovalValidator(
           retryAfterMs: 60_000,
           state: {
             ...nextState,
-            _codex_started_at: codexStartedAt ?? now,
+            _codex_started_at: codexStartedAt ?? githubNow,
             _codex_head_sha: codexResult.headSha,
             _pr_url: prUrl,
           },
@@ -559,7 +565,7 @@ export async function reviewApprovalValidator(
       type: 'retryable_block',
       reason: 'Threshold met. Waiting for codex[bot] approval.',
       retryAfterMs: 60_000,
-      state: { ...nextState, _codex_started_at: codexStartedAt ?? now, _pr_url: prUrl },
+      state: { ...nextState, _codex_started_at: codexStartedAt ?? githubNow, _pr_url: prUrl },
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -1,0 +1,161 @@
+/**
+ * Review Approval Validator
+ *
+ * Built-in hook validator for reviewer approval and multi-reviewer voting flows.
+ * Handles both single-reviewer (Review -> QA) and multi-reviewer (Plan Review ->
+ * Task Dispatcher) scenarios via templateData configuration.
+ *
+ * Vote accumulation uses hook-local state with transactional deep-merge.  A block
+ * response may carry `state` so the vote is persisted even when the threshold has
+ * not yet been reached.
+ */
+
+import type { WorkflowHookResult } from '@neokai/shared';
+import type { HookExecutorContext } from '../hook-executor';
+
+export interface ReviewApprovalTemplateData {
+  /** Number of approvals required to pass. */
+  threshold?: number;
+  /** Key in params.data that holds the vote map. */
+  voteKey?: string;
+  /** Value that counts as an approval. */
+  voteMatch?: string;
+  /** Whether a rejection vote resets accumulated state. */
+  resetOnRejection?: boolean;
+  /** Whether codex[bot] approval is also required. */
+  requireCodex?: boolean;
+  /** Timeout window for codex approval in ms (default 10 min). */
+  codexTimeoutMs?: number;
+}
+
+function getTemplateData(ctx: HookExecutorContext): ReviewApprovalTemplateData {
+  return (ctx.templateData ?? {}) as ReviewApprovalTemplateData;
+}
+
+function extractIncomingVotes(
+  data: Record<string, unknown> | undefined,
+  voteKey: string
+): Record<string, unknown> | undefined {
+  if (!data) return undefined;
+
+  // Map-style votes: { approvals: { architecture: "approved" } }
+  const mapVotes = data[voteKey];
+  if (mapVotes && typeof mapVotes === 'object' && !Array.isArray(mapVotes)) {
+    return mapVotes as Record<string, unknown>;
+  }
+
+  // Boolean-style vote: { approved: true }
+  if (data.approved === true) {
+    return { _approved: 'approved' };
+  }
+
+  return undefined;
+}
+
+function countApprovals(votes: Record<string, unknown>, voteMatch: string): number {
+  return Object.values(votes).filter((v) => v === voteMatch).length;
+}
+
+function hasRejection(votes: Record<string, unknown>): boolean {
+  return Object.values(votes).some(
+    (v) => v === 'rejected' || v === 'reject' || v === 'denied' || v === 'deny'
+  );
+}
+
+/**
+ * Main validator entry point.
+ */
+export async function reviewApprovalValidator(
+  ctx: HookExecutorContext
+): Promise<WorkflowHookResult> {
+  const template = getTemplateData(ctx);
+  const threshold = typeof template.threshold === 'number' ? template.threshold : 1;
+  const voteKey = typeof template.voteKey === 'string' ? template.voteKey : 'approvals';
+  const voteMatch = typeof template.voteMatch === 'string' ? template.voteMatch : 'approved';
+  const resetOnRejection = template.resetOnRejection !== false;
+
+  const data = ctx.params.data as Record<string, unknown> | undefined;
+  const state = ctx.hookLocalState;
+
+  // Merge incoming votes into existing state
+  const currentVotes = (state[voteKey] as Record<string, unknown> | undefined) ?? {};
+  const incoming = extractIncomingVotes(data, voteKey);
+
+  let mergedVotes = { ...currentVotes };
+  if (incoming) {
+    for (const [key, value] of Object.entries(incoming)) {
+      mergedVotes[key] = value;
+    }
+  }
+
+  // Handle rejection reset
+  if (resetOnRejection && hasRejection(mergedVotes)) {
+    return {
+      type: 'block',
+      reason: 'Approval rejected. Resetting vote state and requesting revision.',
+      state: { [voteKey]: {} },
+    };
+  }
+
+  const approvalCount = countApprovals(mergedVotes, voteMatch);
+  const nextState: Record<string, unknown> = { [voteKey]: mergedVotes };
+
+  // Threshold not yet met → block and persist the partial vote
+  if (approvalCount < threshold) {
+    return {
+      type: 'block',
+      reason: `Waiting for approvals (${approvalCount}/${threshold}). Vote recorded.`,
+      state: nextState,
+    };
+  }
+
+  // Threshold met → check codex if required
+  if (template.requireCodex) {
+    const codexKey = '_codex_status';
+    const codexStatus = mergedVotes[codexKey];
+
+    if (codexStatus === 'approved') {
+      return {
+        type: 'allow',
+        message: `Threshold met (${approvalCount}/${threshold}) with codex approval.`,
+      };
+    }
+
+    // Codex not yet approved → retryable block
+    const timeoutMs =
+      typeof template.codexTimeoutMs === 'number' ? template.codexTimeoutMs : 600_000;
+    const codexStartedAt = state._codex_started_at as number | undefined;
+    const now = Date.now();
+
+    if (codexStartedAt === undefined) {
+      // First time we hit threshold — start the codex clock
+      return {
+        type: 'retryable_block',
+        reason: 'Threshold met. Waiting for codex[bot] approval.',
+        retryAfterMs: 60_000,
+        state: { ...nextState, _codex_started_at: now },
+      };
+    }
+
+    if (now - codexStartedAt > timeoutMs) {
+      // Codex timeout elapsed — allow through
+      return {
+        type: 'allow',
+        message: `Threshold met (${approvalCount}/${threshold}). Codex approval timed out after ${timeoutMs}ms; allowing.`,
+      };
+    }
+
+    // Still within timeout window
+    return {
+      type: 'retryable_block',
+      reason: 'Threshold met. Waiting for codex[bot] approval.',
+      retryAfterMs: 60_000,
+      state: nextState,
+    };
+  }
+
+  return {
+    type: 'allow',
+    message: `Threshold met (${approvalCount}/${threshold}).`,
+  };
+}

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -82,6 +82,11 @@ function findPrUrl(ctx: HookExecutorContext): string | undefined {
     if (typeof artifactData?.pr_url === 'string') return artifactData.pr_url;
   }
 
+  for (const gate of ctx.gateData ?? []) {
+    const gateData = gate.data as Record<string, unknown> | undefined;
+    if (typeof gateData?.pr_url === 'string') return gateData.pr_url;
+  }
+
   return undefined;
 }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -73,15 +73,15 @@ function getVotes(state: Record<string, unknown>, voteKey: string): Record<strin
 }
 
 function findPrUrl(ctx: HookExecutorContext): string | undefined {
-  const data = ctx.params.data as Record<string, unknown> | undefined;
-  if (typeof data?.pr_url === 'string') return data.pr_url;
-  if (typeof ctx.hookLocalState._pr_url === 'string') return ctx.hookLocalState._pr_url as string;
-
   // Gate data is the canonical source for the active PR URL
   for (const gate of ctx.gateData ?? []) {
     const gateData = gate.data as Record<string, unknown> | undefined;
     if (typeof gateData?.pr_url === 'string') return gateData.pr_url;
   }
+
+  const data = ctx.params.data as Record<string, unknown> | undefined;
+  if (typeof data?.pr_url === 'string') return data.pr_url;
+  if (typeof ctx.hookLocalState._pr_url === 'string') return ctx.hookLocalState._pr_url as string;
 
   // Fall back to artifacts (may contain stale URLs from prior cycles)
   for (const artifact of ctx.currentArtifacts) {
@@ -342,7 +342,12 @@ export async function reviewApprovalValidator(
     return {
       type: 'block',
       reason: 'Approval rejected. Resetting vote state and requesting revision.',
-      state: { [voteKey]: null },
+      state: {
+        [voteKey]: null,
+        _codex_started_at: null,
+        _codex_head_sha: null,
+        _pr_url: null,
+      },
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-approval-validator.ts
@@ -79,7 +79,10 @@ function parsePrUrl(url: string): { owner: string; repo: string; number: number 
 }
 
 /**
- * Check GitHub for a codex[bot] +1 reaction on the PR.
+ * Check GitHub for a codex[bot] +1 reaction on the PR body, issue comments,
+ * or review comments. Uses the GraphQL API to query all reaction locations
+ * in a single request.
+ *
  * Returns 'approved' if found, 'waiting' if not, 'error' on failure.
  */
 async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting' | 'error'> {
@@ -89,33 +92,116 @@ async function checkCodexApproval(prUrl: string): Promise<'approved' | 'waiting'
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) return 'error';
 
-  try {
-    const res = await fetch(
-      `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}/reactions?per_page=100`,
-      {
-        headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${token}`,
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
+  const query = `
+    query($owner:String!,$name:String!,$number:Int!) {
+      repository(owner:$owner,name:$name) {
+        pullRequest(number:$number) {
+          reactions(first:10) {
+            nodes { content user { login } }
+          }
+          comments(first:100) {
+            nodes {
+              reactions(first:10) {
+                nodes { content user { login } }
+              }
+            }
+          }
+          reviewThreads(first:100) {
+            nodes {
+              comments(first:100) {
+                nodes {
+                  reactions(first:10) {
+                    nodes { content user { login } }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
-    );
+    }
+  `;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        variables: { owner: parsed.owner, name: parsed.repo, number: parsed.number },
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
     if (!res.ok) return 'error';
 
-    const reactions = (await res.json()) as Array<{
-      user?: { login?: string };
-      content?: string;
-    }>;
+    const json = (await res.json()) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reactions?: {
+              nodes?: Array<{ content?: string; user?: { login?: string } }>;
+            };
+            comments?: {
+              nodes?: Array<{
+                reactions?: {
+                  nodes?: Array<{ content?: string; user?: { login?: string } }>;
+                };
+              }>;
+            };
+            reviewThreads?: {
+              nodes?: Array<{
+                comments?: {
+                  nodes?: Array<{
+                    reactions?: {
+                      nodes?: Array<{ content?: string; user?: { login?: string } }>;
+                    };
+                  }>;
+                };
+              }>;
+            };
+          };
+        };
+      };
+      errors?: unknown[];
+    };
 
-    const approved = reactions.some(
-      (r) =>
-        (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
-        r.content === '+1'
-    );
+    if (json.errors) return 'error';
 
-    return approved ? 'approved' : 'waiting';
+    const pr = json.data?.repository?.pullRequest;
+    if (!pr) return 'error';
+
+    const isCodexPlusOne = (r: { content?: string; user?: { login?: string } }): boolean =>
+      (r.user?.login === 'codex[bot]' || r.user?.login === 'chatgpt-codex-connector[bot]') &&
+      r.content === '+1';
+
+    // PR body reactions
+    if (pr.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+
+    // Issue comments
+    for (const comment of pr.comments?.nodes ?? []) {
+      if (comment.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+    }
+
+    // Review comments
+    for (const thread of pr.reviewThreads?.nodes ?? []) {
+      for (const comment of thread.comments?.nodes ?? []) {
+        if (comment.reactions?.nodes?.some(isCodexPlusOne)) return 'approved';
+      }
+    }
+
+    return 'waiting';
   } catch {
     return 'error';
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -213,8 +213,17 @@ async function verifyReviewEvidenceOnGithub(
     const t = createdAt ? Date.parse(createdAt) : Number.NaN;
     return Number.isFinite(t) && t >= since;
   };
-  const matches = (node: { databaseId?: number; createdAt?: string }, expectedId?: number) =>
-    expectedId !== undefined && node.databaseId === expectedId && isFresh(node.createdAt);
+  const isActionableReviewState = (state?: string) =>
+    state === 'APPROVED' || state === 'CHANGES_REQUESTED';
+  const matches = (
+    node: { databaseId?: number; createdAt?: string; state?: string },
+    expectedId?: number,
+    requireActionableState = false
+  ) =>
+    expectedId !== undefined &&
+    node.databaseId === expectedId &&
+    isFresh(node.createdAt) &&
+    (!requireActionableState || isActionableReviewState(node.state));
 
   if (expectedDiscussionId !== undefined) {
     const result = await githubRest(
@@ -267,8 +276,17 @@ async function verifyReviewEvidenceOnGithub(
       `/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}/reviews/${expectedReviewId}`
     );
     if (result.ok) {
-      const review = result.json as { id?: number; submitted_at?: string; submittedAt?: string };
-      if (review.id === expectedReviewId && isFresh(review.submitted_at ?? review.submittedAt)) {
+      const review = result.json as {
+        id?: number;
+        submitted_at?: string;
+        submittedAt?: string;
+        state?: string;
+      };
+      if (
+        review.id === expectedReviewId &&
+        isFresh(review.submitted_at ?? review.submittedAt) &&
+        isActionableReviewState(review.state)
+      ) {
         return 'verified';
       }
     }
@@ -284,7 +302,7 @@ async function verifyReviewEvidenceOnGithub(
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
             reviews(first:100, after:$reviewsCursor) {
-              nodes { databaseId createdAt }
+              nodes { databaseId createdAt state }
               pageInfo { hasNextPage endCursor }
             }
             comments(first:100, after:$commentsCursor) {
@@ -315,7 +333,7 @@ async function verifyReviewEvidenceOnGithub(
         repository?: {
           pullRequest?: {
             reviews?: {
-              nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+              nodes?: Array<{ databaseId?: number; createdAt?: string; state?: string }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             comments?: {
@@ -337,7 +355,7 @@ async function verifyReviewEvidenceOnGithub(
     const pr = json.data?.repository?.pullRequest;
     if (!pr) return 'error';
 
-    if (pr.reviews?.nodes?.some((n) => matches(n, expectedReviewId))) return 'verified';
+    if (pr.reviews?.nodes?.some((n) => matches(n, expectedReviewId, true))) return 'verified';
     if (pr.comments?.nodes?.some((n) => matches(n, expectedIssueCommentId))) return 'verified';
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       if (thread.comments?.nodes?.some((n) => matches(n, expectedDiscussionId))) {
@@ -417,7 +435,7 @@ async function findReviewEvidence(
         if (!(await verifyUrl(url))) continue;
         return { reviewUrl: url, source: 'artifact' };
       }
-    } else {
+    } else if (artifact.nodeId !== ctx.nodeId) {
       break;
     }
   }

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -239,6 +239,7 @@ async function verifyReviewEvidenceOnGithub(
       submittedAt?: string;
       state?: string;
       user?: { login?: string };
+      author?: { login?: string };
     },
     expectedId?: number,
     options: { requireActionableState?: boolean; requirePrAuthor?: boolean } = {}
@@ -253,7 +254,7 @@ async function verifyReviewEvidenceOnGithub(
       (prAuthorLogin !== undefined &&
         viewerLogin !== undefined &&
         viewerLogin === prAuthorLogin &&
-        node.user?.login === prAuthorLogin));
+        (node.user?.login ?? node.author?.login) === prAuthorLogin));
 
   if (expectedDiscussionId !== undefined) {
     const result = await githubRest(
@@ -341,7 +342,7 @@ async function verifyReviewEvidenceOnGithub(
               pageInfo { hasNextPage endCursor }
             }
             comments(first:100, after:$commentsCursor) @include(if:$includeComments) {
-              nodes { databaseId createdAt user { login } }
+              nodes { databaseId createdAt author { login } }
               pageInfo { hasNextPage endCursor }
             }
             reviewThreads(first:100, after:$threadsCursor) @include(if:$includeThreads) {
@@ -380,7 +381,11 @@ async function verifyReviewEvidenceOnGithub(
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             comments?: {
-              nodes?: Array<{ databaseId?: number; createdAt?: string; user?: { login?: string } }>;
+              nodes?: Array<{
+                databaseId?: number;
+                createdAt?: string;
+                author?: { login?: string };
+              }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             reviewThreads?: {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -14,10 +14,26 @@ function isValidReviewUrl(url: string): boolean {
   return /^https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+/.test(url);
 }
 
+/** Extract the PR base URL (host/owner/repo/pull/N) from a full URL. */
+function extractPrBaseUrl(url: string): string | undefined {
+  const m = url.match(/^(https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+)/);
+  return m?.[1];
+}
+
+/** Find the active PR URL from gate data (canonical source). */
+function getActivePrUrl(ctx: HookExecutorContext): string | undefined {
+  for (const gate of ctx.gateData ?? []) {
+    const gateData = gate.data as Record<string, unknown> | undefined;
+    if (typeof gateData?.pr_url === 'string') return gateData.pr_url;
+  }
+  return undefined;
+}
+
 function findReviewEvidence(
   ctx: HookExecutorContext
 ): { reviewUrl?: string; source: string } | undefined {
   const data = ctx.params.data as Record<string, unknown> | undefined;
+  const activePrBase = extractPrBaseUrl(getActivePrUrl(ctx) ?? '');
 
   // Immediate evidence in the message data
   if (
@@ -25,6 +41,11 @@ function findReviewEvidence(
     typeof data.review_url === 'string' &&
     isValidReviewUrl(data.review_url)
   ) {
+    // If we know the active PR, verify the review URL is for the same PR
+    if (activePrBase) {
+      const reviewBase = extractPrBaseUrl(data.review_url);
+      if (reviewBase !== activePrBase) return undefined;
+    }
     return { reviewUrl: data.review_url, source: 'message_data' };
   }
 
@@ -37,6 +58,10 @@ function findReviewEvidence(
       const artifactData = artifact.data as Record<string, unknown> | undefined;
       const url = artifactData?.review_url;
       if (typeof url === 'string' && isValidReviewUrl(url)) {
+        if (activePrBase) {
+          const reviewBase = extractPrBaseUrl(url);
+          if (reviewBase !== activePrBase) continue;
+        }
         return { reviewUrl: url, source: 'artifact' };
       }
     } else {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -53,87 +53,149 @@ function trustedGithubHosts(): Set<string> {
   return trustedHosts;
 }
 
+function githubTokenForHost(host: string): string | undefined {
+  if (host !== 'github.com') {
+    return (
+      process.env.GH_ENTERPRISE_TOKEN ||
+      process.env.GITHUB_ENTERPRISE_TOKEN ||
+      process.env.GITHUB_TOKEN ||
+      process.env.GH_TOKEN
+    );
+  }
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+}
+
+async function githubGraphql(
+  host: string,
+  query: string,
+  variables: Record<string, string | number>
+): Promise<{ ok: true; json: unknown } | { ok: false }> {
+  if (!trustedGithubHosts().has(host)) return { ok: false };
+
+  const token = githubTokenForHost(host);
+  if (token) {
+    const endpoint =
+      host === 'github.com' ? 'https://api.github.com/graphql' : `https://${host}/api/graphql`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+      if (!res.ok) return { ok: false };
+      return { ok: true, json: await res.json() };
+    } catch {
+      return { ok: false };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  try {
+    const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
+    for (const [key, value] of Object.entries(variables)) {
+      args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+    }
+    const proc = Bun.spawn(['gh', ...args], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: process.env,
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return { ok: false };
+    return { ok: true, json: JSON.parse(output) };
+  } catch {
+    return { ok: false };
+  }
+}
+
 async function verifyReviewEvidenceOnGithub(
   prUrl: string,
+  reviewUrl: string,
   sinceIso?: string
 ): Promise<'verified' | 'missing' | 'error'> {
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return 'error';
-  if (!trustedGithubHosts().has(parsed.host)) return 'error';
+
+  const discussionMatch = reviewUrl.match(/discussion_r(\d+)/);
+  const reviewMatch = reviewUrl.match(/pullrequestreview-(\d+)/);
+  const expectedDiscussionId = discussionMatch ? Number(discussionMatch[1]) : undefined;
+  const expectedReviewId = reviewMatch ? Number(reviewMatch[1]) : undefined;
+  if (!expectedDiscussionId && !expectedReviewId) return 'missing';
 
   const query = `
     query($owner:String!,$name:String!,$number:Int!) {
       repository(owner:$owner,name:$name) {
         pullRequest(number:$number) {
-          reviews(first:100) { nodes { createdAt } }
-          comments(first:100) { nodes { createdAt } }
+          reviews(first:100) { nodes { databaseId createdAt } }
+          comments(first:100) { nodes { databaseId createdAt } }
           reviewThreads(first:100) {
-            nodes { comments(first:100) { nodes { createdAt } } }
+            nodes { comments(first:100) { nodes { databaseId createdAt } } }
           }
         }
       }
     }
   `;
 
-  const token =
-    parsed.host === 'github.com'
-      ? process.env.GITHUB_TOKEN || process.env.GH_TOKEN
-      : process.env.GH_ENTERPRISE_TOKEN ||
-        process.env.GITHUB_ENTERPRISE_TOKEN ||
-        process.env.GITHUB_TOKEN ||
-        process.env.GH_TOKEN;
-  if (!token) return 'error';
+  const result = await githubGraphql(parsed.host, query, {
+    owner: parsed.owner,
+    name: parsed.repo,
+    number: parsed.number,
+  });
+  if (!result.ok) return 'error';
 
-  const endpoint =
-    parsed.host === 'github.com'
-      ? 'https://api.github.com/graphql'
-      : `https://${parsed.host}/api/graphql`;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
-  try {
-    const res = await fetch(endpoint, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query,
-        variables: { owner: parsed.owner, name: parsed.repo, number: parsed.number },
-      }),
-      signal: controller.signal,
-    });
-    if (!res.ok) return 'error';
-    const json = (await res.json()) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviews?: { nodes?: Array<{ createdAt?: string }> };
-            comments?: { nodes?: Array<{ createdAt?: string }> };
-            reviewThreads?: {
-              nodes?: Array<{ comments?: { nodes?: Array<{ createdAt?: string }> } }>;
-            };
+  const json = result.json as {
+    data?: {
+      repository?: {
+        pullRequest?: {
+          reviews?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
+          comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
+          reviewThreads?: {
+            nodes?: Array<{
+              comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
+            }>;
           };
         };
       };
-      errors?: unknown[];
     };
-    if (json.errors) return 'error';
-    const pr = json.data?.repository?.pullRequest;
-    if (!pr) return 'error';
-    const since = sinceIso ? Date.parse(sinceIso) : 0;
-    const isFresh = (createdAt?: string) => {
-      const t = createdAt ? Date.parse(createdAt) : Number.NaN;
-      return Number.isFinite(t) && t >= since;
-    };
-    if (pr.reviews?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
-    if (pr.comments?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
-    for (const thread of pr.reviewThreads?.nodes ?? []) {
-      if (thread.comments?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
-    }
-    return 'missing';
-  } catch {
-    return 'error';
-  } finally {
-    clearTimeout(timeout);
+    errors?: unknown[];
+  };
+  if (json.errors) return 'error';
+  const pr = json.data?.repository?.pullRequest;
+  if (!pr) return 'error';
+  const since = sinceIso ? Date.parse(sinceIso) : 0;
+  const isFresh = (createdAt?: string) => {
+    const t = createdAt ? Date.parse(createdAt) : Number.NaN;
+    return Number.isFinite(t) && t >= since;
+  };
+
+  if (
+    expectedReviewId !== undefined &&
+    pr.reviews?.nodes?.some((n) => n.databaseId === expectedReviewId && isFresh(n.createdAt))
+  ) {
+    return 'verified';
   }
+  if (
+    expectedDiscussionId !== undefined &&
+    pr.comments?.nodes?.some((n) => n.databaseId === expectedDiscussionId && isFresh(n.createdAt))
+  ) {
+    return 'verified';
+  }
+  for (const thread of pr.reviewThreads?.nodes ?? []) {
+    if (
+      expectedDiscussionId !== undefined &&
+      thread.comments?.nodes?.some(
+        (n) => n.databaseId === expectedDiscussionId && isFresh(n.createdAt)
+      )
+    ) {
+      return 'verified';
+    }
+  }
+  return 'missing';
 }
 
 async function findReviewEvidence(
@@ -152,7 +214,11 @@ async function findReviewEvidence(
     if (activePrBase) {
       const reviewBase = extractPrBaseUrl(data.review_url);
       if (reviewBase !== activePrBase) return undefined;
-      const verified = await verifyReviewEvidenceOnGithub(activePrBase, ctx.workflowStartIso);
+      const verified = await verifyReviewEvidenceOnGithub(
+        activePrBase,
+        data.review_url,
+        ctx.workflowStartIso
+      );
       if (verified !== 'verified') return undefined;
     }
     return { reviewUrl: data.review_url, source: 'message_data' };
@@ -170,7 +236,11 @@ async function findReviewEvidence(
         if (activePrBase) {
           const reviewBase = extractPrBaseUrl(url);
           if (reviewBase !== activePrBase) continue;
-          const verified = await verifyReviewEvidenceOnGithub(activePrBase, ctx.workflowStartIso);
+          const verified = await verifyReviewEvidenceOnGithub(
+            activePrBase,
+            url,
+            ctx.workflowStartIso
+          );
           if (verified !== 'verified') continue;
         }
         return { reviewUrl: url, source: 'artifact' };

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -39,12 +39,27 @@ function getActivePrUrl(ctx: HookExecutorContext): string | undefined {
   return undefined;
 }
 
+function trustedGithubHosts(): Set<string> {
+  const trustedHosts = new Set(['github.com']);
+  const ghHost = process.env.GH_HOST;
+  if (ghHost) trustedHosts.add(ghHost);
+  const extraHosts = process.env.NEOKAI_TRUSTED_GITHUB_HOSTS;
+  if (extraHosts) {
+    for (const h of extraHosts.split(',')) {
+      const trimmed = h.trim();
+      if (trimmed) trustedHosts.add(trimmed);
+    }
+  }
+  return trustedHosts;
+}
+
 async function verifyReviewEvidenceOnGithub(
   prUrl: string,
   sinceIso?: string
 ): Promise<'verified' | 'missing' | 'error'> {
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return 'error';
+  if (!trustedGithubHosts().has(parsed.host)) return 'error';
 
   const query = `
     query($owner:String!,$name:String!,$number:Int!) {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -10,14 +10,24 @@ import type { WorkflowHookResult } from '@neokai/shared';
 import type { HookExecutorContext } from '../hook-executor';
 
 function isValidReviewUrl(url: string): boolean {
-  // Must look like a GitHub (or Enterprise) PR or review comment URL
-  return /^https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+/.test(url);
+  // Must reference a concrete GitHub PR review/comment, not just the PR base URL.
+  return (
+    /^https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+/.test(url) &&
+    (url.includes('discussion_r') || url.includes('pullrequestreview-'))
+  );
+}
+
+function parsePrUrl(
+  url: string
+): { host: string; owner: string; repo: string; number: number; baseUrl: string } | undefined {
+  const m = url.match(/^(https:\/\/([^/]+)\/([^/]+)\/([^/]+)\/pull\/(\d+))/);
+  if (!m) return undefined;
+  return { baseUrl: m[1], host: m[2], owner: m[3], repo: m[4], number: Number(m[5]) };
 }
 
 /** Extract the PR base URL (host/owner/repo/pull/N) from a full URL. */
 function extractPrBaseUrl(url: string): string | undefined {
-  const m = url.match(/^(https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+)/);
-  return m?.[1];
+  return parsePrUrl(url)?.baseUrl;
 }
 
 /** Find the active PR URL from gate data (canonical source). */
@@ -29,9 +39,91 @@ function getActivePrUrl(ctx: HookExecutorContext): string | undefined {
   return undefined;
 }
 
-function findReviewEvidence(
+async function verifyReviewEvidenceOnGithub(
+  prUrl: string,
+  sinceIso?: string
+): Promise<'verified' | 'missing' | 'error'> {
+  const parsed = parsePrUrl(prUrl);
+  if (!parsed) return 'error';
+
+  const query = `
+    query($owner:String!,$name:String!,$number:Int!) {
+      repository(owner:$owner,name:$name) {
+        pullRequest(number:$number) {
+          reviews(first:100) { nodes { createdAt } }
+          comments(first:100) { nodes { createdAt } }
+          reviewThreads(first:100) {
+            nodes { comments(first:100) { nodes { createdAt } } }
+          }
+        }
+      }
+    }
+  `;
+
+  const token =
+    parsed.host === 'github.com'
+      ? process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+      : process.env.GH_ENTERPRISE_TOKEN ||
+        process.env.GITHUB_ENTERPRISE_TOKEN ||
+        process.env.GITHUB_TOKEN ||
+        process.env.GH_TOKEN;
+  if (!token) return 'error';
+
+  const endpoint =
+    parsed.host === 'github.com'
+      ? 'https://api.github.com/graphql'
+      : `https://${parsed.host}/api/graphql`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        variables: { owner: parsed.owner, name: parsed.repo, number: parsed.number },
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return 'error';
+    const json = (await res.json()) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviews?: { nodes?: Array<{ createdAt?: string }> };
+            comments?: { nodes?: Array<{ createdAt?: string }> };
+            reviewThreads?: {
+              nodes?: Array<{ comments?: { nodes?: Array<{ createdAt?: string }> } }>;
+            };
+          };
+        };
+      };
+      errors?: unknown[];
+    };
+    if (json.errors) return 'error';
+    const pr = json.data?.repository?.pullRequest;
+    if (!pr) return 'error';
+    const since = sinceIso ? Date.parse(sinceIso) : 0;
+    const isFresh = (createdAt?: string) => {
+      const t = createdAt ? Date.parse(createdAt) : Number.NaN;
+      return Number.isFinite(t) && t >= since;
+    };
+    if (pr.reviews?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
+    if (pr.comments?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
+    for (const thread of pr.reviewThreads?.nodes ?? []) {
+      if (thread.comments?.nodes?.some((n) => isFresh(n.createdAt))) return 'verified';
+    }
+    return 'missing';
+  } catch {
+    return 'error';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function findReviewEvidence(
   ctx: HookExecutorContext
-): { reviewUrl?: string; source: string } | undefined {
+): Promise<{ reviewUrl?: string; source: string } | undefined> {
   const data = ctx.params.data as Record<string, unknown> | undefined;
   const activePrBase = extractPrBaseUrl(getActivePrUrl(ctx) ?? '');
 
@@ -45,6 +137,8 @@ function findReviewEvidence(
     if (activePrBase) {
       const reviewBase = extractPrBaseUrl(data.review_url);
       if (reviewBase !== activePrBase) return undefined;
+      const verified = await verifyReviewEvidenceOnGithub(activePrBase, ctx.workflowStartIso);
+      if (verified !== 'verified') return undefined;
     }
     return { reviewUrl: data.review_url, source: 'message_data' };
   }
@@ -61,6 +155,8 @@ function findReviewEvidence(
         if (activePrBase) {
           const reviewBase = extractPrBaseUrl(url);
           if (reviewBase !== activePrBase) continue;
+          const verified = await verifyReviewEvidenceOnGithub(activePrBase, ctx.workflowStartIso);
+          if (verified !== 'verified') continue;
         }
         return { reviewUrl: url, source: 'artifact' };
       }
@@ -76,7 +172,7 @@ function findReviewEvidence(
  * Main validator entry point.
  */
 export async function reviewPostedValidator(ctx: HookExecutorContext): Promise<WorkflowHookResult> {
-  const evidence = findReviewEvidence(ctx);
+  const evidence = await findReviewEvidence(ctx);
 
   if (!evidence) {
     return {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -67,6 +67,15 @@ function githubTokenForHost(host: string): string | undefined {
   return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 }
 
+function apiPathMatches(path: string | undefined, suffix: string): boolean {
+  if (!path) return false;
+  try {
+    return new URL(path).pathname.endsWith(suffix);
+  } catch {
+    return path.endsWith(suffix);
+  }
+}
+
 async function githubGraphql(
   host: string,
   query: string,
@@ -157,10 +166,36 @@ async function githubRest(
   }
 }
 
+async function getPrAuthorLogin(prUrl: string): Promise<string | undefined> {
+  const parsed = parsePrUrl(prUrl);
+  if (!parsed) return undefined;
+
+  const result = await githubGraphql(
+    parsed.host,
+    `
+      query($owner:String!,$name:String!,$number:Int!) {
+        repository(owner:$owner,name:$name) {
+          pullRequest(number:$number) { author { login } }
+        }
+      }
+    `,
+    { owner: parsed.owner, name: parsed.repo, number: parsed.number }
+  );
+  if (!result.ok) return undefined;
+
+  const json = result.json as {
+    data?: { repository?: { pullRequest?: { author?: { login?: string } } } };
+    errors?: unknown[];
+  };
+  if (json.errors) return undefined;
+  return json.data?.repository?.pullRequest?.author?.login;
+}
+
 async function verifyReviewEvidenceOnGithub(
   prUrl: string,
   reviewUrl: string,
-  sinceIso?: string
+  sinceIso?: string,
+  prAuthorLogin?: string
 ): Promise<'verified' | 'missing' | 'error'> {
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return 'error';
@@ -194,7 +229,7 @@ async function verifyReviewEvidenceOnGithub(
       };
       if (
         comment.id === expectedDiscussionId &&
-        comment.pull_request_url?.endsWith(`/pulls/${parsed.number}`) &&
+        apiPathMatches(comment.pull_request_url, `/pulls/${parsed.number}`) &&
         isFresh(comment.created_at)
       ) {
         return 'verified';
@@ -208,11 +243,18 @@ async function verifyReviewEvidenceOnGithub(
       `/repos/${parsed.owner}/${parsed.repo}/issues/comments/${expectedIssueCommentId}`
     );
     if (result.ok) {
-      const comment = result.json as { id?: number; issue_url?: string; created_at?: string };
+      const comment = result.json as {
+        id?: number;
+        issue_url?: string;
+        created_at?: string;
+        user?: { login?: string };
+      };
       if (
         comment.id === expectedIssueCommentId &&
-        comment.issue_url?.endsWith(`/issues/${parsed.number}`) &&
-        isFresh(comment.created_at)
+        apiPathMatches(comment.issue_url, `/issues/${parsed.number}`) &&
+        isFresh(comment.created_at) &&
+        prAuthorLogin !== undefined &&
+        comment.user?.login === prAuthorLogin
       ) {
         return 'verified';
       }
@@ -343,7 +385,13 @@ async function findReviewEvidence(
     if (!reviewBase) return false;
     if (activePrBase && reviewBase !== activePrBase) return false;
     const prUrl = activePrBase ?? reviewBase;
-    const verified = await verifyReviewEvidenceOnGithub(prUrl, url, evidenceSinceIso);
+    const prAuthorLogin = await getPrAuthorLogin(prUrl);
+    const verified = await verifyReviewEvidenceOnGithub(
+      prUrl,
+      url,
+      evidenceSinceIso,
+      prAuthorLogin
+    );
     return verified === 'verified';
   };
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -116,6 +116,47 @@ async function githubGraphql(
   }
 }
 
+async function githubRest(
+  host: string,
+  path: string
+): Promise<{ ok: true; json: unknown } | { ok: false }> {
+  if (!trustedGithubHosts().has(host)) return { ok: false };
+
+  const token = githubTokenForHost(host);
+  if (token) {
+    const endpoint =
+      host === 'github.com' ? `https://api.github.com${path}` : `https://${host}/api/v3${path}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    try {
+      const res = await fetch(endpoint, {
+        headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' },
+        signal: controller.signal,
+      });
+      if (!res.ok) return { ok: false };
+      return { ok: true, json: await res.json() };
+    } catch {
+      return { ok: false };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  try {
+    const proc = Bun.spawn(['gh', 'api', '--hostname', host, path], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: process.env,
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return { ok: false };
+    return { ok: true, json: JSON.parse(output) };
+  } catch {
+    return { ok: false };
+  }
+}
+
 async function verifyReviewEvidenceOnGithub(
   prUrl: string,
   reviewUrl: string,
@@ -139,6 +180,57 @@ async function verifyReviewEvidenceOnGithub(
   };
   const matches = (node: { databaseId?: number; createdAt?: string }, expectedId?: number) =>
     expectedId !== undefined && node.databaseId === expectedId && isFresh(node.createdAt);
+
+  if (expectedDiscussionId !== undefined) {
+    const result = await githubRest(
+      parsed.host,
+      `/repos/${parsed.owner}/${parsed.repo}/pulls/comments/${expectedDiscussionId}`
+    );
+    if (result.ok) {
+      const comment = result.json as {
+        id?: number;
+        pull_request_url?: string;
+        created_at?: string;
+      };
+      if (
+        comment.id === expectedDiscussionId &&
+        comment.pull_request_url?.endsWith(`/pulls/${parsed.number}`) &&
+        isFresh(comment.created_at)
+      ) {
+        return 'verified';
+      }
+    }
+  }
+
+  if (expectedIssueCommentId !== undefined) {
+    const result = await githubRest(
+      parsed.host,
+      `/repos/${parsed.owner}/${parsed.repo}/issues/comments/${expectedIssueCommentId}`
+    );
+    if (result.ok) {
+      const comment = result.json as { id?: number; issue_url?: string; created_at?: string };
+      if (
+        comment.id === expectedIssueCommentId &&
+        comment.issue_url?.endsWith(`/issues/${parsed.number}`) &&
+        isFresh(comment.created_at)
+      ) {
+        return 'verified';
+      }
+    }
+  }
+
+  if (expectedReviewId !== undefined) {
+    const result = await githubRest(
+      parsed.host,
+      `/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}/reviews/${expectedReviewId}`
+    );
+    if (result.ok) {
+      const review = result.json as { id?: number; submitted_at?: string; submittedAt?: string };
+      if (review.id === expectedReviewId && isFresh(review.submitted_at ?? review.submittedAt)) {
+        return 'verified';
+      }
+    }
+  }
 
   let reviewsCursor: string | undefined;
   let commentsCursor: string | undefined;
@@ -231,6 +323,7 @@ function freshEvidenceSinceIso(ctx: HookExecutorContext): string | undefined {
   let since = ctx.workflowStartIso ? Date.parse(ctx.workflowStartIso) : 0;
   for (const artifact of ctx.currentArtifacts) {
     if (artifact.type === 'review' || artifact.type === 'review_feedback') continue;
+    if (artifact.nodeId === ctx.nodeId) continue;
     const updatedAt = typeof artifact.updatedAt === 'number' ? artifact.updatedAt : 0;
     const createdAt = typeof artifact.createdAt === 'number' ? artifact.createdAt : 0;
     since = Math.max(since, updatedAt, createdAt);
@@ -245,23 +338,22 @@ async function findReviewEvidence(
   const activePrBase = extractPrBaseUrl(getActivePrUrl(ctx) ?? '');
   const evidenceSinceIso = freshEvidenceSinceIso(ctx);
 
+  const verifyUrl = async (url: string): Promise<boolean> => {
+    const reviewBase = extractPrBaseUrl(url);
+    if (!reviewBase) return false;
+    if (activePrBase && reviewBase !== activePrBase) return false;
+    const prUrl = activePrBase ?? reviewBase;
+    const verified = await verifyReviewEvidenceOnGithub(prUrl, url, evidenceSinceIso);
+    return verified === 'verified';
+  };
+
   // Immediate evidence in the message data
   if (
     data?.review_url &&
     typeof data.review_url === 'string' &&
     isValidReviewUrl(data.review_url)
   ) {
-    // If we know the active PR, verify the review URL is for the same PR
-    if (activePrBase) {
-      const reviewBase = extractPrBaseUrl(data.review_url);
-      if (reviewBase !== activePrBase) return undefined;
-      const verified = await verifyReviewEvidenceOnGithub(
-        activePrBase,
-        data.review_url,
-        evidenceSinceIso
-      );
-      if (verified !== 'verified') return undefined;
-    }
+    if (!(await verifyUrl(data.review_url))) return undefined;
     return { reviewUrl: data.review_url, source: 'message_data' };
   }
 
@@ -274,12 +366,7 @@ async function findReviewEvidence(
       const artifactData = artifact.data as Record<string, unknown> | undefined;
       const url = artifactData?.review_url;
       if (typeof url === 'string' && isValidReviewUrl(url)) {
-        if (activePrBase) {
-          const reviewBase = extractPrBaseUrl(url);
-          if (reviewBase !== activePrBase) continue;
-          const verified = await verifyReviewEvidenceOnGithub(activePrBase, url, evidenceSinceIso);
-          if (verified !== 'verified') continue;
-        }
+        if (!(await verifyUrl(url))) continue;
         return { reviewUrl: url, source: 'artifact' };
       }
     } else {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -76,6 +76,10 @@ function apiPathMatches(path: string | undefined, suffix: string): boolean {
   }
 }
 
+function floorToGithubSecond(ms: number): number {
+  return Math.floor(ms / 1000) * 1000;
+}
+
 async function githubGraphql(
   host: string,
   query: string,
@@ -221,7 +225,7 @@ async function verifyReviewEvidenceOnGithub(
   const expectedReviewId = reviewMatch ? Number(reviewMatch[1]) : undefined;
   if (!expectedDiscussionId && !expectedIssueCommentId && !expectedReviewId) return 'missing';
 
-  const since = sinceIso ? Date.parse(sinceIso) : 0;
+  const since = sinceIso ? floorToGithubSecond(Date.parse(sinceIso)) : 0;
   const isFresh = (createdAt?: string) => {
     const t = createdAt ? Date.parse(createdAt) : Number.NaN;
     return Number.isFinite(t) && t >= since;
@@ -229,13 +233,21 @@ async function verifyReviewEvidenceOnGithub(
   const isActionableReviewState = (state?: string) =>
     state === 'APPROVED' || state === 'CHANGES_REQUESTED';
   const matches = (
-    node: { databaseId?: number; createdAt?: string; state?: string; user?: { login?: string } },
+    node: {
+      databaseId?: number;
+      createdAt?: string;
+      submittedAt?: string;
+      state?: string;
+      user?: { login?: string };
+    },
     expectedId?: number,
     options: { requireActionableState?: boolean; requirePrAuthor?: boolean } = {}
   ) =>
     expectedId !== undefined &&
     node.databaseId === expectedId &&
-    isFresh(node.createdAt) &&
+    isFresh(
+      options.requireActionableState ? (node.submittedAt ?? node.createdAt) : node.createdAt
+    ) &&
     (!options.requireActionableState || isActionableReviewState(node.state)) &&
     (!options.requirePrAuthor ||
       (prAuthorLogin !== undefined &&
@@ -325,7 +337,7 @@ async function verifyReviewEvidenceOnGithub(
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
             reviews(first:100, after:$reviewsCursor) @include(if:$includeReviews) {
-              nodes { databaseId createdAt state }
+              nodes { databaseId createdAt submittedAt state }
               pageInfo { hasNextPage endCursor }
             }
             comments(first:100, after:$commentsCursor) @include(if:$includeComments) {
@@ -359,7 +371,12 @@ async function verifyReviewEvidenceOnGithub(
         repository?: {
           pullRequest?: {
             reviews?: {
-              nodes?: Array<{ databaseId?: number; createdAt?: string; state?: string }>;
+              nodes?: Array<{
+                databaseId?: number;
+                createdAt?: string;
+                submittedAt?: string;
+                state?: string;
+              }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             comments?: {

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -79,7 +79,7 @@ function apiPathMatches(path: string | undefined, suffix: string): boolean {
 async function githubGraphql(
   host: string,
   query: string,
-  variables: Record<string, string | number | null | undefined>
+  variables: Record<string, string | number | boolean | null | undefined>
 ): Promise<{ ok: true; json: unknown } | { ok: false }> {
   if (!trustedGithubHosts().has(host)) return { ok: false };
 
@@ -109,7 +109,10 @@ async function githubGraphql(
     const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
     for (const [key, value] of Object.entries(variables)) {
       if (value === null || value === undefined) continue;
-      args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
+      args.push(
+        typeof value === 'number' || typeof value === 'boolean' ? '-F' : '-f',
+        `${key}=${value}`
+      );
     }
     const proc = Bun.spawn(['gh', ...args], {
       stdout: 'pipe',
@@ -216,14 +219,16 @@ async function verifyReviewEvidenceOnGithub(
   const isActionableReviewState = (state?: string) =>
     state === 'APPROVED' || state === 'CHANGES_REQUESTED';
   const matches = (
-    node: { databaseId?: number; createdAt?: string; state?: string },
+    node: { databaseId?: number; createdAt?: string; state?: string; user?: { login?: string } },
     expectedId?: number,
-    requireActionableState = false
+    options: { requireActionableState?: boolean; requirePrAuthor?: boolean } = {}
   ) =>
     expectedId !== undefined &&
     node.databaseId === expectedId &&
     isFresh(node.createdAt) &&
-    (!requireActionableState || isActionableReviewState(node.state));
+    (!options.requireActionableState || isActionableReviewState(node.state)) &&
+    (!options.requirePrAuthor ||
+      (prAuthorLogin !== undefined && node.user?.login === prAuthorLogin));
 
   if (expectedDiscussionId !== undefined) {
     const result = await githubRest(
@@ -295,21 +300,24 @@ async function verifyReviewEvidenceOnGithub(
   let reviewsCursor: string | undefined;
   let commentsCursor: string | undefined;
   let threadsCursor: string | undefined;
+  let reviewsDone = false;
+  let commentsDone = false;
+  let threadsDone = false;
 
   for (;;) {
     const query = `
-      query($owner:String!,$name:String!,$number:Int!,$reviewsCursor:String,$commentsCursor:String,$threadsCursor:String) {
+      query($owner:String!,$name:String!,$number:Int!,$reviewsCursor:String,$commentsCursor:String,$threadsCursor:String,$includeReviews:Boolean!,$includeComments:Boolean!,$includeThreads:Boolean!) {
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) {
-            reviews(first:100, after:$reviewsCursor) {
+            reviews(first:100, after:$reviewsCursor) @include(if:$includeReviews) {
               nodes { databaseId createdAt state }
               pageInfo { hasNextPage endCursor }
             }
-            comments(first:100, after:$commentsCursor) {
-              nodes { databaseId createdAt }
+            comments(first:100, after:$commentsCursor) @include(if:$includeComments) {
+              nodes { databaseId createdAt user { login } }
               pageInfo { hasNextPage endCursor }
             }
-            reviewThreads(first:100, after:$threadsCursor) {
+            reviewThreads(first:100, after:$threadsCursor) @include(if:$includeThreads) {
               nodes { comments(first:100) { nodes { databaseId createdAt } } }
               pageInfo { hasNextPage endCursor }
             }
@@ -325,6 +333,9 @@ async function verifyReviewEvidenceOnGithub(
       reviewsCursor,
       commentsCursor,
       threadsCursor,
+      includeReviews: !reviewsDone,
+      includeComments: !commentsDone,
+      includeThreads: !threadsDone,
     });
     if (!result.ok) return 'error';
 
@@ -337,7 +348,7 @@ async function verifyReviewEvidenceOnGithub(
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             comments?: {
-              nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+              nodes?: Array<{ databaseId?: number; createdAt?: string; user?: { login?: string } }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
             reviewThreads?: {
@@ -355,27 +366,39 @@ async function verifyReviewEvidenceOnGithub(
     const pr = json.data?.repository?.pullRequest;
     if (!pr) return 'error';
 
-    if (pr.reviews?.nodes?.some((n) => matches(n, expectedReviewId, true))) return 'verified';
-    if (pr.comments?.nodes?.some((n) => matches(n, expectedIssueCommentId))) return 'verified';
+    if (
+      pr.reviews?.nodes?.some((n) => matches(n, expectedReviewId, { requireActionableState: true }))
+    ) {
+      return 'verified';
+    }
+    if (
+      pr.comments?.nodes?.some((n) => matches(n, expectedIssueCommentId, { requirePrAuthor: true }))
+    ) {
+      return 'verified';
+    }
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       if (thread.comments?.nodes?.some((n) => matches(n, expectedDiscussionId))) {
         return 'verified';
       }
     }
 
-    const nextReviewsCursor = pr.reviews?.pageInfo?.hasNextPage
-      ? pr.reviews.pageInfo.endCursor
-      : undefined;
-    const nextCommentsCursor = pr.comments?.pageInfo?.hasNextPage
-      ? pr.comments.pageInfo.endCursor
-      : undefined;
-    const nextThreadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
-      ? pr.reviewThreads.pageInfo.endCursor
-      : undefined;
-    if (!nextReviewsCursor && !nextCommentsCursor && !nextThreadsCursor) return 'missing';
-    reviewsCursor = nextReviewsCursor;
-    commentsCursor = nextCommentsCursor;
-    threadsCursor = nextThreadsCursor;
+    if (!reviewsDone) {
+      reviewsCursor = pr.reviews?.pageInfo?.hasNextPage ? pr.reviews.pageInfo.endCursor : undefined;
+      reviewsDone = !reviewsCursor;
+    }
+    if (!commentsDone) {
+      commentsCursor = pr.comments?.pageInfo?.hasNextPage
+        ? pr.comments.pageInfo.endCursor
+        : undefined;
+      commentsDone = !commentsCursor;
+    }
+    if (!threadsDone) {
+      threadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
+        ? pr.reviewThreads.pageInfo.endCursor
+        : undefined;
+      threadsDone = !threadsCursor;
+    }
+    if (reviewsDone && commentsDone && threadsDone) return 'missing';
   }
 }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -1,0 +1,54 @@
+/**
+ * Review Posted Validator
+ *
+ * Built-in hook validator for the Review → Coding feedback channel.
+ * Ensures that the reviewer has posted review evidence (either as an artifact
+ * or embedded in the message data) before the message is delivered.
+ */
+
+import type { WorkflowHookResult } from '@neokai/shared';
+import type { HookExecutorContext } from '../hook-executor';
+
+function findReviewEvidence(
+  ctx: HookExecutorContext
+): { reviewUrl?: string; source: string } | undefined {
+  const data = ctx.params.data as Record<string, unknown> | undefined;
+
+  // Immediate evidence in the message data
+  if (data?.review_url && typeof data.review_url === 'string') {
+    return { reviewUrl: data.review_url, source: 'message_data' };
+  }
+
+  // Look through recent artifacts for a review artifact
+  for (const artifact of ctx.currentArtifacts) {
+    if (artifact.type === 'review' || artifact.type === 'review_feedback') {
+      const artifactData = artifact.data as Record<string, unknown> | undefined;
+      if (artifactData?.review_url && typeof artifactData.review_url === 'string') {
+        return { reviewUrl: artifactData.review_url as string, source: 'artifact' };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Main validator entry point.
+ */
+export async function reviewPostedValidator(ctx: HookExecutorContext): Promise<WorkflowHookResult> {
+  const evidence = findReviewEvidence(ctx);
+
+  if (!evidence) {
+    return {
+      type: 'block',
+      reason:
+        'No review evidence found. Post a GitHub review on the PR and include ' +
+        '`data: { review_url: "..." }` in your message, or save a review artifact first.',
+    };
+  }
+
+  return {
+    type: 'allow',
+    message: `Review evidence verified (${evidence.source}).`,
+  };
+}

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -169,14 +169,17 @@ async function githubRest(
   }
 }
 
-async function getPrAuthorLogin(prUrl: string): Promise<string | undefined> {
+async function getReviewIdentityLogins(
+  prUrl: string
+): Promise<{ prAuthorLogin?: string; viewerLogin?: string }> {
   const parsed = parsePrUrl(prUrl);
-  if (!parsed) return undefined;
+  if (!parsed) return {};
 
   const result = await githubGraphql(
     parsed.host,
     `
       query($owner:String!,$name:String!,$number:Int!) {
+        viewer { login }
         repository(owner:$owner,name:$name) {
           pullRequest(number:$number) { author { login } }
         }
@@ -184,21 +187,28 @@ async function getPrAuthorLogin(prUrl: string): Promise<string | undefined> {
     `,
     { owner: parsed.owner, name: parsed.repo, number: parsed.number }
   );
-  if (!result.ok) return undefined;
+  if (!result.ok) return {};
 
   const json = result.json as {
-    data?: { repository?: { pullRequest?: { author?: { login?: string } } } };
+    data?: {
+      viewer?: { login?: string };
+      repository?: { pullRequest?: { author?: { login?: string } } };
+    };
     errors?: unknown[];
   };
-  if (json.errors) return undefined;
-  return json.data?.repository?.pullRequest?.author?.login;
+  if (json.errors) return {};
+  return {
+    prAuthorLogin: json.data?.repository?.pullRequest?.author?.login,
+    viewerLogin: json.data?.viewer?.login,
+  };
 }
 
 async function verifyReviewEvidenceOnGithub(
   prUrl: string,
   reviewUrl: string,
   sinceIso?: string,
-  prAuthorLogin?: string
+  prAuthorLogin?: string,
+  viewerLogin?: string
 ): Promise<'verified' | 'missing' | 'error'> {
   const parsed = parsePrUrl(prUrl);
   if (!parsed) return 'error';
@@ -228,7 +238,10 @@ async function verifyReviewEvidenceOnGithub(
     isFresh(node.createdAt) &&
     (!options.requireActionableState || isActionableReviewState(node.state)) &&
     (!options.requirePrAuthor ||
-      (prAuthorLogin !== undefined && node.user?.login === prAuthorLogin));
+      (prAuthorLogin !== undefined &&
+        viewerLogin !== undefined &&
+        viewerLogin === prAuthorLogin &&
+        node.user?.login === prAuthorLogin));
 
   if (expectedDiscussionId !== undefined) {
     const result = await githubRest(
@@ -268,6 +281,8 @@ async function verifyReviewEvidenceOnGithub(
         apiPathMatches(comment.issue_url, `/issues/${parsed.number}`) &&
         isFresh(comment.created_at) &&
         prAuthorLogin !== undefined &&
+        viewerLogin !== undefined &&
+        viewerLogin === prAuthorLogin &&
         comment.user?.login === prAuthorLogin
       ) {
         return 'verified';
@@ -426,12 +441,13 @@ async function findReviewEvidence(
     if (!reviewBase) return false;
     if (activePrBase && reviewBase !== activePrBase) return false;
     const prUrl = activePrBase ?? reviewBase;
-    const prAuthorLogin = await getPrAuthorLogin(prUrl);
+    const { prAuthorLogin, viewerLogin } = await getReviewIdentityLogins(prUrl);
     const verified = await verifyReviewEvidenceOnGithub(
       prUrl,
       url,
       evidenceSinceIso,
-      prAuthorLogin
+      prAuthorLogin,
+      viewerLogin
     );
     return verified === 'verified';
   };

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -346,7 +346,13 @@ async function verifyReviewEvidenceOnGithub(
               pageInfo { hasNextPage endCursor }
             }
             reviewThreads(first:100, after:$threadsCursor) @include(if:$includeThreads) {
-              nodes { comments(first:100) { nodes { databaseId createdAt } } }
+              nodes {
+                id
+                comments(first:100) {
+                  nodes { databaseId createdAt }
+                  pageInfo { hasNextPage endCursor }
+                }
+              }
               pageInfo { hasNextPage endCursor }
             }
           }
@@ -390,7 +396,11 @@ async function verifyReviewEvidenceOnGithub(
             };
             reviewThreads?: {
               nodes?: Array<{
-                comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
+                id?: string;
+                comments?: {
+                  nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+                  pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+                };
               }>;
               pageInfo?: { hasNextPage?: boolean; endCursor?: string };
             };
@@ -416,6 +426,47 @@ async function verifyReviewEvidenceOnGithub(
     for (const thread of pr.reviewThreads?.nodes ?? []) {
       if (thread.comments?.nodes?.some((n) => matches(n, expectedDiscussionId))) {
         return 'verified';
+      }
+      let threadCommentsCursor = thread.comments?.pageInfo?.hasNextPage
+        ? thread.comments.pageInfo.endCursor
+        : undefined;
+      while (thread.id && threadCommentsCursor) {
+        const threadResult = await githubGraphql(
+          parsed.host,
+          `
+            query($threadId:ID!,$commentsCursor:String) {
+              node(id:$threadId) {
+                ... on PullRequestReviewThread {
+                  comments(first:100, after:$commentsCursor) {
+                    nodes { databaseId createdAt }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }
+          `,
+          { threadId: thread.id, commentsCursor: threadCommentsCursor }
+        );
+        if (!threadResult.ok) return 'error';
+        const threadJson = threadResult.json as {
+          data?: {
+            node?: {
+              comments?: {
+                nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+                pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+              };
+            };
+          };
+          errors?: unknown[];
+        };
+        if (threadJson.errors) return 'error';
+        const comments = threadJson.data?.node?.comments;
+        if (comments?.nodes?.some((n) => matches(n, expectedDiscussionId))) {
+          return 'verified';
+        }
+        threadCommentsCursor = comments?.pageInfo?.hasNextPage
+          ? comments.pageInfo.endCursor
+          : undefined;
       }
     }
 
@@ -447,6 +498,10 @@ function freshEvidenceSinceIso(ctx: HookExecutorContext): string | undefined {
     const updatedAt = typeof artifact.updatedAt === 'number' ? artifact.updatedAt : 0;
     const createdAt = typeof artifact.createdAt === 'number' ? artifact.createdAt : 0;
     since = Math.max(since, updatedAt, createdAt);
+  }
+  for (const gate of ctx.gateData ?? []) {
+    const updatedAt = typeof gate.updatedAt === 'number' ? gate.updatedAt : 0;
+    since = Math.max(since, updatedAt);
   }
   return since > 0 ? new Date(since).toISOString() : undefined;
 }

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -9,13 +9,22 @@
 import type { WorkflowHookResult } from '@neokai/shared';
 import type { HookExecutorContext } from '../hook-executor';
 
+function isValidReviewUrl(url: string): boolean {
+  // Must look like a GitHub PR or review comment URL
+  return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(url);
+}
+
 function findReviewEvidence(
   ctx: HookExecutorContext
 ): { reviewUrl?: string; source: string } | undefined {
   const data = ctx.params.data as Record<string, unknown> | undefined;
 
   // Immediate evidence in the message data
-  if (data?.review_url && typeof data.review_url === 'string') {
+  if (
+    data?.review_url &&
+    typeof data.review_url === 'string' &&
+    isValidReviewUrl(data.review_url)
+  ) {
     return { reviewUrl: data.review_url, source: 'message_data' };
   }
 
@@ -23,8 +32,9 @@ function findReviewEvidence(
   for (const artifact of ctx.currentArtifacts) {
     if (artifact.type === 'review' || artifact.type === 'review_feedback') {
       const artifactData = artifact.data as Record<string, unknown> | undefined;
-      if (artifactData?.review_url && typeof artifactData.review_url === 'string') {
-        return { reviewUrl: artifactData.review_url as string, source: 'artifact' };
+      const url = artifactData?.review_url;
+      if (typeof url === 'string' && isValidReviewUrl(url)) {
+        return { reviewUrl: url, source: 'artifact' };
       }
     }
   }
@@ -43,7 +53,7 @@ export async function reviewPostedValidator(ctx: HookExecutorContext): Promise<W
       type: 'block',
       reason:
         'No review evidence found. Post a GitHub review on the PR and include ' +
-        '`data: { review_url: "..." }` in your message, or save a review artifact first.',
+        '`data: { review_url: "<github-pull-url>" }` in your message, or save a review artifact first.',
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -13,7 +13,9 @@ function isValidReviewUrl(url: string): boolean {
   // Must reference a concrete GitHub PR review/comment, not just the PR base URL.
   return (
     /^https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+/.test(url) &&
-    (url.includes('discussion_r') || url.includes('pullrequestreview-'))
+    (url.includes('discussion_r') ||
+      url.includes('pullrequestreview-') ||
+      url.includes('issuecomment-'))
   );
 }
 
@@ -68,7 +70,7 @@ function githubTokenForHost(host: string): string | undefined {
 async function githubGraphql(
   host: string,
   query: string,
-  variables: Record<string, string | number>
+  variables: Record<string, string | number | null | undefined>
 ): Promise<{ ok: true; json: unknown } | { ok: false }> {
   if (!trustedGithubHosts().has(host)) return { ok: false };
 
@@ -97,6 +99,7 @@ async function githubGraphql(
   try {
     const args = ['api', '--hostname', host, 'graphql', '-f', `query=${query}`];
     for (const [key, value] of Object.entries(variables)) {
+      if (value === null || value === undefined) continue;
       args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
     }
     const proc = Bun.spawn(['gh', ...args], {
@@ -122,80 +125,117 @@ async function verifyReviewEvidenceOnGithub(
   if (!parsed) return 'error';
 
   const discussionMatch = reviewUrl.match(/discussion_r(\d+)/);
+  const issueCommentMatch = reviewUrl.match(/issuecomment-(\d+)/);
   const reviewMatch = reviewUrl.match(/pullrequestreview-(\d+)/);
   const expectedDiscussionId = discussionMatch ? Number(discussionMatch[1]) : undefined;
+  const expectedIssueCommentId = issueCommentMatch ? Number(issueCommentMatch[1]) : undefined;
   const expectedReviewId = reviewMatch ? Number(reviewMatch[1]) : undefined;
-  if (!expectedDiscussionId && !expectedReviewId) return 'missing';
+  if (!expectedDiscussionId && !expectedIssueCommentId && !expectedReviewId) return 'missing';
 
-  const query = `
-    query($owner:String!,$name:String!,$number:Int!) {
-      repository(owner:$owner,name:$name) {
-        pullRequest(number:$number) {
-          reviews(first:100) { nodes { databaseId createdAt } }
-          comments(first:100) { nodes { databaseId createdAt } }
-          reviewThreads(first:100) {
-            nodes { comments(first:100) { nodes { databaseId createdAt } } }
-          }
-        }
-      }
-    }
-  `;
-
-  const result = await githubGraphql(parsed.host, query, {
-    owner: parsed.owner,
-    name: parsed.repo,
-    number: parsed.number,
-  });
-  if (!result.ok) return 'error';
-
-  const json = result.json as {
-    data?: {
-      repository?: {
-        pullRequest?: {
-          reviews?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
-          comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
-          reviewThreads?: {
-            nodes?: Array<{
-              comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
-            }>;
-          };
-        };
-      };
-    };
-    errors?: unknown[];
-  };
-  if (json.errors) return 'error';
-  const pr = json.data?.repository?.pullRequest;
-  if (!pr) return 'error';
   const since = sinceIso ? Date.parse(sinceIso) : 0;
   const isFresh = (createdAt?: string) => {
     const t = createdAt ? Date.parse(createdAt) : Number.NaN;
     return Number.isFinite(t) && t >= since;
   };
+  const matches = (node: { databaseId?: number; createdAt?: string }, expectedId?: number) =>
+    expectedId !== undefined && node.databaseId === expectedId && isFresh(node.createdAt);
 
-  if (
-    expectedReviewId !== undefined &&
-    pr.reviews?.nodes?.some((n) => n.databaseId === expectedReviewId && isFresh(n.createdAt))
-  ) {
-    return 'verified';
-  }
-  if (
-    expectedDiscussionId !== undefined &&
-    pr.comments?.nodes?.some((n) => n.databaseId === expectedDiscussionId && isFresh(n.createdAt))
-  ) {
-    return 'verified';
-  }
-  for (const thread of pr.reviewThreads?.nodes ?? []) {
-    if (
-      expectedDiscussionId !== undefined &&
-      thread.comments?.nodes?.some(
-        (n) => n.databaseId === expectedDiscussionId && isFresh(n.createdAt)
-      )
-    ) {
-      return 'verified';
+  let reviewsCursor: string | undefined;
+  let commentsCursor: string | undefined;
+  let threadsCursor: string | undefined;
+
+  for (;;) {
+    const query = `
+      query($owner:String!,$name:String!,$number:Int!,$reviewsCursor:String,$commentsCursor:String,$threadsCursor:String) {
+        repository(owner:$owner,name:$name) {
+          pullRequest(number:$number) {
+            reviews(first:100, after:$reviewsCursor) {
+              nodes { databaseId createdAt }
+              pageInfo { hasNextPage endCursor }
+            }
+            comments(first:100, after:$commentsCursor) {
+              nodes { databaseId createdAt }
+              pageInfo { hasNextPage endCursor }
+            }
+            reviewThreads(first:100, after:$threadsCursor) {
+              nodes { comments(first:100) { nodes { databaseId createdAt } } }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await githubGraphql(parsed.host, query, {
+      owner: parsed.owner,
+      name: parsed.repo,
+      number: parsed.number,
+      reviewsCursor,
+      commentsCursor,
+      threadsCursor,
+    });
+    if (!result.ok) return 'error';
+
+    const json = result.json as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviews?: {
+              nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+            };
+            comments?: {
+              nodes?: Array<{ databaseId?: number; createdAt?: string }>;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+            };
+            reviewThreads?: {
+              nodes?: Array<{
+                comments?: { nodes?: Array<{ databaseId?: number; createdAt?: string }> };
+              }>;
+              pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+            };
+          };
+        };
+      };
+      errors?: unknown[];
+    };
+    if (json.errors) return 'error';
+    const pr = json.data?.repository?.pullRequest;
+    if (!pr) return 'error';
+
+    if (pr.reviews?.nodes?.some((n) => matches(n, expectedReviewId))) return 'verified';
+    if (pr.comments?.nodes?.some((n) => matches(n, expectedIssueCommentId))) return 'verified';
+    for (const thread of pr.reviewThreads?.nodes ?? []) {
+      if (thread.comments?.nodes?.some((n) => matches(n, expectedDiscussionId))) {
+        return 'verified';
+      }
     }
+
+    const nextReviewsCursor = pr.reviews?.pageInfo?.hasNextPage
+      ? pr.reviews.pageInfo.endCursor
+      : undefined;
+    const nextCommentsCursor = pr.comments?.pageInfo?.hasNextPage
+      ? pr.comments.pageInfo.endCursor
+      : undefined;
+    const nextThreadsCursor = pr.reviewThreads?.pageInfo?.hasNextPage
+      ? pr.reviewThreads.pageInfo.endCursor
+      : undefined;
+    if (!nextReviewsCursor && !nextCommentsCursor && !nextThreadsCursor) return 'missing';
+    reviewsCursor = nextReviewsCursor;
+    commentsCursor = nextCommentsCursor;
+    threadsCursor = nextThreadsCursor;
   }
-  return 'missing';
+}
+
+function freshEvidenceSinceIso(ctx: HookExecutorContext): string | undefined {
+  let since = ctx.workflowStartIso ? Date.parse(ctx.workflowStartIso) : 0;
+  for (const artifact of ctx.currentArtifacts) {
+    if (artifact.type === 'review' || artifact.type === 'review_feedback') continue;
+    const updatedAt = typeof artifact.updatedAt === 'number' ? artifact.updatedAt : 0;
+    const createdAt = typeof artifact.createdAt === 'number' ? artifact.createdAt : 0;
+    since = Math.max(since, updatedAt, createdAt);
+  }
+  return since > 0 ? new Date(since).toISOString() : undefined;
 }
 
 async function findReviewEvidence(
@@ -203,6 +243,7 @@ async function findReviewEvidence(
 ): Promise<{ reviewUrl?: string; source: string } | undefined> {
   const data = ctx.params.data as Record<string, unknown> | undefined;
   const activePrBase = extractPrBaseUrl(getActivePrUrl(ctx) ?? '');
+  const evidenceSinceIso = freshEvidenceSinceIso(ctx);
 
   // Immediate evidence in the message data
   if (
@@ -217,7 +258,7 @@ async function findReviewEvidence(
       const verified = await verifyReviewEvidenceOnGithub(
         activePrBase,
         data.review_url,
-        ctx.workflowStartIso
+        evidenceSinceIso
       );
       if (verified !== 'verified') return undefined;
     }
@@ -236,11 +277,7 @@ async function findReviewEvidence(
         if (activePrBase) {
           const reviewBase = extractPrBaseUrl(url);
           if (reviewBase !== activePrBase) continue;
-          const verified = await verifyReviewEvidenceOnGithub(
-            activePrBase,
-            url,
-            ctx.workflowStartIso
-          );
+          const verified = await verifyReviewEvidenceOnGithub(activePrBase, url, evidenceSinceIso);
           if (verified !== 'verified') continue;
         }
         return { reviewUrl: url, source: 'artifact' };

--- a/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
+++ b/packages/daemon/src/lib/space/runtime/built-in-validators/review-posted-validator.ts
@@ -10,8 +10,8 @@ import type { WorkflowHookResult } from '@neokai/shared';
 import type { HookExecutorContext } from '../hook-executor';
 
 function isValidReviewUrl(url: string): boolean {
-  // Must look like a GitHub PR or review comment URL
-  return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(url);
+  // Must look like a GitHub (or Enterprise) PR or review comment URL
+  return /^https:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/\d+/.test(url);
 }
 
 function findReviewEvidence(
@@ -28,7 +28,10 @@ function findReviewEvidence(
     return { reviewUrl: data.review_url, source: 'message_data' };
   }
 
-  // Look through recent artifacts for a review artifact
+  // Look through recent artifacts for a fresh review artifact.
+  // currentArtifacts is sorted by updatedAt descending. If the most recent
+  // artifact is non-review work (e.g., a new code revision), any older review
+  // artifact is considered stale for this cycle.
   for (const artifact of ctx.currentArtifacts) {
     if (artifact.type === 'review' || artifact.type === 'review_feedback') {
       const artifactData = artifact.data as Record<string, unknown> | undefined;
@@ -36,6 +39,8 @@ function findReviewEvidence(
       if (typeof url === 'string' && isValidReviewUrl(url)) {
         return { reviewUrl: url, source: 'artifact' };
       }
+    } else {
+      break;
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -22,6 +22,8 @@ import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { validateWorkflowHookResult } from '../workflow-hook-validation';
+import { reviewApprovalValidator } from './built-in-validators/review-approval-validator';
+import { reviewPostedValidator } from './built-in-validators/review-posted-validator';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -137,6 +139,8 @@ registerBuiltInValidator('task_reported_status', async () => ({
   type: 'block',
   reason: NOT_IMPLEMENTED,
 }));
+registerBuiltInValidator('review_approval', reviewApprovalValidator);
+registerBuiltInValidator('review_posted', reviewPostedValidator);
 
 // ---------------------------------------------------------------------------
 // Environment builder

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -47,6 +47,8 @@ export interface HookExecutorContext {
   permittedExternalLookups: string[];
   /** Optional bounded template data from the hook definition. */
   templateData?: Record<string, unknown>;
+  /** Current gate runtime data for this workflow run, when available. */
+  gateData?: Record<string, unknown>[];
 }
 
 /** Result of executing a single hook validator. */

--- a/packages/daemon/src/lib/space/runtime/hook-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/hook-executor.ts
@@ -40,6 +40,7 @@ export interface HookExecutorContext {
   nodeName: string;
   sessionId: string;
   taskId: string;
+  agentName: string;
   targetNode?: string;
   hookLocalState: Record<string, unknown>;
   currentArtifacts: Record<string, unknown>[];

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3840,6 +3840,7 @@ export class TaskAgentManager {
         hookStateRepo: new WorkflowHookStateRepository(this.config.db.getDatabase()),
         hookExecutor,
         workspacePath,
+        gateDataRepo: this.config.gateDataRepo,
       });
     }
 

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -702,7 +702,7 @@ export class WorkflowHookEngine {
       runId: this.config.workflowRunId,
       hookId: hook.id,
       methodName,
-      params: this.boundParams(params),
+      params: hook.validator.kind === 'built_in' ? params : this.boundParams(params),
       nodeId: meta.nodeId,
       nodeName,
       sessionId: meta.sessionId,

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -26,6 +26,10 @@ import type { NodeExecutionRepository } from '../../../storage/repositories/node
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { WorkflowHookStateRepository } from '../../../storage/repositories/workflow-hook-state-repository';
 import type { HookExecutor, HookExecutorContext } from './hook-executor';
+import type {
+  GateDataRepository,
+  GateDataRecord,
+} from '../../../storage/repositories/gate-data-repository';
 import { ChannelResolver } from './channel-resolver';
 import { Logger } from '../../logger';
 import { parseAddress } from '../../../../../messaging/src/address';
@@ -94,6 +98,8 @@ export interface WorkflowHookEngineConfig {
   hookStateRepo: WorkflowHookStateRepository;
   hookExecutor: HookExecutor;
   workspacePath?: string;
+  /** Optional gate data repository for exposing runtime gate data to hook validators. */
+  gateDataRepo?: GateDataRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -702,6 +708,21 @@ export class WorkflowHookEngine {
       mappedArtifacts.push(item);
     }
 
+    // Load current gate data when available
+    let gateData: Record<string, unknown>[] | undefined;
+    try {
+      const records = this.config.gateDataRepo?.listByRun(this.config.workflowRunId);
+      if (records) {
+        gateData = records.map((r: GateDataRecord) => ({
+          gateId: r.gateId,
+          data: r.data,
+          updatedAt: r.updatedAt,
+        }));
+      }
+    } catch {
+      // best effort
+    }
+
     return {
       workspacePath: this.config.workspacePath ?? '',
       runId: this.config.workflowRunId,
@@ -718,6 +739,7 @@ export class WorkflowHookEngine {
       currentArtifacts: mappedArtifacts,
       permittedExternalLookups,
       templateData: hook.templateData,
+      gateData,
     };
   }
 

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -290,6 +290,9 @@ export class WorkflowHookEngine {
           if ((hook.classification ?? 'validation') === 'validation') {
             blockedByValidation = { hookId: hook.id, result, isRetryable: false };
           }
+          if (result.state && typeof result.state === 'object') {
+            stateUpdates.push({ hookId: hook.id, state: result.state as Record<string, unknown> });
+          }
           // side_effect block is recorded but does not stop
           break;
 
@@ -344,6 +347,9 @@ export class WorkflowHookEngine {
                 }
               }
             }
+          }
+          if (result.state && typeof result.state === 'object') {
+            stateUpdates.push({ hookId: hook.id, state: result.state as Record<string, unknown> });
           }
           break;
         }

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -792,7 +792,8 @@ export class WorkflowHookEngine {
       // target to compare, so a hook with targetNode on those methods is skipped.
       if (hook.targetNode) {
         if (methodName !== 'send_message') return false;
-        if (actionTargets.size > 0 && !actionTargets.has(hook.targetNode)) return false;
+        if (actionTargets.size === 0) return false;
+        if (!actionTargets.has(hook.targetNode)) return false;
       }
 
       // Authorized callers check
@@ -1371,32 +1372,55 @@ export function wrapHandlerWithHooks<T extends Record<string, unknown>>(
   if (!engine) return handler;
 
   const wrapped = async (args: T) => {
-    const outcome = await engine.executeAction(methodName, args as Record<string, unknown>, meta);
+    let outcome = await engine.executeAction(methodName, args as Record<string, unknown>, meta);
 
-    // Batch persist hook state updates and execution results.
-    // Each hook gets at most one repo write to avoid version conflicts.
-    const updatesByHook = new Map<
-      string,
-      { state: Record<string, unknown>; result?: WorkflowHookResult }
-    >();
-    for (const update of outcome.stateUpdates) {
-      updatesByHook.set(update.hookId, { state: update.state });
-    }
-    for (const record of outcome.executionLog) {
-      const existing = updatesByHook.get(record.hookId);
-      if (existing) {
-        existing.result = record.result;
-      } else {
-        updatesByHook.set(record.hookId, { state: {}, result: record.result });
+    for (let attempt = 0; attempt < 2; attempt++) {
+      // Batch persist hook state updates and execution results.
+      // Each hook gets at most one repo write to avoid version conflicts.
+      const updatesByHook = new Map<
+        string,
+        { state: Record<string, unknown>; result?: WorkflowHookResult }
+      >();
+      for (const update of outcome.stateUpdates) {
+        updatesByHook.set(update.hookId, { state: update.state });
       }
-    }
-    for (const [hookId, { state, result }] of updatesByHook) {
-      const ok = engine.persistStateUpdate(hookId, state, result);
-      if (!ok) {
-        log.warn(
-          `Failed to persist hook state/result for ${hookId}: version conflict or repo error`
-        );
+      for (const record of outcome.executionLog) {
+        const existing = updatesByHook.get(record.hookId);
+        if (existing) {
+          existing.result = record.result;
+        } else {
+          updatesByHook.set(record.hookId, { state: {}, result: record.result });
+        }
       }
+      for (const [hookId, { state, result }] of updatesByHook) {
+        const ok = engine.persistStateUpdate(hookId, state, result);
+        if (!ok) {
+          log.warn(
+            `Failed to persist hook state/result for ${hookId}: version conflict or repo error`
+          );
+        }
+      }
+
+      if (
+        attempt > 0 ||
+        outcome.decision !== 'retryable_block' ||
+        !outcome.userState.reason?.includes('retry after state merge')
+      ) {
+        break;
+      }
+
+      const retryOutcome = await engine.executeAction(
+        methodName,
+        args as Record<string, unknown>,
+        meta
+      );
+      if (
+        retryOutcome.decision === 'retryable_block' &&
+        retryOutcome.userState.reason === outcome.userState.reason
+      ) {
+        break;
+      }
+      outcome = retryOutcome;
     }
 
     // Handle block

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -400,7 +400,12 @@ export class WorkflowHookEngine {
 
         case 'record_state':
           if (result.state && typeof result.state === 'object') {
-            stateUpdates.push({ hookId: hook.id, state: result.state as Record<string, unknown> });
+            const targetHookId =
+              typeof result.targetHookId === 'string' ? result.targetHookId : hook.id;
+            stateUpdates.push({
+              hookId: targetHookId,
+              state: result.state as Record<string, unknown>,
+            });
           }
           break;
       }

--- a/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-hook-engine.ts
@@ -154,17 +154,20 @@ export class WorkflowHookEngine {
     state: Record<string, unknown>,
     lastResult?: WorkflowHookResult
   ): boolean {
-    try {
-      const repoState = this.config.hookStateRepo.get(this.config.workflowRunId, hookId);
-      const result = this.config.hookStateRepo.update(this.config.workflowRunId, hookId, {
-        expectedVersion: repoState?.version ?? 0,
-        localState: state,
-        lastResult,
-      });
-      return result !== null;
-    } catch {
-      return false;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const repoState = this.config.hookStateRepo.get(this.config.workflowRunId, hookId);
+        const result = this.config.hookStateRepo.update(this.config.workflowRunId, hookId, {
+          expectedVersion: repoState?.version ?? 0,
+          localState: state,
+          lastResult,
+        });
+        if (result !== null) return true;
+      } catch {
+        // retry on version conflict or error
+      }
     }
+    return false;
   }
 
   /**
@@ -704,6 +707,7 @@ export class WorkflowHookEngine {
       nodeName,
       sessionId: meta.sessionId,
       taskId: meta.taskId,
+      agentName: meta.agentName,
       targetNode: hook.targetNode ?? meta.targetNode,
       hookLocalState: this.boundHookLocalState(hookLocalState),
       currentArtifacts: mappedArtifacts,

--- a/packages/daemon/src/lib/space/workflow-hook-validation.ts
+++ b/packages/daemon/src/lib/space/workflow-hook-validation.ts
@@ -13,9 +13,8 @@ const VALID_METHODS = new Set([
   'submit_for_approval',
   'approve_task',
 ]);
-// Built-in validators are not yet implemented; reject them at validation time
-// so workflows cannot declare IDs that would unconditionally block at runtime.
-const VALID_BUILT_IN_VALIDATORS = new Set<string>([]);
+// Allow built-in validator IDs that have real implementations registered.
+const VALID_BUILT_IN_VALIDATORS = new Set<string>(['review_approval', 'review_posted']);
 const VALID_RESULT_TYPES = new Set([
   'allow',
   'block',

--- a/packages/daemon/src/lib/space/workflow-hook-validation.ts
+++ b/packages/daemon/src/lib/space/workflow-hook-validation.ts
@@ -133,6 +133,9 @@ export function validateWorkflowHookResult(result: unknown): string[] {
       break;
     case 'record_state':
       if (!isRecord(result.state)) errors.push('result.state: expected object');
+      if (result.targetHookId !== undefined && typeof result.targetHookId !== 'string') {
+        errors.push('result.targetHookId: expected string');
+      }
       break;
   }
   if (result.data !== undefined && !isRecord(result.data))

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -28,6 +28,7 @@ import type {
   Gate,
   SpaceWorkflow,
   WorkflowChannel,
+  WorkflowHook,
   WorkflowNode,
 } from '@neokai/shared';
 import { generateUUID, resolveNodeAgents, hasEnabledGateFeature } from '@neokai/shared';
@@ -1684,6 +1685,15 @@ function remapTemplateHook(
   };
 }
 
+function hookKey(hook: WorkflowHook): string {
+  return JSON.stringify({
+    id: hook.id,
+    sourceNode: hook.sourceNode,
+    targetNode: hook.targetNode ?? null,
+    method: hook.method,
+  });
+}
+
 function mergeHooksFromTemplate(
   existingHooks: SpaceWorkflow['hooks'],
   templateHooks: SpaceWorkflow['hooks'],
@@ -1696,29 +1706,32 @@ function mergeHooksFromTemplate(
   );
   if (!existingHooks) return remappedTemplateHooks;
 
-  const existingKeys = new Set(
-    existingHooks.map((hook) =>
-      JSON.stringify({
-        id: hook.id,
-        sourceNode: hook.sourceNode,
-        targetNode: hook.targetNode ?? null,
-        method: hook.method,
-      })
-    )
-  );
+  // Build a map of template hooks by key for efficient lookup
+  const templateByKey = new Map<string, WorkflowHook>();
+  for (const th of remappedTemplateHooks) {
+    templateByKey.set(hookKey(th), th);
+  }
+
+  // For existing hooks that match a template key, update structural fields
+  // (templateData, validator, retryPolicy) while preserving user-customized fields.
+  const updatedExisting = existingHooks.map((hook) => {
+    const templateMatch = templateByKey.get(hookKey(hook));
+    if (templateMatch) {
+      return {
+        ...hook,
+        templateData: templateMatch.templateData,
+        validator: templateMatch.validator,
+      };
+    }
+    return hook;
+  });
+
+  const existingKeys = new Set(existingHooks.map(hookKey));
   const missingTemplateHooks = remappedTemplateHooks.filter(
-    (hook) =>
-      !existingKeys.has(
-        JSON.stringify({
-          id: hook.id,
-          sourceNode: hook.sourceNode,
-          targetNode: hook.targetNode ?? null,
-          method: hook.method,
-        })
-      )
+    (hook) => !existingKeys.has(hookKey(hook))
   );
 
-  return [...existingHooks, ...missingTemplateHooks];
+  return [...updatedExisting, ...missingTemplateHooks];
 }
 
 /** @internal Exported for testing. */

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -714,6 +714,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Review',
       to: 'Coding',
+      hookIds: ['review-posted-hook'],
       maxCycles: 5,
       label: 'Review → Coding (changes requested)',
     },
@@ -1091,6 +1092,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Plan Review',
       to: 'Task Dispatcher',
+      hookIds: ['plan-approval-hook'],
       label: 'Plan Review → Task Dispatcher',
     },
     {
@@ -1305,6 +1307,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Review',
       to: 'QA',
+      hookIds: ['review-approval-hook'],
       label: 'Review → QA',
     },
     {

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1132,7 +1132,8 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
       validator: {
         kind: 'script',
         interpreter: 'bash',
-        source: 'echo \'{"type":"record_state","state":{"approvals":null}}\'',
+        source:
+          'echo \'{"type":"record_state","state":{"approvals":null},"targetHookId":"plan-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'Plan Review' }],
       label: 'Plan Approval Reset',
@@ -1340,7 +1341,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
         kind: 'script',
         interpreter: 'bash',
         source:
-          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null}}\'',
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null},"targetHookId":"review-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'Review' }],
       label: 'Review Approval Reset',
@@ -1356,7 +1357,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
         kind: 'script',
         interpreter: 'bash',
         source:
-          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null}}\'',
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null},"targetHookId":"review-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'QA' }],
       label: 'QA Approval Reset',
@@ -1746,6 +1747,26 @@ export function mergeChannelsFromTemplate(
   return [...keptExisting, ...remappedTemplateChannels];
 }
 
+/**
+ * Remove gates that are no longer in the template and no longer referenced by
+ * any channel. Preserves user-added custom gates as long as a channel still
+ * references them.
+ *
+ * @internal Exported for testing.
+ */
+export function removeOrphanedGates(
+  gates: Gate[] | undefined,
+  channels: SpaceWorkflow['channels'] | undefined,
+  templateGates: Gate[] | undefined
+): Gate[] | undefined {
+  if (!gates) return gates;
+  const templateGateIds = new Set(templateGates?.map((g) => g.id) ?? []);
+  const referencedGateIds = new Set(
+    (channels ?? []).map((ch) => ch.gateId).filter((id): id is string => typeof id === 'string')
+  );
+  return gates.filter((gate) => templateGateIds.has(gate.id) || referencedGateIds.has(gate.id));
+}
+
 /** @internal Exported for testing. */
 export function mergeGateStructuralFieldsFromTemplate(
   existingGates: Gate[] | undefined,
@@ -1758,44 +1779,43 @@ export function mergeGateStructuralFieldsFromTemplate(
   const existingGateIds = new Set(existingGates.map((gate) => gate.id));
   const missingTemplateGates = templateGates.filter((gate) => !existingGateIds.has(gate.id));
 
-  const mergedExisting = existingGates
-    .filter((gate) => templateGatesById.has(gate.id))
-    .map((gate) => {
-      const templateGate = templateGatesById.get(gate.id)!;
+  const mergedExisting = existingGates.map((gate) => {
+    const templateGate = templateGatesById.get(gate.id);
+    if (!templateGate) return gate;
 
-      const templateFieldsByName = new Map(
-        (templateGate.fields ?? []).map((field) => [field.name, field])
-      );
-      const fields = (gate.fields ?? []).map((field) => {
-        const templateField = templateFieldsByName.get(field.name);
-        if (!templateField) return field;
-        return { ...field, writers: templateField.writers };
-      });
-
-      // Skip copying template features if the existing gate already has a custom
-      // script or poll, so feature-backed mechanisms do not silently override
-      // custom gate logic at runtime. When copying is allowed, propagate the
-      // template's features (including undefined when the template removed them).
-      // Preserve existing codex_review_bot feature during transition to node-level
-      // config so pre-existing workflows that relied on gate-level codex keep working.
-      const shouldCopyFeatures = !gate.script && !gate.poll;
-      let nextFeatures: Gate['features'] | undefined;
-      if (shouldCopyFeatures) {
-        if (templateGate.features) {
-          nextFeatures = { ...templateGate.features };
-        }
-        if (hasEnabledGateFeature(gate, 'codex_review_bot')) {
-          nextFeatures = { codex_review_bot: true, ...nextFeatures };
-        }
-      } else {
-        nextFeatures = gate.features;
-      }
-      return {
-        ...gate,
-        fields,
-        features: nextFeatures,
-      } as Gate;
+    const templateFieldsByName = new Map(
+      (templateGate.fields ?? []).map((field) => [field.name, field])
+    );
+    const fields = (gate.fields ?? []).map((field) => {
+      const templateField = templateFieldsByName.get(field.name);
+      if (!templateField) return field;
+      return { ...field, writers: templateField.writers };
     });
+
+    // Skip copying template features if the existing gate already has a custom
+    // script or poll, so feature-backed mechanisms do not silently override
+    // custom gate logic at runtime. When copying is allowed, propagate the
+    // template's features (including undefined when the template removed them).
+    // Preserve existing codex_review_bot feature during transition to node-level
+    // config so pre-existing workflows that relied on gate-level codex keep working.
+    const shouldCopyFeatures = !gate.script && !gate.poll;
+    let nextFeatures: Gate['features'] | undefined;
+    if (shouldCopyFeatures) {
+      if (templateGate.features) {
+        nextFeatures = { ...templateGate.features };
+      }
+      if (hasEnabledGateFeature(gate, 'codex_review_bot')) {
+        nextFeatures = { codex_review_bot: true, ...nextFeatures };
+      }
+    } else {
+      nextFeatures = gate.features;
+    }
+    return {
+      ...gate,
+      fields,
+      features: nextFeatures,
+    } as Gate;
+  });
 
   return [...mergedExisting, ...missingTemplateGates];
 }
@@ -1909,7 +1929,11 @@ export function seedBuiltInWorkflows(
           template.nodes,
           row.nodes
         );
-        const mergedGates = mergeGateStructuralFieldsFromTemplate(row.gates, template.gates);
+        const mergedGates = removeOrphanedGates(
+          mergeGateStructuralFieldsFromTemplate(row.gates, template.gates),
+          mergedChannels,
+          template.gates
+        );
         const mergedHooks = mergeHooksFromTemplate(
           row.hooks,
           template.hooks,

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -369,13 +369,13 @@ const CODEX_REACTION_APPROVAL_GUIDANCE =
   'reacted at all, comment `@codex review` on the PR to trigger its review, then wait ' +
   'for an `eyes` or `+1` reaction. ' +
   'Only a +1 newer than the current PR head commit counts — after a revision push, ' +
-  'an older +1 from a previous cycle is stale and will not open the gate. If the +1 ' +
+  'an older +1 from a previous cycle is stale and will not release the hand-off. If the +1 ' +
   'looks old, retrigger Codex with a fresh `@codex review` comment. ' +
-  'Write the approval gate to start the Codex timeout (10 minutes). If the gate ' +
-  'blocks because Codex has not yet posted `+1`, poll every 60 seconds and retry the ' +
-  'gate write. If codex[bot] still has not posted `+1` after the timeout, proceed ' +
-  'only with a warning recorded in your result artifact. Do not close the task ' +
-  'before codex[bot] has `+1` unless that timeout has elapsed.';
+  'Send your hook-validated hand-off message to start the Codex timeout (10 minutes). ' +
+  'If the message is blocked because Codex has not yet posted `+1`, wait for the retryable ' +
+  'block or resend after 60 seconds. If codex[bot] still has not posted `+1` after the ' +
+  'timeout, proceed only with a warning recorded in your result artifact. Do not close the ' +
+  'task before codex[bot] has `+1` unless that timeout has elapsed.';
 
 const PD_PLAN_REVIEW_PROMPT =
   'You are one of four independent Plan Reviewers. Review the plan PR through your lens before ' +

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1750,13 +1750,12 @@ export function mergeChannelsFromTemplate(
   // Template channels are the source of truth for from→to pairs. Replace
   // any existing channel with the same from→to so that gate changes
   // (including ungating) are reflected on re-stamp.
-  const templateFromTo = new Set(
-    remappedTemplateChannels.map((ch) => JSON.stringify({ from: ch.from, to: ch.to }))
-  );
-  const keptExisting = existingChannels.filter((ch) => {
-    const key = JSON.stringify({ from: ch.from, to: ch.to });
-    return !templateFromTo.has(key);
-  });
+  const fromToKey = (ch: NonNullable<SpaceWorkflow['channels']>[number]) => {
+    const to = Array.isArray(ch.to) && ch.to.length === 1 ? ch.to[0] : ch.to;
+    return JSON.stringify({ from: ch.from, to });
+  };
+  const templateFromTo = new Set(remappedTemplateChannels.map(fromToKey));
+  const keptExisting = existingChannels.filter((ch) => !templateFromTo.has(fromToKey(ch)));
 
   return [...keptExisting, ...remappedTemplateChannels];
 }

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1719,7 +1719,8 @@ function mergeHooksFromTemplate(
   return [...existingHooks, ...missingTemplateHooks];
 }
 
-function mergeChannelsFromTemplate(
+/** @internal Exported for testing. */
+export function mergeChannelsFromTemplate(
   existingChannels: SpaceWorkflow['channels'],
   templateChannels: SpaceWorkflow['channels'],
   templateNodes: WorkflowNode[],
@@ -1731,19 +1732,18 @@ function mergeChannelsFromTemplate(
   );
   if (!existingChannels) return remappedTemplateChannels;
 
-  const existingKeys = new Set(
-    existingChannels.map((channel) =>
-      JSON.stringify({ from: channel.from, to: channel.to, gateId: channel.gateId ?? null })
-    )
+  // Template channels are the source of truth for from→to pairs. Replace
+  // any existing channel with the same from→to so that gate changes
+  // (including ungating) are reflected on re-stamp.
+  const templateFromTo = new Set(
+    remappedTemplateChannels.map((ch) => JSON.stringify({ from: ch.from, to: ch.to }))
   );
-  const missingTemplateChannels = remappedTemplateChannels.filter(
-    (channel) =>
-      !existingKeys.has(
-        JSON.stringify({ from: channel.from, to: channel.to, gateId: channel.gateId ?? null })
-      )
-  );
+  const keptExisting = existingChannels.filter((ch) => {
+    const key = JSON.stringify({ from: ch.from, to: ch.to });
+    return !templateFromTo.has(key);
+  });
 
-  return [...existingChannels, ...missingTemplateChannels];
+  return [...keptExisting, ...remappedTemplateChannels];
 }
 
 /** @internal Exported for testing. */
@@ -1758,10 +1758,10 @@ export function mergeGateStructuralFieldsFromTemplate(
   const existingGateIds = new Set(existingGates.map((gate) => gate.id));
   const missingTemplateGates = templateGates.filter((gate) => !existingGateIds.has(gate.id));
 
-  return existingGates
+  const mergedExisting = existingGates
+    .filter((gate) => templateGatesById.has(gate.id))
     .map((gate) => {
-      const templateGate = templateGatesById.get(gate.id);
-      if (!templateGate) return gate;
+      const templateGate = templateGatesById.get(gate.id)!;
 
       const templateFieldsByName = new Map(
         (templateGate.fields ?? []).map((field) => [field.name, field])
@@ -1794,9 +1794,10 @@ export function mergeGateStructuralFieldsFromTemplate(
         ...gate,
         fields,
         features: nextFeatures,
-      };
-    })
-    .concat(missingTemplateGates);
+      } as Gate;
+    });
+
+  return [...mergedExisting, ...missingTemplateGates];
 }
 
 /**

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1134,7 +1134,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
         kind: 'script',
         interpreter: 'bash',
         source:
-          'echo \'{"type":"record_state","state":{"approvals":null},"targetHookId":"plan-approval-hook"}\'',
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null,"_codex_head_sha":null,"_pr_url":null},"targetHookId":"plan-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'Plan Review' }],
       label: 'Plan Approval Reset',
@@ -1342,7 +1342,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
         kind: 'script',
         interpreter: 'bash',
         source:
-          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null},"targetHookId":"review-approval-hook"}\'',
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null,"_codex_head_sha":null,"_pr_url":null},"targetHookId":"review-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'Review' }],
       label: 'Review Approval Reset',
@@ -1358,7 +1358,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
         kind: 'script',
         interpreter: 'bash',
         source:
-          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null},"targetHookId":"review-approval-hook"}\'',
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null,"_codex_head_sha":null,"_pr_url":null},"targetHookId":"review-approval-hook"}\'',
       },
       authorizedCallers: [{ sourceNode: 'QA' }],
       label: 'QA Approval Reset',
@@ -1946,7 +1946,8 @@ export function seedBuiltInWorkflows(
           mergedChannels ?? row.channels ?? [],
           mergedGates ?? row.gates ?? []
         );
-        const hasNewTemplateChannels = (mergedChannels?.length ?? 0) > (row.channels?.length ?? 0);
+        const channelsChanged =
+          JSON.stringify(mergedChannels) !== JSON.stringify(row.channels ?? []);
 
         workflowManager.updateWorkflow(row.id, {
           completionAutonomyLevel: template.completionAutonomyLevel,
@@ -1956,7 +1957,7 @@ export function seedBuiltInWorkflows(
           gates: migratedGates,
           nodes: migratedNodes,
           hooks: mergedHooks ?? null,
-          ...(hasNewTemplateChannels ? { channels: mergedChannels } : {}),
+          ...(channelsChanged ? { channels: mergedChannels } : {}),
           templateHash: expectedHash,
         });
         restamped.push(template.name);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -315,65 +315,6 @@ const PR_READY_BASH_SCRIPT = [
 ].join('\n');
 
 /**
- * Review-posted gate script.
- *
- * Verifies that the Reviewer has actually posted review evidence on the PR
- * since the workflow run started. This gate guards the Review → Coding feedback
- * channel: the runtime refuses to deliver a "changes requested" message until
- * a formal review or at least one PR comment is visible on GitHub.
- *
- * Primary check: formal GitHub review (gh pr review / pulls/{n}/reviews)
- * with APPROVED or CHANGES_REQUESTED state.
- * Own-PR fallback: COMMENTED reviews or PR conversation comments since workflow
- * start. GitHub blocks APPROVE/REQUEST_CHANGES on your own PR, so comment-only
- * evidence is accepted only when the authenticated GitHub user is the PR author.
- *
- * Environment variables:
- *   NEOKAI_GATE_DATA_JSON       — current gate data; contains `pr_url` (PR URL, preferred)
- *                                 and `review_url` (review permalink, fallback)
- *   NEOKAI_WORKFLOW_START_ISO   — ISO8601 timestamp of workflowRun.createdAt,
- *                                 injected by the gate script runner
- */
-const REVIEW_POSTED_BASH_SCRIPT = [
-  'PR_URL=$(jq -r \'.pr_url // .review_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-{}}" 2>/dev/null || true)',
-  'if [ -z "$PR_URL" ]; then',
-  '  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
-  'fi',
-  'if [ -z "$PR_URL" ]; then',
-  '  echo "No PR URL available to verify review" >&2',
-  '  exit 1',
-  'fi',
-  'START_ISO="${NEOKAI_WORKFLOW_START_ISO:-}"',
-  'if [ -z "$START_ISO" ]; then',
-  '  echo "NEOKAI_WORKFLOW_START_ISO not injected — cannot determine review window" >&2',
-  '  exit 1',
-  'fi',
-  'if ! PR_JSON=$(gh pr view "$PR_URL" --json reviews,comments,author); then',
-  '  echo "Failed to fetch review evidence for ${PR_URL}" >&2',
-  '  exit 1',
-  'fi',
-  'FORMAL_REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since) | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")] | length\' <<< "$PR_JSON")',
-  'if [ "$FORMAL_REVIEW_COUNT" != "0" ] && [ -n "$FORMAL_REVIEW_COUNT" ]; then',
-  '  jq -n --arg url "$PR_URL" --argjson n "$FORMAL_REVIEW_COUNT" \'{"pr_url":$url,"review_count":$n,"review_evidence":"formal_review"}\'',
-  '  exit 0',
-  'fi',
-  'AUTHOR_LOGIN=$(jq -r \'.author.login // empty\' <<< "$PR_JSON")',
-  'VIEWER_LOGIN=$(gh api user --jq .login 2>/dev/null || true)',
-  'if [ -z "$AUTHOR_LOGIN" ] || [ -z "$VIEWER_LOGIN" ] || [ "$AUTHOR_LOGIN" != "$VIEWER_LOGIN" ]; then',
-  '  echo "No APPROVED or CHANGES_REQUESTED review found on ${PR_URL} since workflow start (${START_ISO}); comment-only evidence is accepted only for own PRs" >&2',
-  '  exit 1',
-  'fi',
-  'COMMENT_REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since) | select(.state == "COMMENTED")] | length\' <<< "$PR_JSON")',
-  'PR_COMMENT_COUNT=$(jq --arg since "$START_ISO" \'[.comments[] | select(.createdAt > $since)] | length\' <<< "$PR_JSON")',
-  'COMMENT_COUNT=$((COMMENT_REVIEW_COUNT + PR_COMMENT_COUNT))',
-  'if [ "$COMMENT_COUNT" = "0" ]; then',
-  '  echo "No review or PR comment found on own PR ${PR_URL} since workflow start (${START_ISO})" >&2',
-  '  exit 1',
-  'fi',
-  'jq -n --arg url "$PR_URL" --argjson n "$COMMENT_COUNT" \'{"pr_url":$url,"review_count":$n,"review_evidence":"own_pr_comment"}\'',
-].join('\n');
-
-/**
  * Reviewer Terminal Action Pre-conditions block.
  *
  * Prepended to every review-style end-node prompt that exposes the terminal
@@ -439,13 +380,13 @@ const PD_PLAN_REVIEW_PROMPT =
   'You are one of four independent Plan Reviewers. Review the plan PR through your lens before ' +
   'tasks are dispatched. Use the Reviewer System Contract for review quality and severity.\n\n' +
   'Plan Review is not the end node: do not call approve_task or submit_for_approval. Your terminal ' +
-  'action is your `approvals` vote on `plan-approval-gate`. Vote approved only for zero P0-P3 ' +
+  'action is your `approvals` vote via the plan-approval hook. Vote approved only for zero P0-P3 ' +
   'lens findings; otherwise vote rejected and send actionable feedback to Planning.\n\n' +
   CODEX_REACTION_APPROVAL_GUIDANCE +
   '\n\n' +
   'Procedure: read `gh pr diff`/`gh pr view`, post a visible PR review comment, then ' +
   'send_message(target="Task Dispatcher", message: "<short summary>", data: { approvals: { "<your lens>": "approved" }, ' +
-  'pr_url: "<plan PR url>" }). First three approvals normally get a gate-blocked response; ' +
+  'pr_url: "<plan PR url>" }). First three approvals normally get a hook-blocked response; ' +
   'the vote is still recorded. On rejection, write `{ "<your lens>": "rejected" }` and also ' +
   'message Planning with required changes.';
 
@@ -538,11 +479,11 @@ const FULLSTACK_REVIEW_PROMPT =
   'maintainability, and coverage before QA. Follow the Reviewer System Contract for ' +
   'review quality and severity.\n\n' +
   'Review is not the end node: approve_task/submit_for_approval are unavailable. Your ' +
-  'terminal hand-off is writing approved = true to review-approval-gate after an ' +
-  'APPROVE verdict with zero P0-P3 findings. Write the gate first to start the 10-minute ' +
-  'Codex timeout, then wait for codex[bot] `+1` or timeout before proceeding. ' +
+  'terminal hand-off is sending a message to QA with `data: { approved: true }` after an ' +
+  'APPROVE verdict with zero P0-P3 findings. The review-approval hook starts the 10-minute ' +
+  'Codex timeout and waits for codex[bot] `+1` or timeout before releasing your message to QA. ' +
   CODEX_REACTION_APPROVAL_GUIDANCE +
-  ' If findings remain, do not write the gate; send actionable feedback to Coding and stop. ' +
+  ' If findings remain, do not send the approval message; send actionable feedback to Coding and stop. ' +
   'Never set a PR to auto-merge.';
 
 const FULLSTACK_QA_PROMPT =
@@ -664,13 +605,14 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               'might not surface (e.g. callers of changed functions, integration points).\n' +
               '- All feedback MUST be posted to the PR on GitHub — not just summarized in your ' +
               'response. Use the Reviewer System Contract GitHub review procedure.\n' +
-              '- The Review → Coding channel is gated by `review-posted-gate` — the runtime ' +
-              'checks GitHub for a fresh review before releasing your message. If you skip ' +
-              '`gh pr review`, the gate will block and the coder will never hear from you.\n\n' +
+              '- The Review → Coding channel has a `review-posted` hook — the runtime ' +
+              'checks for review evidence before releasing your message. Include ' +
+              '`data: { review_url: "..." }` in your message, or save a review artifact first. ' +
+              'If you skip posting the review, the hook will block and the coder will never hear from you.\n\n' +
               reviewerFeedbackProcedure('Coding') +
               'Use save_artifact every cycle. Nest pr_url inside artifact data for post-approval dispatch.\n\n' +
               'Review checklist: inspect PR diff and related worktree context, run tests if uncertain, ' +
-              'post visible GitHub review before gate write. If changes needed, include pr_url, ' +
+              'post visible GitHub review, then message Coding with review_url. If changes needed, include pr_url, ' +
               'review_url, and comment_urls when messaging Coding. If approved, ' +
               REVIEW_THREAD_APPROVAL_CHECK_GUIDANCE +
               ' Call save_artifact({ type: "result", data: { pr_url: "<url>" } }) then approve_task() or submit_for_approval. ' +
@@ -747,35 +689,6 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
       },
       resetOnCycle: true,
     },
-    {
-      id: 'review-posted-gate',
-      label: 'Review Posted',
-      description:
-        'Reviewer has posted a GitHub review or PR comment since the workflow started. ' +
-        'Accepts a formal review (via `gh pr review`) as primary evidence; falls back to ' +
-        'PR conversation comments for same-account setups where GitHub blocks self-reviews. ' +
-        'Blocks the Review → Coding feedback channel until review evidence is visible on the PR.',
-      fields: [
-        {
-          name: 'pr_url',
-          type: 'string',
-          writers: ['Review'],
-          check: { op: 'exists' },
-        },
-        {
-          name: 'review_url',
-          type: 'string',
-          writers: ['Review'],
-          check: { op: 'exists' },
-        },
-      ],
-      script: {
-        interpreter: 'bash',
-        source: REVIEW_POSTED_BASH_SCRIPT,
-        timeoutMs: 30000,
-      },
-      resetOnCycle: true,
-    },
   ],
   channels: [
     {
@@ -800,9 +713,21 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Review',
       to: 'Coding',
-      gateId: 'review-posted-gate',
       maxCycles: 5,
       label: 'Review → Coding (changes requested)',
+    },
+  ],
+  hooks: [
+    {
+      id: 'review-posted-hook',
+      enabled: true,
+      sourceNode: 'Review',
+      targetNode: 'Coding',
+      method: 'send_message',
+      classification: 'validation',
+      validator: { kind: 'built_in', id: 'review_posted' },
+      authorizedCallers: [{ sourceNode: 'Review', agentSlots: ['reviewer'] }],
+      label: 'Review Posted',
     },
   ],
 };
@@ -982,7 +907,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
  *
  * Main progression:
  *   Planning → Plan Review (plan-pr-gate: script verifies plan PR is open/mergeable)
- *   Plan Review → Task Dispatcher (plan-approval-gate: all 4 reviewers approve)
+ *   Plan Review → Task Dispatcher (plan-approval hook: all 4 reviewers approve)
  *
  * Cyclic feedback:
  *   Plan Review → Planning (revision requests, maxCycles: 5)
@@ -1053,9 +978,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
               'items, long-term maintainability, and whether the decomposition will hold up as ' +
               'the system grows. Flag items that smuggle unrelated concerns together or create ' +
               'hidden cross-cutting dependencies.\n\n' +
-              'When voting, your lens key is `"architecture"` — write ' +
-              '`data: { approvals: { architecture: "approved" } }` (or `"rejected"`) on the ' +
-              '`plan-approval-gate`.',
+              'When voting, your lens key is `"architecture"` — send a message to Task Dispatcher ' +
+              'with `data: { approvals: { architecture: "approved" } }` (or `"rejected"`). ' +
+              'The plan-approval hook accumulates votes and blocks until all 4 reviewers approve.',
           },
         },
         {
@@ -1069,9 +994,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
               'authentication/authorization, secrets handling, and supply-chain risk for any ' +
               'new dependencies. Flag items that expose user data, bypass existing auth checks, ' +
               'or rely on untrusted input without validation.\n\n' +
-              'When voting, your lens key is `"security"` — write ' +
-              '`data: { approvals: { security: "approved" } }` (or `"rejected"`) on the ' +
-              '`plan-approval-gate`.',
+              'When voting, your lens key is `"security"` — send a message to Task Dispatcher ' +
+              'with `data: { approvals: { security: "approved" } }` (or `"rejected"`). ' +
+              'The plan-approval hook accumulates votes and blocks until all 4 reviewers approve.',
           },
         },
         {
@@ -1085,9 +1010,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
               'consistency across failures, idempotency, and race conditions. Flag items ' +
               'whose acceptance criteria are vague, whose failure modes are unclear, or ' +
               'whose tests would not catch the obvious regressions.\n\n' +
-              'When voting, your lens key is `"correctness"` — write ' +
-              '`data: { approvals: { correctness: "approved" } }` (or `"rejected"`) on the ' +
-              '`plan-approval-gate`.',
+              'When voting, your lens key is `"correctness"` — send a message to Task Dispatcher ' +
+              'with `data: { approvals: { correctness: "approved" } }` (or `"rejected"`). ' +
+              'The plan-approval hook accumulates votes and blocks until all 4 reviewers approve.',
           },
         },
         {
@@ -1101,9 +1026,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
               'documentation, error messages, and upgrade/migration experience for ' +
               'existing users. Flag items that change public interfaces without describing ' +
               'what users will see or how docs will be updated.\n\n' +
-              'When voting, your lens key is `"ux"` — write ' +
-              '`data: { approvals: { ux: "approved" } }` (or `"rejected"`) on the ' +
-              '`plan-approval-gate`.',
+              'When voting, your lens key is `"ux"` — send a message to Task Dispatcher ' +
+              'with `data: { approvals: { ux: "approved" } }` (or `"rejected"`). ' +
+              'The plan-approval hook accumulates votes and blocks until all 4 reviewers approve.',
           },
         },
       ],
@@ -1119,8 +1044,8 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
             value:
               PD_TASK_DISPATCHER_PROMPT +
               '\n\n' +
-              'Expected inputs: An approved plan PR (plan-approval-gate satisfied — all 4 ' +
-              'reviewers voted `approved: true`).\n' +
+              'Expected inputs: An approved plan PR (plan-approval hook satisfied — all 4 ' +
+              'reviewers voted `approved`).\n' +
               'Expected outputs: One standalone task per actionable work item in the plan, ' +
               'then save_artifact({ type: "result", append: true, created_task_ids: [...] }).\n\n' +
               'Tool contract:\n' +
@@ -1154,28 +1079,6 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
       poll: PR_INLINE_COMMENTS_POLL,
       resetOnCycle: true,
     },
-    {
-      id: 'plan-approval-gate',
-      label: 'Plan Approvals',
-      description:
-        'All four Plan Reviewers must approve the plan before Task Dispatcher activates. ' +
-        'Each reviewer writes to the `approvals` map with their lens name as the key ' +
-        '(architecture, security, correctness, ux) and the string `"approved"` as the ' +
-        "value. The auto-gate-write deep-merges map fields, so each reviewer's entry " +
-        'accumulates without overwriting earlier votes. Gate passes when ≥ 4 entries ' +
-        'have value `"approved"`. Note: `resetOnCycle: true` means all approvals are ' +
-        'cleared when Plan Review→Planning revision feedback fires — fresh votes are ' +
-        'collected after each plan revision because the plan diff has changed.',
-      fields: [
-        {
-          name: 'approvals',
-          type: 'map',
-          writers: ['Plan Review'],
-          check: { op: 'count', match: 'approved', min: 4 },
-        },
-      ],
-      resetOnCycle: true,
-    },
   ],
   channels: [
     {
@@ -1187,7 +1090,6 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Plan Review',
       to: 'Task Dispatcher',
-      gateId: 'plan-approval-gate',
       label: 'Plan Review → Task Dispatcher',
     },
     {
@@ -1195,6 +1097,30 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
       to: 'Planning',
       maxCycles: 5,
       label: 'Plan Review → Planning (revision requested)',
+    },
+  ],
+  hooks: [
+    {
+      id: 'plan-approval-hook',
+      enabled: true,
+      sourceNode: 'Plan Review',
+      targetNode: 'Task Dispatcher',
+      method: 'send_message',
+      classification: 'validation',
+      validator: { kind: 'built_in', id: 'review_approval' },
+      templateData: {
+        threshold: 4,
+        voteKey: 'approvals',
+        voteMatch: 'approved',
+        resetOnRejection: true,
+      },
+      authorizedCallers: [
+        { sourceNode: 'Plan Review', agentSlots: ['architecture-reviewer'] },
+        { sourceNode: 'Plan Review', agentSlots: ['security-reviewer'] },
+        { sourceNode: 'Plan Review', agentSlots: ['correctness-reviewer'] },
+        { sourceNode: 'Plan Review', agentSlots: ['ux-reviewer'] },
+      ],
+      label: 'Plan Approval',
     },
   ],
 };
@@ -1207,7 +1133,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
  *
  * Main progression:
  *   Coding → Review (code-pr-gate: script verifies PR is open/mergeable)
- *   Review → QA (review-approval-gate: reviewer approves)
+ *   Review → QA (review-approval hook: reviewer approves)
  *
  * Feedback cycles:
  *   Review → Coding (changes requested)
@@ -1261,10 +1187,10 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
               FULLSTACK_REVIEW_PROMPT +
               '\n\n' +
               'Expected inputs: Open PR from Coding.\n' +
-              'Expected outputs: Approval gate write or actionable feedback.\n\n' +
+              'Expected outputs: Approval message to QA or actionable feedback to Coding.\n\n' +
               'Steps:\n' +
               '1. Review diff quality, correctness, and test coverage\n' +
-              '2. If approved: write review-approval-gate (field: approved = true) to start the 10-minute Codex timeout, then wait for codex[bot] +1 or timeout\n' +
+              '2. If approved: send a message to QA with `data: { approved: true }`. The review-approval hook starts the 10-minute Codex timeout and waits for codex[bot] +1 or timeout before releasing your message to QA.\n' +
               '3. If changes needed: send clear feedback to Coding',
           },
         },
@@ -1344,20 +1270,6 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
       poll: PR_INLINE_COMMENTS_POLL,
       resetOnCycle: true,
     },
-    {
-      id: 'review-approval-gate',
-      label: 'Review',
-      description: 'Reviewer approved the PR for QA and codex[bot] review passed or timed out.',
-      fields: [
-        {
-          name: 'approved',
-          type: 'boolean',
-          writers: ['Review', 'reviewer'],
-          check: { op: '==', value: true },
-        },
-      ],
-      resetOnCycle: true,
-    },
   ],
   layout: {
     [FULLSTACK_CODING_NODE]: { x: 80, y: 160 },
@@ -1374,7 +1286,6 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
     {
       from: 'Review',
       to: 'QA',
-      gateId: 'review-approval-gate',
       label: 'Review → QA',
     },
     {
@@ -1388,6 +1299,20 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
       to: 'Coding',
       maxCycles: 6,
       label: 'QA → Coding (issues found)',
+    },
+  ],
+  hooks: [
+    {
+      id: 'review-approval-hook',
+      enabled: true,
+      sourceNode: 'Review',
+      targetNode: 'QA',
+      method: 'send_message',
+      classification: 'validation',
+      validator: { kind: 'built_in', id: 'review_approval' },
+      templateData: { threshold: 1, requireCodex: true, codexTimeoutMs: 600_000 },
+      authorizedCallers: [{ sourceNode: 'Review', agentSlots: ['reviewer'] }],
+      label: 'Review Approval',
     },
   ],
 };
@@ -1693,6 +1618,60 @@ function remapTemplateChannel(
   };
 }
 
+function remapTemplateHook(
+  hook: NonNullable<SpaceWorkflow['hooks']>[number],
+  templateNodes: WorkflowNode[],
+  existingNodes: WorkflowNode[]
+): NonNullable<SpaceWorkflow['hooks']>[number] {
+  const remapRef = (ref: string) => remapTemplateChannelRef(ref, templateNodes, existingNodes);
+  return {
+    ...hook,
+    sourceNode: remapRef(hook.sourceNode),
+    targetNode: hook.targetNode ? remapRef(hook.targetNode) : undefined,
+    authorizedCallers: hook.authorizedCallers?.map((caller) => ({
+      ...caller,
+      sourceNode: remapRef(caller.sourceNode),
+    })),
+  };
+}
+
+function mergeHooksFromTemplate(
+  existingHooks: SpaceWorkflow['hooks'],
+  templateHooks: SpaceWorkflow['hooks'],
+  templateNodes: WorkflowNode[],
+  existingNodes: WorkflowNode[]
+): SpaceWorkflow['hooks'] {
+  if (!templateHooks) return existingHooks;
+  const remappedTemplateHooks = templateHooks.map((hook) =>
+    remapTemplateHook(hook, templateNodes, existingNodes)
+  );
+  if (!existingHooks) return remappedTemplateHooks;
+
+  const existingKeys = new Set(
+    existingHooks.map((hook) =>
+      JSON.stringify({
+        id: hook.id,
+        sourceNode: hook.sourceNode,
+        targetNode: hook.targetNode ?? null,
+        method: hook.method,
+      })
+    )
+  );
+  const missingTemplateHooks = remappedTemplateHooks.filter(
+    (hook) =>
+      !existingKeys.has(
+        JSON.stringify({
+          id: hook.id,
+          sourceNode: hook.sourceNode,
+          targetNode: hook.targetNode ?? null,
+          method: hook.method,
+        })
+      )
+  );
+
+  return [...existingHooks, ...missingTemplateHooks];
+}
+
 function mergeChannelsFromTemplate(
   existingChannels: SpaceWorkflow['channels'],
   templateChannels: SpaceWorkflow['channels'],
@@ -1883,12 +1862,19 @@ export function seedBuiltInWorkflows(
           row.nodes
         );
         const mergedGates = mergeGateStructuralFieldsFromTemplate(row.gates, template.gates);
+        const mergedHooks = mergeHooksFromTemplate(
+          row.hooks,
+          template.hooks,
+          template.nodes,
+          row.nodes
+        );
         const { nodes: migratedNodes, gates: migratedGates } = migrateCodexFeatureToNodeToggle(
           mergedNodes,
           mergedChannels ?? row.channels ?? [],
           mergedGates ?? row.gates ?? []
         );
         const hasNewTemplateChannels = (mergedChannels?.length ?? 0) > (row.channels?.length ?? 0);
+        const hasNewTemplateHooks = (mergedHooks?.length ?? 0) > (row.hooks?.length ?? 0);
 
         workflowManager.updateWorkflow(row.id, {
           completionAutonomyLevel: template.completionAutonomyLevel,
@@ -1896,9 +1882,10 @@ export function seedBuiltInWorkflows(
           // workflow-level value while the node updater writes node routes.
           postApproval: null,
           gates: migratedGates,
-          hooks: template.hooks ?? null,
+          hooks: mergedHooks ?? null,
           nodes: migratedNodes,
           ...(hasNewTemplateChannels ? { channels: mergedChannels } : {}),
+          ...(hasNewTemplateHooks ? { hooks: mergedHooks } : {}),
           templateHash: expectedHash,
         });
         restamped.push(template.name);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1113,6 +1113,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
         voteKey: 'approvals',
         voteMatch: 'approved',
         resetOnRejection: true,
+        requireCodex: true,
       },
       authorizedCallers: [
         { sourceNode: 'Plan Review', agentSlots: ['architecture-reviewer'] },

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1113,6 +1113,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
         threshold: 4,
         voteKey: 'approvals',
         voteMatch: 'approved',
+        voteBinding: 'agent_lens',
         resetOnRejection: true,
         requireCodex: true,
       },
@@ -1505,10 +1506,21 @@ export function mergeNodeStructuralFieldsFromTemplate(
         : node.codexPollIntervalMs,
       agents: node.agents.map((agent) => {
         const key = `${node.name}::${agent.name}`;
+        const templateAgent = templateNode?.agents.find((a) => a.name === agent.name);
         const templateGuards = templateAgentsByKey.get(key);
-        if (templateGuards === undefined) return agent;
-        // Merge: overwrite toolGuards from template, keep everything else
-        return { ...agent, toolGuards: templateGuards };
+        const shouldRefreshPrompt =
+          templateAgent?.customPrompt &&
+          typeof agent.customPrompt?.value === 'string' &&
+          (agent.customPrompt.value.includes('review-approval-gate') ||
+            agent.customPrompt.value.includes('plan-approval-gate'));
+        if (templateGuards === undefined && !shouldRefreshPrompt) return agent;
+        // Merge: overwrite toolGuards from template and refresh only prompts that
+        // still reference removed approval gates from the hook migration.
+        return {
+          ...agent,
+          ...(shouldRefreshPrompt ? { customPrompt: templateAgent.customPrompt } : {}),
+          ...(templateGuards !== undefined ? { toolGuards: templateGuards } : {}),
+        };
       }),
     };
   });
@@ -1754,10 +1766,15 @@ export function mergeChannelsFromTemplate(
     const to = Array.isArray(ch.to) && ch.to.length === 1 ? ch.to[0] : ch.to;
     return JSON.stringify({ from: ch.from, to });
   };
+  const existingByFromTo = new Map(existingChannels.map((ch) => [fromToKey(ch), ch]));
   const templateFromTo = new Set(remappedTemplateChannels.map(fromToKey));
   const keptExisting = existingChannels.filter((ch) => !templateFromTo.has(fromToKey(ch)));
+  const replacementChannels = remappedTemplateChannels.map((channel) => {
+    const existing = existingByFromTo.get(fromToKey(channel));
+    return { ...channel, id: channel.id ?? existing?.id ?? generateUUID() };
+  });
 
-  return [...keptExisting, ...remappedTemplateChannels];
+  return [...keptExisting, ...replacementChannels];
 }
 
 /**

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1122,6 +1122,21 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
       ],
       label: 'Plan Approval',
     },
+    {
+      id: 'plan-approval-reset-hook',
+      enabled: true,
+      sourceNode: 'Plan Review',
+      targetNode: 'Planning',
+      method: 'send_message',
+      classification: 'side_effect',
+      validator: {
+        kind: 'script',
+        interpreter: 'bash',
+        source: 'echo \'{"type":"record_state","state":{"approvals":null}}\'',
+      },
+      authorizedCallers: [{ sourceNode: 'Plan Review' }],
+      label: 'Plan Approval Reset',
+    },
   ],
 };
 
@@ -1313,6 +1328,38 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
       templateData: { threshold: 1, requireCodex: true, codexTimeoutMs: 600_000 },
       authorizedCallers: [{ sourceNode: 'Review', agentSlots: ['reviewer'] }],
       label: 'Review Approval',
+    },
+    {
+      id: 'review-approval-reset-hook',
+      enabled: true,
+      sourceNode: 'Review',
+      targetNode: 'Coding',
+      method: 'send_message',
+      classification: 'side_effect',
+      validator: {
+        kind: 'script',
+        interpreter: 'bash',
+        source:
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null}}\'',
+      },
+      authorizedCallers: [{ sourceNode: 'Review' }],
+      label: 'Review Approval Reset',
+    },
+    {
+      id: 'qa-approval-reset-hook',
+      enabled: true,
+      sourceNode: 'QA',
+      targetNode: 'Coding',
+      method: 'send_message',
+      classification: 'side_effect',
+      validator: {
+        kind: 'script',
+        interpreter: 'bash',
+        source:
+          'echo \'{"type":"record_state","state":{"approvals":null,"_codex_started_at":null}}\'',
+      },
+      authorizedCallers: [{ sourceNode: 'QA' }],
+      label: 'QA Approval Reset',
     },
   ],
 };
@@ -1874,7 +1921,6 @@ export function seedBuiltInWorkflows(
           mergedGates ?? row.gates ?? []
         );
         const hasNewTemplateChannels = (mergedChannels?.length ?? 0) > (row.channels?.length ?? 0);
-        const hasNewTemplateHooks = (mergedHooks?.length ?? 0) > (row.hooks?.length ?? 0);
 
         workflowManager.updateWorkflow(row.id, {
           completionAutonomyLevel: template.completionAutonomyLevel,
@@ -1882,10 +1928,9 @@ export function seedBuiltInWorkflows(
           // workflow-level value while the node updater writes node routes.
           postApproval: null,
           gates: migratedGates,
-          hooks: mergedHooks ?? null,
           nodes: migratedNodes,
+          hooks: mergedHooks ?? null,
           ...(hasNewTemplateChannels ? { channels: mergedChannels } : {}),
-          ...(hasNewTemplateHooks ? { hooks: mergedHooks } : {}),
           templateHash: expectedHash,
         });
         restamped.push(template.name);

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -28,7 +28,7 @@ function makeCtx(overrides: Partial<HookExecutorContext> = {}): HookExecutorCont
 }
 
 describe('reviewApprovalValidator', () => {
-  test('blocks and records vote when threshold not met', async () => {
+  test('retry-blocks and records vote when threshold not met', async () => {
     const ctx = makeCtx({
       params: { data: { approvals: { arch: 'approved' } } },
       templateData: { threshold: 2 },
@@ -36,7 +36,7 @@ describe('reviewApprovalValidator', () => {
 
     const result = await reviewApprovalValidator(ctx);
 
-    expect(result.type).toBe('block');
+    expect(result.type).toBe('retryable_block');
     expect((result as { reason: string }).reason).toContain('1/2');
     expect((result as { state?: Record<string, unknown> }).state).toEqual({
       approvals: { arch: 'approved' },
@@ -65,7 +65,7 @@ describe('reviewApprovalValidator', () => {
 
     const result = await reviewApprovalValidator(ctx);
 
-    expect(result.type).toBe('block');
+    expect(result.type).toBe('retryable_block');
     const state = (result as { state?: Record<string, unknown> }).state;
     expect(state?.approvals).toEqual({
       arch: 'approved',
@@ -102,7 +102,7 @@ describe('reviewApprovalValidator', () => {
 
     const result = await reviewApprovalValidator(ctx);
 
-    expect(result.type).toBe('block');
+    expect(result.type).toBe('retryable_block');
     const state = (result as { state?: Record<string, unknown> }).state;
     expect(state?.approvals).toEqual({
       arch: 'rejected',
@@ -131,7 +131,7 @@ describe('reviewApprovalValidator', () => {
 
     const result = await reviewApprovalValidator(ctx);
 
-    expect(result.type).toBe('block');
+    expect(result.type).toBe('retryable_block');
     expect((result as { reason: string }).reason).toContain('2/3');
   });
 
@@ -418,7 +418,7 @@ describe('reviewApprovalValidator', () => {
     expect(state?._codex_started_at).toBeTypeOf('number');
   });
 
-  test('persists partial votes even when blocked', async () => {
+  test('persists partial votes even when retry-blocked', async () => {
     const ctx = makeCtx({
       params: { data: { approvals: { a: 'approved' } } },
       hookLocalState: {},
@@ -427,7 +427,7 @@ describe('reviewApprovalValidator', () => {
 
     const result = await reviewApprovalValidator(ctx);
 
-    expect(result.type).toBe('block');
+    expect(result.type).toBe('retryable_block');
     expect((result as { state?: Record<string, unknown> }).state).toEqual({
       approvals: { a: 'approved' },
     });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -175,11 +175,39 @@ describe('reviewApprovalValidator', () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
     process.env.GITHUB_TOKEN = 'test-token';
-    globalThis.fetch = async () =>
-      ({
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
         ok: true,
-        json: async () => [{ user: { login: 'codex[bot]' }, content: '+1' }],
-      }) as Response;
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reactions: { nodes: [] },
+                comments: {
+                  nodes: [
+                    {
+                      reactions: {
+                        nodes: [{ user: { login: 'codex[bot]' }, content: '+1' }],
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
 
     const ctx = makeCtx({
       params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -422,4 +422,63 @@ describe('reviewApprovalValidator', () => {
 
     expect(requestedUrl).toBe('https://github.enterprise.com/api/graphql');
   });
+
+  test('finds pr_url in gate data when not in message data or artifacts', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                reactions: { nodes: [] },
+                comments: {
+                  nodes: [
+                    {
+                      reactions: {
+                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/42' },
+          updatedAt: Date.now(),
+        },
+      ],
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('codex approval');
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -265,6 +265,49 @@ describe('reviewApprovalValidator', () => {
     expect(state?._codex_head_sha).toBe('abc123');
   });
 
+  test('uses head baseline after reset when codex approval is already fresh', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-02T00:00:00Z',
+                    },
+                  ],
+                },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: { _codex_started_at: null, _codex_head_sha: null },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
   test('finds codex approval on later issue comment pages', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -301,6 +344,85 @@ describe('reviewApprovalValidator', () => {
                         pageInfo: { hasNextPage: false },
                       },
                 reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(callCount).toBe(2);
+  });
+
+  test('finds codex approval after first 100 comments in a review thread', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let callCount = 0;
+    globalThis.fetch = async (_url, init) => {
+      callCount += 1;
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      if (query.includes('node(id:$threadId)')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              node: {
+                comments: {
+                  nodes: [
+                    {
+                      reactions: {
+                        nodes: [
+                          {
+                            user: { login: 'chatgpt-codex-connector[bot]' },
+                            content: 'THUMBS_UP',
+                            createdAt: '2026-01-02T00:00:00Z',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                reactions: { nodes: [] },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'thread-1',
+                      comments: {
+                        nodes: [],
+                        pageInfo: { hasNextPage: true, endCursor: 'thread-comment-cursor' },
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
               },
             },
           },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -86,7 +86,7 @@ describe('reviewApprovalValidator', () => {
     expect(result.type).toBe('block');
     expect((result as { reason: string }).reason).toContain('rejected');
     expect((result as { state?: Record<string, unknown> }).state).toEqual({
-      approvals: {},
+      approvals: null,
     });
   });
 
@@ -172,13 +172,23 @@ describe('reviewApprovalValidator', () => {
   });
 
   test('allows immediately when codex already approved', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => [{ user: { login: 'codex[bot]' }, content: '+1' }],
+      }) as Response;
+
     const ctx = makeCtx({
-      params: { data: { approved: true } },
-      hookLocalState: { approvals: { _codex_status: 'approved' } },
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
       templateData: { threshold: 1, requireCodex: true },
     });
 
     const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('codex approval');

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -87,6 +87,9 @@ describe('reviewApprovalValidator', () => {
     expect((result as { reason: string }).reason).toContain('rejected');
     expect((result as { state?: Record<string, unknown> }).state).toEqual({
       approvals: null,
+      _codex_started_at: null,
+      _codex_head_sha: null,
+      _pr_url: null,
     });
   });
 

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -223,6 +223,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2025-12-31T00:00:00Z' } },
                 updatedAt: '2025-12-31T00:00:00Z',
                 reactions: {
                   nodes: [
@@ -302,7 +303,7 @@ describe('reviewApprovalValidator', () => {
     expect(state?._codex_head_sha).toBe('abc123');
   });
 
-  test('uses PR update baseline instead of commit timestamp for first-cycle codex freshness', async () => {
+  test('uses head commit baseline instead of PR activity for first-cycle codex freshness', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
     process.env.GITHUB_TOKEN = 'test-token';
@@ -314,6 +315,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 updatedAt: '2026-01-03T00:00:00Z',
                 reactions: {
                   nodes: [
@@ -342,8 +344,7 @@ describe('reviewApprovalValidator', () => {
     globalThis.fetch = originalFetch;
     process.env.GITHUB_TOKEN = originalToken;
 
-    expect(result.type).toBe('retryable_block');
-    expect((result as { reason?: string }).reason).toContain('codex');
+    expect(result.type).toBe('allow');
   });
 
   test('floors codex wait start to GitHub timestamp precision', async () => {
@@ -375,6 +376,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 updatedAt: '2026-01-01T00:00:00Z',
                 reactions: {
                   nodes: [
@@ -420,6 +422,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 updatedAt: '2026-01-01T00:00:00Z',
                 reactions: { nodes: [] },
                 comments:
@@ -506,6 +509,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 updatedAt: '2026-01-01T00:00:00Z',
                 reactions: { nodes: [] },
                 comments: { nodes: [], pageInfo: { hasNextPage: false } },
@@ -748,6 +752,7 @@ describe('reviewApprovalValidator', () => {
               pullRequest: {
                 id: 'pr-node',
                 headRefOid: 'abc123',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 updatedAt: '2026-01-01T00:00:00Z',
                 reactions: {
                   nodes: [],
@@ -798,7 +803,7 @@ describe('reviewApprovalValidator', () => {
               pullRequest: {
                 id: 'pr-node',
                 headRefOid: 'new-sha-456',
-                updatedAt: '2026-01-01T00:00:00Z',
+                headRef: { target: { committedDate: '2026-01-01T00:00:00Z' } },
                 reactions: {
                   nodes: [
                     {
@@ -832,6 +837,57 @@ describe('reviewApprovalValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
+  });
+
+  test('resets codex timer before accepting stale approval from previous PR head', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                id: 'pr-node',
+                headRefOid: 'new-sha-456',
+                headRef: { target: { committedDate: '2026-01-03T00:00:00Z' } },
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-02T00:00:00Z',
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {
+        _codex_started_at: Date.parse('2026-01-01T00:00:00Z'),
+        _codex_head_sha: 'old-sha-123',
+      },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_head_sha).toBe('new-sha-456');
+    expect((result as { reason: string }).reason).toContain('New PR revision');
   });
 
   test('resets codex timer when PR head SHA changes', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -196,7 +196,7 @@ describe('reviewApprovalValidator', () => {
                   nodes: [
                     {
                       reactions: {
-                        nodes: [{ user: { login: 'codex[bot]' }, content: '+1' }],
+                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
                       },
                     },
                   ],
@@ -220,6 +220,92 @@ describe('reviewApprovalValidator', () => {
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
+  test('finds pr_url in artifacts when not in message data', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reactions: { nodes: [] },
+                comments: {
+                  nodes: [
+                    {
+                      reactions: {
+                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                      },
+                    },
+                  ],
+                },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      currentArtifacts: [
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'result',
+          key: 'cycle-0',
+          data: { pr_url: 'https://github.com/test/repo/pull/42' },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
+  test('starts codex timeout on API error so timeout can eventually allow', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: false,
+        status: 500,
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_started_at).toBeTypeOf('number');
   });
 
   test('persists partial votes even when blocked', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -673,6 +673,130 @@ describe('reviewApprovalValidator', () => {
     });
   });
 
+  test('finds codex approval on later reaction pages', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let callCount = 0;
+    globalThis.fetch = async (_url, init) => {
+      callCount += 1;
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      if (query.includes('node(id:$nodeId)')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              node: {
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-02T00:00:00Z',
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                id: 'pr-node',
+                headRefOid: 'abc123',
+                updatedAt: '2026-01-01T00:00:00Z',
+                reactions: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: true, endCursor: 'reaction-cursor' },
+                },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(callCount).toBe(2);
+  });
+
+  test('allows fresh codex approval when PR head SHA changes', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                id: 'pr-node',
+                headRefOid: 'new-sha-456',
+                updatedAt: '2026-01-01T00:00:00Z',
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-02T00:00:00Z',
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {
+        _codex_started_at: Date.parse('2026-01-01T00:00:00Z'),
+        _codex_head_sha: 'old-sha-123',
+      },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
   test('resets codex timer when PR head SHA changes', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -693,18 +817,12 @@ describe('reviewApprovalValidator', () => {
           data: {
             repository: {
               pullRequest: {
+                id: 'pr-node',
                 headRefOid: 'new-sha-456',
-                reactions: {
-                  nodes: [
-                    {
-                      user: { login: 'codex[bot]' },
-                      content: 'THUMBS_UP',
-                      createdAt: '2999-01-01T00:00:00Z',
-                    },
-                  ],
-                },
-                comments: { nodes: [] },
-                reviewThreads: { nodes: [] },
+                updatedAt: '3000-01-01T00:00:00Z',
+                reactions: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
               },
             },
           },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for reviewApprovalValidator.
+ *
+ * Covers: vote extraction, threshold activation, concurrent vote deep-merge,
+ * rejection reset, codex timeout, and boolean/map vote styles.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { reviewApprovalValidator } from '../../../../../src/lib/space/runtime/built-in-validators/review-approval-validator';
+import type { HookExecutorContext } from '../../../../../src/lib/space/runtime/hook-executor';
+
+function makeCtx(overrides: Partial<HookExecutorContext> = {}): HookExecutorContext {
+  return {
+    workspacePath: '/tmp',
+    runId: 'run-1',
+    hookId: 'hook-1',
+    methodName: 'send_message',
+    params: {},
+    nodeId: 'node-review',
+    nodeName: 'Review',
+    sessionId: 'sess-1',
+    taskId: 'task-1',
+    hookLocalState: {},
+    currentArtifacts: [],
+    permittedExternalLookups: [],
+    ...overrides,
+  };
+}
+
+describe('reviewApprovalValidator', () => {
+  test('blocks and records vote when threshold not met', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { arch: 'approved' } } },
+      templateData: { threshold: 2 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('1/2');
+    expect((result as { state?: Record<string, unknown> }).state).toEqual({
+      approvals: { arch: 'approved' },
+    });
+  });
+
+  test('allows when threshold is met', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { sec: 'approved' } } },
+      hookLocalState: { approvals: { arch: 'approved' } },
+      templateData: { threshold: 2 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('2/2');
+  });
+
+  test('deep-merges votes without overwriting prior entries', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { ux: 'approved' } } },
+      hookLocalState: { approvals: { arch: 'approved', sec: 'approved' } },
+      templateData: { threshold: 4 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?.approvals).toEqual({
+      arch: 'approved',
+      sec: 'approved',
+      ux: 'approved',
+    });
+  });
+
+  test('resets state on rejection when resetOnRejection is true', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { arch: 'rejected' } } },
+      hookLocalState: { approvals: { sec: 'approved', ux: 'approved' } },
+      templateData: { threshold: 4, resetOnRejection: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('rejected');
+    expect((result as { state?: Record<string, unknown> }).state).toEqual({
+      approvals: {},
+    });
+  });
+
+  test('does not reset on rejection when resetOnRejection is false', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { arch: 'rejected' } } },
+      hookLocalState: { approvals: { sec: 'approved' } },
+      templateData: { threshold: 4, resetOnRejection: false },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?.approvals).toEqual({
+      arch: 'rejected',
+      sec: 'approved',
+    });
+  });
+
+  test('handles boolean-style approval', async () => {
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      templateData: { threshold: 1 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('1/1');
+  });
+
+  test('counts only matching vote values', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { arch: 'approved', sec: 'pending' } } },
+      hookLocalState: { approvals: { ux: 'approved' } },
+      templateData: { threshold: 3 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('2/3');
+  });
+
+  test('uses templateData defaults when unspecified', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { arch: 'approved' } } },
+      // no templateData → threshold 1, voteKey 'approvals', voteMatch 'approved'
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('allow');
+  });
+
+  test('starts codex timeout on first threshold hit', async () => {
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('retryable_block');
+    expect((result as { reason: string }).reason).toContain('codex');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_started_at).toBeTypeOf('number');
+  });
+
+  test('allows after codex timeout elapsed', async () => {
+    const now = Date.now();
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      hookLocalState: { _codex_started_at: now - 700_000 }, // 700s ago, timeout 600s
+      templateData: { threshold: 1, requireCodex: true, codexTimeoutMs: 600_000 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('timed out');
+  });
+
+  test('allows immediately when codex already approved', async () => {
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      hookLocalState: { approvals: { _codex_status: 'approved' } },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
+  test('persists partial votes even when blocked', async () => {
+    const ctx = makeCtx({
+      params: { data: { approvals: { a: 'approved' } } },
+      hookLocalState: {},
+      templateData: { threshold: 3 },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { state?: Record<string, unknown> }).state).toEqual({
+      approvals: { a: 'approved' },
+    });
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -174,6 +174,49 @@ describe('reviewApprovalValidator', () => {
     expect((result as { message?: string }).message).toContain('timed out');
   });
 
+  test('accepts codex approval already posted for current head before threshold vote', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-01T00:00:00Z',
+                    },
+                  ],
+                },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
   test('allows immediately when codex already approved', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -560,7 +603,7 @@ describe('reviewApprovalValidator', () => {
     // After reset, _codex_head_sha is null (no storedHeadSha)
     const ctx = makeCtx({
       params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
-      hookLocalState: { _codex_started_at: Date.now() - 10_000 },
+      hookLocalState: { _codex_started_at: null, _codex_head_sha: null },
       templateData: { threshold: 1, requireCodex: true },
     });
 

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -212,6 +212,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: { _codex_head_sha: 'abc123' },
       templateData: { threshold: 1, requireCodex: true },
     });
 
@@ -264,6 +265,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true } },
+      hookLocalState: { _codex_head_sha: 'abc123' },
       currentArtifacts: [
         {
           id: 'a1',
@@ -379,7 +381,9 @@ describe('reviewApprovalValidator', () => {
   test('uses enterprise GraphQL endpoint for non-github.com hosts', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
+    const originalGhHost = process.env.GH_HOST;
     process.env.GITHUB_TOKEN = 'test-token';
+    process.env.GH_HOST = 'github.enterprise.com';
     let requestedUrl = '';
     globalThis.fetch = async (url, init) => {
       requestedUrl = url as string;
@@ -413,12 +417,14 @@ describe('reviewApprovalValidator', () => {
       params: {
         data: { approved: true, pr_url: 'https://github.enterprise.com/org/repo/pull/42' },
       },
+      hookLocalState: { _codex_head_sha: 'ent-sha-789' },
       templateData: { threshold: 1, requireCodex: true },
     });
 
     await reviewApprovalValidator(ctx);
     globalThis.fetch = originalFetch;
     process.env.GITHUB_TOKEN = originalToken;
+    process.env.GH_HOST = originalGhHost;
 
     expect(requestedUrl).toBe('https://github.enterprise.com/api/graphql');
   });
@@ -464,6 +470,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true } },
+      hookLocalState: { _codex_head_sha: 'abc123' },
       gateData: [
         {
           gateId: 'code-pr-gate',
@@ -480,5 +487,148 @@ describe('reviewApprovalValidator', () => {
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
+  test('records head SHA and blocks after reset when stale codex exists', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'sha-after-reset',
+                reactions: {
+                  nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    // After reset, _codex_head_sha is null (no storedHeadSha)
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: { _codex_started_at: Date.now() - 10_000 },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    // Should NOT allow even though codex thumbs-up exists — SHA was reset
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_head_sha).toBe('sha-after-reset');
+    expect((result as { reason: string }).reason).toContain('reset');
+  });
+
+  test('rejects untrusted host for codex lookup', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return { ok: false, status: 403 } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { approved: true, pr_url: 'https://attacker.example/org/repo/pull/1' },
+      },
+      hookLocalState: { _codex_head_sha: 'abc123' },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    // Should NOT make any API call and should block
+    expect(fetchCalled).toBe(false);
+    expect(result.type).toBe('retryable_block');
+  });
+
+  test('prefers gate data pr_url over stale artifact pr_url', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let queriedRepo = '';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      queriedRepo = `${body.variables.owner}/${body.variables.name}`;
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                reactions: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      hookLocalState: { _codex_head_sha: 'abc123' },
+      currentArtifacts: [
+        {
+          id: 'old-artifact',
+          nodeId: 'node-coding',
+          type: 'result',
+          key: 'old',
+          data: { pr_url: 'https://github.com/old/repo/pull/99' },
+          createdAt: Date.now() - 100_000,
+          updatedAt: Date.now() - 100_000,
+        },
+      ],
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/new/repo/pull/42' },
+          updatedAt: Date.now(),
+        },
+      ],
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    // Should query the gate data URL (new/repo), not the artifact URL (old/repo)
+    expect(queriedRepo).toBe('new/repo');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -265,6 +265,63 @@ describe('reviewApprovalValidator', () => {
     expect(state?._codex_head_sha).toBe('abc123');
   });
 
+  test('finds codex approval on later issue comment pages', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                reactions: { nodes: [] },
+                comments:
+                  callCount === 1
+                    ? { nodes: [], pageInfo: { hasNextPage: true, endCursor: 'comment-cursor' } }
+                    : {
+                        nodes: [
+                          {
+                            reactions: {
+                              nodes: [
+                                {
+                                  user: { login: 'chatgpt-codex-connector[bot]' },
+                                  content: 'THUMBS_UP',
+                                  createdAt: '2026-01-02T00:00:00Z',
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false },
+                      },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(callCount).toBe(2);
+  });
+
   test('allows immediately when codex already approved', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -191,6 +191,7 @@ describe('reviewApprovalValidator', () => {
           data: {
             repository: {
               pullRequest: {
+                headRefOid: 'abc123',
                 reactions: { nodes: [] },
                 comments: {
                   nodes: [
@@ -242,6 +243,7 @@ describe('reviewApprovalValidator', () => {
           data: {
             repository: {
               pullRequest: {
+                headRefOid: 'abc123',
                 reactions: { nodes: [] },
                 comments: {
                   nodes: [
@@ -321,5 +323,103 @@ describe('reviewApprovalValidator', () => {
     expect((result as { state?: Record<string, unknown> }).state).toEqual({
       approvals: { a: 'approved' },
     });
+  });
+
+  test('resets codex timer when PR head SHA changes', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'new-sha-456',
+                reactions: { nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {
+        _codex_started_at: Date.now() - 10_000,
+        _codex_head_sha: 'old-sha-123',
+      },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_head_sha).toBe('new-sha-456');
+    expect(state?._codex_started_at).toBeTypeOf('number');
+    expect((result as { reason: string }).reason).toContain('New PR revision');
+  });
+
+  test('uses enterprise GraphQL endpoint for non-github.com hosts', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let requestedUrl = '';
+    globalThis.fetch = async (url, init) => {
+      requestedUrl = url as string;
+      const body = JSON.parse((init as { body: string }).body);
+      const query = body.query as string;
+      const isGraphQL = query.includes('repository(owner:$owner,name:$name)');
+      if (!isGraphQL) {
+        return {
+          ok: true,
+          json: async () => ({ data: { repository: null } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'ent-sha-789',
+                reactions: { nodes: [] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { approved: true, pr_url: 'https://github.enterprise.com/org/repo/pull/42' },
+      },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(requestedUrl).toBe('https://github.enterprise.com/api/graphql');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -186,6 +186,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
+                commits: { nodes: [{ commit: { committedDate: '2025-12-31T00:00:00Z' } }] },
                 reactions: {
                   nodes: [
                     {
@@ -215,6 +216,53 @@ describe('reviewApprovalValidator', () => {
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('codex approval');
+  });
+
+  test('rejects first-cycle codex reaction older than current head', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                commits: { nodes: [{ commit: { committedDate: '2026-01-02T00:00:00Z' } }] },
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-01T00:00:00Z',
+                    },
+                  ],
+                },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('retryable_block');
+    expect((result as { reason?: string }).reason).toContain('codex');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_started_at).toBeTypeOf('number');
+    expect(state?._codex_head_sha).toBe('abc123');
   });
 
   test('allows immediately when codex already approved', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -74,6 +74,43 @@ describe('reviewApprovalValidator', () => {
     });
   });
 
+  test('binds map-style plan vote to calling reviewer lens', async () => {
+    const ctx = makeCtx({
+      agentName: 'security-reviewer',
+      params: {
+        data: {
+          approvals: {
+            architecture: 'approved',
+            security: 'approved',
+            correctness: 'approved',
+            ux: 'approved',
+          },
+        },
+      },
+      templateData: { threshold: 4, voteBinding: 'agent_lens' },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?.approvals).toEqual({ security: 'approved' });
+  });
+
+  test('uses calling reviewer lens for boolean plan vote binding', async () => {
+    const ctx = makeCtx({
+      agentName: 'ux-reviewer',
+      params: { data: { approved: true } },
+      templateData: { threshold: 4, voteBinding: 'agent_lens' },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?.approvals).toEqual({ ux: 'approved' });
+  });
+
   test('resets state on rejection when resetOnRejection is true', async () => {
     const ctx = makeCtx({
       params: { data: { approvals: { arch: 'rejected' } } },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -186,7 +186,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
-                commits: { nodes: [{ commit: { committedDate: '2025-12-31T00:00:00Z' } }] },
+                updatedAt: '2025-12-31T00:00:00Z',
                 reactions: {
                   nodes: [
                     {
@@ -230,7 +230,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
-                commits: { nodes: [{ commit: { committedDate: '2026-01-02T00:00:00Z' } }] },
+                updatedAt: '2026-01-02T00:00:00Z',
                 reactions: {
                   nodes: [
                     {
@@ -265,6 +265,67 @@ describe('reviewApprovalValidator', () => {
     expect(state?._codex_head_sha).toBe('abc123');
   });
 
+  test('uses PR update baseline instead of commit timestamp for first-cycle codex freshness', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                headRefOid: 'abc123',
+                updatedAt: '2026-01-03T00:00:00Z',
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2026-01-02T00:00:00Z',
+                    },
+                  ],
+                },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
+      hookLocalState: {},
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('retryable_block');
+    expect((result as { reason?: string }).reason).toContain('codex');
+  });
+
+  test('floors codex wait start to GitHub timestamp precision', async () => {
+    const originalNow = Date.now;
+    Date.now = () => Date.parse('2026-01-01T12:00:00.800Z');
+
+    const ctx = makeCtx({
+      params: { data: { approved: true } },
+      templateData: { threshold: 1, requireCodex: true },
+    });
+
+    const result = await reviewApprovalValidator(ctx);
+    Date.now = originalNow;
+
+    expect(result.type).toBe('retryable_block');
+    const state = (result as { state?: Record<string, unknown> }).state;
+    expect(state?._codex_started_at).toBe(Date.parse('2026-01-01T12:00:00.000Z'));
+  });
+
   test('uses head baseline after reset when codex approval is already fresh', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -277,7 +338,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
-                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                updatedAt: '2026-01-01T00:00:00Z',
                 reactions: {
                   nodes: [
                     {
@@ -322,7 +383,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
-                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                updatedAt: '2026-01-01T00:00:00Z',
                 reactions: { nodes: [] },
                 comments:
                   callCount === 1
@@ -408,7 +469,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'abc123',
-                commits: { nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }] },
+                updatedAt: '2026-01-01T00:00:00Z',
                 reactions: { nodes: [] },
                 comments: { nodes: [], pageInfo: { hasNextPage: false } },
                 reviewThreads: {
@@ -809,6 +870,7 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'sha-after-reset',
+                updatedAt: '3000-01-01T00:00:00Z',
                 reactions: {
                   nodes: [
                     {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-approval-validator.test.ts
@@ -197,7 +197,13 @@ describe('reviewApprovalValidator', () => {
                   nodes: [
                     {
                       reactions: {
-                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                        nodes: [
+                          {
+                            user: { login: 'codex[bot]' },
+                            content: 'THUMBS_UP',
+                            createdAt: '2999-01-01T00:00:00Z',
+                          },
+                        ],
                       },
                     },
                   ],
@@ -212,7 +218,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true, pr_url: 'https://github.com/test/repo/pull/42' } },
-      hookLocalState: { _codex_head_sha: 'abc123' },
+      hookLocalState: { _codex_head_sha: 'abc123', _codex_started_at: Date.now() - 10_000 },
       templateData: { threshold: 1, requireCodex: true },
     });
 
@@ -250,7 +256,13 @@ describe('reviewApprovalValidator', () => {
                   nodes: [
                     {
                       reactions: {
-                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                        nodes: [
+                          {
+                            user: { login: 'codex[bot]' },
+                            content: 'THUMBS_UP',
+                            createdAt: '2999-01-01T00:00:00Z',
+                          },
+                        ],
                       },
                     },
                   ],
@@ -265,7 +277,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true } },
-      hookLocalState: { _codex_head_sha: 'abc123' },
+      hookLocalState: { _codex_head_sha: 'abc123', _codex_started_at: Date.now() - 10_000 },
       currentArtifacts: [
         {
           id: 'a1',
@@ -348,7 +360,15 @@ describe('reviewApprovalValidator', () => {
             repository: {
               pullRequest: {
                 headRefOid: 'new-sha-456',
-                reactions: { nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }] },
+                reactions: {
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2999-01-01T00:00:00Z',
+                    },
+                  ],
+                },
                 comments: { nodes: [] },
                 reviewThreads: { nodes: [] },
               },
@@ -417,7 +437,7 @@ describe('reviewApprovalValidator', () => {
       params: {
         data: { approved: true, pr_url: 'https://github.enterprise.com/org/repo/pull/42' },
       },
-      hookLocalState: { _codex_head_sha: 'ent-sha-789' },
+      hookLocalState: { _codex_head_sha: 'ent-sha-789', _codex_started_at: Date.now() - 10_000 },
       templateData: { threshold: 1, requireCodex: true },
     });
 
@@ -455,7 +475,13 @@ describe('reviewApprovalValidator', () => {
                   nodes: [
                     {
                       reactions: {
-                        nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                        nodes: [
+                          {
+                            user: { login: 'codex[bot]' },
+                            content: 'THUMBS_UP',
+                            createdAt: '2999-01-01T00:00:00Z',
+                          },
+                        ],
                       },
                     },
                   ],
@@ -470,7 +496,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true } },
-      hookLocalState: { _codex_head_sha: 'abc123' },
+      hookLocalState: { _codex_head_sha: 'abc123', _codex_started_at: Date.now() - 10_000 },
       gateData: [
         {
           gateId: 'code-pr-gate',
@@ -511,7 +537,13 @@ describe('reviewApprovalValidator', () => {
               pullRequest: {
                 headRefOid: 'sha-after-reset',
                 reactions: {
-                  nodes: [{ user: { login: 'codex[bot]' }, content: 'THUMBS_UP' }],
+                  nodes: [
+                    {
+                      user: { login: 'codex[bot]' },
+                      content: 'THUMBS_UP',
+                      createdAt: '2999-01-01T00:00:00Z',
+                    },
+                  ],
                 },
                 comments: { nodes: [] },
                 reviewThreads: { nodes: [] },
@@ -554,7 +586,7 @@ describe('reviewApprovalValidator', () => {
       params: {
         data: { approved: true, pr_url: 'https://attacker.example/org/repo/pull/1' },
       },
-      hookLocalState: { _codex_head_sha: 'abc123' },
+      hookLocalState: { _codex_head_sha: 'abc123', _codex_started_at: Date.now() - 10_000 },
       templateData: { threshold: 1, requireCodex: true },
     });
 
@@ -602,7 +634,7 @@ describe('reviewApprovalValidator', () => {
 
     const ctx = makeCtx({
       params: { data: { approved: true } },
-      hookLocalState: { _codex_head_sha: 'abc123' },
+      hookLocalState: { _codex_head_sha: 'abc123', _codex_started_at: Date.now() - 10_000 },
       currentArtifacts: [
         {
           id: 'old-artifact',

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -169,10 +169,54 @@ describe('reviewPostedValidator', () => {
       params: {
         data: { review_url: 'https://github.enterprise.com/org/repo/pull/42#discussion_r1' },
       },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.enterprise.com/org/repo/pull/42' },
+          updatedAt: Date.now(),
+        },
+      ],
     });
     const result = await reviewPostedValidator(ctx);
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('message_data');
+  });
+
+  test('blocks review URL from a different PR than the active one', async () => {
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/other/repo/pull/99#discussion_r1' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('No review evidence');
+  });
+
+  test('allows review URL matching the active PR', async () => {
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -165,6 +165,25 @@ describe('reviewPostedValidator', () => {
   });
 
   test('accepts enterprise GitHub host for review URL', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GH_ENTERPRISE_TOKEN;
+    process.env.GH_ENTERPRISE_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [{ createdAt: '2999-01-01T00:00:00Z' }] },
+                comments: { nodes: [] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
     const ctx = makeCtx({
       params: {
         data: { review_url: 'https://github.enterprise.com/org/repo/pull/42#discussion_r1' },
@@ -178,6 +197,8 @@ describe('reviewPostedValidator', () => {
       ],
     });
     const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GH_ENTERPRISE_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('message_data');
@@ -203,6 +224,25 @@ describe('reviewPostedValidator', () => {
   });
 
   test('allows review URL matching the active PR', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [] },
+                comments: { nodes: [{ createdAt: '2999-01-01T00:00:00Z' }] },
+                reviewThreads: { nodes: [] },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
     const ctx = makeCtx({
       params: {
         data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
@@ -216,6 +256,8 @@ describe('reviewPostedValidator', () => {
       ],
     });
     const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
   });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -86,6 +86,16 @@ describe('reviewPostedValidator', () => {
     expect((result as { message?: string }).message).toContain('message_data');
   });
 
+  test('blocks when review_url is not a valid GitHub PR URL', async () => {
+    const ctx = makeCtx({
+      params: { data: { review_url: 'https://example.com/anything' } },
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('No review evidence');
+  });
+
   test('blocks when artifact has no review_url', async () => {
     const ctx = makeCtx({
       currentArtifacts: [

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -850,6 +850,143 @@ describe('reviewPostedValidator', () => {
     expect(callCount).toBe(3);
   });
 
+  test('finds review-thread comment on a later thread comment page', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let graphqlCalls = 0;
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/comments/123')) {
+        return { ok: false, json: async () => ({}) } as Response;
+      }
+      if (path.endsWith('/graphql')) {
+        graphqlCalls += 1;
+        if (graphqlCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: {
+                viewer: { login: 'reviewer' },
+                repository: { pullRequest: { author: { login: 'pr-author' } } },
+              },
+            }),
+          } as Response;
+        }
+        if (graphqlCalls === 2) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: {
+                repository: {
+                  pullRequest: {
+                    reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                    comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                    reviewThreads: {
+                      nodes: [
+                        {
+                          id: 'thread-1',
+                          comments: {
+                            nodes: [],
+                            pageInfo: { hasNextPage: true, endCursor: 'comments-1' },
+                          },
+                        },
+                      ],
+                      pageInfo: { hasNextPage: false },
+                    },
+                  },
+                },
+              },
+            }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              node: {
+                comments: {
+                  nodes: [{ databaseId: 123, createdAt: '2999-01-01T00:00:00Z' }],
+                  pageInfo: { hasNextPage: false },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r123' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(graphqlCalls).toBe(3);
+  });
+
+  test('blocks review evidence older than the active PR gate update', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    const now = Date.parse('2026-01-01T12:00:00Z');
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/comments/42')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 42,
+            pull_request_url: 'https://api.github.com/repos/test/repo/pulls/1',
+            created_at: new Date(now - 10_000).toISOString(),
+          }),
+        } as Response;
+      }
+      if (path.endsWith('/graphql')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              viewer: { login: 'reviewer' },
+              repository: { pullRequest: { author: { login: 'pr-author' } } },
+            },
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: now,
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+  });
+
   test('floors review evidence freshness cutoff to GitHub timestamp precision', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -889,7 +1026,7 @@ describe('reviewPostedValidator', () => {
         {
           gateId: 'code-pr-gate',
           data: { pr_url: 'https://github.com/test/repo/pull/1' },
-          updatedAt: now,
+          updatedAt: now - 10_000,
         },
       ],
     });
@@ -1045,7 +1182,7 @@ describe('reviewPostedValidator', () => {
         {
           gateId: 'code-pr-gate',
           data: { pr_url: 'https://github.com/test/repo/pull/1' },
-          updatedAt: now,
+          updatedAt: now - 10_000,
         },
       ],
     });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -516,6 +516,136 @@ describe('reviewPostedValidator', () => {
     expect(result.type).toBe('block');
   });
 
+  test('rejects PR comment GraphQL fallback when author is not the PR author', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let callCount = 0;
+    globalThis.fetch = async (url) => {
+      callCount += 1;
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/issues/comments/99')) {
+        return { ok: false, json: async () => ({}) } as Response;
+      }
+      if (callCount === 2) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                  comments: {
+                    nodes: [
+                      {
+                        databaseId: 99,
+                        createdAt: '2999-01-01T00:00:00Z',
+                        user: { login: 'reviewer' },
+                      },
+                    ],
+                    pageInfo: { hasNextPage: false },
+                  },
+                  reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#issuecomment-99' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+  });
+
+  test('returns missing when paginated evidence cursors exhaust at different times', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let evidenceCalls = 0;
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/comments/404')) {
+        return { ok: false, json: async () => ({}) } as Response;
+      }
+      if (path.endsWith('/graphql')) {
+        evidenceCalls += 1;
+        if (evidenceCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+            }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                  comments: {
+                    nodes: [],
+                    pageInfo: { hasNextPage: evidenceCalls === 2, endCursor: 'comment-cursor' },
+                  },
+                  reviewThreads: {
+                    nodes: [],
+                    pageInfo: {
+                      hasNextPage: evidenceCalls === 2 || evidenceCalls === 3,
+                      endCursor: `thread-cursor-${evidenceCalls}`,
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r404' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+    expect(evidenceCalls).toBe(4);
+  });
+
   test('finds review evidence on later pages', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -711,6 +711,87 @@ describe('reviewPostedValidator', () => {
     expect(evidenceCalls).toBe(4);
   });
 
+  test('uses submittedAt for formal review freshness in GraphQL fallback', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let graphqlCalls = 0;
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/1/reviews/77')) {
+        return { ok: false, json: async () => ({}) } as Response;
+      }
+      if (path.endsWith('/graphql')) {
+        graphqlCalls += 1;
+        if (graphqlCalls === 1) {
+          return {
+            ok: true,
+            json: async () => ({
+              data: {
+                viewer: { login: 'reviewer' },
+                repository: { pullRequest: { author: { login: 'pr-author' } } },
+              },
+            }),
+          } as Response;
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviews: {
+                    nodes: [
+                      {
+                        databaseId: 77,
+                        createdAt: '2026-01-01T00:00:00Z',
+                        submittedAt: '2999-01-01T00:00:00Z',
+                        state: 'APPROVED',
+                      },
+                    ],
+                    pageInfo: { hasNextPage: false },
+                  },
+                  comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                  reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+                },
+              },
+            },
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#pullrequestreview-77' },
+      },
+      currentArtifacts: [
+        {
+          id: 'a2',
+          nodeId: 'node-coding',
+          type: 'result',
+          key: 'revision-2',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          createdAt: Date.parse('2026-01-02T00:00:00Z'),
+          updatedAt: Date.parse('2026-01-02T00:00:00Z'),
+        },
+      ],
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
   test('finds review evidence on later pages', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -767,6 +848,56 @@ describe('reviewPostedValidator', () => {
 
     expect(result.type).toBe('allow');
     expect(callCount).toBe(3);
+  });
+
+  test('floors review evidence freshness cutoff to GitHub timestamp precision', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    const now = Date.parse('2026-01-01T12:00:00.800Z');
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/comments/42')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 42,
+            pull_request_url: 'https://api.github.com/repos/test/repo/pulls/1',
+            created_at: '2026-01-01T12:00:00Z',
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+      },
+      currentArtifacts: [
+        {
+          id: 'a2',
+          nodeId: 'node-coding',
+          type: 'result',
+          key: 'revision-2',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: now,
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
   });
 
   test('blocks direct message review URL older than latest coding revision', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -167,7 +167,9 @@ describe('reviewPostedValidator', () => {
   test('accepts enterprise GitHub host for review URL', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GH_ENTERPRISE_TOKEN;
+    const originalGhHost = process.env.GH_HOST;
     process.env.GH_ENTERPRISE_TOKEN = 'test-token';
+    process.env.GH_HOST = 'github.enterprise.com';
     globalThis.fetch = async () =>
       ({
         ok: true,
@@ -199,6 +201,7 @@ describe('reviewPostedValidator', () => {
     const result = await reviewPostedValidator(ctx);
     globalThis.fetch = originalFetch;
     process.env.GH_ENTERPRISE_TOKEN = originalToken;
+    process.env.GH_HOST = originalGhHost;
 
     expect(result.type).toBe('allow');
     expect((result as { message?: string }).message).toContain('message_data');
@@ -260,5 +263,35 @@ describe('reviewPostedValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
+  });
+
+  test('does not send credentials to untrusted review URL host', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return { ok: true, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://attacker.example/org/repo/pull/1#discussion_r42' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://attacker.example/org/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(fetchCalled).toBe(false);
+    expect(result.type).toBe('block');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -177,9 +177,14 @@ describe('reviewPostedValidator', () => {
           data: {
             repository: {
               pullRequest: {
-                reviews: { nodes: [] },
-                comments: { nodes: [{ databaseId: 1, createdAt: '2999-01-01T00:00:00Z' }] },
-                reviewThreads: { nodes: [] },
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: {
+                  nodes: [
+                    { comments: { nodes: [{ databaseId: 1, createdAt: '2999-01-01T00:00:00Z' }] } },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
               },
             },
           },
@@ -237,9 +242,18 @@ describe('reviewPostedValidator', () => {
           data: {
             repository: {
               pullRequest: {
-                reviews: { nodes: [] },
-                comments: { nodes: [{ databaseId: 42, createdAt: '2999-01-01T00:00:00Z' }] },
-                reviewThreads: { nodes: [] },
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: {
+                  nodes: [
+                    {
+                      comments: {
+                        nodes: [{ databaseId: 42, createdAt: '2999-01-01T00:00:00Z' }],
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
               },
             },
           },
@@ -263,6 +277,171 @@ describe('reviewPostedValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
+  });
+
+  test('allows PR issue comment URL matching active PR', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: {
+                  nodes: [{ databaseId: 99, createdAt: '2999-01-01T00:00:00Z' }],
+                  pageInfo: { hasNextPage: false },
+                },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#issuecomment-99' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
+  test('finds review evidence on later pages', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads:
+                  callCount === 1
+                    ? {
+                        nodes: [],
+                        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+                      }
+                    : {
+                        nodes: [
+                          {
+                            comments: {
+                              nodes: [{ databaseId: 123, createdAt: '2999-01-01T00:00:00Z' }],
+                            },
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false },
+                      },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r123' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(callCount).toBe(2);
+  });
+
+  test('blocks direct message review URL older than latest coding revision', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    const now = Date.now();
+    globalThis.fetch = async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: {
+                  nodes: [
+                    {
+                      comments: {
+                        nodes: [
+                          {
+                            databaseId: 42,
+                            createdAt: new Date(now - 10_000).toISOString(),
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false },
+                },
+              },
+            },
+          },
+        }),
+      }) as Response;
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+      },
+      currentArtifacts: [
+        {
+          id: 'a2',
+          nodeId: 'node-coding',
+          type: 'result',
+          key: 'revision-2',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: now,
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
   });
 
   test('does not send credentials to untrusted review URL host', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -599,7 +599,7 @@ describe('reviewPostedValidator', () => {
                       {
                         databaseId: 99,
                         createdAt: '2999-01-01T00:00:00Z',
-                        user: { login: 'reviewer' },
+                        author: { login: 'reviewer' },
                       },
                     ],
                     pageInfo: { hasNextPage: false },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -133,4 +133,46 @@ describe('reviewPostedValidator', () => {
 
     expect(result.type).toBe('allow');
   });
+
+  test('rejects stale review artifact when newer non-review work exists', async () => {
+    const now = Date.now();
+    const ctx = makeCtx({
+      currentArtifacts: [
+        {
+          id: 'a2',
+          nodeId: 'node-coding',
+          type: 'result',
+          key: 'revision-2',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'review',
+          key: 'cycle-0',
+          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+          createdAt: now - 10_000,
+          updatedAt: now - 10_000,
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('No review evidence');
+  });
+
+  test('accepts enterprise GitHub host for review URL', async () => {
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.enterprise.com/org/repo/pull/42#discussion_r1' },
+      },
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('message_data');
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -377,6 +377,101 @@ describe('reviewPostedValidator', () => {
     expect(result.type).toBe('allow');
   });
 
+  test('blocks PR review URL when the formal review was only commented', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/1/reviews/77')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 77,
+            submitted_at: '2999-01-01T00:00:00Z',
+            state: 'COMMENTED',
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              pullRequest: {
+                author: { login: 'pr-author' },
+                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
+                comments: { nodes: [], pageInfo: { hasNextPage: false } },
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#pullrequestreview-77' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+  });
+
+  test('allows PR review URL when the formal review approved', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/1/reviews/77')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 77,
+            submitted_at: '2999-01-01T00:00:00Z',
+            state: 'APPROVED',
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#pullrequestreview-77' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
   test('blocks PR issue comment URL when the comment author is not the PR author', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -633,6 +728,44 @@ describe('reviewPostedValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
+  });
+
+  test('finds review artifact behind same-node audit artifact fallback', async () => {
+    await withMockEvidenceFetch(async () => {
+      const now = Date.now();
+      const ctx = makeCtx({
+        currentArtifacts: [
+          {
+            id: 'reviewer-progress',
+            nodeId: 'node-review',
+            type: 'progress',
+            key: 'audit',
+            data: { summary: 'review posted' },
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: 'review-artifact',
+            nodeId: 'node-review',
+            type: 'review',
+            key: 'current',
+            data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+            createdAt: now - 1_000,
+            updatedAt: now - 1_000,
+          },
+        ],
+        gateData: [
+          {
+            gateId: 'code-pr-gate',
+            data: { pr_url: 'https://github.com/test/repo/pull/1' },
+            updatedAt: now,
+          },
+        ],
+      });
+      const result = await reviewPostedValidator(ctx);
+
+      expect(result.type).toBe('allow');
+    });
   });
 
   test('fails closed for nonexistent review URL when active PR data is unavailable', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for reviewPostedValidator.
+ *
+ * Covers: review evidence validation via message data and artifacts.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { reviewPostedValidator } from '../../../../../src/lib/space/runtime/built-in-validators/review-posted-validator';
+import type { HookExecutorContext } from '../../../../../src/lib/space/runtime/hook-executor';
+
+function makeCtx(overrides: Partial<HookExecutorContext> = {}): HookExecutorContext {
+  return {
+    workspacePath: '/tmp',
+    runId: 'run-1',
+    hookId: 'hook-1',
+    methodName: 'send_message',
+    params: {},
+    nodeId: 'node-review',
+    nodeName: 'Review',
+    sessionId: 'sess-1',
+    taskId: 'task-1',
+    hookLocalState: {},
+    currentArtifacts: [],
+    permittedExternalLookups: [],
+    ...overrides,
+  };
+}
+
+describe('reviewPostedValidator', () => {
+  test('blocks when no review evidence is provided', async () => {
+    const ctx = makeCtx();
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('block');
+    expect((result as { reason: string }).reason).toContain('No review evidence');
+  });
+
+  test('allows when review_url is in message data', async () => {
+    const ctx = makeCtx({
+      params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' } },
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('Review evidence verified');
+  });
+
+  test('allows when a review artifact exists', async () => {
+    const ctx = makeCtx({
+      currentArtifacts: [
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'review',
+          key: 'cycle-0',
+          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('artifact');
+  });
+
+  test('prefers message data over artifacts', async () => {
+    const ctx = makeCtx({
+      params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r2' } },
+      currentArtifacts: [
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'review',
+          key: 'cycle-0',
+          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
+    expect((result as { message?: string }).message).toContain('message_data');
+  });
+
+  test('blocks when artifact has no review_url', async () => {
+    const ctx = makeCtx({
+      currentArtifacts: [
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'review',
+          key: 'cycle-0',
+          data: { summary: 'looks good' },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('block');
+  });
+
+  test('recognizes review_feedback artifact type', async () => {
+    const ctx = makeCtx({
+      currentArtifacts: [
+        {
+          id: 'a1',
+          nodeId: 'node-review',
+          type: 'review_feedback',
+          key: 'current',
+          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+
+    expect(result.type).toBe('allow');
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -26,6 +26,43 @@ function makeCtx(overrides: Partial<HookExecutorContext> = {}): HookExecutorCont
   };
 }
 
+async function withMockEvidenceFetch<T>(fn: () => Promise<T>): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const originalToken = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = 'test-token';
+  globalThis.fetch = async (url) => {
+    const path = new URL(String(url)).pathname;
+    const id = Number(path.split('/').pop());
+    if (path.includes('/pulls/comments/')) {
+      return {
+        ok: true,
+        json: async () => ({
+          id,
+          pull_request_url: 'https://api.github.com/repos/test/repo/pulls/1',
+          created_at: '2999-01-01T00:00:00Z',
+        }),
+      } as Response;
+    }
+    if (path.includes('/issues/comments/')) {
+      return {
+        ok: true,
+        json: async () => ({
+          id,
+          issue_url: 'https://api.github.com/repos/test/repo/issues/1',
+          created_at: '2999-01-01T00:00:00Z',
+        }),
+      } as Response;
+    }
+    return { ok: false, json: async () => ({}) } as Response;
+  };
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+  }
+}
+
 describe('reviewPostedValidator', () => {
   test('blocks when no review evidence is provided', async () => {
     const ctx = makeCtx();
@@ -36,54 +73,60 @@ describe('reviewPostedValidator', () => {
   });
 
   test('allows when review_url is in message data', async () => {
-    const ctx = makeCtx({
-      params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' } },
-    });
-    const result = await reviewPostedValidator(ctx);
+    await withMockEvidenceFetch(async () => {
+      const ctx = makeCtx({
+        params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' } },
+      });
+      const result = await reviewPostedValidator(ctx);
 
-    expect(result.type).toBe('allow');
-    expect((result as { message?: string }).message).toContain('Review evidence verified');
+      expect(result.type).toBe('allow');
+      expect((result as { message?: string }).message).toContain('Review evidence verified');
+    });
   });
 
   test('allows when a review artifact exists', async () => {
-    const ctx = makeCtx({
-      currentArtifacts: [
-        {
-          id: 'a1',
-          nodeId: 'node-review',
-          type: 'review',
-          key: 'cycle-0',
-          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        },
-      ],
-    });
-    const result = await reviewPostedValidator(ctx);
+    await withMockEvidenceFetch(async () => {
+      const ctx = makeCtx({
+        currentArtifacts: [
+          {
+            id: 'a1',
+            nodeId: 'node-review',
+            type: 'review',
+            key: 'cycle-0',
+            data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+      });
+      const result = await reviewPostedValidator(ctx);
 
-    expect(result.type).toBe('allow');
-    expect((result as { message?: string }).message).toContain('artifact');
+      expect(result.type).toBe('allow');
+      expect((result as { message?: string }).message).toContain('artifact');
+    });
   });
 
   test('prefers message data over artifacts', async () => {
-    const ctx = makeCtx({
-      params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r2' } },
-      currentArtifacts: [
-        {
-          id: 'a1',
-          nodeId: 'node-review',
-          type: 'review',
-          key: 'cycle-0',
-          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        },
-      ],
-    });
-    const result = await reviewPostedValidator(ctx);
+    await withMockEvidenceFetch(async () => {
+      const ctx = makeCtx({
+        params: { data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r2' } },
+        currentArtifacts: [
+          {
+            id: 'a1',
+            nodeId: 'node-review',
+            type: 'review',
+            key: 'cycle-0',
+            data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+      });
+      const result = await reviewPostedValidator(ctx);
 
-    expect(result.type).toBe('allow');
-    expect((result as { message?: string }).message).toContain('message_data');
+      expect(result.type).toBe('allow');
+      expect((result as { message?: string }).message).toContain('message_data');
+    });
   });
 
   test('blocks when review_url is not a valid GitHub PR URL', async () => {
@@ -116,22 +159,24 @@ describe('reviewPostedValidator', () => {
   });
 
   test('recognizes review_feedback artifact type', async () => {
-    const ctx = makeCtx({
-      currentArtifacts: [
-        {
-          id: 'a1',
-          nodeId: 'node-review',
-          type: 'review_feedback',
-          key: 'current',
-          data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        },
-      ],
-    });
-    const result = await reviewPostedValidator(ctx);
+    await withMockEvidenceFetch(async () => {
+      const ctx = makeCtx({
+        currentArtifacts: [
+          {
+            id: 'a1',
+            nodeId: 'node-review',
+            type: 'review_feedback',
+            key: 'current',
+            data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r1' },
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+      });
+      const result = await reviewPostedValidator(ctx);
 
-    expect(result.type).toBe('allow');
+      expect(result.type).toBe('allow');
+    });
   });
 
   test('rejects stale review artifact when newer non-review work exists', async () => {
@@ -436,6 +481,115 @@ describe('reviewPostedValidator', () => {
           updatedAt: now,
         },
       ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+  });
+
+  test('verifies review-thread comment by database ID when no page contains it', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    const requestedPaths: string[] = [];
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      requestedPaths.push(path);
+      if (path.endsWith('/repos/test/repo/pulls/comments/555')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 555,
+            pull_request_url: 'https://api.github.com/repos/test/repo/pulls/1',
+            created_at: '2999-01-01T00:00:00Z',
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r555' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+    expect(requestedPaths).toContain('/repos/test/repo/pulls/comments/555');
+  });
+
+  test('ignores reviewer audit artifacts when computing evidence freshness', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    const now = Date.now();
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/pulls/comments/42')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 42,
+            pull_request_url: 'https://api.github.com/repos/test/repo/pulls/1',
+            created_at: new Date(now - 5_000).toISOString(),
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r42' },
+      },
+      currentArtifacts: [
+        {
+          id: 'reviewer-progress',
+          nodeId: 'node-review',
+          type: 'progress',
+          key: 'audit',
+          data: { summary: 'review posted' },
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: now,
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('allow');
+  });
+
+  test('fails closed for nonexistent review URL when active PR data is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async () => ({ ok: false, json: async () => ({}) }) as Response;
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#discussion_r404' },
+      },
     });
     const result = await reviewPostedValidator(ctx);
     globalThis.fetch = originalFetch;

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -50,6 +50,15 @@ async function withMockEvidenceFetch<T>(fn: () => Promise<T>): Promise<T> {
           id,
           issue_url: 'https://api.github.com/repos/test/repo/issues/1',
           created_at: '2999-01-01T00:00:00Z',
+          user: { login: 'test-author' },
+        }),
+      } as Response;
+    }
+    if (path.endsWith('/graphql')) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: { repository: { pullRequest: { author: { login: 'test-author' } } } },
         }),
       } as Response;
     }
@@ -324,28 +333,30 @@ describe('reviewPostedValidator', () => {
     expect(result.type).toBe('allow');
   });
 
-  test('allows PR issue comment URL matching active PR', async () => {
+  test('allows PR issue comment URL when the comment author is the PR author', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
     process.env.GITHUB_TOKEN = 'test-token';
-    globalThis.fetch = async () =>
-      ({
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/issues/comments/99')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 99,
+            issue_url: 'https://api.github.com/repos/test/repo/issues/1',
+            created_at: '2999-01-01T00:00:00Z',
+            user: { login: 'pr-author' },
+          }),
+        } as Response;
+      }
+      return {
         ok: true,
         json: async () => ({
-          data: {
-            repository: {
-              pullRequest: {
-                reviews: { nodes: [], pageInfo: { hasNextPage: false } },
-                comments: {
-                  nodes: [{ databaseId: 99, createdAt: '2999-01-01T00:00:00Z' }],
-                  pageInfo: { hasNextPage: false },
-                },
-                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false } },
-              },
-            },
-          },
+          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
         }),
-      }) as Response;
+      } as Response;
+    };
 
     const ctx = makeCtx({
       params: {
@@ -364,6 +375,50 @@ describe('reviewPostedValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
+  });
+
+  test('blocks PR issue comment URL when the comment author is not the PR author', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/issues/comments/99')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 99,
+            issue_url: 'https://api.github.com/repos/test/repo/issues/1',
+            created_at: '2999-01-01T00:00:00Z',
+            user: { login: 'reviewer' },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#issuecomment-99' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
   });
 
   test('finds review evidence on later pages', async () => {
@@ -421,7 +476,7 @@ describe('reviewPostedValidator', () => {
     process.env.GITHUB_TOKEN = originalToken;
 
     expect(result.type).toBe('allow');
-    expect(callCount).toBe(2);
+    expect(callCount).toBe(3);
   });
 
   test('blocks direct message review URL older than latest coding revision', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -177,8 +177,8 @@ describe('reviewPostedValidator', () => {
           data: {
             repository: {
               pullRequest: {
-                reviews: { nodes: [{ createdAt: '2999-01-01T00:00:00Z' }] },
-                comments: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: { nodes: [{ databaseId: 1, createdAt: '2999-01-01T00:00:00Z' }] },
                 reviewThreads: { nodes: [] },
               },
             },
@@ -238,7 +238,7 @@ describe('reviewPostedValidator', () => {
             repository: {
               pullRequest: {
                 reviews: { nodes: [] },
-                comments: { nodes: [{ createdAt: '2999-01-01T00:00:00Z' }] },
+                comments: { nodes: [{ databaseId: 42, createdAt: '2999-01-01T00:00:00Z' }] },
                 reviewThreads: { nodes: [] },
               },
             },

--- a/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/built-in-validators/review-posted-validator.test.ts
@@ -58,7 +58,10 @@ async function withMockEvidenceFetch<T>(fn: () => Promise<T>): Promise<T> {
       return {
         ok: true,
         json: async () => ({
-          data: { repository: { pullRequest: { author: { login: 'test-author' } } } },
+          data: {
+            viewer: { login: 'test-author' },
+            repository: { pullRequest: { author: { login: 'test-author' } } },
+          },
         }),
       } as Response;
     }
@@ -353,7 +356,10 @@ describe('reviewPostedValidator', () => {
       return {
         ok: true,
         json: async () => ({
-          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+          data: {
+            viewer: { login: 'pr-author' },
+            repository: { pullRequest: { author: { login: 'pr-author' } } },
+          },
         }),
       } as Response;
     };
@@ -448,7 +454,10 @@ describe('reviewPostedValidator', () => {
       return {
         ok: true,
         json: async () => ({
-          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+          data: {
+            viewer: { login: 'pr-author' },
+            repository: { pullRequest: { author: { login: 'pr-author' } } },
+          },
         }),
       } as Response;
     };
@@ -472,6 +481,53 @@ describe('reviewPostedValidator', () => {
     expect(result.type).toBe('allow');
   });
 
+  test('blocks PR issue comment URL when viewer is not the PR author', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'test-token';
+    globalThis.fetch = async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith('/repos/test/repo/issues/comments/99')) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: 99,
+            issue_url: 'https://api.github.com/repos/test/repo/issues/1',
+            created_at: '2999-01-01T00:00:00Z',
+            user: { login: 'pr-author' },
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            viewer: { login: 'reviewer' },
+            repository: { pullRequest: { author: { login: 'pr-author' } } },
+          },
+        }),
+      } as Response;
+    };
+
+    const ctx = makeCtx({
+      params: {
+        data: { review_url: 'https://github.com/test/repo/pull/1#issuecomment-99' },
+      },
+      gateData: [
+        {
+          gateId: 'code-pr-gate',
+          data: { pr_url: 'https://github.com/test/repo/pull/1' },
+          updatedAt: Date.now(),
+        },
+      ],
+    });
+    const result = await reviewPostedValidator(ctx);
+    globalThis.fetch = originalFetch;
+    process.env.GITHUB_TOKEN = originalToken;
+
+    expect(result.type).toBe('block');
+  });
+
   test('blocks PR issue comment URL when the comment author is not the PR author', async () => {
     const originalFetch = globalThis.fetch;
     const originalToken = process.env.GITHUB_TOKEN;
@@ -492,7 +548,10 @@ describe('reviewPostedValidator', () => {
       return {
         ok: true,
         json: async () => ({
-          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+          data: {
+            viewer: { login: 'pr-author' },
+            repository: { pullRequest: { author: { login: 'pr-author' } } },
+          },
         }),
       } as Response;
     };
@@ -555,7 +614,10 @@ describe('reviewPostedValidator', () => {
       return {
         ok: true,
         json: async () => ({
-          data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+          data: {
+            viewer: { login: 'pr-author' },
+            repository: { pullRequest: { author: { login: 'pr-author' } } },
+          },
         }),
       } as Response;
     };
@@ -595,7 +657,10 @@ describe('reviewPostedValidator', () => {
           return {
             ok: true,
             json: async () => ({
-              data: { repository: { pullRequest: { author: { login: 'pr-author' } } } },
+              data: {
+                viewer: { login: 'pr-author' },
+                repository: { pullRequest: { author: { login: 'pr-author' } } },
+              },
             }),
           } as Response;
         }

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -972,6 +972,49 @@ describe('WorkflowHookEngine', () => {
     expect(params.data).toContain('truncated');
   });
 
+  test('built-in validators receive full unbounded params even when data exceeds budget', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([
+        makeHook({
+          id: 'hook-1',
+          classification: 'validation',
+          validator: { kind: 'built_in', id: 'review_posted' },
+        }),
+      ]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+
+    let capturedContext: unknown;
+    mockExecutor.execute = async (_hook, context) => {
+      capturedContext = context;
+      return { result: { type: 'allow' } };
+    };
+
+    const bigData = {
+      review_url: 'https://github.com/test/repo/pull/1',
+      summary: 'x'.repeat(10_000),
+    };
+    await engine.executeAction(
+      'send_message',
+      { target: 'Review', message: 'hi', data: bigData },
+      defaultMeta
+    );
+
+    const params = (capturedContext as { params: Record<string, unknown> }).params;
+    expect((params.data as Record<string, unknown>).review_url).toBe(
+      'https://github.com/test/repo/pull/1'
+    );
+    expect((params.data as Record<string, unknown>).summary).toBe('x'.repeat(10_000));
+  });
+
   test('large arrays in params are capped', async () => {
     const hookStateRepo = makeMockHookStateRepo();
     const mockExecutor = new MockHookExecutor();

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -1378,6 +1378,71 @@ describe('wrapHandlerWithHooks', () => {
     expect(state2?.localState).toEqual({ count: 1 });
   });
 
+  test('persists state on block results', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'validation' })]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+
+    mockExecutor.setResult('hook-1', {
+      type: 'block',
+      reason: 'Threshold not met',
+      state: { approvals: { arch: 'approved' } },
+    });
+
+    const handler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }],
+    });
+
+    const wrapped = wrapHandlerWithHooks('send_message', handler, engine, {}, defaultMeta);
+    await wrapped({ target: 'Review' });
+
+    const state = hookStateRepo.get('run-1', 'hook-1');
+    expect(state?.localState).toEqual({ approvals: { arch: 'approved' } });
+    expect(state?.lastResult?.type).toBe('block');
+  });
+
+  test('persists state on retryable_block results', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'validation' })]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+
+    mockExecutor.setResult('hook-1', {
+      type: 'retryable_block',
+      reason: 'Waiting on CI',
+      retryAfterMs: 5_000,
+      state: { retryCount: 1 },
+    });
+
+    const handler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }],
+    });
+
+    const wrapped = wrapHandlerWithHooks('send_message', handler, engine, {}, defaultMeta);
+    await wrapped({ target: 'Review' });
+
+    const state = hookStateRepo.get('run-1', 'hook-1');
+    expect(state?.localState).toEqual({ retryCount: 1 });
+    expect(state?.lastResult?.type).toBe('retryable_block');
+  });
+
   test('dispatches follow-up through handler pipeline', async () => {
     const { engine, mockExecutor } = makeEngine([
       makeHook({ id: 'hook-1', classification: 'side_effect' }),

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -731,6 +731,21 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.finalParams).toEqual({ target: 'Review', message: 'hi', extra: true });
   });
 
+  test('out-of-channel target does not trigger targetNode hooks', async () => {
+    const { engine } = makeEngine([
+      makeHook({ id: 'hook-1', targetNode: 'Review', method: 'send_message' }),
+    ]);
+
+    const outcome = await engine.executeAction(
+      'send_message',
+      { target: 'space-agent', message: 'need help' },
+      defaultMeta
+    );
+
+    expect(outcome.decision).toBe('allow');
+    expect(outcome.executionLog).toHaveLength(0);
+  });
+
   test('@worker address target is parsed to node name for hook matching', async () => {
     const { engine, mockExecutor } = makeEngine([
       makeHook({ id: 'hook-1', targetNode: 'Review', method: 'send_message' }),
@@ -2388,6 +2403,50 @@ describe('wrapHandlerWithHooks', () => {
     const state = hookStateRepo.get('run-1', 'hook-1');
     expect(state?.localState).toEqual({ retryCount: 1 });
     expect(state?.lastResult?.type).toBe('retryable_block');
+  });
+
+  test('retries state-merge retryable blocks before returning to caller', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+    let callCount = 0;
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([makeHook({ id: 'hook-1', classification: 'validation' })]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+
+    mockExecutor.execute = async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          result: {
+            type: 'retryable_block',
+            reason: 'Waiting for approvals (3/4). Vote recorded; retry after state merge.',
+            retryAfterMs: 1_000,
+            state: { approvals: { correctness: 'approved' } },
+          },
+        };
+      }
+      return { result: { type: 'allow', message: 'Threshold met (4/4).' } };
+    };
+
+    const handler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }],
+    });
+
+    const wrapped = wrapHandlerWithHooks('send_message', handler, engine, {}, defaultMeta);
+    const result = await wrapped({ target: 'Review' });
+
+    expect(JSON.parse(result.content[0].text).success).toBe(true);
+    expect(callCount).toBe(2);
+    const state = hookStateRepo.get('run-1', 'hook-1');
+    expect(state?.localState).toEqual({ approvals: { correctness: 'approved' } });
+    expect(state?.lastResult?.type).toBe('allow');
   });
 
   test('dispatches follow-up through handler pipeline', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -75,6 +75,25 @@ function makeMockHookStateRepo(): WorkflowHookStateRepository {
     }
   >();
 
+  function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function deepMerge(
+    base: Record<string, unknown>,
+    patch: Record<string, unknown>
+  ): Record<string, unknown> {
+    const next: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(patch)) {
+      if (isPlainRecord(value) && isPlainRecord(next[key])) {
+        next[key] = deepMerge(next[key] as Record<string, unknown>, value);
+      } else {
+        next[key] = value;
+      }
+    }
+    return next;
+  }
+
   return {
     get: (runId: string, hookId: string) => {
       const key = `${runId}:${hookId}`;
@@ -135,7 +154,7 @@ function makeMockHookStateRepo(): WorkflowHookStateRepository {
       if (!s || s.version !== patch.expectedVersion) return null;
       s.version += 1;
       if (patch.localState) {
-        s.localState = { ...s.localState, ...patch.localState };
+        s.localState = deepMerge(s.localState, patch.localState);
       }
       if (patch.lastResult !== undefined) {
         s.lastResult = patch.lastResult;
@@ -440,6 +459,78 @@ describe('WorkflowHookEngine', () => {
     expect(outcome.stateUpdates[0].hookId).toBe('hook-1');
     expect(outcome.stateUpdates[0].state).toEqual({ count: 1 });
     expect(outcome.userState.status).toBe('state_recorded');
+  });
+
+  test('concurrent vote deep-merge round-trip: two blocks with partial votes accumulate', async () => {
+    const hookStateRepo = makeMockHookStateRepo();
+    const mockExecutor = new MockHookExecutor();
+
+    const engine = new WorkflowHookEngine({
+      workflow: makeWorkflow([
+        makeHook({
+          id: 'vote-hook',
+          classification: 'validation',
+          validator: { kind: 'built_in', id: 'review_approval' },
+          authorizedCallers: [{ sourceNode: 'Coding' }],
+        }),
+      ]),
+      workflowRunId: 'run-1',
+      nodeExecutionRepo: makeMockNodeExecutionRepo(),
+      artifactRepo: makeMockArtifactRepo(),
+      hookStateRepo,
+      hookExecutor: mockExecutor,
+      workspacePath: '/tmp',
+    });
+
+    // Simulate the built-in validator returning block with partial votes.
+    // First call: architecture reviewer votes.
+    mockExecutor.setResult('vote-hook', {
+      type: 'block',
+      reason: 'Waiting for approvals (1/4)',
+      state: { approvals: { architecture: 'approved' } },
+    });
+
+    const outcome1 = await engine.executeAction(
+      'send_message',
+      { target: 'Task Dispatcher', message: 'arch approved' },
+      { ...defaultMeta, agentName: 'architecture-reviewer' }
+    );
+
+    expect(outcome1.decision).toBe('block');
+    expect(outcome1.stateUpdates).toHaveLength(1);
+    expect(outcome1.stateUpdates[0].state).toEqual({
+      approvals: { architecture: 'approved' },
+    });
+
+    // Persist the first vote via wrapHandlerWithHooks logic.
+    const ok1 = engine.persistStateUpdate('vote-hook', outcome1.stateUpdates[0].state);
+    expect(ok1).toBe(true);
+
+    // Second call: security reviewer votes while architecture vote is already in state.
+    mockExecutor.setResult('vote-hook', {
+      type: 'block',
+      reason: 'Waiting for approvals (2/4)',
+      state: { approvals: { security: 'approved' } },
+    });
+
+    const outcome2 = await engine.executeAction(
+      'send_message',
+      { target: 'Task Dispatcher', message: 'sec approved' },
+      { ...defaultMeta, agentName: 'security-reviewer' }
+    );
+
+    expect(outcome2.decision).toBe('block');
+    expect(outcome2.stateUpdates).toHaveLength(1);
+
+    // The mock repo now deep-merges, so both votes should coexist.
+    const ok2 = engine.persistStateUpdate('vote-hook', outcome2.stateUpdates[0].state);
+    expect(ok2).toBe(true);
+
+    const finalState = hookStateRepo.get('run-1', 'vote-hook');
+    expect(finalState?.localState.approvals).toEqual({
+      architecture: 'approved',
+      security: 'approved',
+    });
   });
 
   test('side_effect patch_params is ignored', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/workflow-hook-engine.test.ts
@@ -533,6 +533,24 @@ describe('WorkflowHookEngine', () => {
     });
   });
 
+  test('record_state with targetHookId routes state to specified hook', async () => {
+    const { engine, mockExecutor } = makeEngine([
+      makeHook({ id: 'reset-hook', classification: 'side_effect' }),
+    ]);
+    mockExecutor.setResult('reset-hook', {
+      type: 'record_state',
+      state: { approvals: null },
+      targetHookId: 'vote-hook',
+    });
+
+    const outcome = await engine.executeAction('send_message', { target: 'Review' }, defaultMeta);
+
+    expect(outcome.decision).toBe('record_state');
+    expect(outcome.stateUpdates).toHaveLength(1);
+    expect(outcome.stateUpdates[0].hookId).toBe('vote-hook');
+    expect(outcome.stateUpdates[0].state).toEqual({ approvals: null });
+  });
+
   test('side_effect patch_params is ignored', async () => {
     const { engine, mockExecutor } = makeEngine([
       makeHook({ id: 'hook-1', classification: 'side_effect' }),

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2024,6 +2024,34 @@ describe('seedBuiltInWorkflows()', () => {
     expect(reviewNode.requireCodexApproval).toBeUndefined();
   });
 
+  test('mergeNodeStructuralFieldsFromTemplate refreshes stale approval-gate prompts', () => {
+    const existingNodes = FULLSTACK_QA_LOOP_WORKFLOW.nodes.map((node) =>
+      node.name === 'Review'
+        ? {
+            ...node,
+            agents: node.agents.map((agent) => ({
+              ...agent,
+              customPrompt: {
+                mode: 'override' as const,
+                value: 'legacy prompt says write review-approval-gate',
+              },
+            })),
+          }
+        : node
+    );
+
+    const result = mergeNodeStructuralFieldsFromTemplate(
+      existingNodes,
+      FULLSTACK_QA_LOOP_WORKFLOW.nodes,
+      resolveAgentId
+    );
+
+    const reviewPrompt = result.find((node) => node.name === 'Review')!.agents[0].customPrompt!
+      .value;
+    expect(reviewPrompt).toContain('hook-validated hand-off message');
+    expect(reviewPrompt).not.toContain('write review-approval-gate');
+  });
+
   test('mergeGateStructuralFieldsFromTemplate clears non-codex features when template removes them', () => {
     const existingGates = [{ id: 'g1', fields: [], features: { some_other_feature: true } }];
     const templateGates = [{ id: 'g1', fields: [] }];
@@ -2052,8 +2080,8 @@ describe('seedBuiltInWorkflows()', () => {
 
   test('mergeChannelsFromTemplate replaces existing channels with same from→to', () => {
     const existingChannels = [
-      { from: 'A', to: 'B', gateId: 'old-gate' },
-      { from: 'C', to: 'D' },
+      { id: 'existing-ab', from: 'A', to: 'B', gateId: 'old-gate' },
+      { id: 'existing-cd', from: 'C', to: 'D' },
     ];
     const templateChannels = [
       { from: 'A', to: 'B' },
@@ -2070,6 +2098,7 @@ describe('seedBuiltInWorkflows()', () => {
     const ab = result!.find((ch) => ch.from === 'A' && ch.to === 'B');
     expect(ab).toBeDefined();
     expect(ab!.gateId).toBeUndefined();
+    expect(ab!.id).toBe('existing-ab');
     const cd = result!.find((ch) => ch.from === 'C' && ch.to === 'D');
     expect(cd).toBeDefined();
     const ef = result!.find((ch) => ch.from === 'E' && ch.to === 'F');
@@ -2078,7 +2107,7 @@ describe('seedBuiltInWorkflows()', () => {
 
   test('mergeChannelsFromTemplate treats single-target arrays as same from→to', () => {
     const existingChannels = [
-      { from: 'Review', to: ['QA'], gateId: 'review-approval-gate' },
+      { id: 'review-qa-channel', from: 'Review', to: ['QA'], gateId: 'review-approval-gate' },
       { from: 'Coding', to: 'Review' },
     ];
     const templateChannels = [{ from: 'Review', to: 'QA', hookIds: ['review-approval-hook'] }];
@@ -2096,6 +2125,7 @@ describe('seedBuiltInWorkflows()', () => {
     expect(reviewQaChannels[0].to).toBe('QA');
     expect(reviewQaChannels[0].gateId).toBeUndefined();
     expect(reviewQaChannels[0].hookIds).toEqual(['review-approval-hook']);
+    expect(reviewQaChannels[0].id).toBe('review-qa-channel');
   });
 
   test('re-stamp appends missing validation node and channels with resolved agent IDs', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -38,6 +38,7 @@ import {
   getBuiltInGateScript,
   getBuiltInWorkflows,
   mergeGateStructuralFieldsFromTemplate,
+  removeOrphanedGates,
   PLAN_AND_DECOMPOSE_WORKFLOW,
   validateWorkflowTemplateGateWriters,
   RESEARCH_WORKFLOW,
@@ -2032,19 +2033,21 @@ describe('seedBuiltInWorkflows()', () => {
     expect(result![0].features).toBeUndefined();
   });
 
-  test('mergeGateStructuralFieldsFromTemplate removes gates no longer in template', () => {
-    const existingGates = [
+  test('removeOrphanedGates removes gates no longer in template and unreferenced by channels', () => {
+    const gates = [
       {
         id: 'old-gate',
         fields: [{ name: 'f1', type: 'string', writers: ['*'], check: { op: 'exists' } }],
       },
       { id: 'kept-gate', fields: [] },
+      { id: 'custom-gate', fields: [] },
     ];
+    const channels = [{ from: 'A', to: 'B', gateId: 'custom-gate' }];
     const templateGates = [{ id: 'kept-gate', fields: [] }];
 
-    const result = mergeGateStructuralFieldsFromTemplate(existingGates, templateGates);
-    expect(result).toHaveLength(1);
-    expect(result![0].id).toBe('kept-gate');
+    const result = removeOrphanedGates(gates, channels as SpaceWorkflow['channels'], templateGates);
+    expect(result).toHaveLength(2);
+    expect(result!.map((g) => g.id).sort()).toEqual(['custom-gate', 'kept-gate']);
   });
 
   test('mergeChannelsFromTemplate replaces existing channels with same from→to', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -165,6 +165,7 @@ describe('CODING_WORKFLOW template', () => {
     // The review-posted hook (not gate) closes the feedback-loop gap where the reviewer
     // summarizes feedback internally without posting to GitHub.
     expect(ch!.gateId).toBeUndefined();
+    expect(ch!.hookIds).toEqual(['review-posted-hook']);
     // direction field removed from WorkflowChannel
     expect(ch!.maxCycles).toBe(5);
   });
@@ -998,6 +999,7 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
       (c) => c.from === 'Plan Review' && c.to === 'Task Dispatcher'
     );
     expect(reviewToDispatcher?.gateId).toBeUndefined();
+    expect(reviewToDispatcher?.hookIds).toEqual(['plan-approval-hook']);
   });
 
   test('feedback channel Plan Review → Planning is ungated and cyclic', () => {
@@ -1373,9 +1375,10 @@ describe('seedBuiltInWorkflows()', () => {
 
     const reviewToCode = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
     expect(reviewToCode).toBeDefined();
-    // Review → Coding is now ungated; the review-posted hook validates
+    // Review → Coding is hook-guarded; the review-posted hook validates
     // the reviewer's message before delivery.
     expect(reviewToCode!.gateId).toBeUndefined();
+    expect(reviewToCode!.hookIds).toEqual(['review-posted-hook']);
     expect(reviewToCode!.maxCycles).toBe(5);
 
     const validationToCode = wf.channels!.find(
@@ -1538,6 +1541,10 @@ describe('seedBuiltInWorkflows()', () => {
       .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
     const gatedChannels = wf.channels!.filter((c) => c.gateId !== undefined);
     expect(gatedChannels).toHaveLength(1); // plan-pr-gate only
+    const hookChannels = wf.channels!.filter((c) => c.hookIds?.includes('plan-approval-hook'));
+    expect(hookChannels).toHaveLength(1);
+    expect(hookChannels[0].from).toBe('Plan Review');
+    expect(hookChannels[0].to).toBe('Task Dispatcher');
     const cyclicChannels = wf.channels!.filter((c) => c.maxCycles !== undefined);
     // One cyclic feedback channel: Plan Review → Planning
     expect(cyclicChannels).toHaveLength(1);

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -27,11 +27,7 @@ import {
 } from '../../../../src/lib/space/export-format.ts';
 import { evaluateFields, validateGate } from '../../../../src/lib/space/runtime/gate-evaluator.ts';
 import { executeGateScript } from '../../../../src/lib/space/runtime/gate-script-executor.ts';
-import {
-  getEffectiveGate,
-  isApprovalGate,
-  resolveCodexPollIntervalMs,
-} from '../../../../src/lib/space/runtime/gate-features.ts';
+
 import { PR_MERGE_POST_APPROVAL_INSTRUCTIONS } from '../../../../src/lib/space/workflows/post-approval-merge-template.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import {
@@ -78,21 +74,6 @@ function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: stri
     `INSERT INTO space_agents (id, space_id, name, description, model, tools, custom_prompt, created_at, updated_at)
      VALUES (?, ?, ?, '', null, '[]', null, ?, ?)`
   ).run(agentId, spaceId, name, Date.now(), Date.now());
-}
-
-/**
- * Helper that returns the effective gate for FULLSTACK_QA_LOOP_WORKFLOW's
- * review-approval-gate with the Review node configured to require codex approval.
- * Used by tests that exercise the codex review bot script/poll.
- */
-function getFullstackReviewApprovalGateWithCodex() {
-  const rawGate = FULLSTACK_QA_LOOP_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
-  return getEffectiveGate(rawGate, {
-    ...FULLSTACK_QA_LOOP_WORKFLOW,
-    nodes: FULLSTACK_QA_LOOP_WORKFLOW.nodes.map((n) =>
-      n.name === 'Review' ? { ...n, requireCodexApproval: true } : n
-    ),
-  });
 }
 
 /** Valid builtin roles — 'leader' must NOT appear in any template step. */
@@ -176,12 +157,12 @@ describe('CODING_WORKFLOW template', () => {
     expect(ch!.maxCycles).toBeUndefined();
   });
 
-  test('Review → Coding channel is gated by review-posted-gate with maxCycles', () => {
+  test('Review → Coding channel is ungated and has maxCycles', () => {
     const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
     expect(ch).toBeDefined();
-    // The review-posted-gate closes the feedback-loop gap where the reviewer
+    // The review-posted hook (not gate) closes the feedback-loop gap where the reviewer
     // summarizes feedback internally without posting to GitHub.
-    expect(ch!.gateId).toBe('review-posted-gate');
+    expect(ch!.gateId).toBeUndefined();
     // direction field removed from WorkflowChannel
     expect(ch!.maxCycles).toBe(5);
   });
@@ -209,16 +190,26 @@ describe('CODING_WORKFLOW template', () => {
     }
   });
 
-  test('has three gates: code-ready-gate, validation-complete-gate, and review-posted-gate', () => {
-    expect(CODING_WORKFLOW.gates).toHaveLength(3);
+  test('has two gates: code-ready-gate and validation-complete-gate', () => {
+    expect(CODING_WORKFLOW.gates).toHaveLength(2);
     const gateIds = CODING_WORKFLOW.gates!.map((g) => g.id).sort();
-    expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate', 'validation-complete-gate']);
+    expect(gateIds).toEqual(['code-ready-gate', 'validation-complete-gate']);
     const codeReadyGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
     expect(codeReadyGate.fields).toHaveLength(1);
     const validationGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'validation-complete-gate')!;
     expect(validationGate.fields).toHaveLength(3);
-    const reviewPostedGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    expect(reviewPostedGate.fields).toHaveLength(2);
+  });
+
+  test('has one hook: review-posted-hook on send_message from Review to Coding', () => {
+    expect(CODING_WORKFLOW.hooks).toHaveLength(1);
+    const hook = CODING_WORKFLOW.hooks![0];
+    expect(hook.id).toBe('review-posted-hook');
+    expect(hook.sourceNode).toBe('Review');
+    expect(hook.targetNode).toBe('Coding');
+    expect(hook.method).toBe('send_message');
+    expect(hook.validator).toEqual({ kind: 'built_in', id: 'review_posted' });
+    expect(hook.enabled).toBe(true);
+    expect(hook.classification).toBe('validation');
   });
 
   test('validation-complete-gate accepts no-code-change completion evidence without pr_url', () => {
@@ -339,266 +330,6 @@ describe('CODING_WORKFLOW template', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
-  });
-
-  test('review-posted-gate has pr_url and review_url fields writable only by Review node', () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    expect(gate.fields).toHaveLength(2);
-
-    const prField = gate.fields.find((f) => f.name === 'pr_url')!;
-    expect(prField.type).toBe('string');
-    expect(prField.writers).toEqual(['Review']);
-    expect(prField.check.op).toBe('exists');
-
-    const reviewField = gate.fields.find((f) => f.name === 'review_url')!;
-    expect(reviewField.type).toBe('string');
-    expect(reviewField.writers).toEqual(['Review']);
-    expect(reviewField.check.op).toBe('exists');
-  });
-
-  test('review-posted-gate has bash script verifying a review submitted after workflow start', () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    expect(gate.script).toBeDefined();
-    expect(gate.script!.interpreter).toBe('bash');
-    expect(gate.script!.timeoutMs).toBe(30000);
-    // The script must consult the workflow start timestamp injected by the runner.
-    expect(gate.script!.source).toContain('NEOKAI_WORKFLOW_START_ISO');
-    // Primary check: query GitHub for formal approval / changes-requested reviews.
-    expect(gate.script!.source).toContain('gh pr view "$PR_URL" --json reviews,comments,author');
-    expect(gate.script!.source).toContain('submittedAt');
-    expect(gate.script!.source).toContain('APPROVED');
-    expect(gate.script!.source).toContain('CHANGES_REQUESTED');
-    // Must fail loudly when neither review nor PR comment has landed since start.
-    expect(gate.script!.source).toContain('exit 1');
-    // Must echo pr_url/review_count on success for downstream consumers.
-    expect(gate.script!.source).toContain('pr_url');
-    expect(gate.script!.source).toContain('review_count');
-  });
-
-  test('review-posted-gate accepts comment-only evidence only for own PRs', () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const src = gate.script!.source;
-    // Fallback: check COMMENTED reviews and PR conversation comments only after
-    // confirming the authenticated account owns the PR. Non-own PRs must still
-    // provide APPROVED or CHANGES_REQUESTED review events.
-    expect(src).toContain('gh api user --jq .login');
-    expect(src).toContain('AUTHOR_LOGIN');
-    expect(src).toContain('VIEWER_LOGIN');
-    expect(src).toContain('[ "$AUTHOR_LOGIN" != "$VIEWER_LOGIN" ]');
-    expect(src).toContain('COMMENTED');
-    expect(src).toContain('createdAt');
-    // Must also filter comments by workflow start timestamp.
-    expect(src).toContain('NEOKAI_WORKFLOW_START_ISO');
-    // Gate passes via comments fallback — outputs the same pr_url/review_count shape.
-    expect(src).toContain('pr_url');
-    expect(src).toContain('review_count');
-    expect(src).toContain('own_pr_comment');
-    // Error message must mention both "review" and "PR comment" so operators understand what was checked.
-    expect(src).toContain('PR comment');
-  });
-
-  test('review-posted-gate passes own-PR COMMENTED reviews', async () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-own-pr-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          `if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
-          `  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"COMMENTED"}],"comments":[],"author":{"login":"lsm"}}'`,
-          '  exit 0',
-          'fi',
-          'if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then',
-          `  printf '%s\\n' 'lsm'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-posted-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: prUrl,
-        review_count: 1,
-        review_evidence: 'own_pr_comment',
-      });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('review-posted-gate rejects comment-only evidence on non-own PRs', async () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-non-own-pr-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          `if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
-          `  printf '%s\\n' '{"reviews":[],"comments":[{"createdAt":"2026-05-01T12:00:00Z"}],"author":{"login":"someone-else"}}'`,
-          '  exit 0',
-          'fi',
-          'if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then',
-          `  printf '%s\\n' 'lsm'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-posted-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('comment-only evidence is accepted only for own PRs');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('review-posted-gate uses review_url gate data when pr_url is absent', async () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const logPath = join(workspace, 'gh-args.log');
-    const reviewUrl = 'https://github.com/test/repo/pull/42#pullrequestreview-123';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
-          `if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(reviewUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
-          `  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"CHANGES_REQUESTED"}],"comments":[],"author":{"login":"other"}}'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-posted-gate',
-          runId: 'run-1',
-          gateData: { review_url: reviewUrl },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: reviewUrl,
-        review_count: 1,
-        review_evidence: 'formal_review',
-      });
-      expect(readFileSync(logPath, 'utf8').trim()).toBe(
-        `pr view ${reviewUrl} --json reviews,comments,author`
-      );
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('review-posted-gate prefers pr_url over review_url when both are in gate data', async () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-prefers-pr-url-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const logPath = join(workspace, 'gh-args.log');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-    const reviewUrl = 'https://github.com/test/repo/pull/42#pullrequestreview-123';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
-          `if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
-          `  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"CHANGES_REQUESTED"}],"comments":[],"author":{"login":"other"}}'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-posted-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, review_url: reviewUrl },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: prUrl,
-        review_count: 1,
-        review_evidence: 'formal_review',
-      });
-      expect(readFileSync(logPath, 'utf8').trim()).toBe(
-        `pr view ${prUrl} --json reviews,comments,author`
-      );
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('review-posted-gate resets on cycle so each feedback round is re-verified', () => {
-    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    expect(gate.resetOnCycle).toBe(true);
   });
 
   test('code-ready-gate has pr_url field writable by Coding node and coder alias', () => {
@@ -1198,14 +929,28 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     expect(nodeIds.has(PLAN_AND_DECOMPOSE_WORKFLOW.endNodeId!)).toBe(true);
   });
 
-  test('has two gates', () => {
-    expect(PLAN_AND_DECOMPOSE_WORKFLOW.gates).toHaveLength(2);
-  });
-
-  test('gate IDs are correct', () => {
+  test('has one gate: plan-pr-gate', () => {
+    expect(PLAN_AND_DECOMPOSE_WORKFLOW.gates).toHaveLength(1);
     const ids = PLAN_AND_DECOMPOSE_WORKFLOW.gates!.map((g) => g.id);
     expect(ids).toContain('plan-pr-gate');
-    expect(ids).toContain('plan-approval-gate');
+  });
+
+  test('has one hook: plan-approval-hook on send_message from Plan Review to Task Dispatcher', () => {
+    expect(PLAN_AND_DECOMPOSE_WORKFLOW.hooks).toBeDefined();
+    expect(PLAN_AND_DECOMPOSE_WORKFLOW.hooks).toHaveLength(1);
+    const hook = PLAN_AND_DECOMPOSE_WORKFLOW.hooks![0];
+    expect(hook.id).toBe('plan-approval-hook');
+    expect(hook.sourceNode).toBe('Plan Review');
+    expect(hook.targetNode).toBe('Task Dispatcher');
+    expect(hook.method).toBe('send_message');
+    expect(hook.validator).toEqual({ kind: 'built_in', id: 'review_approval' });
+    expect(hook.templateData).toMatchObject({
+      threshold: 4,
+      voteKey: 'approvals',
+      voteMatch: 'approved',
+    });
+    expect(hook.enabled).toBe(true);
+    expect(hook.classification).toBe('validation');
   });
 
   test('plan-pr-gate has script-based PR check with pr_url output', () => {
@@ -1221,16 +966,20 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     expect(gate.resetOnCycle).toBe(true);
   });
 
-  test('plan-approval-gate requires all four reviewers to approve', () => {
-    const gate = PLAN_AND_DECOMPOSE_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
-    expect(gate.fields).toHaveLength(1);
-    expect(gate.fields[0].name).toBe('approvals');
-    expect(gate.fields[0].type).toBe('map');
-    expect(gate.fields[0].check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
-    expect(gate.fields[0].writers).toEqual(['Plan Review']);
-    // Codex is no longer hardcoded as a gate feature; it is opt-in via node-level config.
-    expect(gate.features?.codex_review_bot).toBeUndefined();
-    expect(gate.resetOnCycle).toBe(true);
+  test('plan-approval-hook has threshold 4 and vote config in templateData', () => {
+    const hook = PLAN_AND_DECOMPOSE_WORKFLOW.hooks!.find((h) => h.id === 'plan-approval-hook')!;
+    expect(hook.templateData).toMatchObject({
+      threshold: 4,
+      voteKey: 'approvals',
+      voteMatch: 'approved',
+      resetOnRejection: true,
+    });
+    expect(hook.authorizedCallers).toHaveLength(4);
+    const slots = hook.authorizedCallers!.map((c) => c.agentSlots).flat();
+    expect(slots).toContain('architecture-reviewer');
+    expect(slots).toContain('security-reviewer');
+    expect(slots).toContain('correctness-reviewer');
+    expect(slots).toContain('ux-reviewer');
   });
 
   test('has three channels', () => {
@@ -1246,7 +995,7 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     const reviewToDispatcher = ch.find(
       (c) => c.from === 'Plan Review' && c.to === 'Task Dispatcher'
     );
-    expect(reviewToDispatcher?.gateId).toBe('plan-approval-gate');
+    expect(reviewToDispatcher?.gateId).toBeUndefined();
   });
 
   test('feedback channel Plan Review → Planning is ungated and cyclic', () => {
@@ -1293,9 +1042,9 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     for (let i = 0; i < expected.length; i++) {
       const slot = reviewNode.agents[i];
       expect(slot.name).toBe(expected[i].name);
-      // Each reviewer's prompt should reference their lens name and the approval gate
+      // Each reviewer's prompt should reference their lens name and the approval hook
       expect(slot.customPrompt?.value.toLowerCase()).toContain(expected[i].lens);
-      expect(slot.customPrompt?.value).toContain('plan-approval-gate');
+      expect(slot.customPrompt?.value).toContain('plan-approval hook');
     }
   });
 
@@ -1622,9 +1371,9 @@ describe('seedBuiltInWorkflows()', () => {
 
     const reviewToCode = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
     expect(reviewToCode).toBeDefined();
-    // Review → Coding is now gated by review-posted-gate so the reviewer's
-    // message cannot be delivered until a GitHub review is visible.
-    expect(reviewToCode!.gateId).toBe('review-posted-gate');
+    // Review → Coding is now ungated; the review-posted hook validates
+    // the reviewer's message before delivery.
+    expect(reviewToCode!.gateId).toBeUndefined();
     expect(reviewToCode!.maxCycles).toBe(5);
 
     const validationToCode = wf.channels!.find(
@@ -1635,12 +1384,26 @@ describe('seedBuiltInWorkflows()', () => {
     expect(validationToCode!.maxCycles).toBe(5);
   });
 
-  test('CODING_WORKFLOW seeded with three gates including validation-complete-gate', async () => {
+  test('CODING_WORKFLOW seeded with two gates: code-ready-gate and validation-complete-gate', async () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-    expect(wf.gates).toHaveLength(3);
+    expect(wf.gates).toHaveLength(2);
     const gateIds = wf.gates!.map((g) => g.id).sort();
-    expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate', 'validation-complete-gate']);
+    expect(gateIds).toEqual(['code-ready-gate', 'validation-complete-gate']);
+  });
+
+  test('CODING_WORKFLOW seeded with one hook: review-posted-hook', async () => {
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+    expect(wf.hooks).toBeDefined();
+    expect(wf.hooks).toHaveLength(1);
+    const hook = wf.hooks![0];
+    expect(hook.id).toBe('review-posted-hook');
+    expect(hook.sourceNode).toBe('Review');
+    expect(hook.targetNode).toBe('Coding');
+    expect(hook.method).toBe('send_message');
+    expect(hook.validator).toEqual({ kind: 'built_in', id: 'review_posted' });
+    expect(hook.enabled).toBe(true);
   });
 
   test('CODING_WORKFLOW seeded channels all have direction one-way', async () => {
@@ -1742,24 +1505,37 @@ describe('seedBuiltInWorkflows()', () => {
     expect(wf.channels).toHaveLength(3);
   });
 
-  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded with 2 gates', async () => {
+  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded with 1 gate: plan-pr-gate', async () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const wf = manager
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
-    expect(wf.gates).toHaveLength(2);
-    const gateIds = wf.gates!.map((g) => g.id);
-    expect(gateIds).toContain('plan-pr-gate');
-    expect(gateIds).toContain('plan-approval-gate');
+    expect(wf.gates).toHaveLength(1);
+    expect(wf.gates![0].id).toBe('plan-pr-gate');
   });
 
-  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded channels split into 2 gated + 1 ungated feedback', async () => {
+  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded with 1 hook: plan-approval-hook', async () => {
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const wf = manager
+      .listWorkflows(SPACE_ID)
+      .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
+    expect(wf.hooks).toBeDefined();
+    expect(wf.hooks).toHaveLength(1);
+    const hook = wf.hooks![0];
+    expect(hook.id).toBe('plan-approval-hook');
+    expect(hook.sourceNode).toBe('Plan Review');
+    expect(hook.targetNode).toBe('Task Dispatcher');
+    expect(hook.method).toBe('send_message');
+    expect(hook.validator).toEqual({ kind: 'built_in', id: 'review_approval' });
+  });
+
+  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded channels split into 1 gated + 1 hook-guarded + 1 ungated feedback', async () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const wf = manager
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
     const gatedChannels = wf.channels!.filter((c) => c.gateId !== undefined);
-    expect(gatedChannels).toHaveLength(2);
+    expect(gatedChannels).toHaveLength(1); // plan-pr-gate only
     const cyclicChannels = wf.channels!.filter((c) => c.maxCycles !== undefined);
     // One cyclic feedback channel: Plan Review → Planning
     expect(cyclicChannels).toHaveLength(1);
@@ -1972,6 +1748,19 @@ describe('seedBuiltInWorkflows()', () => {
       nodes: coding.nodes.map((node) =>
         node.id === reviewNode.id ? { ...node, name: 'Human Review' } : node
       ),
+      hooks: coding.hooks?.map((hook) =>
+        hook.sourceNode === 'Review'
+          ? {
+              ...hook,
+              sourceNode: 'Human Review',
+              targetNode: hook.targetNode === 'Coding' ? 'Coding' : hook.targetNode,
+              authorizedCallers: hook.authorizedCallers?.map((ac) => ({
+                ...ac,
+                sourceNode: 'Human Review',
+              })),
+            }
+          : hook
+      ),
     });
     db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
       'stale-hash',
@@ -2078,13 +1867,13 @@ describe('seedBuiltInWorkflows()', () => {
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
     const gateWithStaleWriters = workflow.gates!.map((gate) =>
-      gate.id !== 'review-approval-gate'
+      gate.id !== 'code-pr-gate'
         ? gate
         : {
             ...gate,
             features: undefined,
             fields: gate.fields!.map((field) =>
-              field.name === 'approved' ? { ...field, writers: [] } : field
+              field.name === 'pr_url' ? { ...field, writers: [] } : field
             ),
           }
     );
@@ -2099,10 +1888,10 @@ describe('seedBuiltInWorkflows()', () => {
     expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
 
     const after = manager.getWorkflow(workflow.id)!;
-    const gate = after.gates!.find((g) => g.id === 'review-approval-gate')!;
-    const approvedField = gate.fields!.find((f) => f.name === 'approved')!;
-    expect(approvedField.writers).toEqual(['Review', 'reviewer']);
-    expect(approvedField.check).toEqual({ op: '==', value: true });
+    const gate = after.gates!.find((g) => g.id === 'code-pr-gate')!;
+    const prField = gate.fields!.find((f) => f.name === 'pr_url')!;
+    expect(prField.writers).toEqual(['Coding', 'coder']);
+    expect(prField.check).toEqual({ op: 'exists' });
     // Template no longer hardcodes codex as a gate feature; it is opt-in via node config.
     expect(gate.features?.codex_review_bot).toBeUndefined();
   });
@@ -2113,7 +1902,7 @@ describe('seedBuiltInWorkflows()', () => {
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
     const gateWithCustomScript = workflow.gates!.map((gate) =>
-      gate.id !== 'review-approval-gate'
+      gate.id !== 'code-pr-gate'
         ? gate
         : {
             ...gate,
@@ -2122,9 +1911,6 @@ describe('seedBuiltInWorkflows()', () => {
           }
     );
 
-    // Simulate a legacy/customized row that predates scripted-gate validation:
-    // the Review node still has requireCodexApproval, but restamp must unflag it
-    // in the same update that validates the custom scripted approval gate.
     repo.updateWorkflow(workflow.id, { gates: gateWithCustomScript });
     db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
       'pre-custom-script-hash',
@@ -2135,12 +1921,9 @@ describe('seedBuiltInWorkflows()', () => {
     expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
 
     const after = manager.getWorkflow(workflow.id)!;
-    const gate = after.gates!.find((g) => g.id === 'review-approval-gate')!;
+    const gate = after.gates!.find((g) => g.id === 'code-pr-gate')!;
     expect(gate.script?.source).toBe('echo custom');
     expect(gate.features).toBeUndefined();
-    expect(
-      after.nodes.find((node) => node.name === 'Review')?.requireCodexApproval
-    ).toBeUndefined();
   });
 
   test('workflow validation rejects partial wildcard opt-in on scripted approval gates', () => {
@@ -2186,7 +1969,7 @@ describe('seedBuiltInWorkflows()', () => {
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
     const gateWithCustomPoll = workflow.gates!.map((gate) =>
-      gate.id !== 'review-approval-gate'
+      gate.id !== 'code-pr-gate'
         ? gate
         : {
             ...gate,
@@ -2205,7 +1988,7 @@ describe('seedBuiltInWorkflows()', () => {
     expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
 
     const after = manager.getWorkflow(workflow.id)!;
-    const gate = after.gates!.find((g) => g.id === 'review-approval-gate')!;
+    const gate = after.gates!.find((g) => g.id === 'code-pr-gate')!;
     expect(gate.poll?.script).toBe('echo custom poll');
     expect(gate.features).toBeUndefined();
   });
@@ -2219,59 +2002,6 @@ describe('seedBuiltInWorkflows()', () => {
     // Backward-compat: existing codex_review_bot is preserved during transition
     // to node-level config so pre-existing workflows keep working.
     expect(result![0].features).toEqual({ codex_review_bot: true });
-  });
-
-  test('re-stamp preserves codex_review_bot on non-approval gates', () => {
-    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    const workflow = manager
-      .listWorkflows(SPACE_ID)
-      .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
-    const gatesWithNonApprovalCodex = workflow.gates!.map((gate) =>
-      gate.id !== 'code-pr-gate' ? gate : { ...gate, features: { codex_review_bot: true } }
-    );
-
-    repo.updateWorkflow(workflow.id, { gates: gatesWithNonApprovalCodex });
-    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
-      'pre-non-approval-codex-hash',
-      workflow.id
-    );
-
-    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
-
-    const after = manager.getWorkflow(workflow.id)!;
-    const gate = after.gates!.find((g) => g.id === 'code-pr-gate')!;
-    expect(gate.features?.codex_review_bot).toBe(true);
-  });
-
-  test('re-stamp preserves codex_review_bot on custom-polled approval gates', () => {
-    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    const workflow = manager
-      .listWorkflows(SPACE_ID)
-      .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
-    const gatesWithCustomPollCodex = workflow.gates!.map((gate) =>
-      gate.id !== 'review-approval-gate'
-        ? gate
-        : {
-            ...gate,
-            features: { codex_review_bot: true },
-            poll: { intervalMs: 30_000, target: 'from' as const, script: 'echo custom poll' },
-          }
-    );
-
-    repo.updateWorkflow(workflow.id, { gates: gatesWithCustomPollCodex });
-    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
-      'pre-custom-polled-codex-hash',
-      workflow.id
-    );
-
-    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
-
-    const after = manager.getWorkflow(workflow.id)!;
-    const gate = after.gates!.find((g) => g.id === 'review-approval-gate')!;
-    expect(gate.features?.codex_review_bot).toBe(true);
-    expect(gate.poll?.script).toBe('echo custom poll');
   });
 
   test('mergeNodeStructuralFieldsFromTemplate clears removed template Codex approval flags', () => {
@@ -2290,49 +2020,6 @@ describe('seedBuiltInWorkflows()', () => {
 
     const reviewNode = result.find((node) => node.name === 'Review')!;
     expect(reviewNode.requireCodexApproval).toBeUndefined();
-  });
-
-  test('re-stamp preserves migrated codex gate when source node is unflagged', () => {
-    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    const workflow = manager
-      .listWorkflows(SPACE_ID)
-      .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
-    const reviewApprovalGate = workflow.gates!.find((gate) => gate.id === 'review-approval-gate')!;
-    const scriptedReviewGate = {
-      ...reviewApprovalGate,
-      id: 'scripted-review-gate',
-      features: undefined,
-      script: { interpreter: 'bash' as const, source: 'echo custom', timeoutMs: 10000 },
-    };
-
-    repo.updateWorkflow(workflow.id, {
-      gates: workflow
-        .gates!.map((gate) =>
-          gate.id === 'review-approval-gate'
-            ? { ...gate, features: { codex_review_bot: true } }
-            : gate
-        )
-        .concat(scriptedReviewGate),
-      channels: workflow.channels!.concat({
-        id: 'scripted-review-channel',
-        from: 'Review',
-        to: 'Coding',
-        gateId: 'scripted-review-gate',
-      }),
-    });
-    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
-      'pre-unflagged-codex-source-hash',
-      workflow.id
-    );
-
-    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-    expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
-
-    const after = manager.getWorkflow(workflow.id)!;
-    const reviewNode = after.nodes.find((node) => node.name === 'Review')!;
-    const migratedGate = after.gates!.find((gate) => gate.id === 'review-approval-gate')!;
-    expect(reviewNode.requireCodexApproval).toBeUndefined();
-    expect(migratedGate.features?.codex_review_bot).toBe(true);
   });
 
   test('mergeGateStructuralFieldsFromTemplate clears non-codex features when template removes them', () => {
@@ -2435,6 +2122,19 @@ describe('seedBuiltInWorkflows()', () => {
         return node;
       }),
       channels: legacyChannels,
+      hooks: coding.hooks?.map((hook) =>
+        hook.sourceNode === 'Review'
+          ? {
+              ...hook,
+              sourceNode: 'Human Review',
+              targetNode: hook.targetNode === 'Coding' ? 'Implementation' : hook.targetNode,
+              authorizedCallers: hook.authorizedCallers?.map((ac) => ({
+                ...ac,
+                sourceNode: 'Human Review',
+              })),
+            }
+          : hook
+      ),
     });
     db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
       'renamed-node-drift',
@@ -2758,7 +2458,7 @@ describe('seedBuiltInWorkflows()', () => {
     const planNode = wf.nodes.find((n) => n.name === 'Planning');
     expect(planNode?.agents[0].customPrompt?.value).toContain('plan-pr-gate');
     const planReviewNode = wf.nodes.find((n) => n.name === 'Plan Review');
-    expect(planReviewNode?.agents[0].customPrompt?.value).toContain('plan-approval-gate');
+    expect(planReviewNode?.agents[0].customPrompt?.value).toContain('plan-approval hook');
     const dispatcherNode = wf.nodes.find((n) => n.name === 'Task Dispatcher');
     expect(dispatcherNode?.agents[0].customPrompt?.value).toContain('create_standalone_task');
     expect(dispatcherNode?.agents[0].customPrompt?.value).toContain('save_artifact');
@@ -2811,8 +2511,6 @@ describe('seedBuiltInWorkflows()', () => {
     const planPr = wf.gates!.find((g) => g.id === 'plan-pr-gate')!;
     // Planning cycles back on feedback; PR state must be re-verified per cycle.
     expect(planPr.resetOnCycle).toBe(true);
-    const planApproval = wf.gates!.find((g) => g.id === 'plan-approval-gate')!;
-    expect(planApproval.resetOnCycle).toBe(true);
   });
 
   // ─── Channel ID assignment ──────────────────────────────────────────────
@@ -2841,28 +2539,28 @@ describe('seedBuiltInWorkflows()', () => {
     // direction field removed from WorkflowChannel schema
   });
 
-  // ─── plan-approval-gate auto-approval via requiredLevel ──────────────────
+  // ─── plan-approval-hook threshold tests ──────────────────
 
-  test('PLAN_AND_DECOMPOSE_WORKFLOW plan-approval-gate requires four reviewer approvals', () => {
-    const gate = PLAN_AND_DECOMPOSE_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
-    const approvalsField = gate.fields.find((f) => f.name === 'approvals')!;
-    expect(approvalsField.type).toBe('map');
-    expect(approvalsField.writers).toEqual(['Plan Review']);
-    expect(approvalsField.check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
-    // Codex is no longer hardcoded as a gate feature; it is opt-in via node-level config.
-    expect(gate.features?.codex_review_bot).toBeUndefined();
+  test('PLAN_AND_DECOMPOSE_WORKFLOW plan-approval-hook has threshold 4 in templateData', () => {
+    const hook = PLAN_AND_DECOMPOSE_WORKFLOW.hooks!.find((h) => h.id === 'plan-approval-hook')!;
+    expect(hook.templateData).toMatchObject({
+      threshold: 4,
+      voteKey: 'approvals',
+      voteMatch: 'approved',
+    });
   });
 
-  test('seeded plan-approval-gate preserves map-count check with min=4', () => {
+  test('seeded plan-approval-hook preserves templateData with threshold 4', () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const wf = manager
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
-    const gate = wf.gates!.find((g) => g.id === 'plan-approval-gate')!;
-    const approvalsField = gate.fields.find((f) => f.name === 'approvals')!;
-    expect(approvalsField.type).toBe('map');
-    expect(approvalsField.writers).toEqual(['Plan Review']);
-    expect(approvalsField.check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
+    const hook = wf.hooks!.find((h) => h.id === 'plan-approval-hook')!;
+    expect(hook.templateData).toMatchObject({
+      threshold: 4,
+      voteKey: 'approvals',
+      voteMatch: 'approved',
+    });
   });
 
   // ─── getBuiltInWorkflows ordering ────────────────────────────────────────
@@ -3279,26 +2977,10 @@ describe('getBuiltInGateScript()', () => {
     expect(script?.source).toContain('MERGEABLE');
   });
 
-  test('returns the bash script for review-posted-gate in Coding Workflow', () => {
-    const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
-    expect(script).toBeDefined();
-    expect(script?.interpreter).toBe('bash');
-    // The review-posted script should include the PR comment fallback path
-    expect(script?.source).toContain('gh pr view');
-    expect(script?.source).toContain('comments');
-    // Confirm the current fallback message is present (not the stale "No review submitted on…")
-    expect(script?.source).toContain('No review or PR comment found on');
-  });
-
   test('returns the bash script for plan-pr-gate in Plan & Decompose Workflow', () => {
     const script = getBuiltInGateScript(PLAN_AND_DECOMPOSE_WORKFLOW.name, 'plan-pr-gate');
     expect(script).toBeDefined();
     expect(script?.interpreter).toBe('bash');
-  });
-
-  test('returns undefined for a field-only gate (plan-approval-gate has no script)', () => {
-    const script = getBuiltInGateScript(PLAN_AND_DECOMPOSE_WORKFLOW.name, 'plan-approval-gate');
-    expect(script).toBeUndefined();
   });
 
   test('returns undefined when the template name does not match any built-in', () => {
@@ -3309,13 +2991,6 @@ describe('getBuiltInGateScript()', () => {
   test('returns undefined when the gate ID does not exist in the template', () => {
     const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'nonexistent-gate-id');
     expect(script).toBeUndefined();
-  });
-
-  test('returned script matches the gate definition directly from the template', () => {
-    // Verify the helper returns the exact same object reference as the template defines
-    const templateGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
-    const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
-    expect(script).toBe(templateGate.script); // same object reference
   });
 
   test('returns scripts for all script-based gates in all templates', () => {
@@ -3329,13 +3004,6 @@ describe('getBuiltInGateScript()', () => {
         expect(script?.source).toBe(gate.script.source);
       }
     }
-  });
-
-  test('review-posted-gate script includes NEOKAI_WORKFLOW_START_ISO usage', () => {
-    const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
-    // The review-posted-gate script must use NEOKAI_WORKFLOW_START_ISO to filter
-    // reviews that were posted after the workflow started
-    expect(script?.source).toContain('NEOKAI_WORKFLOW_START_ISO');
   });
 });
 
@@ -3420,15 +3088,15 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
     const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
     const reviewer = reviewNode.agents[0];
     const prompt = reviewer.customPrompt!.value;
-    // Reviewer must post to GitHub via gh pr review / gh api.
-    expect(prompt).toContain('gh pr review');
+    // Reviewer must post to GitHub via the Reviewer System Contract.
+    expect(prompt).toContain('GitHub review procedure');
     expect(prompt).toContain('gh api');
     // And on the changes-requested path, send_message to Coding must carry
     // the review URL + comment URLs so the coder can reply inline.
     expect(prompt).toContain('review_url');
     expect(prompt).toContain('comment_urls');
-    // The gate name must be mentioned so the reviewer understands the contract.
-    expect(prompt).toContain('review-posted-gate');
+    // The hook name must be mentioned so the reviewer understands the contract.
+    expect(prompt).toContain('review-posted');
   });
 });
 
@@ -3479,14 +3147,14 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW agent slot customPrompt', () => {
     expect(agent.customPrompt?.value).toContain('plan-pr-gate');
   });
 
-  test('Plan Review node has 4 lens-specific reviewers, each referencing plan-approval-gate and its lens', () => {
+  test('Plan Review node has 4 lens-specific reviewers, each referencing plan-approval hook and its lens', () => {
     const node = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find((n) => n.name === 'Plan Review')!;
     expect(node.agents).toHaveLength(4);
     const lenses = ['architecture', 'security', 'correctness', 'ux'];
     const seenLenses: string[] = [];
     for (const agent of node.agents) {
       expect(agent.customPrompt?.value).toBeDefined();
-      expect(agent.customPrompt?.value).toContain('plan-approval-gate');
+      expect(agent.customPrompt?.value).toContain('plan-approval hook');
       // Each reviewer's prompt references its specific lens
       const lensForAgent = lenses.find((l) => agent.customPrompt!.value.includes(`"${l}"`));
       expect(lensForAgent).toBeDefined();
@@ -3642,684 +3310,18 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     );
   });
 
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate requires reviewer and codex approval', () => {
-    const gate = FULLSTACK_QA_LOOP_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
-    const approvalField = gate.fields!.find((f) => f.name === 'approved')!;
-
-    expect(approvalField.type).toBe('boolean');
-    expect(approvalField.writers).toEqual(['Review', 'reviewer']);
-    expect(approvalField.check).toEqual({ op: '==', value: true });
-    // Codex is no longer hardcoded as a gate feature; it is opt-in via node-level config.
-    expect(gate.features?.codex_review_bot).toBeUndefined();
-    expect(gate.script).toBeUndefined();
-    expect(gate.poll).toBeUndefined();
-
-    const effectiveGate = getFullstackReviewApprovalGateWithCodex();
-    expect(effectiveGate.script?.source).toContain('codex[bot]');
-    expect(effectiveGate.script?.source).toContain('issues/${NUMBER}/reactions?per_page=100');
-    expect(effectiveGate.script?.source).toContain('--paginate');
-    expect(effectiveGate.script?.source).toContain("jq -s 'add // []'");
-    expect(effectiveGate.script?.source).toContain('.content == "+1"');
-    expect(effectiveGate.script?.source).toContain('bun -e');
-    expect(effectiveGate.script?.source).toContain('NEOKAI_GATE_DATA_UPDATED_ISO');
-    expect(effectiveGate.script?.source).toContain('PR_URL="${GATE_PR_URL:-${PR_URL:-}}"');
-    expect(effectiveGate.script?.source).toContain("comment '@codex review'");
-    expect(effectiveGate.script?.source).not.toContain('node -e');
-    expect(effectiveGate.script?.source).toContain('.head.sha');
-    expect(effectiveGate.script?.source).toContain('head_sha');
-    expect(effectiveGate.script?.source).toContain('^https://([^/]+)/');
-    expect(effectiveGate.script?.source).not.toContain('github\\.com');
-    expect(effectiveGate.poll?.intervalMs).toBe(300_000);
-  });
-
-  test('dynamic codex injection honors wildcard source node opt-in', () => {
-    const gate = {
-      id: 'wildcard-approval-gate',
-      fields: [
-        { name: 'approved', type: 'boolean', writers: [], check: { op: '==', value: true } },
-      ],
-      resetOnCycle: false,
-    };
-    const effectiveGate = getEffectiveGate(
-      gate,
-      {
-        id: 'wf-wildcard-codex',
-        spaceId: 'space-1',
-        name: 'Wildcard Codex Workflow',
-        tags: [],
-        nodes: [
-          { id: 'node-coder', name: 'Coder', agents: [], requireCodexApproval: true },
-          { id: 'node-reviewer', name: 'Reviewer', agents: [] },
-        ],
-        startNodeId: 'node-coder',
-        endNodeId: 'node-reviewer',
-        channels: [{ id: 'ch-1', from: '*', to: 'Reviewer', gateId: gate.id }],
-        gates: [gate],
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        completionAutonomyLevel: 3,
-      },
-      'Coder'
-    );
-
-    expect(effectiveGate.script?.source).toContain('codex[bot]');
-  });
-
-  test('isApprovalGate recognizes vote-map approvals by check semantics', () => {
-    expect(
-      isApprovalGate({
-        id: 'semantic-approval-gate',
-        fields: [
-          {
-            name: 'votes',
-            type: 'map',
-            writers: [],
-            check: { op: 'count', match: 'approved', min: 1 },
-          },
-        ],
-        resetOnCycle: false,
-      })
-    ).toBe(true);
-  });
-
-  test('isApprovalGate recognizes boolean approval checks independent of field name', () => {
-    expect(
-      isApprovalGate({
-        id: 'semantic-boolean-approval-gate',
-        fields: [
-          {
-            name: 'signoff',
-            type: 'boolean',
-            writers: [],
-            check: { op: '==', value: true },
-          },
-        ],
-        resetOnCycle: false,
-      })
-    ).toBe(true);
-  });
-
-  test('invalid Codex poll interval env values fall back to default', () => {
-    expect(resolveCodexPollIntervalMs(undefined)).toBe(300000);
-    expect(resolveCodexPollIntervalMs('5m')).toBe(300000);
-    expect(resolveCodexPollIntervalMs('0')).toBe(300000);
-    expect(resolveCodexPollIntervalMs(30000)).toBe(30000);
-  });
-
-  test('dynamic Codex injection handles node and agent source name collision', () => {
-    const gate = {
-      id: 'agent-source-gate',
-      fields: [
-        {
-          name: 'signoff',
-          type: 'boolean' as const,
-          writers: [],
-          check: { op: '==', value: true },
-        },
-      ],
-      resetOnCycle: false,
-    };
-    const workflow = {
-      id: 'wf-agent-source-collision',
-      spaceId: 'space-1',
-      name: 'Agent Source Collision',
-      tags: [],
-      nodes: [
-        {
-          id: 'node-source',
-          name: 'SourceNode',
-          agents: [{ agentId: 'agent-coder', name: 'Reviewer' }],
-        },
-        {
-          id: 'node-collision',
-          name: 'Reviewer',
-          requireCodexApproval: true,
-          agents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
-        },
-      ],
-      channels: [{ id: 'ch-node-source', from: 'Reviewer', to: 'reviewer', gateId: gate.id }],
-      gates: [gate],
-      startNodeId: 'node-source',
-      endNodeId: 'node-collision',
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      completionAutonomyLevel: 3,
-    };
-
-    expect(getEffectiveGate(gate, workflow, 'Reviewer').script?.source).toContain('codex[bot]');
-
-    workflow.nodes[0] = { ...workflow.nodes[0], requireCodexApproval: true };
-    workflow.nodes[1] = { ...workflow.nodes[1], requireCodexApproval: undefined };
-
-    expect(getEffectiveGate(gate, workflow, 'Reviewer').script?.source).toContain('codex[bot]');
-  });
-
-  test('codex feature script and poll override custom script and poll consistently', () => {
-    const gate = getEffectiveGate({
-      id: 'custom-codex-gate',
-      resetOnCycle: false,
-      features: { codex_review_bot: true },
-      script: { interpreter: 'bash', source: 'echo custom', timeoutMs: 10000 },
-      poll: { intervalMs: 30_000, target: 'to', script: 'echo custom poll' },
-    });
-
-    expect(gate.script?.source).toContain('codex[bot]');
-    expect(gate.poll?.script).toContain('codex[bot]');
-    expect(gate.script?.source).not.toContain('echo custom');
-    expect(gate.poll?.script).not.toContain('echo custom poll');
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate blocks without codex thumbs-up', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-blocked-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\n' '[{"user":{"login":"codex[bot]"},"content":"eyes","created_at":"2026-05-29T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('still in progress');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate passes with codex thumbs-up', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-passed-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\n' '[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"2026-05-29T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\n' 'sha-pass'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: prUrl,
-        codex_bot_reaction: '+1',
-        head_sha: 'sha-pass',
-      });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate still blocks before gate-data timeout even when workflow is old', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-fresh-approval-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\n' '[]'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-          gateDataUpdatedIso: new Date().toISOString(),
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('@codex review');
-      expect(result.error).not.toContain('command not found');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate passes after codex timeout', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-timeout-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\n' '[]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\n' 'sha-timeout'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-          workflowStartIso: '2026-05-01T00:00:00Z',
-          gateDataUpdatedIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: prUrl,
-        codex_bot_reaction: 'timeout',
-        head_sha: 'sha-timeout',
-        codex_bot_warning: 'codex review bot +1 reaction missing after timeout; allowing gate',
-      });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate returns +1 even when timeout has elapsed', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-timeout-plus-one-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\\n' '[{"user":{"login":"codex[bot]"},"content":"+1","created_at":"2026-05-01T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\\n' 'sha-timeout-plus-one'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-          // Timeout has elapsed, but +1 is present — +1 should win.
-          workflowStartIso: '2026-05-01T00:00:00Z',
-          gateDataUpdatedIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({
-        pr_url: prUrl,
-        codex_bot_reaction: '+1',
-        head_sha: 'sha-timeout-plus-one',
-      });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate blocks +1 from before cycle_start_at', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-stale-plus-one-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\n' '[{"user":{"login":"codex[bot]"},"content":"+1","created_at":"2026-05-01T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          // Reaction is before cycle_start_at — should be filtered as stale.
-          gateData: {
-            pr_url: prUrl,
-            approved: true,
-            cycle_start_at: new Date('2026-05-02T00:00:00Z').getTime(),
-          },
-          gateDataUpdatedIso: new Date().toISOString(),
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('@codex review');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('FULLSTACK_QA_LOOP_WORKFLOW review-approval-gate outputs head_sha on success', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-head-sha-output-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\\n' '[{"user":{"login":"codex[bot]"},"content":"+1","created_at":"2026-05-02T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\\n' 'abc123'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-          gateDataUpdatedIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({ pr_url: prUrl, codex_bot_reaction: '+1', head_sha: 'abc123' });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('codex script accepts GitHub Enterprise PR URLs', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-gh-enterprise-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.enterprise.example.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" != *"--hostname github.enterprise.example.com"* ]]; then',
-          '  echo "Missing --hostname for GHE URL: $*" >&2',
-          '  exit 2',
-          'fi',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\\n' '[{"user":{"login":"codex[bot]"},"content":"+1","created_at":"2026-05-29T00:00:00Z"}]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\\n' 'ent123'`,
-          '  exit 0',
-          'fi',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}`, GH_HOST: 'github.enterprise.example.com' }
-      );
-
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({ pr_url: prUrl, codex_bot_reaction: '+1', head_sha: 'ent123' });
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('codex script fails closed when gh api reactions fetch fails', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-pipefail-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          '  echo "API rate limit exceeded" >&2',
-          '  exit 1',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to fetch PR reactions');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('codex timeout does not trigger when only workflowStartIso is old', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-gate-timeout-suppressed-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\\n' '[]'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        gate.script!,
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-          // Only workflowStartIso is old; gateDataUpdatedIso is missing.
-          // Timeout should not trigger because it only uses gateDataUpdatedIso.
-          workflowStartIso: '2026-05-01T00:00:00Z',
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('@codex review');
-      expect(result.error).not.toContain('timeout');
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
-  });
-
-  test('codex poll script exits 0 with pending status when no reaction exists', async () => {
-    const gate = getFullstackReviewApprovalGateWithCodex();
-    const workspace = mkdtempSync(join(tmpdir(), 'neokai-codex-poll-pending-'));
-    const binDir = join(workspace, 'bin');
-    const ghPath = join(binDir, 'gh');
-    const prUrl = 'https://github.com/test/repo/pull/42';
-
-    try {
-      mkdirSync(binDir);
-      writeFileSync(
-        ghPath,
-        [
-          '#!/usr/bin/env bash',
-          'if [[ "$*" == *"repos/test/repo/issues/42/reactions"* ]]; then',
-          `  printf '%s\\n' '[]'`,
-          '  exit 0',
-          'fi',
-          'if [[ "$*" =~ repos/test/repo/pulls/42 ]]; then',
-          `  printf '%s\\n' 'sha-poll-pending'`,
-          '  exit 0',
-          'fi',
-          'printf "unexpected gh args: %s\\n" "$*" >&2',
-          'exit 2',
-        ].join('\n')
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = await executeGateScript(
-        { interpreter: 'bash', source: gate.poll!.script },
-        {
-          workspacePath: workspace,
-          gateId: 'review-approval-gate',
-          runId: 'run-1',
-          gateData: { pr_url: prUrl, approved: true },
-        },
-        { PATH: `${binDir}:${process.env.PATH ?? ''}` }
-      );
-
-      // Poll must exit 0 even when pending so GatePollManager continues polling.
-      expect(result.success).toBe(true);
-      expect(result.data).toEqual({});
-    } finally {
-      rmSync(workspace, { recursive: true, force: true });
-    }
+  test('FULLSTACK_QA_LOOP_WORKFLOW has one hook: review-approval-hook on send_message from Review to QA', () => {
+    expect(FULLSTACK_QA_LOOP_WORKFLOW.hooks).toBeDefined();
+    expect(FULLSTACK_QA_LOOP_WORKFLOW.hooks).toHaveLength(1);
+    const hook = FULLSTACK_QA_LOOP_WORKFLOW.hooks![0];
+    expect(hook.id).toBe('review-approval-hook');
+    expect(hook.sourceNode).toBe('Review');
+    expect(hook.targetNode).toBe('QA');
+    expect(hook.method).toBe('send_message');
+    expect(hook.validator).toEqual({ kind: 'built_in', id: 'review_approval' });
+    expect(hook.templateData).toMatchObject({ threshold: 1, requireCodex: true });
+    expect(hook.enabled).toBe(true);
+    expect(hook.classification).toBe('validation');
   });
 
   test('FULLSTACK_QA_LOOP_WORKFLOW reviewer prompt instructs waiting for codex reaction', () => {
@@ -4402,7 +3404,7 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     const prompt = reviewNode.agents[0].customPrompt!.value;
     // Review is mid-graph in this workflow — terminal tools are unavailable
     // to it — but the pre-conditions block must still be present so the
-    // reviewer does not silently flip review-approval-gate while findings
+    // reviewer does not silently flip review-approval hook while findings
     // are open.
     expect(prompt).toMatch(
       /terminal-action tool contract|Terminal-action contract|terminal hand-off|terminal action|terminal calls|terminal actions|terminal-action tool descriptions/
@@ -4413,7 +3415,7 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     expect(prompt).toMatch(
       /REQUEST_CHANGES|changes needed|requesting changes|more research is needed|findings remain|QA fails/i
     );
-    expect(prompt).toContain('review-approval-gate');
+    expect(prompt).toContain('review-approval hook');
     // Failure-path routing: the prompt must explicitly tell the reviewer to
     // send feedback back to Coding via send_message rather than silently
     // stalling. Asserting this catches future drift in the routing wording.
@@ -4421,8 +3423,8 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
       /send_message\(target="Coding", \.\.\.\)|send actionable feedback to Coding|feedback to Coding/i
     );
     // Same approval semantic clarifier: even though approve_task /
-    // submit_for_approval are unavailable on this mid-graph node, writing
-    // the approval gate is the equivalent terminal hand-off and the prompt
+    // submit_for_approval are unavailable on this mid-graph node, the
+    // review-approval hook is the equivalent terminal hand-off and the prompt
     // must call out the parallel so a future split (where the tools become
     // available) does not accidentally remove the gating.
     expect(prompt).toMatch(

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -33,6 +33,7 @@ import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-w
 import {
   CODING_WORKFLOW,
   FULLSTACK_QA_LOOP_WORKFLOW,
+  mergeChannelsFromTemplate,
   mergeNodeStructuralFieldsFromTemplate,
   getBuiltInGateScript,
   getBuiltInWorkflows,
@@ -2029,6 +2030,47 @@ describe('seedBuiltInWorkflows()', () => {
     const result = mergeGateStructuralFieldsFromTemplate(existingGates, templateGates);
     expect(result).toHaveLength(1);
     expect(result![0].features).toBeUndefined();
+  });
+
+  test('mergeGateStructuralFieldsFromTemplate removes gates no longer in template', () => {
+    const existingGates = [
+      {
+        id: 'old-gate',
+        fields: [{ name: 'f1', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+      },
+      { id: 'kept-gate', fields: [] },
+    ];
+    const templateGates = [{ id: 'kept-gate', fields: [] }];
+
+    const result = mergeGateStructuralFieldsFromTemplate(existingGates, templateGates);
+    expect(result).toHaveLength(1);
+    expect(result![0].id).toBe('kept-gate');
+  });
+
+  test('mergeChannelsFromTemplate replaces existing channels with same from→to', () => {
+    const existingChannels = [
+      { from: 'A', to: 'B', gateId: 'old-gate' },
+      { from: 'C', to: 'D' },
+    ];
+    const templateChannels = [
+      { from: 'A', to: 'B' },
+      { from: 'E', to: 'F' },
+    ];
+
+    const result = mergeChannelsFromTemplate(
+      existingChannels as SpaceWorkflow['channels'],
+      templateChannels as SpaceWorkflow['channels'],
+      [],
+      []
+    );
+    expect(result).toHaveLength(3);
+    const ab = result!.find((ch) => ch.from === 'A' && ch.to === 'B');
+    expect(ab).toBeDefined();
+    expect(ab!.gateId).toBeUndefined();
+    const cd = result!.find((ch) => ch.from === 'C' && ch.to === 'D');
+    expect(cd).toBeDefined();
+    const ef = result!.find((ch) => ch.from === 'E' && ch.to === 'F');
+    expect(ef).toBeDefined();
   });
 
   test('re-stamp appends missing validation node and channels with resolved agent IDs', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2076,6 +2076,28 @@ describe('seedBuiltInWorkflows()', () => {
     expect(ef).toBeDefined();
   });
 
+  test('mergeChannelsFromTemplate treats single-target arrays as same from→to', () => {
+    const existingChannels = [
+      { from: 'Review', to: ['QA'], gateId: 'review-approval-gate' },
+      { from: 'Coding', to: 'Review' },
+    ];
+    const templateChannels = [{ from: 'Review', to: 'QA', hookIds: ['review-approval-hook'] }];
+
+    const result = mergeChannelsFromTemplate(
+      existingChannels as SpaceWorkflow['channels'],
+      templateChannels as SpaceWorkflow['channels'],
+      [],
+      []
+    );
+
+    expect(result).toHaveLength(2);
+    const reviewQaChannels = result!.filter((ch) => ch.from === 'Review');
+    expect(reviewQaChannels).toHaveLength(1);
+    expect(reviewQaChannels[0].to).toBe('QA');
+    expect(reviewQaChannels[0].gateId).toBeUndefined();
+    expect(reviewQaChannels[0].hookIds).toEqual(['review-approval-hook']);
+  });
+
   test('re-stamp appends missing validation node and channels with resolved agent IDs', () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -935,10 +935,10 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     expect(ids).toContain('plan-pr-gate');
   });
 
-  test('has one hook: plan-approval-hook on send_message from Plan Review to Task Dispatcher', () => {
+  test('has two hooks: plan-approval-hook and plan-approval-reset-hook', () => {
     expect(PLAN_AND_DECOMPOSE_WORKFLOW.hooks).toBeDefined();
-    expect(PLAN_AND_DECOMPOSE_WORKFLOW.hooks).toHaveLength(1);
-    const hook = PLAN_AND_DECOMPOSE_WORKFLOW.hooks![0];
+    expect(PLAN_AND_DECOMPOSE_WORKFLOW.hooks).toHaveLength(2);
+    const hook = PLAN_AND_DECOMPOSE_WORKFLOW.hooks!.find((h) => h.id === 'plan-approval-hook')!;
     expect(hook.id).toBe('plan-approval-hook');
     expect(hook.sourceNode).toBe('Plan Review');
     expect(hook.targetNode).toBe('Task Dispatcher');
@@ -1514,13 +1514,13 @@ describe('seedBuiltInWorkflows()', () => {
     expect(wf.gates![0].id).toBe('plan-pr-gate');
   });
 
-  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded with 1 hook: plan-approval-hook', async () => {
+  test('PLAN_AND_DECOMPOSE_WORKFLOW seeded with 2 hooks: plan-approval-hook + plan-approval-reset-hook', async () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const wf = manager
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
     expect(wf.hooks).toBeDefined();
-    expect(wf.hooks).toHaveLength(1);
+    expect(wf.hooks).toHaveLength(2);
     const hook = wf.hooks![0];
     expect(hook.id).toBe('plan-approval-hook');
     expect(hook.sourceNode).toBe('Plan Review');
@@ -3310,10 +3310,10 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     );
   });
 
-  test('FULLSTACK_QA_LOOP_WORKFLOW has one hook: review-approval-hook on send_message from Review to QA', () => {
+  test('FULLSTACK_QA_LOOP_WORKFLOW has three hooks: review-approval-hook + two reset hooks', () => {
     expect(FULLSTACK_QA_LOOP_WORKFLOW.hooks).toBeDefined();
-    expect(FULLSTACK_QA_LOOP_WORKFLOW.hooks).toHaveLength(1);
-    const hook = FULLSTACK_QA_LOOP_WORKFLOW.hooks![0];
+    expect(FULLSTACK_QA_LOOP_WORKFLOW.hooks).toHaveLength(3);
+    const hook = FULLSTACK_QA_LOOP_WORKFLOW.hooks!.find((h) => h.id === 'review-approval-hook')!;
     expect(hook.id).toBe('review-approval-hook');
     expect(hook.sourceNode).toBe('Review');
     expect(hook.targetNode).toBe('QA');

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -3231,13 +3231,15 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW agent slot customPrompt', () => {
     expect(seenLenses.sort()).toEqual([...lenses].sort());
   });
 
-  test('Plan Review prompt instructs waiting for codex reaction before voting', () => {
+  test('Plan Review prompt instructs hook hand-off for codex reaction wait', () => {
     const node = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find((n) => n.name === 'Plan Review')!;
     const prompt = node.agents[0].customPrompt!.value;
     expect(prompt).toContain('codex[bot]');
     expect(prompt).toContain('issues/{number}/reactions');
-    expect(prompt).toContain('poll every 60 seconds');
+    expect(prompt).toContain('hook-validated hand-off message');
     expect(prompt).toContain('10 minutes');
+    expect(prompt).not.toContain('Write the approval gate');
+    expect(prompt).not.toContain('retry the gate write');
   });
 
   test('Task Dispatcher node prompt references create_standalone_task and save_artifact', () => {
@@ -3391,14 +3393,16 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     expect(hook.classification).toBe('validation');
   });
 
-  test('FULLSTACK_QA_LOOP_WORKFLOW reviewer prompt instructs waiting for codex reaction', () => {
+  test('FULLSTACK_QA_LOOP_WORKFLOW reviewer prompt instructs hook hand-off for codex reaction wait', () => {
     const reviewNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
     const prompt = reviewNode.agents[0].customPrompt!.value;
 
     expect(prompt).toContain('codex[bot]');
     expect(prompt).toContain('issues/{number}/reactions');
-    expect(prompt).toContain('poll every 60 seconds');
+    expect(prompt).toContain('hook-validated hand-off message');
     expect(prompt).toContain('10 minutes');
+    expect(prompt).not.toContain('Write the approval gate');
+    expect(prompt).not.toContain('retry the gate write');
   });
 
   test('FULLSTACK_QA_LOOP_WORKFLOW code-pr-gate lets only Coding publish PR URL', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1613,6 +1613,8 @@ export interface WorkflowHookEmitFollowUpResult extends WorkflowHookBaseResult {
 export interface WorkflowHookRecordStateResult extends WorkflowHookBaseResult {
   type: 'record_state';
   state: Record<string, unknown>;
+  /** When set, persist state to the specified hook instead of the current one. */
+  targetHookId?: string;
 }
 
 export type WorkflowHookResult =

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1526,7 +1526,9 @@ export type WorkflowHookValidatorId =
   | 'github_review_approved'
   | 'codex_review_approved'
   | 'artifact_exists'
-  | 'task_reported_status';
+  | 'task_reported_status'
+  | 'review_approval'
+  | 'review_posted';
 
 export type WorkflowHookExternalLookup = 'github';
 
@@ -1585,12 +1587,16 @@ export interface WorkflowHookAllowResult extends WorkflowHookBaseResult {
 export interface WorkflowHookBlockResult extends WorkflowHookBaseResult {
   type: 'block';
   reason: string;
+  /** Optional state to persist into hook-local storage even when blocking. */
+  state?: Record<string, unknown>;
 }
 
 export interface WorkflowHookRetryableBlockResult extends WorkflowHookBaseResult {
   type: 'retryable_block';
   reason: string;
   retryAfterMs?: number;
+  /** Optional state to persist into hook-local storage even when blocking. */
+  state?: Record<string, unknown>;
 }
 
 export interface WorkflowHookPatchParamsResult extends WorkflowHookBaseResult {


### PR DESCRIPTION
Part of stack: Redesign workflow gates as MCP action hooks. PR 5 of 10.

Migrates `review-approval-gate`, `plan-approval-gate`, and `review-posted-gate` from gate-based flow control to built-in hook validators attached to reviewer-node `send_message` actions.

**Changes:**
- `review-approval-validator`: generic approval/voting validator supporting single-reviewer (Review → QA) and multi-reviewer (Plan Review → Task Dispatcher) flows. Accumulates typed votes in hook-local state via `block`/`retryable_block` result `state`, checks thresholds, handles rejection reset, and codex timeout.
- `review-posted-validator`: validates review evidence from message `data.review_url` or review artifacts before allowing Review → Coding feedback.
- Extended `WorkflowHookBlockResult` / `WorkflowHookRetryableBlockResult` with optional `state` so votes persist even when blocked.
- Updated `CODING_WORKFLOW`, `FULLSTACK_QA_LOOP_WORKFLOW`, and `PLAN_AND_DECOMPOSE_WORKFLOW` to remove old gates and add corresponding hooks.
- Added hook merging during workflow re-stamp so renamed nodes don't break hook references.
- Updated all affected tests (235 built-in-workflows tests, 75 validator/hook-engine tests, 142 node-agent-tools tests).

**Test coverage:**
- Concurrent reviewer votes and deep-merge race behavior
- Rejection feedback reset
- Review evidence validation (message data + artifacts)
- Threshold activation
- State persistence on `block` and `retryable_block` results
- Codex timeout handling