### PR TITLE
fix: broaden QA ui_changed classification for backend changes

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -14,6 +14,38 @@ Project-specific QA guidance for the QA agent.
 - If a server is already running on your target port, pick a different port
 - Shut down your server when QA is complete
 
+## Classifying `ui_changed`
+
+Before deciding whether to browser-test, classify the PR's `ui_changed` status using these rules:
+
+### Rule 1: Frontend file changes → `ui_changed: true`
+
+Changed files matching these patterns always trigger browser testing:
+- `packages/web/**`
+- `packages/ui/**`
+- `*.css`, `*.html`
+
+### Rule 2: Backend modules with UI-visible effects → `ui_changed: true`
+
+Changes to these backend modules also require browser testing because they feed data rendered in the UI:
+- `packages/daemon/src/lib/agent/context-fetcher.ts` — context window display (token counts, window size)
+- `packages/daemon/src/lib/providers/**` — provider config, model metadata, provider badges, model picker entries
+- `packages/shared/src/models.ts` — ModelInfo type changes that affect model list display
+- `packages/daemon/src/lib/session/**` — session metadata shown in UI (status indicators, labels)
+- `packages/daemon/src/lib/rpc-handlers/**` — RPC responses consumed by frontend components
+
+### Rule 3: Catch-all for UI-rendered data → `ui_changed: true`
+
+If ANY changed file affects data that ends up rendered in the browser — token counts, context windows, model names, provider status, session labels, error messages visible to users — classify `ui_changed: true` and start the dev server.
+
+### Rule 4: Pure backend → browser optional
+
+Only skip browser testing when changes are purely internal backend logic (database schema, internal utilities, build config) with zero path to user-visible UI rendering.
+
+### Standing principle
+
+**When in doubt, browser test.** The cost of testing is 2 minutes; the cost of skipping is a broken UI reaching users.
+
 ## UI/Frontend Testing with Playwright
 
 - Use the Playwright skill (`/playwright`) to launch a real browser and test UI changes or new features interactively


### PR DESCRIPTION
## Summary
- Adds explicit `ui_changed` classification rules to QA.md so backend changes with UI-visible effects trigger browser testing
- Lists specific backend modules (context-fetcher, providers, session, rpc-handlers, models) that feed data rendered in the UI
- Adds catch-all rule for any change affecting UI-rendered data and standing principle: "when in doubt, browser test"

## Why
PR #2088 had backend-only provider changes that directly affected context window display (262k/272k). QA skipped browser testing because no `packages/web` files matched, requiring two manual prompts before validation happened.

## Test plan
- [ ] Verify QA.md contains classification rules 1-4 with specific backend module paths
- [ ] Verify standing principle about browser testing is present