### PR TITLE
docs: clarify coding handoff to review

### DIFF
--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -38,6 +38,14 @@ export type DeleteResourcesTrigger = 'ui_session_delete';
 
 type SdkQueryFunction = typeof import('@anthropic-ai/claude-agent-sdk').query;
 
+function isAssistantMessageWithContent(
+  message: unknown
+): message is { type: 'assistant'; message: { content: Array<{ type: string; text?: string }> } } {
+  if (!message || typeof message !== 'object') return false;
+  const candidate = message as { type?: unknown; message?: { content?: unknown } };
+  return candidate.type === 'assistant' && Array.isArray(candidate.message?.content);
+}
+
 export interface SessionLifecycleConfig {
   defaultModel: string;
   maxTokens: number;
@@ -1158,12 +1166,12 @@ ${messageText.slice(0, 2000)}`;
         },
       });
 
-      // Extract title from the response
-      const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
+      // Extract title from the response. Keep this structural instead of importing
+      // shared SDK type guards so unit tests are isolated from process-wide mock.module state.
       let title = '';
 
       for await (const message of agentQuery) {
-        if (isSDKAssistantMessage(message)) {
+        if (isAssistantMessageWithContent(message)) {
           const textBlocks = message.message.content.filter(
             (b: { type: string }) => b.type === 'text'
           ) as Array<{ text?: string }>;

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -45,6 +45,8 @@ export interface SessionLifecycleConfig {
   disableWorktrees?: boolean;
   /** @internal Test-only SDK query override for title generation. */
   titleGenerationQueryForTesting?: SdkQueryFunction;
+  /** @internal Test-only provider availability override for title generation. */
+  titleGenerationProviderAvailableForTesting?: (providerId: string) => boolean | Promise<boolean>;
 }
 
 export interface CreateSessionParams {
@@ -1046,8 +1048,10 @@ export class SessionLifecycle {
     // available (env vars, stored credentials, or provider-owned auth missing).
     // This delegates to each provider's own isAvailable() implementation so that
     // stored credentials are respected for title generation.
-    const available = await providerService.isProviderAvailable(provider);
-    if (!available) {
+    const available =
+      this.config.titleGenerationProviderAvailableForTesting?.(provider) ??
+      (await providerService.isProviderAvailable(provider));
+    if (!(await available)) {
       this.logger.warn(
         `[SessionLifecycle] Provider ${provider} not available, using fallback title`
       );

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -53,8 +53,6 @@ export interface SessionLifecycleConfig {
   disableWorktrees?: boolean;
   /** @internal Test-only SDK query override for title generation. */
   titleGenerationQueryForTesting?: SdkQueryFunction;
-  /** @internal Test-only provider availability override for title generation. */
-  titleGenerationProviderAvailableForTesting?: (providerId: string) => boolean | Promise<boolean>;
 }
 
 export interface CreateSessionParams {
@@ -1057,9 +1055,9 @@ export class SessionLifecycle {
     // This delegates to each provider's own isAvailable() implementation so that
     // stored credentials are respected for title generation.
     const available =
-      this.config.titleGenerationProviderAvailableForTesting?.(provider) ??
+      this.config.titleGenerationQueryForTesting !== undefined ||
       (await providerService.isProviderAvailable(provider));
-    if (!(await available)) {
+    if (!available) {
       this.logger.warn(
         `[SessionLifecycle] Provider ${provider} not available, using fallback title`
       );

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -507,6 +507,38 @@ function buildRoleSection(
     );
   }
 
+  const gatedHandoffs = buildGatedHandoffLines(workflow, currentNode, agentSlotName);
+  if (gatedHandoffs.length > 0) {
+    lines.push('- Outbound gated handoffs:');
+    lines.push(...gatedHandoffs);
+  }
+
+  return lines;
+}
+
+function buildGatedHandoffLines(
+  workflow: SpaceWorkflow,
+  currentNode: WorkflowNode,
+  agentSlotName: string | undefined
+): string[] {
+  const gateById = new Map((workflow.gates ?? []).map((gate) => [gate.id, gate]));
+  const outboundGatedChannels = (workflow.channels ?? []).filter(
+    (channel) => channel.gateId && isChannelFromNode(channel, currentNode.name)
+  );
+  const lines: string[] = [];
+
+  for (const channel of outboundGatedChannels) {
+    const gate = gateById.get(channel.gateId!);
+    const writableFields = (gate?.fields ?? []).filter((field) =>
+      isGateWritableFromNode([field], currentNode.name, agentSlotName)
+    );
+    if (writableFields.length === 0) continue;
+
+    lines.push(
+      `  - ${describeChannel(channel)}: call \`send_message(target=${formatSendMessageTarget(channel.to)}, message="<short summary>", data: ${formatGateDataShape(writableFields)})\`; \`save_artifact\` alone does not deliver this gated handoff.`
+    );
+  }
+
   return lines;
 }
 
@@ -518,6 +550,31 @@ function isChannelFromNode(channel: WorkflowChannel, nodeName: string): boolean 
 function describeChannel(channel: WorkflowChannel): string {
   const target = Array.isArray(channel.to) ? channel.to.join(', ') : channel.to;
   return channel.label ? `${target} (${channel.label})` : target;
+}
+
+function formatSendMessageTarget(target: string | string[]): string {
+  if (Array.isArray(target)) return `[${target.map((item) => JSON.stringify(item)).join(', ')}]`;
+  return JSON.stringify(target);
+}
+
+function formatGateDataShape(fields: Array<{ name: string; type: string }>): string {
+  const entries = fields.map((field) => `${field.name}: ${formatGateDataPlaceholder(field)}`);
+  return `{ ${entries.join(', ')} }`;
+}
+
+function formatGateDataPlaceholder(field: { name: string; type: string }): string {
+  switch (field.type) {
+    case 'string':
+      return `"<${field.name}>"`;
+    case 'number':
+      return '<number>';
+    case 'boolean':
+      return '<boolean>';
+    case 'map':
+      return '{ "<key>": "<value>" }';
+    default:
+      return '<value>';
+  }
 }
 
 function isGateWritableFromNode(

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -537,7 +537,7 @@ function buildGatedHandoffLines(
 
     for (const target of getSendMessageTargets(
       channel.to,
-      getBroadcastTargets(workflow, currentNode)
+      getBroadcastTargets(workflow, currentNode, agentSlotName)
     )) {
       lines.push(
         `  - ${describeChannelTarget(channel, target)}: call \`${formatGatedHandoffCall(target, writableFields)}\`; \`save_artifact\` alone does not deliver this gated handoff.`
@@ -563,8 +563,21 @@ function describeChannelTarget(channel: WorkflowChannel, target: string): string
   return channel.label ? `${target} (${channel.label})` : target;
 }
 
-function getBroadcastTargets(workflow: SpaceWorkflow, currentNode: WorkflowNode): string[] {
-  return workflow.nodes.filter((node) => node.id !== currentNode.id).map((node) => node.name);
+function getBroadcastTargets(
+  workflow: SpaceWorkflow,
+  currentNode: WorkflowNode,
+  agentSlotName: string | undefined
+): string[] {
+  const targets = new Set<string>();
+  for (const node of workflow.nodes) {
+    if (node.id !== currentNode.id) targets.add(node.name);
+    for (const agent of node.agents ?? []) {
+      if (node.id === currentNode.id && agent.name === agentSlotName) continue;
+      targets.add(agent.name);
+    }
+  }
+  targets.delete(currentNode.name);
+  return [...targets];
 }
 
 function isGateWritableFromNode(

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -31,6 +31,7 @@ import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import { inferProviderForModel } from '../../providers/registry';
 import { Logger } from '../../logger';
 import { SUB_SESSION_FEATURES } from './seed-agents';
+import { formatGatedHandoffCall, getSendMessageTargets } from '../runtime/gated-handoff-guidance';
 
 const DEFAULT_CUSTOM_AGENT_MODEL = 'claude-sonnet-4-6';
 
@@ -534,9 +535,11 @@ function buildGatedHandoffLines(
     );
     if (writableFields.length === 0) continue;
 
-    lines.push(
-      `  - ${describeChannel(channel)}: call \`send_message(target=${formatSendMessageTarget(channel.to)}, message="<short summary>", data: ${formatGateDataShape(writableFields)})\`; \`save_artifact\` alone does not deliver this gated handoff.`
-    );
+    for (const target of getSendMessageTargets(channel.to)) {
+      lines.push(
+        `  - ${describeChannelTarget(channel, target)}: call \`${formatGatedHandoffCall(target, writableFields)}\`; \`save_artifact\` alone does not deliver this gated handoff.`
+      );
+    }
   }
 
   return lines;
@@ -552,29 +555,9 @@ function describeChannel(channel: WorkflowChannel): string {
   return channel.label ? `${target} (${channel.label})` : target;
 }
 
-function formatSendMessageTarget(target: string | string[]): string {
-  if (Array.isArray(target)) return `[${target.map((item) => JSON.stringify(item)).join(', ')}]`;
-  return JSON.stringify(target);
-}
-
-function formatGateDataShape(fields: Array<{ name: string; type: string }>): string {
-  const entries = fields.map((field) => `${field.name}: ${formatGateDataPlaceholder(field)}`);
-  return `{ ${entries.join(', ')} }`;
-}
-
-function formatGateDataPlaceholder(field: { name: string; type: string }): string {
-  switch (field.type) {
-    case 'string':
-      return `"<${field.name}>"`;
-    case 'number':
-      return '<number>';
-    case 'boolean':
-      return '<boolean>';
-    case 'map':
-      return '{ "<key>": "<value>" }';
-    default:
-      return '<value>';
-  }
+function describeChannelTarget(channel: WorkflowChannel, target: string): string {
+  if (!Array.isArray(channel.to)) return describeChannel(channel);
+  return channel.label ? `${target} (${channel.label})` : target;
 }
 
 function isGateWritableFromNode(

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -535,7 +535,10 @@ function buildGatedHandoffLines(
     );
     if (writableFields.length === 0) continue;
 
-    for (const target of getSendMessageTargets(channel.to)) {
+    for (const target of getSendMessageTargets(
+      channel.to,
+      getBroadcastTargets(workflow, currentNode)
+    )) {
       lines.push(
         `  - ${describeChannelTarget(channel, target)}: call \`${formatGatedHandoffCall(target, writableFields)}\`; \`save_artifact\` alone does not deliver this gated handoff.`
       );
@@ -556,8 +559,12 @@ function describeChannel(channel: WorkflowChannel): string {
 }
 
 function describeChannelTarget(channel: WorkflowChannel, target: string): string {
-  if (!Array.isArray(channel.to)) return describeChannel(channel);
+  if (!Array.isArray(channel.to) && channel.to !== '*') return describeChannel(channel);
   return channel.label ? `${target} (${channel.label})` : target;
+}
+
+function getBroadcastTargets(workflow: SpaceWorkflow, currentNode: WorkflowNode): string[] {
+  return workflow.nodes.filter((node) => node.id !== currentNode.id).map((node) => node.name);
 }
 
 function isGateWritableFromNode(

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -38,7 +38,7 @@ function formatGateDataPlaceholder(field: GateDataShapeField): string {
     case 'string':
       return JSON.stringify(`<${field.name}>`);
     case 'number':
-      return '0';
+      return field.check?.op === '!=' && field.check.value === 0 ? '1' : '0';
     case 'boolean':
       return field.check?.op === '!=' && field.check.value === true ? 'false' : 'true';
     case 'map':

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -30,12 +30,12 @@ function formatGateDataPlaceholder(field: GateDataShapeField): string {
     case 'string':
       return `"<${field.name}>"`;
     case 'number':
-      return '<number>';
+      return '0';
     case 'boolean':
-      return '<boolean>';
+      return 'true';
     case 'map':
       return '{ "<key>": "<value>" }';
     default:
-      return '<value>';
+      return 'null';
   }
 }

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -1,0 +1,35 @@
+export interface GateDataShapeField {
+  name: string;
+  type: string;
+}
+
+export function getSendMessageTargets(target: string | string[]): string[] {
+  return Array.isArray(target) ? target : [target];
+}
+
+export function formatGatedHandoffCall(
+  target: string,
+  fields: readonly GateDataShapeField[]
+): string {
+  return `send_message(target=${JSON.stringify(target)}, message="<short summary>", data: ${formatGateDataShape(fields)})`;
+}
+
+function formatGateDataShape(fields: readonly GateDataShapeField[]): string {
+  const entries = fields.map((field) => `${field.name}: ${formatGateDataPlaceholder(field)}`);
+  return `{ ${entries.join(', ')} }`;
+}
+
+function formatGateDataPlaceholder(field: GateDataShapeField): string {
+  switch (field.type) {
+    case 'string':
+      return `"<${field.name}>"`;
+    case 'number':
+      return '<number>';
+    case 'boolean':
+      return '<boolean>';
+    case 'map':
+      return '{ "<key>": "<value>" }';
+    default:
+      return '<value>';
+  }
+}

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -25,18 +25,25 @@ export function formatGatedHandoffCall(
 }
 
 function formatGateDataShape(fields: readonly GateDataShapeField[]): string {
-  const entries = fields.map(
-    (field) => `${JSON.stringify(field.name)}: ${formatGateDataPlaceholder(field)}`
-  );
+  const entries = fields.flatMap((field) => {
+    const placeholder = formatGateDataPlaceholder(field);
+    return placeholder === undefined ? [] : [`${JSON.stringify(field.name)}: ${placeholder}`];
+  });
   return `{ ${entries.join(', ')} }`;
 }
 
-function formatGateDataPlaceholder(field: GateDataShapeField): string {
+function formatGateDataPlaceholder(field: GateDataShapeField): string | undefined {
+  if (field.check?.op === '==' && !('value' in field.check)) return undefined;
   if (field.check?.op === '==') return formatLiteral(field.check.value);
 
   switch (field.type) {
-    case 'string':
-      return JSON.stringify(`<${field.name}>`);
+    case 'string': {
+      const placeholder = `<${field.name}>`;
+      if (field.check?.op === '!=' && field.check.value === placeholder) {
+        return JSON.stringify(`<${field.name}-different>`);
+      }
+      return JSON.stringify(placeholder);
+    }
     case 'number':
       return field.check?.op === '!=' && field.check.value === 0 ? '1' : '0';
     case 'boolean':

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -55,24 +55,11 @@ function formatGateDataPlaceholder(field: GateDataShapeField): string | undefine
   }
 }
 
-const MAX_MAP_PLACEHOLDER_ENTRIES = 3;
-
 function formatMapPlaceholder(field: GateDataShapeField): string {
   if (field.check?.op !== 'count') return '{ "<key>": "<value>" }';
 
   const matchValue = formatLiteral(field.check.match);
-  const count = Math.max(1, field.check.min ?? 1);
-  const shownCount = Math.min(count, MAX_MAP_PLACEHOLDER_ENTRIES);
-  const entries = Array.from(
-    { length: shownCount },
-    (_, index) => `${JSON.stringify(`<key${index + 1}>`)}: ${matchValue}`
-  );
-  if (count > shownCount) {
-    entries.push(
-      `/* add ${count - shownCount} more matching entr${count - shownCount === 1 ? 'y' : 'ies'} */`
-    );
-  }
-  return `{ ${entries.join(', ')} }`;
+  return `{ "<your-key>": ${matchValue} }`;
 }
 
 function formatLiteral(value: unknown): string {

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -3,8 +3,12 @@ export interface GateDataShapeField {
   type: string;
 }
 
-export function getSendMessageTargets(target: string | string[]): string[] {
-  return Array.isArray(target) ? target : [target];
+export function getSendMessageTargets(
+  target: string | string[],
+  broadcastTargets: readonly string[] = []
+): string[] {
+  const targets = Array.isArray(target) ? target : [target];
+  return [...new Set(targets.flatMap((item) => (item === '*' ? broadcastTargets : [item])))];
 }
 
 export function formatGatedHandoffCall(
@@ -15,7 +19,9 @@ export function formatGatedHandoffCall(
 }
 
 function formatGateDataShape(fields: readonly GateDataShapeField[]): string {
-  const entries = fields.map((field) => `${field.name}: ${formatGateDataPlaceholder(field)}`);
+  const entries = fields.map(
+    (field) => `${JSON.stringify(field.name)}: ${formatGateDataPlaceholder(field)}`
+  );
   return `{ ${entries.join(', ')} }`;
 }
 

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -48,15 +48,23 @@ function formatGateDataPlaceholder(field: GateDataShapeField): string {
   }
 }
 
+const MAX_MAP_PLACEHOLDER_ENTRIES = 3;
+
 function formatMapPlaceholder(field: GateDataShapeField): string {
   if (field.check?.op !== 'count') return '{ "<key>": "<value>" }';
 
   const matchValue = formatLiteral(field.check.match);
   const count = Math.max(1, field.check.min ?? 1);
+  const shownCount = Math.min(count, MAX_MAP_PLACEHOLDER_ENTRIES);
   const entries = Array.from(
-    { length: count },
+    { length: shownCount },
     (_, index) => `${JSON.stringify(`<key${index + 1}>`)}: ${matchValue}`
   );
+  if (count > shownCount) {
+    entries.push(
+      `/* add ${count - shownCount} more matching entr${count - shownCount === 1 ? 'y' : 'ies'} */`
+    );
+  }
   return `{ ${entries.join(', ')} }`;
 }
 

--- a/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
+++ b/packages/daemon/src/lib/space/runtime/gated-handoff-guidance.ts
@@ -1,6 +1,12 @@
 export interface GateDataShapeField {
   name: string;
   type: string;
+  check?: {
+    op: string;
+    value?: unknown;
+    match?: unknown;
+    min?: number;
+  };
 }
 
 export function getSendMessageTargets(
@@ -26,16 +32,35 @@ function formatGateDataShape(fields: readonly GateDataShapeField[]): string {
 }
 
 function formatGateDataPlaceholder(field: GateDataShapeField): string {
+  if (field.check?.op === '==') return formatLiteral(field.check.value);
+
   switch (field.type) {
     case 'string':
-      return `"<${field.name}>"`;
+      return JSON.stringify(`<${field.name}>`);
     case 'number':
       return '0';
     case 'boolean':
-      return 'true';
+      return field.check?.op === '!=' && field.check.value === true ? 'false' : 'true';
     case 'map':
-      return '{ "<key>": "<value>" }';
+      return formatMapPlaceholder(field);
     default:
       return 'null';
   }
+}
+
+function formatMapPlaceholder(field: GateDataShapeField): string {
+  if (field.check?.op !== 'count') return '{ "<key>": "<value>" }';
+
+  const matchValue = formatLiteral(field.check.match);
+  const count = Math.max(1, field.check.min ?? 1);
+  const entries = Array.from(
+    { length: count },
+    (_, index) => `${JSON.stringify(`<key${index + 1}>`)}: ${matchValue}`
+  );
+  return `{ ${entries.join(', ')} }`;
+}
+
+function formatLiteral(value: unknown): string {
+  const literal = JSON.stringify(value);
+  return literal === undefined ? 'null' : literal;
 }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2390,7 +2390,7 @@ export class TaskAgentManager {
 
         for (const target of getSendMessageTargets(
           channel.to,
-          this.getBroadcastTargets(workflow, node)
+          this.getBroadcastTargets(workflow, node, execution.agentName)
         )) {
           lines.push(
             `  - When ready, call \`${formatGatedHandoffCall(target, writableFields)}\`; this is required to activate the target. \`save_artifact\` alone does not deliver gated handoffs.`
@@ -2437,8 +2437,21 @@ export class TaskAgentManager {
     return check.op;
   }
 
-  private getBroadcastTargets(workflow: SpaceWorkflow, currentNode: WorkflowNode): string[] {
-    return workflow.nodes.filter((node) => node.id !== currentNode.id).map((node) => node.name);
+  private getBroadcastTargets(
+    workflow: SpaceWorkflow,
+    currentNode: WorkflowNode,
+    agentName: string
+  ): string[] {
+    const targets = new Set<string>();
+    for (const node of workflow.nodes) {
+      if (node.id !== currentNode.id) targets.add(node.name);
+      for (const agent of node.agents ?? []) {
+        if (node.id === currentNode.id && agent.name === agentName) continue;
+        targets.add(agent.name);
+      }
+    }
+    targets.delete(currentNode.name);
+    return [...targets];
   }
 
   private normalizeAgentNameToken(value: string): string {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2386,6 +2386,11 @@ export class TaskAgentManager {
           continue;
         }
 
+        const targetArg = this.formatSendMessageTarget(channel.to);
+        const dataShape = this.formatGateDataShape(writableFields);
+        lines.push(
+          `  - When ready, call \`send_message(target=${targetArg}, message="<short summary>", data: ${dataShape})\`; this is required to activate the target. \`save_artifact\` alone does not deliver gated handoffs.`
+        );
         lines.push(`  - Include in send_message data:`);
         for (const field of writableFields) {
           lines.push(
@@ -2425,6 +2430,33 @@ export class TaskAgentManager {
     if (check.op === '==') return `== ${JSON.stringify(check.value)}`;
     if (check.op === '!=') return `!= ${JSON.stringify(check.value)}`;
     return check.op;
+  }
+
+  private formatSendMessageTarget(target: string | string[]): string {
+    if (Array.isArray(target)) return `[${target.map((item) => JSON.stringify(item)).join(', ')}]`;
+    return JSON.stringify(target);
+  }
+
+  private formatGateDataShape(fields: Array<{ name: string; type: string }>): string {
+    const entries = fields.map(
+      (field) => `${field.name}: ${this.formatGateDataPlaceholder(field)}`
+    );
+    return `{ ${entries.join(', ')} }`;
+  }
+
+  private formatGateDataPlaceholder(field: { name: string; type: string }): string {
+    switch (field.type) {
+      case 'string':
+        return `"<${field.name}>"`;
+      case 'number':
+        return '<number>';
+      case 'boolean':
+        return '<boolean>';
+      case 'map':
+        return '{ "<key>": "<value>" }';
+      default:
+        return '<value>';
+    }
   }
 
   private normalizeAgentNameToken(value: string): string {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -45,6 +45,7 @@ import type {
   MessageContent,
   MessageImage,
   MessageOrigin,
+  WorkflowNode,
   WorkflowNodeAgent,
 } from '@neokai/shared';
 import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
@@ -2387,7 +2388,10 @@ export class TaskAgentManager {
           continue;
         }
 
-        for (const target of getSendMessageTargets(channel.to)) {
+        for (const target of getSendMessageTargets(
+          channel.to,
+          this.getBroadcastTargets(workflow, node)
+        )) {
           lines.push(
             `  - When ready, call \`${formatGatedHandoffCall(target, writableFields)}\`; this is required to activate the target. \`save_artifact\` alone does not deliver gated handoffs.`
           );
@@ -2431,6 +2435,10 @@ export class TaskAgentManager {
     if (check.op === '==') return `== ${JSON.stringify(check.value)}`;
     if (check.op === '!=') return `!= ${JSON.stringify(check.value)}`;
     return check.op;
+  }
+
+  private getBroadcastTargets(workflow: SpaceWorkflow, currentNode: WorkflowNode): string[] {
+    return workflow.nodes.filter((node) => node.id !== currentNode.id).map((node) => node.name);
   }
 
   private normalizeAgentNameToken(value: string): string {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -114,6 +114,7 @@ import {
   type SlotOverrides,
 } from '../agents/custom-agent';
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
+import { formatGatedHandoffCall, getSendMessageTargets } from './gated-handoff-guidance';
 import { Logger } from '../../logger';
 import {
   formatAgentMessage,
@@ -2386,11 +2387,11 @@ export class TaskAgentManager {
           continue;
         }
 
-        const targetArg = this.formatSendMessageTarget(channel.to);
-        const dataShape = this.formatGateDataShape(writableFields);
-        lines.push(
-          `  - When ready, call \`send_message(target=${targetArg}, message="<short summary>", data: ${dataShape})\`; this is required to activate the target. \`save_artifact\` alone does not deliver gated handoffs.`
-        );
+        for (const target of getSendMessageTargets(channel.to)) {
+          lines.push(
+            `  - When ready, call \`${formatGatedHandoffCall(target, writableFields)}\`; this is required to activate the target. \`save_artifact\` alone does not deliver gated handoffs.`
+          );
+        }
         lines.push(`  - Include in send_message data:`);
         for (const field of writableFields) {
           lines.push(
@@ -2430,33 +2431,6 @@ export class TaskAgentManager {
     if (check.op === '==') return `== ${JSON.stringify(check.value)}`;
     if (check.op === '!=') return `!= ${JSON.stringify(check.value)}`;
     return check.op;
-  }
-
-  private formatSendMessageTarget(target: string | string[]): string {
-    if (Array.isArray(target)) return `[${target.map((item) => JSON.stringify(item)).join(', ')}]`;
-    return JSON.stringify(target);
-  }
-
-  private formatGateDataShape(fields: Array<{ name: string; type: string }>): string {
-    const entries = fields.map(
-      (field) => `${field.name}: ${this.formatGateDataPlaceholder(field)}`
-    );
-    return `{ ${entries.join(', ')} }`;
-  }
-
-  private formatGateDataPlaceholder(field: { name: string; type: string }): string {
-    switch (field.type) {
-      case 'string':
-        return `"<${field.name}>"`;
-      case 'number':
-        return '<number>';
-      case 'boolean':
-        return '<boolean>';
-      case 'map':
-        return '{ "<key>": "<value>" }';
-      default:
-        return '<value>';
-    }
   }
 
   private normalizeAgentNameToken(value: string): string {

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -860,7 +860,11 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
               ...routedTargetNames.map(resolveNodeName),
             ]);
             return tos.some(
-              (to) => candidateTargets.includes(to) || to === myNodeName || to === myAgentName
+              (to) =>
+                to === '*' ||
+                candidateTargets.includes(to) ||
+                to === myNodeName ||
+                to === myAgentName
             );
           });
 

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -860,13 +860,28 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
             ...routedTargetNames,
             ...routedTargetNames.map(resolveNodeName),
           ]);
+          const broadcastTargetRefs = new Set<string>();
+          for (const targetNode of workflow.nodes) {
+            if (targetNode.id === workflowNodeId) continue;
+            broadcastTargetRefs.add(targetNode.name);
+            for (const agent of resolveNodeAgents(targetNode)) {
+              broadcastTargetRefs.add(agent.name);
+            }
+          }
+          const targetIsBroadcastRecipient = candidateTargets.some((targetRef) =>
+            broadcastTargetRefs.has(targetRef)
+          );
           const gatedChannel =
             channelsFromCurrentNode.find((ch) => {
               const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
               return tos.some(
                 (to) => candidateTargets.includes(to) || to === myNodeName || to === myAgentName
               );
-            }) ?? channelsFromCurrentNode.find((ch) => ch.to === '*');
+            }) ??
+            channelsFromCurrentNode.find((ch) => {
+              const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
+              return targetIsBroadcastRecipient && tos.includes('*');
+            });
 
           if (gatedChannel?.gateId) {
             const gateId = gatedChannel.gateId;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -863,9 +863,13 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
           const broadcastTargetRefs = new Set<string>();
           for (const targetNode of workflow.nodes) {
             broadcastTargetRefs.add(targetNode.name);
-            for (const agent of resolveNodeAgents(targetNode)) {
-              if (targetNode.id === workflowNodeId && agent.name === myAgentName) continue;
-              broadcastTargetRefs.add(agent.name);
+            try {
+              for (const agent of resolveNodeAgents(targetNode)) {
+                if (targetNode.id === workflowNodeId && agent.name === myAgentName) continue;
+                broadcastTargetRefs.add(agent.name);
+              }
+            } catch {
+              // Malformed node definitions have no resolvable agent slots to include.
             }
           }
           const targetIsBroadcastRecipient = candidateTargets.some((targetRef) =>

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -851,22 +851,22 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
           const myNodeName = node?.name ?? myAgentName;
           const fromRefs = new Set([myAgentName, myNodeName]);
 
-          const gatedChannel = (workflow.channels ?? []).find((ch) => {
+          const channelsFromCurrentNode = (workflow.channels ?? []).filter((ch) => {
             if (!ch.gateId) return false;
             if (ch.from !== '*' && !fromRefs.has(ch.from)) return false;
-            const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
-            const candidateTargets = uniqueTargetRefs([
-              ...routedTargetNames,
-              ...routedTargetNames.map(resolveNodeName),
-            ]);
-            return tos.some(
-              (to) =>
-                to === '*' ||
-                candidateTargets.includes(to) ||
-                to === myNodeName ||
-                to === myAgentName
-            );
+            return true;
           });
+          const candidateTargets = uniqueTargetRefs([
+            ...routedTargetNames,
+            ...routedTargetNames.map(resolveNodeName),
+          ]);
+          const gatedChannel =
+            channelsFromCurrentNode.find((ch) => {
+              const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
+              return tos.some(
+                (to) => candidateTargets.includes(to) || to === myNodeName || to === myAgentName
+              );
+            }) ?? channelsFromCurrentNode.find((ch) => ch.to === '*');
 
           if (gatedChannel?.gateId) {
             const gateId = gatedChannel.gateId;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -862,9 +862,9 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
           ]);
           const broadcastTargetRefs = new Set<string>();
           for (const targetNode of workflow.nodes) {
-            if (targetNode.id === workflowNodeId) continue;
             broadcastTargetRefs.add(targetNode.name);
             for (const agent of resolveNodeAgents(targetNode)) {
+              if (targetNode.id === workflowNodeId && agent.name === myAgentName) continue;
               broadcastTargetRefs.add(agent.name);
             }
           }

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1682,10 +1682,86 @@ function migrateCodexFeatureToNodeToggle(
   return { nodes: migratedNodes, gates: migratedGates };
 }
 
-const BUILT_IN_PROMPT_PATCH_MARKERS = [
-  'write code-pr-gate with field pr_url so Review can activate',
-  'hand off by sending a message to Review with `data: { pr_url: "<url>" }`',
-  'then send_message to Review again (again with `data: { pr_url }`)',
+const CURRENT_CODING_WORKFLOW_HANDOFF_PROMPT =
+  '6. If code changed: hand off by calling `send_message` on the outbound gated ' +
+  'review channel with the PR URL in its `data` payload. Use the current target and ' +
+  'required data fields from the Runtime Execution Contract injected into your task ' +
+  'prompt. `save_artifact` alone is insufficient; only `send_message` delivers ' +
+  'the gated handoff. Always include the PR URL data field on every `send_message` ' +
+  'handoff — gate data resets each cycle, so even on round 2+ you must re-supply it.\n';
+const RETIRED_CODING_WORKFLOW_HANDOFF_PROMPT =
+  '6. If code changed: hand off by sending a message to Review with ' +
+  '`data: { pr_url: "<url>" }`. The gate script verifies the PR is open and ' +
+  'mergeable, so make sure it actually is before sending. ' +
+  '**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
+  'data resets each cycle, so even on round 2+ you must re-supply it.\n';
+const RETIRED_HARDCODED_CODING_WORKFLOW_HANDOFF_PROMPT =
+  '6. If code changed: hand off by calling ' +
+  '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
+  'The `data.pr_url` payload is auto-merged into `code-ready-gate`; the gate script verifies ' +
+  'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
+  'only `send_message` delivers the gated handoff. ' +
+  '**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
+  'data resets each cycle, so even on round 2+ you must re-supply it.\n';
+const CURRENT_CODING_WORKFLOW_REHANDOFF_PROMPT =
+  '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
+  'then call `send_message` on the outbound gated review channel again to ' +
+  're-trigger the review cycle. Re-supplying the PR URL data field is required; ' +
+  '`save_artifact` alone will not deliver the gated handoff.';
+const RETIRED_CODING_WORKFLOW_REHANDOFF_PROMPT =
+  '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
+  'then send_message to Review again (again with `data: { pr_url }`) to ' +
+  're-trigger the review cycle';
+const RETIRED_HARDCODED_CODING_WORKFLOW_REHANDOFF_PROMPT =
+  '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
+  'then call `send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })` ' +
+  'again to re-trigger the review cycle. Re-supplying `data.pr_url` is required; ' +
+  '`save_artifact` alone will not open `code-ready-gate`.';
+const CURRENT_FULLSTACK_CODING_READY_PROMPT =
+  'When implementation is ready, ensure the PR is open and mergeable, then call `send_message` ' +
+  'on the outbound gated review channel with the PR URL in its `data` payload. Use the current ' +
+  'target and required data fields from the Runtime Execution Contract injected into your task ' +
+  'prompt. `save_artifact` alone is insufficient; only `send_message` delivers the gated ' +
+  'handoff. Coding is not the end node — the task-completion tools (`approve_task`, ' +
+  '`submit_for_approval`) are not available to you.\n\n';
+const RETIRED_FULLSTACK_CODING_READY_PROMPT =
+  'When implementation is ready, ensure the PR is open and mergeable and write code-pr-gate with ' +
+  'field pr_url so Review can activate. Coding is not the end node — the task-completion tools ' +
+  '(`approve_task`, `submit_for_approval`) are not available to you.\n\n';
+const RETIRED_HARDCODED_FULLSTACK_CODING_READY_PROMPT =
+  'When implementation is ready, ensure the PR is open and mergeable, then call ' +
+  '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
+  'The `data.pr_url` payload is auto-merged into `code-pr-gate`; the gate script verifies ' +
+  'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
+  'only `send_message` delivers the gated handoff. Coding is not the end node — the ' +
+  'task-completion tools (`approve_task`, `submit_for_approval`) are not available to you.\n\n';
+const CURRENT_FULLSTACK_CODING_STEP_PROMPT =
+  '4. Hand off by calling `send_message` on the outbound gated review channel with ' +
+  'the PR URL in its `data` payload; `save_artifact` alone will not deliver the handoff\n';
+const RETIRED_FULLSTACK_CODING_STEP_PROMPT =
+  '4. Write code-pr-gate with field pr_url so Review can activate\n';
+const RETIRED_HARDCODED_FULLSTACK_CODING_STEP_PROMPT =
+  '4. Hand off to Review by calling ' +
+  '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`; ' +
+  '`save_artifact` alone will not open `code-pr-gate`\n';
+
+const BUILT_IN_PROMPT_PATCH_VARIANTS = [
+  [
+    [CURRENT_CODING_WORKFLOW_HANDOFF_PROMPT, RETIRED_CODING_WORKFLOW_HANDOFF_PROMPT],
+    [CURRENT_CODING_WORKFLOW_REHANDOFF_PROMPT, RETIRED_CODING_WORKFLOW_REHANDOFF_PROMPT],
+  ],
+  [
+    [CURRENT_CODING_WORKFLOW_HANDOFF_PROMPT, RETIRED_HARDCODED_CODING_WORKFLOW_HANDOFF_PROMPT],
+    [CURRENT_CODING_WORKFLOW_REHANDOFF_PROMPT, RETIRED_HARDCODED_CODING_WORKFLOW_REHANDOFF_PROMPT],
+  ],
+  [
+    [CURRENT_FULLSTACK_CODING_READY_PROMPT, RETIRED_FULLSTACK_CODING_READY_PROMPT],
+    [CURRENT_FULLSTACK_CODING_STEP_PROMPT, RETIRED_FULLSTACK_CODING_STEP_PROMPT],
+  ],
+  [
+    [CURRENT_FULLSTACK_CODING_READY_PROMPT, RETIRED_HARDCODED_FULLSTACK_CODING_READY_PROMPT],
+    [CURRENT_FULLSTACK_CODING_STEP_PROMPT, RETIRED_HARDCODED_FULLSTACK_CODING_STEP_PROMPT],
+  ],
 ] as const;
 
 function patchKnownBuiltInPromptDrift<T extends WorkflowNodeAgentOverride | undefined>(
@@ -1695,10 +1771,28 @@ function patchKnownBuiltInPromptDrift<T extends WorkflowNodeAgentOverride | unde
   const existingValue = existingPrompt?.value;
   const templateValue = templatePrompt?.value;
   if (!existingValue || !templateValue || existingValue === templateValue) return existingPrompt;
-  if (!BUILT_IN_PROMPT_PATCH_MARKERS.some((marker) => existingValue.includes(marker))) {
-    return existingPrompt;
-  }
+  if (!isExactRetiredBuiltInPrompt(existingValue, templateValue)) return existingPrompt;
   return { ...existingPrompt, value: templateValue } as T;
+}
+
+function isExactRetiredBuiltInPrompt(existingValue: string, templateValue: string): boolean {
+  return buildRetiredBuiltInPromptValues(templateValue).some((value) => existingValue === value);
+}
+
+function buildRetiredBuiltInPromptValues(templateValue: string): string[] {
+  const values: string[] = [];
+  for (const replacements of BUILT_IN_PROMPT_PATCH_VARIANTS) {
+    let value = templateValue;
+    for (const [currentText, retiredText] of replacements) {
+      if (!value.includes(currentText)) {
+        value = templateValue;
+        break;
+      }
+      value = value.replace(currentText, retiredText);
+    }
+    if (value !== templateValue) values.push(value);
+  }
+  return values;
 }
 
 function nodeReferences(node: WorkflowNode): Set<string> {

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -22,6 +22,7 @@
 
 import type {
   DeclarativeToolGuard,
+  WorkflowNodeAgentOverride,
   GateField,
   GatePoll,
   GateScript,
@@ -528,12 +529,12 @@ const REVIEW_THREAD_APPROVAL_CHECK_GUIDANCE =
 const FULLSTACK_CODING_PROMPT =
   'You are the Coder in a Fullstack QA Loop workflow. You implement backend + frontend changes, ' +
   'write tests, and keep one PR updated across review and QA cycles.\n\n' +
-  'When implementation is ready, ensure the PR is open and mergeable, then call ' +
-  '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
-  'The `data.pr_url` payload is auto-merged into `code-pr-gate`; the gate script verifies ' +
-  'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
-  'only `send_message` delivers the gated handoff. Coding is not the end node — the ' +
-  'task-completion tools (`approve_task`, `submit_for_approval`) are not available to you.\n\n' +
+  'When implementation is ready, ensure the PR is open and mergeable, then call `send_message` ' +
+  'on the outbound gated review channel with the PR URL in its `data` payload. Use the current ' +
+  'target and required data fields from the Runtime Execution Contract injected into your task ' +
+  'prompt. `save_artifact` alone is insufficient; only `send_message` delivers the gated ' +
+  'handoff. Coding is not the end node — the task-completion tools (`approve_task`, ' +
+  '`submit_for_approval`) are not available to you.\n\n' +
   REVIEW_THREAD_RESOLUTION_GUIDANCE;
 
 const FULLSTACK_REVIEW_PROMPT =
@@ -604,13 +605,12 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               '3. Write or update tests to cover new behavior\n' +
               '4. Run the test suite and fix any failures\n' +
               '5. If code changed: open a PR with `gh pr create` — include a clear title and description\n' +
-              '6. If code changed: hand off by calling ' +
-              '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
-              'The `data.pr_url` payload is auto-merged into `code-ready-gate`; the gate script verifies ' +
-              'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
-              'only `send_message` delivers the gated handoff. ' +
-              '**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
-              'data resets each cycle, so even on round 2+ you must re-supply it.\n' +
+              '6. If code changed: hand off by calling `send_message` on the outbound gated ' +
+              'review channel with the PR URL in its `data` payload. Use the current target and ' +
+              'required data fields from the Runtime Execution Contract injected into your task ' +
+              'prompt. `save_artifact` alone is insufficient; only `send_message` delivers ' +
+              'the gated handoff. Always include the PR URL data field on every `send_message` ' +
+              'handoff — gate data resets each cycle, so even on round 2+ you must re-supply it.\n' +
               '7. If the task is validation-only and produced no code changes: do NOT create an empty commit or PR. ' +
               'Instead, call `save_artifact({ type: "result", append: true, summary: "<validation outcome>", data: { completion_mode: "validation_only", changed_files: 0, validation_outcome: "<passed|failed + evidence>" } })`, then ' +
               '`send_message(target="Validation Complete", message="<short outcome>", data: { completion_mode: "validation_only", changed_files: 0, validation_outcome: "<outcome>" })`. ' +
@@ -630,9 +630,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               REVIEW_THREAD_RESOLUTION_GUIDANCE +
               '\n' +
               '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
-              'then call `send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })` ' +
-              'again to re-trigger the review cycle. Re-supplying `data.pr_url` is required; ' +
-              '`save_artifact` alone will not open `code-ready-gate`.',
+              'then call `send_message` on the outbound gated review channel again to ' +
+              're-trigger the review cycle. Re-supplying the PR URL data field is required; ' +
+              '`save_artifact` alone will not deliver the gated handoff.',
           },
           toolGuards: [CODER_NO_MERGE_GUARD],
         },
@@ -1247,9 +1247,8 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
               '1. Implement backend and frontend changes with focused commits\n' +
               '2. Add/update unit, integration, and UI tests as needed\n' +
               '3. Open or update the PR and ensure it remains mergeable\n' +
-              '4. Hand off to Review by calling ' +
-              '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`; ' +
-              '`save_artifact` alone will not open `code-pr-gate`\n' +
+              '4. Hand off by calling `send_message` on the outbound gated review channel with ' +
+              'the PR URL in its `data` payload; `save_artifact` alone will not deliver the handoff\n' +
               '5. Share blockers clearly with Reviewer/QA when needed',
           },
           toolGuards: [CODER_NO_MERGE_GUARD],
@@ -1467,7 +1466,8 @@ export interface SeedBuiltInWorkflowsResult {
    * PR 3/5 uses this path to land `postApproval` routes, updated
    * `completionAutonomyLevel`, and refreshed `templateHash` values onto
    * existing spaces without rewriting user-customisable fields (node
-   * UUIDs, prompt text, channels, gates).
+   * UUIDs, custom prompt text, channels, gates), except for known retired
+   * built-in prompt text patched during restamp.
    */
   restamped: string[];
   /** Errors for workflows that failed to seed or re-stamp */
@@ -1485,7 +1485,8 @@ export interface SeedBuiltInWorkflowsResult {
  * Unlike `customPrompt` (user-configurable), `toolGuards` are structural enforcement
  * metadata that must stay in sync with the template. `postApproval` is also structural
  * routing metadata for the terminal node. This function only touches `postApproval`
- * on the node and `toolGuards` on each agent slot — all other fields (customPrompt,
+ * on the node and `toolGuards` on each agent slot, with a narrow exception for known
+ * retired built-in prompt text that must be re-stamped. All other fields (customPrompt,
  * model, disabledSkillIds, etc.) are preserved from the existing row.
  *
  * Template matching is by node name + agent name. If a user renamed a node,
@@ -1518,10 +1519,19 @@ export function mergeNodeStructuralFieldsFromTemplate(
         agentId: resolveAgentId(agent.agentId) ?? agent.agentId,
       })),
     }));
-  const templateAgentsByKey = new Map<string, DeclarativeToolGuard[] | undefined>();
+  const templateAgentsByKey = new Map<
+    string,
+    {
+      toolGuards: DeclarativeToolGuard[] | undefined;
+      customPrompt?: WorkflowNodeAgentOverride;
+    }
+  >();
   for (const node of templateNodes) {
     for (const agent of node.agents) {
-      templateAgentsByKey.set(`${node.name}::${agent.name}`, agent.toolGuards);
+      templateAgentsByKey.set(`${node.name}::${agent.name}`, {
+        toolGuards: agent.toolGuards,
+        customPrompt: agent.customPrompt,
+      });
     }
   }
 
@@ -1538,10 +1548,20 @@ export function mergeNodeStructuralFieldsFromTemplate(
         : node.codexPollIntervalMs,
       agents: node.agents.map((agent) => {
         const key = `${node.name}::${agent.name}`;
-        const templateGuards = templateAgentsByKey.get(key);
-        if (templateGuards === undefined) return agent;
-        // Merge: overwrite toolGuards from template, keep everything else
-        return { ...agent, toolGuards: templateGuards };
+        const templateAgent = templateAgentsByKey.get(key);
+        if (templateAgent === undefined) return agent;
+        // Merge: overwrite structural toolGuards, preserve user custom prompts except
+        // for known retired built-in prompt text that would otherwise survive restamp.
+        return {
+          ...agent,
+          ...(templateAgent.toolGuards === undefined
+            ? {}
+            : { toolGuards: templateAgent.toolGuards }),
+          customPrompt: patchKnownBuiltInPromptDrift(
+            agent.customPrompt,
+            templateAgent.customPrompt
+          ),
+        };
       }),
     };
   });
@@ -1660,6 +1680,25 @@ function migrateCodexFeatureToNodeToggle(
   });
 
   return { nodes: migratedNodes, gates: migratedGates };
+}
+
+const BUILT_IN_PROMPT_PATCH_MARKERS = [
+  'write code-pr-gate with field pr_url so Review can activate',
+  'hand off by sending a message to Review with `data: { pr_url: "<url>" }`',
+  'then send_message to Review again (again with `data: { pr_url }`)',
+] as const;
+
+function patchKnownBuiltInPromptDrift<T extends WorkflowNodeAgentOverride | undefined>(
+  existingPrompt: T,
+  templatePrompt: T
+): T {
+  const existingValue = existingPrompt?.value;
+  const templateValue = templatePrompt?.value;
+  if (!existingValue || !templateValue || existingValue === templateValue) return existingPrompt;
+  if (!BUILT_IN_PROMPT_PATCH_MARKERS.some((marker) => existingValue.includes(marker))) {
+    return existingPrompt;
+  }
+  return { ...existingPrompt, value: templateValue } as T;
 }
 
 function nodeReferences(node: WorkflowNode): Set<string> {
@@ -1787,8 +1826,9 @@ export function mergeGateStructuralFieldsFromTemplate(
  *
  * - Node-level `postApproval`, `completionAutonomyLevel`, and `templateHash`
  *   are updated. The legacy workflow-level `postApproval` is cleared. Persisted
- *   node agent `customPrompt.value` is deliberately left untouched so daemon
- *   restart / startup seed passes cannot replace user-configured runtime prompts.
+ *   node agent `customPrompt.value` is preserved except for known retired built-in
+ *   prompt text, so daemon restart / startup seed passes cannot replace user-configured
+ *   runtime prompts.
  * - Agent `toolGuards` are merged onto matching agent slots (by node name +
  *   agent name) so structural enforcement metadata stays in sync with the
  *   template when node + agent names still match. Other node fields

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -528,9 +528,12 @@ const REVIEW_THREAD_APPROVAL_CHECK_GUIDANCE =
 const FULLSTACK_CODING_PROMPT =
   'You are the Coder in a Fullstack QA Loop workflow. You implement backend + frontend changes, ' +
   'write tests, and keep one PR updated across review and QA cycles.\n\n' +
-  'When implementation is ready, ensure the PR is open and mergeable and write code-pr-gate with ' +
-  'field pr_url so Review can activate. Coding is not the end node — the task-completion tools ' +
-  '(`approve_task`, `submit_for_approval`) are not available to you.\n\n' +
+  'When implementation is ready, ensure the PR is open and mergeable, then call ' +
+  '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
+  'The `data.pr_url` payload is auto-merged into `code-pr-gate`; the gate script verifies ' +
+  'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
+  'only `send_message` delivers the gated handoff. Coding is not the end node — the ' +
+  'task-completion tools (`approve_task`, `submit_for_approval`) are not available to you.\n\n' +
   REVIEW_THREAD_RESOLUTION_GUIDANCE;
 
 const FULLSTACK_REVIEW_PROMPT =
@@ -601,9 +604,11 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               '3. Write or update tests to cover new behavior\n' +
               '4. Run the test suite and fix any failures\n' +
               '5. If code changed: open a PR with `gh pr create` — include a clear title and description\n' +
-              '6. If code changed: hand off by sending a message to Review with ' +
-              '`data: { pr_url: "<url>" }`. The gate script verifies the PR is open and ' +
-              'mergeable, so make sure it actually is before sending. ' +
+              '6. If code changed: hand off by calling ' +
+              '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`. ' +
+              'The `data.pr_url` payload is auto-merged into `code-ready-gate`; the gate script verifies ' +
+              'the PR is open and mergeable before Review activates. `save_artifact` alone is insufficient; ' +
+              'only `send_message` delivers the gated handoff. ' +
               '**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
               'data resets each cycle, so even on round 2+ you must re-supply it.\n' +
               '7. If the task is validation-only and produced no code changes: do NOT create an empty commit or PR. ' +
@@ -625,8 +630,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               REVIEW_THREAD_RESOLUTION_GUIDANCE +
               '\n' +
               '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
-              'then send_message to Review again (again with `data: { pr_url }`) to ' +
-              're-trigger the review cycle',
+              'then call `send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })` ' +
+              'again to re-trigger the review cycle. Re-supplying `data.pr_url` is required; ' +
+              '`save_artifact` alone will not open `code-ready-gate`.',
           },
           toolGuards: [CODER_NO_MERGE_GUARD],
         },
@@ -1241,7 +1247,9 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
               '1. Implement backend and frontend changes with focused commits\n' +
               '2. Add/update unit, integration, and UI tests as needed\n' +
               '3. Open or update the PR and ensure it remains mergeable\n' +
-              '4. Write code-pr-gate with field pr_url so Review can activate\n' +
+              '4. Hand off to Review by calling ' +
+              '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`; ' +
+              '`save_artifact` alone will not open `code-pr-gate`\n' +
               '5. Share blockers clearly with Reviewer/QA when needed',
           },
           toolGuards: [CODER_NO_MERGE_GUARD],

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
@@ -181,7 +181,16 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
     };
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    const { getProviderRegistry, resetProviderRegistry } = await import(
+      '../../../../src/lib/providers/registry'
+    );
+    const { AnthropicProvider } = await import('../../../../src/lib/providers/anthropic-provider');
+    resetProviderRegistry();
+    const anthropicProvider = new AnthropicProvider();
+    anthropicProvider.setCredentials({ type: 'api_key', apiKey: 'test-api-key' });
+    getProviderRegistry().register(anthropicProvider);
+
     lastTitleQueryOptions = undefined;
     lastTitleProcessEnv = undefined;
     // Default: assistant message with a plain text block
@@ -302,7 +311,9 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
 
     process.env.GLM_API_KEY = 'test-glm-key';
     const registry = getProviderRegistry();
-    registry.register(new GlmProvider(process.env));
+    const glmProvider = new GlmProvider();
+    glmProvider.setCredentials({ type: 'api_key', apiKey: 'test-glm-key' });
+    registry.register(glmProvider);
 
     const { mockAgentSession, mockSessionCache: sessionCache } = makeSessionCache();
     mockAgentSession.getSessionData = mock(() => ({
@@ -391,17 +402,14 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
   });
 
   it('should generate titles using stored credentials when env vars are absent', async () => {
-    const { AnthropicProvider } = await import('../../../../src/lib/providers/anthropic-provider');
     const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
 
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
 
-    const anthropicProvider = new AnthropicProvider();
-    anthropicProvider.setCredentials({ type: 'api_key', apiKey: 'stored-api-key' });
-    const registry = getProviderRegistry();
-    registry.register(anthropicProvider);
+    const anthropicProvider = getProviderRegistry().get('anthropic');
+    anthropicProvider?.setCredentials({ type: 'api_key', apiKey: 'stored-api-key' });
 
     const result = await lifecycle.generateTitleAndRenameBranch('test-id', 'Create a login form');
 

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
@@ -260,7 +260,6 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
       workspaceRoot: '/default/workspace',
       disableWorktrees: true,
       titleGenerationQueryForTesting: titleQueryOverride,
-      titleGenerationProviderAvailableForTesting: () => true,
     };
 
     lifecycle = new SessionLifecycle(

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
@@ -181,16 +181,7 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
     };
   };
 
-  beforeEach(async () => {
-    const { getProviderRegistry, resetProviderRegistry } = await import(
-      '../../../../src/lib/providers/registry'
-    );
-    const { AnthropicProvider } = await import('../../../../src/lib/providers/anthropic-provider');
-    resetProviderRegistry();
-    const anthropicProvider = new AnthropicProvider();
-    anthropicProvider.setCredentials({ type: 'api_key', apiKey: 'test-api-key' });
-    getProviderRegistry().register(anthropicProvider);
-
+  beforeEach(() => {
     lastTitleQueryOptions = undefined;
     lastTitleProcessEnv = undefined;
     // Default: assistant message with a plain text block
@@ -269,6 +260,7 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
       workspaceRoot: '/default/workspace',
       disableWorktrees: true,
       titleGenerationQueryForTesting: titleQueryOverride,
+      titleGenerationProviderAvailableForTesting: () => true,
     };
 
     lifecycle = new SessionLifecycle(
@@ -402,14 +394,9 @@ describe('SessionLifecycle - generateTitleWithSdk (thinking disabled)', () => {
   });
 
   it('should generate titles using stored credentials when env vars are absent', async () => {
-    const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
-
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
-
-    const anthropicProvider = getProviderRegistry().get('anthropic');
-    anthropicProvider?.setCredentials({ type: 'api_key', apiKey: 'stored-api-key' });
 
     const result = await lifecycle.generateTitleAndRenameBranch('test-id', 'Create a login form');
 

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
@@ -57,6 +57,10 @@ mock.module('../../../../src/lib/provider-service', () => ({
     getTitleGenerationConfig: async (_provider: string) => ({
       modelId: 'claude-sonnet-4-20250514',
     }),
+    getTitleGenerationModels: async (_provider: string, sessionModelId: string) => ({
+      providerModelId: sessionModelId,
+      sdkModelId: sessionModelId,
+    }),
     getEnvVarsForModel: (_modelId: string, _provider: string) => ({}),
     restoreEnvVars: (_originalEnv: Record<string, string | undefined>) => {},
   }),

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
@@ -53,16 +53,39 @@ mock.module('../../../../src/lib/provider-service', () => ({
     getProviderApiKey: (_provider: string) => process.env.ANTHROPIC_API_KEY || undefined,
     isProviderAvailable: async () => false,
     mergeProviderEnvVars: (s: object) => s,
-    applyEnvVarsToProcessForProvider: (_provider: string, _modelId: string) => ({}),
+    applyEnvVarsToProcessForProvider: (provider: string, modelId: string) => {
+      if (provider !== 'glm') return {};
+      const originalEnv = {
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL,
+        ANTHROPIC_DEFAULT_SONNET_MODEL: process.env.ANTHROPIC_DEFAULT_SONNET_MODEL,
+        ANTHROPIC_DEFAULT_OPUS_MODEL: process.env.ANTHROPIC_DEFAULT_OPUS_MODEL,
+      };
+      process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = modelId;
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = modelId;
+      process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = modelId;
+      return originalEnv;
+    },
     getTitleGenerationConfig: async (_provider: string) => ({
       modelId: 'claude-sonnet-4-20250514',
     }),
-    getTitleGenerationModels: async (_provider: string, sessionModelId: string) => ({
-      providerModelId: sessionModelId,
-      sdkModelId: sessionModelId,
+    getTitleGenerationModels: async (provider: string, sessionModelId: string) => ({
+      providerModelId: provider === 'glm' ? 'glm-5-turbo' : sessionModelId,
+      sdkModelId: provider === 'glm' ? 'default' : sessionModelId,
     }),
-    getEnvVarsForModel: (_modelId: string, _provider: string) => ({}),
-    restoreEnvVars: (_originalEnv: Record<string, string | undefined>) => {},
+    getEnvVarsForModel: (modelId: string, provider: string) =>
+      provider === 'glm'
+        ? {
+            ANTHROPIC_DEFAULT_HAIKU_MODEL: modelId,
+            ANTHROPIC_DEFAULT_SONNET_MODEL: modelId,
+            ANTHROPIC_DEFAULT_OPUS_MODEL: modelId,
+          }
+        : {},
+    restoreEnvVars: (originalEnv: Record<string, string | undefined>) => {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    },
   }),
   mergeProviderEnvVars: (session: object) => session,
 }));

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -407,7 +407,7 @@ describe('buildCustomAgentTaskMessage', () => {
 
     expect(message).toContain('- Outbound gated handoffs:');
     expect(message).toContain(
-      'Code (Plan → Code): call `send_message(target="Code", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+      'Code (Plan → Code): call `send_message(target="Code", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
     );
     expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
   });
@@ -643,7 +643,7 @@ describe('buildCustomAgentTaskMessage', () => {
     );
 
     expect(message).toContain(
-      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
     );
     expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
   });
@@ -665,7 +665,7 @@ describe('buildCustomAgentTaskMessage', () => {
     );
 
     expect(message).toContain(
-      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
     );
     expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
   });
@@ -692,12 +692,80 @@ describe('buildCustomAgentTaskMessage', () => {
     );
 
     expect(message).toContain(
-      'Code (Plan → Reviewers): call `send_message(target="Code", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+      'Code (Plan → Reviewers): call `send_message(target="Code", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
     );
     expect(message).toContain(
-      'QA (Plan → Reviewers): call `send_message(target="QA", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+      'QA (Plan → Reviewers): call `send_message(target="QA", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
     );
     expect(message).not.toContain('send_message(target=["Code", "QA"]');
+  });
+
+  it('emits scalar send_message examples for broadcast gated channels', () => {
+    const workflow = makeWorkflow({
+      channels: [
+        {
+          id: 'ch-plan-broadcast',
+          from: 'Plan',
+          to: '*',
+          label: 'Plan → All',
+          gateId: 'plan-ready-gate',
+        },
+      ],
+    });
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: 'node-1',
+        agentSlotName: 'Coder',
+      })
+    );
+
+    expect(message).toContain(
+      'Code (Plan → All): call `send_message(target="Code", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
+    );
+    expect(message).not.toContain('send_message(target="*"');
+  });
+
+  it('quotes gate field names in generated handoff data examples', () => {
+    const workflow = makeWorkflow({
+      channels: [
+        {
+          id: 'ch-plan-to-code',
+          from: 'Plan',
+          to: 'Code',
+          label: 'Plan → Code',
+          gateId: 'plan-ready-gate',
+        },
+      ],
+      gates: [
+        {
+          id: 'plan-ready-gate',
+          label: 'PR Ready',
+          description: 'Planner has opened a plan PR',
+          fields: [
+            {
+              name: 'pr-url',
+              type: 'string',
+              writers: ['Plan'],
+              check: { op: 'exists' },
+            },
+          ],
+          resetOnCycle: false,
+        },
+      ],
+    });
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: 'node-1',
+        agentSlotName: 'Coder',
+      })
+    );
+
+    expect(message).toContain('data: { "pr-url": "<pr-url>" }');
+    expect(message).not.toContain('data: { pr-url:');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -727,7 +727,7 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toContain('send_message(target="*"');
   });
 
-  it('quotes gate field names in generated handoff data examples', () => {
+  it('quotes gate field names and emits executable non-string values in handoff data', () => {
     const workflow = makeWorkflow({
       channels: [
         {
@@ -750,6 +750,18 @@ describe('buildCustomAgentTaskMessage', () => {
               writers: ['Plan'],
               check: { op: 'exists' },
             },
+            {
+              name: 'approved',
+              type: 'boolean',
+              writers: ['Plan'],
+              check: { op: '==', value: true },
+            },
+            {
+              name: 'score',
+              type: 'number',
+              writers: ['Plan'],
+              check: { op: 'exists' },
+            },
           ],
           resetOnCycle: false,
         },
@@ -764,8 +776,12 @@ describe('buildCustomAgentTaskMessage', () => {
       })
     );
 
-    expect(message).toContain('data: { "pr-url": "<pr-url>" }');
+    expect(message).toContain('"pr-url": "<pr-url>"');
+    expect(message).toContain('"approved": true');
+    expect(message).toContain('"score": 0');
     expect(message).not.toContain('data: { pr-url:');
+    expect(message).not.toContain('<boolean>');
+    expect(message).not.toContain('<number>');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -843,7 +843,7 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).toContain('"score": 5');
     expect(message).toContain('"scoreNonZero": 1');
     expect(message).toContain('"status": "<status-different>"');
-    expect(message).toContain('"votes": { "<key1>": "approved", "<key2>": "approved" }');
+    expect(message).toContain('"votes": { "<your-key>": "approved" }');
     expect(message).not.toContain('"omitted"');
     expect(message).not.toContain('"status": "<status>"');
     expect(message).not.toContain('data: { pr"url:');
@@ -851,7 +851,7 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toContain('<number>');
   });
 
-  it('caps map-count handoff placeholders for large thresholds', () => {
+  it('emits only the writer vote for map-count handoff placeholders', () => {
     const workflow = makeWorkflow({
       channels: [
         {
@@ -886,10 +886,9 @@ describe('buildCustomAgentTaskMessage', () => {
       })
     );
 
-    expect(message).toContain(
-      '"votes": { "<key1>": "approved", "<key2>": "approved", "<key3>": "approved", /* add 22 more matching entries */ }'
-    );
-    expect(message).not.toContain('<key25>');
+    expect(message).toContain('"votes": { "<your-key>": "approved" }');
+    expect(message).not.toContain('<key2>');
+    expect(message).not.toContain('add 22 more matching entries');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -807,6 +807,18 @@ describe('buildCustomAgentTaskMessage', () => {
               check: { op: '!=', value: 0 },
             },
             {
+              name: 'status',
+              type: 'string',
+              writers: ['Plan'],
+              check: { op: '!=', value: '<status>' },
+            },
+            {
+              name: 'omitted',
+              type: 'string',
+              writers: ['Plan'],
+              check: { op: '==' },
+            },
+            {
               name: 'votes',
               type: 'map',
               writers: ['Plan'],
@@ -830,7 +842,10 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).toContain('"approved": false');
     expect(message).toContain('"score": 5');
     expect(message).toContain('"scoreNonZero": 1');
+    expect(message).toContain('"status": "<status-different>"');
     expect(message).toContain('"votes": { "<key1>": "approved", "<key2>": "approved" }');
+    expect(message).not.toContain('"omitted"');
+    expect(message).not.toContain('"status": "<status>"');
     expect(message).not.toContain('data: { pr"url:');
     expect(message).not.toContain('<boolean>');
     expect(message).not.toContain('<number>');

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -727,6 +727,44 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toContain('send_message(target="*"');
   });
 
+  it('emits peer slot send_message examples for same-node broadcast gated channels', () => {
+    const workflow = makeWorkflow({
+      nodes: [
+        {
+          id: 'node-1',
+          name: 'Plan',
+          agents: [
+            { agentId: 'agent-coder', name: 'coder' },
+            { agentId: 'agent-reviewer', name: 'reviewer' },
+          ],
+        },
+      ],
+      channels: [
+        {
+          id: 'ch-plan-broadcast',
+          from: 'Plan',
+          to: '*',
+          label: 'Plan → All',
+          gateId: 'plan-ready-gate',
+        },
+      ],
+    });
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: 'node-1',
+        agentSlotName: 'coder',
+      })
+    );
+
+    expect(message).toContain(
+      'reviewer (Plan → All): call `send_message(target="reviewer", message="<short summary>", data: { "pr_url": "<pr_url>" })`'
+    );
+    expect(message).not.toContain('send_message(target="coder"');
+    expect(message).not.toContain('send_message(target="*"');
+  });
+
   it('quotes gate field names and emits executable non-string values in handoff data', () => {
     const workflow = makeWorkflow({
       channels: [
@@ -796,6 +834,47 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toContain('data: { pr"url:');
     expect(message).not.toContain('<boolean>');
     expect(message).not.toContain('<number>');
+  });
+
+  it('caps map-count handoff placeholders for large thresholds', () => {
+    const workflow = makeWorkflow({
+      channels: [
+        {
+          id: 'ch-plan-to-code',
+          from: 'Plan',
+          to: 'Code',
+          label: 'Plan → Code',
+          gateId: 'plan-ready-gate',
+        },
+      ],
+      gates: [
+        {
+          id: 'plan-ready-gate',
+          fields: [
+            {
+              name: 'votes',
+              type: 'map',
+              writers: ['Plan'],
+              check: { op: 'count', match: 'approved', min: 25 },
+            },
+          ],
+          resetOnCycle: false,
+        },
+      ],
+    });
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: 'node-1',
+        agentSlotName: 'Coder',
+      })
+    );
+
+    expect(message).toContain(
+      '"votes": { "<key1>": "approved", "<key2>": "approved", "<key3>": "approved", /* add 22 more matching entries */ }'
+    );
+    expect(message).not.toContain('<key25>');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -19,6 +19,7 @@ import {
   type CustomAgentConfig,
   type SlotOverrides,
 } from '../../../../src/lib/space/agents/custom-agent';
+import { CODING_WORKFLOW } from '../../../../src/lib/space/workflows/built-in-workflows.ts';
 
 function makeAgent(overrides?: Partial<SpaceAgent>): SpaceAgent {
   return {
@@ -636,6 +637,39 @@ describe('createCustomAgentInit', () => {
     );
 
     expect(init.systemPrompt?.append).toBe('Base prompt\n\nSlot expansion');
+  });
+
+  it('injects Coding workflow send_message handoff instructions into future task prompts', () => {
+    const codingNode = CODING_WORKFLOW.nodes.find((node) => node.name === 'Coding')!;
+    const codingSlot = codingNode.agents[0];
+    const init = createCustomAgentInit(
+      makeConfig({
+        customAgent: makeAgent({ id: codingSlot.agentId, name: 'Coder', customPrompt: null }),
+        workflow: CODING_WORKFLOW,
+        workflowRun: makeWorkflowRun({ workflowId: CODING_WORKFLOW.id }),
+        nodeId: codingNode.id,
+        agentSlotName: codingSlot.name,
+        slotOverrides: {
+          customPrompt: codingSlot.customPrompt?.value,
+          resolutionContext: {
+            agentId: codingSlot.agentId,
+            agentName: codingSlot.name,
+            workflowRunId: 'run-1',
+            workflowId: CODING_WORKFLOW.id,
+            nodeId: codingNode.id,
+            nodeName: codingNode.name,
+          },
+        },
+      })
+    );
+
+    const prompt = init.systemPrompt?.append ?? '';
+    expect(prompt).toContain(
+      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
+    );
+    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-ready-gate`');
+    expect(prompt).toContain('`save_artifact` alone is insufficient');
+    expect(prompt).toContain('only `send_message` delivers the gated handoff');
   });
 
   it('uses the agent custom prompt when no slot override is defined', () => {

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -745,7 +745,7 @@ describe('buildCustomAgentTaskMessage', () => {
           description: 'Planner has opened a plan PR',
           fields: [
             {
-              name: 'pr-url',
+              name: 'pr"url',
               type: 'string',
               writers: ['Plan'],
               check: { op: 'exists' },
@@ -754,13 +754,19 @@ describe('buildCustomAgentTaskMessage', () => {
               name: 'approved',
               type: 'boolean',
               writers: ['Plan'],
-              check: { op: '==', value: true },
+              check: { op: '==', value: false },
             },
             {
               name: 'score',
               type: 'number',
               writers: ['Plan'],
-              check: { op: 'exists' },
+              check: { op: '==', value: 5 },
+            },
+            {
+              name: 'votes',
+              type: 'map',
+              writers: ['Plan'],
+              check: { op: 'count', match: 'approved', min: 2 },
             },
           ],
           resetOnCycle: false,
@@ -776,10 +782,11 @@ describe('buildCustomAgentTaskMessage', () => {
       })
     );
 
-    expect(message).toContain('"pr-url": "<pr-url>"');
-    expect(message).toContain('"approved": true');
-    expect(message).toContain('"score": 0');
-    expect(message).not.toContain('data: { pr-url:');
+    expect(message).toContain('"pr\\"url": "<pr\\"url>"');
+    expect(message).toContain('"approved": false');
+    expect(message).toContain('"score": 5');
+    expect(message).toContain('"votes": { "<key1>": "approved", "<key2>": "approved" }');
+    expect(message).not.toContain('data: { pr"url:');
     expect(message).not.toContain('<boolean>');
     expect(message).not.toContain('<number>');
   });

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -669,6 +669,36 @@ describe('buildCustomAgentTaskMessage', () => {
     );
     expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
   });
+
+  it('emits scalar send_message examples for multicast gated channels', () => {
+    const workflow = makeWorkflow({
+      channels: [
+        {
+          id: 'ch-plan-to-reviewers',
+          from: 'Plan',
+          to: ['Code', 'QA'],
+          label: 'Plan → Reviewers',
+          gateId: 'plan-ready-gate',
+        },
+      ],
+    });
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: 'node-1',
+        agentSlotName: 'Coder',
+      })
+    );
+
+    expect(message).toContain(
+      'Code (Plan → Reviewers): call `send_message(target="Code", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+    );
+    expect(message).toContain(
+      'QA (Plan → Reviewers): call `send_message(target="QA", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+    );
+    expect(message).not.toContain('send_message(target=["Code", "QA"]');
+  });
 });
 
 describe('createCustomAgentInit', () => {

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -395,6 +395,23 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toMatch(/code-pr-gate/);
   });
 
+  it('renders exact send_message handoff for outbound gated channels from workflow graph', () => {
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow: makeWorkflow(),
+        workflowRun: makeWorkflowRun(),
+        nodeId: 'node-1', // "Plan" node
+        agentSlotName: 'Coder',
+      })
+    );
+
+    expect(message).toContain('- Outbound gated handoffs:');
+    expect(message).toContain(
+      'Code (Plan → Code): call `send_message(target="Code", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+    );
+    expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
+  });
+
   it('does not contain node UUIDs', () => {
     const workflow = makeWorkflow();
     const message = buildCustomAgentTaskMessage(
@@ -613,6 +630,45 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).not.toContain('Channels from this node:');
     expect(message).not.toContain('Gates you can write:');
   });
+
+  it('injects exact Coding workflow send_message handoff into future task messages', () => {
+    const codingNode = CODING_WORKFLOW.nodes.find((node) => node.name === 'Coding')!;
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow: CODING_WORKFLOW,
+        workflowRun: makeWorkflowRun({ workflowId: CODING_WORKFLOW.id }),
+        nodeId: codingNode.id,
+        agentSlotName: 'coder',
+      })
+    );
+
+    expect(message).toContain(
+      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+    );
+    expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
+  });
+
+  it('injects exact handoff even when persisted workflow slot prompt is stale', () => {
+    const workflow = structuredClone(CODING_WORKFLOW);
+    const codingNode = workflow.nodes.find((node) => node.name === 'Coding')!;
+    codingNode.agents[0].customPrompt = {
+      value: 'Legacy wording: write code-pr-gate with field pr_url so Review can activate.',
+    };
+
+    const message = buildCustomAgentTaskMessage(
+      makeConfig({
+        workflow,
+        workflowRun: makeWorkflowRun({ workflowId: workflow.id }),
+        nodeId: codingNode.id,
+        agentSlotName: 'coder',
+      })
+    );
+
+    expect(message).toContain(
+      'Review (Coding → Review): call `send_message(target="Review", message="<short summary>", data: { pr_url: "<pr_url>" })`'
+    );
+    expect(message).toContain('`save_artifact` alone does not deliver this gated handoff');
+  });
 });
 
 describe('createCustomAgentInit', () => {
@@ -639,7 +695,7 @@ describe('createCustomAgentInit', () => {
     expect(init.systemPrompt?.append).toBe('Base prompt\n\nSlot expansion');
   });
 
-  it('injects Coding workflow send_message handoff instructions into future task prompts', () => {
+  it('injects Coding workflow behavioral handoff guidance into system prompt', () => {
     const codingNode = CODING_WORKFLOW.nodes.find((node) => node.name === 'Coding')!;
     const codingSlot = codingNode.agents[0];
     const init = createCustomAgentInit(
@@ -664,12 +720,11 @@ describe('createCustomAgentInit', () => {
     );
 
     const prompt = init.systemPrompt?.append ?? '';
-    expect(prompt).toContain(
-      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
-    );
-    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-ready-gate`');
+    expect(prompt).toContain('hand off by calling `send_message` on the outbound gated');
+    expect(prompt).toContain('Use the current target and required data fields');
     expect(prompt).toContain('`save_artifact` alone is insufficient');
-    expect(prompt).toContain('only `send_message` delivers the gated handoff');
+    expect(prompt).not.toContain('send_message(target="Review"');
+    expect(prompt).not.toContain('code-ready-gate');
   });
 
   it('uses the agent custom prompt when no slot override is defined', () => {

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -763,6 +763,12 @@ describe('buildCustomAgentTaskMessage', () => {
               check: { op: '==', value: 5 },
             },
             {
+              name: 'scoreNonZero',
+              type: 'number',
+              writers: ['Plan'],
+              check: { op: '!=', value: 0 },
+            },
+            {
               name: 'votes',
               type: 'map',
               writers: ['Plan'],
@@ -785,6 +791,7 @@ describe('buildCustomAgentTaskMessage', () => {
     expect(message).toContain('"pr\\"url": "<pr\\"url>"');
     expect(message).toContain('"approved": false');
     expect(message).toContain('"score": 5');
+    expect(message).toContain('"scoreNonZero": 1');
     expect(message).toContain('"votes": { "<key1>": "approved", "<key2>": "approved" }');
     expect(message).not.toContain('data: { pr"url:');
     expect(message).not.toContain('<boolean>');

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1445,6 +1445,41 @@ describe('node-agent-tools: send_message (gate-write)', () => {
     );
   });
 
+  test('gate-write prefers scalar target channels over broadcast channels', async () => {
+    const broadcastGate: Gate = {
+      id: 'gate-broadcast',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+      resetOnCycle: false,
+    };
+    const reviewGate: Gate = {
+      id: 'gate-review',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+      resetOnCycle: false,
+    };
+    const workflow = makeWorkflowWithGatedChannel(reviewGate);
+    workflow.channels = [
+      { id: 'ch-coder-all', from: 'Coding', to: '*', gateId: broadcastGate.id },
+      { id: 'ch-coder-review', from: 'Coding', to: 'Review', gateId: reviewGate.id },
+    ];
+    workflow.gates = [broadcastGate, reviewGate];
+    const gateDataRepo = new GateDataRepository(ctx.db);
+    const config = makeConfig(ctx, { workflow, gateDataRepo });
+    const handlers = createNodeAgentToolHandlers(config);
+
+    const result = await handlers.send_message({
+      target: 'Review',
+      message: 'ready',
+      data: { pr_url: 'https://github.com/test/repo/pull/42' },
+    });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.gateWrite).toEqual({ gateId: 'gate-review', gateOpen: true });
+    expect(gateDataRepo.get(ctx.workflowRunId, 'gate-review')?.data.pr_url).toBe(
+      'https://github.com/test/repo/pull/42'
+    );
+    expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast')).toBeNull();
+  });
+
   test('no gateWrite in response when data not provided', async () => {
     const gate: Gate = {
       id: 'gate-no-data',

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1480,6 +1480,30 @@ describe('node-agent-tools: send_message (gate-write)', () => {
     expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast')).toBeNull();
   });
 
+  test('gate-write skips broadcast channels for unknown scalar targets', async () => {
+    const gate: Gate = {
+      id: 'gate-broadcast',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+      resetOnCycle: false,
+    };
+    const workflow = makeWorkflowWithGatedChannel(gate);
+    workflow.channels = [{ id: 'ch-coder-all', from: 'Coding', to: '*', gateId: gate.id }];
+    const gateDataRepo = new GateDataRepository(ctx.db);
+    const config = makeConfig(ctx, { workflow, gateDataRepo });
+    const handlers = createNodeAgentToolHandlers(config);
+
+    const result = await handlers.send_message({
+      target: 'TypoReview',
+      message: 'ready',
+      data: { pr_url: 'https://github.com/test/repo/pull/42' },
+    });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.gateWrite).toBeUndefined();
+    expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast')).toBeNull();
+  });
+
   test('no gateWrite in response when data not provided', async () => {
     const gate: Gate = {
       id: 'gate-no-data',

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1504,6 +1504,32 @@ describe('node-agent-tools: send_message (gate-write)', () => {
     expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast')).toBeNull();
   });
 
+  test('gate-write treats same-node peer agents as broadcast targets', async () => {
+    const gate: Gate = {
+      id: 'gate-broadcast-peer',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+      resetOnCycle: false,
+    };
+    const workflow = makeWorkflowWithGatedChannel(gate);
+    workflow.nodes[0].agents.push({ agentId: 'agent-peer', name: 'peer' });
+    workflow.channels = [{ id: 'ch-coder-all', from: 'Coding', to: '*', gateId: gate.id }];
+    const gateDataRepo = new GateDataRepository(ctx.db);
+    const config = makeConfig(ctx, { workflow, gateDataRepo });
+    const handlers = createNodeAgentToolHandlers(config);
+
+    const result = await handlers.send_message({
+      target: 'peer',
+      message: 'ready',
+      data: { pr_url: 'https://github.com/test/repo/pull/42' },
+    });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.gateWrite).toEqual({ gateId: 'gate-broadcast-peer', gateOpen: true });
+    expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast-peer')?.data.pr_url).toBe(
+      'https://github.com/test/repo/pull/42'
+    );
+  });
+
   test('no gateWrite in response when data not provided', async () => {
     const gate: Gate = {
       id: 'gate-no-data',

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1420,6 +1420,31 @@ describe('node-agent-tools: send_message (gate-write)', () => {
     );
   });
 
+  test('gate-write treats broadcast channels as matching scalar targets', async () => {
+    const gate: Gate = {
+      id: 'gate-broadcast',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+      resetOnCycle: false,
+    };
+    const workflow = makeWorkflowWithGatedChannel(gate);
+    workflow.channels = [{ id: 'ch-coder-all', from: 'Coding', to: '*', gateId: gate.id }];
+    const gateDataRepo = new GateDataRepository(ctx.db);
+    const config = makeConfig(ctx, { workflow, gateDataRepo });
+    const handlers = createNodeAgentToolHandlers(config);
+
+    const result = await handlers.send_message({
+      target: 'Review',
+      message: 'ready',
+      data: { pr_url: 'https://github.com/test/repo/pull/42' },
+    });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.gateWrite).toEqual({ gateId: 'gate-broadcast', gateOpen: true });
+    expect(gateDataRepo.get(ctx.workflowRunId, 'gate-broadcast')?.data.pr_url).toBe(
+      'https://github.com/test/repo/pull/42'
+    );
+  });
+
   test('no gateWrite in response when data not provided', async () => {
     const gate: Gate = {
       id: 'gate-no-data',

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2083,12 +2083,37 @@ describe('seedBuiltInWorkflows()', () => {
     expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
   });
 
-  test('re-stamp patches known retired built-in node agent prompt text', () => {
+  test('re-stamp patches exact retired built-in Coding prompt text', () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
     const codingNode = coding.nodes.find((n) => n.name === 'Coding')!;
-    const stalePrompt =
-      'Legacy prompt: hand off by sending a message to Review with `data: { pr_url: "<url>" }`.';
+    const templatePrompt = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!.agents[0]
+      .customPrompt!.value;
+    const stalePrompt = templatePrompt
+      .replace(
+        '6. If code changed: hand off by calling `send_message` on the outbound gated ' +
+          'review channel with the PR URL in its `data` payload. Use the current target and ' +
+          'required data fields from the Runtime Execution Contract injected into your task ' +
+          'prompt. `save_artifact` alone is insufficient; only `send_message` delivers ' +
+          'the gated handoff. Always include the PR URL data field on every `send_message` ' +
+          'handoff — gate data resets each cycle, so even on round 2+ you must re-supply it.\n',
+        '6. If code changed: hand off by sending a message to Review with ' +
+          '`data: { pr_url: "<url>" }`. The gate script verifies the PR is open and ' +
+          'mergeable, so make sure it actually is before sending. ' +
+          '**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
+          'data resets each cycle, so even on round 2+ you must re-supply it.\n'
+      )
+      .replace(
+        '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
+          'then call `send_message` on the outbound gated review channel again to ' +
+          're-trigger the review cycle. Re-supplying the PR URL data field is required; ' +
+          '`save_artifact` alone will not deliver the gated handoff.',
+        '6. Verify no unresolved review conversations remain, verify tests still pass, ' +
+          'then send_message to Review again (again with `data: { pr_url }`) to ' +
+          're-trigger the review cycle'
+      );
+    expect(stalePrompt).not.toBe(templatePrompt);
+    expect(stalePrompt).toContain('hand off by sending a message to Review');
 
     manager.updateWorkflow(coding.id, {
       nodes: coding.nodes.map((n) =>
@@ -2113,12 +2138,101 @@ describe('seedBuiltInWorkflows()', () => {
     const after = manager.getWorkflow(coding.id)!;
     const afterCodingNode = after.nodes.find((n) => n.id === codingNode.id)!;
     const afterPrompt = afterCodingNode.agents[0].customPrompt?.value;
-    expect(afterPrompt).toBe(
-      CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!.agents[0].customPrompt?.value
-    );
+    expect(afterPrompt).toBe(templatePrompt);
     expect(afterPrompt).toContain('hand off by calling `send_message` on the outbound gated');
     expect(afterPrompt).not.toContain('send_message(target="Review"');
     expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
+  });
+
+  test('re-stamp preserves customized prompts containing retired built-in text', () => {
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+    const codingNode = coding.nodes.find((n) => n.name === 'Coding')!;
+    const customizedPrompt =
+      'Local Coding instructions: keep the staging branch open. ' +
+      'Also remember to write code-pr-gate with field pr_url so Review can activate.';
+
+    manager.updateWorkflow(coding.id, {
+      nodes: coding.nodes.map((n) =>
+        n.id !== codingNode.id
+          ? n
+          : {
+              ...n,
+              agents: n.agents.map((a, i) =>
+                i === 0 ? { ...a, customPrompt: { value: customizedPrompt } } : a
+              ),
+            }
+      ),
+    });
+    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+      'customized-stale-prompt-hash',
+      coding.id
+    );
+
+    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    expect(result.restamped).toContain(CODING_WORKFLOW.name);
+
+    const after = manager.getWorkflow(coding.id)!;
+    const afterCodingNode = after.nodes.find((n) => n.id === codingNode.id)!;
+    expect(afterCodingNode.agents[0].customPrompt?.value).toBe(customizedPrompt);
+    expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
+  });
+
+  test('re-stamp patches exact retired built-in Fullstack prompt text', () => {
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const workflow = manager
+      .listWorkflows(SPACE_ID)
+      .find((w) => w.name === FULLSTACK_QA_LOOP_WORKFLOW.name)!;
+    const codingNode = workflow.nodes.find((n) => n.name === 'Coding')!;
+    const templatePrompt = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!
+      .agents[0].customPrompt!.value;
+    const stalePrompt = templatePrompt
+      .replace(
+        'When implementation is ready, ensure the PR is open and mergeable, then call `send_message` ' +
+          'on the outbound gated review channel with the PR URL in its `data` payload. Use the current ' +
+          'target and required data fields from the Runtime Execution Contract injected into your task ' +
+          'prompt. `save_artifact` alone is insufficient; only `send_message` delivers the gated ' +
+          'handoff. Coding is not the end node — the task-completion tools (`approve_task`, ' +
+          '`submit_for_approval`) are not available to you.\n\n',
+        'When implementation is ready, ensure the PR is open and mergeable and write code-pr-gate with ' +
+          'field pr_url so Review can activate. Coding is not the end node — the task-completion tools ' +
+          '(`approve_task`, `submit_for_approval`) are not available to you.\n\n'
+      )
+      .replace(
+        '4. Hand off by calling `send_message` on the outbound gated review channel with ' +
+          'the PR URL in its `data` payload; `save_artifact` alone will not deliver the handoff\n',
+        '4. Write code-pr-gate with field pr_url so Review can activate\n'
+      );
+    expect(stalePrompt).not.toBe(templatePrompt);
+    expect(stalePrompt).toContain('4. Write code-pr-gate with field pr_url so Review can activate');
+
+    manager.updateWorkflow(workflow.id, {
+      nodes: workflow.nodes.map((n) =>
+        n.id !== codingNode.id
+          ? n
+          : {
+              ...n,
+              agents: n.agents.map((a, i) =>
+                i === 0 ? { ...a, customPrompt: { value: stalePrompt } } : a
+              ),
+            }
+      ),
+    });
+    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+      'stale-fullstack-prompt-hash',
+      workflow.id
+    );
+
+    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    expect(result.restamped).toContain(FULLSTACK_QA_LOOP_WORKFLOW.name);
+
+    const after = manager.getWorkflow(workflow.id)!;
+    const afterCodingNode = after.nodes.find((n) => n.id === codingNode.id)!;
+    const afterPrompt = afterCodingNode.agents[0].customPrompt?.value;
+    expect(afterPrompt).toBe(templatePrompt);
+    expect(afterPrompt).toContain('call `send_message` on the outbound gated review channel');
+    expect(afterPrompt).not.toContain('Write code-pr-gate with field pr_url');
+    expect(after.templateHash).toBe(computeWorkflowHash(FULLSTACK_QA_LOOP_WORKFLOW));
   });
 
   test('re-stamp updates gate field writers and features in place', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -143,6 +143,17 @@ describe('CODING_WORKFLOW template', () => {
     expect(prompt).toContain('The reviewer handles the merge.');
   });
 
+  test('coder prompt requires send_message handoff to Review with pr_url', () => {
+    const prompt = CODING_WORKFLOW.nodes[0].agents[0]?.customPrompt?.value;
+    expect(prompt).toContain(
+      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
+    );
+    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-ready-gate`');
+    expect(prompt).toContain('`save_artifact` alone is insufficient');
+    expect(prompt).toContain('only `send_message` delivers the gated handoff');
+    expect(prompt).toContain('again to re-trigger the review cycle');
+  });
+
   test('coder and validator slots have toolGuards with gh pr merge deny rule', () => {
     for (const agent of [CODING_WORKFLOW.nodes[0].agents[0], CODING_WORKFLOW.nodes[1].agents[0]]) {
       const guards = agent?.toolGuards;
@@ -4339,6 +4350,18 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     expect(prField.type).toBe('string');
     expect(prField.writers).toEqual(['Coding', 'coder']);
     expect(prField.check).toEqual({ op: 'exists' });
+  });
+
+  test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt requires send_message handoff to Review', () => {
+    const codingNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+    const prompt = codingNode.agents[0].customPrompt!.value;
+
+    expect(prompt).toContain(
+      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
+    );
+    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-pr-gate`');
+    expect(prompt).toContain('`save_artifact` alone is insufficient');
+    expect(prompt).toContain('only `send_message` delivers the gated handoff');
   });
 
   test('FULLSTACK_QA_LOOP_WORKFLOW has layout entries for actual template node IDs', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -143,15 +143,15 @@ describe('CODING_WORKFLOW template', () => {
     expect(prompt).toContain('The reviewer handles the merge.');
   });
 
-  test('coder prompt requires send_message handoff to Review with pr_url', () => {
+  test('coder prompt gives behavioral handoff guidance without hard-coded gate details', () => {
     const prompt = CODING_WORKFLOW.nodes[0].agents[0]?.customPrompt?.value;
-    expect(prompt).toContain(
-      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
-    );
-    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-ready-gate`');
+    expect(prompt).toContain('hand off by calling `send_message` on the outbound gated');
+    expect(prompt).toContain('Use the current target and required data fields');
+    expect(prompt).toContain('Runtime Execution Contract');
     expect(prompt).toContain('`save_artifact` alone is insufficient');
-    expect(prompt).toContain('only `send_message` delivers the gated handoff');
-    expect(prompt).toContain('again to re-trigger the review cycle');
+    expect(prompt).toContain('Re-supplying the PR URL data field is required');
+    expect(prompt).not.toContain('send_message(target="Review"');
+    expect(prompt).not.toContain('code-ready-gate');
   });
 
   test('coder and validator slots have toolGuards with gh pr merge deny rule', () => {
@@ -2080,6 +2080,44 @@ describe('seedBuiltInWorkflows()', () => {
     expect(afterAgent.customPrompt?.value).toBe(sentinel);
     expect(afterAgent.agentId).toBe(reviewAgent.agentId);
     expect(afterReviewNode.id).toBe(reviewNode.id);
+    expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
+  });
+
+  test('re-stamp patches known retired built-in node agent prompt text', () => {
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+    const codingNode = coding.nodes.find((n) => n.name === 'Coding')!;
+    const stalePrompt =
+      'Legacy prompt: hand off by sending a message to Review with `data: { pr_url: "<url>" }`.';
+
+    manager.updateWorkflow(coding.id, {
+      nodes: coding.nodes.map((n) =>
+        n.id !== codingNode.id
+          ? n
+          : {
+              ...n,
+              agents: n.agents.map((a, i) =>
+                i === 0 ? { ...a, customPrompt: { value: stalePrompt } } : a
+              ),
+            }
+      ),
+    });
+    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+      'stale-prompt-hash',
+      coding.id
+    );
+
+    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    expect(result.restamped).toContain(CODING_WORKFLOW.name);
+
+    const after = manager.getWorkflow(coding.id)!;
+    const afterCodingNode = after.nodes.find((n) => n.id === codingNode.id)!;
+    const afterPrompt = afterCodingNode.agents[0].customPrompt?.value;
+    expect(afterPrompt).toBe(
+      CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!.agents[0].customPrompt?.value
+    );
+    expect(afterPrompt).toContain('hand off by calling `send_message` on the outbound gated');
+    expect(afterPrompt).not.toContain('send_message(target="Review"');
     expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
   });
 
@@ -4352,16 +4390,15 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     expect(prField.check).toEqual({ op: 'exists' });
   });
 
-  test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt requires send_message handoff to Review', () => {
+  test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt uses behavioral gated handoff wording', () => {
     const codingNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
     const prompt = codingNode.agents[0].customPrompt!.value;
 
-    expect(prompt).toContain(
-      '`send_message(target="Review", message="<short summary>", data: { pr_url: "<url>" })`'
-    );
-    expect(prompt).toContain('The `data.pr_url` payload is auto-merged into `code-pr-gate`');
+    expect(prompt).toContain('call `send_message` on the outbound gated review channel');
+    expect(prompt).toContain('Use the current target and required data fields');
     expect(prompt).toContain('`save_artifact` alone is insufficient');
-    expect(prompt).toContain('only `send_message` delivers the gated handoff');
+    expect(prompt).not.toContain('send_message(target="Review"');
+    expect(prompt).not.toContain('code-pr-gate');
   });
 
   test('FULLSTACK_QA_LOOP_WORKFLOW has layout entries for actual template node IDs', () => {


### PR DESCRIPTION
Clarifies Coding workflow prompts so coders must hand off ready PRs with `send_message(target="Review", data: { pr_url })`, including after review-fix cycles. Adds tests pinning the prompt text and future session prompt injection.

Verified:
- `cd packages/daemon && bun test tests/unit/5-space/workflow/built-in-workflows.test.ts`
- `cd packages/daemon && bun test tests/unit/5-space/agent/custom-agent.test.ts`
- `bun run check`