### PR TITLE
fix(daemon): stable Codex bridge key across OAuth token refresh

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -384,15 +384,22 @@ export class AnthropicToCodexBridgeProvider implements Provider {
     };
   }
 
+  /**
+   * Stable identifier for bridge server reuse.
+   *
+   * Must NOT include the raw OAuth access token: the bridge server performs its
+   * own in-request token refresh, so rotating the token must not create a new
+   * bridge (which would kill the old port and leave the SDK subprocess talking
+   * to a dead server). API keys are hashed so switching keys still changes the
+   * key and triggers cleanup of the stale bridge.
+   */
   private bridgeAuthCacheKey(auth: OpenAIResponsesBridgeAuth | undefined): string {
     if (!auth) return 'none';
-    if (auth.source === 'api_key') return `api_key:${auth.apiKey}`;
-    return [
-      'chatgpt',
-      auth.apiKey,
-      auth.accountId,
-      auth.isFedrampAccount ? 'fedramp' : 'standard',
-    ].join(':');
+    if (auth.source === 'api_key') {
+      const hash = crypto.createHash('sha256').update(auth.apiKey).digest('hex').slice(0, 16);
+      return `api_key:${hash}`;
+    }
+    return ['chatgpt', auth.accountId, auth.isFedrampAccount ? 'fedramp' : 'standard'].join(':');
   }
 
   /**

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -21,6 +21,7 @@ import {
 } from 'node:fs';
 import * as path from 'path';
 import * as os from 'os';
+import type { ProviderCredentials } from '@neokai/shared/provider';
 import { AnthropicToCodexBridgeProvider } from '../../../../src/lib/providers/anthropic-to-codex-bridge-provider';
 
 // ---------------------------------------------------------------------------
@@ -415,6 +416,56 @@ describe('AnthropicToCodexBridgeProvider', () => {
         );
       } finally {
         p.stopAllBridgeServers();
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reuses the same bridge server after OAuth token refresh', async () => {
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'neokai-build-cfg-refresh-'));
+      try {
+        const neokaiDir = path.join(tmpDir, 'neokai');
+        const accessToken1 = makeJwt({
+          'https://api.openai.com/auth': { chatgpt_account_id: 'acct_refresh' },
+          jti: 'token-1',
+        });
+        writeNeokaiAuth(neokaiDir, {
+          type: 'oauth',
+          access: accessToken1,
+          refresh: 'refresh-token-1',
+        });
+        const p = makeProvider({}, neokaiDir, path.join(tmpDir, 'codex'));
+        await p.getApiKey();
+
+        const cfg1 = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-refresh' });
+        const port1 = new URL(cfg1.envVars.ANTHROPIC_BASE_URL as string).port;
+
+        // Simulate token rotation while preserving account identity.
+        const accessToken2 = makeJwt({
+          'https://api.openai.com/auth': { chatgpt_account_id: 'acct_refresh' },
+          jti: 'token-2',
+        });
+        p.setCredentials({
+          type: 'oauth',
+          accessToken: accessToken2,
+          refreshToken: 'refresh-token-2',
+          expiresAt: Date.now() + 3600_000,
+          raw: { accountId: 'acct_refresh' },
+        } as ProviderCredentials);
+
+        const cfg2 = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-refresh' });
+        const port2 = new URL(cfg2.envVars.ANTHROPIC_BASE_URL as string).port;
+
+        expect(port2).toBe(port1);
+
+        // The original port must still be reachable: the bridge was not killed.
+        const resp = await fetch(`${cfg1.envVars.ANTHROPIC_BASE_URL}/v1/models`);
+        expect(resp.status).toBe(200);
+
+        const servers = (p as unknown as { bridgeServers: Map<string, unknown> }).bridgeServers;
+        expect(servers.size).toBe(1);
+
+        p.stopAllBridgeServers();
+      } finally {
         rmSync(tmpDir, { recursive: true, force: true });
       }
     });


### PR DESCRIPTION
Stop including the raw OAuth access token in the Codex Responses bridge key. Token refresh now keeps the same bridge server/port, preventing `ConnectionRefused` errors when the SDK subprocess still points at the old port.

- OAuth bridge key is now `chatgpt:<accountId>:<fedramp|standard>`
- API key bridge key is now `api_key:<sha256(key).slice(0,16)>`
- Added unit test verifying the bridge survives token rotation
- Existing auth-change test still ensures stale bridges are cleaned up

Closes #595