### PR TITLE
Render compact boundaries in task threads

### DIFF
--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -114,6 +114,24 @@ function replayUserMessage(uuid: string, text: string) {
   };
 }
 
+function compactBoundaryMessage(
+  uuid: string,
+  metadata: {
+    trigger: 'manual' | 'auto';
+    pre_tokens: number;
+    post_tokens?: number;
+    duration_ms?: number;
+  }
+) {
+  return {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid,
+    session_id: 'test-session',
+    compact_metadata: metadata,
+  };
+}
+
 function systemInitMessage(uuid: string) {
   // Minimal `system:init` envelope. ResultInfoDropdown / MessageInfoDropdown
   // only require the discriminator fields to render the affordance trigger;
@@ -170,6 +188,45 @@ describe('MinimalThreadFeed', () => {
   it('renders nothing when there are no rows', () => {
     const { container } = render(<MinimalThreadFeed parsedRows={[]} />);
     expect(container.querySelector('[data-testid="space-task-event-feed-minimal"]')).toBeNull();
+  });
+
+  it('renders compact boundary rows with trigger and token counts', () => {
+    const baseTime = new Date('2026-04-25T18:00:00Z').getTime();
+    const rows = [
+      makeRow({
+        id: 'a1',
+        label: 'Coder Agent',
+        createdAt: baseTime,
+        message: assistantText('a1', 'before compaction'),
+      }),
+      makeRow({
+        id: 'c1',
+        label: 'Coder Agent',
+        createdAt: baseTime + 1000,
+        message: compactBoundaryMessage('c1', {
+          trigger: 'auto',
+          pre_tokens: 125000,
+          post_tokens: 24000,
+          duration_ms: 2100,
+        }),
+      }),
+      makeRow({
+        id: 'a2',
+        label: 'Coder Agent',
+        createdAt: baseTime + 2000,
+        message: assistantText('a2', 'after compaction'),
+      }),
+    ];
+
+    render(<MinimalThreadFeed parsedRows={rows} />);
+
+    const compactBoundary = screen.getByTestId('minimal-thread-compact-boundary');
+    expect(compactBoundary.textContent).toContain('Compact Boundary');
+    expect(compactBoundary.textContent).toContain('auto');
+    expect(compactBoundary.textContent).toContain('125,000 → 24,000 tokens');
+    expect(compactBoundary.textContent).toContain('saved 101,000');
+    expect(screen.getByText('before compaction')).not.toBeNull();
+    expect(screen.getByText('after compaction')).not.toBeNull();
   });
 
   it('renders one turn row per agent block with name and clock', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -903,6 +903,48 @@ describe('MinimalThreadFeed', () => {
       expect(trigger).not.toBeNull();
     });
 
+    it('only renders result trigger on the segment that contains the result row', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          message: assistantText('a1', 'before compact'),
+        }),
+        makeRow({
+          id: 'c1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: compactBoundaryMessage('c1', {
+            trigger: 'manual',
+            pre_tokens: 90000,
+            post_tokens: 15000,
+          }),
+        }),
+        makeRow({
+          id: 'a2',
+          label: 'Coder Agent',
+          createdAt: t + 2000,
+          message: assistantText('a2', 'after compact'),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 3000,
+          message: resultMessage('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const turns = screen.getAllByTestId('minimal-thread-turn');
+      const completedTurns = turns.filter((turn) => turn.dataset.turnState === 'completed');
+      expect(completedTurns.length).toBe(2);
+      expect(completedTurns[0].querySelector('button[title="Run result"]')).toBeNull();
+      expect(completedTurns[1].querySelector('button[title="Run result"]')).not.toBeNull();
+      expect(container.querySelectorAll('button[title="Run result"]').length).toBe(1);
+    });
+
     it('does not render the result trigger when the block has no result envelope', () => {
       const t = Date.now();
       const rows = [

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -773,14 +773,15 @@ function buildFeedTurns(
       if (pendingAgentRows.length === 0) return;
       const turnId = `${block.id}:${String(pendingAgentRows[0].id)}`;
       const sessionId = latestSessionId(pendingAgentRows);
-      const transitionSummary = rowsContainResult(pendingAgentRows, blockResult)
+      const resultInfo = rowsContainResult(pendingAgentRows, blockResult) ? blockResult : undefined;
+      const transitionSummary = resultInfo
         ? summaryMatchesTurn(
             sessionId ? summariesBySession.get(sessionId) : undefined,
             pendingAgentRows
           )
         : undefined;
       turns.push(
-        buildCompletedTurn(block, pendingAgentRows, turnId, blockResult, transitionSummary)
+        buildCompletedTurn(block, pendingAgentRows, turnId, resultInfo, transitionSummary)
       );
       perAgentTrailing.set(blockKey, {
         turnIdx: turns.length - 1,

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -26,12 +26,14 @@ import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { ActiveTurnSummary, ActivityEntry, ActorMessageDeliveryState } from '@neokai/shared';
 import {
   isSDKAssistantMessage,
+  isSDKCompactBoundary,
   isSDKResultMessage,
   isSDKSystemInit,
   isToolUseBlock,
 } from '@neokai/shared/sdk/type-guards';
 
 type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }>;
+type CompactBoundaryMessage = Extract<SDKMessage, { type: 'system'; subtype: 'compact_boundary' }>;
 type ResultMessage = Extract<SDKMessage, { type: 'result' }>;
 import { useEffect, useState } from 'preact/hooks';
 import MarkdownRenderer from '../../../chat/MarkdownRenderer.tsx';
@@ -199,6 +201,22 @@ interface ActiveFeedTurn {
   sessionId: string | null;
 }
 
+interface CompactBoundaryFeedTurn {
+  state: 'compact_boundary';
+  id: string;
+  agent: string;
+  agentKind: 'task_agent' | 'node_agent';
+  agentRole: string;
+  agentNodeExecutionId?: string | null;
+  createdAt: number;
+  trigger: 'manual' | 'auto';
+  preTokens: number;
+  postTokens?: number;
+  durationMs?: number;
+  sessionId: string | null;
+  highlightMessageUuid?: string;
+}
+
 interface MessageFeedTurn {
   state: 'message';
   id: string;
@@ -234,7 +252,7 @@ interface MessageFeedTurn {
   sessionInit?: SystemInitMessage;
 }
 
-type FeedTurn = CompletedFeedTurn | ActiveFeedTurn | MessageFeedTurn;
+type FeedTurn = CompletedFeedTurn | ActiveFeedTurn | CompactBoundaryFeedTurn | MessageFeedTurn;
 
 const ROSTER_MAX_ENTRIES = 8;
 
@@ -613,6 +631,30 @@ function extractUserMessageText(row: ParsedThreadRow): { body: string; fallback:
   return { body: '', fallback: false };
 }
 
+function buildCompactBoundaryTurn(row: ParsedThreadRow): CompactBoundaryFeedTurn | null {
+  if (!row.message || !isSDKCompactBoundary(row.message)) return null;
+  const metadata = (row.message as CompactBoundaryMessage).compact_metadata;
+  const highlightUuid =
+    typeof (row.message as { uuid?: unknown }).uuid === 'string'
+      ? ((row.message as { uuid: string }).uuid as string)
+      : undefined;
+  return {
+    state: 'compact_boundary',
+    id: `compact-boundary-${String(row.id)}`,
+    agent: row.label,
+    agentKind: row.kind,
+    agentRole: row.role,
+    agentNodeExecutionId: row.nodeExecutionId ?? null,
+    createdAt: row.createdAt,
+    trigger: metadata.trigger,
+    preTokens: metadata.pre_tokens,
+    postTokens: metadata.post_tokens,
+    durationMs: metadata.duration_ms,
+    sessionId: row.sessionId,
+    highlightMessageUuid: highlightUuid,
+  };
+}
+
 function buildMessageTurn(
   row: ParsedThreadRow,
   previousAgentLabel: string | null,
@@ -749,6 +791,12 @@ function buildFeedTurns(
     };
 
     for (const row of block.rows) {
+      const compactBoundaryTurn = buildCompactBoundaryTurn(row);
+      if (compactBoundaryTurn) {
+        flushAgent();
+        turns.push(compactBoundaryTurn);
+        continue;
+      }
       if (isUserRow(row)) {
         flushAgent();
         turns.push(buildMessageTurn(row, previousAgentLabel, blockInit));
@@ -1245,6 +1293,86 @@ function HumanMessageTurn({ turn }: { turn: MessageFeedTurn }) {
  *   • An "open in session" callback that pops the session overlay scrolled
  *     to this synthetic message.
  */
+function CompactBoundaryTurn({
+  turn,
+  overlayTaskId,
+}: {
+  turn: CompactBoundaryFeedTurn;
+  overlayTaskId?: string;
+}) {
+  const color = getAgentColor(turn.agent);
+  const tokenDelta =
+    typeof turn.postTokens === 'number' ? Math.max(0, turn.preTokens - turn.postTokens) : null;
+  const tokenSummary = `${turn.preTokens.toLocaleString()} → ${turn.postTokens?.toLocaleString() ?? '—'} tokens`;
+  const openSession = turn.sessionId
+    ? () => {
+        if (overlayTaskId && turn.agentKind === 'node_agent') {
+          pushOverlayHistory(turn.sessionId as string, turn.agent, turn.highlightMessageUuid, {
+            taskId: overlayTaskId,
+            agentName: turn.agentRole,
+            ...(turn.agentNodeExecutionId ? { nodeExecutionId: turn.agentNodeExecutionId } : {}),
+          });
+        } else {
+          pushOverlayHistory(turn.sessionId as string, turn.agent, turn.highlightMessageUuid);
+        }
+      }
+    : undefined;
+  const card = (
+    <div class="w-full rounded-lg border border-yellow-300/50 bg-yellow-400/10 px-3 py-2 text-yellow-100 shadow-sm shadow-yellow-950/20 dark:border-yellow-400/30 dark:bg-yellow-400/10">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="h-2 w-2 rounded-full bg-yellow-300 shadow-[0_0_10px_rgba(253,224,71,0.65)]" />
+          <span class="text-xs font-semibold uppercase tracking-[0.16em] text-yellow-200">
+            Compact Boundary
+          </span>
+          <span class="text-[11px] text-yellow-300/80" style={{ color }}>
+            {shortAgentName(turn.agent)}
+          </span>
+        </div>
+        <span class="shrink-0 text-[11px] text-yellow-200/70">{formatClock(turn.createdAt)}</span>
+      </div>
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-yellow-100/90">
+        <span class="rounded-full border border-yellow-300/30 bg-yellow-300/10 px-2 py-0.5 font-medium capitalize text-yellow-100">
+          {turn.trigger}
+        </span>
+        <span>{tokenSummary}</span>
+        {tokenDelta !== null ? (
+          <span class="text-yellow-200/75">saved {tokenDelta.toLocaleString()}</span>
+        ) : null}
+        {typeof turn.durationMs === 'number' ? (
+          <span class="text-yellow-200/75">
+            {formatDuration(Math.max(1, Math.round(turn.durationMs / 1000)))}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return (
+    <div
+      data-testid="minimal-thread-turn"
+      data-turn-state="compact_boundary"
+      data-agent-label={turn.agent}
+      data-agent-color={color}
+    >
+      {openSession ? (
+        <button
+          type="button"
+          class="w-full rounded-lg text-left transition-colors hover:bg-yellow-400/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-300/60"
+          onClick={openSession}
+          title="Open session"
+          aria-label={`Open ${turn.agent} session at compact boundary`}
+          data-testid="minimal-thread-compact-boundary"
+        >
+          {card}
+        </button>
+      ) : (
+        <div data-testid="minimal-thread-compact-boundary">{card}</div>
+      )}
+    </div>
+  );
+}
+
 function SyntheticMessageTurn({
   turn,
   overlayTaskId,
@@ -1313,6 +1441,9 @@ function SyntheticMessageTurn({
 }
 
 function MinimalTurnRow({ turn, overlayTaskId }: { turn: FeedTurn; overlayTaskId?: string }) {
+  if (turn.state === 'compact_boundary') {
+    return <CompactBoundaryTurn turn={turn} overlayTaskId={overlayTaskId} />;
+  }
   if (turn.state === 'message') {
     return turn.isSynthetic ? (
       <SyntheticMessageTurn turn={turn} overlayTaskId={overlayTaskId} />

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -3,6 +3,7 @@ import {
   type ContentBlock,
   hasRenderableThinking,
   isSDKAssistantMessage,
+  isSDKCompactBoundary,
   isSDKRateLimitEvent,
   isSDKResultMessage,
   isSDKSystemMessage,
@@ -21,6 +22,7 @@ export type SpaceTaskThreadEventKind =
   | 'text'
   | 'user'
   | 'system'
+  | 'compact_boundary'
   | 'result'
   | 'rate_limit'
   | 'progress'
@@ -495,6 +497,26 @@ export function buildThreadEvents(parsedRows: ParsedThreadRow[]): SpaceTaskThrea
     }
 
     if (isSDKSystemMessage(row.message)) {
+      if (isSDKCompactBoundary(row.message)) {
+        const metadata = row.message.compact_metadata;
+        const tokenSummary = `${metadata.pre_tokens} → ${metadata.post_tokens ?? '—'} tokens`;
+        events.push({
+          id: `${String(row.id)}-compact-boundary`,
+          label: row.label,
+          role: row.role,
+          taskId: row.taskId,
+          taskTitle: row.taskTitle,
+          sessionId: row.sessionId,
+          createdAt: row.createdAt,
+          kind: 'compact_boundary',
+          title: 'Compact Boundary',
+          summary: `${metadata.trigger} · ${tokenSummary}`,
+          message: row.message,
+          systemSubtype: row.message.subtype,
+        });
+        continue;
+      }
+
       const subtype = row.message.subtype ?? 'system';
       let summary = subtype.replace(/_/g, ' ');
 


### PR DESCRIPTION
Render compact boundary events as distinct yellow task-thread rows with trigger and token metadata.

Tests:
- bun run check
- cd packages/web && bunx vitest run src/components/space/thread/minimal/MinimalThreadFeed.test.tsx