### PR TITLE
Fix input lock after terminal result

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -554,6 +554,13 @@ export class SDKMessageHandler {
       message,
     });
 
+    // Terminal messages end the turn even when they represent errors.
+    // Clear stale waiting_for_input state before type-specific handling so
+    // interrupted AskUserQuestion turns cannot keep the composer locked.
+    if (isSDKResultMessage(message)) {
+      await stateManager.setIdle();
+    }
+
     // Handle specific message types
     if (isSDKUserMessage(message)) {
       await this.handleUserMessage(message);
@@ -646,7 +653,7 @@ export class SDKMessageHandler {
    * Handle result message (end of turn)
    */
   private async handleResultMessage(message: SDKMessage): Promise<void> {
-    const { session, db, internalEventBus, stateManager } = this.ctx;
+    const { session, db, internalEventBus } = this.ctx;
 
     // Type guard to ensure this is a successful result
     if (!isSDKResultSuccess(message)) return;
@@ -736,9 +743,8 @@ export class SDKMessageHandler {
       sessionId: session.id,
     });
 
-    // Set state back to idle
-    // Note: Title generation now handled by TitleGenerationQueue (decoupled via EventBus)
-    await stateManager.setIdle();
+    // Note: Terminal result handling resets processing state before this success-only branch runs.
+    // Title generation now handled by TitleGenerationQueue (decoupled via EventBus).
 
     // Auto-dispatch deferred messages in immediate mode (next-turn queue replay)
     if (session.config.queryMode !== 'manual') {

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
@@ -139,6 +139,18 @@ describe('ProcessingStateManager', () => {
 
       expect(callbackMock).toHaveBeenCalled();
     });
+
+    test('clears pending question state', async () => {
+      await manager.setWaitingForInput({ toolUseId: 'tool-123', questions: [] });
+
+      await manager.setIdle();
+
+      expect(manager.getState()).toEqual({ status: 'idle' });
+      const savedState = JSON.parse(
+        updateSessionMock.mock.calls[updateSessionMock.mock.calls.length - 1][1].processingState
+      );
+      expect(savedState).toEqual({ status: 'idle' });
+    });
   });
 
   describe('setQueued', () => {

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -17,6 +17,7 @@
  */
 
 import type {
+  AgentProcessingState,
   ChatMessage,
   MessageDeliveryMode,
   MessageImage,
@@ -29,7 +30,7 @@ import {
   DEFAULT_WORKER_FEATURES,
   normalizeThinkingLevel,
 } from '@neokai/shared';
-import type { SDKSystemMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import type { SDKMessage, SDKSystemMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import { useSignalEffect } from '@preact/signals';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { ArchiveConfirmDialog } from '../components/ArchiveConfirmDialog.tsx';
@@ -76,6 +77,14 @@ import { toast } from '../lib/toast.ts';
 import { cn } from '../lib/utils';
 import type { StructuredError } from '../types/error.ts';
 import { ErrorCategory } from '../types/error.ts';
+
+export function shouldBlockForPendingQuestion(
+  agentState: AgentProcessingState,
+  messages: SDKMessage[]
+): agentState is Extract<AgentProcessingState, { status: 'waiting_for_input' }> {
+  const lastMessage = messages.length > 0 ? messages[messages.length - 1] : null;
+  return agentState.status === 'waiting_for_input' && lastMessage?.type !== 'result';
+}
 
 export async function sendChatContainerMessage({
   content,
@@ -531,7 +540,7 @@ export default function ChatContainer({
 
   // Derived processing state
   const isProcessing = agentState.status === 'processing' || agentState.status === 'queued';
-  const isWaitingForInput = agentState.status === 'waiting_for_input';
+  const isWaitingForInput = shouldBlockForPendingQuestion(agentState, messages as SDKMessage[]);
   const pendingQuestion = isWaitingForInput ? agentState.pendingQuestion : null;
 
   const {

--- a/packages/web/src/islands/__tests__/ChatContainer.test.ts
+++ b/packages/web/src/islands/__tests__/ChatContainer.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { shouldBlockForPendingQuestion } from '../ChatContainer.tsx';
+import type { AgentProcessingState } from '@neokai/shared';
+import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 // Vite-native raw import — works in both Node and browser-like test environments
 // (happy-dom) without reaching for Node built-ins like `fs`/`path`/`url`, which
 // are externalized by Vite and unavailable at runtime in the test environment.
@@ -26,6 +29,23 @@ function flushRAF(): void {
   rafCallbacks.length = 0;
   callbacks.forEach((cb) => cb());
 }
+
+describe('ChatContainer input guard', () => {
+  const waitingState: AgentProcessingState = {
+    status: 'waiting_for_input',
+    pendingQuestion: { toolUseId: 'tool-123', questions: [], askedAt: 1000 },
+  };
+
+  it('blocks input while waiting_for_input without terminal result', () => {
+    expect(shouldBlockForPendingQuestion(waitingState, [])).toBe(true);
+  });
+
+  it('allows input when stale waiting_for_input follows a terminal result', () => {
+    const messages = [{ type: 'result' }] as SDKMessage[];
+
+    expect(shouldBlockForPendingQuestion(waitingState, messages)).toBe(false);
+  });
+});
 
 describe('ChatContainer State Batching', () => {
   const originalRAF = globalThis.requestAnimationFrame;


### PR DESCRIPTION
Fixes stale `waiting_for_input` state when a terminal SDK result ends a turn.

- Clear processing state to idle for every terminal result message.
- Let chat input ignore stale pending-question state when the last SDK message is terminal.
- Add focused backend and frontend coverage.

Tests: `bun run check`