### PR TITLE
test: add workflow hook runtime coverage

### DIFF
--- a/docs/features/workflow-hooks.md
+++ b/docs/features/workflow-hooks.md
@@ -59,7 +59,7 @@ Script validators must declare external lookup needs with `validator.externalLoo
 
 ## Human approval flow
 
-Hooks are MCP-action based; agents satisfy handoffs by sending required data on `send_message`. Human approval remains field-gate based where humans write gate fields through UI/RPC. Example: Plan Review writes approval votes, then approval hooks record/reset vote state as review cycles progress.
+Hooks are MCP-action based; agents satisfy handoffs by sending required data on `send_message`. Human approval remains field-gate based only for channels that still declare `gateId`. Migrated plan-approval channels remove the gate from the handoff path; Plan Review agents must include approval votes in the `send_message` payload so the approval hook can record them in hook-local state.
 
 ## Retryable block behavior
 

--- a/docs/features/workflow-hooks.md
+++ b/docs/features/workflow-hooks.md
@@ -51,11 +51,11 @@ Invalid JSON, unknown result type, schema-invalid patches, or script timeout bec
 
 Script hooks run with bounded stdout/stderr. Large params, artifacts, arrays, and objects are capped before injection into hook context so scripts cannot receive unbounded payloads. Scripts must emit compact JSON on stdout; diagnostic text belongs in `message` or stderr.
 
-Credential-bearing path environment variables are stripped before script execution. Do not depend on inherited config paths such as credential files. Use daemon-provided hook context and approved external lookups instead.
+Known credential path environment variables are stripped before script execution and hooks receive an isolated temporary `HOME`. This is not a full network or filesystem sandbox: unlisted environment variables and tools may still find credentials from the host environment. Operators should only install trusted hook scripts and should not rely on hook isolation as a secret-boundary control.
 
 ## External lookup policy
 
-Script validators must declare external lookup needs with `validator.externalLookups`. Current allowlist supports `github`. GitHub lookups must only call approved GitHub hosts used by repository remotes and standard GitHub API endpoints. Custom hosts require explicit allowlist support before workflow rollout.
+Script validators must declare external lookup needs with `validator.externalLookups`. Current declared lookup value is `github`. Runtime exposes the declaration to scripts through hook context/environment but does not sandbox network access or enforce `gh --hostname`/`curl` targets for custom scripts. Built-in migration scripts self-check GitHub hosts; custom scripts must implement their own host checks and should be treated as trusted operator code.
 
 ## Human approval flow
 
@@ -85,12 +85,12 @@ Legacy custom gates and poll-based progression are migrating to hooks:
 
 - PR-ready gates become `send_message` validation hooks with `pr_ready` built-in validator.
 - Approval poll scripts become validation hooks that return `record_state`, `allow`, or `block`.
-- Feedback-cycle reset behavior becomes non-blocking pre-action side-effect hooks.
+- Feedback-cycle reset behavior becomes validation hooks that reset hook-local state before feedback handoff; script errors block delivery until fixed.
 - Existing gate field approvals remain supported for human UI approval flows.
 
 Deprecation path:
 
-1. Current release: built-in workflows use hooks for PR readiness, review feedback evidence, Codex retry checks, and approval reset side effects. Legacy gates still load.
+1. Current release: built-in workflows use hooks for PR readiness, review feedback evidence, Codex retry checks, and approval reset state updates. Legacy gates still load.
 2. Next release: custom workflow save strips unsupported hook `poll` fields and warns on legacy poll configuration.
 3. Later release: legacy custom-gate polls stop running by default; operators must migrate to hooks or explicit human approval gates.
 

--- a/docs/features/workflow-hooks.md
+++ b/docs/features/workflow-hooks.md
@@ -16,21 +16,21 @@ Add `hooks` to a `SpaceWorkflow`:
   classification: 'validation',
   authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
   validator: { kind: 'built_in', id: 'pr_ready' },
-  retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
 }
 ```
 
 Fields:
 
-- `sourceNode` / `targetNode`: workflow node names, not node IDs.
+- `sourceNode`: workflow node name, not node ID.
+- `targetNode`: workflow node name used for `send_message` target matching. Omit it for non-`send_message` methods, because those actions have no target node to compare and target-specific hooks will not match.
 - `method`: MCP method that triggers hook.
 - `classification`: `validation` blocks or patches action before handler; `side_effect` records state or emits follow-up after validation.
 - `authorizedCallers`: fail-closed caller allowlist. Include node name and optional agent slots.
-- `validator`: built-in validator or script validator.
+- `validator`: script validator or built-in `pr_ready` validator. Other built-in IDs exist in shared types but create/update validation rejects them until implemented.
+- `retry`: retry budget for `retryable_block` results. Omit `retry` for `pr_ready` hooks so transient GitHub mergeability/check states do not become hard blocks after a small retry budget.
+- `localState`: default hook state plus references to recent results from other hooks.
 
 Unsupported today: `humanOnly: true` is present in shared types for future UI-only hook actions, but create/update validation rejects it. Do not set `humanOnly` until UI/human hook execution ships.
-- `retry`: retry budget for `retryable_block` results.
-- `localState`: default hook state plus references to recent results from other hooks.
 
 ## Hook result contract
 

--- a/docs/features/workflow-hooks.md
+++ b/docs/features/workflow-hooks.md
@@ -1,6 +1,6 @@
 # Workflow hooks
 
-Workflow hooks replace legacy workflow gate polling for MCP action checks. They run inside the daemon before or after a node-agent MCP action such as `send_message`, `save_artifact`, or `approve_task`.
+Workflow hooks replace legacy workflow gate polling for MCP action checks. They run inside the daemon before a node-agent MCP action such as `send_message`, `save_artifact`, or `approve_task`. Hook results are persisted before the underlying action handler runs, so `side_effect` classification means "non-blocking pre-action side effect", not post-success handling.
 
 ## Configure hooks
 
@@ -26,8 +26,9 @@ Fields:
 - `method`: MCP method that triggers hook.
 - `classification`: `validation` blocks or patches action before handler; `side_effect` records state or emits follow-up after validation.
 - `authorizedCallers`: fail-closed caller allowlist. Include node name and optional agent slots.
-- `humanOnly`: only UI/human retry actions may trigger hook.
 - `validator`: built-in validator or script validator.
+
+Unsupported today: `humanOnly: true` is present in shared types for future UI-only hook actions, but create/update validation rejects it. Do not set `humanOnly` until UI/human hook execution ships.
 - `retry`: retry budget for `retryable_block` results.
 - `localState`: default hook state plus references to recent results from other hooks.
 
@@ -62,9 +63,9 @@ Hooks are MCP-action based; agents satisfy handoffs by sending required data on 
 
 ## Retryable block behavior
 
-`retryable_block` does not fail workflow immediately. Runtime persists queued action metadata, schedules retry, and rehydrates queued retries after daemon restart. Retry count resets after any non-retryable result. When attempts exceed `retry.maxAttempts`, runtime converts retryable block into hard `block` and notifies source session.
+`retryable_block` does not fail workflow immediately. For `send_message` hooks, runtime persists queued action metadata, schedules retry, and rehydrates queued retries after daemon restart. Other MCP methods return retryable metadata to the caller but are not auto-queued today. Retry count resets after any non-retryable result. When attempts exceed `retry.maxAttempts`, runtime converts retryable block into hard `block` and notifies source session.
 
-Codex review waits use this path: hook blocks retryably while codex[bot] review is pending, retries on configured delay, and eventually allows on `+1` or blocks after timeout depending workflow script.
+Current built-in Codex approval waits use `block` results with persisted hook-local wait metadata; agents retry the handoff after the documented delay. Use `retryable_block` only when automatic queued replay for `send_message` is desired.
 
 ## Restart recovery
 
@@ -83,8 +84,8 @@ Troubleshooting steps:
 Legacy custom gates and poll-based progression are migrating to hooks:
 
 - PR-ready gates become `send_message` validation hooks with `pr_ready` built-in validator.
-- Approval poll scripts become validation hooks that return `record_state`, `retryable_block`, or `block`.
-- Feedback-cycle reset behavior becomes side-effect hooks.
+- Approval poll scripts become validation hooks that return `record_state`, `allow`, or `block`.
+- Feedback-cycle reset behavior becomes non-blocking pre-action side-effect hooks.
 - Existing gate field approvals remain supported for human UI approval flows.
 
 Deprecation path:

--- a/docs/features/workflow-hooks.md
+++ b/docs/features/workflow-hooks.md
@@ -1,0 +1,96 @@
+# Workflow hooks
+
+Workflow hooks replace legacy workflow gate polling for MCP action checks. They run inside the daemon before or after a node-agent MCP action such as `send_message`, `save_artifact`, or `approve_task`.
+
+## Configure hooks
+
+Add `hooks` to a `SpaceWorkflow`:
+
+```ts
+{
+  id: 'code-pr-ready',
+  enabled: true,
+  sourceNode: 'Coding',
+  targetNode: 'Review',
+  method: 'send_message',
+  classification: 'validation',
+  authorizedCallers: [{ sourceNode: 'Coding', agentSlots: ['coder'] }],
+  validator: { kind: 'built_in', id: 'pr_ready' },
+  retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
+}
+```
+
+Fields:
+
+- `sourceNode` / `targetNode`: workflow node names, not node IDs.
+- `method`: MCP method that triggers hook.
+- `classification`: `validation` blocks or patches action before handler; `side_effect` records state or emits follow-up after validation.
+- `authorizedCallers`: fail-closed caller allowlist. Include node name and optional agent slots.
+- `humanOnly`: only UI/human retry actions may trigger hook.
+- `validator`: built-in validator or script validator.
+- `retry`: retry budget for `retryable_block` results.
+- `localState`: default hook state plus references to recent results from other hooks.
+
+## Hook result contract
+
+Validator stdout must be one JSON object:
+
+| Result type | Effect | Banner/user-state mapping |
+| --- | --- | --- |
+| `allow` | Let action run. | `allowed` / no blocking banner. |
+| `block` | Stop action with non-retryable reason. | `blocked_by_hook`; banner shows `reason` and `message`/`remediation` when present. |
+| `retryable_block` | Queue retry until `retryAfterMs` or hook retry delay. | `waiting_on_hook_retry`; banner shows retryable block and next retry time. |
+| `patch_params` | Merge `patch` into MCP params, then revalidate method schema. | `patched`; banner/debug state lists patched keys. |
+| `emit_follow_up` | Dispatch follow-up message through same handler pipeline. | `follow_up_emitted`; debug state lists emitted action IDs. |
+| `record_state` | Persist `state` for current hook or `stateForHook` for named hooks. | `state_recorded`; recent hook results panel shows stored result. |
+
+Invalid JSON, unknown result type, schema-invalid patches, or script timeout become `block` results. For `send_message`, target changes from `patch_params` are ignored to prevent route hijack.
+
+## Script execution limits and environment
+
+Script hooks run with bounded stdout/stderr. Large params, artifacts, arrays, and objects are capped before injection into hook context so scripts cannot receive unbounded payloads. Scripts must emit compact JSON on stdout; diagnostic text belongs in `message` or stderr.
+
+Credential-bearing path environment variables are stripped before script execution. Do not depend on inherited config paths such as credential files. Use daemon-provided hook context and approved external lookups instead.
+
+## External lookup policy
+
+Script validators must declare external lookup needs with `validator.externalLookups`. Current allowlist supports `github`. GitHub lookups must only call approved GitHub hosts used by repository remotes and standard GitHub API endpoints. Custom hosts require explicit allowlist support before workflow rollout.
+
+## Human approval flow
+
+Hooks are MCP-action based; agents satisfy handoffs by sending required data on `send_message`. Human approval remains field-gate based where humans write gate fields through UI/RPC. Example: Plan Review writes approval votes, then approval hooks record/reset vote state as review cycles progress.
+
+## Retryable block behavior
+
+`retryable_block` does not fail workflow immediately. Runtime persists queued action metadata, schedules retry, and rehydrates queued retries after daemon restart. Retry count resets after any non-retryable result. When attempts exceed `retry.maxAttempts`, runtime converts retryable block into hard `block` and notifies source session.
+
+Codex review waits use this path: hook blocks retryably while codex[bot] review is pending, retries on configured delay, and eventually allows on `+1` or blocks after timeout depending workflow script.
+
+## Restart recovery
+
+On daemon restart, in-progress and blocked workflow runs are rehydrated. Hook state repository restores local state, last result, retry count, next retry time, and queued retry metadata. Done, cancelled, and pending runs are not reactivated.
+
+Troubleshooting steps:
+
+1. Inspect task banner for current hook status.
+2. Open recent hook results in task auxiliary panel.
+3. Check hook `lastResult`, `retryCount`, and `nextRetryAt` in runtime state.
+4. Verify agent used correct `send_message` target and included required `data` keys.
+5. For scripts, confirm stdout is valid JSON and external lookup host is allowed.
+
+## Migration and deprecation
+
+Legacy custom gates and poll-based progression are migrating to hooks:
+
+- PR-ready gates become `send_message` validation hooks with `pr_ready` built-in validator.
+- Approval poll scripts become validation hooks that return `record_state`, `retryable_block`, or `block`.
+- Feedback-cycle reset behavior becomes side-effect hooks.
+- Existing gate field approvals remain supported for human UI approval flows.
+
+Deprecation path:
+
+1. Current release: built-in workflows use hooks for PR readiness, review feedback evidence, Codex retry checks, and approval reset side effects. Legacy gates still load.
+2. Next release: custom workflow save strips unsupported hook `poll` fields and warns on legacy poll configuration.
+3. Later release: legacy custom-gate polls stop running by default; operators must migrate to hooks or explicit human approval gates.
+
+Gates/polls were replaced because polling hid ownership, created daemon restart gaps, and required out-of-band state. Hooks bind validation to exact MCP action, persist result state, expose banners, and retry deterministically.

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -242,6 +242,21 @@ describe('CODING_WORKFLOW template', () => {
     expect(hook!.method).toBe('send_message');
     expect(hook!.validator).toEqual({ kind: 'built_in', id: 'pr_ready' });
     expect(hook!.enabled).toBe(true);
+    expect(hook!.classification).toBe('validation');
+    expect(hook!.authorizedCallers).toEqual([{ sourceNode: 'Coding', agentSlots: ['coder'] }]);
+  });
+
+  test('review feedback cycle is gated by fresh GitHub review evidence', () => {
+    const channel = CODING_WORKFLOW.channels!.find(
+      (c) => c.from === 'Review' && c.to === 'Coding'
+    )!;
+    const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+
+    expect(channel.gateId).toBe('review-posted-gate');
+    expect(channel.maxCycles).toBe(5);
+    expect(gate.script).toMatchObject({ interpreter: 'bash', timeoutMs: 30000 });
+    expect(gate.script?.source).toContain('FORMAL_REVIEW_COUNT');
+    expect(gate.fields?.map((field) => field.name)).toEqual(['pr_url', 'review_url']);
   });
 
   test('validation-complete-gate accepts no-code-change completion evidence without pr_url', () => {
@@ -895,6 +910,43 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
     // Codex is no longer hardcoded as a gate feature; it is opt-in via node-level config.
     expect(gate.features?.codex_review_bot).toBeUndefined();
     expect(gate.resetOnCycle).toBe(true);
+  });
+
+  test('plan review approval migration carries vote data and resets votes on revision feedback', () => {
+    const workflow = migrateWorkflowGateProgressionToHooks({
+      ...PLAN_AND_DECOMPOSE_WORKFLOW,
+      templateName: PLAN_AND_DECOMPOSE_WORKFLOW.name,
+      templateGates: PLAN_AND_DECOMPOSE_WORKFLOW.gates ?? [],
+    }).workflow;
+    const approvalHook = workflow.hooks!.find(
+      (hook) => hook.sourceNode === 'Plan Review' && hook.targetNode === 'Task Dispatcher'
+    )!;
+    const resetHook = workflow.hooks!.find(
+      (hook) => hook.id === 'plan-approval-reset' && hook.targetNode === 'Planning'
+    )!;
+
+    expect(approvalHook).toMatchObject({
+      enabled: true,
+      sourceNode: 'Plan Review',
+      targetNode: 'Task Dispatcher',
+      method: 'send_message',
+      classification: 'validation',
+    });
+    expect(approvalHook.validator).toMatchObject({ kind: 'script', interpreter: 'bash' });
+    const approvalSource =
+      approvalHook.validator.kind === 'script' ? approvalHook.validator.source : '';
+    expect(approvalSource).toContain('NEOKAI_HOOK_LOCAL_STATE_JSON');
+    expect(approvalSource).toContain('"approval_count":4');
+    expect(resetHook).toMatchObject({
+      enabled: true,
+      sourceNode: 'Plan Review',
+      targetNode: 'Planning',
+      method: 'send_message',
+      classification: 'validation',
+    });
+    const resetSource = resetHook.validator.kind === 'script' ? resetHook.validator.source : '';
+    expect(resetSource).toContain('"type":"record_state"');
+    expect(resetSource).toContain('"approvals":null');
   });
 
   test('has three channels', () => {

--- a/packages/web/src/components/space/visual-editor/HookEditorPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/HookEditorPanel.tsx
@@ -134,6 +134,7 @@ export function HookEditorPanel({
     [validatorKind, scriptSource]
   );
 
+  const isPrReadyValidator = validatorKind === 'built_in' && builtInId === 'pr_ready';
   const maxAttempts = hook.retry?.maxAttempts ?? 3;
   const delayMs = hook.retry?.delayMs ?? 5000;
   const backoffMultiplier = hook.retry?.backoffMultiplier ?? 1;
@@ -691,57 +692,67 @@ export function HookEditorPanel({
             <label class="text-[11px] uppercase tracking-[0.12em] text-gray-400">
               Retry Settings
             </label>
-            <div class="grid grid-cols-3 gap-2">
-              <div class="space-y-0.5">
-                <label class="text-[10px] text-gray-400">Max attempts</label>
-                <input
-                  type="number"
-                  data-testid="hook-editor-retry-max-attempts"
-                  value={maxAttempts}
-                  min={1}
-                  max={20}
-                  onInput={(e) => {
-                    const val = Number((e.currentTarget as HTMLInputElement).value);
-                    if (isNaN(val)) return;
-                    updateRetry({ maxAttempts: Math.max(1, Math.min(20, val)) });
-                  }}
-                  class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
-                />
+            {isPrReadyValidator ? (
+              <p
+                class="rounded border border-blue-700/50 bg-blue-900/10 px-2 py-1.5 text-[11px] text-blue-200"
+                data-testid="hook-editor-pr-ready-retry-note"
+              >
+                PR-ready hooks retry on transient GitHub states without a visible attempt cap. Retry
+                fields are hidden so saved behavior matches built-in workflow defaults.
+              </p>
+            ) : (
+              <div class="grid grid-cols-3 gap-2">
+                <div class="space-y-0.5">
+                  <label class="text-[10px] text-gray-400">Max attempts</label>
+                  <input
+                    type="number"
+                    data-testid="hook-editor-retry-max-attempts"
+                    value={maxAttempts}
+                    min={1}
+                    max={20}
+                    onInput={(e) => {
+                      const val = Number((e.currentTarget as HTMLInputElement).value);
+                      if (isNaN(val)) return;
+                      updateRetry({ maxAttempts: Math.max(1, Math.min(20, val)) });
+                    }}
+                    class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
+                  />
+                </div>
+                <div class="space-y-0.5">
+                  <label class="text-[10px] text-gray-400">Delay (ms)</label>
+                  <input
+                    type="number"
+                    data-testid="hook-editor-retry-delay"
+                    value={delayMs}
+                    min={0}
+                    step={1000}
+                    onInput={(e) => {
+                      const val = Number((e.currentTarget as HTMLInputElement).value);
+                      if (isNaN(val)) return;
+                      updateRetry({ delayMs: Math.max(0, val) });
+                    }}
+                    class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
+                  />
+                </div>
+                <div class="space-y-0.5">
+                  <label class="text-[10px] text-gray-400">Backoff</label>
+                  <input
+                    type="number"
+                    data-testid="hook-editor-retry-backoff"
+                    value={backoffMultiplier}
+                    min={1}
+                    max={10}
+                    step={0.1}
+                    onInput={(e) => {
+                      const val = Number((e.currentTarget as HTMLInputElement).value);
+                      if (isNaN(val)) return;
+                      updateRetry({ backoffMultiplier: Math.max(1, Math.min(10, val)) });
+                    }}
+                    class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
+                  />
+                </div>
               </div>
-              <div class="space-y-0.5">
-                <label class="text-[10px] text-gray-400">Delay (ms)</label>
-                <input
-                  type="number"
-                  data-testid="hook-editor-retry-delay"
-                  value={delayMs}
-                  min={0}
-                  step={1000}
-                  onInput={(e) => {
-                    const val = Number((e.currentTarget as HTMLInputElement).value);
-                    if (isNaN(val)) return;
-                    updateRetry({ delayMs: Math.max(0, val) });
-                  }}
-                  class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
-                />
-              </div>
-              <div class="space-y-0.5">
-                <label class="text-[10px] text-gray-400">Backoff</label>
-                <input
-                  type="number"
-                  data-testid="hook-editor-retry-backoff"
-                  value={backoffMultiplier}
-                  min={1}
-                  max={10}
-                  step={0.1}
-                  onInput={(e) => {
-                    const val = Number((e.currentTarget as HTMLInputElement).value);
-                    if (isNaN(val)) return;
-                    updateRetry({ backoffMultiplier: Math.max(1, Math.min(10, val)) });
-                  }}
-                  class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1 text-gray-200 font-mono focus:outline-none focus:border-blue-500"
-                />
-              </div>
-            </div>
+            )}
           </div>
 
           <p

--- a/packages/web/src/components/space/visual-editor/__tests__/HookEditorPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/HookEditorPanel.test.tsx
@@ -276,6 +276,18 @@ describe('HookEditorPanel', () => {
     );
   });
 
+  it('hides retry inputs for pr_ready validators', () => {
+    const hook = makeHook({ validator: { kind: 'built_in', id: 'pr_ready' } });
+    const { getByTestId, queryByTestId } = render(
+      <HookEditorPanel hook={hook} onChange={onChange} onBack={onBack} nodeNames={nodeNames} />
+    );
+    fireEvent.click(getByTestId('hook-editor-section-retry'));
+    expect(getByTestId('hook-editor-pr-ready-retry-note').textContent).toContain('PR-ready');
+    expect(queryByTestId('hook-editor-retry-max-attempts')).toBeNull();
+    expect(queryByTestId('hook-editor-retry-delay')).toBeNull();
+    expect(queryByTestId('hook-editor-retry-backoff')).toBeNull();
+  });
+
   it('shows unsupported poll notice without editable poll controls', () => {
     const hook = makeHook({ poll: { intervalMs: 30_000 } });
     const { getByTestId, queryByTestId } = render(

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -451,6 +451,7 @@ describe('visualStateToCreateParams', () => {
         sourceNode: 'Step 1',
         targetNode: 'Review',
         authorizedCallers: [expect.objectContaining({ sourceNode: 'Step 1' })],
+        retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
       }),
     ]);
     expect(params.hooks![0].poll).toBeUndefined();
@@ -479,6 +480,47 @@ describe('visualStateToCreateParams', () => {
       delayMs: 1000,
       backoffMultiplier: 2,
     });
+  });
+
+  it('omits retry defaults for built-in pr_ready hooks', () => {
+    const params = visualStateToCreateParams(
+      makeState({
+        hooks: [
+          {
+            id: 'hook-1',
+            enabled: true,
+            sourceNode: 'Step 1',
+            method: 'send_message',
+            validator: { kind: 'built_in', id: 'pr_ready' },
+          },
+        ],
+      }),
+      'space-1',
+      'WF'
+    );
+
+    expect(params.hooks?.[0].retry).toBeUndefined();
+  });
+
+  it('drops unsupported human-only hooks without authorized callers', () => {
+    const params = visualStateToCreateParams(
+      makeState({
+        hooks: [
+          {
+            id: 'hook-1',
+            enabled: true,
+            sourceNode: 'Step 1',
+            method: 'send_message',
+            humanOnly: true,
+            validator: { kind: 'script', interpreter: 'bash', source: 'echo ok' },
+          },
+        ],
+      }),
+      'space-1',
+      'WF'
+    );
+
+    expect(params.hooks).toBeUndefined();
   });
 
   it('serializes hook result contract fields and strips unsupported humanOnly', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -482,7 +482,7 @@ describe('visualStateToCreateParams', () => {
     });
   });
 
-  it('omits retry defaults for built-in pr_ready hooks', () => {
+  it('omits retry settings for built-in pr_ready hooks', () => {
     const params = visualStateToCreateParams(
       makeState({
         hooks: [
@@ -492,6 +492,7 @@ describe('visualStateToCreateParams', () => {
             sourceNode: 'Step 1',
             method: 'send_message',
             validator: { kind: 'built_in', id: 'pr_ready' },
+            retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
           },
         ],
       }),

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -451,7 +451,6 @@ describe('visualStateToCreateParams', () => {
         sourceNode: 'Step 1',
         targetNode: 'Review',
         authorizedCallers: [expect.objectContaining({ sourceNode: 'Step 1' })],
-        retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
       }),
     ]);
     expect(params.hooks![0].poll).toBeUndefined();
@@ -482,7 +481,7 @@ describe('visualStateToCreateParams', () => {
     });
   });
 
-  it('serializes hook result contract fields without dropping UI-only details', () => {
+  it('serializes hook result contract fields and strips unsupported humanOnly', () => {
     const params = visualStateToCreateParams(
       makeState({
         hooks: [
@@ -519,7 +518,6 @@ describe('visualStateToCreateParams', () => {
       id: 'hook-1',
       label: 'PR ready',
       classification: 'validation',
-      humanOnly: true,
       sourceNode: 'Step 1',
       targetNode: 'Step 2',
       validator: {
@@ -536,6 +534,7 @@ describe('visualStateToCreateParams', () => {
       templateData: { banner: 'needs_pr' },
       authorizedCallers: [{ sourceNode: 'Step 1', agentSlots: ['coder'] }],
     });
+    expect(params.hooks?.[0].humanOnly).toBeUndefined();
   });
 
   it('passes endNodeId through to create params', () => {

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -482,6 +482,62 @@ describe('visualStateToCreateParams', () => {
     });
   });
 
+  it('serializes hook result contract fields without dropping UI-only details', () => {
+    const params = visualStateToCreateParams(
+      makeState({
+        hooks: [
+          {
+            id: 'hook-1',
+            enabled: true,
+            sourceNode: 'Step 1',
+            targetNode: 'Step 2',
+            method: 'send_message',
+            label: 'PR ready',
+            classification: 'validation',
+            humanOnly: true,
+            validator: {
+              kind: 'script',
+              interpreter: 'bash',
+              source: 'echo {"type":"allow"}',
+              timeoutMs: 2000,
+              externalLookups: ['github'],
+            },
+            localState: {
+              defaults: { pr_url: null },
+              recentResultRef: { hookId: 'hook-0', key: 'lastResult' },
+            },
+            templateData: { banner: 'needs_pr' },
+            authorizedCallers: [{ sourceNode: 'Step 1', agentSlots: ['coder'] }],
+          },
+        ],
+      }),
+      'space-1',
+      'WF'
+    );
+
+    expect(params.hooks?.[0]).toMatchObject({
+      id: 'hook-1',
+      label: 'PR ready',
+      classification: 'validation',
+      humanOnly: true,
+      sourceNode: 'Step 1',
+      targetNode: 'Step 2',
+      validator: {
+        kind: 'script',
+        interpreter: 'bash',
+        source: 'echo {"type":"allow"}',
+        timeoutMs: 2000,
+        externalLookups: ['github'],
+      },
+      localState: {
+        defaults: { pr_url: null },
+        recentResultRef: { hookId: 'hook-0', key: 'lastResult' },
+      },
+      templateData: { banner: 'needs_pr' },
+      authorizedCallers: [{ sourceNode: 'Step 1', agentSlots: ['coder'] }],
+    });
+  });
+
   it('passes endNodeId through to create params', () => {
     const state = makeState({ endNodeId: 's2' });
     const params = visualStateToCreateParams(state, 'space-1', 'WF');

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -259,17 +259,22 @@ function remapHookNodeReference(value: string | undefined, nodeNames: Map<string
 }
 
 function serializeHook(hook: WorkflowHook, nodeNames: Map<string, string>): WorkflowHook | null {
-  const { poll: _poll, humanOnly: _humanOnly, ...hookWithoutUnsupportedFields } = hook;
+  const {
+    poll: _poll,
+    humanOnly: _humanOnly,
+    retry: _retry,
+    ...hookWithoutUnsupportedFields
+  } = hook;
   if (hook.humanOnly && (!hook.authorizedCallers || hook.authorizedCallers.length === 0)) {
     return null;
   }
-  const shouldMaterializeRetry =
-    !hook.retry && !(hook.validator.kind === 'built_in' && hook.validator.id === 'pr_ready');
+  const isPrReadyValidator = hook.validator.kind === 'built_in' && hook.validator.id === 'pr_ready';
+  const retry = isPrReadyValidator
+    ? undefined
+    : (hook.retry ?? { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 });
   return {
     ...hookWithoutUnsupportedFields,
-    ...(shouldMaterializeRetry
-      ? { retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 } }
-      : {}),
+    ...(retry ? { retry } : {}),
     sourceNode: remapHookNodeReference(hook.sourceNode, nodeNames) ?? hook.sourceNode,
     targetNode: remapHookNodeReference(hook.targetNode, nodeNames),
     authorizedCallers: hook.authorizedCallers?.map((caller) => ({

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -259,10 +259,9 @@ function remapHookNodeReference(value: string | undefined, nodeNames: Map<string
 }
 
 function serializeHook(hook: WorkflowHook, nodeNames: Map<string, string>): WorkflowHook {
-  const { poll: _poll, ...hookWithoutUnsupportedPoll } = hook;
+  const { poll: _poll, humanOnly: _humanOnly, ...hookWithoutUnsupportedFields } = hook;
   return {
-    ...hookWithoutUnsupportedPoll,
-    retry: hook.retry ?? { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 },
+    ...hookWithoutUnsupportedFields,
     sourceNode: remapHookNodeReference(hook.sourceNode, nodeNames) ?? hook.sourceNode,
     targetNode: remapHookNodeReference(hook.targetNode, nodeNames),
     authorizedCallers: hook.authorizedCallers?.map((caller) => ({

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -258,10 +258,18 @@ function remapHookNodeReference(value: string | undefined, nodeNames: Map<string
   return nodeNames.get(value) ?? value;
 }
 
-function serializeHook(hook: WorkflowHook, nodeNames: Map<string, string>): WorkflowHook {
+function serializeHook(hook: WorkflowHook, nodeNames: Map<string, string>): WorkflowHook | null {
   const { poll: _poll, humanOnly: _humanOnly, ...hookWithoutUnsupportedFields } = hook;
+  if (hook.humanOnly && (!hook.authorizedCallers || hook.authorizedCallers.length === 0)) {
+    return null;
+  }
+  const shouldMaterializeRetry =
+    !hook.retry && !(hook.validator.kind === 'built_in' && hook.validator.id === 'pr_ready');
   return {
     ...hookWithoutUnsupportedFields,
+    ...(shouldMaterializeRetry
+      ? { retry: { maxAttempts: 3, delayMs: 5000, backoffMultiplier: 1 } }
+      : {}),
     sourceNode: remapHookNodeReference(hook.sourceNode, nodeNames) ?? hook.sourceNode,
     targetNode: remapHookNodeReference(hook.targetNode, nodeNames),
     authorizedCallers: hook.authorizedCallers?.map((caller) => ({
@@ -385,7 +393,9 @@ function buildWorkflowFields(state: VisualEditorState): {
   );
   const gates = state.gates.filter((gate) => referencedGateIds.has(gate.id));
   const hookNodeNames = buildHookNodeNameMap(persistableNodes);
-  const hooks = state.hooks.map((hook) => serializeHook(hook, hookNodeNames));
+  const hooks = state.hooks
+    .map((hook) => serializeHook(hook, hookNodeNames))
+    .filter((hook): hook is WorkflowHook => hook !== null);
 
   return {
     fields: {


### PR DESCRIPTION
Part of stack: Redesign workflow gates as MCP action hooks. PR 10 of 10 (top).

Adds focused workflow hook runtime coverage plus operator docs for hook result contracts, retry behavior, script limits, external lookups, restart recovery, and legacy gate migration.

Tests:
- ./scripts/test-daemon.sh 0-shared-handlers-workflow
- cd packages/web && bunx vitest run src/components/space/visual-editor/__tests__/serialization.test.ts
- bun run check