### PR TITLE
Add GLM-5.2 context support

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -144,6 +144,22 @@ export class ContextFetcher {
       };
     }
 
+    if (useMetadata && capacity > 0 && sdkCapacityValue !== capacity) {
+      const nonFreeSpaceTokens = Object.entries(breakdown)
+        .filter(([name]) => !name.toLowerCase().includes('free space'))
+        .reduce((sum, [, data]) => sum + data.tokens, 0);
+      const freeSpaceKey = Object.keys(breakdown).find((name) =>
+        name.toLowerCase().includes('free space')
+      );
+      if (freeSpaceKey) {
+        const correctedTokens = Math.max(0, capacity - nonFreeSpaceTokens);
+        breakdown[freeSpaceKey] = {
+          tokens: correctedTokens,
+          percent: Math.round((correctedTokens / capacity) * 1000) / 10,
+        };
+      }
+    }
+
     const apiUsage: ContextAPIUsage | undefined = response.apiUsage
       ? {
           inputTokens: response.apiUsage.input_tokens,

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -69,7 +69,7 @@ export class GlmProvider implements Provider {
       available: true,
     },
     {
-      id: 'glm-5.2',
+      id: 'glm-5.2[1m]',
       name: 'GLM-5.2',
       alias: 'glm-5.2',
       family: 'glm',
@@ -205,7 +205,12 @@ export class GlmProvider implements Provider {
     const baseUrl = sessionConfig?.baseUrl || GlmProvider.BASE_URL;
 
     // If modelId is not a GLM model ID (e.g. 'default'), fall back to glm-5-turbo.
-    const routingModelId = modelId.toLowerCase().startsWith('glm-') ? modelId : 'glm-5-turbo';
+    const routingModelId =
+      modelId === 'glm-5.2'
+        ? 'glm-5.2[1m]'
+        : modelId.toLowerCase().startsWith('glm-')
+          ? modelId
+          : 'glm-5-turbo';
 
     // Build environment variables
     const envVars: Record<string, string> = {

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -29,7 +29,7 @@ export class GlmProvider implements Provider {
     streaming: true,
     extendedThinking: true,
     thinkingModes: 'granular',
-    maxContextWindow: 200000,
+    maxContextWindow: 1_000_000,
     functionCalling: true,
     vision: true,
   };
@@ -66,6 +66,17 @@ export class GlmProvider implements Provider {
       contextWindow: 200000,
       description: 'GLM-5.1 · Enhanced reasoning and instruction following',
       releaseDate: '2026-04-08',
+      available: true,
+    },
+    {
+      id: 'glm-5.2',
+      name: 'GLM-5.2',
+      alias: 'glm-5.2',
+      family: 'glm',
+      provider: 'glm',
+      contextWindow: 1_000_000,
+      description: 'GLM-5.2 · 1M context window, recommended thinking mode "max"',
+      releaseDate: '2026-06-10',
       available: true,
     },
     {

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -381,6 +381,82 @@ describe('ContextFetcher.toContextInfo', () => {
     expect(info.breakdown.Messages).toEqual({ tokens: 50000, percent: 25 });
   });
 
+  it('recalculates free space when metadata capacity differs from SDK capacity', () => {
+    const response = baseResponse({
+      totalTokens: 127300,
+      maxTokens: 1000000,
+      rawMaxTokens: 1000000,
+      percentage: 12.7,
+      model: 'glm-5.1',
+      categories: [
+        { name: 'System prompt', tokens: 3600, color: 'gray' },
+        { name: 'System tools', tokens: 18000, color: 'gray' },
+        { name: 'Messages', tokens: 105700, color: 'blue' },
+        { name: 'Free space', tokens: 872700, color: 'gray-dim' },
+      ],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.1',
+      alias: 'glm-5.1',
+      contextWindow: 200000,
+      provider: 'glm',
+    });
+
+    expect(info.totalCapacity).toBe(200000);
+    expect(info.breakdown['Free space']).toEqual({ tokens: 72700, percent: 36.4 });
+  });
+
+  it('keeps SDK free space when metadata matches SDK capacity', () => {
+    const response = baseResponse({
+      totalTokens: 127300,
+      maxTokens: 1000000,
+      rawMaxTokens: 1000000,
+      percentage: 12.7,
+      model: 'glm-5.2',
+      categories: [
+        { name: 'System prompt', tokens: 3600, color: 'gray' },
+        { name: 'System tools', tokens: 18000, color: 'gray' },
+        { name: 'Messages', tokens: 105700, color: 'blue' },
+        { name: 'Free space', tokens: 872700, color: 'gray-dim' },
+      ],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.2',
+      alias: 'glm-5.2',
+      contextWindow: 1000000,
+      provider: 'glm',
+    });
+
+    expect(info.totalCapacity).toBe(1000000);
+    expect(info.breakdown['Free space']).toEqual({ tokens: 872700, percent: 87.3 });
+  });
+
+  it('clamps recalculated free space to zero when usage exceeds metadata capacity', () => {
+    const response = baseResponse({
+      totalTokens: 250000,
+      maxTokens: 1000000,
+      rawMaxTokens: 1000000,
+      percentage: 25,
+      model: 'glm-5.1',
+      categories: [
+        { name: 'System tools', tokens: 50000, color: 'gray' },
+        { name: 'Messages', tokens: 200000, color: 'blue' },
+        { name: 'Free space', tokens: 750000, color: 'gray-dim' },
+      ],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.1',
+      alias: 'glm-5.1',
+      contextWindow: 200000,
+      provider: 'glm',
+    });
+
+    expect(info.breakdown['Free space']).toEqual({ tokens: 0, percent: 0 });
+  });
+
   it('uses SDK capacity for native Anthropic providers even when metadata differs', () => {
     const response = baseResponse({
       totalTokens: 50000,

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -77,7 +77,7 @@ describe('GlmProvider', () => {
       expect(models.map((m) => m.id)).toEqual([
         'glm-5',
         'glm-5.1',
-        'glm-5.2',
+        'glm-5.2[1m]',
         'glm-5-turbo',
         'glm-5v-turbo',
         'glm-4.7',
@@ -166,6 +166,16 @@ describe('GlmProvider', () => {
       expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-4.7');
     });
 
+    it('should route glm-5.2 to the 1M SDK model id', () => {
+      process.env.GLM_API_KEY = 'test-key';
+
+      const config = provider.buildSdkConfig('glm-5.2');
+
+      expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5.2[1m]');
+      expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5.2[1m]');
+      expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]');
+    });
+
     it('should build correct config for glm-5-turbo', () => {
       process.env.GLM_API_KEY = 'test-key';
 
@@ -250,7 +260,7 @@ describe('GlmProvider', () => {
       expect(GlmProvider.MODELS.map((m) => m.id)).toEqual([
         'glm-5',
         'glm-5.1',
-        'glm-5.2',
+        'glm-5.2[1m]',
         'glm-5-turbo',
         'glm-5v-turbo',
         'glm-4.7',
@@ -258,10 +268,10 @@ describe('GlmProvider', () => {
     });
 
     it('should have correct glm-5.2 model definition', () => {
-      const model = GlmProvider.MODELS.find((m) => m.id === 'glm-5.2');
+      const model = GlmProvider.MODELS.find((m) => m.id === 'glm-5.2[1m]');
       expect(model).toBeDefined();
       expect(model).toEqual({
-        id: 'glm-5.2',
+        id: 'glm-5.2[1m]',
         name: 'GLM-5.2',
         alias: 'glm-5.2',
         family: 'glm',

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -35,7 +35,7 @@ describe('GlmProvider', () => {
       expect(provider.capabilities).toEqual({
         streaming: true,
         extendedThinking: true,
-        maxContextWindow: 200000,
+        maxContextWindow: 1_000_000,
         functionCalling: true,
         vision: true,
         thinkingModes: 'granular',
@@ -73,10 +73,11 @@ describe('GlmProvider', () => {
 
       const models = await provider.getModels();
 
-      expect(models).toHaveLength(5);
+      expect(models).toHaveLength(6);
       expect(models.map((m) => m.id)).toEqual([
         'glm-5',
         'glm-5.1',
+        'glm-5.2',
         'glm-5-turbo',
         'glm-5v-turbo',
         'glm-4.7',
@@ -245,14 +246,31 @@ describe('GlmProvider', () => {
 
   describe('static models', () => {
     it('should have static models defined', () => {
-      expect(GlmProvider.MODELS).toHaveLength(5);
+      expect(GlmProvider.MODELS).toHaveLength(6);
       expect(GlmProvider.MODELS.map((m) => m.id)).toEqual([
         'glm-5',
         'glm-5.1',
+        'glm-5.2',
         'glm-5-turbo',
         'glm-5v-turbo',
         'glm-4.7',
       ]);
+    });
+
+    it('should have correct glm-5.2 model definition', () => {
+      const model = GlmProvider.MODELS.find((m) => m.id === 'glm-5.2');
+      expect(model).toBeDefined();
+      expect(model).toEqual({
+        id: 'glm-5.2',
+        name: 'GLM-5.2',
+        alias: 'glm-5.2',
+        family: 'glm',
+        provider: 'glm',
+        contextWindow: 1_000_000,
+        description: 'GLM-5.2 · 1M context window, recommended thinking mode "max"',
+        releaseDate: '2026-06-10',
+        available: true,
+      });
     });
 
     it('should have correct glm-5-turbo model definition', () => {


### PR DESCRIPTION
Adds GLM-5.2 with 1M context and updates GLM provider max context capability.

Fixes context free space breakdown when metadata capacity overrides SDK capacity, preventing >100% free space display.

Tests:
- ./scripts/test-daemon.sh 1-core
- bun run check