### PR TITLE
Inject chat_template_kwargs in OpenAI Chat bridge

### DIFF
--- a/packages/daemon/src/lib/providers/custom-endpoint-provider.ts
+++ b/packages/daemon/src/lib/providers/custom-endpoint-provider.ts
@@ -308,6 +308,7 @@ export class CustomEndpointProvider implements Provider {
       params.caps.vision,
       params.caps.thinking,
       params.caps.streamUsage,
+      JSON.stringify(params.caps.chatTemplateKwargs ?? {}),
     ].join(' ');
     const existing = this.bridges.get(key);
     if (existing) return existing;
@@ -366,6 +367,7 @@ export class CustomEndpointProvider implements Provider {
           thinkingSupported: caps.thinking,
           streamUsageSupported: caps.streamUsage,
           modelContextWindow: caps.maxContextTokens,
+          ...(caps.chatTemplateKwargs ? { chatTemplateKwargs: caps.chatTemplateKwargs } : {}),
           ...(fetchImpl ? { fetchImpl } : {}),
         });
       }

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -78,6 +78,13 @@ export type OpenAIChatBridgeConfig = {
    * — accuracy degrades but the endpoint remains usable.
    */
   streamUsageSupported?: boolean;
+  /**
+   * Per-model `chat_template_kwargs` forwarded verbatim into every upstream
+   * request body. Used for fields the OpenAI Chat schema does not define but
+   * llama.cpp / vLLM templates read — most notably
+   * `{ enable_thinking: false }` to skip Qwen3 `<think>` blocks.
+   */
+  chatTemplateKwargs?: Record<string, unknown>;
 };
 
 // ---------------------------------------------------------------------------
@@ -129,6 +136,12 @@ type OpenAIChatRequest = {
    * ignore unknown fields silently.
    */
   reasoning_effort?: 'low' | 'medium' | 'high';
+  /**
+   * Jinja template kwargs (e.g. `{ enable_thinking: false }`). Forwarded
+   * verbatim; only llama.cpp / vLLM-style backends interpret it. Other
+   * OpenAI-compatible servers ignore unknown fields silently.
+   */
+  chat_template_kwargs?: Record<string, unknown>;
 };
 
 type OpenAIChatStreamChoice = {
@@ -320,7 +333,8 @@ function buildChatRequest(
   toolUseSupported: boolean,
   visionSupported: boolean,
   thinkingSupported: boolean,
-  streamUsageSupported = false
+  streamUsageSupported = false,
+  chatTemplateKwargs?: Record<string, unknown>
 ): OpenAIChatRequest {
   const request: OpenAIChatRequest = {
     model,
@@ -345,6 +359,13 @@ function buildChatRequest(
   if (thinkingSupported) {
     const effort = thinkingToReasoningEffort(body.thinking);
     if (effort) request.reasoning_effort = effort;
+  }
+  // llama.cpp / vLLM-style Jinja kwargs. Forwarded verbatim; other
+  // OpenAI-compatible servers ignore unknown fields silently. Most
+  // common use: `{ enable_thinking: false }` to skip Qwen3 `<think>`
+  // blocks for simple prompts that don't need reasoning.
+  if (chatTemplateKwargs) {
+    request.chat_template_kwargs = chatTemplateKwargs;
   }
   return request;
 }
@@ -741,6 +762,7 @@ export function createOpenAIChatBridgeServer(
   const visionSupported = config.visionSupported ?? false;
   const thinkingSupported = config.thinkingSupported ?? false;
   const streamUsageSupported = config.streamUsageSupported ?? false;
+  const chatTemplateKwargs = config.chatTemplateKwargs;
   const modelContextWindow = config.modelContextWindow;
 
   // Per-session thinking config injected by the daemon when the Anthropic SDK client
@@ -824,7 +846,8 @@ export function createOpenAIChatBridgeServer(
         toolUseSupported,
         visionSupported,
         thinkingSupported,
-        streamUsageSupported
+        streamUsageSupported,
+        chatTemplateKwargs
       );
       const inputTokens = estimateAnthropicInputTokens(body);
 

--- a/packages/daemon/tests/unit/1-core/providers/custom-endpoint-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/custom-endpoint-provider.test.ts
@@ -539,4 +539,64 @@ describe('CustomEndpointProvider', () => {
       });
     });
   });
+
+  describe('chatTemplateKwargs', () => {
+    it('forwards chatTemplateKwargs into the bridge config when declared on a model', () => {
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(
+        {
+          ...baseConfig,
+          models: [
+            {
+              id: 'qwen3',
+              capabilities: { toolUse: true, chatTemplateKwargs: { enable_thinking: false } },
+            },
+          ],
+          defaultModelId: 'qwen3',
+        },
+        { bridgeFactory: fake.factory }
+      );
+      p.buildSdkConfig('qwen3');
+      expect(fake.configs[0].chatTemplateKwargs).toEqual({ enable_thinking: false });
+    });
+
+    it('produces distinct bridge instances for models that differ only in chatTemplateKwargs', () => {
+      // Without chatTemplateKwargs in the cache key, the model declaring
+      // `enable_thinking:false` would silently share its bridge with the
+      // sibling model that wants thinking on.
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(
+        {
+          id: 'qwen3-shop',
+          name: 'Qwen3 Shop',
+          baseUrl: 'http://localhost:1234/v1',
+          models: [
+            {
+              id: 'qwen3-thinking',
+              capabilities: { toolUse: true, chatTemplateKwargs: { enable_thinking: true } },
+            },
+            {
+              id: 'qwen3-fast',
+              capabilities: { toolUse: true, chatTemplateKwargs: { enable_thinking: false } },
+            },
+          ],
+          defaultModelId: 'qwen3-thinking',
+        },
+        { bridgeFactory: fake.factory }
+      );
+      const a = p.buildSdkConfig('qwen3-thinking');
+      const b = p.buildSdkConfig('qwen3-fast');
+      expect(a.envVars.ANTHROPIC_BASE_URL).not.toBe(b.envVars.ANTHROPIC_BASE_URL);
+      expect(fake.configs).toHaveLength(2);
+      expect(fake.configs[0].chatTemplateKwargs).toEqual({ enable_thinking: true });
+      expect(fake.configs[1].chatTemplateKwargs).toEqual({ enable_thinking: false });
+    });
+
+    it('omits chatTemplateKwargs from the bridge config when the model does not declare it', () => {
+      const fake = makeFakeBridge();
+      const p = new CustomEndpointProvider(baseConfig, { bridgeFactory: fake.factory });
+      p.buildSdkConfig('qwen2.5-7b');
+      expect(fake.configs[0].chatTemplateKwargs).toBeUndefined();
+    });
+  });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -1176,4 +1176,98 @@ describe('OpenAI Chat Completions bridge server', () => {
       expect(capturedRequest.reasoning_effort).toBe('medium');
     });
   });
+
+  describe('chat_template_kwargs injection', () => {
+    // Per-model Jinja template kwargs (e.g. `{ enable_thinking: false }`)
+    // forward verbatim into every upstream request body. The field is not
+    // part of the OpenAI Chat schema — only llama.cpp / vLLM-style backends
+    // read it — but other OpenAI-compatible servers ignore unknown fields
+    // silently, so it's safe to inject unconditionally.
+    it('forwards chat_template_kwargs into the upstream request body when configured', async () => {
+      let capturedRequest: Record<string, unknown> = {};
+      const fetchMock = mock(async (_url: string, init?: RequestInit) => {
+        capturedRequest = JSON.parse(String(init?.body));
+        return new Response(
+          sseBody([{ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }]),
+          { status: 200 }
+        );
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test/v1',
+        fetchImpl: fetchMock as typeof fetch,
+        chatTemplateKwargs: { enable_thinking: false },
+      });
+      servers.push(server);
+      await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      expect(capturedRequest.chat_template_kwargs).toEqual({ enable_thinking: false });
+    });
+
+    it('omits chat_template_kwargs when not configured', async () => {
+      let capturedRequest: Record<string, unknown> = {};
+      const fetchMock = mock(async (_url: string, init?: RequestInit) => {
+        capturedRequest = JSON.parse(String(init?.body));
+        return new Response(
+          sseBody([{ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }]),
+          { status: 200 }
+        );
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test/v1',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+      await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'm',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+        }),
+      });
+      expect(capturedRequest).not.toHaveProperty('chat_template_kwargs');
+    });
+
+    it('does NOT overwrite model, messages, tools, or stream when injecting kwargs', async () => {
+      let capturedRequest: Record<string, unknown> = {};
+      const fetchMock = mock(async (_url: string, init?: RequestInit) => {
+        capturedRequest = JSON.parse(String(init?.body));
+        return new Response(
+          sseBody([{ choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] }]),
+          { status: 200 }
+        );
+      });
+      const server = createOpenAIChatBridgeServer({
+        baseUrl: 'http://upstream.test/v1',
+        fetchImpl: fetchMock as typeof fetch,
+        chatTemplateKwargs: { enable_thinking: false },
+      });
+      servers.push(server);
+      await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'qwen3:32b',
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: true,
+          tools: [{ name: 'lookup', description: '', input_schema: { type: 'object' } }],
+        }),
+      });
+      expect(capturedRequest.model).toBe('qwen3:32b');
+      expect(capturedRequest.messages).toEqual([{ role: 'user', content: 'hi' }]);
+      expect(capturedRequest.stream).toBe(true);
+      const tools = capturedRequest.tools as Array<{ function: { name: string } }>;
+      expect(tools).toHaveLength(1);
+      expect(tools[0].function.name).toBe('lookup');
+      expect(capturedRequest.chat_template_kwargs).toEqual({ enable_thinking: false });
+    });
+  });
 });

--- a/packages/shared/src/types/custom-endpoint.ts
+++ b/packages/shared/src/types/custom-endpoint.ts
@@ -55,6 +55,14 @@ export interface CustomEndpointModelCapabilities {
    * that are known-good (e.g. real OpenAI, LiteLLM, OpenRouter).
    */
   streamUsage: boolean;
+  /**
+   * Per-model Jinja `chat_template_kwargs` merged into every upstream
+   * `/v1/chat/completions` request body. Used for fields the OpenAI Chat
+   * schema does not define but llama.cpp / vLLM templates read — most
+   * notably `{ enable_thinking: false }` to skip Qwen3 `<think>` blocks.
+   * Omit (or leave undefined) for models that should keep default behaviour.
+   */
+  chatTemplateKwargs?: Record<string, unknown>;
 }
 
 /**

--- a/packages/web/src/components/settings/CustomEndpointEditor.tsx
+++ b/packages/web/src/components/settings/CustomEndpointEditor.tsx
@@ -163,6 +163,7 @@ export function editorToConfig(state: EditorState): CustomEndpointConfig {
       'caching',
       'streamUsage',
       'maxContextTokens',
+      'chatTemplateKwargs',
     ];
     for (const k of keys) {
       if (m.resolved[k] !== baseDefaults[k]) {

--- a/packages/web/src/components/settings/__tests__/CustomEndpointsSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/CustomEndpointsSettings.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../../../lib/connection-manager', () => ({
 import { CustomEndpointsSettings } from '../CustomEndpointsSettings.tsx';
 import { __test__, EditorModal } from '../CustomEndpointEditor.tsx';
 import { CUSTOM_ENDPOINT_PRESETS, findPreset } from '../customEndpointPresets.ts';
+import type { CustomEndpointConfig } from '@neokai/shared';
 
 describe('CustomEndpointsSettings — helpers', () => {
   it('resolveCapabilities applies type + global defaults', () => {
@@ -113,6 +114,32 @@ describe('CustomEndpointsSettings — helpers', () => {
     const cfg = __test__.editorToConfig(editor);
     // Only `thinking` should be persisted as a delta since the rest match defaults.
     expect(cfg.models[0]?.capabilities).toEqual({ thinking: true });
+  });
+
+  it('editorToConfig preserves chatTemplateKwargs through existingToEditor round-trip', () => {
+    // A user sets chatTemplateKwargs via JSON/import. When they open the
+    // endpoint in the Providers UI and click Save (even with no edits),
+    // existingToEditor → editorToConfig must NOT drop the field.
+    const original: CustomEndpointConfig = {
+      id: 'qwen3',
+      type: 'openai-chat',
+      name: 'Qwen3',
+      baseUrl: 'http://localhost:1234/v1',
+      models: [
+        {
+          id: 'qwen3:32b',
+          capabilities: {
+            chatTemplateKwargs: { enable_thinking: false },
+          },
+        },
+      ],
+      defaultModelId: 'qwen3:32b',
+    };
+    const editor = __test__.existingToEditor(original);
+    const roundTripped = __test__.editorToConfig(editor);
+    expect(roundTripped.models[0]?.capabilities?.chatTemplateKwargs).toEqual({
+      enable_thinking: false,
+    });
   });
 
   it('editorToConfig persists baseUrl + apiKey + headers when set', () => {


### PR DESCRIPTION
## Summary
- Add per-model `chatTemplateKwargs?: Record<string, unknown>` to `CustomEndpointModelCapabilities`. Undefined → no injection (default).
- OpenAI Chat bridge merges `chat_template_kwargs` into every upstream `/v1/chat/completions` body before forwarding.
- Provider bridge cache key includes serialised kwargs so two models with different kwargs get distinct bridges.
- Lets users set `chatTemplateKwargs: { enable_thinking: false }` on a Qwen3.6 model to skip `<think>` blocks (168 → 8 completion tokens on "2+2?").

## Test plan
- [x] `bun run check` (lint + typecheck + knip) passes
- [x] `cd packages/daemon && bun test tests/unit/1-core/providers/openai-chat-bridge-server.test.ts tests/unit/1-core/providers/custom-endpoint-provider.test.ts` — 74 pass, 0 fail
- [x] 3 bridge unit tests: inject when configured, omit when not, no overwrite of model/messages/tools/stream
- [x] 3 provider unit tests: forward into bridge config, distinct cache key for different kwargs, omit when model doesn't declare it