### PR TITLE
fix: align context window display + compaction for GLM/Kimi

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -22,6 +22,7 @@ import type {
   ModelInfo,
 } from '@neokai/shared';
 import { Logger } from '../logger';
+import { PROVIDER_NO_SDK_AUTO_COMPACT } from './query-options-builder.js';
 
 type ContextMetadata =
   | Pick<
@@ -51,6 +52,17 @@ export class ContextFetcher {
   }
 
   /**
+   * Fraction above which a mismatch between the SDK-reported context capacity
+   * and the provider metadata is considered suspicious. The Claude Agent SDK's
+   * PP() helper hardcodes a 200k fallback for unknown model IDs; for providers
+   * whose real window differs from that fallback by more than this fraction
+   * (e.g. GLM-5.2[1m] at 1M, Kimi at 262k), we want a runtime breadcrumb in the
+   * daemon log so a regression in `[1m]` suffix recognition or env var plumbing
+   * is visible without having to attach a debugger.
+   */
+  private static readonly CAPACITY_MISMATCH_WARN_FRACTION = 0.1;
+
+  /**
    * Call the SDK's `getContextUsage()` and convert the result to `ContextInfo`.
    *
    * Returns null if the query handle is missing or the call fails. Failures
@@ -66,11 +78,55 @@ export class ContextFetcher {
 
     try {
       const response = await query.getContextUsage();
-      return ContextFetcher.toContextInfo(response, modelMetadata);
+      const info = ContextFetcher.toContextInfo(response, modelMetadata);
+      if (info) {
+        ContextFetcher.warnOnCapacityMismatch(response, modelMetadata, this.logger);
+      }
+      return info;
     } catch (error) {
       this.logger.warn('query.getContextUsage() failed:', error);
       return null;
     }
+  }
+
+  /**
+   * Log a warning when the SDK-reported capacity disagrees with provider
+   * metadata by more than `CAPACITY_MISMATCH_WARN_FRACTION`. This surfaces
+   * regressions in the SDK's PP() recognition of `[1m]` suffixes, env var
+   * plumbing for `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, or any other path that
+   * would silently make the SDK use the wrong context window.
+   *
+   * The check is purely diagnostic — `toContextInfo` already overrides the
+   * SDK value with metadata when `preferContextWindowMetadata` is set, so the
+   * display layer is unaffected. The warning is for operator visibility.
+   */
+  private static warnOnCapacityMismatch(
+    response: SDKControlGetContextUsageResponse,
+    modelMetadata: ContextMetadata,
+    logger: Logger
+  ): void {
+    const providerId = modelMetadata?.provider;
+    // For providers we've already opted out of SDK auto-compact (e.g. Kimi,
+    // where PP() hardcodes 200k and the real window is 262k), the mismatch
+    // is expected — NeoKai's fallback handles compaction. Skip the warning
+    // so the log doesn't drown in expected-state noise.
+    if (providerId && PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) return;
+    const metadataCapacity = positiveInteger(modelMetadata?.contextWindow);
+    if (!metadataCapacity) return;
+    const sdkCapacity =
+      positiveInteger(response.rawMaxTokens) ?? positiveInteger(response.maxTokens);
+    if (!sdkCapacity) return;
+    const larger = Math.max(sdkCapacity, metadataCapacity);
+    if (larger <= 0) return;
+    const mismatch = Math.abs(sdkCapacity - metadataCapacity) / larger;
+    if (mismatch <= ContextFetcher.CAPACITY_MISMATCH_WARN_FRACTION) return;
+    logger.warn(
+      `Context capacity mismatch: SDK reports ${sdkCapacity} tokens for ` +
+        `model=${response.model ?? '<unknown>'} but metadata declares ` +
+        `${metadataCapacity} tokens (mismatch ${(mismatch * 100).toFixed(1)}%). ` +
+        `Display will use metadata; SDK auto-compact may fire at the wrong threshold. ` +
+        `Check PP() model recognition and CLAUDE_CODE_AUTO_COMPACT_WINDOW env var.`
+    );
   }
 
   /**

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -278,8 +278,11 @@ export class ContextFetcher {
       autoCompactThreshold = Math.floor(capacity * 0.9);
     }
 
+    const resolvedModel =
+      responseModel && matchesSdkModelId && modelMetadata?.id ? modelMetadata.id : responseModel;
+
     return {
-      model: response.model ?? null,
+      model: resolvedModel ?? null,
       totalUsed: response.totalTokens,
       totalCapacity: capacity,
       percentUsed,

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -40,11 +40,30 @@ const NATIVE_CONTEXT_WINDOW_PROVIDERS = new Set(['anthropic', 'anthropic-copilot
 
 /** Generic SDK tier names that non-native providers map to via ANTHROPIC_DEFAULT_*_MODEL. */
 const SDK_GENERIC_MODEL_IDS = new Set(['default', 'haiku', 'sonnet', 'opus']);
+const ONE_MILLION_CONTEXT_WINDOW = 1_000_000;
+const ONE_MILLION_MODEL_SUFFIX = /\[1m\]$/i;
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : undefined;
+}
+
+function resolveDisplayModel(
+  responseModel: string | undefined,
+  modelMetadata: ContextMetadata,
+  matchesSdkModelId: boolean,
+  sdkCapacity: number | undefined
+): string | undefined {
+  if (!responseModel) return undefined;
+  if (matchesSdkModelId && modelMetadata?.id) return modelMetadata.id;
+  const metadataCapacity = positiveInteger(modelMetadata?.contextWindow);
+  const isOneMillionWindow =
+    metadataCapacity === ONE_MILLION_CONTEXT_WINDOW || sdkCapacity === ONE_MILLION_CONTEXT_WINDOW;
+  if (ONE_MILLION_MODEL_SUFFIX.test(responseModel) && !isOneMillionWindow) {
+    return responseModel.replace(ONE_MILLION_MODEL_SUFFIX, '');
+  }
+  return responseModel;
 }
 
 export class ContextFetcher {
@@ -186,7 +205,14 @@ export class ContextFetcher {
     // model name doesn't exactly match. Native Anthropic providers keep the
     // exact-match safety guard so fallback/switched models don't display stale
     // metadata.
-    const sdkCapacityValue = sdkRawCapacity ?? sdkCapacity;
+    const hasStaleOneMillionSuffix =
+      responseModel &&
+      ONE_MILLION_MODEL_SUFFIX.test(responseModel) &&
+      sdkCapacity !== undefined &&
+      sdkCapacity < ONE_MILLION_CONTEXT_WINDOW;
+    const sdkCapacityValue = hasStaleOneMillionSuffix
+      ? sdkCapacity
+      : (sdkRawCapacity ?? sdkCapacity);
     const sdkOverreporting =
       shouldPreferMetadata &&
       metadataCapacityAny !== undefined &&
@@ -200,7 +226,7 @@ export class ContextFetcher {
       (shouldPreferMetadata && metadataCapacity) || sdkOverreporting || sdkCapacityUnavailable;
     const capacity = useMetadata
       ? (metadataCapacityAny ?? 0)
-      : (sdkRawCapacity ?? sdkCapacity ?? metadataCapacity ?? 0);
+      : (sdkCapacityValue ?? metadataCapacity ?? 0);
     for (const category of response.categories ?? []) {
       // Compute percent relative to capacity (SDK response doesn't carry it).
       // Round to 1 decimal place to match the display the UI already expects.
@@ -278,8 +304,12 @@ export class ContextFetcher {
       autoCompactThreshold = Math.floor(capacity * 0.9);
     }
 
-    const resolvedModel =
-      responseModel && matchesSdkModelId && modelMetadata?.id ? modelMetadata.id : responseModel;
+    const resolvedModel = resolveDisplayModel(
+      responseModel,
+      modelMetadata,
+      matchesSdkModelId,
+      sdkCapacity
+    );
 
     return {
       model: resolvedModel ?? null,

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -22,7 +22,10 @@ import type {
   ModelInfo,
 } from '@neokai/shared';
 import { Logger } from '../logger';
-import { PROVIDER_NO_SDK_AUTO_COMPACT } from './query-options-builder.js';
+import {
+  NATIVE_CONTEXT_WINDOW_PROVIDER_IDS,
+  PROVIDER_NO_SDK_AUTO_COMPACT,
+} from './query-options-builder.js';
 
 type ContextMetadata =
   | Pick<
@@ -106,15 +109,23 @@ export class ContextFetcher {
     logger: Logger
   ): void {
     const providerId = modelMetadata?.provider;
-    // For providers we've already opted out of SDK auto-compact (e.g. Kimi,
-    // where PP() hardcodes 200k and the real window is 262k), the mismatch
-    // is expected — NeoKai's fallback handles compaction. Skip the warning
-    // so the log doesn't drown in expected-state noise.
-    if (providerId && PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) return;
+    // Only fire for providers where we expect SDK auto-compact to work
+    // correctly. This is the set in NATIVE_CONTEXT_WINDOW_PROVIDER_IDS
+    // (anthropic, anthropic-copilot, anthropic-codex, glm). For everyone
+    // else — Kimi (SDK disabled), OpenRouter/Ollama/custom (PP() returns
+    // 200k for unknown models so the SDK's effective window is always the
+    // wrong 200k) — the mismatch is the known steady state, not a regression,
+    // and logging it on every context refresh is pure noise.
+    if (!providerId || !NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId)) return;
+    if (PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) return;
     const metadataCapacity = positiveInteger(modelMetadata?.contextWindow);
     if (!metadataCapacity) return;
-    const sdkCapacity =
-      positiveInteger(response.rawMaxTokens) ?? positiveInteger(response.maxTokens);
+    // Use the SDK's *effective* window (maxTokens), not the raw capacity
+    // (rawMaxTokens). For Codex, rawMaxTokens can be 1M (the SDK alias's PP
+    // value for claude-opus-4-7) while maxTokens is 272k (clamped by
+    // CLAUDE_CODE_AUTO_COMPACT_WINDOW) — comparing raw vs metadata would
+    // fire a false-positive warning on every refresh.
+    const sdkCapacity = positiveInteger(response.maxTokens);
     if (!sdkCapacity) return;
     const larger = Math.max(sdkCapacity, metadataCapacity);
     if (larger <= 0) return;

--- a/packages/daemon/src/lib/agent/context-tracker.ts
+++ b/packages/daemon/src/lib/agent/context-tracker.ts
@@ -21,6 +21,32 @@ const DEFAULT_COMPACTION_COOLDOWN_MS = 60_000;
  */
 export const COMPACTION_THRESHOLD = 0.85;
 
+/**
+ * Reserve used by `reserveBasedThreshold` to compute a NeoKai fallback
+ * threshold that sits above the SDK's own auto-compact trigger.
+ *
+ * The SDK fires compaction at `window - 13_000`. To leave the SDK a chance to
+ * fire first (so NeoKai is a true safety net), NeoKai's threshold must be at
+ * least `window - 13_000`. For larger windows, 15 % gives NeoKai a wider
+ * margin so the SDK has multiple turns to react before NeoKai intervenes.
+ */
+const SDK_AUTO_COMPACT_RESERVE_TOKENS = 13_000;
+const RESERVE_FRACTION = 0.15;
+
+/**
+ * Compute the NeoKai fallback threshold for a context window. Returns
+ * `window - max(13_000, 0.15 * window)` so NeoKai fires only when the SDK's
+ * own auto-compact (which fires at `window - 13_000`) has not kept up.
+ */
+export function reserveBasedThreshold(contextWindow: number): number {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return 0;
+  const reserve = Math.max(
+    SDK_AUTO_COMPACT_RESERVE_TOKENS,
+    Math.floor(contextWindow * RESERVE_FRACTION)
+  );
+  return Math.max(0, contextWindow - reserve);
+}
+
 export class ContextTracker {
   /**
    * Current context info - the latest snapshot of context window usage.
@@ -86,6 +112,34 @@ export class ContextTracker {
     }
 
     const threshold = Math.floor(actualContextWindow * COMPACTION_THRESHOLD);
+    if (info.totalUsed < threshold) {
+      return false;
+    }
+
+    if (Date.now() - this.lastCompactionTriggerAt < cooldownMs) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Threshold-based variant of `shouldCompact`. Fires when `totalUsed` is at
+   * or above `threshold` (an absolute token count, typically computed by
+   * `reserveBasedThreshold(contextWindow)` so NeoKai stays behind the SDK's
+   * own auto-compact trigger).
+   *
+   * Used by `sdk-message-handler` to install a NeoKai fallback that runs even
+   * for providers where the SDK *reports* auto-compact as enabled but may not
+   * actually fire (e.g. unknown model IDs whose PP() capacity caps below the
+   * real window).
+   */
+  shouldCompactAt(threshold: number, cooldownMs = DEFAULT_COMPACTION_COOLDOWN_MS): boolean {
+    const info = this.currentContextInfo;
+    if (!info || !Number.isFinite(threshold) || threshold <= 0) {
+      return false;
+    }
+
     if (info.totalUsed < threshold) {
       return false;
     }

--- a/packages/daemon/src/lib/agent/context-tracker.ts
+++ b/packages/daemon/src/lib/agent/context-tracker.ts
@@ -22,29 +22,40 @@ const DEFAULT_COMPACTION_COOLDOWN_MS = 60_000;
 export const COMPACTION_THRESHOLD = 0.85;
 
 /**
- * Reserve used by `reserveBasedThreshold` to compute a NeoKai fallback
- * threshold that sits above the SDK's own auto-compact trigger.
- *
- * The SDK fires compaction at `window - 13_000`. To leave the SDK a chance to
- * fire first (so NeoKai is a true safety net), NeoKai's threshold must be at
- * least `window - 13_000`. For larger windows, 15 % gives NeoKai a wider
- * margin so the SDK has multiple turns to react before NeoKai intervenes.
+ * The SDK's own auto-compact reserve. The SDK fires compaction at
+ * `window - 13_000`. NeoKai's fallback uses the same reserve (clamped for
+ * small windows) so it fires at the same point the SDK would have — for
+ * providers in `PROVIDER_NO_SDK_AUTO_COMPACT` (e.g. Kimi) the SDK never
+ * fires, so NeoKai is the sole compaction path and matching the SDK's
+ * threshold gives consistent behaviour.
  */
 const SDK_AUTO_COMPACT_RESERVE_TOKENS = 13_000;
-const RESERVE_FRACTION = 0.15;
 
 /**
- * Compute the NeoKai fallback threshold for a context window. Returns
- * `window - max(13_000, 0.15 * window)` so NeoKai fires only when the SDK's
- * own auto-compact (which fires at `window - 13_000`) has not kept up.
+ * Cap on the SDK reserve as a fraction of the window. For small windows the
+ * 13_000 fixed reserve can exceed 10% of the window (or even the whole
+ * window), which would produce a zero or negative threshold. Scale the
+ * reserve down proportionally so the threshold stays positive and meaningful.
+ */
+const RESERVE_FRACTION_CAP = 0.1;
+
+/**
+ * Compute the NeoKai fallback threshold for a context window. Uses the SDK's
+ * own 13_000 token reserve, scaled down for small windows so the threshold
+ * is always at least 1 token.
+ *
+ * This matches where the SDK's own auto-compact would have fired, so for
+ * providers where the SDK is disabled (`PROVIDER_NO_SDK_AUTO_COMPACT`,
+ * e.g. Kimi) NeoKai behaves consistently with the SDK's intended trigger
+ * point.
  */
 export function reserveBasedThreshold(contextWindow: number): number {
   if (!Number.isFinite(contextWindow) || contextWindow <= 0) return 0;
-  const reserve = Math.max(
+  const reserve = Math.min(
     SDK_AUTO_COMPACT_RESERVE_TOKENS,
-    Math.floor(contextWindow * RESERVE_FRACTION)
+    Math.floor(contextWindow * RESERVE_FRACTION_CAP)
   );
-  return Math.max(0, contextWindow - reserve);
+  return Math.max(1, contextWindow - reserve);
 }
 
 export class ContextTracker {

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -194,11 +194,19 @@ export function ensureAgentTools(
  *                   capacities cover the real Codex windows, AND sets
  *                   CLAUDE_CODE_AUTO_COMPACT_WINDOW explicitly. SDK auto-compact
  *                   fires at the correct threshold.
+ * glm              — Sets CLAUDE_CODE_AUTO_COMPACT_WINDOW per model (1M for
+ *                   glm-5.2[1m], 200k for the rest). The `[1m]` suffix is
+ *                   recognised by PP() so the SDK's effective window matches
+ *                   metadata. NeoKai fallback would otherwise fire at 850k
+ *                   (reserveBasedThreshold(1M)) and preempt the SDK's correct
+ *                   ~987k trigger. If `[1m]` recognition regresses, the
+ *                   context-fetcher capacity-mismatch warning surfaces it.
  */
 export const NATIVE_CONTEXT_WINDOW_PROVIDER_IDS = [
   'anthropic',
   'anthropic-copilot',
   'anthropic-codex',
+  'glm',
 ];
 
 /**

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -189,22 +189,47 @@ export function ensureAgentTools(
  *
  * anthropic        — native Anthropic API, SDK knows all model context windows.
  * anthropic-copilot — Copilot bridge still routes to Anthropic API.
+ * anthropic-codex  — Codex bridge routes through recognised Anthropic model IDs
+ *                   (claude-opus-4-7, claude-sonnet-4-20250514) whose PP()
+ *                   capacities cover the real Codex windows, AND sets
+ *                   CLAUDE_CODE_AUTO_COMPACT_WINDOW explicitly. SDK auto-compact
+ *                   fires at the correct threshold.
  */
-export const NATIVE_CONTEXT_WINDOW_PROVIDER_IDS = ['anthropic', 'anthropic-copilot'];
+export const NATIVE_CONTEXT_WINDOW_PROVIDER_IDS = [
+  'anthropic',
+  'anthropic-copilot',
+  'anthropic-codex',
+];
 
-export const PROVIDER_NATIVE_AUTO_COMPACT_WINDOWS: Record<string, number> = {
-  kimi: 262_144,
-};
+/**
+ * Providers that cannot use SDK auto-compaction because the SDK's PP() helper
+ * caps unknown model IDs to 200k tokens, mismatching the real provider window.
+ * For these providers we disable SDK auto-compact entirely and rely on NeoKai's
+ * fallback trigger (sdk-message-handler) which uses the model metadata's real
+ * context window.
+ *
+ * kimi — kimi-for-coding is unknown to PP() (returns 200k). Real window is 262k.
+ *        Adding a [1m] suffix would break the upstream Kimi API call (the bridge
+ *        forwards the model name verbatim), so we cannot use the SDK workaround
+ *        that GLM-5.2[1m] uses.
+ */
+export const PROVIDER_NO_SDK_AUTO_COMPACT: ReadonlySet<string> = new Set(['kimi']);
 
+/**
+ * Returns true when the SDK's built-in auto-compaction works correctly for this
+ * provider (i.e. the SDK reports the right context window AND fires compaction
+ * at the right threshold without NeoKai's help).
+ *
+ * Used by sdk-message-handler to decide whether to install the NeoKai fallback.
+ */
 export function providerUsesNativeAutoCompact(
   providerId: string,
-  contextWindow?: number | null
+  _contextWindow?: number | null
 ): boolean {
-  return (
-    NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId) ||
-    providerId in PROVIDER_NATIVE_AUTO_COMPACT_WINDOWS ||
-    (providerId === 'anthropic-codex' && !!contextWindow)
-  );
+  if (PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) {
+    return false;
+  }
+  return NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId);
 }
 
 /**
@@ -217,6 +242,11 @@ export function providerUsesNativeAutoCompact(
  * SDK cannot infer the provider model's real context window from its Anthropic
  * model alias. We pass the real window here so SDK auto-compaction fires at the
  * correct threshold without injecting `/compact` as prompt text.
+ *
+ * Providers in PROVIDER_NO_SDK_AUTO_COMPACT (e.g. Kimi) cannot use SDK
+ * auto-compact at all because PP() caps the effective window below the real
+ * model capacity. For these, we disable SDK auto-compact and let NeoKai's
+ * fallback handle compaction.
  */
 export function buildProviderSettings(
   providerId: string,
@@ -226,8 +256,14 @@ export function buildProviderSettings(
     return undefined;
   }
 
-  const nativeAutoCompactWindow = PROVIDER_NATIVE_AUTO_COMPACT_WINDOWS[providerId];
-  const autoCompactWindow = nativeAutoCompactWindow ?? contextWindow;
+  if (PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) {
+    // SDK auto-compact would fire at the wrong threshold (200k PP fallback
+    // instead of the real model window). Disable it and let NeoKai's
+    // fallback trigger handle compaction at 85% of the metadata context window.
+    return { autoCompactEnabled: false };
+  }
+
+  const autoCompactWindow = contextWindow;
   if (!autoCompactWindow) {
     return {
       autoCompactEnabled: false,

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -224,20 +224,6 @@ export const NATIVE_CONTEXT_WINDOW_PROVIDER_IDS = [
 export const PROVIDER_NO_SDK_AUTO_COMPACT: ReadonlySet<string> = new Set(['kimi']);
 
 /**
- * Returns true when the SDK's built-in auto-compaction works correctly for this
- * provider (i.e. the SDK reports the right context window AND fires compaction
- * at the right threshold without NeoKai's help).
- *
- * Used by sdk-message-handler to decide whether to install the NeoKai fallback.
- */
-export function providerUsesNativeAutoCompact(providerId: string): boolean {
-  if (PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) {
-    return false;
-  }
-  return NATIVE_CONTEXT_WINDOW_PROVIDER_IDS.includes(providerId);
-}
-
-/**
  * Provider-specific SDK settings overrides.
  *
  * For native Anthropic providers the SDK already knows the correct context

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -222,10 +222,7 @@ export const PROVIDER_NO_SDK_AUTO_COMPACT: ReadonlySet<string> = new Set(['kimi'
  *
  * Used by sdk-message-handler to decide whether to install the NeoKai fallback.
  */
-export function providerUsesNativeAutoCompact(
-  providerId: string,
-  _contextWindow?: number | null
-): boolean {
+export function providerUsesNativeAutoCompact(providerId: string): boolean {
   if (PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId)) {
     return false;
   }

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -916,15 +916,14 @@ export class SDKMessageHandler {
         // The raised threshold (vs. the SDK's 13k reserve) leaves the SDK a
         // wider window to fire first; NeoKai only kicks in if the SDK hasn't
         // compacted by the time context crosses the higher threshold. The
-        // shared cooldown prevents double-compaction when both layers race.
+        // NeoKai-only cooldown (60s) prevents back-to-back NeoKai `/compact`
+        // enqueues while a previous compaction is still in flight. The SDK has
+        // its own internal state and does not consult this cooldown.
         const providerId = session.config.provider;
         if (!providerId) {
           return;
         }
-        const usesNativeAutoCompact = providerUsesNativeAutoCompact(
-          providerId,
-          modelInfo?.contextWindow
-        );
+        const usesNativeAutoCompact = providerUsesNativeAutoCompact(providerId);
         const actualContextWindow = modelInfo?.contextWindow;
         if (!usesNativeAutoCompact && actualContextWindow && actualContextWindow > 0) {
           const neoKaiCompactThreshold = reserveBasedThreshold(actualContextWindow);

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -44,7 +44,7 @@ import { ApiErrorCircuitBreaker } from './api-error-circuit-breaker';
 import type { MessageQueue } from './message-queue';
 import type { QueryLifecycleManager } from './query-lifecycle-manager';
 import { getSessionModelInfo } from '../model-service';
-import { providerUsesNativeAutoCompact } from './query-options-builder.js';
+import { PROVIDER_NO_SDK_AUTO_COMPACT } from './query-options-builder.js';
 import { reserveBasedThreshold } from './context-tracker.js';
 
 /**
@@ -901,31 +901,32 @@ export class SDKMessageHandler {
 
         // NeoKai-level compaction fallback.
         //
-        // Two layers of defence against runaway context:
-        //   1. SDK native auto-compact — fires at `window - 13_000` when the
-        //      provider's model is recognised by the SDK's PP() helper (Anthropic
-        //      native, Anthropic-Codex bridge, GLM with `[1m]` suffix).
-        //   2. NeoKai fallback — fires at `contextWindow - max(13_000, 15%)`
-        //      when the SDK's auto-compact hasn't kept up. This catches:
-        //        - Providers whose model ID is unknown to PP() (Kimi, plain
-        //          GLM-5/5.1) where SDK auto-compact is disabled because it
-        //          would fire at the wrong threshold.
-        //        - Any case where the SDK reports `isAutoCompactEnabled: true`
-        //          but fails to actually trigger compaction (bug, hang, etc.).
+        // Scoped to providers in `PROVIDER_NO_SDK_AUTO_COMPACT` (currently
+        // Kimi). For these providers, the SDK's PP() helper hardcodes a 200k
+        // capacity for unknown model IDs and we cannot use the `[1m]` suffix
+        // workaround (Kimi's bridge forwards the model name verbatim, so
+        // `kimi-for-coding[1m]` would be rejected upstream). SDK auto-compact
+        // is disabled via Options.settings; NeoKai is the sole compaction
+        // path and fires at the same threshold the SDK would have used
+        // (window - 13_000, clamped for small windows — see
+        // `reserveBasedThreshold`).
         //
-        // The raised threshold (vs. the SDK's 13k reserve) leaves the SDK a
-        // wider window to fire first; NeoKai only kicks in if the SDK hasn't
-        // compacted by the time context crosses the higher threshold. The
-        // NeoKai-only cooldown (60s) prevents back-to-back NeoKai `/compact`
-        // enqueues while a previous compaction is still in flight. The SDK has
-        // its own internal state and does not consult this cooldown.
+        // For all other providers (Anthropic native, GLM, Codex, OpenRouter,
+        // Ollama, custom endpoints) we trust the SDK's own auto-compact.
+        // Installing NeoKai as a competing trigger would either race with the
+        // SDK (same threshold) or preempt it (lower threshold, cutting off
+        // advertised context). The context-fetcher capacity-mismatch warning
+        // surfaces any regression in SDK behaviour for those providers.
+        //
+        // The NeoKai-only cooldown (60s) prevents back-to-back `/compact`
+        // enqueues while a previous compaction is still in flight.
         const providerId = session.config.provider;
         if (!providerId) {
           return;
         }
-        const usesNativeAutoCompact = providerUsesNativeAutoCompact(providerId);
+        const sdkAutoCompactDisabled = PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId);
         const actualContextWindow = modelInfo?.contextWindow;
-        if (!usesNativeAutoCompact && actualContextWindow && actualContextWindow > 0) {
+        if (sdkAutoCompactDisabled && actualContextWindow && actualContextWindow > 0) {
           const neoKaiCompactThreshold = reserveBasedThreshold(actualContextWindow);
           if (
             contextInfo.totalUsed >= neoKaiCompactThreshold &&

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -45,6 +45,7 @@ import type { MessageQueue } from './message-queue';
 import type { QueryLifecycleManager } from './query-lifecycle-manager';
 import { getSessionModelInfo } from '../model-service';
 import { providerUsesNativeAutoCompact } from './query-options-builder.js';
+import { reserveBasedThreshold } from './context-tracker.js';
 
 /**
  * Number of SDK stream events between automatic context-usage refreshes.
@@ -898,27 +899,49 @@ export class SDKMessageHandler {
           contextInfo,
         });
 
-        // NeoKai-level compaction fallback for providers without SDK-native compaction.
+        // NeoKai-level compaction fallback.
+        //
+        // Two layers of defence against runaway context:
+        //   1. SDK native auto-compact — fires at `window - 13_000` when the
+        //      provider's model is recognised by the SDK's PP() helper (Anthropic
+        //      native, Anthropic-Codex bridge, GLM with `[1m]` suffix).
+        //   2. NeoKai fallback — fires at `contextWindow - max(13_000, 15%)`
+        //      when the SDK's auto-compact hasn't kept up. This catches:
+        //        - Providers whose model ID is unknown to PP() (Kimi, plain
+        //          GLM-5/5.1) where SDK auto-compact is disabled because it
+        //          would fire at the wrong threshold.
+        //        - Any case where the SDK reports `isAutoCompactEnabled: true`
+        //          but fails to actually trigger compaction (bug, hang, etc.).
+        //
+        // The raised threshold (vs. the SDK's 13k reserve) leaves the SDK a
+        // wider window to fire first; NeoKai only kicks in if the SDK hasn't
+        // compacted by the time context crosses the higher threshold. The
+        // shared cooldown prevents double-compaction when both layers race.
         const providerId = session.config.provider;
         if (!providerId) {
           return;
         }
-        const usesNativeAutoCompact =
-          providerUsesNativeAutoCompact(providerId, modelInfo?.contextWindow) ||
-          contextInfo.isAutoCompactEnabled;
-        if (
-          !usesNativeAutoCompact &&
-          modelInfo?.contextWindow &&
-          contextTracker.shouldCompact(modelInfo.contextWindow)
-        ) {
-          contextTracker.markCompactionTriggered();
-          this.logger.info(
-            `Triggering compaction for session ${session.id} ` +
-              `(${contextInfo.totalUsed} / ${modelInfo.contextWindow} tokens)`
-          );
-          void this.ctx.messageQueue.enqueue('/compact', /* internal */ true).catch((error) => {
-            this.logger.warn(`compaction enqueue failed for session ${session.id}:`, error);
-          });
+        const usesNativeAutoCompact = providerUsesNativeAutoCompact(
+          providerId,
+          modelInfo?.contextWindow
+        );
+        const actualContextWindow = modelInfo?.contextWindow;
+        if (!usesNativeAutoCompact && actualContextWindow && actualContextWindow > 0) {
+          const neoKaiCompactThreshold = reserveBasedThreshold(actualContextWindow);
+          if (
+            contextInfo.totalUsed >= neoKaiCompactThreshold &&
+            contextTracker.shouldCompactAt(neoKaiCompactThreshold)
+          ) {
+            contextTracker.markCompactionTriggered();
+            this.logger.info(
+              `Triggering NeoKai compaction fallback for session ${session.id} ` +
+                `(provider=${providerId}, ${contextInfo.totalUsed} >= ${neoKaiCompactThreshold} ` +
+                `of ${actualContextWindow} tokens)`
+            );
+            void this.ctx.messageQueue.enqueue('/compact', /* internal */ true).catch((error) => {
+              this.logger.warn(`compaction enqueue failed for session ${session.id}:`, error);
+            });
+          }
         }
       } catch (error) {
         this.logger.warn(`context refresh (${reason}) failed:`, error);

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -533,7 +533,15 @@ function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undef
     found = models.find((m) => m.alias === idOrAlias);
   }
 
-  // 3. Legacy model mapping (maps old full IDs to SDK short IDs)
+  // 3. sdkModelIds match (additional IDs/aliases the provider accepts).
+  //    Used both by ContextFetcher for SDK-reported names AND by model-service
+  //    for provider-accepted aliases (e.g. Kimi accepts moonshot-v1-32k that
+  //    normalises to kimi-for-coding at the bridge layer).
+  if (!found) {
+    found = models.find((m) => m.sdkModelIds?.includes(idOrAlias));
+  }
+
+  // 4. Legacy model mapping (maps old full IDs to SDK short IDs)
   if (!found) {
     const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
     if (legacyMappedId) {

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -16,6 +16,8 @@ import { initializeProviders, waitForOptionalProviderRegistration } from './prov
 import { getProviderRegistry } from './providers/registry.js';
 import type { Provider } from '@neokai/shared/provider';
 import { getCodexBridgeModelInfos, resolveCodexBridgeModelId } from './providers/codex-models.js';
+import { GlmProvider } from './providers/glm-provider.js';
+import { KimiProvider } from './providers/kimi-provider.js';
 
 /**
  * Legacy model ID mappings to SDK model IDs
@@ -104,8 +106,20 @@ const FALLBACK_MODELS: ModelInfo[] = [
  * This is used only for deterministic metadata lookup (current model display,
  * context-window resolution) when live provider loading is unavailable. It does
  * not make those providers available for use.
+ *
+ * GLM and Kimi are included because their context windows must be resolvable
+ * even when the daemon starts without the provider's env var set globally but
+ * the session supplies credentials via `session.config.providerConfig.apiKey`.
+ * Without these entries, `getSessionModelInfo()` returns null and the NeoKai
+ * fallback compaction threshold can't be computed — sessions would run into the
+ * real context limit with no compaction trigger.
  */
-const STATIC_MODEL_METADATA: ModelInfo[] = [...FALLBACK_MODELS, ...getCodexBridgeModelInfos()];
+const STATIC_MODEL_METADATA: ModelInfo[] = [
+  ...FALLBACK_MODELS,
+  ...getCodexBridgeModelInfos(),
+  ...GlmProvider.MODELS,
+  ...KimiProvider.MODELS,
+];
 const CODEX_STATIC_MODEL_METADATA = getCodexBridgeModelInfos();
 
 /**

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -556,7 +556,16 @@ function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undef
     );
   }
 
-  // 6. Legacy model mapping (maps old full IDs to SDK short IDs)
+  // 6. Provider-accepted alias prefixes. Used for open-ended alias families
+  // such as Kimi's moonshot-* IDs. Keep separate from sdkModelIds for the same
+  // reason as providerAliases: SDK-only bridge IDs must not become valid input.
+  if (!found) {
+    found = models.find((m) =>
+      m.providerAliasPrefixes?.some((prefix) => normalized.startsWith(prefix.toLowerCase()))
+    );
+  }
+
+  // 7. Legacy model mapping (maps old full IDs to SDK short IDs)
   if (!found) {
     const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
     if (legacyMappedId) {

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -525,23 +525,38 @@ export function setModelsCache(cache: Map<string, ModelInfo[]>, timestamp?: numb
  * 3. Legacy model mapping
  */
 function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undefined {
+  const normalized = idOrAlias.toLowerCase();
+
   // 1. Exact ID match (works for SDK's short IDs like 'opus', 'default')
   let found = models.find((m) => m.id === idOrAlias);
 
-  // 2. Alias field match
+  // 2. Case-insensitive ID match for providers whose routing accepts aliases
+  // after lowercasing (e.g. Kimi accepts `KIMI` and `Moonshot-v1-32k`).
+  if (!found) {
+    found = models.find((m) => m.id.toLowerCase() === normalized);
+  }
+
+  // 3. Alias field match
   if (!found) {
     found = models.find((m) => m.alias === idOrAlias);
   }
 
-  // 3. sdkModelIds match (additional IDs/aliases the provider accepts).
-  //    Used both by ContextFetcher for SDK-reported names AND by model-service
-  //    for provider-accepted aliases (e.g. Kimi accepts moonshot-v1-32k that
-  //    normalises to kimi-for-coding at the bridge layer).
+  // 4. Case-insensitive alias field match
   if (!found) {
-    found = models.find((m) => m.sdkModelIds?.includes(idOrAlias));
+    found = models.find((m) => m.alias.toLowerCase() === normalized);
   }
 
-  // 4. Legacy model mapping (maps old full IDs to SDK short IDs)
+  // 5. Provider-accepted aliases. These are user/config spellings that should
+  // pass validation and resolve metadata. Do NOT use sdkModelIds here: those are
+  // SDK-reported bridge aliases (e.g. Codex's claude-opus-4-7) and must not
+  // become user-selectable/provider-accepted IDs.
+  if (!found) {
+    found = models.find((m) =>
+      m.providerAliases?.some((alias) => alias.toLowerCase() === normalized)
+    );
+  }
+
+  // 6. Legacy model mapping (maps old full IDs to SDK short IDs)
   if (!found) {
     const legacyMappedId = LEGACY_MODEL_MAPPINGS[idOrAlias];
     if (legacyMappedId) {

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -606,7 +606,15 @@ export class ProviderService {
     }
     if (envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW !== undefined) {
       original.CLAUDE_CODE_AUTO_COMPACT_WINDOW = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
-      process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+      // Empty string means "explicitly clear" — providers whose auto-compact
+      // is disabled (e.g. Kimi, which would otherwise inherit a stale value
+      // from a previous GLM/Codex query) return '' so the SDK subprocess
+      // doesn't pick up the wrong window.
+      if (envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW === '') {
+        delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+      } else {
+        process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+      }
     }
     if (envVars.ANTHROPIC_DEFAULT_SONNET_MODEL !== undefined) {
       original.ANTHROPIC_DEFAULT_SONNET_MODEL = process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -53,6 +53,12 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 200000,
+      // GLM model IDs are unknown to the Claude Agent SDK's hardcoded model table.
+      // PP() falls back to 200k for unknown IDs, which happens to match the real
+      // GLM context window for these models — but the context-fetcher must still
+      // trust this metadata because the SDK may report the generic fallback as
+      // the model's actual capacity, which can drift if the SDK's default changes.
+      preferContextWindowMetadata: true,
       description: "GLM-5 · Zhipu AI's Next-Generation Frontier Model",
       releaseDate: '2026-02-11',
       available: true,
@@ -64,6 +70,7 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 200000,
+      preferContextWindowMetadata: true,
       description: 'GLM-5.1 · Enhanced reasoning and instruction following',
       releaseDate: '2026-04-08',
       available: true,
@@ -75,6 +82,12 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 1_000_000,
+      // The [1m] suffix is recognised by the SDK's PP() helper, so it returns
+      // 1M for this ID. Combined with CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000
+      // (set in buildSdkConfig), the SDK auto-compact window becomes
+      // min(1M, 1M) = 1M, matching the real GLM-5.2 context window. Compaction
+      // fires at ~987k (window - 13k SDK reserve).
+      preferContextWindowMetadata: true,
       description: 'GLM-5.2 · 1M context window, recommended thinking mode "max"',
       releaseDate: '2026-06-10',
       available: true,
@@ -86,6 +99,7 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 200000,
+      preferContextWindowMetadata: true,
       description: 'GLM-5-Turbo · Optimized for long-chain agent tasks and tool calling',
       releaseDate: '2026-03-15',
       available: true,
@@ -97,6 +111,7 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 200000,
+      preferContextWindowMetadata: true,
       description: 'GLM-5V-Turbo · Vision-capable turbo model optimized for multimodal agent tasks',
       releaseDate: '2026-05-01',
       available: true,
@@ -108,11 +123,22 @@ export class GlmProvider implements Provider {
       family: 'glm',
       provider: 'glm',
       contextWindow: 200000,
+      preferContextWindowMetadata: true,
       description: 'GLM-4.7 · Zhipu AI high-performance model',
       releaseDate: '2025-12-01',
       available: true,
     },
   ];
+
+  /**
+   * Lookup map for the real context window of each GLM model ID, including
+   * the [1m] suffix variant used for SDK routing. Used by buildSdkConfig()
+   * to set CLAUDE_CODE_AUTO_COMPACT_WINDOW so the SDK's auto-compact threshold
+   * matches the provider's real capacity instead of its hardcoded 200k fallback.
+   */
+  private static readonly CONTEXT_WINDOW_BY_MODEL_ID: Record<string, number> = Object.fromEntries(
+    GlmProvider.MODELS.map((m) => [m.id, m.contextWindow])
+  );
 
   private credentials: ProviderCredentials | null = null;
 
@@ -212,6 +238,14 @@ export class GlmProvider implements Provider {
           ? modelId
           : 'glm-5-turbo';
 
+    // Resolve the real context window for the routing model ID so we can tell
+    // the SDK the correct auto-compact threshold. Without this, the SDK uses
+    // PP(model) which returns 200k for unknown model IDs — wrong for glm-5.2[1m]
+    // (1M). Belt-and-suspenders with Options.settings.autoCompactWindow set by
+    // buildProviderSettings(): env var has highest priority in the SDK's
+    // resolution chain.
+    const contextWindow = GlmProvider.CONTEXT_WINDOW_BY_MODEL_ID[routingModelId] ?? 200_000;
+
     // Build environment variables
     const envVars: Record<string, string> = {
       ANTHROPIC_BASE_URL: baseUrl,
@@ -220,6 +254,12 @@ export class GlmProvider implements Provider {
       API_TIMEOUT_MS: '3000000',
       // Disable non-essential traffic (telemetry, etc.)
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      // Tell the SDK the real GLM context window so auto-compact fires at the
+      // correct threshold instead of the SDK's hardcoded 200k fallback for
+      // unknown models. For glm-5.2[1m], this is 1M; for the 200k models, this
+      // matches the SDK fallback but pins it explicitly so future SDK defaults
+      // can't silently change compaction behaviour.
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(contextWindow),
       // Route all tiers to the selected model
       ANTHROPIC_DEFAULT_HAIKU_MODEL: routingModelId,
       ANTHROPIC_DEFAULT_SONNET_MODEL: routingModelId,

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -237,11 +237,12 @@ export class GlmProvider implements Provider {
     const normalisedModelId = modelId.toLowerCase();
 
     // If modelId is not a GLM model ID (e.g. 'default'), fall back to glm-5-turbo.
+    const baseModelId = normalisedModelId.replace(/\[1m\]$/, '');
     const routingModelId =
-      normalisedModelId === 'glm-5.2'
+      baseModelId === 'glm-5.2'
         ? 'glm-5.2[1m]'
-        : normalisedModelId.startsWith('glm-')
-          ? normalisedModelId
+        : baseModelId.startsWith('glm-')
+          ? baseModelId
           : 'glm-5-turbo';
 
     // Resolve the real context window for the routing model ID so we can tell

--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -230,12 +230,18 @@ export class GlmProvider implements Provider {
     // Get base URL: session override > default
     const baseUrl = sessionConfig?.baseUrl || GlmProvider.BASE_URL;
 
+    // Normalise case so "GLM-5.2" / "GLM-5" route the same as their lowercase
+    // forms. Without this, an uppercase modelId bypasses the glm-5.2 → [1m]
+    // shortcut, falls through to verbatim routing, misses the context-window
+    // lookup, and silently falls back to 200k.
+    const normalisedModelId = modelId.toLowerCase();
+
     // If modelId is not a GLM model ID (e.g. 'default'), fall back to glm-5-turbo.
     const routingModelId =
-      modelId === 'glm-5.2'
+      normalisedModelId === 'glm-5.2'
         ? 'glm-5.2[1m]'
-        : modelId.toLowerCase().startsWith('glm-')
-          ? modelId
+        : normalisedModelId.startsWith('glm-')
+          ? normalisedModelId
           : 'glm-5-turbo';
 
     // Resolve the real context window for the routing model ID so we can tell

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -190,14 +190,18 @@ export class KimiProvider implements Provider {
         ANTHROPIC_API_KEY: '',
         ANTHROPIC_AUTH_TOKEN: '',
         API_TIMEOUT_MS: '3000000',
-        // NOTE: CLAUDE_CODE_AUTO_COMPACT_WINDOW intentionally NOT set for Kimi.
-        // The SDK's PP() helper returns 200k for the unknown 'kimi-for-coding'
-        // model ID, so even with this env var the effective window would be
-        // min(200k, 262144) = 200k, and SDK auto-compact would fire at ~187k
-        // — 60k too early. Instead, Options.settings.autoCompactEnabled=false
-        // (set via buildProviderSettings) disables SDK auto-compact entirely,
-        // and NeoKai's fallback trigger (sdk-message-handler) handles
-        // compaction at the correct 85% of the real 262k window.
+        // Explicitly clear CLAUDE_CODE_AUTO_COMPACT_WINDOW so a previous
+        // provider's value (e.g. GLM's 1M, Codex's 272k) cannot leak into
+        // the Kimi subprocess. The SDK's PP() helper returns 200k for the
+        // unknown 'kimi-for-coding' model ID, so even an inherited 262144
+        // value would cap the effective window to min(200k, 262k) = 200k
+        // and make SDK auto-compact fire ~60k too early. SDK auto-compact
+        // is disabled via Options.settings.autoCompactEnabled=false (set
+        // by buildProviderSettings); NeoKai's fallback trigger handles
+        // compaction at the correct 85% of the real 262k window. The empty
+        // string deletes the env var when applied (see applyEnvVars in
+        // provider-service.ts).
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: '',
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
         ANTHROPIC_DEFAULT_HAIKU_MODEL: routingModelId,
         ANTHROPIC_DEFAULT_SONNET_MODEL: routingModelId,

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -79,15 +79,23 @@ export class KimiProvider implements Provider {
       family: 'kimi',
       provider: 'kimi',
       contextWindow: 262144,
-      // Kimi accepts moonshot-* model IDs (e.g. moonshot-v1-32k) that all
-      // normalise to kimi-for-coding at the bridge layer. List them here so
-      // model-service lookups (used by getSessionModelInfo → context bar
-      // display and NeoKai fallback threshold) resolve them to the canonical
-      // Kimi entry instead of returning null. Without this, sessions whose
-      // stored model is a moonshot-* ID have SDK auto-compact disabled (via
-      // buildProviderSettings) AND no NeoKai fallback threshold — they would
-      // run into Kimi's real context limit with no compaction trigger.
-      sdkModelIds: ['moonshot-v1-32k', 'moonshot-v1-8k', 'moonshot-v1-128k'],
+      // Kimi accepts alternate model spellings (including case variants and
+      // moonshot-* IDs) that all normalise to kimi-for-coding at the bridge
+      // layer. List provider-accepted aliases here so model-service lookups
+      // (used by getSessionModelInfo → context bar display and NeoKai fallback
+      // threshold) resolve them to the canonical Kimi entry instead of returning
+      // null. Without this, sessions whose stored model is a moonshot-* ID have
+      // SDK auto-compact disabled (via buildProviderSettings) AND no NeoKai
+      // fallback threshold — they would run into Kimi's real context limit with
+      // no compaction trigger.
+      providerAliases: [
+        'KIMI',
+        'Kimi',
+        'Moonshot-v1-32k',
+        'moonshot-v1-32k',
+        'moonshot-v1-8k',
+        'moonshot-v1-128k',
+      ],
       // Kimi's real context window is 262k but the SDK's PP() helper returns
       // 200k for unknown model IDs (and there is no [1m] suffix we can use
       // without breaking the upstream Kimi API call). We must trust this

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -79,6 +79,15 @@ export class KimiProvider implements Provider {
       family: 'kimi',
       provider: 'kimi',
       contextWindow: 262144,
+      // Kimi accepts moonshot-* model IDs (e.g. moonshot-v1-32k) that all
+      // normalise to kimi-for-coding at the bridge layer. List them here so
+      // model-service lookups (used by getSessionModelInfo → context bar
+      // display and NeoKai fallback threshold) resolve them to the canonical
+      // Kimi entry instead of returning null. Without this, sessions whose
+      // stored model is a moonshot-* ID have SDK auto-compact disabled (via
+      // buildProviderSettings) AND no NeoKai fallback threshold — they would
+      // run into Kimi's real context limit with no compaction trigger.
+      sdkModelIds: ['moonshot-v1-32k', 'moonshot-v1-8k', 'moonshot-v1-128k'],
       // Kimi's real context window is 262k but the SDK's PP() helper returns
       // 200k for unknown model IDs (and there is no [1m] suffix we can use
       // without breaking the upstream Kimi API call). We must trust this

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -79,6 +79,14 @@ export class KimiProvider implements Provider {
       family: 'kimi',
       provider: 'kimi',
       contextWindow: 262144,
+      // Kimi's real context window is 262k but the SDK's PP() helper returns
+      // 200k for unknown model IDs (and there is no [1m] suffix we can use
+      // without breaking the upstream Kimi API call). We must trust this
+      // metadata for the context bar display; compaction is handled by
+      // NeoKai's fallback trigger (sdk-message-handler) rather than the SDK's
+      // native auto-compact, because the SDK would cap the window to 200k
+      // and fire compaction 60k too early.
+      preferContextWindowMetadata: true,
       description:
         'Kimi Code model (auto-upgrades to latest flagship). Fixed model ID for all requests.',
       releaseDate: '',
@@ -182,7 +190,14 @@ export class KimiProvider implements Provider {
         ANTHROPIC_API_KEY: '',
         ANTHROPIC_AUTH_TOKEN: '',
         API_TIMEOUT_MS: '3000000',
-        CLAUDE_CODE_AUTO_COMPACT_WINDOW: '262144',
+        // NOTE: CLAUDE_CODE_AUTO_COMPACT_WINDOW intentionally NOT set for Kimi.
+        // The SDK's PP() helper returns 200k for the unknown 'kimi-for-coding'
+        // model ID, so even with this env var the effective window would be
+        // min(200k, 262144) = 200k, and SDK auto-compact would fire at ~187k
+        // — 60k too early. Instead, Options.settings.autoCompactEnabled=false
+        // (set via buildProviderSettings) disables SDK auto-compact entirely,
+        // and NeoKai's fallback trigger (sdk-message-handler) handles
+        // compaction at the correct 85% of the real 262k window.
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
         ANTHROPIC_DEFAULT_HAIKU_MODEL: routingModelId,
         ANTHROPIC_DEFAULT_SONNET_MODEL: routingModelId,

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -88,14 +88,8 @@ export class KimiProvider implements Provider {
       // SDK auto-compact disabled (via buildProviderSettings) AND no NeoKai
       // fallback threshold — they would run into Kimi's real context limit with
       // no compaction trigger.
-      providerAliases: [
-        'KIMI',
-        'Kimi',
-        'Moonshot-v1-32k',
-        'moonshot-v1-32k',
-        'moonshot-v1-8k',
-        'moonshot-v1-128k',
-      ],
+      providerAliases: ['KIMI', 'Kimi'],
+      providerAliasPrefixes: ['moonshot-'],
       // Kimi's real context window is 262k but the SDK's PP() helper returns
       // 200k for unknown model IDs (and there is no [1m] suffix we can use
       // without breaking the upstream Kimi API call). We must trust this

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -216,6 +216,28 @@ describe('ContextFetcher.toContextInfo', () => {
     expect(info.autoCompactThreshold).toBe(244800);
   });
 
+  it('resolves SDK alias model name to canonical Codex model ID via sdkModelIds', () => {
+    const response = baseResponse({
+      totalTokens: 10000,
+      maxTokens: 272000,
+      rawMaxTokens: 272000,
+      percentage: 4,
+      model: 'claude-opus-4-7',
+      categories: [{ name: 'Messages', tokens: 10000, color: 'blue' }],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'gpt-5.5',
+      sdkModelIds: ['claude-opus-4-7'],
+      provider: 'anthropic-codex',
+      preferContextWindowMetadata: true,
+      contextWindow: 272000,
+    });
+
+    expect(info.model).toBe('gpt-5.5');
+    expect(info.totalCapacity).toBe(272000);
+  });
+
   it('uses Codex model metadata when SDK reports the generic 200k capacity', () => {
     const response = baseResponse({
       totalTokens: 136000,

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -5,7 +5,7 @@
  * `query.getContextUsage()` response into NeoKai's `ContextInfo` shape.
  */
 
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, spyOn } from 'bun:test';
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
 import type { SDKControlGetContextUsageResponse } from '@anthropic-ai/claude-agent-sdk';
 import { ContextFetcher } from '../../../../src/lib/agent/context-fetcher';
@@ -684,5 +684,123 @@ describe('ContextFetcher.fetch', () => {
     const info = await fetcher.fetch(query);
 
     expect(info).toBeNull();
+  });
+
+  describe('capacity mismatch warning', () => {
+    it('warns when SDK capacity differs from metadata by more than 10%', async () => {
+      // Simulates a glm-5.2[1m] regression: PP() would return 200k if the
+      // SDK no longer recognises the [1m] suffix. The metadata still says 1M.
+      // Mismatch = (1M - 200k) / 1M = 80% > 10% → warn.
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          totalTokens: 100_000,
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          model: 'glm-5.2[1m]',
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('mismatch-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'glm-5.2[1m]',
+        contextWindow: 1_000_000,
+        provider: 'glm',
+        preferContextWindowMetadata: true,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [message] = warnSpy.mock.calls[0] as unknown[];
+      expect(String(message)).toContain('Context capacity mismatch');
+      expect(String(message)).toContain('200000');
+      expect(String(message)).toContain('1000000');
+    });
+
+    it('does not warn when SDK capacity matches metadata within 10%', async () => {
+      // Trivial mismatch (e.g. 200k SDK vs 262k metadata = ~23% — should warn).
+      // Use 200k vs 210k (~4.8%) — should NOT warn.
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          totalTokens: 10_000,
+          maxTokens: 210_000,
+          rawMaxTokens: 210_000,
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('match-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'some-model',
+        contextWindow: 200_000,
+        provider: 'custom',
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when metadata is missing', async () => {
+      const getContextUsage = mock(async () => baseResponse({ maxTokens: 200_000 }));
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('no-metadata-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when SDK capacity is zero or unavailable', async () => {
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          maxTokens: 0,
+          rawMaxTokens: 0,
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('no-sdk-capacity-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'some-model',
+        contextWindow: 1_000_000,
+        provider: 'custom',
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for providers opted out of SDK auto-compact (e.g. Kimi)', async () => {
+      // Kimi is in PROVIDER_NO_SDK_AUTO_COMPACT because the SDK's PP() caps
+      // kimi-for-coding to 200k regardless of metadata. A 23% mismatch is the
+      // expected steady state, not a regression — skip the warning so the log
+      // isn't drowned in expected-state noise.
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          totalTokens: 100_000,
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          model: 'kimi-for-coding',
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('kimi-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'kimi-for-coding',
+        contextWindow: 262_144,
+        provider: 'kimi',
+        preferContextWindowMetadata: true,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -238,6 +238,85 @@ describe('ContextFetcher.toContextInfo', () => {
     expect(info.totalCapacity).toBe(272000);
   });
 
+  it('keeps [1m] suffix in context display when effective capacity is 1M', () => {
+    const response = baseResponse({
+      totalTokens: 10000,
+      maxTokens: 1_000_000,
+      rawMaxTokens: 1_000_000,
+      percentage: 1,
+      model: 'glm-5.2[1m]',
+      categories: [{ name: 'Messages', tokens: 10000, color: 'blue' }],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.2[1m]',
+      provider: 'glm',
+      preferContextWindowMetadata: true,
+      contextWindow: 1_000_000,
+    });
+
+    expect(info.model).toBe('glm-5.2[1m]');
+    expect(info.totalCapacity).toBe(1_000_000);
+  });
+
+  it('strips stale [1m] suffix from context display when effective capacity is below 1M', () => {
+    const response = baseResponse({
+      totalTokens: 10000,
+      maxTokens: 200000,
+      rawMaxTokens: 200000,
+      percentage: 5,
+      model: 'glm-5.1[1m]',
+      categories: [{ name: 'Messages', tokens: 10000, color: 'blue' }],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.1',
+      provider: 'glm',
+      preferContextWindowMetadata: true,
+      contextWindow: 200000,
+    });
+
+    expect(info.model).toBe('glm-5.1');
+    expect(info.totalCapacity).toBe(200000);
+  });
+
+  it('strips stale [1m] suffix when raw capacity overreports but effective window is 200k', () => {
+    const response = baseResponse({
+      totalTokens: 10000,
+      maxTokens: 200000,
+      rawMaxTokens: 1_000_000,
+      percentage: 5,
+      model: 'glm-5.1[1m]',
+      categories: [{ name: 'Messages', tokens: 10000, color: 'blue' }],
+    });
+
+    const info = ContextFetcher.toContextInfo(response, {
+      id: 'glm-5.1',
+      provider: 'glm',
+      preferContextWindowMetadata: true,
+      contextWindow: 200000,
+    });
+
+    expect(info.model).toBe('glm-5.1');
+    expect(info.totalCapacity).toBe(200000);
+  });
+
+  it('ignores raw 1M capacity from stale [1m] suffix even without metadata', () => {
+    const response = baseResponse({
+      totalTokens: 10000,
+      maxTokens: 200000,
+      rawMaxTokens: 1_000_000,
+      percentage: 5,
+      model: 'glm-5.1[1m]',
+      categories: [{ name: 'Messages', tokens: 10000, color: 'blue' }],
+    });
+
+    const info = ContextFetcher.toContextInfo(response);
+
+    expect(info.model).toBe('glm-5.1');
+    expect(info.totalCapacity).toBe(200000);
+  });
+
   it('uses Codex model metadata when SDK reports the generic 200k capacity', () => {
     const response = baseResponse({
       totalTokens: 136000,

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -687,15 +687,16 @@ describe('ContextFetcher.fetch', () => {
   });
 
   describe('capacity mismatch warning', () => {
-    it('warns when SDK capacity differs from metadata by more than 10%', async () => {
+    it('warns when SDK effective capacity differs from metadata by >10% for NATIVE providers', async () => {
       // Simulates a glm-5.2[1m] regression: PP() would return 200k if the
-      // SDK no longer recognises the [1m] suffix. The metadata still says 1M.
+      // SDK no longer recognises the [1m] suffix. With CLAUDE_CODE_AUTO_COMPACT_WINDOW
+      // env=1M, effective window=min(200k, 1M)=200k. metadata=1M.
       // Mismatch = (1M - 200k) / 1M = 80% > 10% → warn.
       const getContextUsage = mock(async () =>
         baseResponse({
           totalTokens: 100_000,
           maxTokens: 200_000,
-          rawMaxTokens: 200_000,
+          rawMaxTokens: 1_000_000, // raw PP capacity — should NOT be used
           model: 'glm-5.2[1m]',
         })
       );
@@ -714,13 +715,12 @@ describe('ContextFetcher.fetch', () => {
       expect(warnSpy).toHaveBeenCalledTimes(1);
       const [message] = warnSpy.mock.calls[0] as unknown[];
       expect(String(message)).toContain('Context capacity mismatch');
-      expect(String(message)).toContain('200000');
+      // The warning should reference the effective maxTokens (200k), not raw.
+      expect(String(message)).toContain('reports 200000');
       expect(String(message)).toContain('1000000');
     });
 
-    it('does not warn when SDK capacity matches metadata within 10%', async () => {
-      // Trivial mismatch (e.g. 200k SDK vs 262k metadata = ~23% — should warn).
-      // Use 200k vs 210k (~4.8%) — should NOT warn.
+    it('does not warn when SDK effective capacity matches metadata within 10%', async () => {
       const getContextUsage = mock(async () =>
         baseResponse({
           totalTokens: 10_000,
@@ -736,7 +736,7 @@ describe('ContextFetcher.fetch', () => {
       await fetcher.fetch(query, {
         id: 'some-model',
         contextWindow: 200_000,
-        provider: 'custom',
+        provider: 'glm',
       });
 
       expect(warnSpy).not.toHaveBeenCalled();
@@ -754,11 +754,11 @@ describe('ContextFetcher.fetch', () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('does not warn when SDK capacity is zero or unavailable', async () => {
+    it('does not warn when SDK effective capacity is zero or unavailable', async () => {
       const getContextUsage = mock(async () =>
         baseResponse({
           maxTokens: 0,
-          rawMaxTokens: 0,
+          rawMaxTokens: 1_000_000,
         })
       );
       const query = { getContextUsage } as unknown as Query;
@@ -769,17 +769,15 @@ describe('ContextFetcher.fetch', () => {
       await fetcher.fetch(query, {
         id: 'some-model',
         contextWindow: 1_000_000,
-        provider: 'custom',
+        provider: 'glm',
       });
 
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('does not warn for providers opted out of SDK auto-compact (e.g. Kimi)', async () => {
-      // Kimi is in PROVIDER_NO_SDK_AUTO_COMPACT because the SDK's PP() caps
-      // kimi-for-coding to 200k regardless of metadata. A 23% mismatch is the
-      // expected steady state, not a regression — skip the warning so the log
-      // isn't drowned in expected-state noise.
+    it('does not warn for providers opted out of SDK auto-compact (Kimi)', async () => {
+      // Kimi: PP() caps kimi-for-coding to 200k regardless of metadata.
+      // Mismatch is the expected steady state — skip to avoid log noise.
       const getContextUsage = mock(async () =>
         baseResponse({
           totalTokens: 100_000,
@@ -797,6 +795,59 @@ describe('ContextFetcher.fetch', () => {
         id: 'kimi-for-coding',
         contextWindow: 262_144,
         provider: 'kimi',
+        preferContextWindowMetadata: true,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for non-NATIVE providers (OpenRouter/Ollama/custom)', async () => {
+      // For these providers, SDK PP() returns 200k for unknown models —
+      // mismatch is the known steady state, not a regression.
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          totalTokens: 100_000,
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          model: 'deepseek-v4',
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('openrouter-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'deepseek-v4',
+        contextWindow: 1_000_000,
+        provider: 'openrouter',
+        preferContextWindowMetadata: true,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for Codex when SDK effective window matches metadata', async () => {
+      // Codex gpt-5.5: SDK alias claude-opus-4-7 has PP=1M (rawMaxTokens),
+      // but CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 caps the effective window
+      // to 272k (maxTokens). Comparing effective vs metadata → no mismatch.
+      const getContextUsage = mock(async () =>
+        baseResponse({
+          totalTokens: 100_000,
+          maxTokens: 272_000, // effective
+          rawMaxTokens: 1_000_000, // raw PP capacity — should NOT trigger warning
+          model: 'claude-opus-4-7',
+        })
+      );
+      const query = { getContextUsage } as unknown as Query;
+
+      const fetcher = new ContextFetcher('codex-session');
+      const warnSpy = spyOn(fetcher.logger, 'warn');
+
+      await fetcher.fetch(query, {
+        id: 'gpt-5.5',
+        contextWindow: 272_000,
+        provider: 'anthropic-codex',
         preferContextWindowMetadata: true,
       });
 

--- a/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
@@ -196,50 +196,51 @@ describe('ContextTracker', () => {
         percentUsed: 76,
         breakdown: {},
       });
-      expect(tracker.shouldCompactAt(222_823)).toBe(false);
+      // Kimi 262k threshold = 262144 - 13000 = 249144.
+      expect(tracker.shouldCompactAt(249_144)).toBe(false);
     });
 
     it('returns true when totalUsed is at or above threshold', () => {
       tracker.updateWithDetailedBreakdown({
         model: 'kimi-for-coding',
-        totalUsed: 230_000,
+        totalUsed: 250_000,
         totalCapacity: 262_144,
-        percentUsed: 88,
+        percentUsed: 95,
         breakdown: {},
       });
-      expect(tracker.shouldCompactAt(222_823)).toBe(true);
+      expect(tracker.shouldCompactAt(249_144)).toBe(true);
     });
 
     it('returns false when cooldown has not elapsed', () => {
       tracker.updateWithDetailedBreakdown({
         model: 'kimi-for-coding',
-        totalUsed: 230_000,
+        totalUsed: 250_000,
         totalCapacity: 262_144,
-        percentUsed: 88,
+        percentUsed: 95,
         breakdown: {},
       });
       tracker.markCompactionTriggered();
-      expect(tracker.shouldCompactAt(222_823, 60_000)).toBe(false);
+      expect(tracker.shouldCompactAt(249_144, 60_000)).toBe(false);
     });
 
     it('returns true after cooldown elapses', () => {
       tracker.updateWithDetailedBreakdown({
         model: 'kimi-for-coding',
-        totalUsed: 230_000,
+        totalUsed: 250_000,
         totalCapacity: 262_144,
-        percentUsed: 88,
+        percentUsed: 95,
         breakdown: {},
       });
       tracker.markCompactionTriggered();
-      expect(tracker.shouldCompactAt(222_823, 0)).toBe(true);
+      expect(tracker.shouldCompactAt(249_144, 0)).toBe(true);
     });
 
     it('returns false for invalid threshold', () => {
       tracker.updateWithDetailedBreakdown({
         model: 'kimi-for-coding',
-        totalUsed: 230_000,
+        totalUsed: 250_000,
         totalCapacity: 262_144,
-        percentUsed: 88,
+        percentUsed: 95,
         breakdown: {},
       });
       expect(tracker.shouldCompactAt(0)).toBe(false);
@@ -255,25 +256,37 @@ describe('ContextTracker', () => {
       expect(reserveBasedThreshold(Number.NaN)).toBe(0);
     });
 
-    it('uses 13k SDK reserve when 15% would be smaller (small windows)', () => {
-      // 80k window: 15% = 12k. max(13k, 12k) = 13k. Threshold = 80k - 13k = 67k.
-      expect(reserveBasedThreshold(80_000)).toBe(67_000);
+    it('uses the SDK 13k reserve for windows where 10% would exceed it', () => {
+      // 200k window: 10% = 20k > 13k. Reserve = min(13k, 20k) = 13k.
+      // Threshold = 200k - 13k = 187k. Matches the SDK's own trigger.
+      expect(reserveBasedThreshold(200_000)).toBe(187_000);
+      // 1M window: 10% = 100k > 13k. Threshold = 1M - 13k = 987k.
+      expect(reserveBasedThreshold(1_000_000)).toBe(987_000);
     });
 
-    it('uses 15% reserve when larger than 13k (large windows)', () => {
-      // 200k window: 15% = 30k. max(13k, 30k) = 30k. Threshold = 200k - 30k = 170k.
-      expect(reserveBasedThreshold(200_000)).toBe(170_000);
-      // 1M window: 15% = 150k. Threshold = 1M - 150k = 850k.
-      expect(reserveBasedThreshold(1_000_000)).toBe(850_000);
+    it('uses a proportional 10% reserve for small windows', () => {
+      // 80k window: 10% = 8k < 13k. Reserve = min(13k, 8k) = 8k.
+      // Threshold = 80k - 8k = 72k.
+      expect(reserveBasedThreshold(80_000)).toBe(72_000);
+      // 8k window (custom endpoint): 10% = 800. Threshold = 8k - 800 = 7200.
+      expect(reserveBasedThreshold(8_000)).toBe(7_200);
     });
 
-    it('uses 15% reserve for Kimi 262k window', () => {
-      // 262144 * 0.15 = 39321.6 → 39321. Threshold = 262144 - 39321 = 222823.
-      expect(reserveBasedThreshold(262_144)).toBe(222_823);
+    it('clamps the threshold to at least 1 for tiny windows', () => {
+      // Pathological case: very tiny window where reserve > window would
+      // produce 0 or negative. Clamp to 1 so shouldCompactAt still fires.
+      expect(reserveBasedThreshold(100)).toBe(90); // 100 - min(13k, 10) = 100 - 10 = 90
+      expect(reserveBasedThreshold(1)).toBe(1); // 1 - min(13k, 0) = 1 - 0 = 1 (floored)
     });
 
-    it('uses 15% reserve for GLM 1M window', () => {
-      expect(reserveBasedThreshold(1_000_000)).toBe(850_000);
+    it('matches SDK trigger for Kimi 262k window', () => {
+      // Kimi: SDK auto-compact disabled, NeoKai is sole path. Use the same
+      // reserve the SDK would have used so NeoKai fires at the same point.
+      expect(reserveBasedThreshold(262_144)).toBe(249_144);
+    });
+
+    it('matches SDK trigger for GLM 1M window', () => {
+      expect(reserveBasedThreshold(1_000_000)).toBe(987_000);
     });
   });
 });

--- a/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it, beforeEach, mock } from 'bun:test';
-import { ContextTracker } from '../../../../src/lib/agent/context-tracker';
+import { ContextTracker, reserveBasedThreshold } from '../../../../src/lib/agent/context-tracker';
 import type { ContextInfo } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 
@@ -180,6 +180,100 @@ describe('ContextTracker', () => {
       });
       expect(tracker.shouldCompact(0)).toBe(false);
       expect(tracker.shouldCompact(-1)).toBe(false);
+    });
+  });
+
+  describe('shouldCompactAt', () => {
+    it('returns false when no context info exists', () => {
+      expect(tracker.shouldCompactAt(100_000)).toBe(false);
+    });
+
+    it('returns false when totalUsed is below threshold', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'kimi-for-coding',
+        totalUsed: 200_000,
+        totalCapacity: 262_144,
+        percentUsed: 76,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompactAt(222_823)).toBe(false);
+    });
+
+    it('returns true when totalUsed is at or above threshold', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'kimi-for-coding',
+        totalUsed: 230_000,
+        totalCapacity: 262_144,
+        percentUsed: 88,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompactAt(222_823)).toBe(true);
+    });
+
+    it('returns false when cooldown has not elapsed', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'kimi-for-coding',
+        totalUsed: 230_000,
+        totalCapacity: 262_144,
+        percentUsed: 88,
+        breakdown: {},
+      });
+      tracker.markCompactionTriggered();
+      expect(tracker.shouldCompactAt(222_823, 60_000)).toBe(false);
+    });
+
+    it('returns true after cooldown elapses', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'kimi-for-coding',
+        totalUsed: 230_000,
+        totalCapacity: 262_144,
+        percentUsed: 88,
+        breakdown: {},
+      });
+      tracker.markCompactionTriggered();
+      expect(tracker.shouldCompactAt(222_823, 0)).toBe(true);
+    });
+
+    it('returns false for invalid threshold', () => {
+      tracker.updateWithDetailedBreakdown({
+        model: 'kimi-for-coding',
+        totalUsed: 230_000,
+        totalCapacity: 262_144,
+        percentUsed: 88,
+        breakdown: {},
+      });
+      expect(tracker.shouldCompactAt(0)).toBe(false);
+      expect(tracker.shouldCompactAt(-1)).toBe(false);
+      expect(tracker.shouldCompactAt(Number.NaN)).toBe(false);
+    });
+  });
+
+  describe('reserveBasedThreshold', () => {
+    it('returns 0 for invalid context windows', () => {
+      expect(reserveBasedThreshold(0)).toBe(0);
+      expect(reserveBasedThreshold(-1)).toBe(0);
+      expect(reserveBasedThreshold(Number.NaN)).toBe(0);
+    });
+
+    it('uses 13k SDK reserve when 15% would be smaller (small windows)', () => {
+      // 80k window: 15% = 12k. max(13k, 12k) = 13k. Threshold = 80k - 13k = 67k.
+      expect(reserveBasedThreshold(80_000)).toBe(67_000);
+    });
+
+    it('uses 15% reserve when larger than 13k (large windows)', () => {
+      // 200k window: 15% = 30k. max(13k, 30k) = 30k. Threshold = 200k - 30k = 170k.
+      expect(reserveBasedThreshold(200_000)).toBe(170_000);
+      // 1M window: 15% = 150k. Threshold = 1M - 150k = 850k.
+      expect(reserveBasedThreshold(1_000_000)).toBe(850_000);
+    });
+
+    it('uses 15% reserve for Kimi 262k window', () => {
+      // 262144 * 0.15 = 39321.6 → 39321. Threshold = 262144 - 39321 = 222823.
+      expect(reserveBasedThreshold(262_144)).toBe(222_823);
+    });
+
+    it('uses 15% reserve for GLM 1M window', () => {
+      expect(reserveBasedThreshold(1_000_000)).toBe(850_000);
     });
   });
 });

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -204,21 +204,19 @@ describe('QueryOptionsBuilder', () => {
   });
 
   describe('provider settings', () => {
-    it('should disable SDK auto-compaction for Codex bridge without model context', () => {
-      expect(buildProviderSettings('anthropic-codex')).toEqual({
-        autoCompactEnabled: false,
-      });
-    });
-
     it('should not override SDK auto-compaction settings for native anthropic provider', () => {
       expect(buildProviderSettings('anthropic')).toBeUndefined();
     });
 
-    it('should enable SDK auto-compaction for all non-native providers with context windows', () => {
-      expect(buildProviderSettings('anthropic-codex', 128_000)).toEqual({
-        autoCompactEnabled: true,
-        autoCompactWindow: 128_000,
-      });
+    it('should not override SDK auto-compaction for anthropic-codex (handled natively)', () => {
+      // anthropic-codex routes through recognised Anthropic model IDs whose
+      // PP() capacities cover the real Codex windows, so SDK auto-compact is
+      // trusted. Belt-and-suspenders with CLAUDE_CODE_AUTO_COMPACT_WINDOW env.
+      expect(buildProviderSettings('anthropic-codex')).toBeUndefined();
+      expect(buildProviderSettings('anthropic-codex', 272_000)).toBeUndefined();
+    });
+
+    it('should enable SDK auto-compaction for non-native providers with context windows', () => {
       expect(buildProviderSettings('openrouter', 1_000_000)).toEqual({
         autoCompactEnabled: true,
         autoCompactWindow: 1_000_000,
@@ -239,10 +237,17 @@ describe('QueryOptionsBuilder', () => {
       });
     });
 
-    it('should enable SDK auto-compaction for Kimi with its known window', () => {
+    it('should disable SDK auto-compaction for Kimi (PP() caps at 200k, NeoKai fallback instead)', () => {
+      // The SDK's PP() returns 200k for 'kimi-for-coding'. Even with the
+      // autoCompactWindow setting, the SDK's effective window would be
+      // min(200k, 262k) = 200k, firing compaction at ~187k instead of ~249k.
+      // We disable SDK auto-compact entirely and let NeoKai's fallback
+      // (sdk-message-handler) trigger compaction at the correct threshold.
       expect(buildProviderSettings('kimi')).toEqual({
-        autoCompactEnabled: true,
-        autoCompactWindow: 262_144,
+        autoCompactEnabled: false,
+      });
+      expect(buildProviderSettings('kimi', 262_144)).toEqual({
+        autoCompactEnabled: false,
       });
     });
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -216,14 +216,23 @@ describe('QueryOptionsBuilder', () => {
       expect(buildProviderSettings('anthropic-codex', 272_000)).toBeUndefined();
     });
 
+    it('should not override SDK auto-compaction for GLM (env var + [1m] suffix configures SDK correctly)', () => {
+      // GLM sets CLAUDE_CODE_AUTO_COMPACT_WINDOW per model in buildSdkConfig,
+      // and the [1m] suffix on glm-5.2[1m] is recognised by PP(). The SDK's
+      // effective window matches metadata, so SDK auto-compact fires at the
+      // correct threshold. If [1m] recognition regresses, the context-fetcher
+      // capacity-mismatch warning surfaces it. We must NOT enable NeoKai
+      // fallback here — it would fire at 850k (reserveBasedThreshold(1M)) and
+      // preempt the SDK's correct ~987k trigger, cutting off 137k of the
+      // advertised 1M context.
+      expect(buildProviderSettings('glm')).toBeUndefined();
+      expect(buildProviderSettings('glm', 1_000_000)).toBeUndefined();
+    });
+
     it('should enable SDK auto-compaction for non-native providers with context windows', () => {
       expect(buildProviderSettings('openrouter', 1_000_000)).toEqual({
         autoCompactEnabled: true,
         autoCompactWindow: 1_000_000,
-      });
-      expect(buildProviderSettings('glm', 128_000)).toEqual({
-        autoCompactEnabled: true,
-        autoCompactWindow: 128_000,
       });
       expect(buildProviderSettings('ollama', 32_000)).toEqual({
         autoCompactEnabled: true,

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -1342,11 +1342,11 @@ describe('SDKMessageHandler', () => {
         setModelsCache(new Map());
       });
 
-      it('enqueues /compact for non-native provider above reserve threshold even when SDK reports auto-compact enabled', async () => {
-        // Regression: OpenRouter and other non-native providers may report
-        // isAutoCompactEnabled=true from the SDK, but the SDK's auto-compact
-        // isn't reliable for unknown model IDs. NeoKai must still fire as a
-        // safety net at the higher reserve-based threshold.
+      it('does not enqueue /compact for non-PROVIDER_NO_SDK_AUTO_COMPACT providers (SDK handles)', async () => {
+        // OpenRouter is NOT in PROVIDER_NO_SDK_AUTO_COMPACT — its SDK
+        // auto-compact is enabled via Options.settings.autoCompactWindow.
+        // NeoKai must not preempt the SDK's own trigger, even when context is
+        // near capacity and even when the SDK reports isAutoCompactEnabled=true.
         setModelsCache(
           new Map([
             [
@@ -1404,76 +1404,12 @@ describe('SDKMessageHandler', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
-        expect(mockContextTracker.shouldCompactAt).toHaveBeenCalledWith(850_000);
-        expect(mockContextTracker.markCompactionTriggered).toHaveBeenCalled();
-        expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
-      });
-
-      it('does not enqueue /compact for non-native provider below reserve threshold', async () => {
-        // totalUsed=800k vs contextWindow=1M. Reserve = max(13k, 150k) = 150k.
-        // Threshold = 850k. 800k < 850k → NeoKai does not fire.
-        setModelsCache(
-          new Map([
-            [
-              'global',
-              [
-                {
-                  id: 'deepseek-v4',
-                  name: 'DeepSeek V4',
-                  provider: 'openrouter',
-                  contextWindow: 1_000_000,
-                  available: true,
-                },
-              ],
-            ],
-          ])
-        );
-
-        const getContextUsageSpy = mock(async () => ({
-          categories: [{ name: 'Messages', tokens: 800_000 }],
-          totalTokens: 800_000,
-          maxTokens: 1_000_000,
-          rawMaxTokens: 1_000_000,
-          percentage: 80,
-          gridRows: [],
-          model: 'deepseek-v4',
-          memoryFiles: [],
-          mcpTools: [],
-          agents: [],
-          isAutoCompactEnabled: true,
-          apiUsage: null,
-        }));
-
-        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
-        mockContext.session.config.provider = 'openrouter';
-        mockContext.session.config.model = 'deepseek-v4';
-        mockContextTracker.shouldCompactAt = mock(() => false);
-
-        const h = new SDKMessageHandler(mockContext);
-
-        const resultMessage: SDKMessage = {
-          type: 'result',
-          subtype: 'success',
-          uuid: 'result-uuid',
-          usage: {
-            input_tokens: 10,
-            output_tokens: 5,
-            cache_read_input_tokens: 0,
-            cache_creation_input_tokens: 0,
-          },
-          total_cost_usd: 0.001,
-          modelUsage: {},
-        } as unknown as SDKMessage;
-
-        await h.handleMessage(resultMessage);
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
-        expect(mockContextTracker.markCompactionTriggered).not.toHaveBeenCalled();
+        expect(mockContextTracker.shouldCompactAt).not.toHaveBeenCalled();
         expect(enqueueMessageSpy).not.toHaveBeenCalledWith('/compact', true);
       });
 
-      it('handles rejected fallback /compact enqueue', async () => {
+      it('does not enqueue /compact for custom-provider sessions (SDK handles via Options.settings)', async () => {
+        // custom-provider is not in PROVIDER_NO_SDK_AUTO_COMPACT either.
         setModelsCache(
           new Map([
             [
@@ -1510,6 +1446,70 @@ describe('SDKMessageHandler', () => {
         mockContext.session.config.provider = 'custom-provider';
         mockContext.session.config.model = 'fallback-model';
         mockContextTracker.shouldCompactAt = mock(() => true);
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(mockContextTracker.shouldCompactAt).not.toHaveBeenCalled();
+        expect(enqueueMessageSpy).not.toHaveBeenCalledWith('/compact', true);
+      });
+
+      it('handles rejected fallback /compact enqueue for Kimi', async () => {
+        // Kimi IS in PROVIDER_NO_SDK_AUTO_COMPACT, so NeoKai fires. Simulate
+        // the message queue rejecting the enqueue and verify the handler
+        // doesn't throw.
+        setModelsCache(
+          new Map([
+            [
+              'global',
+              [
+                {
+                  id: 'kimi-for-coding',
+                  name: 'Kimi For Coding',
+                  provider: 'kimi',
+                  contextWindow: 262_144,
+                  available: true,
+                },
+              ],
+            ],
+          ])
+        );
+
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 250_000 }],
+          totalTokens: 250_000,
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          percentage: 100,
+          gridRows: [],
+          model: 'kimi-for-coding',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: false,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'kimi';
+        mockContext.session.config.model = 'kimi-for-coding';
+        mockContextTracker.shouldCompactAt = mock(() => true);
         enqueueMessageSpy = mock(async () => {
           throw new Error('queue stopped');
         });
@@ -1539,8 +1539,7 @@ describe('SDKMessageHandler', () => {
 
       it('does not enqueue /compact for native anthropic provider (SDK handles)', async () => {
         // Native Anthropic provider: SDK auto-compact works correctly, so
-        // NeoKai fallback is not installed. Verify no /compact enqueue even
-        // when context is near capacity.
+        // NeoKai fallback is not installed.
         setModelsCache(
           new Map([
             [
@@ -1618,7 +1617,9 @@ describe('SDKMessageHandler', () => {
         }));
 
         mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
-        mockContext.session.config.provider = 'openrouter';
+        // kimi is in PROVIDER_NO_SDK_AUTO_COMPACT, but model info lookup
+        // fails so NeoKai cannot compute a threshold.
+        mockContext.session.config.provider = 'kimi';
         mockContext.session.config.model = 'unknown-model';
 
         const h = new SDKMessageHandler(mockContext);
@@ -1647,7 +1648,7 @@ describe('SDKMessageHandler', () => {
       it('enqueues /compact for Kimi (SDK auto-compact disabled, NeoKai fallback)', async () => {
         // Kimi: SDK auto-compact is disabled because PP() caps kimi-for-coding
         // to 200k while the real window is 262k. NeoKai fallback must fire at
-        // reserveBasedThreshold(262144) = 262144 - max(13k, ~39k) = ~223k.
+        // reserveBasedThreshold(262144) = 262144 - 13000 = 249144.
         setModelsCache(
           new Map([
             [
@@ -1667,8 +1668,8 @@ describe('SDKMessageHandler', () => {
         );
 
         const getContextUsageSpy = mock(async () => ({
-          categories: [{ name: 'Messages', tokens: 230_000 }],
-          totalTokens: 230_000,
+          categories: [{ name: 'Messages', tokens: 250_000 }],
+          totalTokens: 250_000,
           // SDK reports the 200k PP fallback — display layer should override
           // to 262k via preferContextWindowMetadata.
           maxTokens: 200_000,
@@ -1708,8 +1709,8 @@ describe('SDKMessageHandler', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
-        // reserveBasedThreshold(262144) = 262144 - 39321 = 222823
-        expect(mockContextTracker.shouldCompactAt).toHaveBeenCalledWith(222_823);
+        // reserveBasedThreshold(262144) = 262144 - 13000 = 249144
+        expect(mockContextTracker.shouldCompactAt).toHaveBeenCalledWith(249_144);
         expect(mockContextTracker.markCompactionTriggered).toHaveBeenCalled();
         expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
       });

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -134,6 +134,7 @@ describe('SDKMessageHandler', () => {
       getContextInfo: getContextInfoSpy,
       updateWithDetailedBreakdown: updateWithDetailedBreakdownSpy,
       shouldCompact: mock(() => false),
+      shouldCompactAt: mock(() => false),
       markCompactionTriggered: mock(() => {}),
     } as unknown as ContextTracker;
 
@@ -1341,7 +1342,11 @@ describe('SDKMessageHandler', () => {
         setModelsCache(new Map());
       });
 
-      it('does not enqueue /compact when non-native provider exceeds 85% threshold', async () => {
+      it('enqueues /compact for non-native provider above reserve threshold even when SDK reports auto-compact enabled', async () => {
+        // Regression: OpenRouter and other non-native providers may report
+        // isAutoCompactEnabled=true from the SDK, but the SDK's auto-compact
+        // isn't reliable for unknown model IDs. NeoKai must still fire as a
+        // safety net at the higher reserve-based threshold.
         setModelsCache(
           new Map([
             [
@@ -1377,7 +1382,7 @@ describe('SDKMessageHandler', () => {
         mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
         mockContext.session.config.provider = 'openrouter';
         mockContext.session.config.model = 'deepseek-v4';
-        mockContextTracker.shouldCompact = mock(() => true);
+        mockContextTracker.shouldCompactAt = mock(() => true);
 
         const h = new SDKMessageHandler(mockContext);
 
@@ -1399,7 +1404,72 @@ describe('SDKMessageHandler', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
-        expect(mockContextTracker.shouldCompact).not.toHaveBeenCalled();
+        expect(mockContextTracker.shouldCompactAt).toHaveBeenCalledWith(850_000);
+        expect(mockContextTracker.markCompactionTriggered).toHaveBeenCalled();
+        expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
+      });
+
+      it('does not enqueue /compact for non-native provider below reserve threshold', async () => {
+        // totalUsed=800k vs contextWindow=1M. Reserve = max(13k, 150k) = 150k.
+        // Threshold = 850k. 800k < 850k → NeoKai does not fire.
+        setModelsCache(
+          new Map([
+            [
+              'global',
+              [
+                {
+                  id: 'deepseek-v4',
+                  name: 'DeepSeek V4',
+                  provider: 'openrouter',
+                  contextWindow: 1_000_000,
+                  available: true,
+                },
+              ],
+            ],
+          ])
+        );
+
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 800_000 }],
+          totalTokens: 800_000,
+          maxTokens: 1_000_000,
+          rawMaxTokens: 1_000_000,
+          percentage: 80,
+          gridRows: [],
+          model: 'deepseek-v4',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: true,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'openrouter';
+        mockContext.session.config.model = 'deepseek-v4';
+        mockContextTracker.shouldCompactAt = mock(() => false);
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
+        expect(mockContextTracker.markCompactionTriggered).not.toHaveBeenCalled();
         expect(enqueueMessageSpy).not.toHaveBeenCalledWith('/compact', true);
       });
 
@@ -1439,7 +1509,7 @@ describe('SDKMessageHandler', () => {
         mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
         mockContext.session.config.provider = 'custom-provider';
         mockContext.session.config.model = 'fallback-model';
-        mockContextTracker.shouldCompact = mock(() => true);
+        mockContextTracker.shouldCompactAt = mock(() => true);
         enqueueMessageSpy = mock(async () => {
           throw new Error('queue stopped');
         });
@@ -1467,7 +1537,10 @@ describe('SDKMessageHandler', () => {
         expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
       });
 
-      it('does not enqueue /compact for providers with native auto-compaction', async () => {
+      it('does not enqueue /compact for native anthropic provider (SDK handles)', async () => {
+        // Native Anthropic provider: SDK auto-compact works correctly, so
+        // NeoKai fallback is not installed. Verify no /compact enqueue even
+        // when context is near capacity.
         setModelsCache(
           new Map([
             [
@@ -1501,8 +1574,8 @@ describe('SDKMessageHandler', () => {
         }));
 
         mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
-        mockContext.session.config.provider = 'kimi';
-        mockContext.session.config.model = 'kimi-for-coding';
+        mockContext.session.config.provider = 'anthropic';
+        mockContext.session.config.model = 'sonnet';
 
         const h = new SDKMessageHandler(mockContext);
 
@@ -1524,7 +1597,8 @@ describe('SDKMessageHandler', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
-        expect(enqueueMessageSpy).not.toHaveBeenCalled();
+        expect(mockContextTracker.shouldCompactAt).not.toHaveBeenCalled();
+        expect(enqueueMessageSpy).not.toHaveBeenCalledWith('/compact', true);
       });
 
       it('does not enqueue /compact when model info is missing', async () => {
@@ -1568,6 +1642,76 @@ describe('SDKMessageHandler', () => {
 
         expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
         expect(enqueueMessageSpy).not.toHaveBeenCalled();
+      });
+
+      it('enqueues /compact for Kimi (SDK auto-compact disabled, NeoKai fallback)', async () => {
+        // Kimi: SDK auto-compact is disabled because PP() caps kimi-for-coding
+        // to 200k while the real window is 262k. NeoKai fallback must fire at
+        // reserveBasedThreshold(262144) = 262144 - max(13k, ~39k) = ~223k.
+        setModelsCache(
+          new Map([
+            [
+              'global',
+              [
+                {
+                  id: 'kimi-for-coding',
+                  name: 'Kimi For Coding',
+                  provider: 'kimi',
+                  contextWindow: 262_144,
+                  preferContextWindowMetadata: true,
+                  available: true,
+                },
+              ],
+            ],
+          ])
+        );
+
+        const getContextUsageSpy = mock(async () => ({
+          categories: [{ name: 'Messages', tokens: 230_000 }],
+          totalTokens: 230_000,
+          // SDK reports the 200k PP fallback — display layer should override
+          // to 262k via preferContextWindowMetadata.
+          maxTokens: 200_000,
+          rawMaxTokens: 200_000,
+          percentage: 100,
+          gridRows: [],
+          model: 'kimi-for-coding',
+          memoryFiles: [],
+          mcpTools: [],
+          agents: [],
+          isAutoCompactEnabled: false,
+          apiUsage: null,
+        }));
+
+        mockContext.queryObject = { getContextUsage: getContextUsageSpy } as never;
+        mockContext.session.config.provider = 'kimi';
+        mockContext.session.config.model = 'kimi-for-coding';
+        mockContextTracker.shouldCompactAt = mock(() => true);
+
+        const h = new SDKMessageHandler(mockContext);
+
+        const resultMessage: SDKMessage = {
+          type: 'result',
+          subtype: 'success',
+          uuid: 'result-uuid',
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          total_cost_usd: 0.001,
+          modelUsage: {},
+        } as unknown as SDKMessage;
+
+        await h.handleMessage(resultMessage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(getContextUsageSpy).toHaveBeenCalledTimes(1);
+        // reserveBasedThreshold(262144) = 262144 - 39321 = 222823
+        expect(mockContextTracker.shouldCompactAt).toHaveBeenCalledWith(222_823);
+        expect(mockContextTracker.markCompactionTriggered).toHaveBeenCalled();
+        expect(enqueueMessageSpy).toHaveBeenCalledWith('/compact', true);
       });
     });
 

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -139,6 +139,7 @@ describe('GlmProvider', () => {
         ANTHROPIC_AUTH_TOKEN: 'test-key',
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: '200000',
         ANTHROPIC_DEFAULT_HAIKU_MODEL: 'glm-5',
         ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-5',
         ANTHROPIC_DEFAULT_OPUS_MODEL: 'glm-5',
@@ -174,6 +175,32 @@ describe('GlmProvider', () => {
       expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5.2[1m]');
       expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5.2[1m]');
       expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.2[1m]');
+    });
+
+    it('should set CLAUDE_CODE_AUTO_COMPACT_WINDOW per model context window', () => {
+      process.env.GLM_API_KEY = 'test-key';
+
+      // glm-5.2[1m] has a 1M context window — env var must reflect it so the
+      // SDK's auto-compact threshold matches the real capacity (otherwise the
+      // SDK would cap to its 200k fallback for unknown models).
+      expect(provider.buildSdkConfig('glm-5.2').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '1000000'
+      );
+      expect(provider.buildSdkConfig('glm-5').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '200000'
+      );
+      expect(provider.buildSdkConfig('glm-5.1').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '200000'
+      );
+      expect(provider.buildSdkConfig('glm-5-turbo').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '200000'
+      );
+      expect(provider.buildSdkConfig('glm-5v-turbo').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '200000'
+      );
+      expect(provider.buildSdkConfig('glm-4.7').envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        '200000'
+      );
     });
 
     it('should build correct config for glm-5-turbo', () => {
@@ -277,10 +304,21 @@ describe('GlmProvider', () => {
         family: 'glm',
         provider: 'glm',
         contextWindow: 1_000_000,
+        preferContextWindowMetadata: true,
         description: 'GLM-5.2 · 1M context window, recommended thinking mode "max"',
         releaseDate: '2026-06-10',
         available: true,
       });
+    });
+
+    it('should mark every GLM model with preferContextWindowMetadata', () => {
+      // GLM IDs are unknown to the SDK's PP() helper. The context-fetcher must
+      // trust this metadata for the context bar instead of falling back to the
+      // SDK's reported capacity (which is the generic 200k fallback for unknown
+      // IDs and doesn't reflect the real GLM window).
+      for (const model of GlmProvider.MODELS) {
+        expect(model.preferContextWindowMetadata).toBe(true);
+      }
     });
 
     it('should have correct glm-5-turbo model definition', () => {

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -203,6 +203,24 @@ describe('GlmProvider', () => {
       );
     });
 
+    it('should route uppercase model IDs through the same lookup as lowercase', () => {
+      // Regression: without normalising case, "GLM-5.2" bypassed the
+      // glm-5.2 → [1m] shortcut, fell through to verbatim routing, missed
+      // the context-window lookup, and silently fell back to 200k.
+      process.env.GLM_API_KEY = 'test-key';
+
+      const upperConfig = provider.buildSdkConfig('GLM-5.2');
+      const lowerConfig = provider.buildSdkConfig('glm-5.2');
+      expect(upperConfig.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
+        lowerConfig.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL
+      );
+      expect(upperConfig.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5.2[1m]');
+      expect(upperConfig.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe(
+        lowerConfig.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW
+      );
+      expect(upperConfig.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000');
+    });
+
     it('should build correct config for glm-5-turbo', () => {
       process.env.GLM_API_KEY = 'test-key';
 

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -221,6 +221,17 @@ describe('GlmProvider', () => {
       expect(upperConfig.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000');
     });
 
+    it('should ignore [1m] suffix for non-1M GLM models', () => {
+      process.env.GLM_API_KEY = 'test-key';
+
+      const config = provider.buildSdkConfig('glm-5.1[1m]');
+
+      expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5.1');
+      expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5.1');
+      expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.1');
+      expect(config.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('200000');
+    });
+
     it('should build correct config for glm-5-turbo', () => {
       process.env.GLM_API_KEY = 'test-key';
 

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -180,7 +180,13 @@ describe('KimiProvider', () => {
       expect(config.envVars.ANTHROPIC_API_KEY).toBe('');
       expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('');
       expect(config.envVars.API_TIMEOUT_MS).toBe('3000000');
-      expect(config.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('262144');
+      // CLAUDE_CODE_AUTO_COMPACT_WINDOW intentionally NOT set for Kimi. The
+      // SDK's PP() caps unknown model IDs (kimi-for-coding) to 200k, so even
+      // with this env var the effective window would be min(200k, 262k) = 200k
+      // and SDK auto-compact would fire at ~187k — 60k too early. SDK
+      // auto-compact is disabled via Options.settings; NeoKai's fallback
+      // trigger handles compaction at the correct 85% of the real 262k window.
+      expect(config.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
       expect(config.envVars.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe('1');
       expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('kimi-for-coding');
       expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('kimi-for-coding');
@@ -312,6 +318,12 @@ describe('KimiProvider', () => {
       expect(KimiProvider.MODELS.find((m) => m.id === 'kimi-for-coding')?.contextWindow).toBe(
         262144
       );
+    });
+
+    it('should mark Kimi model with preferContextWindowMetadata', () => {
+      // The SDK's PP() caps kimi-for-coding to 200k, but the real window is
+      // 262k. The context-fetcher must trust metadata for the context bar.
+      expect(KimiProvider.MODELS[0].preferContextWindowMetadata).toBe(true);
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -326,14 +326,15 @@ describe('KimiProvider', () => {
       expect(KimiProvider.MODELS[0].preferContextWindowMetadata).toBe(true);
     });
 
-    it('should expose moonshot-* aliases via sdkModelIds', () => {
+    it('should expose moonshot-* provider aliases via providerAliases', () => {
       // KimiProvider.ownsModel accepts moonshot-* IDs but model-service
-      // lookups go through findInModels which only checks id/alias/sdkModelIds.
-      // Without sdkModelIds, sessions stored with a moonshot-* ID have null
+      // lookups go through findInModels which checks id/alias/providerAliases.
+      // Without providerAliases, sessions stored with a moonshot-* ID have null
       // modelInfo and NeoKai fallback compaction can't compute a threshold.
-      const sdkModelIds = KimiProvider.MODELS[0].sdkModelIds ?? [];
-      expect(sdkModelIds).toContain('moonshot-v1-32k');
-      expect(sdkModelIds).toContain('moonshot-v1-8k');
+      const providerAliases = KimiProvider.MODELS[0].providerAliases ?? [];
+      expect(providerAliases).toContain('moonshot-v1-32k');
+      expect(providerAliases).toContain('moonshot-v1-8k');
+      expect(providerAliases).toContain('KIMI');
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -325,6 +325,16 @@ describe('KimiProvider', () => {
       // 262k. The context-fetcher must trust metadata for the context bar.
       expect(KimiProvider.MODELS[0].preferContextWindowMetadata).toBe(true);
     });
+
+    it('should expose moonshot-* aliases via sdkModelIds', () => {
+      // KimiProvider.ownsModel accepts moonshot-* IDs but model-service
+      // lookups go through findInModels which only checks id/alias/sdkModelIds.
+      // Without sdkModelIds, sessions stored with a moonshot-* ID have null
+      // modelInfo and NeoKai fallback compaction can't compute a threshold.
+      const sdkModelIds = KimiProvider.MODELS[0].sdkModelIds ?? [];
+      expect(sdkModelIds).toContain('moonshot-v1-32k');
+      expect(sdkModelIds).toContain('moonshot-v1-8k');
+    });
   });
 
   describe('getTitleGenerationModel', () => {

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -326,15 +326,16 @@ describe('KimiProvider', () => {
       expect(KimiProvider.MODELS[0].preferContextWindowMetadata).toBe(true);
     });
 
-    it('should expose moonshot-* provider aliases via providerAliases', () => {
-      // KimiProvider.ownsModel accepts moonshot-* IDs but model-service
-      // lookups go through findInModels which checks id/alias/providerAliases.
-      // Without providerAliases, sessions stored with a moonshot-* ID have null
-      // modelInfo and NeoKai fallback compaction can't compute a threshold.
+    it('should expose moonshot-* provider aliases via providerAliasPrefixes', () => {
+      // KimiProvider.ownsModel accepts any moonshot-* ID but model-service
+      // lookups go through findInModels which checks id/alias/providerAliases/
+      // providerAliasPrefixes. Without the prefix, sessions stored with a
+      // moonshot-* ID have null modelInfo and NeoKai fallback compaction can't
+      // compute a threshold.
       const providerAliases = KimiProvider.MODELS[0].providerAliases ?? [];
-      expect(providerAliases).toContain('moonshot-v1-32k');
-      expect(providerAliases).toContain('moonshot-v1-8k');
+      const providerAliasPrefixes = KimiProvider.MODELS[0].providerAliasPrefixes ?? [];
       expect(providerAliases).toContain('KIMI');
+      expect(providerAliasPrefixes).toContain('moonshot-');
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -180,13 +180,13 @@ describe('KimiProvider', () => {
       expect(config.envVars.ANTHROPIC_API_KEY).toBe('');
       expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('');
       expect(config.envVars.API_TIMEOUT_MS).toBe('3000000');
-      // CLAUDE_CODE_AUTO_COMPACT_WINDOW intentionally NOT set for Kimi. The
-      // SDK's PP() caps unknown model IDs (kimi-for-coding) to 200k, so even
-      // with this env var the effective window would be min(200k, 262k) = 200k
-      // and SDK auto-compact would fire at ~187k — 60k too early. SDK
-      // auto-compact is disabled via Options.settings; NeoKai's fallback
-      // trigger handles compaction at the correct 85% of the real 262k window.
-      expect(config.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+      // CLAUDE_CODE_AUTO_COMPACT_WINDOW is explicitly cleared (empty string)
+      // so a previous GLM/Codex query's value cannot leak into Kimi's SDK
+      // subprocess. The SDK's PP() caps kimi-for-coding to 200k regardless,
+      // so an inherited 262144 would still cap to 200k and fire ~60k too
+      // early. SDK auto-compact is disabled via Options.settings; NeoKai's
+      // fallback trigger handles compaction at the correct 85% of 262k.
+      expect(config.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('');
       expect(config.envVars.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe('1');
       expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('kimi-for-coding');
       expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('kimi-for-coding');

--- a/packages/daemon/tests/unit/4-space-storage/model-service-provider-routing.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/model-service-provider-routing.test.ts
@@ -87,6 +87,8 @@ const codexModels: ModelInfo[] = [
     id: 'gpt-5.3-codex',
     name: 'GPT-5.3 Codex',
     alias: 'codex',
+    // SDK-only bridge alias. This must NOT become user-selectable/provider-accepted.
+    sdkModelIds: ['claude-opus-4-7'],
     family: 'gpt',
     provider: 'anthropic-codex',
     contextWindow: 200000,
@@ -94,8 +96,26 @@ const codexModels: ModelInfo[] = [
   },
 ];
 
-// All models from all three providers in one flat list (simulates populated cache)
-const allModels: ModelInfo[] = [...anthropicModels, ...copilotModels, ...codexModels];
+const kimiModels: ModelInfo[] = [
+  {
+    id: 'kimi-for-coding',
+    name: 'Kimi For Coding',
+    alias: 'kimi',
+    providerAliases: ['KIMI', 'Moonshot-v1-32k', 'moonshot-v1-8k'],
+    family: 'kimi',
+    provider: 'kimi',
+    contextWindow: 262144,
+    available: true,
+  },
+];
+
+// All models from all providers in one flat list (simulates populated cache)
+const allModels: ModelInfo[] = [
+  ...anthropicModels,
+  ...copilotModels,
+  ...codexModels,
+  ...kimiModels,
+];
 
 describe('Model Service — provider routing', () => {
   beforeEach(() => {
@@ -145,6 +165,26 @@ describe('Model Service — provider routing', () => {
       expect(model?.provider).toBe('anthropic-codex');
     });
 
+    it('does not treat Codex SDK-only model IDs as provider-accepted aliases', async () => {
+      const model = await getModelInfo('claude-opus-4-7', 'global', 'anthropic-codex');
+      expect(model).toBeNull();
+    });
+
+    it('resolves Kimi provider aliases case-insensitively to canonical metadata', async () => {
+      const byUpperAlias = await getModelInfo('KIMI', 'global', 'kimi');
+      const byMoonshotAlias = await getModelInfo('Moonshot-v1-32k', 'global', 'kimi');
+
+      expect(byUpperAlias?.id).toBe('kimi-for-coding');
+      expect(byUpperAlias?.contextWindow).toBe(262144);
+      expect(byMoonshotAlias?.id).toBe('kimi-for-coding');
+      expect(byMoonshotAlias?.contextWindow).toBe(262144);
+    });
+
+    it('returns null when Kimi alias is requested for a different provider', async () => {
+      const model = await getModelInfo('Moonshot-v1-32k', 'global', 'anthropic-codex');
+      expect(model).toBeNull();
+    });
+
     it('returns null when providerId is anthropic but model only exists in anthropic-codex', async () => {
       const model = await getModelInfo('gpt-5.3-codex', 'global', 'anthropic');
       expect(model).toBeNull();
@@ -179,6 +219,16 @@ describe('Model Service — provider routing', () => {
     it('resolves codex alias to gpt-5.3-codex for anthropic-codex', async () => {
       const resolved = await resolveModelAlias('codex', 'global', 'anthropic-codex');
       expect(resolved).toBe('gpt-5.3-codex');
+    });
+
+    it('does not resolve Codex SDK-only IDs as user-selectable aliases', async () => {
+      const resolved = await resolveModelAlias('claude-opus-4-7', 'global', 'anthropic-codex');
+      expect(resolved).toBe('claude-opus-4-7');
+    });
+
+    it('resolves Kimi provider aliases to canonical model ID', async () => {
+      expect(await resolveModelAlias('KIMI', 'global', 'kimi')).toBe('kimi-for-coding');
+      expect(await resolveModelAlias('Moonshot-v1-32k', 'global', 'kimi')).toBe('kimi-for-coding');
     });
 
     it('returns alias as-is when no matching model found for the specified provider', async () => {
@@ -246,6 +296,19 @@ describe('Model Service — provider routing', () => {
 
     it('validates gpt-5.3-codex as valid for anthropic-codex', async () => {
       expect(await isValidModel('gpt-5.3-codex', 'global', 'anthropic-codex')).toBe(true);
+    });
+
+    it('rejects Codex SDK-only IDs for anthropic-codex validation', async () => {
+      expect(await isValidModel('claude-opus-4-7', 'global', 'anthropic-codex')).toBe(false);
+    });
+
+    it('validates Kimi provider aliases case-insensitively', async () => {
+      expect(await isValidModel('KIMI', 'global', 'kimi')).toBe(true);
+      expect(await isValidModel('Moonshot-v1-32k', 'global', 'kimi')).toBe(true);
+    });
+
+    it('rejects Kimi provider aliases for other providers', async () => {
+      expect(await isValidModel('Moonshot-v1-32k', 'global', 'anthropic-codex')).toBe(false);
     });
 
     it('rejects unknown model for any provider', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/model-service-provider-routing.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/model-service-provider-routing.test.ts
@@ -101,7 +101,8 @@ const kimiModels: ModelInfo[] = [
     id: 'kimi-for-coding',
     name: 'Kimi For Coding',
     alias: 'kimi',
-    providerAliases: ['KIMI', 'Moonshot-v1-32k', 'moonshot-v1-8k'],
+    providerAliases: ['KIMI'],
+    providerAliasPrefixes: ['moonshot-'],
     family: 'kimi',
     provider: 'kimi',
     contextWindow: 262144,
@@ -173,11 +174,14 @@ describe('Model Service — provider routing', () => {
     it('resolves Kimi provider aliases case-insensitively to canonical metadata', async () => {
       const byUpperAlias = await getModelInfo('KIMI', 'global', 'kimi');
       const byMoonshotAlias = await getModelInfo('Moonshot-v1-32k', 'global', 'kimi');
+      const byUnlistedMoonshotAlias = await getModelInfo('moonshot-v1-256k', 'global', 'kimi');
 
       expect(byUpperAlias?.id).toBe('kimi-for-coding');
       expect(byUpperAlias?.contextWindow).toBe(262144);
       expect(byMoonshotAlias?.id).toBe('kimi-for-coding');
       expect(byMoonshotAlias?.contextWindow).toBe(262144);
+      expect(byUnlistedMoonshotAlias?.id).toBe('kimi-for-coding');
+      expect(byUnlistedMoonshotAlias?.contextWindow).toBe(262144);
     });
 
     it('returns null when Kimi alias is requested for a different provider', async () => {
@@ -229,6 +233,7 @@ describe('Model Service — provider routing', () => {
     it('resolves Kimi provider aliases to canonical model ID', async () => {
       expect(await resolveModelAlias('KIMI', 'global', 'kimi')).toBe('kimi-for-coding');
       expect(await resolveModelAlias('Moonshot-v1-32k', 'global', 'kimi')).toBe('kimi-for-coding');
+      expect(await resolveModelAlias('moonshot-v1-256k', 'global', 'kimi')).toBe('kimi-for-coding');
     });
 
     it('returns alias as-is when no matching model found for the specified provider', async () => {
@@ -305,6 +310,7 @@ describe('Model Service — provider routing', () => {
     it('validates Kimi provider aliases case-insensitively', async () => {
       expect(await isValidModel('KIMI', 'global', 'kimi')).toBe(true);
       expect(await isValidModel('Moonshot-v1-32k', 'global', 'kimi')).toBe(true);
+      expect(await isValidModel('moonshot-v1-256k', 'global', 'kimi')).toBe(true);
     });
 
     it('rejects Kimi provider aliases for other providers', async () => {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -26,8 +26,16 @@ export interface ModelInfo {
    * Additional model IDs the SDK may report for this model (e.g. Anthropic
    * bridge aliases). ContextFetcher treats these as equivalent to `id` and
    * `alias` when matching SDK-reported model names to provider metadata.
+   * These are NOT provider-accepted/user-selectable aliases.
    */
   sdkModelIds?: string[];
+  /**
+   * Additional model spellings accepted by the provider/user config path.
+   * Model service lookups treat these as aliases for validation and metadata
+   * resolution. Keep separate from `sdkModelIds` so SDK-only bridge aliases
+   * (e.g. Codex's Anthropic IDs) do not become user-selectable model IDs.
+   */
+  providerAliases?: string[];
   /** Model family */
   family: ModelFamily;
   /** Provider that owns this model (e.g., 'anthropic', 'glm', 'deepseek') */

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -36,6 +36,12 @@ export interface ModelInfo {
    * (e.g. Codex's Anthropic IDs) do not become user-selectable model IDs.
    */
   providerAliases?: string[];
+  /**
+   * Provider-accepted alias prefixes. Used for open-ended alias families such
+   * as Kimi's `moonshot-*` IDs, where listing every spelling would be brittle.
+   * Matched case-insensitively by model-service lookup.
+   */
+  providerAliasPrefixes?: string[];
   /** Model family */
   family: ModelFamily;
   /** Provider that owns this model (e.g., 'anthropic', 'glm', 'deepseek') */


### PR DESCRIPTION
## Summary

Two-layer fix for broken context window display and auto-compaction on non-native providers (GLM, Kimi). Codex was already correct — no change.

### Layer 1 — SDK configuration

- **GLM**: add `preferContextWindowMetadata: true` to all model entries so the context bar trusts provider metadata (1M for glm-5.2[1m], 200k for the rest) instead of the SDK's hardcoded 200k fallback for unknown model IDs. Add `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var per model so SDK auto-compact fires at the correct threshold.
- **Kimi**: add `preferContextWindowMetadata: true` (display 262k). Remove `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var — the SDK's PP() helper caps `kimi-for-coding` to 200k regardless, so the env var would cause SDK auto-compact to fire 60k too early. Move Kimi into a new `PROVIDER_NO_SDK_AUTO_COMPACT` set; `buildProviderSettings` returns `{ autoCompactEnabled: false }` for Kimi so NeoKai's fallback handles compaction.
- **Codex**: no change. Already correct via `claude-opus-4-7` SDK alias (PP returns 1M) plus existing `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env var.

### Layer 2 — NeoKai fallback safety net

- Add `reserveBasedThreshold()` helper + `ContextTracker.shouldCompactAt()` that fire at `contextWindow - max(13k, 15%)`. Higher than the SDK's own `window - 13k` trigger so the SDK has multiple turns to react first; NeoKai only kicks in if SDK auto-compact hasn't kept up.
- Rewrite `sdk-message-handler` guard: NeoKai fallback no longer disabled by the SDK's `isAutoCompactEnabled` flag (which can be wrong for non-native providers whose PP() capacity is wrong). Only native providers (`anthropic`, `anthropic-copilot`, `anthropic-codex`) skip the fallback.
- Existing 60s cooldown prevents double-compaction when both layers race.

### Behavior after fix

| Provider | Model | Display | Compaction trigger |
|---|---|---|---|
| Anthropic | sonnet | 200k (SDK) | SDK at ~187k |
| GLM | glm-5.2[1m] | **1M** (metadata) | SDK at ~987k via env var |
| GLM | glm-5 / 5.1 | 200k (metadata) | SDK at ~187k via env var |
| Kimi | kimi-for-coding | **262k** (metadata) | NeoKai fallback at ~223k |
| Codex | gpt-5.5 | 272k (metadata) | SDK at ~259k via env var |

## Test plan

- [x] `packages/daemon/tests/unit/1-core/agent/context-tracker.test.ts` — added `shouldCompactAt` + `reserveBasedThreshold` coverage
- [x] `packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts` — rewritten NeoKai trigger tests (Kimi fallback, OpenRouter above/below threshold, Anthropic native skip, custom-provider rejection)
- [x] `packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts` — assert `preferContextWindowMetadata` + per-model `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
- [x] `packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts` — assert `preferContextWindowMetadata` + absence of `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
- [x] `packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts` — Kimi now disables SDK auto-compact; Codex trusted natively
- [x] `bun run check` (lint + typecheck + knip + session guards + db parity + test quality) — all green
- [x] `./scripts/test-daemon.sh` — 10715 tests pass across 8 shards
- [ ] QA: browser verification per the test plan in task #606 (GLM 1M display, Kimi 262k display + compaction trigger)