### PR TITLE
feat(providers): add region support to Kimi provider (China vs Global)

### DIFF
--- a/packages/daemon/src/lib/credential-discovery.ts
+++ b/packages/daemon/src/lib/credential-discovery.ts
@@ -218,6 +218,12 @@ export async function migrateProvidersIfNeeded(
       (mapping.altEnvVar ? process.env[mapping.altEnvVar] : undefined);
     if (!apiKey) continue;
 
+    // Kimi supports two regions (china / global). Existing credentials without
+    // an explicit region default to 'china' so legacy users keep hitting the
+    // api.kimi.com endpoint they always have.
+    const configJson =
+      mapping.providerId === 'kimi' ? JSON.stringify({ region: 'china' }) : undefined;
+
     db.providers.createProvider({
       providerId: mapping.providerId,
       displayName: mapping.displayName,
@@ -226,6 +232,7 @@ export async function migrateProvidersIfNeeded(
       isEnabled: true,
       isDefault: mapping.providerId === 'anthropic',
       sortOrder: sortOrder++,
+      configJson,
     });
 
     try {

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -94,10 +94,18 @@ export const KIMI_REGION_ENDPOINTS: Record<
  * `'china'` for anything missing or unrecognised. This is the single source
  * of truth for backward compatibility — existing credentials without a region
  * continue to route to the China endpoint.
+ *
+ * Matching is case-insensitive so hand-crafted payloads using `'CHINA'` or
+ * `'Global'` normalise correctly. The UI uses a `<select>` so it always
+ * emits a canonical lowercase value, but defensive normalisation here keeps
+ * the API tolerant of direct RPC callers.
  */
 export function resolveKimiRegion(region: unknown): KimiRegion {
-  if (typeof region === 'string' && VALID_REGIONS.has(region as KimiRegion)) {
-    return region as KimiRegion;
+  if (typeof region === 'string') {
+    const normalised = region.toLowerCase() as KimiRegion;
+    if (VALID_REGIONS.has(normalised)) {
+      return normalised;
+    }
   }
   return 'china';
 }

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -1,11 +1,20 @@
 /**
  * Kimi Provider - Moonshot AI（月之暗面）
  *
- * Kimi Code exposes a native Anthropic-compatible API at
- * https://api.kimi.com/coding/ — designed for coding agents.
+ * Kimi Code exposes a native Anthropic-compatible API in two regions:
+ *
+ * - China (`api.kimi.com`): `https://api.kimi.com/coding/` — the original
+ *   domestic endpoint. Default for backward compatibility.
+ * - Global (`api.moonshot.ai`): `https://api.moonshot.ai/anthropic` — for
+ *   users outside China.
  *
  * The API uses a single fixed model ID `kimi-for-coding` that automatically
  * maps to the latest Kimi flagship model.
+ *
+ * Region is read from `sessionConfig.region` (string `'china' | 'global'`)
+ * falling back to `'china'` for backward compatibility with existing
+ * credentials that predate region support. An explicit `sessionConfig.baseUrl`
+ * always wins (used by tests and advanced overrides).
  *
  * ## Bridge architecture
  *
@@ -48,6 +57,51 @@ function keyFingerprint(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
 }
 
+/**
+ * Region identifiers supported by the Kimi provider.
+ *
+ * - `china`  — domestic endpoint at `api.kimi.com`.
+ * - `global` — international endpoint at `api.moonshot.ai`.
+ */
+export type KimiRegion = 'china' | 'global';
+
+const VALID_REGIONS: ReadonlySet<KimiRegion> = new Set<KimiRegion>(['china', 'global']);
+
+/**
+ * Per-region endpoint table for the Kimi provider.
+ *
+ * Anthropic-compatible base URLs are used by the bridge (which forwards
+ * `/v1/messages` traffic to the upstream Anthropic-compatible API). The
+ * OpenAI-compatible endpoints are exposed for direct callers that prefer the
+ * OpenAI schema (not currently used by the bridge).
+ */
+export const KIMI_REGION_ENDPOINTS: Record<
+  KimiRegion,
+  { anthropicBaseUrl: string; openAiBaseUrl: string }
+> = {
+  china: {
+    anthropicBaseUrl: 'https://api.kimi.com/coding',
+    openAiBaseUrl: 'https://api.kimi.com/coding/v1',
+  },
+  global: {
+    anthropicBaseUrl: 'https://api.moonshot.ai/anthropic',
+    openAiBaseUrl: 'https://api.moonshot.ai/v1',
+  },
+};
+
+/**
+ * Coerce an unknown region value into a valid `KimiRegion`, defaulting to
+ * `'china'` for anything missing or unrecognised. This is the single source
+ * of truth for backward compatibility — existing credentials without a region
+ * continue to route to the China endpoint.
+ */
+export function resolveKimiRegion(region: unknown): KimiRegion {
+  if (typeof region === 'string' && VALID_REGIONS.has(region as KimiRegion)) {
+    return region as KimiRegion;
+  }
+  return 'china';
+}
+
 export class KimiProvider implements Provider {
   readonly id = 'kimi';
   readonly displayName = 'Kimi (Moonshot AI)';
@@ -61,10 +115,16 @@ export class KimiProvider implements Provider {
     vision: false,
   };
 
-  /** Anthropic-compatible base URL for Kimi Code. */
-  static readonly BASE_URL = 'https://api.kimi.com/coding';
-  /** OpenAI-compatible base URL for Kimi Code. */
-  static readonly OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1';
+  /**
+   * Anthropic-compatible base URL for the default (China) region. Retained for
+   * backward compatibility — new code should use `getBaseUrlForRegion()`.
+   */
+  static readonly BASE_URL = KIMI_REGION_ENDPOINTS.china.anthropicBaseUrl;
+  /**
+   * OpenAI-compatible base URL for the default (China) region. Retained for
+   * backward compatibility — new code should use `getOpenAiBaseUrlForRegion()`.
+   */
+  static readonly OPENAI_BASE_URL = KIMI_REGION_ENDPOINTS.china.openAiBaseUrl;
   /**
    * Fixed model ID that automatically maps to the latest Kimi flagship model.
    * See https://www.kimi.com/code/docs/ — "统一使用模型 ID kimi-for-coding"
@@ -107,6 +167,13 @@ export class KimiProvider implements Provider {
 
   private readonly env: NodeJS.ProcessEnv;
   private credentials: ProviderCredentials | null = null;
+  /**
+   * Provider-level default region, populated from the providers table
+   * `configJson` blob by `syncProviderToRegistry`. Falls back to `'china'`
+   * when unset (e.g., env-var-only setups, legacy credentials, or unit tests
+   * that construct the provider directly).
+   */
+  private defaultRegion: KimiRegion = 'china';
 
   /**
    * Bridge servers keyed by `{baseUrl}::{apiKey}` so that sessions with
@@ -129,6 +196,39 @@ export class KimiProvider implements Provider {
 
   getCredentials(): ProviderCredentials | null {
     return this.credentials;
+  }
+
+  /**
+   * Set the provider-level default region from the providers table
+   * `configJson` blob. Called by `syncProviderToRegistry` after reading the
+   * persisted record. Per-session `sessionConfig.region` overrides still win.
+   */
+  setDefaultRegion(region: KimiRegion): void {
+    this.defaultRegion = region;
+  }
+
+  /**
+   * Get the provider-level default region (set from the providers table).
+   * Mainly useful for diagnostics and tests.
+   */
+  getDefaultRegion(): KimiRegion {
+    return this.defaultRegion;
+  }
+
+  /**
+   * Resolve the Anthropic-compatible base URL for the given region, ignoring
+   * any per-session `baseUrl` override. Returns the China endpoint by default.
+   */
+  static getBaseUrlForRegion(region: KimiRegion = 'china'): string {
+    return KIMI_REGION_ENDPOINTS[region].anthropicBaseUrl;
+  }
+
+  /**
+   * Resolve the OpenAI-compatible base URL for the given region. Returns the
+   * China endpoint by default.
+   */
+  static getOpenAiBaseUrlForRegion(region: KimiRegion = 'china'): string {
+    return KIMI_REGION_ENDPOINTS[region].openAiBaseUrl;
   }
 
   isAvailable(): boolean {
@@ -162,7 +262,13 @@ export class KimiProvider implements Provider {
       throw new Error('Kimi API key not configured. Set KIMI_API_KEY or MOONSHOT_API_KEY.');
     }
 
-    const baseUrl = normalizeBaseUrl(sessionConfig?.baseUrl || KimiProvider.BASE_URL);
+    // Resolve base URL: explicit sessionConfig.baseUrl wins, otherwise pick the
+    // region endpoint. Per-session region overrides the provider-level default
+    // region (set from the providers table configJson); both default to 'china'
+    // for backward compatibility with pre-region credentials.
+    const region = resolveKimiRegion(sessionConfig?.region ?? this.defaultRegion);
+    const regionBaseUrl = KimiProvider.getBaseUrlForRegion(region);
+    const baseUrl = normalizeBaseUrl(sessionConfig?.baseUrl || regionBaseUrl);
     // All Kimi Code requests use the fixed model ID
     const routingModelId = KimiProvider.DEFAULT_MODEL;
 

--- a/packages/daemon/src/lib/providers/provider-sync.ts
+++ b/packages/daemon/src/lib/providers/provider-sync.ts
@@ -14,6 +14,7 @@ import { initializeProviders, registerBuiltInProvider } from './factory.js';
 import { CustomEndpointProvider, customProviderIdFor } from './custom-endpoint-provider.js';
 import { Logger } from '../logger.js';
 import type { ProviderCredentialManager } from '../credentials/provider-credential-manager.js';
+import { resolveKimiRegion } from './kimi-provider.js';
 
 const logger = new Logger('providers:sync');
 
@@ -34,6 +35,21 @@ export async function syncProviderToRegistry(
   if (record.kind === 'built_in') {
     await registerBuiltInProvider(registry, record.providerId);
     const provider = registry.get(record.providerId);
+    // Kimi: apply provider-level region from configJson so the correct base
+    // URL (api.kimi.com vs api.moonshot.ai) is used without requiring
+    // per-session configuration. Falls back to 'china' when configJson is
+    // missing or malformed.
+    if (provider && provider.id === 'kimi' && 'setDefaultRegion' in provider) {
+      let parsedRegion: unknown;
+      try {
+        parsedRegion = record.configJson ? JSON.parse(record.configJson).region : undefined;
+      } catch {
+        parsedRegion = undefined;
+      }
+      const region = resolveKimiRegion(parsedRegion);
+      (provider as { setDefaultRegion: (r: 'china' | 'global') => void }).setDefaultRegion(region);
+      logger.info(`Kimi provider region set to '${region}'`);
+    }
     if (provider?.setCredentials && credentials) {
       // On startup sync, for providers that manage their own auth state (e.g.
       // Codex), skip applying stale credential-store rows when the provider's

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { KimiProvider } from '../../../../src/lib/providers/kimi-provider';
+import {
+  KimiProvider,
+  KIMI_REGION_ENDPOINTS,
+  resolveKimiRegion,
+} from '../../../../src/lib/providers/kimi-provider';
 import type {
   AnthropicMessagesBridgeServer,
   AnthropicMessagesBridgeConfig,
@@ -294,6 +298,161 @@ describe('KimiProvider', () => {
       expect(() => provider.buildSdkConfig('kimi-for-coding')).toThrow(
         'Kimi API key not configured'
       );
+    });
+  });
+
+  describe('region resolution', () => {
+    beforeEach(() => {
+      provider = new KimiProvider();
+    });
+
+    it('exposes china + global endpoints in KIMI_REGION_ENDPOINTS', () => {
+      expect(KIMI_REGION_ENDPOINTS.china.anthropicBaseUrl).toBe('https://api.kimi.com/coding');
+      expect(KIMI_REGION_ENDPOINTS.china.openAiBaseUrl).toBe('https://api.kimi.com/coding/v1');
+      expect(KIMI_REGION_ENDPOINTS.global.anthropicBaseUrl).toBe(
+        'https://api.moonshot.ai/anthropic'
+      );
+      expect(KIMI_REGION_ENDPOINTS.global.openAiBaseUrl).toBe('https://api.moonshot.ai/v1');
+    });
+
+    it('resolveKimiRegion returns the region for valid inputs', () => {
+      expect(resolveKimiRegion('china')).toBe('china');
+      expect(resolveKimiRegion('global')).toBe('global');
+    });
+
+    it('resolveKimiRegion defaults to china for missing/invalid region', () => {
+      expect(resolveKimiRegion(undefined)).toBe('china');
+      expect(resolveKimiRegion(null)).toBe('china');
+      expect(resolveKimiRegion('')).toBe('china');
+      expect(resolveKimiRegion('us')).toBe('china');
+      expect(resolveKimiRegion(42)).toBe('china');
+    });
+
+    it('static getBaseUrlForRegion returns the correct Anthropic-compatible URL', () => {
+      expect(KimiProvider.getBaseUrlForRegion('china')).toBe('https://api.kimi.com/coding');
+      expect(KimiProvider.getBaseUrlForRegion('global')).toBe('https://api.moonshot.ai/anthropic');
+      // Default argument falls back to china.
+      expect(KimiProvider.getBaseUrlForRegion()).toBe('https://api.kimi.com/coding');
+    });
+
+    it('static getOpenAiBaseUrlForRegion returns the correct OpenAI-compatible URL', () => {
+      expect(KimiProvider.getOpenAiBaseUrlForRegion('china')).toBe(
+        'https://api.kimi.com/coding/v1'
+      );
+      expect(KimiProvider.getOpenAiBaseUrlForRegion('global')).toBe('https://api.moonshot.ai/v1');
+    });
+
+    it('default provider region is china when unset', () => {
+      expect(provider.getDefaultRegion()).toBe('china');
+    });
+
+    it('setDefaultRegion updates the provider-level default region', () => {
+      provider.setDefaultRegion('global');
+      expect(provider.getDefaultRegion()).toBe('global');
+    });
+
+    it('BASE_URL static stays on the China endpoint for backward compatibility', () => {
+      // Legacy callers that still reference KimiProvider.BASE_URL must keep
+      // resolving to api.kimi.com — existing credentials without a region
+      // continue to work unchanged.
+      expect(KimiProvider.BASE_URL).toBe('https://api.kimi.com/coding');
+      expect(KimiProvider.OPENAI_BASE_URL).toBe('https://api.kimi.com/coding/v1');
+    });
+  });
+
+  describe('buildSdkConfig region routing', () => {
+    it('routes to the China endpoint when no region is configured', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      process.env.KIMI_API_KEY = 'test-key';
+      provider = new KimiProvider(process.env, factory);
+
+      provider.buildSdkConfig('kimi-for-coding');
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+    });
+
+    it('routes to the Global endpoint when sessionConfig.region is global', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+
+      provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        region: 'global',
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].baseUrl).toBe('https://api.moonshot.ai/anthropic');
+    });
+
+    it('routes to the China endpoint when sessionConfig.region is china', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+
+      provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        region: 'china',
+      });
+
+      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+    });
+
+    it('falls back to provider-level default region when sessionConfig omits region', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+      // Simulate region loaded from ProviderRecord configJson by provider-sync.
+      provider.setDefaultRegion('global');
+
+      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key' });
+
+      expect(calls[0].baseUrl).toBe('https://api.moonshot.ai/anthropic');
+    });
+
+    it('per-session region overrides provider-level default region', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+      provider.setDefaultRegion('global');
+
+      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'china' });
+
+      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+    });
+
+    it('explicit sessionConfig.baseUrl overrides region selection', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+      provider.setDefaultRegion('global');
+
+      provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        baseUrl: 'https://custom.example.com/anthropic',
+      });
+
+      expect(calls[0].baseUrl).toBe('https://custom.example.com/anthropic');
+    });
+
+    it('invalid sessionConfig.region falls back to china (not global)', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+
+      provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        region: 'us' as unknown,
+      });
+
+      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+    });
+
+    it('creates separate bridges for different regions', () => {
+      const { factory, calls } = createFakeBridgeFactory();
+      provider = new KimiProvider(process.env, factory);
+
+      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'china' });
+      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'global' });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+      expect(calls[1].baseUrl).toBe('https://api.moonshot.ai/anthropic');
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -320,6 +320,12 @@ describe('KimiProvider', () => {
       expect(resolveKimiRegion('global')).toBe('global');
     });
 
+    it('resolveKimiRegion is case-insensitive for hand-crafted payloads', () => {
+      expect(resolveKimiRegion('CHINA')).toBe('china');
+      expect(resolveKimiRegion('Global')).toBe('global');
+      expect(resolveKimiRegion('  Global  ')).toBe('china'); // whitespace not trimmed
+    });
+
     it('resolveKimiRegion defaults to china for missing/invalid region', () => {
       expect(resolveKimiRegion(undefined)).toBe('china');
       expect(resolveKimiRegion(null)).toBe('china');

--- a/packages/web/src/components/settings/AddProviderModal.tsx
+++ b/packages/web/src/components/settings/AddProviderModal.tsx
@@ -97,6 +97,17 @@ interface AddProviderModalProps {
   onProviderAdded: () => void;
 }
 
+/**
+ * Kimi region options. Region is persisted in the provider record's
+ * `configJson` blob as `{ region: 'china' | 'global' }` and resolved by the
+ * KimiProvider at SDK-config build time to pick the correct base URL
+ * (api.kimi.com vs api.moonshot.ai).
+ */
+const KIMI_REGION_OPTIONS = [
+  { value: 'china', label: 'China (api.kimi.com)' },
+  { value: 'global', label: 'Global (api.moonshot.ai)' },
+] as const;
+
 export function AddProviderModal({
   existingProviderIds,
   onClose,
@@ -110,6 +121,7 @@ export function AddProviderModal({
   const [showPresets, setShowPresets] = useState(false);
   const [savingCustom, setSavingCustom] = useState(false);
   const [testingCustom, setTestingCustom] = useState(false);
+  const [kimiRegion, setKimiRegion] = useState<'china' | 'global'>('china');
   const { fetchingModels, fetchedModels, fetchModelsError, fetchedAt, handleFetchModels } =
     useFetchModels(customEditor);
 
@@ -134,6 +146,11 @@ export function AddProviderModal({
           kind: 'built_in',
           authType: preset.authType,
           isEnabled: true,
+          // Kimi needs an explicit region so the provider knows whether to hit
+          // api.kimi.com (China) or api.moonshot.ai (Global). Other built-ins
+          // don't carry config.
+          configJson:
+            preset.providerId === 'kimi' ? JSON.stringify({ region: kimiRegion }) : undefined,
         },
         preset.authType === 'api_key' && key ? { apiKey: key } : undefined
       );
@@ -261,6 +278,7 @@ export function AddProviderModal({
 
   const renderProviderCard = (preset: BuiltInProviderPreset) => {
     const added = isAdded(preset.providerId);
+    const showRegionPicker = preset.providerId === 'kimi' && !added;
     return (
       <div
         key={preset.providerId}
@@ -287,6 +305,29 @@ export function AddProviderModal({
                 : 'None'}
           </span>
         </div>
+
+        {showRegionPicker && (
+          <div class="flex flex-col gap-1">
+            <label
+              for={`kimi-region-${preset.providerId}`}
+              class="text-[10px] uppercase tracking-wider text-gray-500"
+            >
+              Region
+            </label>
+            <select
+              id={`kimi-region-${preset.providerId}`}
+              value={kimiRegion}
+              onChange={(e) => setKimiRegion(e.currentTarget.value as 'china' | 'global')}
+              class="bg-dark-950 border border-dark-700 rounded px-2 py-1 text-xs text-gray-100 focus:outline-none focus:border-blue-500"
+            >
+              {KIMI_REGION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {added ? (
           <div class="text-xs text-gray-500">Already added</div>

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -42,6 +42,25 @@ interface EnrichedProvider extends ProviderRecord {
   authStatus?: ProviderAuthStatus;
 }
 
+/**
+ * Parse the region out of a Kimi provider record's configJson blob.
+ * Returns 'china' for missing/invalid values (backward compatibility).
+ */
+function readKimiRegion(provider: EnrichedProvider): 'china' | 'global' {
+  if (!provider.configJson) return 'china';
+  try {
+    const parsed = JSON.parse(provider.configJson) as { region?: unknown };
+    return parsed.region === 'global' ? 'global' : 'china';
+  } catch {
+    return 'china';
+  }
+}
+
+const KIMI_REGION_LABELS: Record<'china' | 'global', string> = {
+  china: 'China (api.kimi.com)',
+  global: 'Global (api.moonshot.ai)',
+};
+
 export function ProvidersSettings() {
   const [providers, setProviders] = useState<EnrichedProvider[]>([]);
   const [loading, setLoading] = useState(true);
@@ -50,6 +69,7 @@ export function ProvidersSettings() {
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [oauthFlow, setOauthFlow] = useState<OAuthFlowState | null>(null);
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
+  const [kimiRegions, setKimiRegions] = useState<Record<string, 'china' | 'global'>>({});
   const [customEditor, setCustomEditor] = useState<EditorState | null>(null);
   const [editingCustomId, setEditingCustomId] = useState<string | null>(null);
   const [savingCustom, setSavingCustom] = useState(false);
@@ -79,6 +99,14 @@ export function ProvidersSettings() {
         authStatus: authById.get(r.providerId),
       }));
       setProviders(enriched);
+      // Seed region state for any Kimi rows from their persisted configJson.
+      const nextRegions: Record<string, 'china' | 'global'> = {};
+      for (const p of enriched) {
+        if (p.providerId === 'kimi') {
+          nextRegions[p.id] = readKimiRegion(p);
+        }
+      }
+      setKimiRegions((prev) => ({ ...nextRegions, ...prev }));
       // If an OAuth flow is active and the provider was deleted, stop polling.
       if (oauthFlow && !enriched.some((p) => p.providerId === oauthFlow.providerId)) {
         setOauthFlow(null);
@@ -182,6 +210,22 @@ export function ProvidersSettings() {
       await updateProvider(provider.id, {}, { apiKey: key });
       toast.success(`API key updated for ${provider.displayName}`);
       setApiKeys((prev) => ({ ...prev, [provider.id]: '' }));
+      await loadProviders();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleUpdateKimiRegion = async (provider: EnrichedProvider) => {
+    const region = kimiRegions[provider.id] ?? 'china';
+    setPendingId(provider.id);
+    try {
+      await updateProvider(provider.id, {
+        configJson: JSON.stringify({ region }),
+      });
+      toast.success(`${provider.displayName} region set to ${KIMI_REGION_LABELS[region]}`);
       await loadProviders();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Update failed');
@@ -575,6 +619,43 @@ export function ProvidersSettings() {
                               Configuration
                             </h5>
                             <div class="text-xs text-gray-500 font-mono">{provider.baseUrl}</div>
+                          </div>
+                        )}
+
+                        {/* Kimi region selector — only for built-in Kimi rows. */}
+                        {provider.providerId === 'kimi' && !isCustom && (
+                          <div>
+                            <h5 class="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+                              Region
+                            </h5>
+                            <div class="flex gap-2 items-center">
+                              <select
+                                value={kimiRegions[provider.id] ?? 'china'}
+                                onChange={(e) =>
+                                  setKimiRegions((prev) => ({
+                                    ...prev,
+                                    [provider.id]: e.currentTarget.value as 'china' | 'global',
+                                  }))
+                                }
+                                class="flex-1 min-w-0 bg-dark-950 border border-dark-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+                              >
+                                <option value="china">{KIMI_REGION_LABELS.china}</option>
+                                <option value="global">{KIMI_REGION_LABELS.global}</option>
+                              </select>
+                              <Button
+                                size="sm"
+                                variant="primary"
+                                onClick={() => handleUpdateKimiRegion(provider)}
+                                loading={isPending}
+                                disabled={isPending}
+                              >
+                                Save
+                              </Button>
+                            </div>
+                            <p class="text-[11px] text-gray-500 mt-1">
+                              Switching region changes the upstream base URL — use the endpoint that
+                              matches your Kimi account.
+                            </p>
                           </div>
                         )}
 

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -625,11 +625,15 @@ export function ProvidersSettings() {
                         {/* Kimi region selector — only for built-in Kimi rows. */}
                         {provider.providerId === 'kimi' && !isCustom && (
                           <div>
-                            <h5 class="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+                            <label
+                              for={`kimi-region-${provider.id}`}
+                              class="block text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2"
+                            >
                               Region
-                            </h5>
+                            </label>
                             <div class="flex gap-2 items-center">
                               <select
+                                id={`kimi-region-${provider.id}`}
                                 value={kimiRegions[provider.id] ?? 'china'}
                                 onChange={(e) =>
                                   setKimiRegions((prev) => ({
@@ -647,7 +651,10 @@ export function ProvidersSettings() {
                                 variant="primary"
                                 onClick={() => handleUpdateKimiRegion(provider)}
                                 loading={isPending}
-                                disabled={isPending}
+                                disabled={
+                                  isPending ||
+                                  (kimiRegions[provider.id] ?? 'china') === readKimiRegion(provider)
+                                }
                               >
                                 Save
                               </Button>


### PR DESCRIPTION
## Summary

Adds region-aware endpoint resolution to the Kimi provider so users can pick between the China (`api.kimi.com`) and Global (`api.moonshot.ai`) Anthropic-compatible APIs. Existing credentials default to China for backward compatibility.

| Region | Anthropic-compat | OpenAI-compat |
|---|---|---|
| China  | `https://api.kimi.com/coding`     | `https://api.kimi.com/coding/v1` |
| Global | `https://api.moonshot.ai/anthropic` | `https://api.moonshot.ai/v1` |

## Changes

- **KimiProvider** (`packages/daemon/src/lib/providers/kimi-provider.ts`): exports `KIMI_REGION_ENDPOINTS`, `resolveKimiRegion()`, `KimiRegion`; resolves base URL from per-session region → provider-level default region → `'china'` fallback. Adds `setDefaultRegion`/`getDefaultRegion` so provider-sync can push the configured region onto the instance. Static `BASE_URL`/`OPENAI_BASE_URL` retained on the China endpoint for legacy callers.
- **provider-sync** (`packages/daemon/src/lib/providers/provider-sync.ts`): reads `region` from the ProviderRecord `configJson` blob on every sync and applies it via `KimiProvider.setDefaultRegion`, so existing sessions route correctly without per-session changes.
- **credential-discovery** (`packages/daemon/src/lib/credential-discovery.ts`): Kimi rows seeded with `configJson: {region:'china'}` so legacy credentials keep hitting `api.kimi.com`.
- **AddProviderModal** (`packages/web/src/components/settings/AddProviderModal.tsx`): region selector shown only on the Kimi card; choice persisted into `configJson` at create time.
- **ProvidersSettings** (`packages/web/src/components/settings/ProvidersSettings.tsx`): region dropdown + Save button on Kimi detail panels; updates `configJson` live via `providers.update`.

## Tests

`packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts` — added a `region resolution` suite and a `buildSdkConfig region routing` suite covering: endpoint table, `resolveKimiRegion` defaults for missing/invalid input, static accessors, provider-level default region, per-session override of provider default, explicit `baseUrl` override, invalid-region fallback, and separate bridges per region.

## Test plan

- [x] `bun run check` (lint + typecheck + knip + session-guard + db-schema-parity + test-quality) — clean
- [x] `bun test tests/unit/1-core/providers/kimi-provider.test.ts` — 46 pass
- [x] `bun test tests/unit/1-core/providers/provider-sync.test.ts tests/unit/1-core/core/credential-discovery.test.ts` — 39 pass
- [x] `bun test tests/unit/1-core/providers/` — 778 pass, 0 fail
- [x] `bunx tsc --noEmit` in `packages/web` — clean