### PR TITLE
fix(openai-chat-bridge): guard catch-block send() against closed controller

### DIFF
--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -742,8 +742,16 @@ async function streamChatToAnthropic(params: {
       'openai-chat-bridge: streaming failed:',
       error instanceof Error ? error.message : String(error)
     );
-    send(errorSSE('api_error', error instanceof Error ? error.message : 'OpenAI stream failed'));
-    send(messageStopSSE());
+    try {
+      send(errorSSE('api_error', error instanceof Error ? error.message : 'OpenAI stream failed'));
+    } catch {
+      // Controller already closed (client disconnect or upstream tear-down).
+    }
+    try {
+      send(messageStopSSE());
+    } catch {
+      // Controller already closed.
+    }
   } finally {
     try {
       controller.close();

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -218,6 +218,46 @@ describe('OpenAI Chat Completions bridge server', () => {
     expect(body.error.type).toBe('authentication_error');
   });
 
+  it('does not crash when controller is already closed before upstream error', async () => {
+    // Regression: catch-block `send()` calls used to throw TypeError when the
+    // ReadableStreamDefaultController was already closed (client disconnect /
+    // upstream tear-down), taking the daemon down with them. The catch block
+    // must now swallow those secondary errors.
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('upstream blew up mid-stream'));
+      },
+    });
+    const upstreamResponse = new Response(upstreamBody, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    // Create a stream that is already closed by the time streamChatToAnthropic
+    // reaches its catch block.
+    let captured: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const closedStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        captured = controller;
+      },
+    });
+    const reader = closedStream.getReader();
+    // Close the underlying controller and release the reader so the controller
+    // is in the "closed" state.
+    captured!.close();
+    reader.releaseLock();
+
+    // Must NOT throw — this is the regression.
+    await expect(
+      _openAIChatBridgeTesting.streamChatToAnthropic({
+        upstreamResponse,
+        controller: captured!,
+        model: 'm',
+        inputTokens: 1,
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it('serves Anthropic-compatible model listing for SDK initialization', async () => {
     const fetchMock = mock(async () => new Response('', { status: 500 }));
     const server = createOpenAIChatBridgeServer({


### PR DESCRIPTION
## Summary

`streamChatToAnthropic` in `packages/daemon/src/lib/providers/openai-chat-bridge/server.ts` crashed the daemon when its catch block ran on an already-closed `ReadableStreamDefaultController`. `send()` calls `controller.enqueue(...)`, which throws `TypeError: Invalid state: Controller is already closed` if the readable side has been torn down (client disconnect, or upstream returning data that closed the stream before the error surfaced). That secondary TypeError escaped the catch and took the daemon down.

The adjacent `finally { controller.close() }` was already guarded. This PR mirrors that guard on the two `send()` calls in the catch block, so upstream errors are logged but no longer crash the process.

## Changes
- `packages/daemon/src/lib/providers/openai-chat-bridge/server.ts`: wrap both catch-block `send()` calls in try/catch.
- `packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts`: regression test that closes the controller up front, errors the upstream stream, and asserts `streamChatToAnthropic` resolves instead of throwing.

## Test plan
- [x] `cd packages/daemon && bun test tests/unit/1-core/providers/openai-chat-bridge-server.test.ts` — 40 pass
- [x] `bun run typecheck` clean
- [x] `bunx oxlint <changed files>` clean