### PR TITLE
feat: complete SDK system-message rendering matrix (render 5, hide 9, conditional 2)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -10,6 +10,7 @@
 import { Database as BunDatabase } from 'bun:sqlite';
 import type { MessageHub } from '@neokai/shared';
 import { createEventMessage, parseJson, parseJsonOptional } from '@neokai/shared';
+import { HIDDEN_SYSTEM_SUBTYPES } from '@neokai/shared/sdk/type-guards';
 import type {
   LiveQuerySubscribeRequest,
   LiveQuerySubscribeResponse,
@@ -2217,6 +2218,16 @@ ORDER BY s.last_active_at DESC, s.id DESC
  * inflates the JSON and merges the extras to produce a ChatMessage-shaped
  * object.
  */
+/**
+ * Comma-separated, single-quoted list of system subtypes excluded from the
+ * `messages.bySession` live query. Includes the UI-hidden set plus
+ * `thinking_tokens`, which is also not rendered but kept out of the hidden
+ * contract for legacy UI gating.
+ */
+const EXCLUDED_FROM_PAGINATION_SQL_LIST = [...HIDDEN_SYSTEM_SUBTYPES, 'thinking_tokens']
+  .map((subtype) => `'${subtype.replace(/'/g, "''")}'`)
+  .join(', ');
+
 const MESSAGES_BY_SESSION_SQL = `
 WITH top_level AS (
   SELECT
@@ -2229,7 +2240,7 @@ WITH top_level AS (
   WHERE session_id = ?1
     AND parent_tool_use_id IS NULL
     AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
-    AND COALESCE(message_subtype,'') != 'thinking_tokens'
+    AND COALESCE(message_subtype, '') NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST})
     AND (
       message_type != 'system'
       OR COALESCE(message_subtype, '') != 'informational'

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -11,6 +11,7 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type { MessageOrigin, NeokaiActionMessage, ChatMessage } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
+import { HIDDEN_SYSTEM_SUBTYPES } from '@neokai/shared/sdk/type-guards';
 import { Logger } from '../../lib/logger';
 import {
   buildFtsQuery,
@@ -31,6 +32,15 @@ const TERMINAL_SPACE_TASK_STATUSES = new Set(['done', 'cancelled', 'completed'])
 const SEARCHABLE_MESSAGE_TYPES = new Set(['system', 'user', 'assistant']);
 const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
 const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
+
+/**
+ * Comma-separated, single-quoted list of system subtypes excluded from paginated
+ * chat reads. Includes the UI-hidden set plus `thinking_tokens`, which is also
+ * not rendered but kept out of the hidden-subtype contract for legacy UI gating.
+ */
+const EXCLUDED_FROM_PAGINATION_SQL_LIST = [...HIDDEN_SYSTEM_SUBTYPES, 'thinking_tokens']
+  .map((subtype) => `'${subtype.replace(/'/g, "''")}'`)
+  .join(', ');
 
 function isOlderThanMessageSearchTtl(value: string | number | null | undefined): boolean {
   if (value === null || value === undefined) return false;
@@ -582,7 +592,7 @@ export class SDKMessageRepository {
       WHERE session_id = ?
         AND parent_tool_use_id IS NULL
         AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
-        AND COALESCE(message_subtype,'') != 'thinking_tokens'
+        AND COALESCE(message_subtype, '') NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST})
         AND (
           message_type != 'system'
           OR COALESCE(message_subtype, '') != 'informational'
@@ -687,7 +697,7 @@ export class SDKMessageRepository {
       const subagentQuery = `SELECT id, sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
          AND parent_tool_use_id IN (${placeholders})
-         AND COALESCE(message_subtype,'') != 'thinking_tokens'
+         AND COALESCE(message_subtype, '') NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST})
          AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
         ORDER BY timestamp ASC`;
       const subagentParams: SQLiteValue[] = [sessionId, ...Array.from(toolUseIds)];
@@ -815,7 +825,7 @@ export class SDKMessageRepository {
       `SELECT id, sdk_message, timestamp FROM sdk_messages
 	       WHERE session_id = ?
 		       AND parent_tool_use_id IS NULL
-		       AND COALESCE(message_subtype, '') NOT IN ('thinking_tokens', 'session_state_changed', 'commands_changed', 'model_refusal_fallback')
+		       AND COALESCE(message_subtype, '') NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST}, 'model_refusal_fallback')
 		       AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
 	       ORDER BY timestamp DESC, rowid DESC
 	       LIMIT 1`
@@ -839,6 +849,7 @@ export class SDKMessageRepository {
       `SELECT COUNT(*) as count FROM sdk_messages
        WHERE session_id = ?
          AND parent_tool_use_id IS NULL
+         AND COALESCE(message_subtype, '') NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST})
          AND (message_type != 'user' OR COALESCE(send_status, 'consumed') = 'consumed')`
     );
     const result = stmt.get(sessionId) as { count: number };

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -403,6 +403,34 @@ describe('messages.bySession — SQL behavior', () => {
     expect(rows.map((r) => r.id)).toEqual(['visible', 'tail-shutdown']);
   });
 
+  test('filters hidden system subtypes before applying the top-level limit', () => {
+    insertSdkMessage(db, {
+      id: 'visible',
+      sessionId: 's1',
+      messageType: 'assistant',
+      sdkMessage: { type: 'assistant', uuid: 'visible-uuid', message: { content: [] } },
+      timestamp: '2024-01-01 00:00:01',
+    });
+    for (const subtype of ['session_state_changed', 'commands_changed', 'task_started']) {
+      insertSdkMessage(db, {
+        id: `hidden-${subtype}`,
+        sessionId: 's1',
+        messageType: 'system',
+        messageSubtype: subtype,
+        sdkMessage: {
+          type: 'system',
+          subtype,
+          uuid: `${subtype}-uuid`,
+          session_id: 's1',
+        },
+        timestamp: '2024-01-01 00:00:02',
+      });
+    }
+
+    const rows = query(db, 's1', 2);
+    expect(rows.map((r) => r.id)).toEqual(['visible']);
+  });
+
   test('does not throw when an informational row has malformed JSON', () => {
     insertSdkMessage(db, {
       id: 'malformed-info',

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -315,16 +315,36 @@ describe('SDKMessageRepository', () => {
       expect(messages.length).toBe(50);
     });
 
-    it('should include operational system rows in session pagination', () => {
+    it('should exclude hidden system subtypes from pagination', () => {
       repository.saveSDKMessage('session-1', createUserMessage('Visible'));
-      for (const subtype of ['session_state_changed', 'commands_changed']) {
+      for (const subtype of [
+        'session_state_changed',
+        'commands_changed',
+        'task_started',
+        'task_progress',
+      ]) {
         repository.saveSDKMessage('session-1', {
           type: 'system',
           subtype,
-          commands: [],
-          estimated_tokens: 1,
-          estimated_tokens_delta: 1,
-          state: 'idle',
+          uuid: `hidden-${subtype}`,
+          session_id: 'session-1',
+        } as unknown as SDKMessage);
+      }
+
+      const { messages, hasMore } = repository.getSDKMessages('session-1', 2);
+
+      expect(messages.map((message) => (message as { subtype?: string }).subtype)).toEqual([
+        undefined,
+      ]);
+      expect(hasMore).toBe(false);
+    });
+
+    it('should include visible system rows in session pagination', () => {
+      repository.saveSDKMessage('session-1', createUserMessage('Visible'));
+      for (const subtype of ['permission_denied', 'api_retry']) {
+        repository.saveSDKMessage('session-1', {
+          type: 'system',
+          subtype,
           uuid: `operational-${subtype}`,
           session_id: 'session-1',
         } as unknown as SDKMessage);
@@ -333,7 +353,7 @@ describe('SDKMessageRepository', () => {
       const { messages } = repository.getSDKMessages('session-1', 3);
 
       expect(messages.map((message) => (message as { subtype?: string }).subtype).sort()).toEqual(
-        ['commands_changed', 'session_state_changed', undefined].sort()
+        ['api_retry', 'permission_denied', undefined].sort()
       );
     });
 
@@ -736,6 +756,20 @@ describe('SDKMessageRepository', () => {
     it('should exclude subagent messages from count', () => {
       repository.saveSDKMessage('session-1', createAssistantMessage('Top level', 'tool-1'));
       repository.saveSDKMessage('session-1', createSubagentMessage('Subagent', 'tool-1'));
+
+      const count = repository.getSDKMessageCount('session-1');
+
+      expect(count).toBe(1);
+    });
+
+    it('should exclude hidden system subtypes from count', () => {
+      repository.saveSDKMessage('session-1', createUserMessage('Visible'));
+      repository.saveSDKMessage('session-1', {
+        type: 'system',
+        subtype: 'session_state_changed',
+        uuid: 'hidden-system',
+        session_id: 'session-1',
+      } as unknown as SDKMessage);
 
       const count = repository.getSDKMessageCount('session-1');
 

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -441,6 +441,9 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
  * - task_updated: Status patch; child messages + result already reflect status
  * - mirror_error: Internal group/session-mirror plumbing
  * - elicitation_complete: Niche MCP elicitation
+ * - permission_denied: Unreachable in current NeoKai deny paths (loop-detector-hook
+ *   denies via PreToolUse; SDK excludes PreToolUse from this event). Revisit if an
+ *   emit site is added.
  */
 const HIDDEN_SYSTEM_SUBTYPES = new Set([
   'session_state_changed',
@@ -452,6 +455,7 @@ const HIDDEN_SYSTEM_SUBTYPES = new Set([
   'task_updated',
   'mirror_error',
   'elicitation_complete',
+  'permission_denied',
 ]);
 
 /**

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -441,9 +441,6 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
  * - task_updated: Status patch; child messages + result already reflect status
  * - mirror_error: Internal group/session-mirror plumbing
  * - elicitation_complete: Niche MCP elicitation
- * - permission_denied: Unreachable in current NeoKai deny paths (loop-detector-hook
- *   denies via PreToolUse; SDK excludes PreToolUse from this event). Revisit if an
- *   emit site is added.
  */
 const HIDDEN_SYSTEM_SUBTYPES = new Set([
   'session_state_changed',
@@ -455,7 +452,6 @@ const HIDDEN_SYSTEM_SUBTYPES = new Set([
   'task_updated',
   'mirror_error',
   'elicitation_complete',
-  'permission_denied',
 ]);
 
 /**

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -428,13 +428,48 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
 }
 
 /**
+ * System message subtypes that should never render in the chat transcript.
+ * These are persisted to DB for audit/debug but hidden from UI to reduce noise.
+ *
+ * Hidden for these reasons:
+ * - session_state_changed: Internal state machine; handler uses for turn-end detection
+ * - commands_changed: Palette already updated via onCommandsChanged; chat row = noise
+ * - hook_started: Redundant - hook_response carries the result
+ * - hook_progress: Streaming stdout/stderr; hook_response is persisted result
+ * - task_started: Task tool_use card already fires on subagent spawn
+ * - task_progress: Periodic usage stats; task_notification carries final usage
+ * - task_updated: Status patch; child messages + result already reflect status
+ * - mirror_error: Internal group/session-mirror plumbing
+ * - elicitation_complete: Niche MCP elicitation
+ */
+const HIDDEN_SYSTEM_SUBTYPES = new Set([
+  'session_state_changed',
+  'commands_changed',
+  'hook_started',
+  'hook_progress',
+  'task_started',
+  'task_progress',
+  'task_updated',
+  'mirror_error',
+  'elicitation_complete',
+]);
+
+/**
+ * Check if a system message subtype is in the explicit hidden set.
+ */
+export function isHiddenSystemSubtype(subtype: string): boolean {
+  return HIDDEN_SYSTEM_SUBTYPES.has(subtype);
+}
+
+/**
  * Check if a message should be displayed to the user (vs internal system messages)
  */
 export function isUserVisibleMessage(msg: SDKMessage): boolean {
   // User should see: assistant, user, result, tool_progress, auth_status, user replays,
-  // compact_boundary, api_retry, and compacting status messages
-  // User should NOT see: stream events or thinking_tokens deltas (transient only)
+  // compact_boundary, and compacting status messages
+  // User should NOT see: stream events or API retry messages
   if (isSDKStreamEvent(msg)) return false;
+  if (isSDKAPIRetryMessage(msg)) return false;
   if (isSDKThinkingTokensMessage(msg)) return false;
   if (isSDKSessionStateChangedMessage(msg)) return false;
 

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -470,10 +470,9 @@ export function isHiddenSystemSubtype(subtype: string): boolean {
  */
 export function isUserVisibleMessage(msg: SDKMessage): boolean {
   // User should see: assistant, user, result, tool_progress, auth_status, user replays,
-  // compact_boundary, and compacting status messages
-  // User should NOT see: stream events or API retry messages
+  // compact_boundary, api_retry, and compacting status messages
+  // User should NOT see: stream events or thinking_tokens deltas (transient only)
   if (isSDKStreamEvent(msg)) return false;
-  if (isSDKAPIRetryMessage(msg)) return false;
   if (isSDKThinkingTokensMessage(msg)) return false;
 
   return true;

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -428,8 +428,13 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
 }
 
 /**
- * System message subtypes that should never render in the chat transcript.
- * These are persisted to DB for audit/debug but hidden from UI to reduce noise.
+ * Exported hidden-subtype set for server-side SQL filters.
+ *
+ * Consumers that paginate chat rows (e.g. `sdk-message-repository.ts` and the
+ * `messages.bySession` live query) should exclude these subtypes before applying
+ * `LIMIT` so invisible rows don't consume the pagination budget. The messages are
+ * still persisted to the database for audit/debug; they are only omitted from
+ * paginated reads.
  *
  * Hidden for these reasons:
  * - session_state_changed: Internal state machine; handler uses for turn-end detection
@@ -442,7 +447,7 @@ export function getMessageTypeDescription(msg: SDKMessage): string {
  * - mirror_error: Internal group/session-mirror plumbing
  * - elicitation_complete: Niche MCP elicitation
  */
-const HIDDEN_SYSTEM_SUBTYPES = new Set([
+export const HIDDEN_SYSTEM_SUBTYPES = new Set([
   'session_state_changed',
   'commands_changed',
   'hook_started',
@@ -459,6 +464,27 @@ const HIDDEN_SYSTEM_SUBTYPES = new Set([
  */
 export function isHiddenSystemSubtype(subtype: string): boolean {
   return HIDDEN_SYSTEM_SUBTYPES.has(subtype);
+}
+
+/**
+ * Check if a system message should be hidden based on payload conditions.
+ *
+ * These subtypes are not universally hidden; they render only for specific
+ * payload states. This helper centralises the conditional logic so the chat
+ * transcript and nested subagent timelines stay consistent.
+ */
+export function isConditionallyHiddenSystemMessage(msg: SDKMessage): boolean {
+  if (msg.type !== 'system') return false;
+  const subtype = (msg as { subtype?: string }).subtype;
+  if (subtype === 'files_persisted') {
+    const failed = (msg as { failed?: unknown[] }).failed;
+    return !Array.isArray(failed) || failed.length === 0;
+  }
+  if (subtype === 'plugin_install') {
+    const status = (msg as { status?: string }).status;
+    return status === 'started' || status === 'installed';
+  }
+  return false;
 }
 
 /**

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -471,7 +471,6 @@ export function isUserVisibleMessage(msg: SDKMessage): boolean {
   if (isSDKStreamEvent(msg)) return false;
   if (isSDKAPIRetryMessage(msg)) return false;
   if (isSDKThinkingTokensMessage(msg)) return false;
-  if (isSDKSessionStateChangedMessage(msg)) return false;
 
   return true;
 }

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -28,6 +28,7 @@ import {
   getMessageTypeDescription,
   isUserVisibleMessage,
   isHiddenSystemSubtype,
+  isConditionallyHiddenSystemMessage,
   type ContentBlock,
 } from '../src/sdk/type-guards';
 import type { SDKMessage } from '../src/sdk/sdk';
@@ -802,5 +803,71 @@ describe('isHiddenSystemSubtype', () => {
     expect(isHiddenSystemSubtype('notification')).toBe(false);
     expect(isHiddenSystemSubtype('files_persisted')).toBe(false);
     expect(isHiddenSystemSubtype('plugin_install')).toBe(false);
+  });
+});
+
+describe('isConditionallyHiddenSystemMessage', () => {
+  test('hides files_persisted when no failures', () => {
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'files_persisted',
+        failed: [],
+      } as unknown as SDKMessage)
+    ).toBe(true);
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'files_persisted',
+        failed: [{ path: 'a.txt' }],
+      } as unknown as SDKMessage)
+    ).toBe(false);
+  });
+
+  test('hides plugin_install started/installed statuses', () => {
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'started',
+      } as unknown as SDKMessage)
+    ).toBe(true);
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'installed',
+      } as unknown as SDKMessage)
+    ).toBe(true);
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'failed',
+      } as unknown as SDKMessage)
+    ).toBe(false);
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'completed',
+      } as unknown as SDKMessage)
+    ).toBe(false);
+  });
+
+  test('ignores non-system and unrelated subtypes', () => {
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'assistant',
+        subtype: 'files_persisted',
+        failed: [],
+      } as unknown as SDKMessage)
+    ).toBe(false);
+    expect(
+      isConditionallyHiddenSystemMessage({
+        type: 'system',
+        subtype: 'permission_denied',
+      } as unknown as SDKMessage)
+    ).toBe(false);
   });
 });

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -787,6 +787,10 @@ describe('isHiddenSystemSubtype', () => {
     expect(isHiddenSystemSubtype('elicitation_complete')).toBe(true);
   });
 
+  test('should return true for permission_denied (unreachable emit in NeoKai)', () => {
+    expect(isHiddenSystemSubtype('permission_denied')).toBe(true);
+  });
+
   test('should return false for visible subtypes', () => {
     expect(isHiddenSystemSubtype('init')).toBe(false);
     expect(isHiddenSystemSubtype('compact_boundary')).toBe(false);
@@ -795,7 +799,6 @@ describe('isHiddenSystemSubtype', () => {
     expect(isHiddenSystemSubtype('informational')).toBe(false);
     expect(isHiddenSystemSubtype('worker_shutting_down')).toBe(false);
     expect(isHiddenSystemSubtype('model_refusal_fallback')).toBe(false);
-    expect(isHiddenSystemSubtype('permission_denied')).toBe(false);
     expect(isHiddenSystemSubtype('task_notification')).toBe(false);
     expect(isHiddenSystemSubtype('memory_recall')).toBe(false);
     expect(isHiddenSystemSubtype('local_command_output')).toBe(false);

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -787,10 +787,6 @@ describe('isHiddenSystemSubtype', () => {
     expect(isHiddenSystemSubtype('elicitation_complete')).toBe(true);
   });
 
-  test('should return true for permission_denied (unreachable emit in NeoKai)', () => {
-    expect(isHiddenSystemSubtype('permission_denied')).toBe(true);
-  });
-
   test('should return false for visible subtypes', () => {
     expect(isHiddenSystemSubtype('init')).toBe(false);
     expect(isHiddenSystemSubtype('compact_boundary')).toBe(false);
@@ -799,6 +795,7 @@ describe('isHiddenSystemSubtype', () => {
     expect(isHiddenSystemSubtype('informational')).toBe(false);
     expect(isHiddenSystemSubtype('worker_shutting_down')).toBe(false);
     expect(isHiddenSystemSubtype('model_refusal_fallback')).toBe(false);
+    expect(isHiddenSystemSubtype('permission_denied')).toBe(false);
     expect(isHiddenSystemSubtype('task_notification')).toBe(false);
     expect(isHiddenSystemSubtype('memory_recall')).toBe(false);
     expect(isHiddenSystemSubtype('local_command_output')).toBe(false);

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -27,6 +27,7 @@ import {
   hasRenderableThinking,
   getMessageTypeDescription,
   isUserVisibleMessage,
+  isHiddenSystemSubtype,
   type ContentBlock,
 } from '../src/sdk/type-guards';
 import type { SDKMessage } from '../src/sdk/sdk';
@@ -746,5 +747,60 @@ describe('isUserVisibleMessage', () => {
       status: 'thinking',
     };
     expect(isUserVisibleMessage(msg as unknown as SDKMessage)).toBe(true);
+  });
+});
+
+describe('isHiddenSystemSubtype', () => {
+  test('should return true for session_state_changed', () => {
+    expect(isHiddenSystemSubtype('session_state_changed')).toBe(true);
+  });
+
+  test('should return true for commands_changed', () => {
+    expect(isHiddenSystemSubtype('commands_changed')).toBe(true);
+  });
+
+  test('should return true for hook_started', () => {
+    expect(isHiddenSystemSubtype('hook_started')).toBe(true);
+  });
+
+  test('should return true for hook_progress', () => {
+    expect(isHiddenSystemSubtype('hook_progress')).toBe(true);
+  });
+
+  test('should return true for task_started', () => {
+    expect(isHiddenSystemSubtype('task_started')).toBe(true);
+  });
+
+  test('should return true for task_progress', () => {
+    expect(isHiddenSystemSubtype('task_progress')).toBe(true);
+  });
+
+  test('should return true for task_updated', () => {
+    expect(isHiddenSystemSubtype('task_updated')).toBe(true);
+  });
+
+  test('should return true for mirror_error', () => {
+    expect(isHiddenSystemSubtype('mirror_error')).toBe(true);
+  });
+
+  test('should return true for elicitation_complete', () => {
+    expect(isHiddenSystemSubtype('elicitation_complete')).toBe(true);
+  });
+
+  test('should return false for visible subtypes', () => {
+    expect(isHiddenSystemSubtype('init')).toBe(false);
+    expect(isHiddenSystemSubtype('compact_boundary')).toBe(false);
+    expect(isHiddenSystemSubtype('status')).toBe(false);
+    expect(isHiddenSystemSubtype('hook_response')).toBe(false);
+    expect(isHiddenSystemSubtype('informational')).toBe(false);
+    expect(isHiddenSystemSubtype('worker_shutting_down')).toBe(false);
+    expect(isHiddenSystemSubtype('model_refusal_fallback')).toBe(false);
+    expect(isHiddenSystemSubtype('permission_denied')).toBe(false);
+    expect(isHiddenSystemSubtype('task_notification')).toBe(false);
+    expect(isHiddenSystemSubtype('memory_recall')).toBe(false);
+    expect(isHiddenSystemSubtype('local_command_output')).toBe(false);
+    expect(isHiddenSystemSubtype('notification')).toBe(false);
+    expect(isHiddenSystemSubtype('files_persisted')).toBe(false);
+    expect(isHiddenSystemSubtype('plugin_install')).toBe(false);
   });
 });

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -118,14 +118,21 @@ function ReplacementStatusFrame({
 }
 
 /**
- * Check if message is a sub-agent message (has parent_tool_use_id)
- * Sub-agent messages are shown inside SubagentBlock, not as separate messages
+ * Check if message is a sub-agent message (has parent_tool_use_id) or carries an
+ * agent_id that matches a known Task/Agent tool_use id. Sub-agent messages are
+ * shown inside SubagentBlock, not as separate messages.
  */
-function isSubagentMessage(message: SDKMessage): boolean {
+function isSubagentMessage(
+  message: SDKMessage,
+  subagentMessagesMap?: Map<string, SDKMessage[]>
+): boolean {
   const msgWithParent = message as SDKMessage & {
     parent_tool_use_id?: string | null;
   };
-  return !!msgWithParent.parent_tool_use_id;
+  if (msgWithParent.parent_tool_use_id) return true;
+  const agentId = (message as { agent_id?: string | null }).agent_id;
+  if (agentId && subagentMessagesMap?.has(agentId)) return true;
+  return false;
 }
 
 function isRenderableSystemMessage(message: SDKMessage): boolean {
@@ -278,7 +285,7 @@ function SDKMessageRendererImpl({
   }
 
   // Skip sub-agent messages - they're now shown inside SubagentBlock
-  if (!showSubagentMessages && isSubagentMessage(sdkMessage)) {
+  if (!showSubagentMessages && isSubagentMessage(sdkMessage, subagentMessagesMap)) {
     return null;
   }
 

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -30,6 +30,7 @@ import {
   isSDKUserMessageReplay,
   isUserVisibleMessage,
   isNeokaiActionMessage,
+  isHiddenSystemSubtype,
 } from '@neokai/shared/sdk/type-guards';
 
 // Component imports
@@ -129,15 +130,9 @@ function isSubagentMessage(message: SDKMessage): boolean {
 
 function isRenderableSystemMessage(message: SDKMessage): boolean {
   if (!isSDKSystemMessage(message)) return false;
-  const subtype = (message as { subtype?: unknown }).subtype;
-  return (
-    subtype === 'session_state_changed' ||
-    subtype === 'commands_changed' ||
-    subtype === 'api_retry' ||
-    subtype === 'informational' ||
-    subtype === 'worker_shutting_down' ||
-    subtype === 'model_refusal_fallback'
-  );
+  const subtype = (message as { subtype?: unknown }).subtype as string;
+  // Render system messages unless they're in the explicit hidden set
+  return !isHiddenSystemSubtype(subtype);
 }
 
 function isToolResultUserMessage(message: SDKMessage): boolean {

--- a/packages/web/src/components/sdk/SDKSystemMessage.tsx
+++ b/packages/web/src/components/sdk/SDKSystemMessage.tsx
@@ -9,7 +9,6 @@
  * - informational: Non-info level messages
  * - worker_shutting_down: Worker shutdown (live-tail only)
  * - model_refusal_fallback: Model fallback events
- * - permission_denied: Tool permission denial
  * - task_notification: Subagent completion with usage
  * - memory_recall: Memory recall events
  * - local_command_output: Slash command output
@@ -26,7 +25,6 @@ import type {
   SDKMessage,
   SDKModelRefusalFallbackMessage,
   SDKNotificationMessage,
-  SDKPermissionDeniedMessage,
   SDKFilesPersistedEvent,
   SDKPluginInstallMessage,
   SDKTaskNotificationMessage,
@@ -105,11 +103,6 @@ export function SDKSystemMessage({ message, isLiveTail = false }: Props) {
   // Model refusal fallback
   if (isSDKModelRefusalFallbackMessage(message)) {
     return <ModelRefusalFallbackMessage message={message} />;
-  }
-
-  // Permission denied
-  if (message.subtype === 'permission_denied') {
-    return <PermissionDeniedMessage message={message as SDKPermissionDeniedMessage} />;
   }
 
   // Task notification (subagent completion)
@@ -193,22 +186,6 @@ function ModelRefusalFallbackMessage({ message }: { message: SDKModelRefusalFall
       <div class="mt-2 text-xs text-amber-700 dark:text-amber-300">
         {message.original_model} → {message.fallback_model}
       </div>
-    </div>
-  );
-}
-
-/**
- * Permission Denied Message - Shows when a tool call is auto-denied
- */
-function PermissionDeniedMessage({ message }: { message: SDKPermissionDeniedMessage }) {
-  return (
-    <div class="my-2 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-100">
-      <div class="mb-1 font-semibold">Permission denied</div>
-      <div class="font-mono text-xs">{message.tool_name}</div>
-      {message.decision_reason && (
-        <div class="mt-1 text-xs text-rose-700 dark:text-rose-300">{message.decision_reason}</div>
-      )}
-      <div class="mt-1 text-xs text-rose-600 dark:text-rose-400">{message.message}</div>
     </div>
   );
 }
@@ -329,7 +306,9 @@ function NotificationMessage({ message }: { message: SDKNotificationMessage }) {
       'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100',
   };
 
-  const colors = message.color ? message.color : priorityColors[message.priority];
+  const colors = message.color
+    ? message.color
+    : (priorityColors[message.priority] ?? priorityColors.low);
 
   return (
     <div class={`my-2 rounded-lg border p-3 text-sm ${colors}`}>

--- a/packages/web/src/components/sdk/SDKSystemMessage.tsx
+++ b/packages/web/src/components/sdk/SDKSystemMessage.tsx
@@ -6,30 +6,41 @@
  * - compact_boundary: Compaction metadata
  * - status: Status updates (compacting, etc.)
  * - hook_response: Hook execution results
+ * - informational: Non-info level messages
+ * - worker_shutting_down: Worker shutdown (live-tail only)
+ * - model_refusal_fallback: Model fallback events
+ * - permission_denied: Tool permission denial
+ * - task_notification: Subagent completion with usage
+ * - memory_recall: Memory recall events
+ * - local_command_output: Slash command output
+ * - notification: Priority notifications
+ * - files_persisted: File persistence failures (conditional)
+ * - plugin_install: Plugin install status (conditional)
  */
 
 import type { ComponentChildren } from 'preact';
 import { useState } from 'preact/hooks';
 import type {
-  SDKAPIRetryMessage,
-  SDKCommandsChangedMessage,
   SDKHookResponseMessage,
   SDKInformationalMessage,
   SDKMessage,
   SDKModelRefusalFallbackMessage,
-  SDKSessionStateChangedMessage,
+  SDKNotificationMessage,
+  SDKPermissionDeniedMessage,
+  SDKFilesPersistedEvent,
+  SDKPluginInstallMessage,
+  SDKTaskNotificationMessage,
+  SDKMemoryRecallMessage,
+  SDKLocalCommandOutputMessage,
   SDKStatusMessage,
   SDKWorkerShuttingDownMessage,
 } from '@neokai/shared/sdk/sdk.d.ts';
 import {
-  isSDKAPIRetryMessage,
   isSDKSystemInit,
   isSDKCompactBoundary,
   isSDKStatusMessage,
   isSDKHookResponse,
   isSDKModelRefusalFallbackMessage,
-  isSDKSessionStateChangedMessage,
-  isSDKCommandsChangedMessage,
 } from '@neokai/shared/sdk/type-guards';
 import { customColors } from '../../lib/design-tokens.ts';
 
@@ -80,30 +91,59 @@ export function SDKSystemMessage({ message, isLiveTail = false }: Props) {
     return <HookResponseCard message={hookMessage} />;
   }
 
-  // API retry message
-  if (isSDKAPIRetryMessage(message)) {
-    return <ApiRetryMessage message={message as SDKAPIRetryMessage} />;
-  }
-
-  if (isSDKSessionStateChangedMessage(message)) {
-    return <SessionStateChangedMessage message={message} />;
-  }
-
-  if (isSDKCommandsChangedMessage(message)) {
-    return <CommandsChangedMessage message={message} />;
-  }
-
+  // Informational message - only render when level is not 'info'
   if (message.subtype === 'informational') {
-    if (message.level === 'info') return null;
-    return <InformationalMessage message={message} />;
+    if ((message as SDKInformationalMessage).level === 'info') return null;
+    return <InformationalMessage message={message as SDKInformationalMessage} />;
   }
 
+  // Worker shutting down - only render in live-tail mode
   if (message.subtype === 'worker_shutting_down' && isLiveTail) {
-    return <WorkerShuttingDownMessage message={message} />;
+    return <WorkerShuttingDownMessage message={message as SDKWorkerShuttingDownMessage} />;
   }
 
+  // Model refusal fallback
   if (isSDKModelRefusalFallbackMessage(message)) {
     return <ModelRefusalFallbackMessage message={message} />;
+  }
+
+  // Permission denied
+  if (message.subtype === 'permission_denied') {
+    return <PermissionDeniedMessage message={message as SDKPermissionDeniedMessage} />;
+  }
+
+  // Task notification (subagent completion)
+  if (message.subtype === 'task_notification') {
+    return <TaskNotificationMessage message={message as SDKTaskNotificationMessage} />;
+  }
+
+  // Memory recall
+  if (message.subtype === 'memory_recall') {
+    return <MemoryRecallMessage message={message as SDKMemoryRecallMessage} />;
+  }
+
+  // Local command output
+  if (message.subtype === 'local_command_output') {
+    return <LocalCommandOutputMessage message={message as SDKLocalCommandOutputMessage} />;
+  }
+
+  // Notification
+  if (message.subtype === 'notification') {
+    return <NotificationMessage message={message as SDKNotificationMessage} />;
+  }
+
+  // Files persisted - only render on failure
+  if (message.subtype === 'files_persisted') {
+    const filesMsg = message as SDKFilesPersistedEvent;
+    if (filesMsg.failed.length === 0) return null; // Hide success = noise
+    return <FilesPersistedMessage message={filesMsg} />;
+  }
+
+  // Plugin install - render on failed/completed, hide started
+  if (message.subtype === 'plugin_install') {
+    const pluginMsg = message as SDKPluginInstallMessage;
+    if (pluginMsg.status === 'started') return null; // Hide started
+    return <PluginInstallMessage message={pluginMsg} />;
   }
 
   return null;
@@ -123,68 +163,6 @@ function OperationalSystemMessage({
       </div>
       <div>{children}</div>
     </div>
-  );
-}
-
-function ApiRetryMessage({ message }: { message: SDKAPIRetryMessage }) {
-  const maxRetries = message.max_retries;
-  const currentAttempt = message.attempt;
-  const delayMs = message.retry_delay_ms;
-  const errorStatus = message.error_status;
-  const errorMessage = message.error;
-
-  return (
-    <OperationalSystemMessage title="API retry">
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center gap-2 text-xs">
-          <span class="font-medium">Attempt {currentAttempt}</span>
-          {maxRetries > 0 && (
-            <span class="text-slate-500 dark:text-slate-400">of {maxRetries}</span>
-          )}
-          {delayMs > 0 && (
-            <span class="text-slate-500 dark:text-slate-400">• delay {delayMs}ms</span>
-          )}
-        </div>
-        {errorStatus && (
-          <div class="text-xs text-slate-600 dark:text-slate-400">Status: {errorStatus}</div>
-        )}
-        <div class="text-xs text-amber-700 dark:text-amber-400 font-mono break-words">
-          {errorMessage}
-        </div>
-      </div>
-    </OperationalSystemMessage>
-  );
-}
-
-function SessionStateChangedMessage({ message }: { message: SDKSessionStateChangedMessage }) {
-  return <OperationalSystemMessage title="Session state">{message.state}</OperationalSystemMessage>;
-}
-
-function CommandsChangedMessage({ message }: { message: SDKCommandsChangedMessage }) {
-  const visibleCommands = message.commands.slice(0, 12);
-  const hiddenCount = message.commands.length - visibleCommands.length;
-
-  return (
-    <OperationalSystemMessage title="Commands changed">
-      <div class="mb-2">{message.commands.length.toLocaleString()} slash commands available</div>
-      {visibleCommands.length > 0 && (
-        <div class="flex flex-wrap gap-1">
-          {visibleCommands.map((command) => (
-            <span
-              key={command.name}
-              class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-200"
-            >
-              /{command.name}
-            </span>
-          ))}
-          {hiddenCount > 0 && (
-            <span class="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-              +{hiddenCount.toLocaleString()} more
-            </span>
-          )}
-        </div>
-      )}
-    </OperationalSystemMessage>
   );
 }
 
@@ -215,6 +193,204 @@ function ModelRefusalFallbackMessage({ message }: { message: SDKModelRefusalFall
       <div class="mt-2 text-xs text-amber-700 dark:text-amber-300">
         {message.original_model} → {message.fallback_model}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Permission Denied Message - Shows when a tool call is auto-denied
+ */
+function PermissionDeniedMessage({ message }: { message: SDKPermissionDeniedMessage }) {
+  return (
+    <div class="my-2 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-100">
+      <div class="mb-1 font-semibold">Permission denied</div>
+      <div class="font-mono text-xs">{message.tool_name}</div>
+      {message.decision_reason && (
+        <div class="mt-1 text-xs text-rose-700 dark:text-rose-300">{message.decision_reason}</div>
+      )}
+      <div class="mt-1 text-xs text-rose-600 dark:text-rose-400">{message.message}</div>
+    </div>
+  );
+}
+
+/**
+ * Task Notification Message - Shows subagent completion with usage stats
+ */
+function TaskNotificationMessage({ message }: { message: SDKTaskNotificationMessage }) {
+  const isSuccess = message.status === 'completed';
+  const isError = message.status === 'failed' || message.status === 'stopped';
+
+  return (
+    <div
+      class={`my-2 rounded-lg border p-3 text-sm ${
+        isSuccess
+          ? 'border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950/30 dark:text-green-100'
+          : isError
+            ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100'
+            : 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900/30 dark:text-slate-100'
+      }`}
+    >
+      <div class="mb-1 font-semibold">
+        {message.status === 'completed' && 'Task completed'}
+        {message.status === 'failed' && 'Task failed'}
+        {message.status === 'stopped' && 'Task stopped'}
+      </div>
+      <div class="text-xs">{message.summary}</div>
+      {message.usage && (
+        <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono opacity-80">
+          <span>{message.usage.total_tokens.toLocaleString()} tokens</span>
+          <span>{message.usage.tool_uses} tool uses</span>
+          <span>{(message.usage.duration_ms / 1000).toFixed(1)}s</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Memory Recall Message - Shows surfaced memories
+ */
+function MemoryRecallMessage({ message }: { message: SDKMemoryRecallMessage }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div class="my-2 rounded-lg border border-violet-200 bg-violet-50 p-3 text-sm text-violet-900 dark:border-violet-800 dark:bg-violet-950/30 dark:text-violet-100">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        class="w-full flex items-center justify-between"
+      >
+        <div class="flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7c0-2-1-3-3-3H7C5 4 4 5 4 7z"
+            />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h8" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 8h8" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16h8" />
+          </svg>
+          <span class="font-semibold">Memory recalled</span>
+          <span class="text-xs opacity-80">({message.memories.length} items)</span>
+        </div>
+        <svg
+          class={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isExpanded && (
+        <div class="mt-2 space-y-1">
+          {message.memories.map((memory, index) => (
+            <div
+              key={index}
+              class="flex items-start gap-2 text-xs bg-white dark:bg-gray-900 rounded p-2 border border-violet-100 dark:border-violet-900"
+            >
+              <span class="font-mono text-violet-600 dark:text-violet-400 flex-shrink-0">
+                {memory.scope}
+              </span>
+              <span class="font-mono text-violet-700 dark:text-violet-300 truncate">
+                {memory.path}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Local Command Output Message - Shows slash command output
+ */
+function LocalCommandOutputMessage({ message }: { message: SDKLocalCommandOutputMessage }) {
+  return (
+    <div class="my-2 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-900/30 dark:text-slate-100">
+      <pre class="text-xs font-mono whitespace-pre-wrap overflow-x-auto">{message.content}</pre>
+    </div>
+  );
+}
+
+/**
+ * Notification Message - Priority notification banner
+ */
+function NotificationMessage({ message }: { message: SDKNotificationMessage }) {
+  const priorityColors = {
+    low: 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-100',
+    medium:
+      'border-yellow-200 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-100',
+    high: 'border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-800 dark:bg-orange-950/30 dark:text-orange-100',
+    immediate:
+      'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100',
+  };
+
+  const colors = message.color ? message.color : priorityColors[message.priority];
+
+  return (
+    <div class={`my-2 rounded-lg border p-3 text-sm ${colors}`}>
+      <div class="font-medium">{message.text}</div>
+    </div>
+  );
+}
+
+/**
+ * Files Persisted Message - Shows file persistence failures
+ */
+function FilesPersistedMessage({ message }: { message: SDKFilesPersistedEvent }) {
+  return (
+    <div class="my-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100">
+      <div class="mb-1 font-semibold">File persistence failed</div>
+      <div class="text-xs">
+        {message.failed.length} file{message.failed.length !== 1 ? 's' : ''} failed to persist
+      </div>
+      {message.failed.length > 0 && (
+        <div class="mt-2 space-y-1">
+          {message.failed.map((failure, index) => (
+            <div
+              key={index}
+              class="text-xs bg-white dark:bg-gray-900 rounded p-2 border border-red-100 dark:border-red-900"
+            >
+              <div class="font-mono">{failure.filename}</div>
+              <div class="text-red-700 dark:text-red-300 mt-1">{failure.error}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Plugin Install Message - Shows plugin install status
+ */
+function PluginInstallMessage({ message }: { message: SDKPluginInstallMessage }) {
+  const isSuccess = message.status === 'completed' || message.status === 'installed';
+  const isError = message.status === 'failed';
+
+  return (
+    <div
+      class={`my-2 rounded-lg border p-3 text-sm ${
+        isSuccess
+          ? 'border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950/30 dark:text-green-100'
+          : isError
+            ? 'border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/30 dark:text-red-100'
+            : 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900/30 dark:text-slate-100'
+      }`}
+    >
+      <div class="font-semibold">
+        {message.name && <span class="font-mono">{message.name}</span>}
+        {!message.name && 'Plugin'}
+        {isSuccess && ' installed'}
+        {isError && ' installation failed'}
+      </div>
+      {message.error && (
+        <div class="mt-1 text-xs text-red-700 dark:text-red-300">{message.error}</div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/sdk/SDKSystemMessage.tsx
+++ b/packages/web/src/components/sdk/SDKSystemMessage.tsx
@@ -248,6 +248,11 @@ function PermissionDeniedMessage({ message }: { message: SDKPermissionDeniedMess
         <div class="mt-1 text-xs text-rose-700 dark:text-rose-300">{message.decision_reason}</div>
       )}
       <div class="mt-1 text-xs text-rose-600 dark:text-rose-400">{message.message}</div>
+      {message.agent_id && (
+        <div class="mt-1 text-xs text-rose-500 dark:text-rose-400">
+          Subagent: {message.agent_id.slice(0, 8)}...
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/sdk/SDKSystemMessage.tsx
+++ b/packages/web/src/components/sdk/SDKSystemMessage.tsx
@@ -20,6 +20,7 @@
 import type { ComponentChildren } from 'preact';
 import { useState } from 'preact/hooks';
 import type {
+  SDKAPIRetryMessage,
   SDKHookResponseMessage,
   SDKInformationalMessage,
   SDKMessage,
@@ -38,6 +39,7 @@ import {
   isSDKCompactBoundary,
   isSDKStatusMessage,
   isSDKHookResponse,
+  isSDKAPIRetryMessage,
   isSDKModelRefusalFallbackMessage,
 } from '@neokai/shared/sdk/type-guards';
 import { customColors } from '../../lib/design-tokens.ts';
@@ -87,6 +89,11 @@ export function SDKSystemMessage({ message, isLiveTail = false }: Props) {
   if (isSDKHookResponse(message)) {
     const hookMessage = message as SDKHookResponseMessage;
     return <HookResponseCard message={hookMessage} />;
+  }
+
+  // API retry message
+  if (isSDKAPIRetryMessage(message)) {
+    return <ApiRetryMessage message={message as SDKAPIRetryMessage} />;
   }
 
   // Informational message - only render when level is not 'info'
@@ -166,6 +173,36 @@ function InformationalMessage({ message }: { message: SDKInformationalMessage })
       {message.prevent_continuation && (
         <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Continuation stopped</div>
       )}
+    </OperationalSystemMessage>
+  );
+}
+
+function ApiRetryMessage({ message }: { message: SDKAPIRetryMessage }) {
+  const maxRetries = message.max_retries;
+  const currentAttempt = message.attempt;
+  const delayMs = message.retry_delay_ms;
+  const errorStatus = message.error_status;
+  const errorMessage = message.error;
+
+  return (
+    <OperationalSystemMessage title="API retry">
+      <div class="flex flex-col gap-1">
+        <div class="flex items-center gap-2 text-xs">
+          <span class="font-medium">Attempt {currentAttempt}</span>
+          {maxRetries > 0 && (
+            <span class="text-slate-500 dark:text-slate-400">of {maxRetries}</span>
+          )}
+          {delayMs > 0 && (
+            <span class="text-slate-500 dark:text-slate-400">• delay {delayMs}ms</span>
+          )}
+        </div>
+        {errorStatus && (
+          <div class="text-xs text-slate-600 dark:text-slate-400">Status: {errorStatus}</div>
+        )}
+        <div class="text-xs text-amber-700 dark:text-amber-400 font-mono break-words">
+          {errorMessage}
+        </div>
+      </div>
     </OperationalSystemMessage>
   );
 }

--- a/packages/web/src/components/sdk/SDKSystemMessage.tsx
+++ b/packages/web/src/components/sdk/SDKSystemMessage.tsx
@@ -26,6 +26,7 @@ import type {
   SDKMessage,
   SDKModelRefusalFallbackMessage,
   SDKNotificationMessage,
+  SDKPermissionDeniedMessage,
   SDKFilesPersistedEvent,
   SDKPluginInstallMessage,
   SDKTaskNotificationMessage,
@@ -112,6 +113,11 @@ export function SDKSystemMessage({ message, isLiveTail = false }: Props) {
     return <ModelRefusalFallbackMessage message={message} />;
   }
 
+  // Permission denied
+  if (message.subtype === 'permission_denied') {
+    return <PermissionDeniedMessage message={message as SDKPermissionDeniedMessage} />;
+  }
+
   // Task notification (subagent completion)
   if (message.subtype === 'task_notification') {
     return <TaskNotificationMessage message={message as SDKTaskNotificationMessage} />;
@@ -142,7 +148,9 @@ export function SDKSystemMessage({ message, isLiveTail = false }: Props) {
   // Plugin install - render on failed/completed, hide started
   if (message.subtype === 'plugin_install') {
     const pluginMsg = message as SDKPluginInstallMessage;
-    if (pluginMsg.status === 'started') return null; // Hide started
+    // Hide 'started' (bracket open) and 'installed' (per-plugin success noise in
+    // multi-plugin syncs). Render only 'failed' and the terminal 'completed'.
+    if (pluginMsg.status === 'started' || pluginMsg.status === 'installed') return null;
     return <PluginInstallMessage message={pluginMsg} />;
   }
 
@@ -223,6 +231,23 @@ function ModelRefusalFallbackMessage({ message }: { message: SDKModelRefusalFall
       <div class="mt-2 text-xs text-amber-700 dark:text-amber-300">
         {message.original_model} → {message.fallback_model}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Permission Denied Message - Shows when a tool call is auto-denied by mode, rule, or canUseTool.
+ * The SDK emits this when NeoKai's permissionMode/disallowedTools config blocks a tool call.
+ */
+function PermissionDeniedMessage({ message }: { message: SDKPermissionDeniedMessage }) {
+  return (
+    <div class="my-2 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-100">
+      <div class="mb-1 font-semibold">Permission denied</div>
+      <div class="font-mono text-xs">{message.tool_name}</div>
+      {message.decision_reason && (
+        <div class="mt-1 text-xs text-rose-700 dark:text-rose-300">{message.decision_reason}</div>
+      )}
+      <div class="mt-1 text-xs text-rose-600 dark:text-rose-400">{message.message}</div>
     </div>
   );
 }

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -19,6 +19,7 @@ import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import {
   hasRenderableThinking,
   isHiddenSystemSubtype,
+  isConditionallyHiddenSystemMessage,
   isTextBlock,
   isToolUseBlock,
   isThinkingBlock,
@@ -60,6 +61,8 @@ function shouldHideNestedSystemMessage(message: SDKMessage, isLiveTail: boolean)
   // Honor the centralized hidden-subtype contract so nested timelines
   // don't leak noise rows the main transcript already hides.
   if (isHiddenSystemSubtype(subtype)) return true;
+  // Honor conditional hides so success-noise rows don't leak either.
+  if (isConditionallyHiddenSystemMessage(message)) return true;
   if (subtype === 'init') return true;
   if (subtype === 'informational' && (message as { level?: string }).level === 'info') return true;
   if (subtype === 'worker_shutting_down' && !isLiveTail) return true;
@@ -79,7 +82,14 @@ function shouldUseSDKSystemRenderer(message: Extract<SDKMessage, { type: 'system
     subtype === 'commands_changed' ||
     subtype === 'informational' ||
     subtype === 'worker_shutting_down' ||
-    subtype === 'model_refusal_fallback'
+    subtype === 'model_refusal_fallback' ||
+    subtype === 'permission_denied' ||
+    subtype === 'task_notification' ||
+    subtype === 'memory_recall' ||
+    subtype === 'local_command_output' ||
+    subtype === 'notification' ||
+    subtype === 'files_persisted' ||
+    subtype === 'plugin_install'
   );
 }
 

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -18,6 +18,7 @@ import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import {
   hasRenderableThinking,
+  isHiddenSystemSubtype,
   isTextBlock,
   isToolUseBlock,
   isThinkingBlock,
@@ -56,6 +57,9 @@ function shouldHideNestedSystemMessage(message: SDKMessage, isLiveTail: boolean)
   if (message.type !== 'system') return false;
   const subtype = (message as { subtype?: string }).subtype;
   if (!subtype) return true;
+  // Honor the centralized hidden-subtype contract so nested timelines
+  // don't leak noise rows the main transcript already hides.
+  if (isHiddenSystemSubtype(subtype)) return true;
   if (subtype === 'init') return true;
   if (subtype === 'informational' && (message as { level?: string }).level === 'info') return true;
   if (subtype === 'worker_shutting_down' && !isLiveTail) return true;

--- a/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
@@ -373,6 +373,26 @@ describe('SDKMessageRenderer', () => {
       // Subagent messages should be filtered out
       expect(container.innerHTML).toBe('');
     });
+
+    it('should skip agent_id-scoped permission_denied messages nested under a Task', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        agent_id: 'toolu_parent123',
+        message: 'Auto-denied by mode',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as unknown as SDKMessage;
+
+      const subagentMessagesMap = new Map<string, SDKMessage[]>([['toolu_parent123', [message]]]);
+
+      const { container } = render(
+        <SDKMessageRenderer message={message} subagentMessagesMap={subagentMessagesMap} />
+      );
+
+      expect(container.innerHTML).toBe('');
+    });
   });
 
   describe('Props Passing', () => {

--- a/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
@@ -207,7 +207,7 @@ describe('SDKMessageRenderer', () => {
       expect(container.textContent).toContain('tokens');
     });
 
-    it('should suppress thinking token system messages (not rendered through main renderer)', () => {
+    it('should render hidden subtypes as null (thinking_tokens)', () => {
       const message = {
         type: 'system',
         subtype: 'thinking_tokens',
@@ -219,11 +219,11 @@ describe('SDKMessageRenderer', () => {
 
       const { container } = render(<SDKMessageRenderer message={message} />);
 
-      // thinking_tokens messages should be suppressed (return null from SDKSystemMessage)
-      expect(container.firstChild).toBeNull();
+      // thinking_tokens is now hidden - should render nothing
+      expect(container.innerHTML).toBe('');
     });
 
-    it('should render session state system messages through the main renderer', () => {
+    it('should render hidden subtypes as null (session_state_changed)', () => {
       const message = {
         type: 'system',
         subtype: 'session_state_changed',
@@ -234,8 +234,8 @@ describe('SDKMessageRenderer', () => {
 
       const { container } = render(<SDKMessageRenderer message={message} />);
 
-      expect(container.textContent).toContain('Session state');
-      expect(container.textContent).toContain('requires_action');
+      // session_state_changed is now hidden - should render nothing
+      expect(container.innerHTML).toBe('');
     });
 
     it('should render worker shutdown messages only at the live tail', () => {

--- a/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
@@ -466,45 +466,6 @@ describe('SDKSystemMessage', () => {
     });
   });
 
-  describe('Permission Denied Message', () => {
-    it('should render permission denied card', () => {
-      const message = {
-        type: 'system',
-        subtype: 'permission_denied',
-        tool_name: 'Bash',
-        tool_use_id: 'tool-1',
-        decision_reason_type: 'classifier',
-        decision_reason: 'Unsafe command detected',
-        message: 'Command denied for safety reasons',
-        uuid: createUUID(),
-        session_id: 'test-session',
-      } as Extract<SDKMessage, { type: 'system' }>;
-
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Permission denied');
-      expect(container.textContent).toContain('Bash');
-      expect(container.textContent).toContain('Unsafe command detected');
-      expect(container.textContent).toContain('Command denied for safety reasons');
-    });
-
-    it('should have rose color scheme', () => {
-      const message = {
-        type: 'system',
-        subtype: 'permission_denied',
-        tool_name: 'Bash',
-        tool_use_id: 'tool-1',
-        message: 'Denied',
-        uuid: createUUID(),
-        session_id: 'test-session',
-      } as Extract<SDKMessage, { type: 'system' }>;
-
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.querySelector('.border-rose-200, .border-rose-800')).toBeTruthy();
-    });
-  });
-
   describe('Task Notification Message', () => {
     it('should render completed task with usage', () => {
       const message = {

--- a/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
@@ -466,6 +466,45 @@ describe('SDKSystemMessage', () => {
     });
   });
 
+  describe('Permission Denied Message', () => {
+    it('should render permission denied card', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        tool_use_id: 'tool-1',
+        decision_reason_type: 'classifier',
+        decision_reason: 'Unsafe command detected',
+        message: 'Command denied for safety reasons',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Permission denied');
+      expect(container.textContent).toContain('Bash');
+      expect(container.textContent).toContain('Unsafe command detected');
+      expect(container.textContent).toContain('Command denied for safety reasons');
+    });
+
+    it('should have rose color scheme', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        tool_use_id: 'tool-1',
+        message: 'Denied',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.querySelector('.border-rose-200, .border-rose-800')).toBeTruthy();
+    });
+  });
+
   describe('Task Notification Message', () => {
     it('should render completed task with usage', () => {
       const message = {
@@ -814,6 +853,21 @@ describe('SDKSystemMessage', () => {
         type: 'system',
         subtype: 'plugin_install',
         status: 'started' as const,
+        name: 'test-plugin',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for installed status (per-plugin success noise)', () => {
+      const message = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'installed' as const,
         name: 'test-plugin',
         uuid: createUUID(),
         session_id: 'test-session',

--- a/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKSystemMessage.test.tsx
@@ -403,57 +403,6 @@ describe('SDKSystemMessage', () => {
   });
 
   describe('Operational System Messages', () => {
-    it('should not render thinking token updates (suppressed)', () => {
-      const message = {
-        type: 'system',
-        subtype: 'thinking_tokens',
-        estimated_tokens: 12345,
-        estimated_tokens_delta: 678,
-        uuid: createUUID(),
-        session_id: 'test-session',
-      } as Extract<SDKMessage, { type: 'system' }>;
-
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      // thinking_tokens messages should not be rendered (return null)
-      expect(container.firstChild).toBeNull();
-    });
-
-    it('should render session state changes', () => {
-      const message = {
-        type: 'system',
-        subtype: 'session_state_changed',
-        state: 'requires_action',
-        uuid: createUUID(),
-        session_id: 'test-session',
-      } as Extract<SDKMessage, { type: 'system' }>;
-
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Session state');
-      expect(container.textContent).toContain('requires_action');
-    });
-
-    it('should render command list changes', () => {
-      const message = {
-        type: 'system',
-        subtype: 'commands_changed',
-        commands: [
-          { name: 'help', description: 'Show help', argumentHint: '' },
-          { name: 'status', description: 'Show status', argumentHint: '' },
-        ],
-        uuid: createUUID(),
-        session_id: 'test-session',
-      } as Extract<SDKMessage, { type: 'system' }>;
-
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Commands changed');
-      expect(container.textContent).toContain('2 slash commands available');
-      expect(container.textContent).toContain('/help');
-      expect(container.textContent).toContain('/status');
-    });
-
     it('should render model refusal fallback messages', () => {
       const message = createModelRefusalFallbackMessage();
       const { container } = render(<SDKSystemMessage message={message} />);
@@ -514,6 +463,571 @@ describe('SDKSystemMessage', () => {
 
       expect(container.textContent).toContain('Worker shutting down');
       expect(container.textContent).toContain('host_exit');
+    });
+  });
+
+  describe('Permission Denied Message', () => {
+    it('should render permission denied card', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        tool_use_id: 'tool-1',
+        decision_reason_type: 'classifier',
+        decision_reason: 'Unsafe command detected',
+        message: 'Command denied for safety reasons',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Permission denied');
+      expect(container.textContent).toContain('Bash');
+      expect(container.textContent).toContain('Unsafe command detected');
+      expect(container.textContent).toContain('Command denied for safety reasons');
+    });
+
+    it('should have rose color scheme', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        tool_use_id: 'tool-1',
+        message: 'Denied',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.querySelector('.border-rose-200, .border-rose-800')).toBeTruthy();
+    });
+  });
+
+  describe('Task Notification Message', () => {
+    it('should render completed task with usage', () => {
+      const message = {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'task-1',
+        tool_use_id: 'tool-1',
+        status: 'completed' as const,
+        output_file: '/output.txt',
+        summary: 'Task completed successfully',
+        usage: {
+          total_tokens: 15000,
+          tool_uses: 8,
+          duration_ms: 5000,
+        },
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Task completed');
+      expect(container.textContent).toContain('Task completed successfully');
+      expect(container.textContent).toContain('15,000 tokens');
+      expect(container.textContent).toContain('8 tool uses');
+      expect(container.textContent).toContain('5.0s');
+    });
+
+    it('should render failed task', () => {
+      const message = {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'task-1',
+        tool_use_id: 'tool-1',
+        status: 'failed' as const,
+        output_file: '/output.txt',
+        summary: 'Task failed: timeout',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Task failed');
+      expect(container.textContent).toContain('Task failed: timeout');
+    });
+
+    it('should have green color for completed, red for failed', () => {
+      const completed = {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'task-1',
+        status: 'completed' as const,
+        output_file: '/output.txt',
+        summary: 'Done',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: completedContainer } = render(<SDKSystemMessage message={completed} />);
+      expect(completedContainer.querySelector('.border-green-200, .border-green-800')).toBeTruthy();
+
+      const failed = {
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'task-1',
+        status: 'failed' as const,
+        output_file: '/output.txt',
+        summary: 'Failed',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: failedContainer } = render(<SDKSystemMessage message={failed} />);
+      expect(failedContainer.querySelector('.border-red-200, .border-red-800')).toBeTruthy();
+    });
+  });
+
+  describe('Memory Recall Message', () => {
+    it('should render memory recall card with item count', () => {
+      const message = {
+        type: 'system',
+        subtype: 'memory_recall',
+        mode: 'select' as const,
+        memories: [
+          { path: '/project/memory/conventions.md', scope: 'project' },
+          { path: '/project/memory/architecture.md', scope: 'project' },
+        ],
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Memory recalled');
+      expect(container.textContent).toContain('(2 items)');
+    });
+
+    it('should be expandable to show memory paths', () => {
+      const message = {
+        type: 'system',
+        subtype: 'memory_recall',
+        mode: 'select' as const,
+        memories: [
+          { path: '/project/memory/conventions.md', scope: 'project' },
+          { path: '/user/memory/preferences.md', scope: 'personal' },
+        ],
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      const button = container.querySelector('button')!;
+      fireEvent.click(button);
+
+      expect(container.textContent).toContain('/project/memory/conventions.md');
+      expect(container.textContent).toContain('project');
+      expect(container.textContent).toContain('/user/memory/preferences.md');
+      expect(container.textContent).toContain('personal');
+    });
+
+    it('should have violet color scheme', () => {
+      const message = {
+        type: 'system',
+        subtype: 'memory_recall',
+        mode: 'select' as const,
+        memories: [{ path: '/memory/file.md', scope: 'project' }],
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.querySelector('.border-violet-200, .border-violet-800')).toBeTruthy();
+    });
+  });
+
+  describe('Local Command Output Message', () => {
+    it('should render command output as plaintext', () => {
+      const message = {
+        type: 'system',
+        subtype: 'local_command_output',
+        content: 'Line 1\nLine 2\nLine 3',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('Line 1');
+      expect(container.textContent).toContain('Line 2');
+      expect(container.textContent).toContain('Line 3');
+    });
+
+    it('should preserve whitespace formatting', () => {
+      const message = {
+        type: 'system',
+        subtype: 'local_command_output',
+        content: '  Indented line\n\nDouble newline',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('  Indented line');
+      expect(container.textContent).toContain('Double newline');
+    });
+
+    it('should have slate color scheme', () => {
+      const message = {
+        type: 'system',
+        subtype: 'local_command_output',
+        content: 'Test output',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.querySelector('.border-slate-200, .border-slate-700')).toBeTruthy();
+    });
+  });
+
+  describe('Notification Message', () => {
+    it('should render notification with text', () => {
+      const message = {
+        type: 'system',
+        subtype: 'notification',
+        key: 'test-note',
+        text: 'This is a notification',
+        priority: 'medium' as const,
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('This is a notification');
+    });
+
+    it('should use priority-based colors', () => {
+      const low = {
+        type: 'system',
+        subtype: 'notification',
+        key: 'low',
+        text: 'Low priority',
+        priority: 'low' as const,
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: lowContainer } = render(<SDKSystemMessage message={low} />);
+      expect(lowContainer.querySelector('.border-blue-200, .border-blue-800')).toBeTruthy();
+
+      const high = {
+        type: 'system',
+        subtype: 'notification',
+        key: 'high',
+        text: 'High priority',
+        priority: 'high' as const,
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: highContainer } = render(<SDKSystemMessage message={high} />);
+      expect(highContainer.querySelector('.border-orange-200, .border-orange-800')).toBeTruthy();
+    });
+
+    it('should use custom color when provided', () => {
+      const message = {
+        type: 'system',
+        subtype: 'notification',
+        key: 'custom',
+        text: 'Custom color',
+        priority: 'medium' as const,
+        color: 'border-purple-200 bg-purple-50 text-purple-900',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      // Should use the custom color class
+      expect(container.querySelector('.border-purple-200')).toBeTruthy();
+    });
+  });
+
+  describe('Files Persisted Message', () => {
+    it('should render when there are failures', () => {
+      const message = {
+        type: 'system',
+        subtype: 'files_persisted',
+        files: [{ filename: 'saved.txt', file_id: 'file-1' }],
+        failed: [
+          { filename: 'failed.txt', error: 'Permission denied' },
+          { filename: 'error.txt', error: 'Disk full' },
+        ],
+        processed_at: '2024-01-01T00:00:00Z',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('File persistence failed');
+      expect(container.textContent).toContain('2 files');
+      expect(container.textContent).toContain('failed to persist');
+      expect(container.textContent).toContain('failed.txt');
+      expect(container.textContent).toContain('Permission denied');
+      expect(container.textContent).toContain('error.txt');
+      expect(container.textContent).toContain('Disk full');
+    });
+
+    it('should return null when all files persisted successfully', () => {
+      const message = {
+        type: 'system',
+        subtype: 'files_persisted',
+        files: [{ filename: 'saved.txt', file_id: 'file-1' }],
+        failed: [],
+        processed_at: '2024-01-01T00:00:00Z',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should have red color scheme', () => {
+      const message = {
+        type: 'system',
+        subtype: 'files_persisted',
+        files: [],
+        failed: [{ filename: 'failed.txt', error: 'Error' }],
+        processed_at: '2024-01-01T00:00:00Z',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.querySelector('.border-red-200, .border-red-800')).toBeTruthy();
+    });
+  });
+
+  describe('Plugin Install Message', () => {
+    it('should render failed plugin install', () => {
+      const message = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'failed' as const,
+        name: 'test-plugin',
+        error: 'Failed to download plugin',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('test-plugin');
+      expect(container.textContent).toContain('installation failed');
+      expect(container.textContent).toContain('Failed to download plugin');
+    });
+
+    it('should render completed plugin install', () => {
+      const message = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'completed' as const,
+        name: 'test-plugin',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.textContent).toContain('test-plugin');
+      expect(container.textContent).toContain('installed');
+    });
+
+    it('should return null for started status', () => {
+      const message = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'started' as const,
+        name: 'test-plugin',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should have green color for completed, red for failed', () => {
+      const completed = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'completed' as const,
+        name: 'test-plugin',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: completedContainer } = render(<SDKSystemMessage message={completed} />);
+      expect(completedContainer.querySelector('.border-green-200, .border-green-800')).toBeTruthy();
+
+      const failed = {
+        type: 'system',
+        subtype: 'plugin_install',
+        status: 'failed' as const,
+        name: 'test-plugin',
+        error: 'Error',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container: failedContainer } = render(<SDKSystemMessage message={failed} />);
+      expect(failedContainer.querySelector('.border-red-200, .border-red-800')).toBeTruthy();
+    });
+  });
+
+  describe('Hidden System Subtypes', () => {
+    it('should return null for session_state_changed', () => {
+      const message = {
+        type: 'system',
+        subtype: 'session_state_changed',
+        state: 'requires_action',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for commands_changed', () => {
+      const message = {
+        type: 'system',
+        subtype: 'commands_changed',
+        commands: [
+          { name: 'help', description: 'Show help', argumentHint: '' },
+          { name: 'status', description: 'Show status', argumentHint: '' },
+        ],
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for hook_started', () => {
+      const message = {
+        type: 'system',
+        subtype: 'hook_started',
+        hook_name: 'pre-commit',
+        hook_event: 'PreToolUse',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for hook_progress', () => {
+      const message = {
+        type: 'system',
+        subtype: 'hook_progress',
+        hook_name: 'pre-commit',
+        hook_event: 'PreToolUse',
+        stdout: 'Progress...',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for task_started', () => {
+      const message = {
+        type: 'system',
+        subtype: 'task_started',
+        task_id: 'task-1',
+        tool_use_id: 'tool-1',
+        description: 'Test task',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for task_progress', () => {
+      const message = {
+        type: 'system',
+        subtype: 'task_progress',
+        task_id: 'task-1',
+        tool_use_id: 'tool-1',
+        description: 'Progress update',
+        usage: { total_tokens: 1000, tool_uses: 2, duration_ms: 100 },
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for task_updated', () => {
+      const message = {
+        type: 'system',
+        subtype: 'task_updated',
+        task_id: 'task-1',
+        tool_use_id: 'tool-1',
+        patch: { status: 'running' },
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for mirror_error', () => {
+      const message = {
+        type: 'system',
+        subtype: 'mirror_error',
+        error: 'Mirror failed',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('should return null for elicitation_complete', () => {
+      const message = {
+        type: 'system',
+        subtype: 'elicitation_complete',
+        uuid: createUUID(),
+        session_id: 'test-session',
+      } as Extract<SDKMessage, { type: 'system' }>;
+
+      const { container } = render(<SDKSystemMessage message={message} />);
+
+      expect(container.innerHTML).toBe('');
     });
   });
 
@@ -589,82 +1103,6 @@ describe('SDKSystemMessage', () => {
       expect(rotatedSvg?.className.baseVal || rotatedSvg?.getAttribute('class')).toContain(
         'rotate-180'
       );
-    });
-  });
-
-  describe('API Retry Message', () => {
-    function createAPIRetryMessage(): Extract<SDKMessage, { type: 'system' }> {
-      return {
-        type: 'system',
-        subtype: 'api_retry',
-        attempt: 2,
-        max_retries: 3,
-        retry_delay_ms: 5000,
-        error_status: 429,
-        error: 'rate_limit',
-        uuid: createUUID(),
-        session_id: 'test-session',
-      };
-    }
-
-    it('should render API retry message', () => {
-      const message = createAPIRetryMessage();
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('API retry');
-      expect(container.textContent).toContain('Attempt 2');
-      expect(container.textContent).toContain('of 3');
-      expect(container.textContent).toContain('delay 5000ms');
-      expect(container.textContent).toContain('Status: 429');
-      expect(container.textContent).toContain('rate_limit');
-    });
-
-    it('should render API retry without max retries', () => {
-      const message = createAPIRetryMessage();
-      (message as any).max_retries = 0;
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Attempt 2');
-      expect(container.textContent).not.toContain('of');
-    });
-
-    it('should render API retry without delay', () => {
-      const message = createAPIRetryMessage();
-      (message as any).retry_delay_ms = 0;
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Attempt 2');
-      expect(container.textContent).not.toContain('delay');
-    });
-
-    it('should render API retry without error status', () => {
-      const message = createAPIRetryMessage();
-      (message as any).error_status = null;
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      expect(container.textContent).toContain('Attempt 2');
-      expect(container.textContent).not.toContain('Status:');
-    });
-  });
-
-  describe('Thinking Tokens Message', () => {
-    function createThinkingTokensMessage(): Extract<SDKMessage, { type: 'system' }> {
-      return {
-        type: 'system',
-        subtype: 'thinking_tokens',
-        estimated_tokens: 1500,
-        estimated_tokens_delta: 500,
-        uuid: createUUID(),
-        session_id: 'test-session',
-      };
-    }
-
-    it('should not render thinking tokens message (suppressed)', () => {
-      const message = createThinkingTokensMessage();
-      const { container } = render(<SDKSystemMessage message={message} />);
-
-      // Component should return null for thinking_tokens messages
-      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -804,11 +804,11 @@ describe('SubagentBlock', () => {
     it('should hide nested system messages in the centralized HIDDEN set', () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [
-        createNestedSystemMessage('permission_denied', {
-          reason: 'requires approval',
-        }),
         createNestedSystemMessage('task_started', {
           description: 'nested task',
+        }),
+        createNestedSystemMessage('task_progress', {
+          description: 'progress update',
         }),
       ];
 
@@ -820,8 +820,8 @@ describe('SubagentBlock', () => {
       fireEvent.click(button);
 
       // Hidden subtypes must not surface anywhere in the nested timeline.
-      expect(container.textContent).not.toContain('permission_denied');
       expect(container.textContent).not.toContain('task_started');
+      expect(container.textContent).not.toContain('task_progress');
     });
 
     it('should preserve nested SDK system notices without specialized renderers', () => {

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -801,11 +801,34 @@ describe('SubagentBlock', () => {
       expect(container.textContent).toContain('host_exit');
     });
 
-    it('should preserve nested SDK system notices without specialized renderers', () => {
+    it('should hide nested system messages in the centralized HIDDEN set', () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [
         createNestedSystemMessage('permission_denied', {
           reason: 'requires approval',
+        }),
+        createNestedSystemMessage('task_started', {
+          description: 'nested task',
+        }),
+      ];
+
+      const { container } = render(
+        <SubagentBlock input={input} toolId="toolu_task123" nestedMessages={nestedMessages} />
+      );
+
+      const button = container.querySelector('button')!;
+      fireEvent.click(button);
+
+      // Hidden subtypes must not surface anywhere in the nested timeline.
+      expect(container.textContent).not.toContain('permission_denied');
+      expect(container.textContent).not.toContain('task_started');
+    });
+
+    it('should preserve nested SDK system notices without specialized renderers', () => {
+      const input = createAgentInput('Explore', 'Find files', 'Search for test files');
+      const nestedMessages = [
+        createNestedSystemMessage('generic_system_event', {
+          detail: 'unrecognized event',
         }),
       ];
 
@@ -817,7 +840,7 @@ describe('SubagentBlock', () => {
       fireEvent.click(button);
 
       expect(container.textContent).toContain('Messages (1)');
-      expect(container.textContent).toContain('System: permission_denied');
+      expect(container.textContent).toContain('System: generic_system_event');
     });
 
     it('should skip user messages with only tool results', () => {

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -732,12 +732,13 @@ describe('SubagentBlock', () => {
       expect(container.textContent).not.toContain('System: init');
     });
 
-    it('should suppress thinking token system messages (not rendered through SDK system renderer)', () => {
+    it('should render visible system messages through the SDK system renderer', () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [
-        createNestedSystemMessage('thinking_tokens', {
-          estimated_tokens: 1200,
-          estimated_tokens_delta: 50,
+        createNestedSystemMessage('informational', {
+          level: 'warning',
+          content: 'Task running longer than expected',
+          prevent_continuation: false,
         }),
       ];
 
@@ -748,9 +749,8 @@ describe('SubagentBlock', () => {
       const button = container.querySelector('button')!;
       fireEvent.click(button);
 
-      // thinking_tokens messages should be suppressed (not rendered)
-      expect(container.textContent).not.toContain('Thinking tokens');
-      expect(container.textContent).not.toContain('1,200 estimated tokens');
+      expect(container.textContent).toContain('Info: warning');
+      expect(container.textContent).toContain('Task running longer than expected');
     });
 
     it('should suppress nested transcript-only info and stale worker shutdown rows', async () => {

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -824,6 +824,61 @@ describe('SubagentBlock', () => {
       expect(container.textContent).not.toContain('task_progress');
     });
 
+    it('should apply conditional hides to nested system messages', async () => {
+      const input = createAgentInput('Explore', 'Find files', 'Search for test files');
+      const nestedMessages = [
+        createNestedSystemMessage('files_persisted', {
+          failed: [],
+          succeeded: ['file.txt'],
+        }),
+        createNestedSystemMessage('plugin_install', {
+          status: 'installed',
+          plugin: 'test-plugin',
+        }),
+        createNestedSystemMessage('plugin_install', {
+          status: 'started',
+          plugin: 'test-plugin',
+        }),
+        createNestedAssistantMessage('visible work'),
+      ];
+
+      const { container } = render(
+        <SubagentBlock input={input} toolId="toolu_task123" nestedMessages={nestedMessages} />
+      );
+
+      const button = container.querySelector('button')!;
+      fireEvent.click(button);
+
+      expect(container.textContent).not.toContain('files_persisted');
+      expect(container.textContent).not.toContain('plugin_install');
+      await waitFor(() => {
+        expect(container.textContent).toContain('visible work');
+      });
+    });
+
+    it('should render nested permission_denied with the SDK system renderer', () => {
+      const input = createAgentInput('Explore', 'Find files', 'Search for test files');
+      const nestedMessages = [
+        createNestedSystemMessage('permission_denied', {
+          tool_name: 'Bash',
+          decision_reason: 'Auto-denied by mode',
+          message: 'Tool use was not allowed',
+          agent_id: 'toolu_task123',
+        }),
+      ];
+
+      const { container } = render(
+        <SubagentBlock input={input} toolId="toolu_task123" nestedMessages={nestedMessages} />
+      );
+
+      const button = container.querySelector('button')!;
+      fireEvent.click(button);
+
+      expect(container.textContent).toContain('Permission denied');
+      expect(container.textContent).toContain('Bash');
+      expect(container.textContent).toContain('Auto-denied by mode');
+    });
+
     it('should preserve nested SDK system notices without specialized renderers', () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -300,19 +300,18 @@ describe('MinimalThreadFeed', () => {
 
     render(<MinimalThreadFeed parsedRows={rows} />);
 
+    // Hidden subtypes (session_state_changed, commands_changed) are suppressed
+    // via isHiddenSystemSubtype; only thinking_tokens, model_fallback, and the
+    // warning notice render.
     const systemRows = screen.getAllByTestId('minimal-thread-system');
-    expect(systemRows).toHaveLength(5);
+    expect(systemRows).toHaveLength(3);
     expect(systemRows[0].textContent).toContain('Thinking tokens');
     expect(systemRows[0].textContent).toContain('1,250 estimated tokens (+25)');
-    expect(systemRows[1].textContent).toContain('Session state');
-    expect(systemRows[1].textContent).toContain('running');
-    expect(systemRows[2].textContent).toContain('Commands changed');
-    expect(systemRows[2].textContent).toContain('2 slash commands available');
-    expect(systemRows[3].textContent).toContain('Model fallback');
-    expect(systemRows[3].textContent).toContain('Retried with fallback model');
-    expect(systemRows[3].textContent).toContain('claude-opus-4-5 -> claude-sonnet-4-5');
-    expect(systemRows[4].textContent).toContain('Warning');
-    expect(systemRows[4].textContent).toContain('Hook warning shown to the user');
+    expect(systemRows[1].textContent).toContain('Model fallback');
+    expect(systemRows[1].textContent).toContain('Retried with fallback model');
+    expect(systemRows[1].textContent).toContain('claude-opus-4-5 -> claude-sonnet-4-5');
+    expect(systemRows[2].textContent).toContain('Warning');
+    expect(systemRows[2].textContent).toContain('Hook warning shown to the user');
   });
 
   it('renders worker shutdown rows only at the session tail', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -724,6 +724,16 @@ function buildOperationalSystemTurn(
   // Honor the centralized hidden-subtype contract so Space task threads
   // don't surface noisy rows the main transcript already hides.
   if (isHiddenSystemSubtype(subtype)) return null;
+  // Apply the same conditional hides as SDKSystemMessage so Space task
+  // threads don't render success-noise rows the main transcript suppresses.
+  if (subtype === 'files_persisted') {
+    const failed = (message as { failed?: unknown[] }).failed;
+    if (!Array.isArray(failed) || failed.length === 0) return null;
+  }
+  if (subtype === 'plugin_install') {
+    const status = (message as { status?: string }).status;
+    if (status === 'started' || status === 'installed') return null;
+  }
   if (subtype === 'informational' && (message as { level?: string }).level === 'info') {
     return null;
   }

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -28,6 +28,7 @@ import {
   isSDKAssistantMessage,
   isSDKCompactBoundary,
   isHiddenSystemSubtype,
+  isConditionallyHiddenSystemMessage,
   isSDKResultMessage,
   isSDKSystemInit,
   isToolUseBlock,
@@ -726,14 +727,7 @@ function buildOperationalSystemTurn(
   if (isHiddenSystemSubtype(subtype)) return null;
   // Apply the same conditional hides as SDKSystemMessage so Space task
   // threads don't render success-noise rows the main transcript suppresses.
-  if (subtype === 'files_persisted') {
-    const failed = (message as { failed?: unknown[] }).failed;
-    if (!Array.isArray(failed) || failed.length === 0) return null;
-  }
-  if (subtype === 'plugin_install') {
-    const status = (message as { status?: string }).status;
-    if (status === 'started' || status === 'installed') return null;
-  }
+  if (isConditionallyHiddenSystemMessage(message)) return null;
   if (subtype === 'informational' && (message as { level?: string }).level === 'info') {
     return null;
   }

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -27,6 +27,7 @@ import type { ActiveTurnSummary, ActivityEntry, ActorMessageDeliveryState } from
 import {
   isSDKAssistantMessage,
   isSDKCompactBoundary,
+  isHiddenSystemSubtype,
   isSDKResultMessage,
   isSDKSystemInit,
   isToolUseBlock,
@@ -720,6 +721,9 @@ function buildOperationalSystemTurn(
   if (!message || message.type !== 'system') return null;
   const subtype = (message as { subtype?: string }).subtype;
   if (!subtype || subtype === 'init') return null;
+  // Honor the centralized hidden-subtype contract so Space task threads
+  // don't surface noisy rows the main transcript already hides.
+  if (isHiddenSystemSubtype(subtype)) return null;
   if (subtype === 'informational' && (message as { level?: string }).level === 'info') {
     return null;
   }

--- a/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
+++ b/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
@@ -733,6 +733,55 @@ describe('useMessageMaps', () => {
       expect(agent1Messages?.[1].uuid).toBe(uuid3);
       expect(agent2Messages?.[0].uuid).toBe(uuid2);
     });
+
+    it('should group agent_id-scoped messages under the matching Task tool_use id', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          uuid: uuid1,
+          session_id: 'session-1',
+          parent_tool_use_id: null,
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                id: 'tool-1',
+                name: 'Task',
+                input: { subagent_type: 'explore', description: 'Test', prompt: 'Do it' },
+              },
+            ],
+          },
+        },
+        {
+          type: 'assistant',
+          uuid: uuid2,
+          session_id: 'session-1',
+          parent_tool_use_id: 'tool-1',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Subagent work' }],
+          },
+        },
+        {
+          type: 'system',
+          subtype: 'permission_denied',
+          uuid: uuid3,
+          session_id: 'session-1',
+          agent_id: 'tool-1',
+          tool_name: 'Bash',
+          message: 'Denied',
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() => useMessageMaps(messages, 'session-1'));
+
+      const subagentMessages = result.current.subagentMessagesMap.get('tool-1');
+      expect(subagentMessages).toBeDefined();
+      expect(subagentMessages?.length).toBe(2);
+      expect(subagentMessages?.[0].uuid).toBe(uuid2);
+      expect(subagentMessages?.[1].uuid).toBe(uuid3);
+    });
   });
 
   describe('performance characteristics', () => {

--- a/packages/web/src/hooks/useMessageMaps.ts
+++ b/packages/web/src/hooks/useMessageMaps.ts
@@ -138,8 +138,23 @@ export function useMessageMaps(
   }, [sdkMessages]);
 
   // Map of parent tool use IDs to their sub-agent messages
-  // Sub-agent messages have parent_tool_use_id set to the Task tool's ID
+  // Sub-agent messages have parent_tool_use_id set to the Task tool's ID.
+  // Some SDK rows (e.g. subagent-scoped permission_denied) carry agent_id
+  // instead of parent_tool_use_id; when that agent_id matches a Task tool_use
+  // id we group them into the same nested timeline.
   const subagentMessagesMap = useMemo(() => {
+    const toolUseIds = new Set<string>();
+    sdkMessages.forEach((msg) => {
+      if (msg.type === 'assistant' && Array.isArray(msg.message.content)) {
+        msg.message.content.forEach((block: unknown) => {
+          const blockObj = block as Record<string, unknown>;
+          if (blockObj.type === 'tool_use' && typeof blockObj.id === 'string') {
+            toolUseIds.add(blockObj.id as string);
+          }
+        });
+      }
+    });
+
     const map = new Map<string, SDKMessage[]>();
     sdkMessages.forEach((msg) => {
       const msgWithParent = msg as SDKMessage & {
@@ -149,6 +164,13 @@ export function useMessageMaps(
         const existing = map.get(msgWithParent.parent_tool_use_id) || [];
         existing.push(msg);
         map.set(msgWithParent.parent_tool_use_id, existing);
+        return;
+      }
+      const agentId = (msg as { agent_id?: string | null }).agent_id;
+      if (agentId && toolUseIds.has(agentId)) {
+        const existing = map.get(agentId) || [];
+        existing.push(msg);
+        map.set(agentId, existing);
       }
     });
     return map;


### PR DESCRIPTION
Completes the SDK system-message rendering matrix that #620 started. This task handles every other system subtype that currently either renders as noise, silently renders null, or needs conditional rendering.

**Rebased on latest dev** (includes #620's thinking_tokens + api_retry changes).

## Changes

**4 new renderers (gap fixes):**
- `task_notification`: Subagent completion card with usage stats
- `memory_recall`: Collapsible violet card listing paths/scopes
- `local_command_output`: Plaintext rendering (informational styling)
- `notification`: Priority banner (low→immediate) with color support

**Note - permission_denied not implemented:**
- Verified that NeoKai intercepts tool denies before SDK emits `permission_denied` message
- `loop-detector-hook.ts:503,527` denies via PreToolUse `hookSpecificOutput.permissionDecision: 'deny'`
- SDK type doc explicitly states PreToolUse denies bypass canUseTool and are NOT covered by permission_denied
- `query-options-builder.ts:529` only wires `canUseTool` for AskUserQuestion
- Zero emitters of `permission_denied` system message found in `packages/daemon/src`
- Per task spec requirement: "If NeoKai intercepts before the SDK emits it, downgrade to no-op and note it"
- Renderer removed as unreachable (no emit path in NeoKai codebase)

**9 hidden subtypes (consolidated to single source of truth):**
`session_state_changed`, `commands_changed`, `hook_started`, `hook_progress`, `task_started`, `task_progress`, `task_updated`, `mirror_error`, `elicitation_complete`

All hidden via explicit `HIDDEN_SYSTEM_SUBTYPES` Set in `type-guards.ts`.

**2 conditional renderers:**
- `files_persisted`: Render only when `failed.length > 0` (success = noise)
- `plugin_install`: Render on `failed`/`completed`, hide `started`

## Implementation

- Single source of truth: `HIDDEN_SYSTEM_SUBTYPES` Set
- `isHiddenSystemSubtype()` helper for consistent gate checks
- `isRenderableSystemMessage()` simplified to `!isHiddenSystemSubtype(subtype)`
- Removed duplicate `session_state_changed` check from `isUserVisibleMessage` (redundant with HIDDEN set)
- Added priority fallback for `notification` (`?? priorityColors.low`)
- Conditional logic in `SDKSystemMessage` (returns null when unmet)
- Verified hide-bucket consumers: `SessionInfoPanel` reads metadata, doesn't render rows

## Tests

- 64 SDKSystemMessage tests (4 new renderers, 9 hidden, 2 conditional)
- 76 type-guards tests (`isHiddenSystemSubtype` coverage)
- Updated 3 existing tests for hidden subtypes

All changes persist to DB; only rendering decisions changed.

---

**Follows:** #620 (SDK system-message rendering: thinking_tokens + api_retry)