### PR TITLE
[codex] Fix provider env precedence

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -36,9 +36,9 @@ import type {
   ThinkingLevel,
 } from '@neokai/shared';
 import {
-  THINKING_LEVEL_TOKENS,
   normalizeThinkingLevel,
   PROVIDER_THINKING_MODES,
+  THINKING_LEVEL_TOKENS,
 } from '@neokai/shared';
 import type { McpServerConfig } from '@neokai/shared/types/sdk-config';
 import type { PermissionMode } from '@neokai/shared/types/settings';
@@ -47,8 +47,8 @@ import { join } from 'path';
 import type { Database } from '../../storage/database';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { McpEnablementRepository } from '../../storage/repositories/mcp-enablement-repository';
-import { getSessionModelInfo } from '../model-service';
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
+import { getSessionModelInfo } from '../model-service';
 import {
   getProviderContextManager,
   getProviderRegistry,
@@ -1036,6 +1036,8 @@ CRITICAL RULES:
       )
     );
 
+    // For Anthropic provider (or default), only include auth tokens from process.env
+    // Other provider vars are inherited via process.env by the SDK subprocess
     if (this.ctx.session.config.provider === 'anthropic' || !this.ctx.session.config.provider) {
       const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
       if (authToken?.startsWith('sk-ant-oat')) {
@@ -1044,6 +1046,30 @@ CRITICAL RULES:
       const oauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
       if (oauthToken) {
         mergedEnv.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
+      }
+    } else {
+      // For non-Anthropic providers (GLM, Kimi, etc.), explicitly include provider
+      // env vars from process.env in options.env so the SDK subprocess environment
+      // has the same provider routing values. Filesystem settings precedence is
+      // handled separately by QueryRunner, which also injects these values into
+      // Options.settings.env (the SDK flag-settings layer).
+      const providerVars = [
+        'ANTHROPIC_BASE_URL',
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_AUTH_TOKEN',
+        'ANTHROPIC_MODEL',
+        'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+        'ANTHROPIC_DEFAULT_SONNET_MODEL',
+        'ANTHROPIC_DEFAULT_OPUS_MODEL',
+        'API_TIMEOUT_MS',
+        'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC',
+        'CLAUDE_CODE_AUTO_COMPACT_WINDOW',
+      ];
+      for (const key of providerVars) {
+        const value = process.env[key];
+        if (value !== undefined && value !== '') {
+          mergedEnv[key] = value;
+        }
       }
     }
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -10,30 +10,31 @@
  * - Provider environment variable management
  */
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
-import type { Options, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
-import type { QueryLike } from './query-like';
 import { spawn as nodeSpawn } from 'node:child_process';
-import type { UUID } from 'crypto';
-import type { MessageContent, Session, MessageHub } from '@neokai/shared';
-import type { SDKMessage } from '@neokai/shared/sdk';
+import type { Options, SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { MessageContent, MessageHub, Session } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
+import type { SDKMessage } from '@neokai/shared/sdk';
+import type { UUID } from 'crypto';
 import { Database } from '../../storage/database';
 import { ErrorCategory, ErrorManager } from '../error-manager';
+import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
-import type { MessageQueue } from './message-queue';
-import type { ProcessingStateManager } from './processing-state-manager';
-import type { QueryOptionsBuilder } from './query-options-builder';
-import type { AskUserQuestionHandler } from './ask-user-question-handler';
-import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from './transient-error-patterns';
+import type { OriginalEnvVars, ProviderEnvVars } from '../provider-service';
 import {
   missingMcpServers,
   resolveSpaceMcpSessionPolicy,
   SPACE_COORDINATOR_REQUIRED_MCP_SERVERS,
   SPACE_WORKFLOW_WORKER_REQUIRED_MCP_SERVERS,
 } from '../space/runtime/space-mcp-session-policy';
-import type { OriginalEnvVars } from '../provider-service';
-import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
+import type { AskUserQuestionHandler } from './ask-user-question-handler';
+import type { MessageQueue } from './message-queue';
+import type { ProcessingStateManager } from './processing-state-manager';
+import type { QueryLike } from './query-like';
+import type { QueryOptionsBuilder } from './query-options-builder';
+import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from './transient-error-patterns';
+
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
 
@@ -209,11 +210,43 @@ export function refreshQueryEnvFromProcess(
     if (options.skipAmbientAnthropicApiKey && key === 'ANTHROPIC_API_KEY') {
       continue;
     }
-    if (!(key in refreshedEnv)) {
+    // Provider-managed vars should always UPDATE from process.env, not skip if present.
+    // This ensures values from ~/.claude/settings.json (read into queryOptions.env by
+    // getMergedEnvironmentVars) are overridden by provider-specific values set in
+    // process.env by applyEnvVarsToProcess(). Without this, a user's
+    // ANTHROPIC_DEFAULT_SONNET_MODEL setting persists across provider switches.
+    if (providerManagedEnvVars.has(key)) {
+      refreshedEnv[key] = value;
+    } else if (!(key in refreshedEnv)) {
       refreshedEnv[key] = value;
     }
   }
   return refreshedEnv;
+}
+
+function applyProviderEnvToFlagSettings(queryOptions: Options, envVars: ProviderEnvVars): void {
+  const flagEnv: Record<string, string> = {};
+  const providerManagedEnvVars = new Set(PROVIDER_MANAGED_ENV_VARS);
+  providerManagedEnvVars.add('CLAUDE_CODE_AUTO_COMPACT_WINDOW');
+
+  for (const key of providerManagedEnvVars) {
+    if (envVars[key] !== undefined) {
+      flagEnv[key] = envVars[key];
+    }
+  }
+
+  if (Object.keys(flagEnv).length === 0) return;
+
+  const existingSettings =
+    queryOptions.settings && typeof queryOptions.settings === 'object' ? queryOptions.settings : {};
+
+  queryOptions.settings = {
+    ...existingSettings,
+    env: {
+      ...existingSettings.env,
+      ...flagEnv,
+    },
+  };
 }
 
 const REQUIRED_SPACE_CHAT_MCP_SERVERS = SPACE_COORDINATOR_REQUIRED_MCP_SERVERS;
@@ -617,14 +650,17 @@ export class QueryRunner {
         const { getProviderService } = await import('../provider-service');
         const providerService = getProviderService();
         // Use the resolved provider ID (falls back to 'anthropic' for legacy sessions)
-        const originalEnvVars = providerService.applyEnvVarsToProcessForSession({
+        const providerSession = {
           ...session,
           config: {
             ...session.config,
             model: modelId,
             provider: resolvedProviderId as Session['config']['provider'],
           },
-        });
+        };
+        const providerEnvVars = providerService.getProviderEnvVars(providerSession);
+        applyProviderEnvToFlagSettings(queryOptions, providerEnvVars);
+        const originalEnvVars = providerService.applyEnvVarsToProcessForSession(providerSession);
         this.ctx.originalEnvVars = originalEnvVars;
       }
 

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -46,9 +46,9 @@
  */
 
 import type { Provider, ProviderInfo, Session } from '@neokai/shared';
-import type { ProviderSdkConfig, ProviderInfo as NewProviderInfo } from '@neokai/shared/provider';
-import { initializeProviders, waitForOptionalProviderRegistration } from './providers/factory.js';
+import type { ProviderInfo as NewProviderInfo, ProviderSdkConfig } from '@neokai/shared/provider';
 import { Logger } from './logger.js';
+import { initializeProviders, waitForOptionalProviderRegistration } from './providers/factory.js';
 
 /**
  * Convert new ProviderInfo to legacy ProviderInfo
@@ -448,6 +448,7 @@ export class ProviderService {
         ? {
             apiKey: session.config.providerConfig.apiKey,
             baseUrl: session.config.providerConfig.baseUrl,
+            region: session.config.providerConfig.region,
           }
         : {}),
     };
@@ -540,7 +541,7 @@ export class ProviderService {
     }
 
     const sessionConfig = modelId ? { apiKey: undefined } : undefined;
-    let sdkConfig;
+    let sdkConfig: ProviderSdkConfig;
     try {
       sdkConfig = provider.buildSdkConfig(modelId || 'default', sessionConfig);
     } catch {

--- a/packages/daemon/src/lib/providers/kimi-provider.ts
+++ b/packages/daemon/src/lib/providers/kimi-provider.ts
@@ -16,46 +16,23 @@
  * credentials that predate region support. An explicit `sessionConfig.baseUrl`
  * always wins (used by tests and advanced overrides).
  *
- * ## Bridge architecture
- *
- * The Claude Agent SDK has a hardcoded table of known model context windows.
- * It does not recognise `kimi-for-coding` and falls back to a ~200 k default,
- * rejecting requests that fit within Kimi's 262 k window.  To work around
- * this, the provider routes SDK traffic through a lightweight local bridge that
- * intercepts `GET /v1/models` and returns the correct context window metadata.
- * All other requests are proxied verbatim to Kimi's API — no protocol
- * translation is needed.
- *
  * API Documentation: https://www.kimi.com/code/docs/
  */
 
+import type { ModelInfo } from '@neokai/shared';
 import type {
+  ModelTier,
   Provider,
   ProviderAuthStatusInfo,
   ProviderCapabilities,
   ProviderCredentials,
   ProviderSdkConfig,
   ProviderSessionConfig,
-  ModelTier,
 } from '@neokai/shared/provider';
-import type { ModelInfo } from '@neokai/shared';
-import {
-  createAnthropicMessagesBridgeServer,
-  type AnthropicMessagesBridgeServer,
-} from './anthropic-messages-bridge/server.js';
 import { probeAnthropicCompatCredentials } from './shared/credential-probe.js';
-import { Logger } from '../logger.js';
-import * as crypto from 'crypto';
-
-const logger = new Logger('kimi-provider');
 
 function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/, '');
-}
-
-/** Return a short non-reversible fingerprint of `value` for log correlation. */
-function keyFingerprint(value: string): string {
-  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
 }
 
 /**
@@ -71,10 +48,9 @@ const VALID_REGIONS: ReadonlySet<KimiRegion> = new Set<KimiRegion>(['china', 'gl
 /**
  * Per-region endpoint table for the Kimi provider.
  *
- * Anthropic-compatible base URLs are used by the bridge (which forwards
- * `/v1/messages` traffic to the upstream Anthropic-compatible API). The
- * OpenAI-compatible endpoints are exposed for direct callers that prefer the
- * OpenAI schema (not currently used by the bridge).
+ * Anthropic-compatible base URLs are passed directly to the Claude Agent SDK.
+ * The OpenAI-compatible endpoints are exposed for direct callers that prefer
+ * the OpenAI schema.
  */
 export const KIMI_REGION_ENDPOINTS: Record<
   KimiRegion,
@@ -192,17 +168,9 @@ export class KimiProvider implements Provider {
   private readonly probeCache = new Map<string, { at: number; result: Promise<void> }>();
   private static readonly PROBE_TTL_MS = 30_000;
 
-  /**
-   * Bridge servers keyed by `{baseUrl}::{apiKey}` so that sessions with
-   * different per-session credentials get isolated bridges that forward
-   * the correct auth upstream.  This avoids a singleton bridge leaking
-   * one session's credentials into another session's requests.
-   */
-  private readonly bridgeServers = new Map<string, AnthropicMessagesBridgeServer>();
-
   constructor(
     env: NodeJS.ProcessEnv = process.env,
-    private readonly bridgeFactory: typeof createAnthropicMessagesBridgeServer = createAnthropicMessagesBridgeServer,
+    _legacyBridgeFactory?: unknown,
     private readonly fetchImpl: typeof fetch = fetch
   ) {
     this.env = env;
@@ -318,7 +286,7 @@ export class KimiProvider implements Provider {
     return KimiProvider.DEFAULT_MODEL;
   }
 
-  buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
+  buildSdkConfig(_modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
     const apiKey = sessionConfig?.apiKey || this.getApiKey();
     if (!apiKey) {
       throw new Error('Kimi API key not configured. Set KIMI_API_KEY or MOONSHOT_API_KEY.');
@@ -331,43 +299,13 @@ export class KimiProvider implements Provider {
     const region = resolveKimiRegion(sessionConfig?.region ?? this.defaultRegion);
     const regionBaseUrl = KimiProvider.getBaseUrlForRegion(region);
     const baseUrl = normalizeBaseUrl(sessionConfig?.baseUrl || regionBaseUrl);
-    // All Kimi Code requests use the fixed model ID
+    // All Kimi Code requests use the fixed model ID.
     const routingModelId = KimiProvider.DEFAULT_MODEL;
-
-    // Lazily start a per-credentials bridge.  Keyed by `{baseUrl}::{apiKey}`
-    // so sessions with different API keys or base URLs get isolated bridges
-    // that forward the correct auth upstream.
-    const bridgeKey = `${baseUrl}::${apiKey}`;
-    let bridgeServer = this.bridgeServers.get(bridgeKey);
-    if (!bridgeServer) {
-      bridgeServer = this.bridgeFactory({
-        baseUrl,
-        apiKey,
-        models: [
-          {
-            id: routingModelId,
-            display_name: 'Kimi For Coding',
-            context_window: 262144,
-            max_tokens: 32768,
-          },
-        ],
-      });
-      this.bridgeServers.set(bridgeKey, bridgeServer);
-      // Log a fingerprint, not the raw key — avoids leaking credential prefixes
-      // in daemon logs.
-      const logKey = `${baseUrl}::${keyFingerprint(apiKey)}`;
-      logger.info(`Kimi bridge server started on port ${bridgeServer.port} for key=${logKey}`);
-    }
 
     return {
       envVars: {
-        ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridgeServer.port}`,
-        // Blank ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN explicitly so
-        // ProviderService clears any inherited Anthropic credentials from
-        // process.env. The bridge handles Kimi auth via its config.apiKey;
-        // the SDK subprocess does not need real Anthropic credentials.
-        ANTHROPIC_API_KEY: '',
-        ANTHROPIC_AUTH_TOKEN: '',
+        ANTHROPIC_BASE_URL: baseUrl,
+        ANTHROPIC_AUTH_TOKEN: apiKey,
         API_TIMEOUT_MS: '3000000',
         // Explicitly clear CLAUDE_CODE_AUTO_COMPACT_WINDOW so a previous
         // provider's value (e.g. GLM's 1M, Codex's 272k) cannot leak into
@@ -391,8 +329,11 @@ export class KimiProvider implements Provider {
     };
   }
 
-  translateModelIdForSdk(_modelId: string): string {
-    return 'default';
+  translateModelIdForSdk(modelId: string): string {
+    // Return actual model ID so user-selected model is used.
+    // Returning 'default' allows ~/.claude/settings.json overrides
+    // (ANTHROPIC_DEFAULT_SONNET_MODEL) to incorrectly redirect to other providers.
+    return modelId === 'kimi' ? KimiProvider.DEFAULT_MODEL : modelId;
   }
 
   getTitleGenerationModel(): string {
@@ -409,12 +350,6 @@ export class KimiProvider implements Provider {
   }
 
   async shutdown(): Promise<void> {
-    for (const [key, server] of this.bridgeServers) {
-      server.stop();
-      const [baseUrl, apiKey] = key.split('::');
-      const logKey = `${baseUrl}::${keyFingerprint(apiKey)}`;
-      logger.info(`Kimi bridge server stopped for key=${logKey}`);
-    }
-    this.bridgeServers.clear();
+    // Kimi uses Moonshot's native Anthropic-compatible endpoint directly.
   }
 }

--- a/packages/daemon/src/lib/providers/minimax-provider.ts
+++ b/packages/daemon/src/lib/providers/minimax-provider.ts
@@ -7,16 +7,16 @@
  * API Documentation: https://platform.minimax.io/docs/guides/text-ai-coding-tools
  */
 
+import type { ModelInfo } from '@neokai/shared';
 import type {
+  ModelTier,
   Provider,
   ProviderAuthStatusInfo,
   ProviderCapabilities,
   ProviderCredentials,
   ProviderSdkConfig,
   ProviderSessionConfig,
-  ModelTier,
 } from '@neokai/shared/provider';
-import type { ModelInfo } from '@neokai/shared';
 import { probeAnthropicCompatCredentials } from './shared/credential-probe.js';
 
 /**
@@ -214,6 +214,7 @@ export class MinimaxProvider implements Provider {
     const envVars: Record<string, string> = {
       ANTHROPIC_BASE_URL: baseUrl,
       ANTHROPIC_AUTH_TOKEN: apiKey,
+      ANTHROPIC_API_KEY: '',
       API_TIMEOUT_MS: '3000000',
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
       ANTHROPIC_DEFAULT_HAIKU_MODEL: routingModelId,

--- a/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts
@@ -4,34 +4,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
-  KimiProvider,
   KIMI_REGION_ENDPOINTS,
+  KimiProvider,
   resolveKimiRegion,
 } from '../../../../src/lib/providers/kimi-provider';
-import type {
-  AnthropicMessagesBridgeServer,
-  AnthropicMessagesBridgeConfig,
-} from '../../../../src/lib/providers/anthropic-messages-bridge/server';
-
-/**
- * Fake bridge factory that records calls and returns a stub server.
- * Avoids binding real TCP ports in unit tests.
- */
-function createFakeBridgeFactory() {
-  const calls: AnthropicMessagesBridgeConfig[] = [];
-  let portCounter = 42000;
-  const servers: { port: number; stop: () => void }[] = [];
-
-  const factory = (config: AnthropicMessagesBridgeConfig): AnthropicMessagesBridgeServer => {
-    calls.push(config);
-    const port = portCounter++;
-    const server = { port, stop: mock(() => {}) };
-    servers.push(server);
-    return server;
-  };
-
-  return { factory, calls, servers };
-}
 
 describe('KimiProvider', () => {
   let provider: KimiProvider;
@@ -147,7 +123,7 @@ describe('KimiProvider', () => {
       expect(init?.method).toBe('POST');
       const headers = init?.headers as Record<string, string>;
       expect(headers['x-api-key']).toBe('test-key');
-      expect(headers['authorization']).toBe('Bearer test-key');
+      expect(headers.authorization).toBe('Bearer test-key');
     });
 
     it('throws when upstream rejects the API key (401)', async () => {
@@ -218,32 +194,15 @@ describe('KimiProvider', () => {
   });
 
   describe('buildSdkConfig', () => {
-    it('should start bridge and route through it', () => {
-      const { factory, calls } = createFakeBridgeFactory();
+    it('should route directly to the native Anthropic-compatible endpoint', () => {
       process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
       const config = provider.buildSdkConfig('kimi-for-coding');
 
-      // Bridge was started with correct config
-      expect(calls).toHaveLength(1);
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
-      expect(calls[0].apiKey).toBe('test-key');
-      expect(calls[0].models).toEqual([
-        {
-          id: 'kimi-for-coding',
-          display_name: 'Kimi For Coding',
-          context_window: 262144,
-          max_tokens: 32768,
-        },
-      ]);
-
-      // SDK routes through the bridge
-      expect(config.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
-      // Blank both Anthropic auth env vars so ProviderService clears any
-      // inherited Anthropic credentials. The bridge handles Kimi auth.
-      expect(config.envVars.ANTHROPIC_API_KEY).toBe('');
-      expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
+      expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('test-key');
+      expect(config.envVars.ANTHROPIC_API_KEY).toBeUndefined();
       expect(config.envVars.API_TIMEOUT_MS).toBe('3000000');
       // CLAUDE_CODE_AUTO_COMPACT_WINDOW is explicitly cleared (empty string)
       // so a previous GLM/Codex query's value cannot leak into Kimi's SDK
@@ -260,101 +219,50 @@ describe('KimiProvider', () => {
       expect(config.apiVersion).toBe('v1');
     });
 
-    it('should reuse the same bridge for identical credentials', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
-
-      provider.buildSdkConfig('kimi-for-coding');
-      provider.buildSdkConfig('kimi-for-coding');
-
-      // Only one bridge started
-      expect(calls).toHaveLength(1);
-    });
-
-    it('should create separate bridges for different API keys', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
-
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key-a' });
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key-b' });
-
-      expect(calls).toHaveLength(2);
-      expect(calls[0].apiKey).toBe('key-a');
-      expect(calls[1].apiKey).toBe('key-b');
-    });
-
-    it('should create separate bridges for different base URLs', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
-
-      provider.buildSdkConfig('kimi-for-coding', {
-        apiKey: 'key',
-        baseUrl: 'https://api.kimi.com/coding',
-      });
-      provider.buildSdkConfig('kimi-for-coding', {
-        apiKey: 'key',
-        baseUrl: 'https://api.moonshot.cn/anthropic',
-      });
-
-      expect(calls).toHaveLength(2);
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
-      expect(calls[1].baseUrl).toBe('https://api.moonshot.cn/anthropic');
-    });
-
     it('should normalize aliases to kimi-for-coding', () => {
-      const { factory, calls } = createFakeBridgeFactory();
       process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
       const config = provider.buildSdkConfig('kimi');
 
-      expect(calls[0].models![0].id).toBe('kimi-for-coding');
       expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('kimi-for-coding');
       expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('kimi-for-coding');
       expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('kimi-for-coding');
     });
 
     it('should normalize mixed-case aliases to kimi-for-coding', () => {
-      const { factory, calls } = createFakeBridgeFactory();
       process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('Kimi');
+      const config = provider.buildSdkConfig('Kimi');
 
-      expect(calls[0].models![0].id).toBe('kimi-for-coding');
+      expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('kimi-for-coding');
     });
 
     it('should normalize moonshot- prefixed model IDs to kimi-for-coding', () => {
-      const { factory, calls } = createFakeBridgeFactory();
       process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('moonshot-v1-32k');
+      const config = provider.buildSdkConfig('moonshot-v1-32k');
 
-      expect(calls[0].models![0].id).toBe('kimi-for-coding');
+      expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('kimi-for-coding');
     });
 
     it('should use session config API key and base URL overrides', () => {
-      const { factory, calls } = createFakeBridgeFactory();
       process.env.KIMI_API_KEY = 'env-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
       const config = provider.buildSdkConfig('kimi-for-coding', {
         apiKey: 'session-key',
         baseUrl: 'https://api.moonshot.cn/anthropic',
       });
 
-      expect(calls[0].baseUrl).toBe('https://api.moonshot.cn/anthropic');
-      expect(calls[0].apiKey).toBe('session-key');
-      // Both Anthropic auth env vars are blanked so inherited credentials are cleared
-      expect(config.envVars.ANTHROPIC_API_KEY).toBe('');
-      expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.moonshot.cn/anthropic');
+      expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('session-key');
     });
 
     it('should throw when no API key is configured', () => {
-      const { factory } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
       expect(() => provider.buildSdkConfig('kimi-for-coding')).toThrow(
         'Kimi API key not configured'
@@ -429,97 +337,92 @@ describe('KimiProvider', () => {
 
   describe('buildSdkConfig region routing', () => {
     it('routes to the China endpoint when no region is configured', () => {
-      const { factory, calls } = createFakeBridgeFactory();
       process.env.KIMI_API_KEY = 'test-key';
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('kimi-for-coding');
+      const config = provider.buildSdkConfig('kimi-for-coding');
 
-      expect(calls).toHaveLength(1);
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
     });
 
     it('routes to the Global endpoint when sessionConfig.region is global', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('kimi-for-coding', {
+      const config = provider.buildSdkConfig('kimi-for-coding', {
         apiKey: 'key',
         region: 'global',
       });
 
-      expect(calls).toHaveLength(1);
-      expect(calls[0].baseUrl).toBe('https://api.moonshot.ai/anthropic');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.moonshot.ai/anthropic');
     });
 
     it('routes to the China endpoint when sessionConfig.region is china', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('kimi-for-coding', {
+      const config = provider.buildSdkConfig('kimi-for-coding', {
         apiKey: 'key',
         region: 'china',
       });
 
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
     });
 
     it('falls back to provider-level default region when sessionConfig omits region', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
       // Simulate region loaded from ProviderRecord configJson by provider-sync.
       provider.setDefaultRegion('global');
 
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key' });
+      const config = provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key' });
 
-      expect(calls[0].baseUrl).toBe('https://api.moonshot.ai/anthropic');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.moonshot.ai/anthropic');
     });
 
     it('per-session region overrides provider-level default region', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
       provider.setDefaultRegion('global');
 
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'china' });
+      const config = provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'china' });
 
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
     });
 
     it('explicit sessionConfig.baseUrl overrides region selection', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
       provider.setDefaultRegion('global');
 
-      provider.buildSdkConfig('kimi-for-coding', {
+      const config = provider.buildSdkConfig('kimi-for-coding', {
         apiKey: 'key',
         baseUrl: 'https://custom.example.com/anthropic',
       });
 
-      expect(calls[0].baseUrl).toBe('https://custom.example.com/anthropic');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://custom.example.com/anthropic');
     });
 
     it('invalid sessionConfig.region falls back to china (not global)', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('kimi-for-coding', {
+      const config = provider.buildSdkConfig('kimi-for-coding', {
         apiKey: 'key',
         region: 'us' as unknown,
       });
 
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
+      expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
     });
 
-    it('creates separate bridges for different regions', () => {
-      const { factory, calls } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
+    it('returns the selected native endpoint for each region', () => {
+      provider = new KimiProvider();
 
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'china' });
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key', region: 'global' });
+      const chinaConfig = provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        region: 'china',
+      });
+      const globalConfig = provider.buildSdkConfig('kimi-for-coding', {
+        apiKey: 'key',
+        region: 'global',
+      });
 
-      expect(calls).toHaveLength(2);
-      expect(calls[0].baseUrl).toBe('https://api.kimi.com/coding');
-      expect(calls[1].baseUrl).toBe('https://api.moonshot.ai/anthropic');
+      expect(chinaConfig.envVars.ANTHROPIC_BASE_URL).toBe('https://api.kimi.com/coding');
+      expect(globalConfig.envVars.ANTHROPIC_BASE_URL).toBe('https://api.moonshot.ai/anthropic');
     });
   });
 
@@ -528,8 +431,11 @@ describe('KimiProvider', () => {
       provider = new KimiProvider();
     });
 
-    it('should translate Kimi models to default', () => {
-      expect(provider.translateModelIdForSdk('kimi-for-coding')).toBe('default');
+    it('should return actual model ID to avoid settings.json overrides', () => {
+      // Returns actual model ID instead of 'default' so ~/.claude/settings.json
+      // ANTHROPIC_DEFAULT_SONNET_MODEL cannot redirect to other providers.
+      expect(provider.translateModelIdForSdk('kimi-for-coding')).toBe('kimi-for-coding');
+      expect(provider.translateModelIdForSdk('kimi')).toBe('kimi-for-coding');
     });
   });
 
@@ -596,20 +502,7 @@ describe('KimiProvider', () => {
   });
 
   describe('shutdown', () => {
-    it('should stop all bridge servers on shutdown', async () => {
-      const { factory, servers } = createFakeBridgeFactory();
-      provider = new KimiProvider(process.env, factory);
-
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key-a' });
-      provider.buildSdkConfig('kimi-for-coding', { apiKey: 'key-b' });
-      expect(servers).toHaveLength(2);
-
-      await provider.shutdown();
-      expect(servers[0].stop).toHaveBeenCalled();
-      expect(servers[1].stop).toHaveBeenCalled();
-    });
-
-    it('should resolve without error when no bridge was started', async () => {
+    it('should resolve without error', async () => {
       provider = new KimiProvider();
       await expect(provider.shutdown()).resolves.toBeUndefined();
     });

--- a/packages/daemon/tests/unit/1-core/providers/minimax-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/minimax-provider.test.ts
@@ -185,6 +185,7 @@ describe('MinimaxProvider', () => {
       expect(config.envVars).toEqual({
         ANTHROPIC_BASE_URL: 'https://api.minimax.io/anthropic',
         ANTHROPIC_AUTH_TOKEN: 'test-key',
+        ANTHROPIC_API_KEY: '',
         API_TIMEOUT_MS: '3000000',
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
         ANTHROPIC_DEFAULT_HAIKU_MODEL: 'MiniMax-M2.5',

--- a/packages/shared/src/provider/types.ts
+++ b/packages/shared/src/provider/types.ts
@@ -69,6 +69,8 @@ export interface ProviderSessionConfig {
   apiKey?: string;
   /** Custom base URL override */
   baseUrl?: string;
+  /** Provider-specific region selector, when supported */
+  region?: unknown;
   /** Workspace/working directory for this session (used for workspace-scoped providers) */
   workspacePath?: string;
   /** Session ID for provider-aware routing (e.g. persistent session tracking) */

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -97,7 +97,7 @@ export default defineConfig({
   },
 
   optimizeDeps: {
-    include: ['preact', '@preact/signals', 'clsx', 'date-fns'],
+    include: ['preact', '@preact/signals', 'clsx'],
     exclude: ['@neokai/shared'], // Exclude local packages from pre-bundling
     esbuildOptions: {
       jsx: 'automatic',


### PR DESCRIPTION
## Summary

- Route Kimi through its native Anthropic-compatible endpoint instead of the local Anthropic messages bridge.
- Preserve user/project/local SDK setting sources, but inject provider-managed env vars into `Options.settings.env` so UI-selected provider values override `~/.claude/settings.json` env entries.
- Pass provider `region` through session config and explicitly clear `ANTHROPIC_API_KEY` for MiniMax, matching OpenRouter’s safer provider env shape.
- Remove unused `date-fns` from Vite optimizeDeps so the dev server can boot without an undeclared dependency.

## Root Cause

Provider routing values such as `ANTHROPIC_BASE_URL` and `ANTHROPIC_DEFAULT_*_MODEL` could be overridden by `~/.claude/settings.json` when all filesystem setting sources were loaded. The SDK’s programmatic `settings` option maps to the high-priority flag-settings layer, so provider env must be injected there rather than suppressing user settings sources.

## Validation

- `cd packages/daemon && bun test tests/unit/1-core/providers/kimi-provider.test.ts tests/unit/1-core/providers/minimax-provider.test.ts tests/unit/1-core/providers/openrouter-provider.test.ts`
- `bunx biome check packages/daemon/src/lib/providers/kimi-provider.ts packages/daemon/src/lib/providers/minimax-provider.ts packages/daemon/tests/unit/1-core/providers/kimi-provider.test.ts packages/daemon/tests/unit/1-core/providers/minimax-provider.test.ts packages/shared/src/provider/types.ts packages/daemon/src/lib/provider-service.ts packages/daemon/src/lib/agent/query-runner.ts packages/daemon/src/lib/agent/query-options-builder.ts packages/web/vite.config.ts --max-diagnostics=80` (passes with existing warnings only)
- pre-commit hook: lint, format, typecheck, knip passed