### PR TITLE
Fix task-agent thinking token counts

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -635,6 +635,9 @@ export class SDKMessageHandler {
 
     if (isSDKResultMessage(message)) {
       this.lastResultWasSuccess = isSDKResultSuccess(message);
+      // Reset turn-level thinking token tracking now, before any turn-end
+      // handler can trigger an immediate queued turn replay.
+      this.resetThinkingTokenTracking();
     }
 
     // Handle specific message types
@@ -675,9 +678,6 @@ export class SDKMessageHandler {
     // triggers a fetch, so short turns still update context once.
     // The 5-event tick below is deduped via pendingContextRefresh.
     if (isSDKResultMessage(message)) {
-      // Reset turn-level thinking token tracking so the next turn starts fresh
-      // and cannot inherit stale cumulative estimates.
-      this.resetThinkingTokenTracking();
       void this.refreshContextUsage('turn-end');
       return;
     }
@@ -868,13 +868,14 @@ export class SDKMessageHandler {
 
     this.usesSessionStateChangedTurnEnd = true;
     if (message.state === 'idle') {
+      // Reset turn-scoped thinking tokens tracking before replaying queued
+      // turns, so the next turn cannot inherit a stale baseline.
+      this.resetThinkingTokenTracking();
       const allowQueueReplay = this.lastResultWasSuccess !== false;
       await this.finishTurn(allowQueueReplay);
       this.usesSessionStateChangedTurnEnd = false;
       this.expectsSessionStateIdleAfterResult = false;
       this.lastResultWasSuccess = null;
-      // Reset turn-scoped thinking tokens tracking to prevent stale leak
-      this.resetThinkingTokenTracking();
     }
   }
 

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -693,6 +693,13 @@ export class SDKMessageHandler {
 
     if (!isSDKSystemMessage(message)) return;
 
+    // A new SDK query/session starts with an init message. Reset any stale
+    // turn-level thinking counters left over from a previously interrupted or
+    // stopped turn so they cannot undercount the new query's first block.
+    if (isSDKSystemInit(message)) {
+      this.resetThinkingTokenTracking();
+    }
+
     // Capture SDK's internal session ID if we don't have it yet
     // This enables session resumption after daemon restart
     // Guard on isSDKSystemInit so that other system subtypes (api_retry, status, etc.)

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -520,7 +520,17 @@ export class SDKMessageHandler {
     // the DB if persisted. The per-block delta is computed and stamped when an
     // assistant message containing a thinking block arrives.
     if (isSDKThinkingTokensMessage(message)) {
-      this.currentThinkingTokensEstimate = message.estimated_tokens;
+      const estimate = message.estimated_tokens;
+      // Some SDK/provider paths reset the running total when a new thinking
+      // block starts. If the cumulative estimate drops below what we already
+      // stamped, treat it as a new block boundary instead of a negative delta.
+      if (
+        this.lastStampedThinkingTokensEstimate > 0 &&
+        estimate < this.lastStampedThinkingTokensEstimate
+      ) {
+        this.lastStampedThinkingTokensEstimate = 0;
+      }
+      this.currentThinkingTokensEstimate = estimate;
       return; // Skip persistence and broadcast - this is internal tracking only
     }
 

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -108,8 +108,14 @@ export class SDKMessageHandler {
   // In-flight context refresh (deduped across event/turn-end/compact triggers)
   private pendingContextRefresh: Promise<void> | null = null;
 
-  // Latest thinking tokens estimate for the current turn (stashed for persistence on assistant message)
+  // Latest turn-level thinking tokens estimate from the SDK. For providers that
+  // emit a cumulative running total, this is the cumulative value, NOT a
+  // per-block count.
   private currentThinkingTokensEstimate: number | null = null;
+  // Cumulative amount already attributed to persisted assistant thinking blocks
+  // in the current turn. The delta between current and last stamped is what we
+  // persist on each new thinking block.
+  private lastStampedThinkingTokensEstimate: number = 0;
 
   constructor(private ctx: SDKMessageHandlerContext) {
     const { session } = ctx;
@@ -508,9 +514,11 @@ export class SDKMessageHandler {
       // DO NOT return - let it fall through to persistence and rendering
     }
 
-    // Handle thinking tokens messages: stash estimate, but do not persist or broadcast
-    // These fire frequently during the redacted thinking phase and would bloat the DB if persisted.
-    // The final estimate is persisted on the assistant message when the thinking block completes.
+    // Handle thinking tokens messages: stash the latest cumulative estimate for
+    // the current turn, but do not persist or broadcast the event itself.
+    // These fire frequently during the redacted thinking phase and would bloat
+    // the DB if persisted. The per-block delta is computed and stamped when an
+    // assistant message containing a thinking block arrives.
     if (isSDKThinkingTokensMessage(message)) {
       this.currentThinkingTokensEstimate = message.estimated_tokens;
       return; // Skip persistence and broadcast - this is internal tracking only
@@ -549,17 +557,23 @@ export class SDKMessageHandler {
       };
     }
 
-    // Stamp the latest thinking tokens estimate onto assistant messages with thinking blocks
-    // This preserves the estimate across page reloads (unlike the transient live event)
+    // Stamp the per-block thinking tokens delta onto assistant messages that
+    // contain a thinking block. The SDK emits a cumulative turn-level estimate,
+    // which can be split across many assistant messages in task-agent sessions.
+    // Persisting the delta since the last stamped block avoids repeating the
+    // same cumulative count on every block. If the delta is not positive
+    // (stale/zero/negative), omit the field so the UI falls back to character
+    // counts only.
     if (isSDKAssistantMessage(message) && this.currentThinkingTokensEstimate !== null) {
       const hasThinkingBlock = message.message.content.some(
         (block: unknown) => (block as Record<string, unknown>).type === 'thinking'
       );
       if (hasThinkingBlock) {
-        (message as Record<string, unknown>).estimated_thinking_tokens =
-          this.currentThinkingTokensEstimate;
-        // Reset after consuming (estimate is per-turn)
-        this.currentThinkingTokensEstimate = null;
+        const delta = this.currentThinkingTokensEstimate - this.lastStampedThinkingTokensEstimate;
+        if (delta > 0) {
+          (message as Record<string, unknown>).estimated_thinking_tokens = delta;
+          this.lastStampedThinkingTokensEstimate = this.currentThinkingTokensEstimate;
+        }
       }
     }
 
@@ -649,6 +663,9 @@ export class SDKMessageHandler {
     // triggers a fetch, so short turns still update context once.
     // The 5-event tick below is deduped via pendingContextRefresh.
     if (isSDKResultMessage(message)) {
+      // Reset turn-level thinking token tracking so the next turn starts fresh
+      // and cannot inherit stale cumulative estimates.
+      this.resetThinkingTokenTracking();
       void this.refreshContextUsage('turn-end');
       return;
     }
@@ -837,9 +854,21 @@ export class SDKMessageHandler {
       this.usesSessionStateChangedTurnEnd = false;
       this.expectsSessionStateIdleAfterResult = false;
       this.lastResultWasSuccess = null;
-      // Reset turn-scoped thinking tokens estimate to prevent stale leak
-      this.currentThinkingTokensEstimate = null;
+      // Reset turn-scoped thinking tokens tracking to prevent stale leak
+      this.resetThinkingTokenTracking();
     }
+  }
+
+  /**
+   * Reset turn-level thinking token tracking.
+   *
+   * Called at turn end (result messages and session_state_changed idle) so
+   * cumulative estimates from one turn cannot be attributed to blocks in the
+   * next turn.
+   */
+  private resetThinkingTokenTracking(): void {
+    this.currentThinkingTokensEstimate = null;
+    this.lastStampedThinkingTokensEstimate = 0;
   }
 
   private async handleModelRefusalFallbackMessage(message: SDKMessage): Promise<void> {

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -521,9 +521,11 @@ export class SDKMessageHandler {
     // assistant message containing a thinking block arrives.
     if (isSDKThinkingTokensMessage(message)) {
       const estimate = message.estimated_tokens;
-      // Some SDK/provider paths reset the running total when a new thinking
-      // block starts. If the cumulative estimate drops below what we already
-      // stamped, treat it as a new block boundary instead of a negative delta.
+      // Heuristic: treat a drop in the cumulative estimate as a new thinking-block
+      // boundary. Non-decreasing values are treated as the same stream so the
+      // delta since the last stamped block is attributed correctly. This handles
+      // both the stuck-cumulative task-agent case (e.g. #614) and per-block resets
+      // where the next block starts lower than the previous block's final total.
       if (
         this.lastStampedThinkingTokensEstimate > 0 &&
         estimate < this.lastStampedThinkingTokensEstimate

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -658,6 +658,229 @@ describe('SDKMessageHandler', () => {
       expect(savedMessage.type).toBe('assistant');
       expect(savedMessage).not.toHaveProperty('estimated_thinking_tokens');
     });
+
+    it('should persist per-block deltas from a cumulative turn-level estimate', async () => {
+      // Simulate a task-agent turn where the SDK emits a cumulative estimate
+      // that increases, and assistant thinking is split across messages.
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 500,
+        estimated_tokens_delta: 500,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'First chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-2',
+        session_id: 'test-session-id',
+        estimated_tokens: 1200,
+        estimated_tokens_delta: 700,
+      } as unknown as SDKMessage);
+
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Second chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      const savedA = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-a'
+      )?.[1] as SDKMessage;
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+
+      expect(savedA).toMatchObject({ estimated_thinking_tokens: 500 });
+      expect(savedB).toMatchObject({ estimated_thinking_tokens: 700 });
+    });
+
+    it('should not repeat the same cumulative count on later thinking blocks', async () => {
+      // Provider keeps emitting the same cumulative estimate while the SDK
+      // streams multiple assistant thinking messages.
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 814,
+        estimated_tokens_delta: 814,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'First chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-2',
+        session_id: 'test-session-id',
+        estimated_tokens: 814,
+        estimated_tokens_delta: 0,
+      } as unknown as SDKMessage);
+
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Second chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      const savedA = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-a'
+      )?.[1] as SDKMessage;
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+
+      expect(savedA).toMatchObject({ estimated_thinking_tokens: 814 });
+      expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
+    });
+
+    it('should reset thinking token tracking at turn end', async () => {
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 500,
+        estimated_tokens_delta: 500,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Turn 1 chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      // End the turn
+      await handler.handleMessage({
+        type: 'result',
+        subtype: 'success',
+        uuid: 'result-1',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        total_cost_usd: 0.001,
+        modelUsage: {},
+      } as unknown as SDKMessage);
+
+      // A later thinking block in a new turn should not inherit stale estimate
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Turn 2 chunk without new thinking_tokens' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+      expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
+    });
+
+    it('should omit stale, zero, or negative deltas', async () => {
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 300,
+        estimated_tokens_delta: 300,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Chunk A' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      // Provider reports a lower cumulative estimate (should not stamp)
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-2',
+        session_id: 'test-session-id',
+        estimated_tokens: 200,
+        estimated_tokens_delta: -100,
+      } as unknown as SDKMessage);
+
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Chunk B' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      const savedA = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-a'
+      )?.[1] as SDKMessage;
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+
+      expect(savedA).toMatchObject({ estimated_thinking_tokens: 300 });
+      expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
+    });
   });
 
   describe('handleResultMessage', () => {

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -827,7 +827,7 @@ describe('SDKMessageHandler', () => {
       expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
     });
 
-    it('should omit stale, zero, or negative deltas', async () => {
+    it('should omit zero and repeated identical deltas', async () => {
       await handler.handleMessage({
         type: 'system',
         subtype: 'thinking_tokens',
@@ -849,14 +849,14 @@ describe('SDKMessageHandler', () => {
       } as unknown as SDKMessage;
       await handler.handleMessage(assistantA);
 
-      // Provider reports a lower cumulative estimate (should not stamp)
+      // Provider repeats the same cumulative estimate.
       await handler.handleMessage({
         type: 'system',
         subtype: 'thinking_tokens',
         uuid: 'thinking-2',
         session_id: 'test-session-id',
-        estimated_tokens: 200,
-        estimated_tokens_delta: -100,
+        estimated_tokens: 300,
+        estimated_tokens_delta: 0,
       } as unknown as SDKMessage);
 
       const assistantB: SDKMessage = {
@@ -880,6 +880,88 @@ describe('SDKMessageHandler', () => {
 
       expect(savedA).toMatchObject({ estimated_thinking_tokens: 300 });
       expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
+    });
+
+    it('should treat a decreased cumulative estimate as a new thinking block', async () => {
+      // First thinking block ends with a cumulative estimate of 300.
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 300,
+        estimated_tokens_delta: 300,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Chunk A' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      // Cumulative drops: the SDK has started a new thinking block.
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-2',
+        session_id: 'test-session-id',
+        estimated_tokens: 200,
+        estimated_tokens_delta: -100,
+      } as unknown as SDKMessage);
+
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Chunk B' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      // Same cumulative repeated again for the new block should not re-stamp.
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-3',
+        session_id: 'test-session-id',
+        estimated_tokens: 200,
+        estimated_tokens_delta: 0,
+      } as unknown as SDKMessage);
+
+      const assistantC: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-c',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Chunk C' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantC);
+
+      const savedA = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-a'
+      )?.[1] as SDKMessage;
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+      const savedC = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-c'
+      )?.[1] as SDKMessage;
+
+      expect(savedA).toMatchObject({ estimated_thinking_tokens: 300 });
+      expect(savedB).toMatchObject({ estimated_thinking_tokens: 200 });
+      expect(savedC).not.toHaveProperty('estimated_thinking_tokens');
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -579,6 +579,57 @@ describe('SDKMessageHandler', () => {
       });
     });
 
+    it('should reset thinking token tracking on system init (new query start)', async () => {
+      // Stale counters from an interrupted previous turn
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'thinking_tokens',
+        uuid: 'thinking-1',
+        session_id: 'test-session-id',
+        estimated_tokens: 500,
+        estimated_tokens_delta: 500,
+      } as unknown as SDKMessage);
+
+      const assistantA: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-a',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Interrupted turn chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantA);
+
+      // New SDK query/session starts with init
+      await handler.handleMessage({
+        type: 'system',
+        subtype: 'init',
+        uuid: 'init-uuid',
+        session_id: 'new-sdk-session-id',
+        slash_commands: [],
+      } as unknown as SDKMessage);
+
+      // Next thinking block should not inherit the previous turn's stamp baseline
+      const assistantB: SDKMessage = {
+        type: 'assistant',
+        uuid: 'assistant-b',
+        session_id: 'test-session-id',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'New query chunk' }],
+        },
+        parent_tool_use_id: null,
+      } as unknown as SDKMessage;
+      await handler.handleMessage(assistantB);
+
+      const savedB = saveSDKMessageSpy.mock.calls.find(
+        (call) => (call[1] as SDKMessage).uuid === 'assistant-b'
+      )?.[1] as SDKMessage;
+      expect(savedB).not.toHaveProperty('estimated_thinking_tokens');
+    });
+
     it('should not persist thinking_tokens but stash estimate', async () => {
       const message: SDKMessage = {
         type: 'system',


### PR DESCRIPTION
Fixes repeated thinking token counts on split task-agent thinking blocks.

The SDK emits thinking_tokens as a cumulative turn-level estimate. The daemon was stamping that cumulative value onto every assistant thinking block, so task-agent sessions showed the same count on many blocks with different content.

Changes in SDKMessageHandler:
- Track the latest cumulative estimate and the cumulative amount already stamped.
- Stamp the delta since the last thinking block; omit non-positive deltas so the UI falls back to character counts.
- Reset tracking at turn end (result messages and session_state_changed idle) to avoid stale attribution.

Added unit tests covering per-block deltas, repeated identical cumulative values, turn-end reset, and stale/zero/negative deltas.

Validation: targeted unit tests pass (packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts).