### PR TITLE
fix: fold background task notifications onto tool cards

### DIFF
--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -899,7 +899,11 @@ export default function ChatContainer({
   // Message Maps (for tool results/inputs)
   // ========================================
   const removedOutputs = session?.metadata?.removedOutputs || [];
-  const maps = useMessageMaps(messages, sessionId, removedOutputs);
+  const messagesWithBackgroundTasks = useMemo(
+    () => [...messages, ...backgroundTaskMessages],
+    [messages, backgroundTaskMessages]
+  );
+  const maps = useMessageMaps(messagesWithBackgroundTasks, sessionId, removedOutputs);
 
   const handleQuestionResolved = useCallback(
     (state: 'submitted' | 'cancelled', responses: QuestionDraftResponse[]) => {


### PR DESCRIPTION
Fixes background task notification folding by including background task rows in the shared message maps used by the chat renderer, so the originating top-level Bash tool_use is visible when suppressing the standalone task_notification row.

Also includes the Bash in-slice regression test.

Tests:
- cd packages/web && bunx vitest run src/components/sdk/__tests__/SDKMessageRenderer.test.tsx src/hooks/__tests__/useMessageMaps.test.ts
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/fix-fold-task-notification-onto-in-slice-bash-card-no check
