### PR TITLE
feat: show running border on active tool cards

### DIFF
--- a/packages/web/src/components/SessionInfoPanel.tsx
+++ b/packages/web/src/components/SessionInfoPanel.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { ChatMessage, Session, GitSessionStatusResponse } from '@neokai/shared';
+import { extractBackgroundTasks, type BackgroundTask } from '../hooks/useRunningToolUseIds.ts';
 import { getGitSessionStatus } from '../lib/api-helpers.ts';
 import { cn } from '../lib/utils.ts';
-import { extractBackgroundTasks, type BackgroundTask } from '../hooks/useRunningToolUseIds.ts';
 import { IconButton } from './ui/IconButton.tsx';
 
 interface SessionInfoPanelButtonProps {

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -54,6 +54,8 @@ interface Props {
    * Set by the compact task thread renderer for the last non-terminal message.
    */
   isRunning?: boolean;
+  /** Tool use IDs within this message whose cards are currently running. */
+  runningToolUseIds?: Set<string>;
   /**
    * When true, Task/Agent tool_use blocks are rendered as normal tool cards
    * instead of SubagentBlock.
@@ -72,6 +74,7 @@ export function SDKAssistantMessage({
   pendingQuestion,
   onQuestionResolved,
   isRunning,
+  runningToolUseIds,
   flattenSubagentTools = false,
 }: Props) {
   const { message: apiMessage } = message;
@@ -275,7 +278,7 @@ export function SDKAssistantMessage({
             pendingQuestion={pendingQuestion}
             onQuestionResolved={onQuestionResolved}
             flattenSubagentTools={flattenSubagentTools}
-            isRunning={!!isRunning}
+            isRunning={!!isRunning || runningToolUseIds?.has(block.id)}
           />
         );
       })}

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -94,6 +94,8 @@ interface Props {
    * animated arc traces exactly that element's rounded-rect border.
    */
   isRunning?: boolean;
+  /** Tool use IDs within this assistant message whose cards are currently running. */
+  runningToolUseIds?: Set<string>;
   /** Visual marker for messages superseded/retracted by later SDK rows. */
   replacementStatus?: MessageReplacementStatus;
   /** True when this row is the latest visible SDK row in the session stream. */
@@ -265,6 +267,7 @@ function SDKMessageRendererImpl({
   flattenSubagentTools = false,
   showToolResultUserMessages = false,
   isRunning,
+  runningToolUseIds,
   replacementStatus,
   isLiveTail = false,
 }: Props) {
@@ -376,6 +379,7 @@ function SDKMessageRendererImpl({
         onQuestionResolved={onQuestionResolved}
         flattenSubagentTools={flattenSubagentTools}
         isRunning={isRunning}
+        runningToolUseIds={runningToolUseIds}
       />
     );
   } else if (isSDKResultMessage(sdkMessage)) {
@@ -449,6 +453,7 @@ function areMessageRendererPropsEqual(prev: Props, next: Props): boolean {
     prev.flattenSubagentTools === next.flattenSubagentTools &&
     prev.showToolResultUserMessages === next.showToolResultUserMessages &&
     prev.isRunning === next.isRunning &&
+    prev.runningToolUseIds === next.runningToolUseIds &&
     prev.replacementStatus === next.replacementStatus &&
     prev.isLiveTail === next.isLiveTail
   );

--- a/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
+++ b/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
@@ -854,6 +854,65 @@ describe('useMessageMaps', () => {
     });
   });
 
+  describe('runningToolUseIdsByMessageUuid', () => {
+    it('maps running tool use IDs to their assistant message UUID', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          uuid: uuid1,
+          session_id: 'session-1',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tool-running', name: 'Bash', input: {} },
+              { type: 'tool_use', id: 'tool-idle', name: 'Read', input: {} },
+            ],
+          },
+        },
+        {
+          type: 'assistant',
+          uuid: uuid2,
+          session_id: 'session-1',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool-running-2', name: 'Task', input: {} }],
+          },
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() =>
+        useMessageMaps(messages, 'session-1', [], new Set(['tool-running', 'tool-running-2']))
+      );
+
+      expect(result.current.runningToolUseIdsByMessageUuid.get(uuid1)).toEqual(
+        new Set(['tool-running'])
+      );
+      expect(result.current.runningToolUseIdsByMessageUuid.get(uuid2)).toEqual(
+        new Set(['tool-running-2'])
+      );
+    });
+
+    it('does not mark idle tool uses as running', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          uuid: uuid1,
+          session_id: 'session-1',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tool-idle', name: 'Bash', input: {} }],
+          },
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() =>
+        useMessageMaps(messages, 'session-1', [], new Set(['other-tool']))
+      );
+
+      expect(result.current.runningToolUseIdsByMessageUuid.size).toBe(0);
+    });
+  });
+
   describe('foldableToolUseIds', () => {
     it('includes top-level tool_uses and nested ones whose parent Task card is present', () => {
       const messages = [

--- a/packages/web/src/hooks/useMessageMaps.ts
+++ b/packages/web/src/hooks/useMessageMaps.ts
@@ -49,6 +49,8 @@ export interface UseMessageMapsResult {
   subagentMessagesMap: Map<string, SDKMessage[]>;
   /** Map of tool use IDs to their terminal task_notification (status/summary/usage) */
   taskNotificationsMap: Map<string, SDKTaskNotificationMessage>;
+  /** Map of assistant message UUIDs to the tool_use IDs currently running in that message. */
+  runningToolUseIdsByMessageUuid: Map<string, Set<string>>;
   /**
    * Tool use IDs whose card is actually rendered in this slice — top-level
    * tool_use ids plus nested tool_use ids whose parent Task/Agent card is
@@ -75,7 +77,8 @@ export interface UseMessageMapsResult {
 export function useMessageMaps(
   messages: ChatMessage[],
   sessionId: string,
-  removedOutputs: string[] = []
+  removedOutputs: string[] = [],
+  runningToolUseIds: Set<string> = new Set()
 ): UseMessageMapsResult {
   // Cast to SDKMessage[] for duck-typed property access; NeokaiActionMessage will not match
   // 'user'/'assistant'/'system' checks and will be safely skipped by all maps.
@@ -143,6 +146,25 @@ export function useMessageMaps(
     });
     return map;
   }, [sdkMessages]);
+
+  const runningToolUseIdsByMessageUuid = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    if (runningToolUseIds.size === 0) return map;
+
+    sdkMessages.forEach((msg) => {
+      if (msg.type !== 'assistant' || !msg.uuid || !Array.isArray(msg.message.content)) return;
+      const ids = new Set<string>();
+      msg.message.content.forEach((block: unknown) => {
+        const blockObj = block as Record<string, unknown>;
+        if (blockObj.type === 'tool_use' && typeof blockObj.id === 'string') {
+          if (runningToolUseIds.has(blockObj.id)) ids.add(blockObj.id);
+        }
+      });
+      if (ids.size > 0) map.set(msg.uuid, ids);
+    });
+
+    return map;
+  }, [sdkMessages, runningToolUseIds]);
 
   // Map of user message UUIDs to their attached session init info
   const sessionInfoMap = useMemo(() => {
@@ -284,6 +306,7 @@ export function useMessageMaps(
     sessionInfoMap,
     subagentMessagesMap,
     taskNotificationsMap,
+    runningToolUseIdsByMessageUuid,
     foldableToolUseIds,
     replacementStatusMap,
     completedHookUuids,

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -55,6 +55,7 @@ import { getProviderLabel } from '../hooks/index.ts';
 import { useAutoScroll } from '../hooks/useAutoScroll.ts';
 import { useChatComposerController } from '../hooks/useChatComposerController.ts';
 import { useMessageMaps } from '../hooks/useMessageMaps.ts';
+import { useRunningToolUseIds } from '../hooks/useRunningToolUseIds.ts';
 // Hooks
 import { useModal } from '../hooks/useModal.ts';
 import { useScrollToMessage } from '../hooks/useScrollToMessage.ts';
@@ -899,7 +900,8 @@ export default function ChatContainer({
   // Message Maps (for tool results/inputs)
   // ========================================
   const removedOutputs = session?.metadata?.removedOutputs || [];
-  const maps = useMessageMaps(messages, sessionId, removedOutputs);
+  const runningToolUseIds = useRunningToolUseIds(backgroundTaskMessages);
+  const maps = useMessageMaps(messages, sessionId, removedOutputs, runningToolUseIds);
 
   const handleQuestionResolved = useCallback(
     (state: 'submitted' | 'cancelled', responses: QuestionDraftResponse[]) => {
@@ -1392,6 +1394,9 @@ export default function ChatContainer({
                     taskNotificationsMap={maps.taskNotificationsMap}
                     foldableToolUseIds={maps.foldableToolUseIds}
                     completedHookUuids={maps.completedHookUuids}
+                    runningToolUseIds={
+                      msg.uuid ? maps.runningToolUseIdsByMessageUuid.get(msg.uuid) : undefined
+                    }
                     replacementStatusMap={maps.replacementStatusMap}
                     sessionInfo={
                       msg.uuid


### PR DESCRIPTION
Wires running tool-use tracking into chat rendering so active Bash/Task tool cards receive the existing RunningBorder treatment.

Changes:
- derives running tool-use ids from background task lifecycle messages
- maps active tool ids to their assistant messages and passes them through SDKMessageRenderer
- reuses the shared background task extraction for SessionInfoPanel
- adds hook coverage for active/terminal task states and message-map running ids

Validation:
- cd packages/web && bunx vitest run src/hooks/__tests__/useMessageMaps.test.ts src/hooks/__tests__/useRunningToolUseIds.test.ts src/components/__tests__/SessionInfoPanel.test.ts
- bun run check