### PR TITLE
feat: expose GitHub polling interval setting

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -126,6 +126,23 @@ async function applyStoredProviderCredentials(
   }
 }
 
+export async function syncGitHubPollingCapability(
+  extensionConfigStore: Pick<
+    ExternalEventExtensionConfigStore,
+    'getGlobalConfig' | 'setGlobalConfig'
+  >,
+  pollingEnabled: boolean
+): Promise<void> {
+  const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
+  await extensionConfigStore.setGlobalConfig('github', {
+    ...githubGlobalConfig,
+    capabilities: {
+      ...githubGlobalConfig.capabilities,
+      polling: pollingEnabled,
+    },
+  });
+}
+
 export interface CreateDaemonAppOptions {
   config: Config;
   /**
@@ -674,16 +691,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     };
     const extensionManager = new ExternalEventExtensionManager();
     const githubPollingEnabled = getGitHubPollingIntervalSeconds() > 0;
-    if (githubPollingEnabled) {
-      const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
-      await extensionConfigStore.setGlobalConfig('github', {
-        ...githubGlobalConfig,
-        capabilities: {
-          ...githubGlobalConfig.capabilities,
-          polling: true,
-        },
-      });
-    }
+    await syncGitHubPollingCapability(extensionConfigStore, githubPollingEnabled);
     extensionManager.register(
       new GitHubEventExtension(db.getDatabase(), process.env.GITHUB_TOKEN, {
         getPollIntervalMs: () => getGitHubPollingIntervalSeconds() * 1000,
@@ -704,14 +712,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
         lastGitHubPollingIntervalSeconds = nextGitHubPollingIntervalSeconds;
         gitHubService?.refreshPolling({ reschedulePending: true });
         void (async () => {
-          const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
-          await extensionConfigStore.setGlobalConfig('github', {
-            ...githubGlobalConfig,
-            capabilities: {
-              ...githubGlobalConfig.capabilities,
-              polling: getGitHubPollingIntervalSeconds() > 0,
-            },
-          });
+          await syncGitHubPollingCapability(
+            extensionConfigStore,
+            getGitHubPollingIntervalSeconds() > 0
+          );
           await githubEventExtension?.refreshPollingInterval();
         })();
       },

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -602,7 +602,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     let gitHubService: GitHubService | null = null;
     const shouldEnableGitHub = config.githubWebhookSecret || getGitHubPollingIntervalSeconds() > 0;
 
-    if (shouldEnableGitHub && hasAnthropicAuth) {
+    if (hasAnthropicAuth) {
       // Get API key for AI agents (security + routing).
       // Fall back to stored provider credentials so GitHub works when the sole
       // auth source is the credential store.
@@ -637,10 +637,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
           getPollingIntervalSeconds: getGitHubPollingIntervalSeconds,
         });
 
-        logInfo('[Daemon] GitHub integration enabled', {
-          webhook: !!config.githubWebhookSecret,
-          polling: getGitHubPollingIntervalSeconds() > 0,
-        });
+        if (shouldEnableGitHub) {
+          logInfo('[Daemon] GitHub integration enabled', {
+            webhook: !!config.githubWebhookSecret,
+            polling: getGitHubPollingIntervalSeconds() > 0,
+          });
+        } else {
+          logInfo('[Daemon] GitHub integration initialized; polling disabled by settings');
+        }
       } else {
         logInfo('[Daemon] GitHub integration disabled - no API key available for AI agents');
       }
@@ -881,7 +885,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     // Start GitHub service after server is ready.
     // GitHubService.start() registers the github.poll handler and enqueues the
     // initial job when jobProcessor/jobQueue are provided.
-    if (gitHubService) {
+    if (gitHubService && shouldEnableGitHub) {
       gitHubService.start();
       logInfo('[Daemon] GitHub service started');
     }

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -690,10 +690,14 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     const githubEventExtension = extensionManager.getExtension('github') as
       | GitHubEventExtension
       | undefined;
+    let lastGitHubPollingIntervalSeconds = getGitHubPollingIntervalSeconds();
     internalEventBus.subscribe(
       'settings.updated',
       (event) => {
         if (event.namespaceId !== 'global') return;
+        const nextGitHubPollingIntervalSeconds = getGitHubPollingIntervalSeconds();
+        if (nextGitHubPollingIntervalSeconds === lastGitHubPollingIntervalSeconds) return;
+        lastGitHubPollingIntervalSeconds = nextGitHubPollingIntervalSeconds;
         gitHubService?.refreshPolling({ reschedulePending: true });
         void (async () => {
           const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -600,7 +600,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     startupPhase('github service');
     // Initialize GitHub service if configured
     let gitHubService: GitHubService | null = null;
-    const shouldEnableGitHub = config.githubWebhookSecret || hasAnthropicAuth;
+    const shouldEnableGitHub = config.githubWebhookSecret || getGitHubPollingIntervalSeconds() > 0;
 
     if (shouldEnableGitHub && hasAnthropicAuth) {
       // Get API key for AI agents (security + routing).

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -12,7 +12,7 @@ import { AuthManager } from './lib/auth-manager';
 import { SettingsManager } from './lib/settings-manager';
 import { StateProjectionService } from './lib/state-projection-service';
 import { createClientEventBridge } from './lib/client-event-bridge';
-import { MessageHub, MessageHubRouter } from '@neokai/shared';
+import { MAX_GITHUB_POLLING_INTERVAL_SECONDS, MessageHub, MessageHubRouter } from '@neokai/shared';
 import type { Provider } from '@neokai/shared/provider';
 import {
   createDaemonInternalEventBus,
@@ -372,7 +372,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     const getGitHubPollingIntervalSeconds = () => {
       const value = settingsManager.getGlobalSettings().githubPollingInterval;
       if (value === undefined || !Number.isFinite(value)) return 120;
-      return Math.max(0, Math.trunc(value));
+      return Math.min(MAX_GITHUB_POLLING_INTERVAL_SECONDS, Math.max(0, Math.trunc(value)));
     };
     applyProviderModelAllowlistsToEnv(settingsManager.getGlobalSettings().providerModelAllowlists);
 
@@ -693,20 +693,17 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     internalEventBus.subscribe(
       'settings.updated',
       (event) => {
-        if (event.namespaceId !== 'global' || event.settings.githubPollingInterval === undefined)
-          return;
-        gitHubService?.refreshPolling();
+        if (event.namespaceId !== 'global') return;
+        gitHubService?.refreshPolling({ reschedulePending: true });
         void (async () => {
-          if (getGitHubPollingIntervalSeconds() > 0) {
-            const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
-            await extensionConfigStore.setGlobalConfig('github', {
-              ...githubGlobalConfig,
-              capabilities: {
-                ...githubGlobalConfig.capabilities,
-                polling: true,
-              },
-            });
-          }
+          const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
+          await extensionConfigStore.setGlobalConfig('github', {
+            ...githubGlobalConfig,
+            capabilities: {
+              ...githubGlobalConfig.capabilities,
+              polling: getGitHubPollingIntervalSeconds() > 0,
+            },
+          });
           await githubEventExtension?.refreshPollingInterval();
         })();
       },

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -369,6 +369,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     // discovered. Room-scoped sessions use their own defaultPath for project-level
     // MCP resolution and are not affected by this global instance.
     const settingsManager = new SettingsManager(db, process.env.NEOKAI_WORKSPACE_PATH ?? homedir());
+    const getGitHubPollingIntervalSeconds = () => {
+      const value = settingsManager.getGlobalSettings().githubPollingInterval;
+      if (value === undefined || !Number.isFinite(value)) return 120;
+      return Math.max(0, Math.trunc(value));
+    };
     applyProviderModelAllowlistsToEnv(settingsManager.getGlobalSettings().providerModelAllowlists);
 
     // Seed disabled built-in state so initializeProviders() won't register
@@ -595,9 +600,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     startupPhase('github service');
     // Initialize GitHub service if configured
     let gitHubService: GitHubService | null = null;
-    const shouldEnableGitHub =
-      config.githubWebhookSecret ||
-      (config.githubPollingInterval && config.githubPollingInterval > 0);
+    const shouldEnableGitHub = config.githubWebhookSecret || hasAnthropicAuth;
 
     if (shouldEnableGitHub && hasAnthropicAuth) {
       // Get API key for AI agents (security + routing).
@@ -631,11 +634,12 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
           githubToken: process.env.GITHUB_TOKEN, // Optional GitHub token for polling
           jobQueue,
           jobProcessor,
+          getPollingIntervalSeconds: getGitHubPollingIntervalSeconds,
         });
 
         logInfo('[Daemon] GitHub integration enabled', {
           webhook: !!config.githubWebhookSecret,
-          polling: !!(config.githubPollingInterval && config.githubPollingInterval > 0),
+          polling: getGitHubPollingIntervalSeconds() > 0,
         });
       } else {
         logInfo('[Daemon] GitHub integration disabled - no API key available for AI agents');
@@ -665,9 +669,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       },
     };
     const extensionManager = new ExternalEventExtensionManager();
-    const githubPollingEnabled = !!(
-      config.githubPollingInterval && config.githubPollingInterval > 0
-    );
+    const githubPollingEnabled = getGitHubPollingIntervalSeconds() > 0;
     if (githubPollingEnabled) {
       const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
       await extensionConfigStore.setGlobalConfig('github', {
@@ -680,9 +682,35 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     }
     extensionManager.register(
       new GitHubEventExtension(db.getDatabase(), process.env.GITHUB_TOKEN, {
-        ...(githubPollingEnabled ? { pollIntervalMs: config.githubPollingInterval! * 1000 } : {}),
+        getPollIntervalMs: () => getGitHubPollingIntervalSeconds() * 1000,
         credentialStore: credentialManager.getCredentialStore(),
       })
+    );
+
+    const githubEventExtension = extensionManager.getExtension('github') as
+      | GitHubEventExtension
+      | undefined;
+    internalEventBus.subscribe(
+      'settings.updated',
+      (event) => {
+        if (event.namespaceId !== 'global' || event.settings.githubPollingInterval === undefined)
+          return;
+        gitHubService?.refreshPolling();
+        void (async () => {
+          if (getGitHubPollingIntervalSeconds() > 0) {
+            const githubGlobalConfig = await extensionConfigStore.getGlobalConfig('github');
+            await extensionConfigStore.setGlobalConfig('github', {
+              ...githubGlobalConfig,
+              capabilities: {
+                ...githubGlobalConfig.capabilities,
+                polling: true,
+              },
+            });
+          }
+          await githubEventExtension?.refreshPollingInterval();
+        })();
+      },
+      { subscriberName: 'github-polling-settings' }
     );
 
     startupPhase('external event extensions');

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -30,7 +30,6 @@ export interface Config {
   disableGoalProcessing?: boolean; // For testing/CI - disables automatic goal processing (tick loop)
   // GitHub integration
   githubWebhookSecret?: string; // Secret for verifying webhook signatures
-  githubPollingInterval?: number; // Polling interval in seconds (0 = disabled)
   githubDefaultFilter?: string; // Default filter config as JSON string
 }
 
@@ -68,7 +67,6 @@ export function getConfig(overrides?: ConfigOverrides): Config {
     disableGoalProcessing: process.env.NEOKAI_DISABLE_GOAL_PROCESSING === '1',
     // GitHub integration
     githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
-    githubPollingInterval: parseInt(process.env.GITHUB_POLLING_INTERVAL || '0'),
     githubDefaultFilter: process.env.GITHUB_DEFAULT_FILTER,
   };
 }

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -219,17 +219,15 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       const willReenablePollingRows = this.repo
         .listWatchedRepos(params.spaceId)
         .some((repo) => repo.pollingEnabled);
-      if (willReenablePollingRows) {
-        this.assertPollingIntervalEnabled();
-      }
       this.repo.setRepoEnabled(params.spaceId, true);
       // Re-enabling a space can revive polling-configured rows whose
       // `enabled` flag was just flipped back on. If the global polling
       // capability was cleared while the space was disabled (see
       // disablePollingCapabilityIfUnused), the timer would never restart
-      // on its own. Re-arm the capability + timer here when any newly
-      // re-enabled polling row exists.
-      if (willReenablePollingRows) {
+      // on its own. Re-arm the capability + timer here only when polling is
+      // globally enabled; interval=0 should still allow webhook delivery to
+      // resume for the space without re-enabling polling.
+      if (willReenablePollingRows && this.getPollIntervalMs() > 0) {
         await this.enablePollingCapability(context);
         this.ensurePollingActive();
       }
@@ -674,6 +672,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       this.pollTimer = null;
       return;
     }
+    if (this.activePollCycle) return;
     const delay = this.getNextPollDelayMs();
     if (delay === null) return;
     this.scheduleNextPollAfter(delay);

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -264,6 +264,9 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       if (!params.spaceId || !params.owner || !params.repo) {
         throw new Error('spaceId, owner and repo are required');
       }
+      if (params.pollingEnabled) {
+        this.assertPollingIntervalEnabled();
+      }
       const existing = this.repo.getWatchedRepo(params.spaceId, params.owner, params.repo);
       const replacingAutoSecret = Boolean(params.webhookSecret && existing?.webhookAutoRegistered);
       const disablingAutoWebhook = Boolean(
@@ -488,6 +491,9 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       const params = data as { spaceId?: string; enabled?: boolean };
       if (!params.spaceId || typeof params.enabled !== 'boolean') {
         throw new Error('spaceId and enabled are required');
+      }
+      if (params.enabled) {
+        this.assertPollingIntervalEnabled();
       }
       const repos = this.repo.listWatchedRepos(params.spaceId);
       for (const repo of repos) {
@@ -855,6 +861,14 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       ...global,
       capabilities: { ...global.capabilities, polling: false },
     });
+  }
+
+  private assertPollingIntervalEnabled(): void {
+    if (this.getPollIntervalMs() <= 0) {
+      throw new Error(
+        'GitHub polling is disabled globally. Set GitHub polling interval above 0 in General settings to enable polling.'
+      );
+    }
   }
 
   private ensurePollingActive(): void {

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -129,6 +129,7 @@ const WEBHOOK_PATH = '/webhook/github/space';
 
 interface GitHubEventExtensionOptions {
   pollIntervalMs?: number;
+  getPollIntervalMs?: () => number | undefined;
   fetchImpl?: typeof fetch;
   /**
    * Optional credential store used to persist the GitHub PAT outside env vars.
@@ -199,7 +200,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
   async start(context: ExternalEventExtensionContext): Promise<void> {
     this.context = context;
     this.stopped = false;
-    if (!(await this.isPollingGloballyEnabled())) return;
+    if (!(await this.isPollingGloballyEnabled()) || this.getPollIntervalMs() <= 0) return;
     this.scheduleNextPoll();
   }
 
@@ -652,8 +653,20 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
     return global.globallyEnabled && global.capabilities.polling !== false;
   }
 
+  async refreshPollingInterval(): Promise<void> {
+    if (this.stopped) return;
+    if (!(await this.isPollingGloballyEnabled()) || this.getPollIntervalMs() <= 0) {
+      if (this.pollTimer) clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+      return;
+    }
+    this.scheduleNextPoll();
+  }
+
   private scheduleNextPoll(): void {
-    this.scheduleNextPollAfter(this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    const intervalMs = this.getPollIntervalMs();
+    if (intervalMs <= 0) return;
+    this.scheduleNextPollAfter(intervalMs);
   }
 
   /**
@@ -706,9 +719,18 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
         ? Math.max(0, this.rateLimitedUntil - now)
         : Math.max(RATE_LIMIT_MIN_BACKOFF_MS, this.rateLimitedUntil - now);
     } else {
-      delay = this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+      delay = this.getPollIntervalMs();
+      if (delay <= 0) return;
     }
     this.scheduleNextPollAfter(delay);
+  }
+
+  private getPollIntervalMs(): number {
+    const configured = this.options.getPollIntervalMs?.() ?? this.options.pollIntervalMs;
+    if (configured === undefined || !Number.isFinite(configured)) {
+      return DEFAULT_POLL_INTERVAL_MS;
+    }
+    return Math.max(0, Math.trunc(configured));
   }
 
   /**
@@ -837,7 +859,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
 
   private ensurePollingActive(): void {
     if (this.stopped) return;
-    if (this.pollTimer) return;
+    if (this.pollTimer || this.getPollIntervalMs() <= 0) return;
     this.scheduleNextPoll();
   }
 

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -224,6 +224,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       // on its own. Re-arm the capability + timer here when any newly
       // re-enabled polling row exists.
       if (this.repo.listPollingRepos(params.spaceId).length > 0) {
+        this.assertPollingIntervalEnabled();
         await this.enablePollingCapability(context);
         this.ensurePollingActive();
       }
@@ -264,10 +265,10 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       if (!params.spaceId || !params.owner || !params.repo) {
         throw new Error('spaceId, owner and repo are required');
       }
-      if (params.pollingEnabled) {
+      const existing = this.repo.getWatchedRepo(params.spaceId, params.owner, params.repo);
+      if (params.pollingEnabled && !existing?.pollingEnabled) {
         this.assertPollingIntervalEnabled();
       }
-      const existing = this.repo.getWatchedRepo(params.spaceId, params.owner, params.repo);
       const replacingAutoSecret = Boolean(params.webhookSecret && existing?.webhookAutoRegistered);
       const disablingAutoWebhook = Boolean(
         existing?.webhookAutoRegistered &&
@@ -297,8 +298,10 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
         // the row is later removed.
         this.repo.setPollingIntent(params.spaceId, true);
         await this.persistSpaceConfig(context, watchedRepo.spaceId);
-        await this.enablePollingCapability(context);
-        this.ensurePollingActive();
+        if (this.getPollIntervalMs() > 0) {
+          await this.enablePollingCapability(context);
+          this.ensurePollingActive();
+        }
       } else {
         // Per-row polling was turned off (or the row was added without
         // polling). If the user explicitly disabled the last polling-configured
@@ -666,13 +669,15 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       this.pollTimer = null;
       return;
     }
-    this.scheduleNextPoll();
+    const delay = this.getNextPollDelayMs();
+    if (delay === null) return;
+    this.scheduleNextPollAfter(delay);
   }
 
   private scheduleNextPoll(): void {
-    const intervalMs = this.getPollIntervalMs();
-    if (intervalMs <= 0) return;
-    this.scheduleNextPollAfter(intervalMs);
+    const delay = this.getNextPollDelayMs();
+    if (delay === null) return;
+    this.scheduleNextPollAfter(delay);
   }
 
   /**
@@ -716,19 +721,25 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       }
       return;
     }
+    const delay = this.getNextPollDelayMs();
+    if (delay === null) return;
+    this.scheduleNextPollAfter(delay);
+  }
+
+  private getNextPollDelayMs(): number | null {
+    const intervalMs = this.getPollIntervalMs();
+    if (intervalMs <= 0) return null;
+
     const now = Date.now();
-    let delay: number;
     if (now < this.rateLimitedUntil) {
       // Retry-After-based cooldowns may be shorter than the minimum backoff;
       // honor them exactly. Primary reset windows are floored to the minimum.
-      delay = this.rateLimitedFromRetryAfter
+      const rateLimitDelay = this.rateLimitedFromRetryAfter
         ? Math.max(0, this.rateLimitedUntil - now)
         : Math.max(RATE_LIMIT_MIN_BACKOFF_MS, this.rateLimitedUntil - now);
-    } else {
-      delay = this.getPollIntervalMs();
-      if (delay <= 0) return;
+      return Math.max(intervalMs, rateLimitDelay);
     }
-    this.scheduleNextPollAfter(delay);
+    return intervalMs;
   }
 
   private getPollIntervalMs(): number {

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -216,6 +216,12 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       await assertRpcConfigEnabled(context, this.sourceId);
       const params = data as { spaceId: string };
       if (!params.spaceId) throw new Error('spaceId is required');
+      const willReenablePollingRows = this.repo
+        .listWatchedRepos(params.spaceId)
+        .some((repo) => repo.pollingEnabled);
+      if (willReenablePollingRows) {
+        this.assertPollingIntervalEnabled();
+      }
       this.repo.setRepoEnabled(params.spaceId, true);
       // Re-enabling a space can revive polling-configured rows whose
       // `enabled` flag was just flipped back on. If the global polling
@@ -223,8 +229,7 @@ export class GitHubEventExtension implements HttpExternalEventExtension, RpcExte
       // disablePollingCapabilityIfUnused), the timer would never restart
       // on its own. Re-arm the capability + timer here when any newly
       // re-enabled polling row exists.
-      if (this.repo.listPollingRepos(params.spaceId).length > 0) {
-        this.assertPollingIntervalEnabled();
+      if (willReenablePollingRows) {
         await this.enablePollingCapability(context);
         this.ensurePollingActive();
       }

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -39,6 +39,7 @@ import { createWebhookHandler } from './webhook-handler';
 import { Logger } from '../logger';
 
 const log = new Logger('github-service');
+const DEFAULT_GITHUB_POLLING_INTERVAL_SECONDS = 120;
 
 /**
  * Configuration options for the GitHub service
@@ -60,6 +61,8 @@ export interface GitHubServiceOptions {
   jobQueue?: JobQueueRepository;
   /** Job queue processor — required to register the github.poll handler */
   jobProcessor?: JobQueueProcessor;
+  /** Live global setting getter for GitHub polling interval in seconds */
+  getPollingIntervalSeconds?: () => number | undefined;
 }
 
 /**
@@ -91,6 +94,8 @@ export class GitHubService {
   private webhookHandler?: (req: Request) => Promise<Response>;
   private jobQueue?: JobQueueRepository;
   private jobProcessor?: JobQueueProcessor;
+  private getPollingIntervalSeconds?: () => number | undefined;
+  private pollJobHandlerRegistered = false;
 
   constructor(options: GitHubServiceOptions) {
     this.db = options.db;
@@ -101,6 +106,7 @@ export class GitHubService {
     this.githubToken = options.githubToken;
     this.jobQueue = options.jobQueue;
     this.jobProcessor = options.jobProcessor;
+    this.getPollingIntervalSeconds = options.getPollingIntervalSeconds;
 
     // Initialize filter config manager
     this.filterConfigManager = createFilterConfigManager(this.db.getDatabase());
@@ -129,7 +135,7 @@ export class GitHubService {
 
     log.info('GitHubService initialized', {
       hasWebhookSecret: !!this.config.githubWebhookSecret,
-      pollingInterval: this.config.githubPollingInterval,
+      pollingInterval: this.getPollingIntervalSecondsValue(),
       hasApiKey: !!this.apiKey,
     });
   }
@@ -150,14 +156,26 @@ export class GitHubService {
       log.info('Webhook handler initialized');
     }
 
-    // Create polling service if interval is configured and token is available
-    if (
-      this.config.githubPollingInterval &&
-      this.config.githubPollingInterval > 0 &&
-      this.githubToken
-    ) {
-      const intervalMs = this.config.githubPollingInterval * 1000;
+    this.refreshPolling();
 
+    log.info('GitHub service started');
+  }
+
+  refreshPolling(): void {
+    const intervalSeconds = this.getPollingIntervalSecondsValue();
+
+    if (intervalSeconds <= 0 || !this.githubToken) {
+      if (this.pollingService) {
+        this.pollingService.stop();
+        this.pollingService = undefined;
+        log.info('Polling service stopped', { intervalSeconds });
+      }
+      return;
+    }
+
+    const intervalMs = intervalSeconds * 1000;
+
+    if (!this.pollingService) {
       this.pollingService = createPollingService(
         {
           token: this.githubToken,
@@ -167,39 +185,44 @@ export class GitHubService {
           await this.processEvent(event);
         }
       );
+    }
 
-      // Register the github.poll job handler so the processor can execute it.
-      // pollingService.start() is called inside this guard so that isRunning() is
-      // consistent with whether an actual poll chain is in place — if jobQueue/
-      // jobProcessor are absent no scheduling exists and the service must not
-      // report itself as running.
-      if (this.jobProcessor && this.jobQueue) {
+    if (this.jobProcessor && this.jobQueue) {
+      if (!this.pollingService.isRunning()) {
         this.pollingService.start();
         log.info('Polling service started (job-queue-driven)', { intervalMs });
+      }
 
+      if (!this.pollJobHandlerRegistered) {
         this.jobProcessor.register(GITHUB_POLL, () =>
           handleGitHubPoll({
             pollingService: this.pollingService,
             jobQueue: this.jobQueue!,
-            intervalMs,
+            intervalMs: this.getPollingIntervalSecondsValue() * 1000,
           })
         );
+        this.pollJobHandlerRegistered = true;
         log.info('github.poll job handler registered');
+      }
 
-        // Enqueue the initial poll immediately if no job is already in flight.
-        const existing = this.jobQueue.listJobs({
-          queue: GITHUB_POLL,
-          status: ['pending', 'processing'],
-          limit: 1,
-        });
-        if (existing.length === 0) {
-          this.jobQueue.enqueue({ queue: GITHUB_POLL, payload: {}, runAt: Date.now() });
-          log.info('Enqueued initial github.poll job');
-        }
+      const existing = this.jobQueue.listJobs({
+        queue: GITHUB_POLL,
+        status: ['pending', 'processing'],
+        limit: 1,
+      });
+      if (existing.length === 0) {
+        this.jobQueue.enqueue({ queue: GITHUB_POLL, payload: {}, runAt: Date.now() });
+        log.info('Enqueued initial github.poll job');
       }
     }
+  }
 
-    log.info('GitHub service started');
+  private getPollingIntervalSecondsValue(): number {
+    const configured = this.getPollingIntervalSeconds?.();
+    if (configured === undefined || !Number.isFinite(configured)) {
+      return DEFAULT_GITHUB_POLLING_INTERVAL_SECONDS;
+    }
+    return Math.max(0, Math.trunc(configured));
   }
 
   /**

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -12,6 +12,7 @@
 
 import type { Database } from '../../storage/database';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
+import { MAX_GITHUB_POLLING_INTERVAL_SECONDS } from '@neokai/shared';
 import type { Config } from '../../config';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
@@ -161,10 +162,11 @@ export class GitHubService {
     log.info('GitHub service started');
   }
 
-  refreshPolling(): void {
+  refreshPolling(options: { reschedulePending?: boolean } = {}): void {
     const intervalSeconds = this.getPollingIntervalSecondsValue();
 
     if (intervalSeconds <= 0 || !this.githubToken) {
+      this.deletePendingPollJobs();
       if (this.pollingService) {
         this.pollingService.stop();
         this.pollingService = undefined;
@@ -205,6 +207,10 @@ export class GitHubService {
         log.info('github.poll job handler registered');
       }
 
+      if (options.reschedulePending) {
+        this.deletePendingPollJobs();
+      }
+
       const existing = this.jobQueue.listJobs({
         queue: GITHUB_POLL,
         status: ['pending', 'processing'],
@@ -222,7 +228,14 @@ export class GitHubService {
     if (configured === undefined || !Number.isFinite(configured)) {
       return DEFAULT_GITHUB_POLLING_INTERVAL_SECONDS;
     }
-    return Math.max(0, Math.trunc(configured));
+    return Math.min(MAX_GITHUB_POLLING_INTERVAL_SECONDS, Math.max(0, Math.trunc(configured)));
+  }
+
+  private deletePendingPollJobs(): void {
+    if (!this.jobQueue) return;
+    for (const job of this.jobQueue.listJobs({ queue: GITHUB_POLL, status: 'pending' })) {
+      this.jobQueue.deleteJob(job.id);
+    }
   }
 
   /**

--- a/packages/daemon/src/lib/github/github-service.ts
+++ b/packages/daemon/src/lib/github/github-service.ts
@@ -200,7 +200,7 @@ export class GitHubService {
           handleGitHubPoll({
             pollingService: this.pollingService,
             jobQueue: this.jobQueue!,
-            intervalMs: this.getPollingIntervalSecondsValue() * 1000,
+            intervalMs: () => this.getPollingIntervalSecondsValue() * 1000,
           })
         );
         this.pollJobHandlerRegistered = true;

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -49,7 +49,7 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 
   // Compute nextRunAt after the poll so the interval is measured from
   // completion, not from when the job was dequeued.
-  const nextRunAt = Date.now() + intervalMs;
+  const nextRunAt = intervalMs > 0 ? Date.now() + intervalMs : 0;
 
   // Only enqueue the next job if no pending job is already waiting.
   // We check 'pending' only (not 'processing') because the current job is
@@ -64,7 +64,7 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
     limit: 1,
   });
 
-  if (existingJobs.length === 0) {
+  if (intervalMs > 0 && existingJobs.length === 0) {
     jobQueue.enqueue({
       queue: GITHUB_POLL,
       payload: {},

--- a/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/github-poll.handler.ts
@@ -15,7 +15,7 @@ const log = new Logger('github-poll-handler');
 export interface GitHubPollHandlerDeps {
   pollingService: GitHubPollingService | undefined;
   jobQueue: JobQueueRepository;
-  intervalMs: number;
+  intervalMs: number | (() => number);
 }
 
 // Extends Record<string, unknown> so the result satisfies JobHandler's return type.
@@ -25,7 +25,7 @@ export interface GitHubPollResult extends Record<string, unknown> {
 }
 
 export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<GitHubPollResult> {
-  const { pollingService, jobQueue, intervalMs } = deps;
+  const { pollingService, jobQueue } = deps;
 
   let polled = false;
 
@@ -49,6 +49,7 @@ export async function handleGitHubPoll(deps: GitHubPollHandlerDeps): Promise<Git
 
   // Compute nextRunAt after the poll so the interval is measured from
   // completion, not from when the job was dequeued.
+  const intervalMs = typeof deps.intervalMs === 'function' ? deps.intervalMs() : deps.intervalMs;
   const nextRunAt = intervalMs > 0 ? Date.now() + intervalMs : 0;
 
   // Only enqueue the next job if no pending job is already waiting.

--- a/packages/daemon/tests/online/features/github-poll-job.test.ts
+++ b/packages/daemon/tests/online/features/github-poll-job.test.ts
@@ -38,16 +38,14 @@ import type { Job, JobStatus } from '../../../src/storage/repositories/job-queue
  * Environment variables injected into the in-process daemon to enable GitHub
  * polling without touching real credentials.
  *
- * GITHUB_POLLING_INTERVAL=300 (5 min) keeps self-scheduled jobs far in the
- * future so the test can assert a single pending job without racing against a
- * second real execution.
+ * The persisted global GitHub polling interval defaults to 120 seconds, which
+ * keeps self-scheduled jobs far enough in the future for stable assertions.
  *
  * GITHUB_TOKEN is a fake value that satisfies the token-presence guard inside
  * GitHubService. No repositories are added to the polling service, so
  * triggerPoll() is a no-op even before the stub is applied.
  */
 const GITHUB_TEST_ENV: Record<string, string> = {
-  GITHUB_POLLING_INTERVAL: '300',
   GITHUB_TOKEN: 'ghp_fake_token_for_job_queue_test',
 };
 
@@ -198,9 +196,9 @@ describe('GitHub polling via job queue (online)', () => {
     expect(next).toBeDefined();
     expect(next!.queue).toBe(GITHUB_POLL);
 
-    // The next job should be scheduled ~300 s from now (GITHUB_POLLING_INTERVAL).
-    // We verify it is at least 200 s in the future to allow for minor clock skew.
-    const minExpectedRunAt = Date.now() + 200_000;
+    // The next job should be scheduled ~120 s from now (default global settings).
+    // We verify it is at least 100 s in the future to allow for minor clock skew.
+    const minExpectedRunAt = Date.now() + 100_000;
     expect(next!.runAt).toBeGreaterThan(minExpectedRunAt);
   }, 15_000);
 
@@ -231,7 +229,7 @@ describe('GitHub polling via job queue (online)', () => {
   test('github service polling is active (isPolling returns true)', () => {
     const daemonCtx = getDaemonCtx(daemon);
 
-    // gitHubService should be initialized because GITHUB_POLLING_INTERVAL > 0
+    // gitHubService should be initialized because the default polling interval is > 0
     // and a GITHUB_TOKEN was provided.
     expect(daemonCtx.gitHubService).not.toBeNull();
     expect(daemonCtx.gitHubService!.isPolling()).toBe(true);

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -3783,6 +3783,9 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
         clientHub.request('space.github.enable', { spaceId: 'space-1' })
       ).rejects.toThrow('GitHub polling is disabled globally');
 
+      const stored = extension.repo.getWatchedRepo('space-1', 'acme', 'widgets')!;
+      expect(stored.enabled).toBe(false);
+      expect(extension.repo.isSpaceEnabled('space-1')).toBe(true);
       const global = await configStore.getGlobalConfig('github');
       expect(global.capabilities.polling).toBe(false);
     } finally {

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -3708,6 +3708,42 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
     }
   });
 
+  test('space.github.setPollingEnabled true rejects when global interval is 0', async () => {
+    const db = setupDb();
+    const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 0 });
+    const { clientHub, hub, ready } = setupHubPair();
+    await ready;
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: false,
+    });
+    const context = {
+      publisher: { publish: async () => {} },
+      config: configStore,
+      onSourceConfigChanged() {},
+    };
+    try {
+      await extension.start(context);
+      extension.registerRpcHandlers(hub, context);
+      extension.repo.upsertWatchedRepo({
+        spaceId: 'space-1',
+        owner: 'acme',
+        repo: 'widgets',
+        pollingEnabled: false,
+      });
+
+      await expect(
+        clientHub.request('space.github.setPollingEnabled', { spaceId: 'space-1', enabled: true })
+      ).rejects.toThrow('GitHub polling is disabled globally');
+
+      const global = await configStore.getGlobalConfig('github');
+      expect(global.capabilities.polling).toBe(false);
+      expect(extension.repo.listWatchedRepos('space-1')[0].pollingEnabled).toBe(false);
+    } finally {
+      await extension.stop();
+    }
+  });
+
   test('space.github.setPollingEnabled false clears the timer when no polling repos remain', async () => {
     const db = setupDb();
     const extension = new GitHubEventExtension(db, undefined, { pollIntervalMs: 60_000 });

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -3754,7 +3754,42 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
     }
   });
 
-  test('space.github.enable rejects polling capability re-arm when global interval is 0', async () => {
+  test('refreshPollingInterval does not schedule over an active poll cycle', async () => {
+    const db = setupDb();
+    const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 5_000 });
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: true,
+    });
+    const context = {
+      publisher: { publish: async () => {} },
+      config: configStore,
+      onSourceConfigChanged() {},
+    };
+    let releasePoll!: () => void;
+    const activePollCycle = new Promise<void>((resolve) => {
+      releasePoll = resolve;
+    });
+    try {
+      await extension.start(context);
+      const internals = extension as unknown as {
+        activePollCycle: Promise<void> | undefined;
+        pollTimer: unknown;
+      };
+      if (internals.pollTimer) clearTimeout(internals.pollTimer as ReturnType<typeof setTimeout>);
+      internals.pollTimer = null;
+      internals.activePollCycle = activePollCycle;
+
+      await extension.refreshPollingInterval();
+
+      expect(internals.pollTimer).toBeNull();
+    } finally {
+      releasePoll();
+      await extension.stop();
+    }
+  });
+
+  test('space.github.enable re-enables webhook delivery without polling re-arm when interval is 0', async () => {
     const db = setupDb();
     const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 0 });
     const { clientHub, hub, ready } = setupHubPair();
@@ -3776,15 +3811,15 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
         owner: 'acme',
         repo: 'widgets',
         pollingEnabled: true,
+        webhookEnabled: true,
+        webhookSecret: 'secret',
         enabled: false,
       });
 
-      await expect(
-        clientHub.request('space.github.enable', { spaceId: 'space-1' })
-      ).rejects.toThrow('GitHub polling is disabled globally');
+      await clientHub.request('space.github.enable', { spaceId: 'space-1' });
 
       const stored = extension.repo.getWatchedRepo('space-1', 'acme', 'widgets')!;
-      expect(stored.enabled).toBe(false);
+      expect(stored.enabled).toBe(true);
       expect(extension.repo.isSpaceEnabled('space-1')).toBe(true);
       const global = await configStore.getGlobalConfig('github');
       expect(global.capabilities.polling).toBe(false);

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -8,6 +8,7 @@ import {
   type ExternalEvent,
 } from '../../../../src/lib/external-events';
 import { GitHubEventExtension } from '../../../../src/lib/external-events/github';
+import { syncGitHubPollingCapability } from '../../../../src/app';
 import {
   mapEventType,
   normalizeGitHubWebhook,
@@ -3667,6 +3668,18 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
     }
   });
 
+  test('syncGitHubPollingCapability clears stale polling capability at startup when interval is 0', async () => {
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: true,
+    });
+
+    await syncGitHubPollingCapability(configStore, false);
+
+    const global = await configStore.getGlobalConfig('github');
+    expect(global.capabilities.polling).toBe(false);
+  });
+
   test('space.github.setPollingEnabled flips global capability and starts timer', async () => {
     const db = setupDb();
     const extension = new GitHubEventExtension(db, undefined, { pollIntervalMs: 60_000 });
@@ -3703,6 +3716,118 @@ describe('GitHubEventExtension — credential store + token RPC', () => {
       expect(global.capabilities.polling).toBe(true);
       expect(extension.repo.listWatchedRepos('space-1')[0].pollingEnabled).toBe(true);
       expect(internals.pollTimer).not.toBeNull();
+    } finally {
+      await extension.stop();
+    }
+  });
+
+  test('refreshPollingInterval preserves active rate-limit deferral', async () => {
+    const db = setupDb();
+    const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 5_000 });
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: true,
+    });
+    const context = {
+      publisher: { publish: async () => {} },
+      config: configStore,
+      onSourceConfigChanged() {},
+    };
+    try {
+      await extension.start(context);
+      const internals = extension as unknown as {
+        rateLimitedUntil: number;
+        rateLimitedFromRetryAfter: boolean;
+        pollTimer: unknown;
+      };
+      internals.rateLimitedUntil = Date.now() + 60_000;
+      internals.rateLimitedFromRetryAfter = true;
+
+      await extension.refreshPollingInterval();
+
+      expect(internals.pollTimer).not.toBeNull();
+      expect((internals.pollTimer as { _idleTimeout?: number })._idleTimeout).toBeGreaterThan(
+        50_000
+      );
+    } finally {
+      await extension.stop();
+    }
+  });
+
+  test('space.github.enable rejects polling capability re-arm when global interval is 0', async () => {
+    const db = setupDb();
+    const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 0 });
+    const { clientHub, hub, ready } = setupHubPair();
+    await ready;
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: false,
+    });
+    const context = {
+      publisher: { publish: async () => {} },
+      config: configStore,
+      onSourceConfigChanged() {},
+    };
+    try {
+      await extension.start(context);
+      extension.registerRpcHandlers(hub, context);
+      extension.repo.upsertWatchedRepo({
+        spaceId: 'space-1',
+        owner: 'acme',
+        repo: 'widgets',
+        pollingEnabled: true,
+        enabled: false,
+      });
+
+      await expect(
+        clientHub.request('space.github.enable', { spaceId: 'space-1' })
+      ).rejects.toThrow('GitHub polling is disabled globally');
+
+      const global = await configStore.getGlobalConfig('github');
+      expect(global.capabilities.polling).toBe(false);
+    } finally {
+      await extension.stop();
+    }
+  });
+
+  test('space.github.watchRepo allows preserving existing pollingEnabled while interval is 0', async () => {
+    const db = setupDb();
+    const extension = new GitHubEventExtension(db, undefined, { getPollIntervalMs: () => 0 });
+    const { clientHub, hub, ready } = setupHubPair();
+    await ready;
+    const configStore = new RecordingConfigStore({
+      globallyEnabled: true,
+      polling: false,
+    });
+    const context = {
+      publisher: { publish: async () => {} },
+      config: configStore,
+      onSourceConfigChanged() {},
+    };
+    try {
+      await extension.start(context);
+      extension.registerRpcHandlers(hub, context);
+      extension.repo.upsertWatchedRepo({
+        spaceId: 'space-1',
+        owner: 'acme',
+        repo: 'widgets',
+        pollingEnabled: true,
+      });
+
+      const result = await clientHub.request<{ watchedRepo: { enabled: boolean } }>(
+        'space.github.watchRepo',
+        {
+          spaceId: 'space-1',
+          owner: 'acme',
+          repo: 'widgets',
+          pollingEnabled: true,
+          enabled: false,
+        }
+      );
+
+      expect(result.watchedRepo.enabled).toBe(false);
+      const global = await configStore.getGlobalConfig('github');
+      expect(global.capabilities.polling).toBe(false);
     } finally {
       await extension.stop();
     }

--- a/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
@@ -60,7 +60,6 @@ function makeDaemonHub() {
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
-    githubPollingInterval: 60, // seconds
     githubWebhookSecret: undefined,
     ...overrides,
   } as never;
@@ -96,15 +95,19 @@ describe('GitHubService — job-queue-driven polling', () => {
     } as never;
   }
 
-  function makeService(configOverrides: Record<string, unknown> = {}) {
+  function makeService(
+    configOverrides: Record<string, unknown> = {},
+    getPollingIntervalSeconds = () => 60
+  ) {
     return new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(configOverrides),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
       jobQueue: makeJobQueue(),
       jobProcessor: makeJobProcessor(),
+      getPollingIntervalSeconds,
     });
   }
 
@@ -133,7 +136,7 @@ describe('GitHubService — job-queue-driven polling', () => {
     const listWithExisting = mock(() => [makeJob({ status: 'pending' })]);
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
@@ -150,7 +153,7 @@ describe('GitHubService — job-queue-driven polling', () => {
     const listWithExisting = mock(() => [makeJob({ status: 'processing' })]);
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
@@ -166,7 +169,7 @@ describe('GitHubService — job-queue-driven polling', () => {
   it('does not register handler or enqueue when jobProcessor is absent', () => {
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
@@ -182,12 +185,13 @@ describe('GitHubService — job-queue-driven polling', () => {
   it('does not register handler or enqueue when polling interval is 0', () => {
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
-      config: makeConfig({ githubPollingInterval: 0 }),
+      internalEventBus: makeDaemonHub(),
+      config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
       jobQueue: makeJobQueue(),
       jobProcessor: makeJobProcessor(),
+      getPollingIntervalSeconds: () => 0,
     });
 
     svc.start();
@@ -199,7 +203,7 @@ describe('GitHubService — job-queue-driven polling', () => {
   it('does not register handler or enqueue when githubToken is absent', () => {
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       // no githubToken
@@ -222,12 +226,13 @@ describe('GitHubService — job-queue-driven polling', () => {
 
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
       jobQueue: makeJobQueue(),
       jobProcessor: { register: capturingRegister } as never,
+      getPollingIntervalSeconds: () => 60,
     });
 
     svc.start();
@@ -296,12 +301,13 @@ describe('GitHubService — job-queue-driven polling', () => {
 
     const svc = new GitHubService({
       db: makeDb(),
-      daemonHub: makeDaemonHub(),
+      internalEventBus: makeDaemonHub(),
       config: makeConfig(),
       apiKey: 'test-api-key',
       githubToken: 'test-github-token',
       jobQueue: makeJobQueue(),
       jobProcessor: { register: capturingRegister } as never,
+      getPollingIntervalSeconds: () => 60,
     });
 
     svc.start();
@@ -332,5 +338,39 @@ describe('GitHubService — job-queue-driven polling', () => {
 
     // But the chain self-schedules so polling resumes automatically when restarted
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest polling interval when self-scheduling jobs', async () => {
+    let intervalSeconds = 60;
+    let capturedHandler: (() => Promise<unknown>) | undefined;
+    const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+      capturedHandler = handler;
+    });
+
+    const svc = new GitHubService({
+      db: makeDb(),
+      internalEventBus: makeDaemonHub(),
+      config: makeConfig(),
+      apiKey: 'test-api-key',
+      githubToken: 'test-github-token',
+      jobQueue: makeJobQueue(),
+      jobProcessor: { register: capturingRegister } as never,
+      getPollingIntervalSeconds: () => intervalSeconds,
+    });
+
+    svc.start();
+    intervalSeconds = 30;
+    enqueueMock.mockClear();
+
+    await capturedHandler!();
+
+    const delayedJob = enqueueMock.mock.calls.find((call) => {
+      const [arg] = call as [{ runAt: number }];
+      return arg.runAt > Date.now() + 20_000;
+    });
+    expect(delayedJob).toBeDefined();
+    const [arg] = delayedJob as [{ runAt: number }];
+    expect(arg.runAt).toBeGreaterThanOrEqual(Date.now() + 29_000);
+    expect(arg.runAt).toBeLessThanOrEqual(Date.now() + 31_000);
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
@@ -343,6 +343,38 @@ describe('GitHubService — job-queue-driven polling', () => {
     expect(enqueueMock).toHaveBeenCalledTimes(1);
   });
 
+  it('recomputes interval after an in-flight poll before self-scheduling', async () => {
+    let intervalSeconds = 60;
+    let capturedHandler: (() => Promise<unknown>) | undefined;
+    const capturingRegister = mock((_queue: string, handler: () => Promise<unknown>) => {
+      capturedHandler = handler;
+    });
+
+    const svc = new GitHubService({
+      db: makeDb(),
+      internalEventBus: makeDaemonHub(),
+      config: makeConfig(),
+      apiKey: 'test-api-key',
+      githubToken: 'test-github-token',
+      jobQueue: makeJobQueue(),
+      jobProcessor: { register: capturingRegister } as never,
+      getPollingIntervalSeconds: () => intervalSeconds,
+    });
+
+    svc.start();
+    const pollingService = svc.getPollingService()!;
+    pollingService.triggerPoll = mock(async () => {
+      intervalSeconds = 30;
+    });
+    enqueueMock.mockClear();
+
+    await capturedHandler!();
+
+    const [arg] = enqueueMock.mock.calls[0] as [{ runAt: number }];
+    expect(arg.runAt).toBeGreaterThanOrEqual(Date.now() + 29_000);
+    expect(arg.runAt).toBeLessThanOrEqual(Date.now() + 31_000);
+  });
+
   it('replaces pending github.poll jobs when rescheduling after an interval change', () => {
     const pendingJob = makeJob({
       id: 'pending-job',

--- a/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-service-polling.test.ts
@@ -71,11 +71,13 @@ describe('GitHubService — job-queue-driven polling', () => {
   let registerMock: ReturnType<typeof mock>;
   let enqueueMock: ReturnType<typeof mock>;
   let listJobsMock: ReturnType<typeof mock>;
+  let deleteJobMock: ReturnType<typeof mock>;
 
   beforeEach(() => {
     registerMock = mock(() => {});
     enqueueMock = mock(() => makeJob());
     listJobsMock = mock(() => []); // no existing jobs → enqueue initial
+    deleteJobMock = mock(() => true);
   });
 
   afterEach(() => {
@@ -92,6 +94,7 @@ describe('GitHubService — job-queue-driven polling', () => {
     return {
       enqueue: enqueueMock,
       listJobs: listOverride ?? listJobsMock,
+      deleteJob: deleteJobMock,
     } as never;
   }
 
@@ -338,6 +341,65 @@ describe('GitHubService — job-queue-driven polling', () => {
 
     // But the chain self-schedules so polling resumes automatically when restarted
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces pending github.poll jobs when rescheduling after an interval change', () => {
+    const pendingJob = makeJob({
+      id: 'pending-job',
+      status: 'pending',
+      runAt: Date.now() + 120_000,
+    });
+    const listWithPending = mock((filter?: { status?: string | string[] }) => {
+      const status = filter?.status;
+      if (status === 'pending') return [pendingJob];
+      if (Array.isArray(status) && status.includes('pending')) return [];
+      return [];
+    });
+
+    const svc = new GitHubService({
+      db: makeDb(),
+      internalEventBus: makeDaemonHub(),
+      config: makeConfig(),
+      apiKey: 'test-api-key',
+      githubToken: 'test-github-token',
+      jobQueue: makeJobQueue(listWithPending),
+      jobProcessor: makeJobProcessor(),
+      getPollingIntervalSeconds: () => 30,
+    });
+
+    svc.start();
+    enqueueMock.mockClear();
+    deleteJobMock.mockClear();
+
+    svc.refreshPolling({ reschedulePending: true });
+
+    expect(deleteJobMock).toHaveBeenCalledWith('pending-job');
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    const [arg] = enqueueMock.mock.calls[0] as [{ runAt: number }];
+    expect(arg.runAt).toBeLessThanOrEqual(Date.now() + 100);
+  });
+
+  it('deletes pending github.poll jobs when polling is disabled', () => {
+    const pendingJob = makeJob({ id: 'pending-job', status: 'pending' });
+    const listWithPending = mock((filter?: { status?: string | string[] }) =>
+      filter?.status === 'pending' ? [pendingJob] : []
+    );
+
+    const svc = new GitHubService({
+      db: makeDb(),
+      internalEventBus: makeDaemonHub(),
+      config: makeConfig(),
+      apiKey: 'test-api-key',
+      githubToken: 'test-github-token',
+      jobQueue: makeJobQueue(listWithPending),
+      jobProcessor: makeJobProcessor(),
+      getPollingIntervalSeconds: () => 0,
+    });
+
+    svc.start();
+
+    expect(deleteJobMock).toHaveBeenCalledWith('pending-job');
+    expect(enqueueMock).not.toHaveBeenCalled();
   });
 
   it('uses the latest polling interval when self-scheduling jobs', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
@@ -36,6 +36,26 @@ describe('SettingsRepository', () => {
     db.close();
   });
 
+  describe('global GitHub polling setting', () => {
+    it('should include the default GitHub polling interval', () => {
+      const settings = repository.getGlobalSettings();
+
+      expect(settings.githubPollingInterval).toBe(120);
+    });
+
+    it('should backfill GitHub polling interval for legacy stored settings', () => {
+      const legacySettings = { ...DEFAULT_GLOBAL_SETTINGS };
+      delete (legacySettings as Partial<GlobalSettings>).githubPollingInterval;
+      db.prepare(
+        `INSERT INTO global_settings (id, settings, updated_at) VALUES (1, ?, datetime('now'))`
+      ).run(JSON.stringify(legacySettings));
+
+      const settings = repository.getGlobalSettings();
+
+      expect(settings.githubPollingInterval).toBe(120);
+    });
+  });
+
   describe('getGlobalToolsConfig', () => {
     it('should return default config when no config exists', () => {
       const config = repository.getGlobalToolsConfig();

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -142,6 +142,9 @@ export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
   // Default auto-scroll setting for new sessions
   autoScroll?: boolean;
 
+  // GitHub polling interval in seconds (0 disables polling)
+  githubPollingInterval?: number;
+
   // Default coordinator mode for new sessions
   coordinatorMode?: boolean;
 
@@ -186,6 +189,7 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   // Default auto-scroll to true so new sessions inherit this setting
   // This must match the display default in GlobalSettingsEditor (autoScroll ?? true)
   autoScroll: true,
+  githubPollingInterval: 120,
   // Default coordinator mode to false (user opts in when needed)
   coordinatorMode: false,
   // Room agent: default to 3 concurrent workers

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -9,6 +9,8 @@
 import type { ThinkingLevel } from '../types.ts';
 import type { CustomEndpointConfig } from './custom-endpoint.ts';
 
+export const MAX_GITHUB_POLLING_INTERVAL_SECONDS = Math.floor(2_147_483_647 / 1000);
+
 export type SettingSource = 'user' | 'project' | 'local';
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk';

--- a/packages/web/src/components/settings/GeneralSettings.tsx
+++ b/packages/web/src/components/settings/GeneralSettings.tsx
@@ -3,7 +3,7 @@ import { globalSettings } from '../../lib/state.ts';
 import { updateGlobalSettings } from '../../lib/api-helpers.ts';
 import { toast } from '../../lib/toast.ts';
 import type { PermissionMode, ThinkingLevel, SettingSource } from '@neokai/shared';
-import { normalizeThinkingLevel } from '@neokai/shared';
+import { MAX_GITHUB_POLLING_INTERVAL_SECONDS, normalizeThinkingLevel } from '@neokai/shared';
 import {
   SettingsSection,
   SettingsRow,
@@ -134,8 +134,14 @@ export function GeneralSettings() {
     }
 
     const interval = Number(trimmed);
-    if (!Number.isInteger(interval) || interval < 0) {
-      toast.error('GitHub polling interval must be a non-negative whole number');
+    if (
+      !Number.isInteger(interval) ||
+      interval < 0 ||
+      interval > MAX_GITHUB_POLLING_INTERVAL_SECONDS
+    ) {
+      toast.error(
+        `GitHub polling interval must be a whole number between 0 and ${MAX_GITHUB_POLLING_INTERVAL_SECONDS}`
+      );
       setLocalGitHubPollingInterval(String(current));
       return;
     }
@@ -219,6 +225,7 @@ export function GeneralSettings() {
         <input
           type="number"
           min="0"
+          max={MAX_GITHUB_POLLING_INTERVAL_SECONDS}
           step="1"
           placeholder="120"
           value={localGitHubPollingInterval}

--- a/packages/web/src/components/settings/GeneralSettings.tsx
+++ b/packages/web/src/components/settings/GeneralSettings.tsx
@@ -121,31 +121,36 @@ export function GeneralSettings() {
     }
   };
 
-  const handleGitHubPollingIntervalChange = async (value: string) => {
+  const handleGitHubPollingIntervalChange = (value: string) => {
     setLocalGitHubPollingInterval(value);
-    if (value.trim() === '') return;
+  };
 
-    const interval = Number(value);
-    if (!Number.isInteger(interval) || interval < 0) {
-      toast.error('GitHub polling interval must be a non-negative whole number');
+  const handleGitHubPollingIntervalBlur = async () => {
+    const trimmed = localGitHubPollingInterval.trim();
+    const current = settings?.githubPollingInterval ?? 120;
+    if (trimmed === '') {
+      setLocalGitHubPollingInterval(String(current));
       return;
     }
+
+    const interval = Number(trimmed);
+    if (!Number.isInteger(interval) || interval < 0) {
+      toast.error('GitHub polling interval must be a non-negative whole number');
+      setLocalGitHubPollingInterval(String(current));
+      return;
+    }
+
+    setLocalGitHubPollingInterval(String(interval));
+    if (interval === current) return;
 
     setIsUpdating(true);
     try {
       await updateGlobalSettings({ githubPollingInterval: interval });
     } catch {
       toast.error('Failed to update GitHub polling interval');
-      setLocalGitHubPollingInterval(String(settings?.githubPollingInterval ?? 120));
+      setLocalGitHubPollingInterval(String(current));
     } finally {
       setIsUpdating(false);
-    }
-  };
-
-  const handleGitHubPollingIntervalBlur = () => {
-    const interval = Number(localGitHubPollingInterval);
-    if (!Number.isInteger(interval) || interval < 0) {
-      setLocalGitHubPollingInterval(String(settings?.githubPollingInterval ?? 120));
     }
   };
 

--- a/packages/web/src/components/settings/GeneralSettings.tsx
+++ b/packages/web/src/components/settings/GeneralSettings.tsx
@@ -39,6 +39,9 @@ export function GeneralSettings() {
     settings?.permissionMode ?? 'default'
   );
   const [localAutoScroll, setLocalAutoScroll] = useState(settings?.autoScroll ?? true);
+  const [localGitHubPollingInterval, setLocalGitHubPollingInterval] = useState(
+    String(settings?.githubPollingInterval ?? 120)
+  );
   const [localThinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>(
     normalizeThinkingLevel(settings?.thinkingLevel)
   );
@@ -54,6 +57,7 @@ export function GeneralSettings() {
       setLocalModel(settings.model ?? 'sonnet');
       setLocalPermissionMode(settings.permissionMode ?? 'default');
       setLocalAutoScroll(settings.autoScroll ?? true);
+      setLocalGitHubPollingInterval(String(settings.githubPollingInterval ?? 120));
       setLocalThinkingLevel(normalizeThinkingLevel(settings.thinkingLevel));
       setLocalShowArchived(settings.showArchived ?? false);
       setLocalSettingSources(settings.settingSources ?? ['user', 'project', 'local']);
@@ -117,6 +121,34 @@ export function GeneralSettings() {
     }
   };
 
+  const handleGitHubPollingIntervalChange = async (value: string) => {
+    setLocalGitHubPollingInterval(value);
+    if (value.trim() === '') return;
+
+    const interval = Number(value);
+    if (!Number.isInteger(interval) || interval < 0) {
+      toast.error('GitHub polling interval must be a non-negative whole number');
+      return;
+    }
+
+    setIsUpdating(true);
+    try {
+      await updateGlobalSettings({ githubPollingInterval: interval });
+    } catch {
+      toast.error('Failed to update GitHub polling interval');
+      setLocalGitHubPollingInterval(String(settings?.githubPollingInterval ?? 120));
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleGitHubPollingIntervalBlur = () => {
+    const interval = Number(localGitHubPollingInterval);
+    if (!Number.isInteger(interval) || interval < 0) {
+      setLocalGitHubPollingInterval(String(settings?.githubPollingInterval ?? 120));
+    }
+  };
+
   const handleShowArchivedChange = async (value: boolean) => {
     setLocalShowArchived(value);
     setIsUpdating(true);
@@ -172,6 +204,25 @@ export function GeneralSettings() {
           onChange={handleThinkingLevelChange}
           options={THINKING_LEVEL_OPTIONS}
           disabled={isUpdating}
+        />
+      </SettingsRow>
+
+      <SettingsRow
+        label="GitHub polling interval (seconds)"
+        description="How often to poll watched GitHub repositories; 0 disables polling."
+      >
+        <input
+          type="number"
+          min="0"
+          step="1"
+          placeholder="120"
+          value={localGitHubPollingInterval}
+          onInput={(event) =>
+            handleGitHubPollingIntervalChange((event.target as HTMLInputElement).value)
+          }
+          onBlur={handleGitHubPollingIntervalBlur}
+          disabled={isUpdating}
+          class="w-24 rounded-lg border border-white/[0.08] bg-dark-800 px-3 py-1.5 text-sm text-gray-200 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
         />
       </SettingsRow>
 


### PR DESCRIPTION
Adds a persisted global GitHub polling interval setting (default 120s), exposes it in General settings, and removes the old GITHUB_POLLING_INTERVAL config path.

Polling cadence is now read from settings at runtime, so updates apply without restarting and 0 disables polling.

Verified:
- cd packages/daemon && bun test tests/unit/4-space-storage/storage/settings-repository.test.ts tests/unit/2-handlers/github/github-service-polling.test.ts
- cd packages/daemon && NEOKAI_USE_DEV_PROXY=1 bun test tests/online/features/github-poll-job.test.ts
- bun run check
