### PR TITLE
fix: persist inactive external event deliveries

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2484,12 +2484,28 @@ export class SpaceRuntime {
   ): void {
     const key = this.buildQueueKey(target);
     const queued = this.pendingExternalEventQueue.get(key);
-    if (!queued) return;
-    this.failQueuedDeliveries(queued, reason);
-    for (const item of queued) {
-      this.clearExternalEventRetry(item.deliveryKey);
+    if (queued) {
+      this.failQueuedDeliveries(queued, reason);
+      for (const item of queued) {
+        this.clearExternalEventRetry(item.deliveryKey);
+      }
+      this.pendingExternalEventQueue.delete(key);
     }
-    this.pendingExternalEventQueue.delete(key);
+
+    const store = this.config.externalEventStore;
+    if (!store) return;
+    for (const delivery of store.listPendingDeliveries(target.workflowRunId)) {
+      if (
+        delivery.taskId !== target.taskId ||
+        delivery.nodeId !== target.nodeId ||
+        delivery.agentName !== target.agentName
+      ) {
+        continue;
+      }
+      store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, { terminal: true, reason });
+      store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+      this.clearExternalEventRetry(delivery.deliveryKey);
+    }
   }
 
   private clearQueuedDeliveriesForRun(workflowRunId: string, reason: string): void {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -27,6 +27,7 @@ import type {
   SpaceApprovalSource,
   SpaceTask,
   SpaceTaskPriority,
+  SpaceTaskStatus,
   SpaceWorkflow,
   SpaceWorkflowRun,
   UpdateSpaceTaskParams,
@@ -704,6 +705,12 @@ function longHorizonSpaceIdFromWorkflowRunId(workflowRunId: string): string | nu
 function isExternallyDeliverableRun(status: SpaceWorkflowRun['status']): boolean {
   return status === 'in_progress' || status === 'blocked';
 }
+
+const EXTERNAL_EVENT_TARGET_TASK_TERMINAL_STATUSES: ReadonlySet<SpaceTaskStatus> = new Set([
+  'done',
+  'cancelled',
+  'archived',
+]);
 
 function parseSubscriptionQueueKey(
   key: string
@@ -1832,7 +1839,13 @@ export class SpaceRuntime {
           continue;
         }
 
-        if (target.sessionId && this.isTargetSessionLive(target.sessionId)) {
+        if (this.isTargetTaskTerminal(target.taskId)) {
+          store.markDeliveryFailed(payload.eventId, deliveryKey, {
+            terminal: true,
+            reason: 'target_task_terminal',
+          });
+          store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
+        } else if (target.sessionId && this.isTargetSessionLive(target.sessionId)) {
           await this.enqueueDeliverableExternalEvent(target, payload, deliveryKey, 'immediate');
         } else if (target.sessionId) {
           await this.enqueueDeliverableExternalEvent(target, payload, deliveryKey, 'defer');
@@ -1845,10 +1858,9 @@ export class SpaceRuntime {
           this.queueForPendingNode(target, payload, deliveryKey);
         } else {
           store.markDeliveryFailed(payload.eventId, deliveryKey, {
-            terminal: true,
+            terminal: false,
             reason: 'node_execution_not_active',
           });
-          store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
         }
       } catch (err) {
         log.warn(
@@ -2560,6 +2572,11 @@ export class SpaceRuntime {
           execution.agentName === target.agentName &&
           (execution.status === 'idle' || execution.status === 'cancelled')
       );
+  }
+
+  private isTargetTaskTerminal(taskId: string): boolean {
+    const task = this.config.taskRepo.getTask(taskId);
+    return task ? EXTERNAL_EVENT_TARGET_TASK_TERMINAL_STATUSES.has(task.status) : true;
   }
 
   private buildQueueKey(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2502,6 +2502,10 @@ export class SpaceRuntime {
       ) {
         continue;
       }
+      const eventRecord = store.getById(delivery.eventId);
+      if (eventRecord?.event && this.isTargetStillSubscribed(target, eventRecord.event.topic)) {
+        continue;
+      }
       store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, { terminal: true, reason });
       store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
       this.clearExternalEventRetry(delivery.deliveryKey);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2493,6 +2493,7 @@ export class SpaceRuntime {
   }
 
   private clearQueuedDeliveriesForRun(workflowRunId: string, reason: string): void {
+    const store = this.config.externalEventStore;
     for (const [queueKey, queued] of this.pendingExternalEventQueue) {
       const parsed = parseSubscriptionQueueKey(queueKey);
       if (!parsed || parsed.workflowRunId !== workflowRunId) continue;
@@ -2501,6 +2502,12 @@ export class SpaceRuntime {
         this.clearExternalEventRetry(item.deliveryKey);
       }
       this.pendingExternalEventQueue.delete(queueKey);
+    }
+    if (!store) return;
+    for (const delivery of store.listPendingDeliveries(workflowRunId)) {
+      store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, { terminal: true, reason });
+      store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+      this.clearExternalEventRetry(delivery.deliveryKey);
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1857,6 +1857,7 @@ export class SpaceRuntime {
         ) {
           this.queueForPendingNode(target, payload, deliveryKey);
         } else {
+          this.clearExternalEventRetry(deliveryKey);
           store.markDeliveryFailed(payload.eventId, deliveryKey, {
             terminal: false,
             reason: 'node_execution_not_active',
@@ -4191,6 +4192,15 @@ export class SpaceRuntime {
         store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
           terminal: true,
           reason: 'run_not_externally_deliverable',
+        });
+        store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+        continue;
+      }
+
+      if (this.isTargetTaskTerminal(target.taskId)) {
+        store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
+          terminal: true,
+          reason: 'target_task_terminal',
         });
         store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
         continue;

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2308,7 +2308,7 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected.some((item) => item.message.includes(events[0]!.id))).toBe(false);
   });
 
-  test('marks delivery failed when target execution is not active', async () => {
+  test('persists pending delivery when target execution is not active', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
     nodeExecutionRepo.update(execution.id, {
@@ -2323,12 +2323,13 @@ describe('SpaceRuntime external event subscriptions', () => {
 
     expect(injected).toHaveLength(0);
     const delivery = eventStore.listDeliveries(event.id)[0]!;
-    expect(delivery.state).toBe('failed');
+    expect(delivery.state).toBe('pending');
     expect(delivery.failureReason).toBe('node_execution_not_active');
-    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(eventStore.listPendingDeliveries()).toContainEqual(delivery);
+    expect(eventStore.getById(event.id)?.state).toBe('published');
   });
 
-  test('does not deliver external events to idle executions with retained sessions', async () => {
+  test('persists pending delivery for idle executions with retained sessions', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
     nodeExecutionRepo.update(execution.id, {
@@ -2343,8 +2344,47 @@ describe('SpaceRuntime external event subscriptions', () => {
 
     expect(injected).toHaveLength(0);
     const delivery = eventStore.listDeliveries(event.id)[0]!;
-    expect(delivery.state).toBe('failed');
+    expect(delivery.state).toBe('pending');
     expect(delivery.failureReason).toBe('node_execution_not_active');
+    expect(eventStore.listPendingDeliveries()).toContainEqual(delivery);
+    expect(eventStore.getById(event.id)?.state).toBe('published');
+  });
+
+  test('fails delivery when inactive target task is already done', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: 'session-done-task',
+      completedAt: Date.now(),
+    });
+    taskRepo.updateTask(task.id, { status: 'done' });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(injected).toHaveLength(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('target_task_terminal');
+    expect(eventStore.listPendingDeliveries()).not.toContainEqual(delivery);
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
+  test('fails delivery when pending target execution belongs to a done task', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    expect(execution.status).toBe('pending');
+    taskRepo.updateTask(task.id, { status: 'done' });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(injected).toHaveLength(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('target_task_terminal');
+    expect(eventStore.listPendingDeliveries()).not.toContainEqual(delivery);
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
 
@@ -2857,12 +2897,12 @@ describe('SpaceRuntime external event subscriptions', () => {
     const event = makeEvent();
     await eventService.publish(event);
 
-    // The code node should be terminalized immediately (no queueable execution)
+    // The code node should be persisted as pending instead of terminalized.
     const deliveries = eventStore.listDeliveries(event.id);
     expect(deliveries).toHaveLength(2);
     const codeDelivery = deliveries.find((d) => d.nodeId === 'code')!;
     expect(codeDelivery).toBeDefined();
-    expect(codeDelivery.state).toBe('failed');
+    expect(codeDelivery.state).toBe('pending');
     expect(codeDelivery.failureReason).toBe('node_execution_not_active');
   });
 
@@ -3347,8 +3387,8 @@ describe('SpaceRuntime external event subscriptions', () => {
     const deliveries = eventStore.listDeliveries(event.id);
     expect(deliveries).toHaveLength(2);
     expect(deliveries.some((delivery) => delivery.state === 'delivered')).toBe(true);
-    expect(deliveries.some((delivery) => delivery.state === 'failed')).toBe(true);
-    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(deliveries.some((delivery) => delivery.state === 'pending')).toBe(true);
+    expect(eventStore.getById(event.id)?.state).toBe('published');
   });
 
   test('terminalizes delivery instead of retrying when run is terminal after transient dispatch failure', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -3869,6 +3869,29 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(delivery.failureReason).toBe('node_execution_cancelled');
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
+
+  test('preserves DB-only pending deliveries when another target subscription survives', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      completedAt: Date.now(),
+    });
+    runtime.registerSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC, {
+      subscriptionKind: 'auto',
+    });
+    const event = makeEvent();
+    await eventService.publish(event);
+    const pendingDelivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(pendingDelivery.state).toBe('pending');
+
+    runtime.clearPrEventSubscriptionsForRun(run.id);
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+    expect(delivery.failureReason).toBe('node_execution_not_active');
+    expect(eventStore.getById(event.id)?.state).toBe('published');
+  });
   test('terminalizes persisted pending deliveries for non-deliverable runs on rehydrate', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const event = makeEvent();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2733,6 +2733,39 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
 
+  test('terminalizes persisted pending deliveries for terminal tasks during runtime rehydrate', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const event = makeEvent();
+    await eventService.publish(event);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+    taskRepo.updateTask(task.id, { status: 'done' });
+
+    await runtime.stop();
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus: createInternalCommandBus(),
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    runtime.registerSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+
+    await runtime.rehydrateExecutors();
+
+    const rehydratedDelivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(rehydratedDelivery.state).toBe('failed');
+    expect(rehydratedDelivery.failureReason).toBe('target_task_terminal');
+    expect(eventStore.listPendingDeliveries()).not.toContainEqual(rehydratedDelivery);
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
   test('ignores terminal runs when matching external event deliveries', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     workflowRunRepo.updateRun(run.id, { status: 'cancelled' });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -3840,6 +3840,21 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected).toHaveLength(0);
   });
 
+  test('terminalizes DB-only pending deliveries when run interests are cleared', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const event = makeEvent();
+    await eventService.publish(event);
+    const pendingDelivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(pendingDelivery.state).toBe('pending');
+
+    runtime.clearRunInterests(run.id);
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('run_terminal_cleanup');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
   test('terminalizes persisted pending deliveries for non-deliverable runs on rehydrate', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const event = makeEvent();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -3855,6 +3855,20 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
 
+  test('terminalizes DB-only pending deliveries when target subscription is cleared', async () => {
+    const { workflow, run, task } = await startRunWithSubscription();
+    const event = makeEvent();
+    await eventService.publish(event);
+    const pendingDelivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(pendingDelivery.state).toBe('pending');
+
+    runtime.unregisterExecution(run.id, task.id, 'code', 'coder');
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('node_execution_cancelled');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
   test('terminalizes persisted pending deliveries for non-deliverable runs on rehydrate', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const event = makeEvent();


### PR DESCRIPTION
## Summary

Persist GitHub event deliveries for inactive worker nodes as pending instead of terminally failing them with `node_execution_not_active`.

## Testing

- `cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-external-events.test.ts`
- `bun run check`
