### PR TITLE
Surface live task progress on running tools

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2384,12 +2384,7 @@ ORDER BY s.last_active_at DESC, s.id DESC
  * inflates the JSON and merges the extras to produce a ChatMessage-shaped
  * object.
  */
-const BACKGROUND_TASK_METADATA_SUBTYPES = [
-  'task_started',
-  'task_updated',
-  'task_progress',
-  'task_notification',
-];
+const BACKGROUND_TASK_METADATA_SUBTYPES = ['task_started', 'task_updated', 'task_notification'];
 const BACKGROUND_TASK_METADATA_BATCH_SIZE = 300;
 
 function toSqlStringList(subtypes: Iterable<string>): string {
@@ -2444,6 +2439,45 @@ task_starts AS (
       task_id
     ) IN (SELECT task_id FROM recent_task_ids)
     AND id NOT IN (SELECT id FROM recent_metadata)
+),
+latest_progress AS (
+  SELECT
+    id,
+    sdk_message,
+    timestamp,
+    send_status,
+    origin,
+    rowid,
+    task_id
+  FROM (
+    SELECT
+      id,
+      sdk_message,
+      timestamp,
+      send_status,
+      origin,
+      rowid,
+      COALESCE(
+        CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.task_id') END,
+        task_id
+      ) AS task_id,
+      ROW_NUMBER() OVER (
+        PARTITION BY COALESCE(
+          CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.tool_use_id') END,
+          ''
+        )
+        ORDER BY timestamp DESC, rowid DESC
+      ) AS rn
+    FROM sdk_messages
+    WHERE session_id = ?
+      AND parent_tool_use_id IS NULL
+      AND COALESCE(message_subtype, '') = 'task_progress'
+      AND COALESCE(
+        CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.tool_use_id') END,
+        ''
+      ) != ''
+  )
+  WHERE rn = 1
 )
 SELECT
   id,
@@ -2455,6 +2489,8 @@ FROM (
   SELECT * FROM recent_metadata
   UNION ALL
   SELECT * FROM task_starts
+  UNION ALL
+  SELECT * FROM latest_progress
 )
 ORDER BY timestamp DESC, rowid DESC
 `.trim();
@@ -3022,7 +3058,7 @@ export function setupLiveQueryHandlers(
     mapResult: (_rawRows, params) => {
       const sessionId = params[0];
       if (typeof sessionId !== 'string' || sessionId.length === 0) return undefined;
-      const rows = stmtBackgroundTaskMetadata.all(sessionId, sessionId) as Record<
+      const rows = stmtBackgroundTaskMetadata.all(sessionId, sessionId, sessionId) as Record<
         string,
         unknown
       >[];

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2384,7 +2384,12 @@ ORDER BY s.last_active_at DESC, s.id DESC
  * inflates the JSON and merges the extras to produce a ChatMessage-shaped
  * object.
  */
-const BACKGROUND_TASK_METADATA_SUBTYPES = ['task_started', 'task_updated', 'task_notification'];
+const BACKGROUND_TASK_METADATA_SUBTYPES = [
+  'task_started',
+  'task_updated',
+  'task_progress',
+  'task_notification',
+];
 const BACKGROUND_TASK_METADATA_BATCH_SIZE = 300;
 
 function toSqlStringList(subtypes: Iterable<string>): string {

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -834,16 +834,55 @@ export class SDKMessageRepository {
                task_id
              ) IN (SELECT task_id FROM recent_task_ids)
              AND id NOT IN (SELECT id FROM recent_metadata)
+         ),
+         latest_progress AS (
+           SELECT
+             id,
+             sdk_message,
+             timestamp,
+             origin,
+             rowid,
+             task_id
+           FROM (
+             SELECT
+               id,
+               sdk_message,
+               timestamp,
+               origin,
+               rowid,
+               COALESCE(
+                 CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.task_id') END,
+                 task_id
+               ) AS task_id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY COALESCE(
+                   CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.tool_use_id') END,
+                   ''
+                 )
+                 ORDER BY timestamp DESC, rowid DESC
+               ) AS rn
+             FROM sdk_messages
+             WHERE session_id = ?
+               AND parent_tool_use_id IS NULL
+               AND COALESCE(message_subtype, '') = 'task_progress'
+               AND COALESCE(
+                 CASE WHEN json_valid(sdk_message) THEN json_extract(sdk_message, '$.tool_use_id') END,
+                 ''
+               ) != ''
+           )
+           WHERE rn = 1
          )
          SELECT id, sdk_message, timestamp, origin
          FROM (
            SELECT * FROM recent_metadata
            UNION ALL
            SELECT * FROM task_starts
+           UNION ALL
+           SELECT * FROM latest_progress
          )
          ORDER BY timestamp DESC, rowid DESC`
       )
-      .all(sessionId, BACKGROUND_TASK_METADATA_BATCH_SIZE, sessionId) as Array<{
+      .all(sessionId, BACKGROUND_TASK_METADATA_BATCH_SIZE, sessionId, sessionId) as Array<{
       id: string;
       sdk_message: string;
       timestamp: string;

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -422,6 +422,44 @@ describe('SDKMessageRepository', () => {
       expect(hasMore).toBe(true);
     });
 
+    it('should include only latest task progress without counting it against metadata cap', () => {
+      repository.saveSDKMessage('session-1', {
+        type: 'system',
+        subtype: 'task_started',
+        uuid: 'metadata-task-started',
+        session_id: 'session-1',
+        task_id: 'task-1',
+        tool_use_id: 'toolu_task123',
+        description: 'Long task',
+      } as unknown as SDKMessage);
+
+      for (let i = 0; i < 305; i++) {
+        repository.saveSDKMessage('session-1', {
+          type: 'system',
+          subtype: 'task_progress',
+          uuid: `metadata-task-progress-${i}`,
+          session_id: 'session-1',
+          task_id: 'task-1',
+          tool_use_id: 'toolu_task123',
+          description: `progress ${i}`,
+          usage: { total_tokens: i, tool_uses: i, duration_ms: i },
+        } as unknown as SDKMessage);
+      }
+
+      const metadataMessages = repository.getBackgroundTaskMessages('session-1');
+      const progressMessages = metadataMessages.filter(
+        (message) => (message as { subtype?: string }).subtype === 'task_progress'
+      );
+
+      expect(
+        metadataMessages.some(
+          (message) => (message as { subtype?: string }).subtype === 'task_started'
+        )
+      ).toBe(true);
+      expect(progressMessages).toHaveLength(1);
+      expect((progressMessages[0] as { description?: string }).description).toBe('progress 304');
+    });
+
     it('should retain task start rows when background task metadata is capped', () => {
       repository.saveSDKMessage('session-1', {
         type: 'system',

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -9,7 +9,11 @@
  */
 
 import type { PendingUserQuestion, QuestionDraftResponse, ResolvedQuestion } from '@neokai/shared';
-import type { SDKMessage, SDKTaskNotificationMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import type {
+  SDKMessage,
+  SDKTaskNotificationMessage,
+  SDKTaskProgressMessage,
+} from '@neokai/shared/sdk/sdk.d.ts';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
 import {
   type ContentBlock,
@@ -39,6 +43,8 @@ interface Props {
   subagentMessagesMap?: Map<string, SDKMessage[]>;
   /** tool_use_id → terminal task_notification (folded onto the tool card). */
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
+  /** tool_use_id → latest live task_progress (folded onto running tool cards). */
+  taskProgressMap?: Map<string, SDKTaskProgressMessage>;
   replacementStatusMap?: Map<string, MessageReplacementStatus>;
   // Question handling props for inline QuestionPrompt rendering
   sessionId?: string;
@@ -68,6 +74,7 @@ export function SDKAssistantMessage({
   toolResultsMap,
   subagentMessagesMap,
   taskNotificationsMap,
+  taskProgressMap,
   replacementStatusMap,
   sessionId,
   resolvedQuestions,
@@ -263,6 +270,7 @@ export function SDKAssistantMessage({
         const toolResult = toolResultsMap?.get(block.id);
         const nestedMessages = subagentMessagesMap?.get(block.id) || [];
         const taskNotification = taskNotificationsMap?.get(block.id);
+        const taskProgress = taskProgressMap?.get(block.id);
         return (
           <ToolUseBlock
             key={`tool-${idx}`}
@@ -273,6 +281,8 @@ export function SDKAssistantMessage({
             replacementStatusMap={replacementStatusMap}
             taskNotification={taskNotification}
             taskNotificationsMap={taskNotificationsMap}
+            taskProgress={taskProgress}
+            taskProgressMap={taskProgressMap}
             sessionId={sessionId}
             resolvedQuestions={resolvedQuestions}
             pendingQuestion={pendingQuestion}
@@ -319,6 +329,8 @@ function ToolUseBlock({
   replacementStatusMap,
   taskNotification,
   taskNotificationsMap,
+  taskProgress,
+  taskProgressMap,
   sessionId: propSessionId,
   resolvedQuestions,
   pendingQuestion,
@@ -333,6 +345,8 @@ function ToolUseBlock({
   replacementStatusMap?: Map<string, MessageReplacementStatus>;
   taskNotification?: SDKTaskNotificationMessage;
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
+  taskProgress?: SDKTaskProgressMessage;
+  taskProgressMap?: Map<string, SDKTaskProgressMessage>;
   sessionId?: string;
   resolvedQuestions?: Map<string, ResolvedQuestion>;
   pendingQuestion?: PendingUserQuestion | null;
@@ -375,6 +389,8 @@ function ToolUseBlock({
         replacementStatusMap={replacementStatusMap}
         taskNotification={taskNotification}
         taskNotificationsMap={taskNotificationsMap}
+        taskProgress={taskProgress}
+        taskProgressMap={taskProgressMap}
         isRunning={isRunning}
       />
     );
@@ -433,6 +449,7 @@ function ToolUseBlock({
             sessionId={sessionId}
             isOutputRemoved={isOutputRemoved}
             taskNotification={taskNotification}
+            taskProgress={taskProgress}
             isRunning={isRunning}
           />
         </div>
@@ -452,6 +469,7 @@ function ToolUseBlock({
           sessionId={sessionId}
           isOutputRemoved={isOutputRemoved}
           taskNotification={taskNotification}
+          taskProgress={taskProgress}
           isRunning={isRunning}
         />
         {/* Render QuestionPrompt inline - ALWAYS show the form */}
@@ -493,6 +511,7 @@ function ToolUseBlock({
       sessionId={sessionId}
       isOutputRemoved={isOutputRemoved}
       taskNotification={taskNotification}
+      taskProgress={taskProgress}
       isRunning={isRunning}
     />
   );

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -10,6 +10,7 @@ import type {
   SDKMessage,
   SDKRateLimitEvent as SDKRateLimitEventType,
   SDKTaskNotificationMessage,
+  SDKTaskProgressMessage,
   SDKToolProgressMessage as SDKToolProgressMessageType,
 } from '@neokai/shared/sdk/sdk.d.ts';
 import type {
@@ -54,6 +55,8 @@ interface Props {
   subagentMessagesMap?: Map<string, SDKMessage[]>;
   /** tool_use_id → terminal task_notification (folded onto the tool card). */
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
+  /** tool_use_id → latest live task_progress (folded onto running tool cards). */
+  taskProgressMap?: Map<string, SDKTaskProgressMessage>;
   /** tool_use_ids whose card is rendered in this slice — gates task_notification
    * suppression (a nested tool_use whose parent is paginated out has no target). */
   foldableToolUseIds?: Set<string>;
@@ -252,6 +255,7 @@ function SDKMessageRendererImpl({
   toolInputsMap,
   subagentMessagesMap,
   taskNotificationsMap,
+  taskProgressMap,
   foldableToolUseIds,
   completedHookUuids,
   replacementStatusMap,
@@ -372,6 +376,7 @@ function SDKMessageRendererImpl({
         toolResultsMap={toolResultsMap}
         subagentMessagesMap={subagentMessagesMap}
         taskNotificationsMap={taskNotificationsMap}
+        taskProgressMap={taskProgressMap}
         replacementStatusMap={replacementStatusMap}
         sessionId={sessionId}
         resolvedQuestions={resolvedQuestions}
@@ -438,6 +443,7 @@ function areMessageRendererPropsEqual(prev: Props, next: Props): boolean {
     prev.toolInputsMap === next.toolInputsMap &&
     prev.subagentMessagesMap === next.subagentMessagesMap &&
     prev.taskNotificationsMap === next.taskNotificationsMap &&
+    prev.taskProgressMap === next.taskProgressMap &&
     prev.foldableToolUseIds === next.foldableToolUseIds &&
     prev.completedHookUuids === next.completedHookUuids &&
     prev.replacementStatusMap === next.replacementStatusMap &&

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -550,6 +550,7 @@ export function SubagentBlock({
                     replacementStatusMap={replacementStatusMap}
                     taskNotificationsMap={taskNotificationsMap}
                     taskProgressMap={taskProgressMap}
+                    isParentRunning={isRunning}
                     completedHookUuids={nestedCompletedHookUuids}
                   />
                 ))}
@@ -597,6 +598,7 @@ function NestedMessageRenderer({
   replacementStatusMap,
   taskNotificationsMap,
   taskProgressMap,
+  isParentRunning,
   completedHookUuids,
 }: {
   message: SDKMessage;
@@ -605,6 +607,7 @@ function NestedMessageRenderer({
   replacementStatusMap?: Map<string, MessageReplacementStatus>;
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
   taskProgressMap?: Map<string, SDKTaskProgressMessage>;
+  isParentRunning?: boolean;
   completedHookUuids?: Set<string>;
 }) {
   const replacementStatus = replacementStatusMap?.get(getMessageUuid(message) ?? '');
@@ -672,6 +675,9 @@ function NestedMessageRenderer({
           const resultData = toolResultsMap?.get(toolBlock.id) as
             | { content: unknown; isOutputRemoved?: boolean }
             | undefined;
+          const taskNotification = taskNotificationsMap?.get(toolBlock.id);
+          const taskProgress = taskProgressMap?.get(toolBlock.id);
+          const isRunningTool = !!isParentRunning && !!taskProgress && !taskNotification;
           return (
             <ToolResultCard
               key={`tool-${idx}`}
@@ -684,9 +690,9 @@ function NestedMessageRenderer({
               }
               variant="default"
               isOutputRemoved={resultData?.isOutputRemoved || false}
-              taskNotification={taskNotificationsMap?.get(toolBlock.id)}
-              taskProgress={taskProgressMap?.get(toolBlock.id)}
-              isRunning={!!taskProgressMap?.has(toolBlock.id)}
+              taskNotification={taskNotification}
+              taskProgress={taskProgress}
+              isRunning={isRunningTool}
             />
           );
         })}

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -15,7 +15,11 @@ import { cn } from '../../lib/utils.ts';
 import { RunningBorder } from './RunningBorder.tsx';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
-import type { SDKMessage, SDKTaskNotificationMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import type {
+  SDKMessage,
+  SDKTaskNotificationMessage,
+  SDKTaskProgressMessage,
+} from '@neokai/shared/sdk/sdk.d.ts';
 import {
   hasRenderableThinking,
   isHiddenSystemSubtype,
@@ -25,6 +29,7 @@ import {
   isThinkingBlock,
   type ContentBlock,
 } from '@neokai/shared/sdk/type-guards';
+import { TaskProgressLine } from './tools/TaskProgressLine.tsx';
 import { ToolResultCard } from './tools/index.ts';
 import { ThinkingBlock } from './ThinkingBlock.tsx';
 import { SDKSystemMessage } from './SDKSystemMessage.tsx';
@@ -122,6 +127,10 @@ interface SubagentBlockProps {
    * (the top-level suppression relies on toolInputsMap having the nested id, so
    * the nested card must actually receive the notification). */
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
+  /** Latest live task_progress for this Task/Agent tool_use. */
+  taskProgress?: SDKTaskProgressMessage;
+  /** Full tool_use_id → task_progress map for nested tool_use blocks. */
+  taskProgressMap?: Map<string, SDKTaskProgressMessage>;
   /** Additional CSS classes */
   className?: string;
   /** When true, wrap this block in <RunningBorder> so the animated arc traces
@@ -309,6 +318,8 @@ export function SubagentBlock({
   replacementStatusMap,
   taskNotification,
   taskNotificationsMap,
+  taskProgress,
+  taskProgressMap,
   className,
   isRunning = false,
 }: SubagentBlockProps) {
@@ -484,6 +495,8 @@ export function SubagentBlock({
         </div>
       </button>
 
+      {isRunning && taskProgress && <TaskProgressLine progress={taskProgress} />}
+
       {/* Expanded content */}
       {isExpanded && (
         <div class={cn('border-t bg-white dark:bg-gray-900', colors.border)}>
@@ -536,6 +549,7 @@ export function SubagentBlock({
                     toolResultsMap={toolResultsMap}
                     replacementStatusMap={replacementStatusMap}
                     taskNotificationsMap={taskNotificationsMap}
+                    taskProgressMap={taskProgressMap}
                     completedHookUuids={nestedCompletedHookUuids}
                   />
                 ))}
@@ -582,6 +596,7 @@ function NestedMessageRenderer({
   toolResultsMap,
   replacementStatusMap,
   taskNotificationsMap,
+  taskProgressMap,
   completedHookUuids,
 }: {
   message: SDKMessage;
@@ -589,6 +604,7 @@ function NestedMessageRenderer({
   toolResultsMap?: Map<string, unknown>;
   replacementStatusMap?: Map<string, MessageReplacementStatus>;
   taskNotificationsMap?: Map<string, SDKTaskNotificationMessage>;
+  taskProgressMap?: Map<string, SDKTaskProgressMessage>;
   completedHookUuids?: Set<string>;
 }) {
   const replacementStatus = replacementStatusMap?.get(getMessageUuid(message) ?? '');
@@ -669,6 +685,7 @@ function NestedMessageRenderer({
               variant="default"
               isOutputRemoved={resultData?.isOutputRemoved || false}
               taskNotification={taskNotificationsMap?.get(toolBlock.id)}
+              taskProgress={taskProgressMap?.get(toolBlock.id)}
             />
           );
         })}

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -686,6 +686,7 @@ function NestedMessageRenderer({
               isOutputRemoved={resultData?.isOutputRemoved || false}
               taskNotification={taskNotificationsMap?.get(toolBlock.id)}
               taskProgress={taskProgressMap?.get(toolBlock.id)}
+              isRunning={!!taskProgressMap?.has(toolBlock.id)}
             />
           );
         })}

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -401,6 +401,58 @@ describe('SubagentBlock', () => {
       expect(container.textContent).toContain('Check in the src folder');
     });
 
+    it('hides stale nested progress after terminal task_notification arrives', async () => {
+      const input = createAgentInput('Explore', 'Find files', 'Search for test files');
+      const nestedMessages = [createNestedToolUseMessage()];
+      const toolResultsMap = new Map([['toolu_nested123', { content: 'File content here' }]]);
+      const taskProgressMap = new Map([
+        [
+          'toolu_nested123',
+          {
+            type: 'system',
+            subtype: 'task_progress',
+            task_id: 't',
+            tool_use_id: 'toolu_nested123',
+            description: 'reading',
+            usage: { total_tokens: 12400, tool_uses: 3, duration_ms: 8200 },
+            last_tool_name: 'Read',
+          } as never,
+        ],
+      ]);
+      const taskNotificationsMap = new Map([
+        [
+          'toolu_nested123',
+          {
+            type: 'system',
+            subtype: 'task_notification',
+            task_id: 't',
+            tool_use_id: 'toolu_nested123',
+            status: 'completed',
+            output_file: '/tmp/o',
+            summary: 'read ok',
+          } as never,
+        ],
+      ]);
+
+      const { container } = render(
+        <SubagentBlock
+          input={input}
+          toolId="toolu_task123"
+          nestedMessages={nestedMessages}
+          toolResultsMap={toolResultsMap}
+          taskProgressMap={taskProgressMap}
+          taskNotificationsMap={taskNotificationsMap}
+          isRunning={true}
+        />
+      );
+
+      fireEvent.click(container.querySelector('button')!);
+      await waitFor(() => expect(container.textContent).toContain('Read'));
+      expect(container.querySelector('[aria-label="running task progress"]')).toBeFalsy();
+      expect(container.textContent).not.toContain('Running · 12.4k tok');
+      expect(container.querySelector('[aria-label="task completed"]')).toBeTruthy();
+    });
+
     it('folds a nested tool_use task_notification onto the nested ToolResultCard', async () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [createNestedToolUseMessage()];

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -357,6 +357,36 @@ describe('SubagentBlock', () => {
       ).toBeTruthy();
     });
 
+    it('shows live progress while the subagent card is running', () => {
+      const input = createAgentInput('Explore', 'Find files', 'Search for test files');
+
+      const { container } = render(
+        <SubagentBlock
+          input={input}
+          toolId="toolu_task123"
+          isRunning={true}
+          taskProgress={
+            {
+              type: 'system',
+              subtype: 'task_progress',
+              task_id: 'task-1',
+              tool_use_id: 'toolu_task123',
+              description: 'searching',
+              usage: { total_tokens: 12400, tool_uses: 3, duration_ms: 8200 },
+              last_tool_name: 'Bash',
+              summary: 'checking files',
+              uuid: 'progress-1',
+              session_id: 'session-1',
+            } as never
+          }
+        />
+      );
+
+      expect(container.textContent).toContain('Running · 12.4k tok · 3 tools · 8.2s · last: Bash');
+      expect(container.textContent).toContain('checking files');
+      expect(container.querySelector('[aria-label="running task progress"]')).toBeTruthy();
+    });
+
     it('should render nested user messages', () => {
       const input = createAgentInput('Explore', 'Find files', 'Search for test files');
       const nestedMessages = [createNestedUserMessage('Check in the src folder.')];

--- a/packages/web/src/components/sdk/tools/TaskProgressLine.tsx
+++ b/packages/web/src/components/sdk/tools/TaskProgressLine.tsx
@@ -1,0 +1,36 @@
+import type { SDKTaskProgressMessage } from '@neokai/shared/sdk/sdk.d.ts';
+
+function formatTokens(totalTokens: number): string {
+  if (totalTokens >= 1000) {
+    return `${(totalTokens / 1000).toFixed(1).replace(/\.0$/, '')}k tok`;
+  }
+  return `${totalTokens.toLocaleString()} tok`;
+}
+
+function formatToolUses(toolUses: number): string {
+  return `${toolUses.toLocaleString()} ${toolUses === 1 ? 'tool' : 'tools'}`;
+}
+
+export function TaskProgressLine({ progress }: { progress: SDKTaskProgressMessage }) {
+  const segments = [
+    'Running',
+    formatTokens(progress.usage.total_tokens),
+    formatToolUses(progress.usage.tool_uses),
+    `${(progress.usage.duration_ms / 1000).toFixed(1)}s`,
+  ];
+  if (progress.last_tool_name) {
+    segments.push(`last: ${progress.last_tool_name}`);
+  }
+  if (progress.summary) {
+    segments.push(progress.summary);
+  }
+
+  return (
+    <div
+      class="border-t border-gray-200/70 dark:border-gray-700/70 px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400"
+      aria-label="running task progress"
+    >
+      <span class="font-mono">{segments.join(' · ')}</span>
+    </div>
+  );
+}

--- a/packages/web/src/components/sdk/tools/ToolResultCard.tsx
+++ b/packages/web/src/components/sdk/tools/ToolResultCard.tsx
@@ -6,6 +6,7 @@ import { useState } from 'preact/hooks';
 import type { ToolResultCardProps } from './tool-types.ts';
 import { ToolIcon } from './ToolIcon.tsx';
 import { ToolSummary } from './ToolSummary.tsx';
+import { TaskProgressLine } from './TaskProgressLine.tsx';
 import { DiffViewer } from './DiffViewer.tsx';
 import { CodeViewer } from './CodeViewer.tsx';
 import {
@@ -76,6 +77,7 @@ export function ToolResultCard({
   className,
   isRunning = false,
   taskNotification,
+  taskProgress,
 }: ToolResultCardProps) {
   // Terminal task_notification status. When present it is the authoritative
   // signal (green check on completed, red X on failed/stopped). When absent we
@@ -338,6 +340,8 @@ export function ToolResultCard({
           )}
         </div>
       </button>
+
+      {isRunning && taskProgress && <TaskProgressLine progress={taskProgress} />}
 
       {/* Expanded content - input and output details */}
       {isExpanded && (

--- a/packages/web/src/components/sdk/tools/__tests__/ToolResultCard.test.tsx
+++ b/packages/web/src/components/sdk/tools/__tests__/ToolResultCard.test.tsx
@@ -321,6 +321,47 @@ describe('ToolResultCard Component', () => {
       expect(screen.queryAllByLabelText('task failed')).toHaveLength(0);
     });
 
+    it('shows live progress only while running', () => {
+      const taskProgress = {
+        type: 'system',
+        subtype: 'task_progress',
+        task_id: 'task-1',
+        tool_use_id: 'bash-progress',
+        description: 'running bash',
+        usage: { total_tokens: 12400, tool_uses: 3, duration_ms: 8200 },
+        last_tool_name: 'Bash',
+        summary: 'checking files',
+        uuid: 'progress-1',
+        session_id: 'session-1',
+      } as const;
+
+      const { rerender } = render(
+        <ToolResultCard
+          toolName="Bash"
+          toolId="bash-progress"
+          input={{ command: 'bun test' }}
+          isRunning={true}
+          taskProgress={taskProgress}
+        />
+      );
+
+      expect(screen.getByLabelText('running task progress')).toBeTruthy();
+      expect(screen.getByText(/Running · 12.4k tok · 3 tools · 8.2s · last: Bash/)).toBeTruthy();
+      expect(screen.getByText(/checking files/)).toBeTruthy();
+
+      rerender(
+        <ToolResultCard
+          toolName="Bash"
+          toolId="bash-progress"
+          input={{ command: 'bun test' }}
+          isRunning={false}
+          taskProgress={taskProgress}
+        />
+      );
+
+      expect(screen.queryByLabelText('running task progress')).toBeNull();
+    });
+
     it('falls back to isError X when no task_notification is present', () => {
       render(
         <ToolResultCard

--- a/packages/web/src/components/sdk/tools/tool-types.ts
+++ b/packages/web/src/components/sdk/tools/tool-types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { JSX } from 'preact';
+import type { SDKTaskProgressMessage } from '@neokai/shared/sdk/sdk.d.ts';
 
 /**
  * Display variant for tool components
@@ -143,6 +144,8 @@ export interface ToolResultCardProps {
     summary?: string;
     usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
   };
+  /** Latest live task_progress for this running tool_use. */
+  taskProgress?: SDKTaskProgressMessage;
 }
 
 /**

--- a/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
+++ b/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
@@ -913,6 +913,76 @@ describe('useMessageMaps', () => {
     });
   });
 
+  describe('taskProgressMap', () => {
+    it('maps tool_use_id to its latest task_progress', () => {
+      const messages = [
+        {
+          type: 'system',
+          uuid: uuid1,
+          session_id: 'session-1',
+          subtype: 'task_progress',
+          task_id: 'task-1',
+          tool_use_id: 'tu-1',
+          description: 'first',
+          usage: { total_tokens: 10, tool_uses: 1, duration_ms: 1000 },
+          last_tool_name: 'Read',
+        },
+        {
+          type: 'system',
+          uuid: uuid2,
+          session_id: 'session-1',
+          subtype: 'task_progress',
+          task_id: 'task-1',
+          tool_use_id: 'tu-1',
+          description: 'second',
+          usage: { total_tokens: 12400, tool_uses: 3, duration_ms: 8200 },
+          last_tool_name: 'Bash',
+          summary: 'still running',
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() => useMessageMaps(messages, 'session-1'));
+      expect(result.current.taskProgressMap.size).toBe(1);
+      const progress = result.current.taskProgressMap.get('tu-1');
+      expect(progress?.description).toBe('second');
+      expect(progress?.usage.total_tokens).toBe(12400);
+      expect(progress?.last_tool_name).toBe('Bash');
+    });
+
+    it('skips task_progress without a tool_use_id', () => {
+      const messages = [
+        {
+          type: 'system',
+          uuid: uuid1,
+          session_id: 'session-1',
+          subtype: 'task_progress',
+          task_id: 'task-1',
+          description: 'orphan',
+          usage: { total_tokens: 10, tool_uses: 1, duration_ms: 1000 },
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() => useMessageMaps(messages, 'session-1'));
+      expect(result.current.taskProgressMap.size).toBe(0);
+    });
+
+    it('ignores non-task_progress system messages', () => {
+      const messages = [
+        {
+          type: 'system',
+          uuid: uuid1,
+          session_id: 'session-1',
+          subtype: 'task_started',
+          task_id: 'task-1',
+          tool_use_id: 'tu-1',
+        },
+      ] as unknown as SDKMessage[];
+
+      const { result } = renderHook(() => useMessageMaps(messages, 'session-1'));
+      expect(result.current.taskProgressMap.size).toBe(0);
+    });
+  });
+
   describe('foldableToolUseIds', () => {
     it('includes top-level tool_uses and nested ones whose parent Task card is present', () => {
       const messages = [

--- a/packages/web/src/hooks/useMessageMaps.ts
+++ b/packages/web/src/hooks/useMessageMaps.ts
@@ -24,6 +24,7 @@ import type {
   SDKMessage,
   SDKSystemMessage,
   SDKTaskNotificationMessage,
+  SDKTaskProgressMessage,
 } from '@neokai/shared/sdk/sdk.d.ts';
 import type { ChatMessage } from '@neokai/shared';
 import {
@@ -51,6 +52,8 @@ export interface UseMessageMapsResult {
   taskNotificationsMap: Map<string, SDKTaskNotificationMessage>;
   /** Map of assistant message UUIDs to the tool_use IDs currently running in that message. */
   runningToolUseIdsByMessageUuid: Map<string, Set<string>>;
+  /** Map of tool use IDs to their latest live task_progress (usage/last tool/summary) */
+  taskProgressMap: Map<string, SDKTaskProgressMessage>;
   /**
    * Tool use IDs whose card is actually rendered in this slice — top-level
    * tool_use ids plus nested tool_use ids whose parent Task/Agent card is
@@ -165,6 +168,21 @@ export function useMessageMaps(
 
     return map;
   }, [sdkMessages, runningToolUseIds]);
+
+  // Map of tool use IDs to their latest live task_progress. task_progress
+  // carries live usage/summary/last-tool data and links directly to its
+  // originating tool_use via tool_use_id. Keep only the latest row per tool.
+  const taskProgressMap = useMemo(() => {
+    const map = new Map<string, SDKTaskProgressMessage>();
+    sdkMessages.forEach((msg) => {
+      if (msg.type !== 'system' || msg.subtype !== 'task_progress') return;
+      const progress = msg as SDKTaskProgressMessage;
+      if (progress.tool_use_id) {
+        map.set(progress.tool_use_id, progress);
+      }
+    });
+    return map;
+  }, [sdkMessages]);
 
   // Map of user message UUIDs to their attached session init info
   const sessionInfoMap = useMemo(() => {
@@ -307,6 +325,7 @@ export function useMessageMaps(
     subagentMessagesMap,
     taskNotificationsMap,
     runningToolUseIdsByMessageUuid,
+    taskProgressMap,
     foldableToolUseIds,
     replacementStatusMap,
     completedHookUuids,

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -1392,6 +1392,7 @@ export default function ChatContainer({
                     toolInputsMap={maps.toolInputsMap}
                     subagentMessagesMap={maps.subagentMessagesMap}
                     taskNotificationsMap={maps.taskNotificationsMap}
+                    taskProgressMap={maps.taskProgressMap}
                     foldableToolUseIds={maps.foldableToolUseIds}
                     completedHookUuids={maps.completedHookUuids}
                     runningToolUseIds={


### PR DESCRIPTION
Shows latest task_progress usage/last-tool details on running tool cards while keeping task_progress rows hidden.

Tests:
- cd packages/web && bunx vitest run src/hooks/__tests__/useMessageMaps.test.ts src/components/sdk/tools/__tests__/ToolResultCard.test.tsx src/components/sdk/__tests__/SubagentBlock.test.tsx
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/surface-task-progress-usage-last-tool-on-running-tool-cards check
- bun run --cwd /Users/lsm/.neokai/projects/dev-neokai-ec0a1deb/worktrees/surface-task-progress-usage-last-tool-on-running-tool-cards format:check
