### PR TITLE
fix: guard activation pending flush with run deliverability check

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1628,9 +1628,32 @@ export class SpaceRuntime {
           a.delivery.deliveryKey.localeCompare(b.delivery.deliveryKey)
       );
 
+    // Mirror requeuePersistedPendingDeliveries: only dispatch persisted rows
+    // when the workflow run is externally deliverable. All deliveries here
+    // share target.workflowRunId, so the run state is computed once. A
+    // 'blocked' run is deliverable only while it still has an active execution
+    // to receive the event; otherwise the persisted rows are terminally failed
+    // with run_not_externally_deliverable and the event's terminal state is
+    // updated.
+    const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
+    const runDeliverable = run
+      ? run.status === 'blocked'
+        ? this.hasActiveExecutionForRun(run.id)
+        : isExternallyDeliverableRun(run.status)
+      : false;
+
     for (const { delivery, eventRecord } of deliveries) {
       if (store.isDeliveryTerminal(delivery.eventId, delivery.deliveryKey)) continue;
       if (this.externalEventDeliveriesInFlight.has(delivery.deliveryKey)) continue;
+      if (!runDeliverable) {
+        store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
+          terminal: true,
+          reason: 'run_not_externally_deliverable',
+        });
+        store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+        this.clearExternalEventRetry(delivery.deliveryKey);
+        continue;
+      }
       if (this.isTargetTaskTerminal(target.taskId)) {
         store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
           terminal: true,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -3976,6 +3976,102 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
 
+  test('activation flush terminalizes persisted pending deliveries for terminal runs', async () => {
+    const { run, task } = await startRunWithSubscription();
+    // Make the node execution non-active so the published event is persisted as
+    // a retryable pending delivery (failureReason = node_execution_not_active),
+    // which is the only kind collectPersistedPendingDeliveries re-dispatches.
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, { status: 'idle', completedAt: Date.now() });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    const persisted = eventStore.listDeliveries(event.id)[0]!;
+    expect(persisted.state).toBe('pending');
+    expect(persisted.failureReason).toBe('node_execution_not_active');
+
+    // Run transitions to terminal before the node reactivates.
+    workflowRunRepo.updateRun(run.id, { status: 'cancelled' });
+
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-activation-after-terminal',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('run_not_externally_deliverable');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(injected).toHaveLength(0);
+  });
+
+  test('activation flush terminalizes persisted pending deliveries for blocked runs without active execution', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, { status: 'idle', completedAt: Date.now() });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe('node_execution_not_active');
+
+    // Run becomes blocked with no active execution to receive the event.
+    workflowRunRepo.updateRun(run.id, { status: 'blocked' });
+
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-activation-blocked-no-exec',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('run_not_externally_deliverable');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(injected).toHaveLength(0);
+  });
+
+  test('activation flush dispatches persisted pending deliveries for blocked runs with active execution', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, { status: 'idle', completedAt: Date.now() });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe('node_execution_not_active');
+
+    // Reactivate the node execution, then leave the run blocked — a blocked run
+    // with an active execution is still externally deliverable.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-activation-blocked-active',
+      startedAt: Date.now(),
+      completedAt: null,
+    });
+    tam.alive.add('session-activation-blocked-active');
+    workflowRunRepo.updateRun(run.id, { status: 'blocked' });
+
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-activation-blocked-active',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(injected).toHaveLength(1);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('delivered');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
+
   test('does not requeue persisted pending deliveries for removed subscriptions', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const event = makeEvent();


### PR DESCRIPTION
## Summary

`collectPersistedPendingDeliveries` — the activation-time persisted pending external delivery flush invoked from `flushPendingNodeQueue` — dispatched persisted rows without verifying the workflow run is still externally deliverable. The rehydrate path (`requeuePersistedPendingDeliveries`) already had this guard; this mirrors it on the activation path.

## Change

Before dispatching persisted rows, compute run deliverability with the same blocked-with-active-execution semantics used in `requeuePersistedPendingDeliveries` and the retry path (`deliverToSession`/`scheduleExternalEventRetry`):
- `in_progress` → deliverable
- `blocked` → deliverable only while an active execution exists (`hasActiveExecutionForRun`)
- otherwise (terminal / blocked-without-active-execution / missing run) → mark the delivery failed terminal with `run_not_externally_deliverable` and update event terminal state

The run state is hoisted and computed once before the loop since every delivery in this function shares `target.workflowRunId`.

## Tests

Added focused unit coverage in `space-runtime-external-events.test.ts`:
- activation flush terminalizes persisted pending deliveries for **terminal** runs (`cancelled`)
- activation flush terminalizes persisted pending deliveries for **blocked runs without active execution**
- activation flush still **dispatches** persisted pending deliveries for **blocked runs with active execution** (covers the deliverable branch)