### PR TITLE
docs: encode event-age TTL anchor for persisted pending external deliveries

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -428,6 +428,25 @@ const EXTERNAL_EVENT_RATE_LIMIT_PER_MIN = parsePositiveIntegerEnv(
   'EXTERNAL_EVENT_RATE_LIMIT_PER_MIN',
   10
 );
+/**
+ * TTL for pending external-event deliveries that are waiting for their target
+ * node to become active (in-memory pending queue, DB-persisted pending rows,
+ * and retry replay).
+ *
+ * **TTL anchor is the external event's age** — i.e. the source-event row's
+ * `created_at` (ingestion time), NOT the delivery row's registration time.
+ * External events are time-sensitive (e.g. a GitHub review comment), so a
+ * delivery is dropped once its *event* is older than this window, regardless
+ * of when the delivery row was registered. This matters for delayed
+ * registration (event backdated/backlogged, subscription added late, or daemon
+ * restart replay): such deliveries must not get a fresh TTL window measured
+ * from registration. The delivery table intentionally has no `created_at`
+ * column; if registration-age TTL were ever wanted, it would require a schema
+ * migration plus changes to both `collectPersistedPendingDeliveries` and the
+ * rehydrate retry sweep (which both read `eventRecord.createdAt`).
+ *
+ * See `isQueuedExternalEventExpired` and design doc §5 "Backpressure — Event TTL".
+ */
 const EXTERNAL_EVENT_QUEUE_TTL_MS = parsePositiveIntegerEnv('EXTERNAL_EVENT_QUEUE_TTL_MS', 300_000);
 
 export function parsePositiveIntegerEnv(name: string, fallback: number): number {
@@ -1689,6 +1708,10 @@ export class SpaceRuntime {
 
       const mode = deliveryModeFromFailureReason(delivery.failureReason);
       const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
+      // TTL anchor is the event's creation/ingestion time, NOT the delivery
+      // row's registration/updated time — see EXTERNAL_EVENT_QUEUE_TTL_MS.
+      // A delivery registered late for an already-stale event must still
+      // expire, so the event age (not the delivery age) drives the check.
       const queuedItem: PendingExternalEvent = {
         event: eventPayload,
         deliveryKey: delivery.deliveryKey,
@@ -2477,6 +2500,14 @@ export class SpaceRuntime {
     this.pendingExternalEventQueue.set(key, queue);
   }
 
+  /**
+   * Whether a pending external-event delivery has exceeded its TTL.
+   *
+   * `item.createdAt` is the event's creation/ingestion time for DB-persisted
+   * deliveries (and the queueing time for in-memory deliveries, which ≈ event
+   * ingestion time since they are queued the moment the event is handled).
+   * Expiry is therefore event-age based — see EXTERNAL_EVENT_QUEUE_TTL_MS.
+   */
   private isQueuedExternalEventExpired(item: PendingExternalEvent, now = Date.now()): boolean {
     return now - item.createdAt > EXTERNAL_EVENT_QUEUE_TTL_MS;
   }
@@ -4283,6 +4314,11 @@ export class SpaceRuntime {
 
       const mode = deliveryModeFromFailureReason(delivery.failureReason);
       const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
+      // TTL anchor is the event's creation/ingestion time, not the delivery's
+      // registration/updated time — see EXTERNAL_EVENT_QUEUE_TTL_MS. This
+      // rehydrate retry sweep must use the same anchor as the activation
+      // flush (collectPersistedPendingDeliveries) so a persisted pending
+      // delivery cannot dodge the TTL by being replayed after a restart.
       const queuedItem = {
         event: eventPayload,
         deliveryKey: delivery.deliveryKey,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2576,6 +2576,65 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(queuedItems.some((item) => item.createdAt === oldCreatedAt)).toBe(true);
   });
 
+  test('drops persisted pending delivery whose event predates TTL even when the delivery row was just registered (event-age TTL anchor)', async () => {
+    // Regression guard for the TTL anchor decision (task #667): the TTL for a
+    // DB-persisted pending delivery is measured from the EVENT's
+    // creation/ingestion time, NOT the delivery row's registration time.
+    // A delivery registered "now" for an already-stale event must still
+    // expire — otherwise delayed registration (backlog replay, a subscription
+    // added late, or a daemon-restart requeue) would resurrect stale events.
+    // If the anchor were ever switched to registration age, this test would
+    // fail (the delivery would be delivered instead of expired).
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    // Idle execution → delivery is persisted as pending (not in-memory queue).
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+
+    const event = makeEvent({
+      id: 'evt-delayed-registration',
+      dedupeKey: 'dedupe-delayed-registration',
+    });
+    await eventService.publish(event);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+    // The delivery row was registered moments ago (updated_at ≈ now).
+    expect(Date.now() - delivery.updatedAt).toBeLessThan(5_000);
+
+    // Backdate only the EVENT's created_at past the TTL window, leaving the
+    // delivery registration time recent. This is the discriminator: under
+    // event-age TTL this must expire; under registration-age TTL it would
+    // still be deliverable.
+    db.prepare(`UPDATE space_external_events SET created_at = ? WHERE id = ?`).run(
+      Date.now() - 301_000, // just over the 5-minute EXTERNAL_EVENT_QUEUE_TTL_MS
+      event.id
+    );
+
+    // Reactivate the worker so the activation flush attempts delivery.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-delayed-registration',
+      completedAt: null,
+    });
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-delayed-registration',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(injected).toHaveLength(0);
+    const finalDelivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(finalDelivery.state).toBe('failed');
+    expect(finalDelivery.failureReason).toBe('ttl_expired');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
   // --- null-failureReason pending delivery invariant -----------------------
   //
   // A `pending` row whose `failureReason` is null is, by contract, still owned


### PR DESCRIPTION
## Summary

Resolves the open question in task #667: **the TTL for DB-persisted pending external-event deliveries is anchored to the external event's creation/ingestion time** (source-event row `created_at`), not the delivery row's registration time.

This was the intended design all along — no behavior change is needed. This PR **encodes the decision in code** so it isn't re-litigated, and adds a **regression guard** for the specific scenario that distinguishes the two interpretations.

## Evidence the anchor is (and should be) event-age

1. **Design doc §5** (*Backpressure*): _"Event TTL: Events older than 5 minutes are dropped from the queue."_ — explicitly event-age.
2. **Both persisted paths already read `eventRecord.createdAt`**: `collectPersistedPendingDeliveries` (activation flush) and the rehydrate retry sweep.
3. **The delivery table has no `created_at` column** (only `updated_at`, which is clobbered on every state transition) — registration-age TTL isn't representable without a schema migration.
4. External events are time-sensitive (e.g. a GitHub review comment); a stale event should not be resurrected just because its delivery was registered/queued late.

## Changes

- **`space-runtime.ts`** — document the TTL anchor at the three places that own it:
  - `EXTERNAL_EVENT_QUEUE_TTL_MS` (canonical statement of the decision + why)
  - `isQueuedExternalEventExpired` (the check)
  - both persisted-path anchor points (`collectPersistedPendingDeliveries` + rehydrate retry sweep), noting they must agree
- **`space-runtime-external-events.test.ts`** — regression test for the **delayed-registration discriminator**: a delivery registered "now" (delivery row `updated_at` ≈ now) for an event already older than the TTL window (event `created_at` backdated past 5 min) is still expired on the activation flush. This test would **fail** if the anchor were switched to registration age.

## Test plan

- [x] New test passes: `drops persisted pending delivery whose event predates TTL even when the delivery row was just registered (event-age TTL anchor)`
- [x] Full `space-runtime-external-events.test.ts` suite — 112 pass, 0 fail
- [x] `space-runtime-rehydration.test.ts` — 22 pass, 0 fail
- [x] `oxlint` + `tsc --noEmit` clean (comments + test only; no behavior change)