### PR TITLE
fix: guard concurrent flush from double-dispatching persisted deliveries

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1519,6 +1519,10 @@ export class SpaceRuntime {
           });
           store.markEventFailedIfAllDeliveriesTerminal(item.event.eventId);
         }
+        // Release the synchronous digest-path claim acquired in
+        // enqueueDeliverableExternalEvent so the terminal delivery key does not
+        // leak in externalEventDeliveriesInFlight.
+        this.externalEventDeliveriesInFlight.delete(item.deliveryKey);
         return false;
       });
       state.pendingDigest = remaining;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2022,6 +2022,14 @@ export class SpaceRuntime {
       createdAt,
       allowTargetSessionFallback,
     });
+    // Claim the delivery synchronously so a concurrent flushPendingNodeQueue
+    // call cannot re-select the same DB-persisted pending delivery before the
+    // digest timer fires. The immediate path already claims synchronously in
+    // deliverToSession; the digest path defers that claim until the timer
+    // callback runs, opening a window where a second flush re-reads the same
+    // row from the DB and dispatches it again. Released in deliverDigestToSession
+    // (success, failure, or session-loss requeue) and on stop().
+    this.externalEventDeliveriesInFlight.add(deliveryKey);
     if (!state.digestTimer) {
       state.digestTimer = setTimeout(() => {
         state.digestTimer = null;
@@ -2063,6 +2071,10 @@ export class SpaceRuntime {
           item.deliveryMode,
           item.createdAt
         );
+        // Release the synchronous digest-path claim acquired in
+        // enqueueDeliverableExternalEvent; the item is back in the pending
+        // queue and will be re-claimed on the next flush.
+        this.externalEventDeliveriesInFlight.delete(item.deliveryKey);
       }
       return;
     }
@@ -3591,6 +3603,10 @@ export class SpaceRuntime {
           reason: `deliveryMode:${item.deliveryMode}; digest pending during runtime stop`,
         });
         this.preservePendingDigestItem(item);
+        // Release the synchronous digest-path claim acquired in
+        // enqueueDeliverableExternalEvent so the requeued delivery can be
+        // retried/flushed after a restart.
+        this.externalEventDeliveriesInFlight.delete(item.deliveryKey);
       }
     }
     this.externalEventRateLimits.clear();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -4361,6 +4361,45 @@ describe('SpaceRuntime event-driven gate evaluation', () => {
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
 
+  test('clearPrEventSubscriptionsForRun releases digest-path in-flight claims for purged auto-PR items', async () => {
+    const { run } = await startRun();
+    const result = runtime.registerPrEventSubscriptionForRun(run.id, PR_URL);
+    expect(result.success).toBe(true);
+
+    // Publish more PR events than the per-minute rate limit (default 10) so the
+    // overflow lands in the rate-limit digest, where enqueueDeliverableExternalEvent
+    // acquires the synchronous in-flight claim.
+    const events = Array.from({ length: 12 }, (_, index) =>
+      makePrEvent({
+        id: `evt-auto-pr-digest-${index}`,
+        dedupeKey: `dedupe-auto-pr-digest-${index}`,
+      })
+    );
+    for (const event of events) {
+      await eventService.publish(event);
+    }
+    // The two overflowed events are buffered in the digest (their setTimeout(0)
+    // flush has not fired — the run is in_progress so no macrotask yields during
+    // the publish loop). Capture their delivery keys before the purge.
+    const overflowKeys = events
+      .slice(10)
+      .map((event) => eventStore.listDeliveries(event.id)[0]!.deliveryKey);
+
+    // Drop the auto subscription while the overflow events are still buffered.
+    runtime.clearPrEventSubscriptionsForRun(run.id);
+
+    const inFlight = runtime as unknown as { externalEventDeliveriesInFlight: Set<string> };
+    // The purged digest items must release their synchronous in-flight claims —
+    // otherwise externalEventDeliveriesInFlight leaks a terminal delivery key on
+    // every cleared subscription and can block later deliveries reusing the key.
+    for (const [index, deliveryKey] of overflowKeys.entries()) {
+      expect(inFlight.externalEventDeliveriesInFlight.has(deliveryKey)).toBe(false);
+      const delivery = eventStore.listDeliveries(events[10 + index]!.id)[0]!;
+      expect(delivery.state).toBe('failed');
+      expect(delivery.failureReason).toBe('auto_pr_subscription_cleared');
+    }
+  });
+
   test('explicit dynamic PR subscription matches PR events', async () => {
     const { run, task, sessionId } = await startRun();
     const result = runtime.registerSubscription(

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2163,6 +2163,69 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.listDeliveries(later.id)[0]!.state).toBe('delivered');
   });
 
+  test('concurrent flushPendingNodeQueue calls do not double-dispatch persisted deliveries', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    // Node idle with no live session → every event persists as a pending
+    // delivery in the DB (failureReason set) waiting for an activation flush.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+
+    // Publish more events than the per-minute rate limit (default 10) so the
+    // flush dispatch overflows into the rate-limit digest path, where the
+    // concurrent-flush race lives (the digest timer defers the in-flight claim).
+    const events = Array.from({ length: 12 }, (_, index) =>
+      makeEvent({
+        id: `evt-concurrent-flush-${index}`,
+        dedupeKey: `dedupe-concurrent-flush-${index}`,
+      })
+    );
+    for (const event of events) {
+      await eventService.publish(event);
+    }
+    expect(eventStore.listPendingDeliveries()).toHaveLength(12);
+
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-concurrent-flush',
+      completedAt: null,
+    });
+    tam.alive.add('session-concurrent-flush');
+
+    const flushTarget = {
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-concurrent-flush',
+    };
+    // Two back-to-back flush calls before the digest timer (setTimeout 0)
+    // fires. The second flush re-reads the same DB-persisted pending rows and
+    // must NOT re-select the deliveries already claimed by the first flush.
+    runtime.flushPendingNodeQueue(flushTarget);
+    runtime.flushPendingNodeQueue(flushTarget);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // 10 immediate injections + 1 digest injection.
+    const immediateInjections = injected.filter(
+      (item) => !item.message.includes('events received')
+    );
+    const digestInjections = injected.filter((item) => item.message.includes('events received'));
+    expect(immediateInjections).toHaveLength(10);
+    expect(digestInjections).toHaveLength(1);
+    // The digest must cover exactly the 2 overflowed events — not 4 (which
+    // would indicate the second flush re-dispatched the same deliveries).
+    expect(digestInjections[0]!.message).toContain('2 events received');
+    // Every delivery is delivered exactly once.
+    for (const event of events) {
+      expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+    }
+  });
+
   test('flushes DB-persisted pending deliveries even when in-memory queue is non-empty', async () => {
     const { run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;


### PR DESCRIPTION
## Summary

`flushPendingNodeQueue` can fire concurrently for the same target when a worker activates (spawn + recovery paths each call it). The DB-persisted pending-delivery flush re-reads the same rows on every call. The **immediate** dispatch path already claims the delivery synchronously via `deliverToSession`'s `externalEventDeliveriesInFlight.add`, but the **rate-limit digest** path deferred that claim until the `setTimeout(0)` callback ran — leaving a window where a second flush re-selected the same persisted rows from the DB and pushed them into the digest again, producing duplicate injections.

## Fix

- **Claim synchronously in the digest path** of `enqueueDeliverableExternalEvent` (`externalEventDeliveriesInFlight.add` before the timer fires), so the existing in-flight check in `collectPersistedPendingDeliveries` blocks re-selection by a concurrent flush.
- **Release the claim** in the digest session-loss requeue path and on `stop()`, so requeued/stopped deliveries are not stranded across the claim window (no leak across stop/start or retry).

This reuses the existing, well-tested `externalEventDeliveriesInFlight` set and its release points rather than introducing parallel state.

## Test

Regression test publishes 12 events (>10 per-minute rate limit → overflow into the digest path), activates the worker, and calls `flushPendingNodeQueue` twice back-to-back. Asserts the digest covers the 2 overflowed events **once** (`2 events received`), not 4. Without the fix the digest read `4 events received`.

- Full `5-space-runtime-b` shard: 705 pass / 0 fail
- lint, typecheck, knip clean