### PR TITLE
refactor(space): extract shared delivery-mode parsing for pending deliveries

### DIFF
--- a/packages/daemon/src/lib/space/runtime/delivery-mode.ts
+++ b/packages/daemon/src/lib/space/runtime/delivery-mode.ts
@@ -1,0 +1,25 @@
+import type { MessageDeliveryMode } from '@neokai/shared';
+
+/**
+ * Prefix SpaceRuntime writes onto a parked external-event delivery's
+ * `failureReason` when it must be re-dispatched in `defer` mode after
+ * rehydration. Only this marker is opt-in — the reader treats every other
+ * value (including `deliveryMode:immediate;…` and `null`) as `immediate`.
+ */
+const DEFER_DELIVERY_MODE_PREFIX = 'deliveryMode:defer;';
+
+/**
+ * Recovers the delivery mode persisted in a pending external-event delivery's
+ * `failureReason`.
+ *
+ * When SpaceRuntime parks a delivery for later re-dispatch it encodes the mode
+ * as a `deliveryMode:<mode>; …` prefix. Only `defer` is distinguished; anything
+ * else (`null`, `deliveryMode:immediate;…`, or an unrelated failure reason)
+ * resolves to the `immediate` default — matching the inline check previously
+ * duplicated across the activation flush and requeue paths.
+ */
+export function deliveryModeFromFailureReason(
+  failureReason: string | null | undefined
+): MessageDeliveryMode {
+  return failureReason?.startsWith(DEFER_DELIVERY_MODE_PREFIX) ? 'defer' : 'immediate';
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -70,6 +70,7 @@ import { MAX_AGENT_SLOT_EVENT_INTERESTS } from '../export-format';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import { getEffectiveGate } from './gate-features';
 import { buildPrEventTopicPattern, parsePrUrl } from './parse-pr-url';
+import { deliveryModeFromFailureReason } from './delivery-mode';
 import { CompletionDetector } from './completion-detector';
 import {
   DEFAULT_AGENT_NO_PROGRESS_THRESHOLD_MS,
@@ -1650,9 +1651,7 @@ export class SpaceRuntime {
         continue;
       }
 
-      const mode: 'immediate' | 'defer' = delivery.failureReason?.startsWith('deliveryMode:defer;')
-        ? 'defer'
-        : 'immediate';
+      const mode = deliveryModeFromFailureReason(delivery.failureReason);
       const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
       const queuedItem: PendingExternalEvent = {
         event: eventPayload,
@@ -4187,9 +4186,7 @@ export class SpaceRuntime {
         continue;
       }
 
-      const mode: 'immediate' | 'defer' = delivery.failureReason?.startsWith('deliveryMode:defer;')
-        ? 'defer'
-        : 'immediate';
+      const mode = deliveryModeFromFailureReason(delivery.failureReason);
       const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
       const queuedItem = {
         event: eventPayload,

--- a/packages/daemon/tests/unit/5-space/runtime/delivery-mode.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/delivery-mode.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { deliveryModeFromFailureReason } from '../../../../src/lib/space/runtime/delivery-mode';
+
+describe('deliveryModeFromFailureReason', () => {
+  test('returns defer for a deliveryMode:defer; prefix with a trailing reason', () => {
+    expect(
+      deliveryModeFromFailureReason('deliveryMode:defer; digest requeued after session loss')
+    ).toBe('defer');
+    expect(
+      deliveryModeFromFailureReason('deliveryMode:defer; retry rescheduled after runtime restart')
+    ).toBe('defer');
+  });
+
+  test('returns defer for the bare prefix with no trailing reason', () => {
+    expect(deliveryModeFromFailureReason('deliveryMode:defer;')).toBe('defer');
+  });
+
+  test('defaults to immediate for deliveryMode:immediate; prefix', () => {
+    expect(deliveryModeFromFailureReason('deliveryMode:immediate; some failure')).toBe('immediate');
+    expect(deliveryModeFromFailureReason('deliveryMode:immediate;')).toBe('immediate');
+  });
+
+  test('defaults to immediate for null or undefined (in-flight / no encoded mode)', () => {
+    expect(deliveryModeFromFailureReason(null)).toBe('immediate');
+    expect(deliveryModeFromFailureReason(undefined)).toBe('immediate');
+  });
+
+  test('defaults to immediate for an unrelated failure reason', () => {
+    expect(deliveryModeFromFailureReason('node_execution_not_active')).toBe('immediate');
+    expect(deliveryModeFromFailureReason('')).toBe('immediate');
+  });
+
+  test('does not match look-alikes that only share a stem (no semicolon boundary)', () => {
+    // The parser keys on the `deliveryMode:defer;` boundary, so a longer mode
+    // label that happens to start with "defer" must not be mistaken for defer.
+    expect(deliveryModeFromFailureReason('deliveryMode:deferred; …')).toBe('immediate');
+    expect(deliveryModeFromFailureReason('deliveryMode:deferrible; …')).toBe('immediate');
+  });
+});


### PR DESCRIPTION
## Summary

Removes the duplicated inline `deliveryMode:defer;` prefix check from the two persisted pending-external-event-delivery re-dispatch paths in `SpaceRuntime`, replacing them with a single shared helper.

## Changes

- **Add** `packages/daemon/src/lib/space/runtime/delivery-mode.ts` — `deliveryModeFromFailureReason(failureReason)` maps the mode encoded in a parked delivery's `failureReason` to a `MessageDeliveryMode`, defaulting to `immediate`. Only the `deliveryMode:defer;` marker is opt-in; everything else (`null`, `deliveryMode:immediate;…`, or an unrelated reason) resolves to `immediate`.
- **Use** the helper in the activation flush and `requeuePersistedPendingDeliveries`, replacing the two identical inline `delivery.failureReason?.startsWith('deliveryMode:defer;') ? 'defer' : 'immediate'` blocks.
- **Tests** — `packages/daemon/tests/unit/5-space/runtime/delivery-mode.test.ts` covers defer/immediate prefixes, null/undefined default, unrelated reasons, and the `;` boundary that prevents look-alike stems (`deferred`) from matching.

## Behavior

Unchanged. The helper reproduces the previous inline check exactly; the 111 existing `space-runtime-external-events` tests still pass.

## Why

Centralizes the wire format (`deliveryMode:<mode>; …`) so the reader cannot drift from the writer, and keeps the re-dispatch paths concise.