### PR TITLE
docs: clarify null-failureReason pending delivery invariant

### DIFF
--- a/packages/daemon/src/lib/external-events/types.ts
+++ b/packages/daemon/src/lib/external-events/types.ts
@@ -74,6 +74,12 @@ export const TERMINAL_EVENT_STATES: ReadonlySet<ExternalEventState> = new Set<Ex
  * `space_external_event_deliveries`.
  *
  * `pending`: registered, not yet attempted or attempt may retry.
+ *   - `failureReason === null`: owned by an in-process dispatch path
+ *     (pending queue, in-flight, or rate-limit digest). The activation
+ *     flush intentionally skips these to avoid duplicate dispatch;
+ *     requeuePersistedPendingDeliveries recovers them across a crash.
+ *   - `failureReason !== null`: explicitly retryable (e.g.
+ *     `node_execution_not_active`); eligible for the activation flush.
  * `delivered` (terminal): command-bus injection succeeded.
  * `failed` (terminal): retry budget exhausted, scope mismatch, node cancellation, etc.
  */

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1609,10 +1609,19 @@ export class SpaceRuntime {
           delivery.nodeId === target.nodeId &&
           delivery.agentName === target.agentName &&
           !skipDeliveryKeys.has(delivery.deliveryKey) &&
-          // Only flush deliveries that were explicitly marked retryable (e.g.
-          // `node_execution_not_active`). Rows with null failureReason are
-          // still being processed by the original dispatch path (in-flight or
-          // digest-pending) and must not be re-dispatched here.
+          // Only flush deliveries that carry an explicit retryable
+          // failureReason (e.g. `node_execution_not_active`). A `pending` row
+          // with a null failureReason is still owned by its original dispatch
+          // path and re-dispatching it here would duplicate delivery. The three
+          // in-process owners of a null-failureReason pending row are:
+          //   1. the in-memory pending queue (queueForPendingNode) — already
+          //      drained by the caller and excluded via `skipDeliveryKeys`,
+          //   2. an in-flight dispatch (externalEventDeliveriesInFlight), and
+          //   3. a pending rate-limit digest (externalEventRateLimits.pendingDigest),
+          //      for which this filter is the *only* guard against a duplicate.
+          // Rows left pending+null by a crash/interruption are recovered by
+          // requeuePersistedPendingDeliveries() on the next rehydrate, which
+          // re-queues ALL pending rows (null or not) so none stay stranded.
           delivery.failureReason !== null
       )
       .map((delivery) => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2405,6 +2405,149 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(queuedItems.some((item) => item.createdAt === oldCreatedAt)).toBe(true);
   });
 
+  // --- null-failureReason pending delivery invariant -----------------------
+  //
+  // A `pending` row whose `failureReason` is null is, by contract, still owned
+  // by its original in-process dispatch path (the in-memory pending queue, an
+  // in-flight dispatch, or a pending rate-limit digest). The activation flush
+  // intentionally skips such rows so it never duplicates a delivery. The
+  // counterpart to that skip is crash recovery: rows left `pending`+null by an
+  // interruption are re-queued by requeuePersistedPendingDeliveries on the next
+  // rehydrate, so the skip can never strand them permanently. These two tests
+  // pin both halves of that invariant.
+
+  test('does not re-dispatch a pending delivery with null failureReason during activation flush', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+
+    // Persist a pending+null delivery row directly, simulating a row owned by
+    // an in-process dispatch path that tracks it in memory (in-flight or
+    // digest-pending) rather than via the failureReason column. The activation
+    // flush must leave it untouched so its owner path delivers it exactly once.
+    const event = makeEvent({ id: 'evt-null-failure-skip', dedupeKey: 'dedupe-null-failure-skip' });
+    eventStore.store(event);
+    const deliveryKey = JSON.stringify([
+      'github',
+      event.dedupeKey,
+      task.id,
+      'code',
+      'coder',
+      run.id,
+    ]);
+    eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+    });
+    expect(eventStore.getDelivery(event.id, deliveryKey)!.state).toBe('pending');
+    expect(eventStore.getDelivery(event.id, deliveryKey)!.failureReason).toBeNull();
+
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-null-failure-skip',
+      completedAt: null,
+    });
+    tam.alive.add('session-null-failure-skip');
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-null-failure-skip',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Not dispatched by the flush, and the row is unchanged — the owner path
+    // remains responsible for it.
+    expect(injected).toHaveLength(0);
+    const delivery = eventStore.getDelivery(event.id, deliveryKey)!;
+    expect(delivery.state).toBe('pending');
+    expect(delivery.failureReason).toBeNull();
+    expect(eventStore.listPendingDeliveries()).toContainEqual(delivery);
+  });
+
+  test('recovers a pending delivery with null failureReason after an interruption via requeue', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+
+    // Persist a pending+null delivery row, as would be left by an in-flight or
+    // digest-pending dispatch that was interrupted by a crash before stop()
+    // could stamp a failureReason.
+    const event = makeEvent({
+      id: 'evt-null-failure-requeue',
+      dedupeKey: 'dedupe-null-failure-requeue',
+    });
+    eventStore.store(event);
+    const deliveryKey = JSON.stringify([
+      'github',
+      event.dedupeKey,
+      task.id,
+      'code',
+      'coder',
+      run.id,
+    ]);
+    eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+    });
+    expect(eventStore.getDelivery(event.id, deliveryKey)!.failureReason).toBeNull();
+
+    // Simulate a crash + restart: tear down the runtime and rebuild it over the
+    // same DB, then rehydrate (which runs requeuePersistedPendingDeliveries).
+    await runtime.stop();
+    const commandBus = createInternalCommandBus();
+    commandBus.register('agent.message.inject', async (command) => {
+      injected.push({
+        sessionId: command.sessionId,
+        message: command.message,
+        deliveryMode: command.deliveryMode,
+      });
+      return { ok: true };
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager: new SpaceManager(db),
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    runtime.registerSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+    await runtime.rehydrateExecutors();
+
+    // Activate the node — requeue re-queued the null-failure row into the
+    // in-memory pending queue, so the activation flush now drains and delivers it.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-null-failure-requeue',
+      completedAt: null,
+    });
+    tam.alive.add('session-null-failure-requeue');
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-null-failure-requeue',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(injected).toHaveLength(1);
+    expect(JSON.parse(injected[0]!.message).eventId).toBe(event.id);
+    expect(eventStore.getDelivery(event.id, deliveryKey)!.state).toBe('delivered');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
+
   test('fails delivery when inactive target task is already done', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;


### PR DESCRIPTION
Closes #664.

## Why

The activation flush (`collectPersistedPendingDeliveries`) skips `pending` delivery rows whose `failureReason` is null. The original comment only mentioned the "in-flight or digest-pending" owners and didn't explain how such rows survive a crash — leaving the invariant easy to misread as a stranding bug. This clarifies the contract and locks it in with tests.

## What changed

- **`space-runtime.ts` / `types.ts`** — Documented the invariant: a `pending`+null row is owned by one of three in-process paths (in-memory pending queue, in-flight dispatch, pending rate-limit digest — the last being the *only* case this filter guards against a duplicate). Crash recovery for null-failure rows is handled by `requeuePersistedPendingDeliveries`, which re-queues **all** pending rows on the next rehydrate, so the skip can never strand a valid delivery. No logic change — the filter is correct and necessary.
- **Tests** — Added two focused cases pinning both halves:
  - `does not re-dispatch a pending delivery with null failureReason during activation flush` — verified to **fail** when the filter is removed, so it meaningfully guards the invariant.
  - `recovers a pending delivery with null failureReason after an interruption via requeue` — a pending+null row left by a simulated crash is re-queued on rehydrate and delivered on the next activation.

## Verification

- `space-runtime-external-events.test.ts`: 113 pass (was 111).
- Filter-removal regression check confirmed the new skip-test catches the duplicate-dispatch path.
- daemon typecheck + lint clean on the changed files.