### PR TITLE
fix(space-runtime): guard activation flush against superseded worker sessions

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2133,14 +2133,32 @@ export class SpaceRuntime {
 
   private resolveDigestDeliveryTarget(item: ExternalEventDigestItem): WorkflowSubscriptionTarget {
     const target = item.target;
-    const resolved = this.resolveSubscriptionTarget({
+    const liveTarget = this.resolveLiveDeliveryTarget({
       workflowRunId: target.workflowRunId,
       taskId: target.taskId,
       nodeId: target.nodeId,
       agentName: target.agentName,
     });
-    if (resolved.sessionId) return resolved;
-    return item.allowTargetSessionFallback ? target : resolved;
+    if (liveTarget?.sessionId) return liveTarget;
+    // No current worker session for this node. The activation flush's
+    // allowTargetSessionFallback may fall back to the sessionId captured at
+    // spawn time — but only when that session is still live. A superseded
+    // (dead) activation session must never receive the digest; returning a
+    // sessionless target makes deliverDigestToSession requeue the items as
+    // pending for the next activation.
+    if (
+      item.allowTargetSessionFallback &&
+      target.sessionId &&
+      this.isTargetSessionLive(target.sessionId)
+    ) {
+      return target;
+    }
+    return {
+      workflowRunId: target.workflowRunId,
+      taskId: target.taskId,
+      nodeId: target.nodeId,
+      agentName: target.agentName,
+    };
   }
 
   private async deliverToSession(
@@ -2496,6 +2514,31 @@ export class SpaceRuntime {
   ): WorkflowSubscriptionTarget {
     const current = this.getCurrentQueueableOrActiveExecution(target);
     return current?.agentSessionId ? { ...target, sessionId: current.agentSessionId } : target;
+  }
+
+  /**
+   * Re-resolves the authoritative live session for `target` — the stale-session
+   * guard used immediately before injecting an external event.
+   *
+   * `target.sessionId` is captured when a delivery is queued (at node spawn /
+   * activation time). By the time the async dispatch runs the worker may have
+   * been superseded: it crashed and was respawned (a new `agentSessionId` on
+   * the same node execution) or its execution was reset to pending
+   * (`agentSessionId` cleared). The node execution record is authoritative —
+   * `spawnWorkflowNodeAgentForExecution` writes the new `agentSessionId`
+   * before returning — so `getCurrentQueueableOrActiveExecution` is trusted
+   * over the captured `sessionId`.
+   *
+   * Returns the target retargeted onto the *current* live session, or `null`
+   * when no live session can be resolved. Callers requeue the delivery as
+   * pending instead of injecting into a superseded (dead) session.
+   */
+  private resolveLiveDeliveryTarget(
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
+  ): WorkflowSubscriptionTarget | null {
+    const current = this.getCurrentQueueableOrActiveExecution(target);
+    if (!current?.agentSessionId) return null;
+    return { ...target, sessionId: current.agentSessionId };
   }
 
   private isPending(target: WorkflowSubscriptionTarget): boolean {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1352,6 +1352,105 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(events[10]!.id)?.state).toBe('delivered');
   });
 
+  test('does not deliver activation-flushed digest to a superseded session', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+
+    // Events queue while the worker is not yet active (no live session).
+    const events = Array.from({ length: 11 }, (_, index) =>
+      makeEvent({
+        id: `evt-digest-superseded-${index}`,
+        dedupeKey: `dedupe-digest-superseded-${index}`,
+        occurredAt: 1_700_000_000_000 + index,
+      })
+    );
+    for (const event of events) {
+      await eventService.publish(event);
+    }
+    for (const event of events) {
+      expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+    }
+
+    // The worker activates — spawn assigns its agentSessionId before the
+    // activation flush drains the pending queue.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-activation',
+      startedAt: Date.now(),
+      completedAt: null,
+    });
+    tam.alive.add('session-activation');
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-activation',
+    });
+
+    // The first ten events dispatch synchronously to the activation session
+    // (under the rate limit); the eleventh is deferred to the digest timer.
+    expect(injected).toHaveLength(10);
+    expect(injected.every((item) => item.sessionId === 'session-activation')).toBe(true);
+
+    // Before the digest timer fires the activation session is superseded: the
+    // worker crashed and its execution was reset to pending (agentSessionId
+    // cleared) with no live session remaining.
+    tam.alive.delete('session-activation');
+    nodeExecutionRepo.update(execution.id, {
+      status: 'pending',
+      agentSessionId: null,
+      startedAt: null,
+      completedAt: null,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The digest must NOT inject into the superseded (dead) session — it is
+    // requeued as pending for the next activation instead.
+    expect(injected).toHaveLength(10);
+    const digestDelivery = eventStore.listDeliveries(events[10]!.id)[0]!;
+    expect(digestDelivery.state).toBe('pending');
+    expect(digestDelivery.failureReason).toContain('session loss');
+    expect(eventStore.getById(events[10]!.id)?.state).toBe('published');
+  });
+
+  test('retargets activation flush to the current session when the activation session is superseded', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // The activation session has been superseded by a respawned worker before
+    // the flush runs: the node execution now points at a different live session.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-current',
+      startedAt: Date.now(),
+      completedAt: null,
+    });
+    tam.alive.add('session-current');
+
+    // flushPendingNodeQueue is invoked with the stale activation session id;
+    // resolveSubscriptionTarget re-resolves onto the current worker so the
+    // event is never injected into the superseded session.
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-stale-activation',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-current');
+    expect(JSON.parse(injected[0]!.message).eventId).toBe(event.id);
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
+
   test('preserves deferred mode when digest delivery is retried after rehydrate', async () => {
     const { workflow, run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
@@ -2009,6 +2108,15 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(oldestDelivery.state).toBe('failed');
     expect(oldestDelivery.failureReason).toBe('pending_node_queue_overflow');
 
+    // The worker activates — spawn assigns its agentSessionId to the node
+    // execution before the activation flush drains the pending queue.
+    nodeExecutionRepo.update(nodeExecutionRepo.listByNode(run.id, 'code')[0]!.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-overflow',
+      startedAt: Date.now(),
+      completedAt: null,
+    });
+    tam.alive.add('session-overflow');
     runtime.flushPendingNodeQueue({
       workflowRunId: run.id,
       taskId: task.id,


### PR DESCRIPTION
## What

Prevents the pending external-event **activation flush** (`SpaceRuntime.flushPendingNodeQueue`) from injecting rate-limited digest deliveries into a worker session that has been **superseded** between spawn and the async digest dispatch.

## Why

When a node activates, `flushPendingNodeQueue` drains queued deliveries. Events past the per-minute rate limit are deferred to a digest via `setTimeout(0)`. That macrotask boundary is the window where the activation session can be replaced — the worker crashes and is respawned (new `agentSessionId`) or its execution is reset to pending (`agentSessionId` cleared).

`resolveDigestDeliveryTarget`'s `allowTargetSessionFallback` then fell back to the `sessionId` captured at spawn time and injected the digest into a stale/dead conversation.

## How

- Add `resolveLiveDeliveryTarget(target)` — re-resolves the authoritative current session from the node execution record immediately before injection, returning `null` when no live session remains.
- Rework `resolveDigestDeliveryTarget` to retarget onto the current live session, and only fall back to the captured activation session when it is **still alive**; otherwise return a sessionless target so `deliverDigestToSession` requeues the items as pending for the next activation.
- The direct (non-digest) path is untouched: it dispatches in the same macrotask as the flush, so `resolveSubscriptionTarget` at flush time is already authoritative (no async window before `commandBus.dispatch`).

## Tests

- \`does not deliver activation-flushed digest to a superseded session\` — verifies the digest is requeued (not injected) when the activation session is dead by the time the digest fires. **Fails against the unfixed code.**
- \`retargets activation flush to the current session when the activation session is superseded\` — direct-path re-resolve invariant coverage.
- Updated the overflow-cap test to mirror realistic activation (spawn assigns \`agentSessionId\` before the flush), which the guard now requires.

## Verification

- \`bun run check\` (lint, typecheck, knip, session-guards, db-parity, test-quality) ✅
- \`bun test tests/unit/5-space/\` → 3168 pass / 0 fail