### PR TITLE
fix: correct reviewer gh api review-body contract (forbid -f body=@-)

### DIFF
--- a/packages/daemon/src/lib/space/agents/system-contracts.ts
+++ b/packages/daemon/src/lib/space/agents/system-contracts.ts
@@ -26,31 +26,43 @@ Every visible GitHub review/comment must include:
 
 GitHub review procedure: post a visible review before gate writes or terminal actions. Use REST API when you need the returned URL, with own-PR fallback from APPROVE/REQUEST_CHANGES to COMMENT while keeping the recommendation explicit in body. For line findings, post anchored PR comments and capture html_url values.
 
-Post top-level review and capture URL (use event matching your actual verdict):
+Posting the review body — read before your first review. The body is multi-line and almost always contains apostrophes or quotes, so two patterns are broken and must NOT be used:
+- Inline -f body='...' breaks the moment the body contains a single quote (the quote terminates the field early and the rest of the body leaks onto the command line).
+- A heredoc piped to -f body=@- does NOT work. Lowercase -f does not interpret ANY @-prefixed value — not @- (stdin) and not @/path (file); it posts the literal string verbatim. So -f body=@- posts the literal "@-" and silently discards the heredoc body (curl supports @- for stdin; gh api does not). Never use -f body=@- or -f body=@/path.
+
+Correct pattern: wrap a quoted heredoc (delimiter 'EOF' — the single quotes disable interpolation and quote escaping inside the body) in command substitution and pass it to -f body="$(...)":
 
 \`\`\`bash
 gh api repos/{owner}/{repo}/pulls/{n}/reviews \
   -f event='<APPROVE|REQUEST_CHANGES>' \
-  -f body='## 🤖 Review by <your model> (<your provider>)
+  -f body="$(cat <<'EOF'
+## 🤖 Review by <your model> (<your provider>)
 
 > **Model:** <your model> | **Client:** NeoKai | **Provider:** <your provider>
 
-<review body>' \
+<review body — apostrophes and quotes are safe inside the 'EOF' heredoc>
+EOF
+)" \
   --jq '.html_url'
 \`\`\`
 
-If reviewing your own PR, GitHub rejects APPROVE/REQUEST_CHANGES. Fallback:
+For an unusually large body, write it to a temp file and pass the real path with the RAW-field flag -F body=@/tmp/review.md (capital F: only -F/--raw-field reads @path; lowercase -f posts "@/path" literally). @- never reads stdin. Capture the returned URL from --jq '.html_url'.
+
+If reviewing your own PR, GitHub rejects APPROVE/REQUEST_CHANGES. Fall back to event='COMMENT' with the same heredoc body shape and state the recommendation explicitly in the body:
 
 \`\`\`bash
 gh api repos/{owner}/{repo}/pulls/{n}/reviews \
   -f event='COMMENT' \
-  -f body='## 🤖 Review by <your model> (<your provider>)
+  -f body="$(cat <<'EOF'
+## 🤖 Review by <your model> (<your provider>)
 
 > **Model:** <your model> | **Client:** NeoKai | **Provider:** <your provider>
 
 Recommendation: <APPROVE or REQUEST_CHANGES — match your actual verdict>
 
-<review body>' \
+<review body>
+EOF
+)" \
   --jq '.html_url'
 \`\`\`
 

--- a/packages/daemon/src/lib/space/agents/system-contracts.ts
+++ b/packages/daemon/src/lib/space/agents/system-contracts.ts
@@ -28,7 +28,7 @@ GitHub review procedure: post a visible review before gate writes or terminal ac
 
 Posting the review body — read before your first review. The body is multi-line and almost always contains apostrophes or quotes, so two patterns are broken and must NOT be used:
 - Inline -f body='...' breaks the moment the body contains a single quote (the quote terminates the field early and the rest of the body leaks onto the command line).
-- A heredoc piped to -f body=@- does NOT work. Lowercase -f does not interpret ANY @-prefixed value — not @- (stdin) and not @/path (file); it posts the literal string verbatim. So -f body=@- posts the literal "@-" and silently discards the heredoc body (curl supports @- for stdin; gh api does not). Never use -f body=@- or -f body=@/path.
+- A heredoc piped to -f body=@- does NOT work. Lowercase -f (== --raw-field) is string-only: it does not interpret @, so -f body=@- posts the literal "@-" and -f body=@/path posts the literal path, silently discarding the heredoc body. Never use -f body=@- or -f body=@/path. (Reading a file or stdin via @ requires the TYPED flag -F == --field; the command-substitution heredoc below is simpler and preferred.)
 
 Correct pattern: wrap a quoted heredoc (delimiter 'EOF' — the single quotes disable interpolation and quote escaping inside the body) in command substitution and pass it to -f body="$(...)":
 
@@ -46,7 +46,7 @@ EOF
   --jq '.html_url'
 \`\`\`
 
-For an unusually large body, write it to a temp file and pass the real path with the RAW-field flag -F body=@/tmp/review.md (capital F: only -F/--raw-field reads @path; lowercase -f posts "@/path" literally). @- never reads stdin. Capture the returned URL from --jq '.html_url'.
+For an unusually large body, write it to a temp file and use the TYPED flag -F body=@/tmp/review.md (capital F = --field; this is the only flag that interprets @ — -F reads @<path> from a file and @- from stdin, while lowercase -f = --raw-field is string-only and posts the @-value verbatim). Capture the returned URL from --jq '.html_url'.
 
 If reviewing your own PR, GitHub rejects APPROVE/REQUEST_CHANGES. Fall back to event='COMMENT' with the same heredoc body shape and state the recommendation explicitly in the body:
 

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -537,10 +537,9 @@ describe('preset agent exact definitions', () => {
   });
 
   // Regression: the reviewer must never teach the `gh api ... -f body=@-`
-  // pattern. `gh api` does NOT read stdin via `@-` (unlike curl) — it posts the
-  // literal string "@-" and silently discards the heredoc body. The contract
-  // must instead show the command-substitution + quoted-heredoc form and warn
-  // about the trap explicitly.
+  // pattern. Lowercase -f (== --raw-field) is string-only and posts the @-value
+  // verbatim, so the heredoc body is discarded. The contract must instead show
+  // the command-substitution + quoted-heredoc form and warn about the trap.
   it('Reviewer custom prompt warns against -f body=@- and teaches the heredoc command-substitution form', async () => {
     const { seeded } = await seedPresetAgents('space-1', manager);
     const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
@@ -554,6 +553,10 @@ describe('preset agent exact definitions', () => {
     // broke on any apostrophe in the body — that fragility is what drove the
     // reviewer to adopt the broken @- workaround. It must be gone.
     expect(prompt).not.toContain("-f body='## 🤖 Review");
+    // Flag-naming accuracy: the typed flag that reads @<path>/@- is -F/--field.
+    // The contract must NOT mislabel -F as --raw-field (which is actually -f);
+    // such a mislabel would steer the agent back to the literal-path bug.
+    expect(prompt).not.toContain('-F/--raw-field');
   });
 
   it('QA has shared system contract prompt', async () => {

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -536,6 +536,26 @@ describe('preset agent exact definitions', () => {
     expect(reviewer.customPrompt).toContain('REVIEW_POSTED');
   });
 
+  // Regression: the reviewer must never teach the `gh api ... -f body=@-`
+  // pattern. `gh api` does NOT read stdin via `@-` (unlike curl) — it posts the
+  // literal string "@-" and silently discards the heredoc body. The contract
+  // must instead show the command-substitution + quoted-heredoc form and warn
+  // about the trap explicitly.
+  it('Reviewer custom prompt warns against -f body=@- and teaches the heredoc command-substitution form', async () => {
+    const { seeded } = await seedPresetAgents('space-1', manager);
+    const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
+    const prompt = reviewer.customPrompt!;
+    // Explicit warning so the model recognises and avoids the @- trap.
+    expect(prompt).toContain('Never use -f body=@-');
+    // Correct multi-line form: a quoted ('EOF') heredoc wrapped in $(...)
+    // passed to -f body="$(...)". Handles apostrophes/quotes in the body.
+    expect(prompt).toContain("-f body=\"$(cat <<'EOF'");
+    // The old inline single-quote body form (`-f body='## 🤖 Review ...`)
+    // broke on any apostrophe in the body — that fragility is what drove the
+    // reviewer to adopt the broken @- workaround. It must be gone.
+    expect(prompt).not.toContain("-f body='## 🤖 Review");
+  });
+
   it('QA has shared system contract prompt', async () => {
     const { seeded } = await seedPresetAgents('space-1', manager);
     const qa = seeded.find((a) => a.name === 'QA')!;


### PR DESCRIPTION
## Problem

The reviewer agent was posting PR reviews whose body was the literal string `@-` instead of the intended review (confirmed on #2157: 6 reviews with body exactly `@-`).

**Root cause:** the agent ran

```
cat <<'EOF' | gh api repos/{owner}/{repo}/pulls/{n}/reviews -f event='COMMENT' -f body=@- --jq '.html_url'
<full review body>
EOF
```

assuming `gh api` reads stdin via `@-` the way `curl` does. It does not. `gh api`'s `-f` field posts the `@`-prefixed value **verbatim**, so the heredoc body was silently discarded and `"@-"` was posted. The agent adopted this pattern to avoid shell-escaping multi-line bodies, because the contract's inline `-f body='...'` example breaks on any apostrophe in the body.

## Fix

Update the Reviewer System Contract (`packages/daemon/src/lib/space/agents/system-contracts.ts`):

- Replace the fragile inline `-f body='...'` example (breaks on any apostrophe — the fragility that drove the `@-` workaround) with a **command-substitution + quoted-heredoc** form: `-f body="$(cat <<'EOF' ... EOF)"`. The `'EOF'` delimiter disables interpolation/escaping, so apostrophes and quotes in the body are safe. Verified end-to-end via httpbin that the full multi-line body posts correctly.
- Add an explicit warning: **never** use `-f body=@-` or `-f body=@/path`. Empirically confirmed lowercase `-f` does NOT interpret any `@`-prefixed value (neither `@-` stdin nor `@/path` file) — it posts them literally. (`curl` supports `@-` for stdin; `gh api` does not.)
- For large bodies, point to the RAW-field form `-F body=@/tmp/review.md` — capital `F` is the **only** flag that reads `@path`.

## Evidence

- `gh api -f body=@-` → posts literal `@-` (confirmed via httpbin)
- `gh api -f body=@/path` → posts literal `@/path` (file NOT read)
- `gh api -F body=@/path` → reads file contents (capital F only)
- The corrected heredoc form → posts the full multi-line body incl. apostrophes/quotes

## Tests

Added a regression test (`seed-agents.test.ts`) pinning the contract: it must warn against `@-`, teach the heredoc command-substitution form, and no longer carry the old inline single-quote body example. All 63 seed-agents tests + 294 built-in-workflows tests pass; typecheck clean.

## Cleanup

Edited the 6 stray `@-` reviews on merged PR #2157 via GraphQL `updatePullRequestReview` (submitted `COMMENTED` reviews can't be deleted/dismissed) to an explanatory note. Scanned the last 30 merged PRs — no other `@-` review bodies found.

## Audit

No other prompts/contracts used the `@-` pattern. The only review-posting template lives in `system-contracts.ts`; the `built-in-workflows.ts` reviewer prompt delegates to the contract, and `post-approval-merge-template.ts` has no review-body posting.
