### PR TITLE
fix: auto-compact + continue on 'prompt is too long' overflow

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -280,11 +280,16 @@ export function buildProviderSettings(
     return { autoCompactEnabled: false };
   }
 
+  // When the real context window is unknown (provider metadata did not report
+  // one), do NOT silently disable SDK auto-compaction — that creates a dead
+  // zone with no compaction path at all and guarantees context overflow.
+  // Returning `undefined` lets the SDK use its built-in auto-compact (enabled by
+  // default with its 200k fallback window). This is strictly better than
+  // disabling: correct for the common (>=200k) case, and the reactive
+  // prompt-too-long recovery (SpaceRuntime) handles any sub-200k mismatch.
   const autoCompactWindow = contextWindow;
   if (!autoCompactWindow) {
-    return {
-      autoCompactEnabled: false,
-    };
+    return undefined;
   }
 
   // Keep SDK auto-compaction enabled for non-native providers only when we can

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -76,6 +76,8 @@ export interface PromptTooLongRecoveryState {
   awaitingResume: boolean;
   /** dbId of the compact-success result that preceded the resume nag. */
   awaitingResumeAfterDbId: string | null;
+  /** Timestamp (ms) the resume nag was delivered, for the resume-wait timeout. */
+  awaitingResumeSince: number | null;
 }
 
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
@@ -88,6 +90,7 @@ export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
     continueNagAttempts: 0,
     awaitingResume: false,
     awaitingResumeAfterDbId: null,
+    awaitingResumeSince: null,
   };
 }
 

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -38,9 +38,9 @@ export const COMPACT_RESULT_TIMEOUT_MS = 5 * 60 * 1000;
  */
 export interface PromptTooLongRecoveryState {
   /**
-   * Consecutive *unproductive* `/compact` attempts. Reset to 0 once a compaction
-   * is productive (the resume nag is delivered), so the cap targets repeated
-   * unhelpful compactions rather than lifetime total.
+   * Consecutive *unproductive* `/compact` attempts. Forgiven implicitly when the
+   * resumed turn makes real progress (a non-overflow result clears the recovery
+   * state); an immediate re-overflow leaves this in place so the cap escalates.
    */
   compactAttempts: number;
   /**
@@ -50,10 +50,10 @@ export interface PromptTooLongRecoveryState {
    */
   awaitingContinue: boolean;
   /**
-   * dbId of the injected `/compact` message. Used to detect when a NEW message
-   * has landed. The wait is cleared only when that new message is a `result`
-   * (real turn completion) — not an intermediate `status: 'compacting'` row —
-   * so the resume nag is never sent mid-compaction.
+   * dbId of the last message observed when `/compact` was injected (the
+   * pre-compact result). `getLastSDKMessage` keeps returning this while the
+   * enqueued `/compact` is in flight; the wait clears only when a newer consumed
+   * `result` lands.
    */
   awaitingContinueAfterDbId: string | null;
   /** Timestamp (ms) the `/compact` was injected, for the wait timeout. */
@@ -65,6 +65,17 @@ export interface PromptTooLongRecoveryState {
   continueNagPending: boolean;
   /** Failed resume-nag deliveries; bounded before giving up. */
   continueNagAttempts: number;
+  /**
+   * True after the resume nag was delivered. Like the `/compact`, the nag is an
+   * enqueued user message invisible to `getLastSDKMessage`, so the sweep keeps
+   * seeing the compact-success result until the resumed turn advances. This
+   * marker keeps recovery entered (preventing the terminal-skip from clearing
+   * the state prematurely); it clears once a message newer than
+   * `awaitingResumeAfterDbId` arrives.
+   */
+  awaitingResume: boolean;
+  /** dbId of the compact-success result that preceded the resume nag. */
+  awaitingResumeAfterDbId: string | null;
 }
 
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
@@ -75,6 +86,8 @@ export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
     awaitingContinueSince: null,
     continueNagPending: false,
     continueNagAttempts: 0,
+    awaitingResume: false,
+    awaitingResumeAfterDbId: null,
   };
 }
 

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -14,11 +14,23 @@
 import type { SDKMessage } from '@neokai/shared/sdk';
 
 /**
- * Maximum `/compact` attempts for a single execution before escalating to
+ * Maximum consecutive *unproductive* `/compact` attempts before escalating to
  * `blocked`. Bounds the loop when compaction cannot shrink the context enough
- * (e.g. a single message already exceeds the limit).
+ * (e.g. a single message already exceeds the limit). Reset to 0 once a
+ * compaction is productive (the resume nag is delivered), so a long-running
+ * worker that legitimately re-fills context over time is not penalised for
+ * stale recovery history.
  */
 export const MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS = 2;
+
+/**
+ * Maximum time to wait for the `/compact` turn to produce a result before
+ * treating the compaction as hung and escalating to `blocked`. The SDK's
+ * compaction involves an LLM summarisation call, so this is generous; if no
+ * result lands in this window the session is stuck (and the execution is
+ * `idle`, so the alive-stuck sweep cannot rescue it).
+ */
+export const COMPACT_RESULT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Per-execution recovery state. Keyed by `${runId}:${executionId}` in
@@ -26,26 +38,33 @@ export const MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS = 2;
  */
 export interface PromptTooLongRecoveryState {
   /**
-   * Total `/compact` injections across the execution's lifetime. Accumulates
-   * across compact→continue→re-overflow cycles so repeated unhelpful compactions
-   * escalate to `blocked` instead of resetting each cycle.
+   * Consecutive *unproductive* `/compact` attempts. Reset to 0 once a compaction
+   * is productive (the resume nag is delivered), so the cap targets repeated
+   * unhelpful compactions rather than lifetime total.
    */
   compactAttempts: number;
   /**
    * True after a `/compact` was successfully injected and we are waiting for the
-   * compacted result to land before sending the "continue your work" nag. Guards
-   * against re-injecting `/compact` while the injected command is still the last
-   * persisted message.
+   * compacted RESULT to land. Guards against re-injecting `/compact` while the
+   * turn is in flight.
    */
   awaitingContinue: boolean;
   /**
-   * dbId of the injected `/compact` message. While `awaitingContinue` is set, a
-   * tick whose last-message dbId differs from this means the `/compact` turn has
-   * landed a new result (success or a fresh overflow) — the wait is over and the
-   * state is re-evaluated. This prevents a fresh overflow result from being
-   * treated like the pre-compact result and stalling forever.
+   * dbId of the injected `/compact` message. Used to detect when a NEW message
+   * has landed. The wait is cleared only when that new message is a `result`
+   * (real turn completion) — not an intermediate `status: 'compacting'` row —
+   * so the resume nag is never sent mid-compaction.
    */
   awaitingContinueAfterDbId: string | null;
+  /** Timestamp (ms) the `/compact` was injected, for the wait timeout. */
+  awaitingContinueSince: number | null;
+  /**
+   * True once compaction produced a non-overflow result and the "resume your
+   * work" nag still needs to be delivered (or retried after a failed delivery).
+   */
+  continueNagPending: boolean;
+  /** Failed resume-nag deliveries; bounded before giving up. */
+  continueNagAttempts: number;
 }
 
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
@@ -53,6 +72,9 @@ export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
     compactAttempts: 0,
     awaitingContinue: false,
     awaitingContinueAfterDbId: null,
+    awaitingContinueSince: null,
+    continueNagPending: false,
+    continueNagAttempts: 0,
   };
 }
 

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -86,6 +86,12 @@ export interface PromptTooLongRecoveryState {
   awaitingResumeAfterDbId: string | null;
   /** Timestamp (ms) the resume nag was delivered, for the resume-wait timeout. */
   awaitingResumeSince: number | null;
+  /**
+   * dbId of the last progress message observed during the resume wait. The
+   * timeout refreshes only when a NEWER message appears (this id changes), so a
+   * turn that hangs after producing one row still times out.
+   */
+  awaitingResumeLastProgressDbId: string | null;
 }
 
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
@@ -100,6 +106,7 @@ export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
     awaitingResume: false,
     awaitingResumeAfterDbId: null,
     awaitingResumeSince: null,
+    awaitingResumeLastProgressDbId: null,
   };
 }
 

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -1,0 +1,85 @@
+/**
+ * Prompt-too-long recovery helpers.
+ *
+ * A worker/node session that overflows its context window receives a terminal
+ * SDK `result` message (`subtype: error_during_execution`,
+ * `terminal_reason: 'prompt_too_long'`). The idle sweep treats any result as a
+ * safe terminal point and skips it, so the execution sticks. These helpers
+ * detect that signature and supply the compact-then-continue recovery messages.
+ *
+ * A plain "continue" on an over-long context is useless — the recovery MUST
+ * compact FIRST, then continue.
+ */
+
+import type { SDKMessage } from '@neokai/shared/sdk';
+
+/**
+ * Maximum `/compact` attempts for a single execution before escalating to
+ * `blocked`. Bounds the loop when compaction cannot shrink the context enough
+ * (e.g. a single message already exceeds the limit).
+ */
+export const MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS = 2;
+
+/**
+ * Per-execution recovery state. Keyed by `${runId}:${executionId}` in
+ * `SpaceRuntime.promptTooLongRecovery`.
+ */
+export interface PromptTooLongRecoveryState {
+  /** Total `/compact` injections across the execution's lifetime. */
+  compactAttempts: number;
+  /**
+   * True after a `/compact` was injected and we are waiting for the compacted
+   * result to land before sending the "continue your work" nag. Guards against
+   * re-injecting `/compact` while the old prompt-too-long result is still the
+   * last persisted message.
+   */
+  awaitingContinue: boolean;
+  lastActionAt: number | null;
+}
+
+export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
+  return { compactAttempts: 0, awaitingContinue: false, lastActionAt: null };
+}
+
+/**
+ * Detect the prompt-too-long signature on a result message.
+ *
+ * The SDK sets `terminal_reason: 'prompt_too_long'` on the result, and/or the
+ * `errors[]` array carries the API message. We accept both, and use a lenient
+ * `/prompt is too long/i` for the errors body since not every provider includes
+ * the `N tokens > M maximum` form.
+ */
+export function isPromptTooLongResult(message: SDKMessage | null | undefined): boolean {
+  if (!message) return false;
+  const msg = message as {
+    type?: string;
+    terminal_reason?: string;
+    errors?: unknown;
+  };
+  if (msg.type !== 'result') return false;
+  if (msg.terminal_reason === 'prompt_too_long') return true;
+  if (Array.isArray(msg.errors)) {
+    for (const err of msg.errors) {
+      if (typeof err === 'string' && /prompt is too long/i.test(err)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * The "continue your work" nag injected after compaction succeeds. Only sent
+ * once the last message is no longer a prompt-too-long result — i.e. the
+ * context dropped back below the limit — so it never re-hits the same wall.
+ */
+export function buildPromptTooLongContinueNag(): string {
+  return [
+    '[Runtime recovery notice]',
+    '',
+    'Your conversation context exceeded the model window and was automatically compacted.',
+    'The context has been reduced. Continue your assigned work from the current state.',
+    'If work is complete, report completion through the workflow tools.',
+    'If you are blocked, report the blocker clearly through the available tools. Do not wait silently.',
+  ].join('\n');
+}

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -44,6 +44,14 @@ export interface PromptTooLongRecoveryState {
    */
   compactAttempts: number;
   /**
+   * Set when a re-compact injection failed (the session was momentarily
+   * unavailable). Included in the recovery gate so the next tick re-enters and
+   * retries/escalates — otherwise a non-overflow-error last message wouldn't
+   * re-enter the gate (it's not prompt-too-long) and the terminal-skip would
+   * clear the state, dropping the promised retry.
+   */
+  compactRetryPending: boolean;
+  /**
    * True after a `/compact` was successfully injected and we are waiting for the
    * compacted RESULT to land. Guards against re-injecting `/compact` while the
    * turn is in flight.
@@ -83,6 +91,7 @@ export interface PromptTooLongRecoveryState {
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
   return {
     compactAttempts: 0,
+    compactRetryPending: false,
     awaitingContinue: false,
     awaitingContinueAfterDbId: null,
     awaitingContinueSince: null,

--- a/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
+++ b/packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts
@@ -25,20 +25,35 @@ export const MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS = 2;
  * `SpaceRuntime.promptTooLongRecovery`.
  */
 export interface PromptTooLongRecoveryState {
-  /** Total `/compact` injections across the execution's lifetime. */
+  /**
+   * Total `/compact` injections across the execution's lifetime. Accumulates
+   * across compact→continue→re-overflow cycles so repeated unhelpful compactions
+   * escalate to `blocked` instead of resetting each cycle.
+   */
   compactAttempts: number;
   /**
-   * True after a `/compact` was injected and we are waiting for the compacted
-   * result to land before sending the "continue your work" nag. Guards against
-   * re-injecting `/compact` while the old prompt-too-long result is still the
-   * last persisted message.
+   * True after a `/compact` was successfully injected and we are waiting for the
+   * compacted result to land before sending the "continue your work" nag. Guards
+   * against re-injecting `/compact` while the injected command is still the last
+   * persisted message.
    */
   awaitingContinue: boolean;
-  lastActionAt: number | null;
+  /**
+   * dbId of the injected `/compact` message. While `awaitingContinue` is set, a
+   * tick whose last-message dbId differs from this means the `/compact` turn has
+   * landed a new result (success or a fresh overflow) — the wait is over and the
+   * state is re-evaluated. This prevents a fresh overflow result from being
+   * treated like the pre-compact result and stalling forever.
+   */
+  awaitingContinueAfterDbId: string | null;
 }
 
 export function createPromptTooLongRecoveryState(): PromptTooLongRecoveryState {
-  return { compactAttempts: 0, awaitingContinue: false, lastActionAt: null };
+  return {
+    compactAttempts: 0,
+    awaitingContinue: false,
+    awaitingContinueAfterDbId: null,
+  };
 }
 
 /**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5345,7 +5345,15 @@ export class SpaceRuntime {
       }
       if (injectedDbId !== null) {
         state.awaitingContinue = true;
-        state.awaitingContinueAfterDbId = injectedDbId;
+        // Anchor the wait on the PRE-COMPACT last message (the overflow result),
+        // NOT the injected `/compact`. `getLastSDKMessage` excludes user messages
+        // saved with send_status='enqueued' (sdk-message-repository.ts:995), and
+        // injectRuntimeRecoveryMessage enqueues the `/compact` — so the injected
+        // row is invisible to getLastSDKMessage until the SDK consumes it. While
+        // the `/compact` is in flight, getLastSDKMessage keeps returning this
+        // pre-compact result; the wait clears only when a newer consumed/result
+        // row lands (the compacted turn's output).
+        state.awaitingContinueAfterDbId = lastMessageDbId;
         state.awaitingContinueSince = now;
         log.warn(
           `SpaceRuntime: injected /compact for overflowed execution ${execution.id} ` +

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -86,6 +86,7 @@ import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
 import {
+  COMPACT_RESULT_TIMEOUT_MS,
   MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS,
   buildPromptTooLongContinueNag,
   createPromptTooLongRecoveryState,
@@ -5223,25 +5224,23 @@ export class SpaceRuntime {
    * context window (terminal `prompt_too_long` result).
    *
    * State machine (keyed by `${runId}:${executionId}`):
-   *  - prompt-too-long & awaitingContinue & last msg unchanged → wait (`/compact`
-   *    turn still in flight; the injected command is still the last message).
-   *  - prompt-too-long & not awaiting & attempts < MAX → inject `/compact`,
-   *    increment attempts, set awaitingContinue + record the injected msg dbId.
+   *  - prompt-too-long & awaitingContinue (compact in flight) & no result yet &
+   *    within timeout → wait.
+   *  - awaitingContinue & a `result` landed → clear the wait; if the result is
+   *    non-overflow, mark continueNagPending; if overflow, re-compact/escalate.
+   *  - awaitingContinue past COMPACT_RESULT_TIMEOUT_MS with no result → the
+   *    compact turn hung → escalate to blocked.
+   *  - prompt-too-long & not awaiting & attempts < MAX → inject `/compact`.
    *  - prompt-too-long & attempts >= MAX → escalate to blocked.
-   *  - NOT prompt-too-long & awaitingContinue (or just-compacted) → compaction
-   *    shrank the context; inject the resume nag and clear state.
+   *  - continueNagPending → deliver the resume nag; on success reset
+   *    compactAttempts (productive compaction) and clear; on failure retry,
+   *    bounded, then escalate.
    *
-   * Message-advance detection: `awaitingContinueAfterDbId` records the injected
-   * `/compact` message. Once the last-message dbId differs, the `/compact` turn
-   * has landed a new result — the wait clears and the new state is re-evaluated.
-   * This prevents a fresh overflow result (compaction couldn't shrink enough)
-   * from being mistaken for the pre-compact result and stalling forever.
-   *
-   * The continue nag fires ONLY once the last message is no longer a
-   * prompt-too-long result, i.e. the context dropped back below the limit — so
-   * it never re-hits the same wall. Injection failures count toward the cap so a
-   * session that cannot receive the compact escalates instead of retrying
-   * forever.
+   * The wait clears ONLY on a `result` message (real turn completion) — not an
+   * intermediate `status: 'compacting'` row — so the resume nag is never sent
+   * mid-compaction. `compactAttempts` counts consecutive *unproductive*
+   * compactions and resets on a productive resume, so a long-running worker is
+   * not penalised for stale recovery history.
    */
   private async recoverPromptTooLongIdleExecution(
     runId: string,
@@ -5258,64 +5257,68 @@ export class SpaceRuntime {
     this.promptTooLongRecovery.set(key, state);
 
     const lastMessageDbId = (lastMessage as { dbId?: string } | null | undefined)?.dbId ?? null;
-    // The `/compact` turn has landed a newer message — end the wait and
-    // re-evaluate the post-compact state (success → resume; fresh overflow →
-    // re-compact/escalate).
+    const lastMessageIsResult =
+      !!lastMessage && (lastMessage as { type?: string }).type === 'result';
+    const overflowed = isPromptTooLongResult(lastMessage);
+
+    // The `/compact` turn landed a RESULT (real completion — not an intermediate
+    // status/compact_boundary row). End the wait and re-evaluate.
     if (
       state.awaitingContinue &&
+      lastMessageIsResult &&
       state.awaitingContinueAfterDbId !== null &&
       lastMessageDbId !== state.awaitingContinueAfterDbId
     ) {
       state.awaitingContinue = false;
       state.awaitingContinueAfterDbId = null;
+      state.awaitingContinueSince = null;
+      // A non-overflow result means compaction shrank the context — queue the
+      // resume nag. A fresh overflow result falls through to re-compact/escalate.
+      if (!overflowed) {
+        state.continueNagPending = true;
+      }
     }
 
-    const overflowed = isPromptTooLongResult(lastMessage);
+    // Bound the post-compact wait: if the /compact turn produced no result
+    // within the timeout, it hung — escalate (the execution is `idle`, so the
+    // alive-stuck sweep cannot rescue it).
+    if (
+      state.awaitingContinue &&
+      state.awaitingContinueSince !== null &&
+      now - state.awaitingContinueSince > COMPACT_RESULT_TIMEOUT_MS
+    ) {
+      const reason = `Context-overflow recovery timed out: the /compact turn did not produce a result within ${COMPACT_RESULT_TIMEOUT_MS / 1000}s for agent ${execution.agentName}.`;
+      await this.escalatePromptTooLongBlocked(
+        runId,
+        spaceId,
+        canonicalTask,
+        execution,
+        now,
+        reason
+      );
+      return 'blocked';
+    }
 
     if (overflowed) {
-      // `/compact` still in flight (the injected command is still the last
-      // persisted message) — wait for it to take effect before re-injecting.
+      // `/compact` still in flight — wait for the result.
       if (state.awaitingContinue) {
         return 'handled';
       }
       if (state.compactAttempts >= MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS) {
         const reason = `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
-        this.promptTooLongRecovery.delete(key);
-        this.config.nodeExecutionRepo.update(execution.id, {
-          status: 'blocked',
-          result: reason,
-        });
-        await this.transitionRunStatusAndEmit(runId, 'blocked');
-        await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
-          status: 'blocked',
-          result: reason,
-          blockReason: 'execution_failed',
-          completedAt: null,
-        });
-        await this.safeNotify({
-          kind: 'task_blocked',
-          spaceId,
-          taskId: canonicalTask.id,
-          reason,
-          timestamp: new Date(now).toISOString(),
-        });
-        await this.safeNotify({
-          kind: 'workflow_run_blocked',
-          spaceId,
+        await this.escalatePromptTooLongBlocked(
           runId,
-          reason,
-          timestamp: new Date(now).toISOString(),
-        });
-        log.warn(
-          `SpaceRuntime: blocked execution ${execution.id} (agent ${execution.agentName}) after repeated context overflow; compaction could not shrink context enough`
+          spaceId,
+          canonicalTask,
+          execution,
+          now,
+          reason
         );
         return 'blocked';
       }
       // Compact FIRST, then continue on a later tick. Count the attempt toward
-      // the cap up front so a session that cannot receive the compact (e.g.
-      // unrehydratable after a daemon restart, or no manager) still escalates
-      // instead of retrying forever. Only mark awaiting after a successful
-      // injection — otherwise the next tick must be free to retry.
+      // the cap up front so a session that cannot receive the compact still
+      // escalates. Only mark awaiting after a successful injection.
       state.compactAttempts += 1;
       let injectedDbId: string | null = null;
       try {
@@ -5330,6 +5333,7 @@ export class SpaceRuntime {
       if (injectedDbId !== null) {
         state.awaitingContinue = true;
         state.awaitingContinueAfterDbId = injectedDbId;
+        state.awaitingContinueSince = now;
         log.warn(
           `SpaceRuntime: injected /compact for overflowed execution ${execution.id} ` +
             `(agent ${execution.agentName}, session ${sessionId}, attempt ${state.compactAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
@@ -5343,37 +5347,106 @@ export class SpaceRuntime {
       return 'handled';
     }
 
-    // Not prompt-too-long. If a `/compact` is still in flight (the injected
-    // command or compact_boundary is the last non-terminal message), wait for
-    // the post-compact result.
+    // Not prompt-too-long. If a `/compact` is still in flight (no result yet),
+    // wait for the post-compact result.
     if (state.awaitingContinue) {
       return 'handled';
     }
 
-    // Not overflowing and not waiting: if we previously compacted, compaction
-    // succeeded (the context dropped below the limit) and the `/compact` turn
-    // landed a non-overflow result. Inject the resume nag. Keep the state so
-    // compactAttempts accumulates across compact→continue→re-overflow cycles
-    // (escalation relies on this); it is cleared by the terminal-skip path once
-    // the session resumes normally, or on escalation to `blocked`.
-    if (state.compactAttempts > 0) {
+    // Compaction succeeded — deliver the resume nag (retryable on failure so a
+    // transient/absent injection is not silently swallowed). On success the
+    // compaction was productive: reset compactAttempts so a long-running worker
+    // that legitimately re-fills context is not blocked by stale history.
+    if (state.continueNagPending) {
+      let nagDelivered = false;
       try {
-        await manager?.injectRuntimeRecoveryMessage(sessionId!, buildPromptTooLongContinueNag());
-        log.warn(
-          `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
-        );
+        nagDelivered =
+          !!(await manager?.injectRuntimeRecoveryMessage(
+            sessionId!,
+            buildPromptTooLongContinueNag()
+          )) && !!manager;
       } catch (err) {
         log.warn(
           `SpaceRuntime: failed to inject continue nag for execution ${execution.id} ` +
             `(session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
         );
       }
+      if (nagDelivered) {
+        state.continueNagPending = false;
+        state.continueNagAttempts = 0;
+        state.compactAttempts = 0; // productive compaction — forgive prior attempts
+        log.warn(
+          `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
+        );
+      } else {
+        state.continueNagAttempts += 1;
+        if (state.continueNagAttempts >= MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS) {
+          const reason = `Context-overflow recovery could not deliver the resume nag to agent ${execution.agentName} after ${state.continueNagAttempts} attempts (session unavailable).`;
+          await this.escalatePromptTooLongBlocked(
+            runId,
+            spaceId,
+            canonicalTask,
+            execution,
+            now,
+            reason
+          );
+          return 'blocked';
+        }
+        log.warn(
+          `SpaceRuntime: continue nag delivery failed for execution ${execution.id} ` +
+            `(session ${sessionId}); will retry (attempt ${state.continueNagAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
+        );
+      }
       return 'handled';
     }
 
-    // No compaction history and not overflowing — nothing to recover.
+    // No active recovery phase and not overflowing — nothing to recover.
     this.promptTooLongRecovery.delete(key);
     return 'handled';
+  }
+
+  /**
+   * Shared escalation: mark the execution + run `blocked`, notify, and clear the
+   * prompt-too-long recovery state.
+   */
+  private async escalatePromptTooLongBlocked(
+    runId: string,
+    spaceId: string,
+    canonicalTask: SpaceTask,
+    execution: NodeExecution,
+    now: number,
+    reason: string
+  ): Promise<void> {
+    const key = `${runId}:${execution.id}`;
+    this.promptTooLongRecovery.delete(key);
+    this.config.nodeExecutionRepo.update(execution.id, {
+      status: 'blocked',
+      result: reason,
+    });
+    await this.transitionRunStatusAndEmit(runId, 'blocked');
+    await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+      status: 'blocked',
+      result: reason,
+      blockReason: 'execution_failed',
+      completedAt: null,
+    });
+    await this.safeNotify({
+      kind: 'task_blocked',
+      spaceId,
+      taskId: canonicalTask.id,
+      reason,
+      timestamp: new Date(now).toISOString(),
+    });
+    await this.safeNotify({
+      kind: 'workflow_run_blocked',
+      spaceId,
+      runId,
+      reason,
+      timestamp: new Date(now).toISOString(),
+    });
+    log.warn(
+      `SpaceRuntime: blocked execution ${execution.id} (agent ${execution.agentName}) — ${reason}`
+    );
   }
 
   private async handleAliveStuckExecutions(
@@ -6550,11 +6623,15 @@ export class SpaceRuntime {
       const key = `${runId}:${execution.id}`;
       // Prompt-too-long recovery takes priority over both the terminal-skip and
       // the generic non-terminal idle path. It must fire for a terminal overflow
-      // result AND while awaiting a post-compact result (the `/compact` user
-      // message and compact_boundary rows are non-terminal), so the resume nag
-      // fires regardless of the compacted message's type.
+      // result, while awaiting a post-compact result, and while a resume nag is
+      // pending (retryable) — regardless of whether the latest message is
+      // classified as terminal.
       const ptlState = this.promptTooLongRecovery.get(key);
-      if (isPromptTooLongResult(lastMessage) || ptlState?.awaitingContinue) {
+      if (
+        isPromptTooLongResult(lastMessage) ||
+        ptlState?.awaitingContinue ||
+        ptlState?.continueNagPending
+      ) {
         const manager = tam ?? this.config.taskAgentManager;
         const outcome = await this.recoverPromptTooLongIdleExecution(
           runId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5276,15 +5276,38 @@ export class SpaceRuntime {
       state.awaitingContinueAfterDbId = null;
       state.awaitingContinueSince = null;
       // Only a SUCCESS result proves compaction shrank the context — queue the
-      // resume nag. A non-overflow ERROR result (model/auth/rate-limit) means
-      // compaction failed; route it to re-compact/escalate instead of resuming
-      // into an unchanged, still-over-limit context.
+      // resume nag and record this result as the resume anchor. A non-overflow
+      // ERROR result (model/auth/rate-limit) means compaction failed; route it to
+      // re-compact/escalate instead of resuming into an unchanged, still-over-limit
+      // context.
       if (lastMessageIsSuccessResult) {
         state.continueNagPending = true;
+        state.awaitingResumeAfterDbId = lastMessageDbId;
       } else if (!overflowed) {
         compactJustFailed = true;
       }
       // A fresh overflow result falls through with `overflowed` to re-compact.
+    }
+
+    // Resume-nag wait: after the continue nag is delivered it is an enqueued
+    // user message invisible to getLastSDKMessage, so the sweep keeps seeing the
+    // compact-success anchor until the resumed turn advances. Hold the recovery
+    // open (preventing the terminal-skip from clearing the state and resetting
+    // compactAttempts prematurely). When the resumed turn advances:
+    //  - a prompt-too-long result → re-compact/escalate with attempts PRESERVED;
+    //  - any other message → productive, clear the recovery state (fresh next time).
+    if (state.awaitingResume && state.awaitingResumeAfterDbId !== null) {
+      if (lastMessageDbId === state.awaitingResumeAfterDbId) {
+        return 'handled'; // nag still in flight / resumed turn hasn't advanced
+      }
+      state.awaitingResume = false;
+      state.awaitingResumeAfterDbId = null;
+      if (!overflowed) {
+        // Resumed turn produced a non-overflow message — real progress.
+        this.promptTooLongRecovery.delete(key);
+        return 'handled';
+      }
+      // Resumed turn overflowed — attempts preserved, fall through to re-compact.
     }
 
     // Bound the post-compact wait: if the /compact turn produced no result
@@ -5395,14 +5418,12 @@ export class SpaceRuntime {
       if (nagDelivered) {
         state.continueNagPending = false;
         state.continueNagAttempts = 0;
-        // NOTE: compactAttempts is NOT reset here. A reset on nag delivery would
-        // let a session that compacts "successfully" but immediately re-overflows
-        // (context right at the edge) loop forever without escalating. Instead,
-        // attempts are forgiven implicitly when the resumed turn makes real
-        // progress: a normal (non-overflow) terminal result hits the terminal-skip
-        // path, which clears this recovery state entirely — so the next overflow
-        // starts fresh. An immediate re-overflow (no progress) leaves the state in
-        // place, so attempts accumulate and escalate at the cap.
+        // compactAttempts is NOT reset here (see awaitingResume handling above).
+        // The delivered nag is an enqueued user message invisible to
+        // getLastSDKMessage, so awaitingResume holds the recovery open until the
+        // resumed turn actually advances — preventing the terminal-skip from
+        // clearing the state (and resetting attempts) while the nag is in flight.
+        state.awaitingResume = true;
         log.warn(
           `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
         );
@@ -6663,7 +6684,8 @@ export class SpaceRuntime {
       if (
         isPromptTooLongResult(lastMessage) ||
         ptlState?.awaitingContinue ||
-        ptlState?.continueNagPending
+        ptlState?.continueNagPending ||
+        ptlState?.awaitingResume
       ) {
         const manager = tam ?? this.config.taskAgentManager;
         const outcome = await this.recoverPromptTooLongIdleExecution(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5223,18 +5223,25 @@ export class SpaceRuntime {
    * context window (terminal `prompt_too_long` result).
    *
    * State machine (keyed by `${runId}:${executionId}`):
+   *  - prompt-too-long & awaitingContinue & last msg unchanged → wait (`/compact`
+   *    turn still in flight; the injected command is still the last message).
    *  - prompt-too-long & not awaiting & attempts < MAX → inject `/compact`,
-   *    increment attempts, set awaitingContinue.
-   *  - prompt-too-long & awaitingContinue               → wait (compact still
-   *    in flight; the old overflow result is still the last persisted message).
-   *  - prompt-too-long & attempts >= MAX                → escalate to blocked.
-   *  - NOT prompt-too-long & awaitingContinue           → compaction shrank the
-   *    context; inject the resume nag and clear awaitingContinue.
+   *    increment attempts, set awaitingContinue + record the injected msg dbId.
+   *  - prompt-too-long & attempts >= MAX → escalate to blocked.
+   *  - NOT prompt-too-long & awaitingContinue (or just-compacted) → compaction
+   *    shrank the context; inject the resume nag and clear state.
+   *
+   * Message-advance detection: `awaitingContinueAfterDbId` records the injected
+   * `/compact` message. Once the last-message dbId differs, the `/compact` turn
+   * has landed a new result — the wait clears and the new state is re-evaluated.
+   * This prevents a fresh overflow result (compaction couldn't shrink enough)
+   * from being mistaken for the pre-compact result and stalling forever.
    *
    * The continue nag fires ONLY once the last message is no longer a
    * prompt-too-long result, i.e. the context dropped back below the limit — so
-   * it never re-hits the same wall. Repeated overflow after continue increments
-   * attempts and escalates to blocked when compaction cannot help.
+   * it never re-hits the same wall. Injection failures count toward the cap so a
+   * session that cannot receive the compact escalates instead of retrying
+   * forever.
    */
   private async recoverPromptTooLongIdleExecution(
     runId: string,
@@ -5250,12 +5257,24 @@ export class SpaceRuntime {
     const state = this.promptTooLongRecovery.get(key) ?? createPromptTooLongRecoveryState();
     this.promptTooLongRecovery.set(key, state);
 
+    const lastMessageDbId = (lastMessage as { dbId?: string } | null | undefined)?.dbId ?? null;
+    // The `/compact` turn has landed a newer message — end the wait and
+    // re-evaluate the post-compact state (success → resume; fresh overflow →
+    // re-compact/escalate).
+    if (
+      state.awaitingContinue &&
+      state.awaitingContinueAfterDbId !== null &&
+      lastMessageDbId !== state.awaitingContinueAfterDbId
+    ) {
+      state.awaitingContinue = false;
+      state.awaitingContinueAfterDbId = null;
+    }
+
     const overflowed = isPromptTooLongResult(lastMessage);
 
     if (overflowed) {
-      // Already injected a compact for this cycle — wait for it to take effect
-      // before re-injecting (prevents double-compact while the old overflow
-      // result is still the last persisted message).
+      // `/compact` still in flight (the injected command is still the last
+      // persisted message) — wait for it to take effect before re-injecting.
       if (state.awaitingContinue) {
         return 'handled';
       }
@@ -5292,31 +5311,52 @@ export class SpaceRuntime {
         );
         return 'blocked';
       }
-      // Compact FIRST, then continue on a later tick.
+      // Compact FIRST, then continue on a later tick. Count the attempt toward
+      // the cap up front so a session that cannot receive the compact (e.g.
+      // unrehydratable after a daemon restart, or no manager) still escalates
+      // instead of retrying forever. Only mark awaiting after a successful
+      // injection — otherwise the next tick must be free to retry.
       state.compactAttempts += 1;
-      state.awaitingContinue = true;
-      state.lastActionAt = now;
+      let injectedDbId: string | null = null;
       try {
-        await manager?.injectRuntimeRecoveryMessage(sessionId!, '/compact');
-        log.warn(
-          `SpaceRuntime: injected /compact for overflowed execution ${execution.id} ` +
-            `(agent ${execution.agentName}, session ${sessionId}, attempt ${state.compactAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
-        );
+        injectedDbId =
+          (await manager?.injectRuntimeRecoveryMessage(sessionId!, '/compact')) ?? null;
       } catch (err) {
         log.warn(
           `SpaceRuntime: failed to inject /compact for overflowed execution ${execution.id} ` +
             `(session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
         );
       }
+      if (injectedDbId !== null) {
+        state.awaitingContinue = true;
+        state.awaitingContinueAfterDbId = injectedDbId;
+        log.warn(
+          `SpaceRuntime: injected /compact for overflowed execution ${execution.id} ` +
+            `(agent ${execution.agentName}, session ${sessionId}, attempt ${state.compactAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
+        );
+      } else {
+        log.warn(
+          `SpaceRuntime: could not inject /compact for overflowed execution ${execution.id} ` +
+            `(session ${sessionId}); will retry or escalate on the next tick`
+        );
+      }
       return 'handled';
     }
 
-    // Not prompt-too-long: if we were awaiting continue, compaction succeeded —
-    // send the resume nag. This is the shrinkage verification: the last message
-    // is no longer an overflow result, so the context is back under the limit.
+    // Not prompt-too-long. If a `/compact` is still in flight (the injected
+    // command or compact_boundary is the last non-terminal message), wait for
+    // the post-compact result.
     if (state.awaitingContinue) {
-      state.awaitingContinue = false;
-      state.lastActionAt = now;
+      return 'handled';
+    }
+
+    // Not overflowing and not waiting: if we previously compacted, compaction
+    // succeeded (the context dropped below the limit) and the `/compact` turn
+    // landed a non-overflow result. Inject the resume nag. Keep the state so
+    // compactAttempts accumulates across compact→continue→re-overflow cycles
+    // (escalation relies on this); it is cleared by the terminal-skip path once
+    // the session resumes normally, or on escalation to `blocked`.
+    if (state.compactAttempts > 0) {
       try {
         await manager?.injectRuntimeRecoveryMessage(sessionId!, buildPromptTooLongContinueNag());
         log.warn(
@@ -5331,8 +5371,7 @@ export class SpaceRuntime {
       return 'handled';
     }
 
-    // No active recovery phase and not overflowing — nothing to do; the caller
-    // clears the state via the normal terminal-skip path.
+    // No compaction history and not overflowing — nothing to recover.
     this.promptTooLongRecovery.delete(key);
     return 'handled';
   }
@@ -6509,28 +6548,27 @@ export class SpaceRuntime {
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const classification = classifyLastMessageForIdleAgent(lastMessage);
       const key = `${runId}:${execution.id}`;
+      // Prompt-too-long recovery takes priority over both the terminal-skip and
+      // the generic non-terminal idle path. It must fire for a terminal overflow
+      // result AND while awaiting a post-compact result (the `/compact` user
+      // message and compact_boundary rows are non-terminal), so the resume nag
+      // fires regardless of the compacted message's type.
+      const ptlState = this.promptTooLongRecovery.get(key);
+      if (isPromptTooLongResult(lastMessage) || ptlState?.awaitingContinue) {
+        const manager = tam ?? this.config.taskAgentManager;
+        const outcome = await this.recoverPromptTooLongIdleExecution(
+          runId,
+          spaceId,
+          canonicalTask,
+          execution,
+          lastMessage,
+          manager
+        );
+        if (outcome === 'blocked') return 'blocked';
+        preservedAny = true;
+        continue;
+      }
       if (classification.terminal) {
-        // Prompt-too-long overflow is a terminal result that the generic idle
-        // sweep would otherwise skip, leaving the execution stuck forever. Route
-        // it to compact-then-continue recovery BEFORE the normal terminal skip.
-        // The branch also fires while `awaitingContinue` is set so we can inject
-        // the resume nag after the compacted result lands (the last message is
-        // then no longer prompt-too-long).
-        const ptlState = this.promptTooLongRecovery.get(key);
-        if (isPromptTooLongResult(lastMessage) || ptlState?.awaitingContinue) {
-          const manager = tam ?? this.config.taskAgentManager;
-          const outcome = await this.recoverPromptTooLongIdleExecution(
-            runId,
-            spaceId,
-            canonicalTask,
-            execution,
-            lastMessage,
-            manager
-          );
-          if (outcome === 'blocked') return 'blocked';
-          preservedAny = true;
-          continue;
-        }
         this.nonTerminalIdleStates.delete(key);
         this.promptTooLongRecovery.delete(key);
         continue;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5260,9 +5260,12 @@ export class SpaceRuntime {
     const lastMessageIsResult =
       !!lastMessage && (lastMessage as { type?: string }).type === 'result';
     const overflowed = isPromptTooLongResult(lastMessage);
+    const lastMessageIsSuccessResult =
+      lastMessageIsResult && !(lastMessage as { is_error?: boolean }).is_error;
 
     // The `/compact` turn landed a RESULT (real completion — not an intermediate
     // status/compact_boundary row). End the wait and re-evaluate.
+    let compactJustFailed = false;
     if (
       state.awaitingContinue &&
       lastMessageIsResult &&
@@ -5272,11 +5275,16 @@ export class SpaceRuntime {
       state.awaitingContinue = false;
       state.awaitingContinueAfterDbId = null;
       state.awaitingContinueSince = null;
-      // A non-overflow result means compaction shrank the context — queue the
-      // resume nag. A fresh overflow result falls through to re-compact/escalate.
-      if (!overflowed) {
+      // Only a SUCCESS result proves compaction shrank the context — queue the
+      // resume nag. A non-overflow ERROR result (model/auth/rate-limit) means
+      // compaction failed; route it to re-compact/escalate instead of resuming
+      // into an unchanged, still-over-limit context.
+      if (lastMessageIsSuccessResult) {
         state.continueNagPending = true;
+      } else if (!overflowed) {
+        compactJustFailed = true;
       }
+      // A fresh overflow result falls through with `overflowed` to re-compact.
     }
 
     // Bound the post-compact wait: if the /compact turn produced no result
@@ -5299,13 +5307,18 @@ export class SpaceRuntime {
       return 'blocked';
     }
 
-    if (overflowed) {
+    // Re-compact/escalate on a fresh overflow OR a just-failed compaction
+    // (non-overflow error result). Both mean compaction did not shrink the
+    // context enough.
+    if (overflowed || compactJustFailed) {
       // `/compact` still in flight — wait for the result.
       if (state.awaitingContinue) {
         return 'handled';
       }
       if (state.compactAttempts >= MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS) {
-        const reason = `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
+        const reason = compactJustFailed
+          ? `Context-overflow recovery: /compact failed (non-overflow error) after ${state.compactAttempts} attempt(s) for agent ${execution.agentName}.`
+          : `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
         await this.escalatePromptTooLongBlocked(
           runId,
           spaceId,
@@ -5422,6 +5435,11 @@ export class SpaceRuntime {
     this.config.nodeExecutionRepo.update(execution.id, {
       status: 'blocked',
       result: reason,
+      // Detach the overflowed session. Its context is exhausted, so reusing it
+      // would just re-overflow. Clearing the id lets the bounded blocked-run
+      // retry (attemptBlockedRunRecovery) spawn fresh on retry instead of
+      // resurrecting this terminal-overflow session into a stuck in_progress.
+      agentSessionId: null,
     });
     await this.transitionRunStatusAndEmit(runId, 'blocked');
     await this.updateTaskAndEmit(spaceId, canonicalTask.id, {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5326,21 +5326,33 @@ export class SpaceRuntime {
         if (!overflowed) {
           compactJustFailed = true;
         }
-      } else if (
-        state.awaitingResumeSince !== null &&
-        now - state.awaitingResumeSince > COMPACT_RESULT_TIMEOUT_MS
-      ) {
-        const reason = `Context-overflow recovery timed out: the resumed turn did not produce a result within ${COMPACT_RESULT_TIMEOUT_MS / 1000}s for agent ${execution.agentName}.`;
-        await this.escalatePromptTooLongBlocked(
-          runId,
-          spaceId,
-          canonicalTask,
-          execution,
-          now,
-          reason
-        );
-        return 'blocked';
       } else {
+        // No resumed-turn result yet. If a newer message than the anchor has
+        // appeared (the consumed nag, an assistant/tool-use row, etc.) the turn
+        // IS progressing — refresh the timeout clock so a legitimately long but
+        // active resumed turn isn't mis-blocked. The timeout fires only when no
+        // new message has landed for the whole window.
+        if (
+          lastMessageDbId !== state.awaitingResumeAfterDbId &&
+          state.awaitingResumeSince !== null
+        ) {
+          state.awaitingResumeSince = now;
+        }
+        if (
+          state.awaitingResumeSince !== null &&
+          now - state.awaitingResumeSince > COMPACT_RESULT_TIMEOUT_MS
+        ) {
+          const reason = `Context-overflow recovery timed out: the resumed turn did not produce a result within ${COMPACT_RESULT_TIMEOUT_MS / 1000}s for agent ${execution.agentName}.`;
+          await this.escalatePromptTooLongBlocked(
+            runId,
+            spaceId,
+            canonicalTask,
+            execution,
+            now,
+            reason
+          );
+          return 'blocked';
+        }
         return 'handled'; // nag enqueued/consumed but resumed turn hasn't produced a result
       }
     }
@@ -5367,16 +5379,20 @@ export class SpaceRuntime {
 
     // Re-compact/escalate on a fresh overflow OR a just-failed compaction
     // (non-overflow error result). Both mean compaction did not shrink the
-    // context enough.
-    if (overflowed || compactJustFailed) {
+    // context enough. Also re-enter on a pending retry after a previously failed
+    // injection (compactRetryPending) — a non-overflow-error last message
+    // wouldn't otherwise re-enter the gate.
+    if (overflowed || compactJustFailed || state.compactRetryPending) {
+      state.compactRetryPending = false;
       // `/compact` still in flight — wait for the result.
       if (state.awaitingContinue) {
         return 'handled';
       }
       if (state.compactAttempts >= MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS) {
-        const reason = compactJustFailed
-          ? `Context-overflow recovery: /compact failed (non-overflow error) after ${state.compactAttempts} attempt(s) for agent ${execution.agentName}.`
-          : `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
+        const reason =
+          compactJustFailed || state.compactRetryPending
+            ? `Context-overflow recovery: /compact failed (non-overflow error) after ${state.compactAttempts} attempt(s) for agent ${execution.agentName}.`
+            : `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
         await this.escalatePromptTooLongBlocked(
           runId,
           spaceId,
@@ -5418,6 +5434,9 @@ export class SpaceRuntime {
             `(agent ${execution.agentName}, session ${sessionId}, attempt ${state.compactAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
         );
       } else {
+        // Injection failed — preserve a retryable flag so the next tick re-enters
+        // (a non-overflow-error last message wouldn't re-enter the gate on its own).
+        state.compactRetryPending = true;
         log.warn(
           `SpaceRuntime: could not inject /compact for overflowed execution ${execution.id} ` +
             `(session ${sessionId}); will retry or escalate on the next tick`
@@ -6721,7 +6740,8 @@ export class SpaceRuntime {
         isPromptTooLongResult(lastMessage) ||
         ptlState?.awaitingContinue ||
         ptlState?.continueNagPending ||
-        ptlState?.awaitingResume
+        ptlState?.awaitingResume ||
+        ptlState?.compactRetryPending
       ) {
         const manager = tam ?? this.config.taskAgentManager;
         const outcome = await this.recoverPromptTooLongIdleExecution(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5293,29 +5293,52 @@ export class SpaceRuntime {
     // user message invisible to getLastSDKMessage, so the sweep keeps seeing the
     // compact-success anchor until the resumed turn advances. Hold the recovery
     // open (preventing the terminal-skip from clearing the state and resetting
-    // compactAttempts prematurely). When the resumed turn advances:
-    //  - a prompt-too-long result → re-compact/escalate with attempts PRESERVED;
-    //  - any other RESULT → productive, clear the recovery state (fresh next time).
+    // compactAttempts prematurely). When the resumed turn produces a RESULT:
+    //  - SUCCESS → productive, clear the recovery state (fresh next time);
+    //  - prompt-too-long → re-compact/escalate with attempts PRESERVED;
+    //  - non-overflow ERROR (auth/rate-limit/model) → route to re-compact/escalate
+    //    (not silently cleared as productive — the resume failed, and a persistent
+    //    error escalates to blocked at the cap rather than leaving the run idle).
+    //
+    // The wait is bounded by COMPACT_RESULT_TIMEOUT_MS: if the resumed turn never
+    // produces a result (provider hang / session died after consuming the nag),
+    // escalate — the execution is `idle`, so the alive-stuck sweep cannot rescue it.
     //
     // The wait clears ONLY on a RESULT from the resumed turn — not on the
-    // consumed continue nag itself. injectRuntimeRecoveryMessage awaits
-    // messageQueue.enqueueWithId, which resolves only after the SDK consumes the
-    // nag (flipping send_status to 'consumed' so getLastSDKMessage includes it),
-    // but before the resumed API call returns. So the consumed nag (a user
-    // message) is briefly the last message; treating it as "advance" would clear
-    // the state and reset attempts before the resumed turn produces anything.
+    // consumed continue nag itself (a user message), which getLastSDKMessage
+    // briefly returns before the resumed API call returns.
     if (state.awaitingResume && state.awaitingResumeAfterDbId !== null) {
+      if (
+        state.awaitingResumeSince !== null &&
+        now - state.awaitingResumeSince > COMPACT_RESULT_TIMEOUT_MS
+      ) {
+        const reason = `Context-overflow recovery timed out: the resumed turn did not produce a result within ${COMPACT_RESULT_TIMEOUT_MS / 1000}s for agent ${execution.agentName}.`;
+        await this.escalatePromptTooLongBlocked(
+          runId,
+          spaceId,
+          canonicalTask,
+          execution,
+          now,
+          reason
+        );
+        return 'blocked';
+      }
       if (!lastMessageIsResult || lastMessageDbId === state.awaitingResumeAfterDbId) {
         return 'handled'; // nag enqueued/consumed but resumed turn hasn't produced a result
       }
       state.awaitingResume = false;
       state.awaitingResumeAfterDbId = null;
-      if (!overflowed) {
-        // Resumed turn produced a non-overflow result — real progress.
+      state.awaitingResumeSince = null;
+      if (lastMessageIsSuccessResult) {
+        // Productive — real progress. Clear the recovery state (fresh next time).
         this.promptTooLongRecovery.delete(key);
         return 'handled';
       }
-      // Resumed turn overflowed — attempts preserved, fall through to re-compact.
+      // Overflow (fall through with `overflowed`) OR non-overflow error: the
+      // resume did not make progress → re-compact/escalate with attempts preserved.
+      if (!overflowed) {
+        compactJustFailed = true;
+      }
     }
 
     // Bound the post-compact wait: if the /compact turn produced no result
@@ -5432,6 +5455,7 @@ export class SpaceRuntime {
         // resumed turn actually advances — preventing the terminal-skip from
         // clearing the state (and resetting attempts) while the nag is in flight.
         state.awaitingResume = true;
+        state.awaitingResumeSince = now;
         log.warn(
           `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
         );

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5295,15 +5295,23 @@ export class SpaceRuntime {
     // open (preventing the terminal-skip from clearing the state and resetting
     // compactAttempts prematurely). When the resumed turn advances:
     //  - a prompt-too-long result → re-compact/escalate with attempts PRESERVED;
-    //  - any other message → productive, clear the recovery state (fresh next time).
+    //  - any other RESULT → productive, clear the recovery state (fresh next time).
+    //
+    // The wait clears ONLY on a RESULT from the resumed turn — not on the
+    // consumed continue nag itself. injectRuntimeRecoveryMessage awaits
+    // messageQueue.enqueueWithId, which resolves only after the SDK consumes the
+    // nag (flipping send_status to 'consumed' so getLastSDKMessage includes it),
+    // but before the resumed API call returns. So the consumed nag (a user
+    // message) is briefly the last message; treating it as "advance" would clear
+    // the state and reset attempts before the resumed turn produces anything.
     if (state.awaitingResume && state.awaitingResumeAfterDbId !== null) {
-      if (lastMessageDbId === state.awaitingResumeAfterDbId) {
-        return 'handled'; // nag still in flight / resumed turn hasn't advanced
+      if (!lastMessageIsResult || lastMessageDbId === state.awaitingResumeAfterDbId) {
+        return 'handled'; // nag enqueued/consumed but resumed turn hasn't produced a result
       }
       state.awaitingResume = false;
       state.awaitingResumeAfterDbId = null;
       if (!overflowed) {
-        // Resumed turn produced a non-overflow message — real progress.
+        // Resumed turn produced a non-overflow result — real progress.
         this.promptTooLongRecovery.delete(key);
         return 'handled';
       }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5308,7 +5308,25 @@ export class SpaceRuntime {
     // consumed continue nag itself (a user message), which getLastSDKMessage
     // briefly returns before the resumed API call returns.
     if (state.awaitingResume && state.awaitingResumeAfterDbId !== null) {
-      if (
+      // Process a visible resumed-turn RESULT before the timeout — a turn that
+      // legitimately took longer than the window (e.g. tick loop paused) but
+      // did complete must not be mis-blocked. Timeout fires only when NO result
+      // has landed (mirrors the /compact wait's result-first ordering).
+      if (lastMessageIsResult && lastMessageDbId !== state.awaitingResumeAfterDbId) {
+        state.awaitingResume = false;
+        state.awaitingResumeAfterDbId = null;
+        state.awaitingResumeSince = null;
+        if (lastMessageIsSuccessResult) {
+          // Productive — real progress. Clear the recovery state (fresh next time).
+          this.promptTooLongRecovery.delete(key);
+          return 'handled';
+        }
+        // Overflow (fall through with `overflowed`) OR non-overflow error: the
+        // resume did not make progress → re-compact/escalate with attempts preserved.
+        if (!overflowed) {
+          compactJustFailed = true;
+        }
+      } else if (
         state.awaitingResumeSince !== null &&
         now - state.awaitingResumeSince > COMPACT_RESULT_TIMEOUT_MS
       ) {
@@ -5322,22 +5340,8 @@ export class SpaceRuntime {
           reason
         );
         return 'blocked';
-      }
-      if (!lastMessageIsResult || lastMessageDbId === state.awaitingResumeAfterDbId) {
+      } else {
         return 'handled'; // nag enqueued/consumed but resumed turn hasn't produced a result
-      }
-      state.awaitingResume = false;
-      state.awaitingResumeAfterDbId = null;
-      state.awaitingResumeSince = null;
-      if (lastMessageIsSuccessResult) {
-        // Productive — real progress. Clear the recovery state (fresh next time).
-        this.promptTooLongRecovery.delete(key);
-        return 'handled';
-      }
-      // Overflow (fall through with `overflowed`) OR non-overflow error: the
-      // resume did not make progress → re-compact/escalate with attempts preserved.
-      if (!overflowed) {
-        compactJustFailed = true;
       }
     }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5395,7 +5395,14 @@ export class SpaceRuntime {
       if (nagDelivered) {
         state.continueNagPending = false;
         state.continueNagAttempts = 0;
-        state.compactAttempts = 0; // productive compaction — forgive prior attempts
+        // NOTE: compactAttempts is NOT reset here. A reset on nag delivery would
+        // let a session that compacts "successfully" but immediately re-overflows
+        // (context right at the edge) loop forever without escalating. Instead,
+        // attempts are forgiven implicitly when the resumed turn makes real
+        // progress: a normal (non-overflow) terminal result hits the terminal-skip
+        // path, which clears this recovery state entirely — so the next overflow
+        // starts fresh. An immediate re-overflow (no progress) leaves the state in
+        // place, so attempts accumulate and escalate at the cap.
         log.warn(
           `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
         );

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -5316,6 +5316,7 @@ export class SpaceRuntime {
         state.awaitingResume = false;
         state.awaitingResumeAfterDbId = null;
         state.awaitingResumeSince = null;
+        state.awaitingResumeLastProgressDbId = null;
         if (lastMessageIsSuccessResult) {
           // Productive — real progress. Clear the recovery state (fresh next time).
           this.promptTooLongRecovery.delete(key);
@@ -5327,16 +5328,17 @@ export class SpaceRuntime {
           compactJustFailed = true;
         }
       } else {
-        // No resumed-turn result yet. If a newer message than the anchor has
-        // appeared (the consumed nag, an assistant/tool-use row, etc.) the turn
-        // IS progressing — refresh the timeout clock so a legitimately long but
-        // active resumed turn isn't mis-blocked. The timeout fires only when no
-        // new message has landed for the whole window.
+        // No resumed-turn result yet. Refresh the timeout clock ONLY when a NEW
+        // progress message appears (dbId differs from the anchor AND from the
+        // last progress dbId). Refreshing on every tick for an unchanged row
+        // would let a turn that hung after producing one message never time out.
         if (
           lastMessageDbId !== state.awaitingResumeAfterDbId &&
+          lastMessageDbId !== state.awaitingResumeLastProgressDbId &&
           state.awaitingResumeSince !== null
         ) {
           state.awaitingResumeSince = now;
+          state.awaitingResumeLastProgressDbId = lastMessageDbId;
         }
         if (
           state.awaitingResumeSince !== null &&
@@ -5349,7 +5351,8 @@ export class SpaceRuntime {
             canonicalTask,
             execution,
             now,
-            reason
+            reason,
+            manager
           );
           return 'blocked';
         }
@@ -5372,7 +5375,8 @@ export class SpaceRuntime {
         canonicalTask,
         execution,
         now,
-        reason
+        reason,
+        manager
       );
       return 'blocked';
     }
@@ -5399,7 +5403,8 @@ export class SpaceRuntime {
           canonicalTask,
           execution,
           now,
-          reason
+          reason,
+          manager
         );
         return 'blocked';
       }
@@ -5492,7 +5497,8 @@ export class SpaceRuntime {
             canonicalTask,
             execution,
             now,
-            reason
+            reason,
+            manager
           );
           return 'blocked';
         }
@@ -5519,9 +5525,23 @@ export class SpaceRuntime {
     canonicalTask: SpaceTask,
     execution: NodeExecution,
     now: number,
-    reason: string
+    reason: string,
+    manager: TaskAgentManager | undefined
   ): Promise<void> {
     const key = `${runId}:${execution.id}`;
+    // Cancel the (possibly still-running) session before detaching. A timed-out
+    // /compact or resumed turn may still be processing; leaving it alive while the
+    // bounded blocked-run retry spawns a fresh agent would run two sessions
+    // concurrently for one execution.
+    if (execution.agentSessionId) {
+      try {
+        manager?.cancelBySessionId?.(execution.agentSessionId);
+      } catch (err) {
+        log.warn(
+          `SpaceRuntime: failed to cancel session ${execution.agentSessionId} during prompt-too-long escalation: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
     this.promptTooLongRecovery.delete(key);
     this.config.nodeExecutionRepo.update(execution.id, {
       status: 'blocked',

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -34,6 +34,7 @@ import type {
   WorkflowChannel,
   WorkflowNode,
 } from '@neokai/shared';
+import type { SDKMessage } from '@neokai/shared/sdk';
 import {
   computeGateDefaults,
   isChannelCyclic,
@@ -83,6 +84,13 @@ import {
 import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
+import {
+  MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS,
+  buildPromptTooLongContinueNag,
+  createPromptTooLongRecoveryState,
+  isPromptTooLongResult,
+  type PromptTooLongRecoveryState,
+} from './prompt-too-long-recovery';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import type {
   InternalEventBus,
@@ -960,6 +968,13 @@ export class SpaceRuntime {
    * can be nudged/restarted without touching sibling agents.
    */
   private agentStuckRecovery = new Map<string, AgentStuckRecoveryState>();
+
+  /**
+   * Prompt-too-long recovery state keyed by `${runId}:${nodeExecutionId}`.
+   * Tracks compact-then-continue progress for executions that overflowed their
+   * context window and received a terminal `prompt_too_long` result.
+   */
+  private promptTooLongRecovery = new Map<string, PromptTooLongRecoveryState>();
   private readonly toolContinuationRepo: ToolContinuationRecoveryRepository;
   private readonly topicTrie = new TopicTrie<SubscriptionTarget>();
   private readonly pendingExternalEventQueue = new Map<string, PendingExternalEvent[]>();
@@ -5026,6 +5041,11 @@ export class SpaceRuntime {
         this.nonTerminalIdleStates.delete(key);
       }
     }
+    for (const key of this.promptTooLongRecovery.keys()) {
+      if (key.startsWith(runId + ':')) {
+        this.promptTooLongRecovery.delete(key);
+      }
+    }
   }
 
   private getAgentNoProgressThresholdMs(workflow: SpaceWorkflow, execution: NodeExecution): number {
@@ -5068,6 +5088,125 @@ export class SpaceRuntime {
       'Continue the same task from the current repository and workflow state. Inspect task/workflow status, recent messages, git state, PR state, and artifacts as needed before acting. Do not start from scratch blindly.',
       'If you are blocked, report the blocker clearly through the available workflow tools.',
     ].join('\n');
+  }
+
+  /**
+   * Compact-then-continue recovery for an idle execution that overflowed its
+   * context window (terminal `prompt_too_long` result).
+   *
+   * State machine (keyed by `${runId}:${executionId}`):
+   *  - prompt-too-long & not awaiting & attempts < MAX → inject `/compact`,
+   *    increment attempts, set awaitingContinue.
+   *  - prompt-too-long & awaitingContinue               → wait (compact still
+   *    in flight; the old overflow result is still the last persisted message).
+   *  - prompt-too-long & attempts >= MAX                → escalate to blocked.
+   *  - NOT prompt-too-long & awaitingContinue           → compaction shrank the
+   *    context; inject the resume nag and clear awaitingContinue.
+   *
+   * The continue nag fires ONLY once the last message is no longer a
+   * prompt-too-long result, i.e. the context dropped back below the limit — so
+   * it never re-hits the same wall. Repeated overflow after continue increments
+   * attempts and escalates to blocked when compaction cannot help.
+   */
+  private async recoverPromptTooLongIdleExecution(
+    runId: string,
+    spaceId: string,
+    canonicalTask: SpaceTask,
+    execution: NodeExecution,
+    lastMessage: SDKMessage | null | undefined,
+    manager: TaskAgentManager | undefined
+  ): Promise<'handled' | 'blocked'> {
+    const key = `${runId}:${execution.id}`;
+    const sessionId = execution.agentSessionId;
+    const now = Date.now();
+    const state = this.promptTooLongRecovery.get(key) ?? createPromptTooLongRecoveryState();
+    this.promptTooLongRecovery.set(key, state);
+
+    const overflowed = isPromptTooLongResult(lastMessage);
+
+    if (overflowed) {
+      // Already injected a compact for this cycle — wait for it to take effect
+      // before re-injecting (prevents double-compact while the old overflow
+      // result is still the last persisted message).
+      if (state.awaitingContinue) {
+        return 'handled';
+      }
+      if (state.compactAttempts >= MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS) {
+        const reason = `Context overflow ("prompt is too long") could not be resolved after ${state.compactAttempts} compaction attempt(s); agent ${execution.agentName} cannot make progress.`;
+        this.promptTooLongRecovery.delete(key);
+        this.config.nodeExecutionRepo.update(execution.id, {
+          status: 'blocked',
+          result: reason,
+        });
+        await this.transitionRunStatusAndEmit(runId, 'blocked');
+        await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+          status: 'blocked',
+          result: reason,
+          blockReason: 'execution_failed',
+          completedAt: null,
+        });
+        await this.safeNotify({
+          kind: 'task_blocked',
+          spaceId,
+          taskId: canonicalTask.id,
+          reason,
+          timestamp: new Date(now).toISOString(),
+        });
+        await this.safeNotify({
+          kind: 'workflow_run_blocked',
+          spaceId,
+          runId,
+          reason,
+          timestamp: new Date(now).toISOString(),
+        });
+        log.warn(
+          `SpaceRuntime: blocked execution ${execution.id} (agent ${execution.agentName}) after repeated context overflow; compaction could not shrink context enough`
+        );
+        return 'blocked';
+      }
+      // Compact FIRST, then continue on a later tick.
+      state.compactAttempts += 1;
+      state.awaitingContinue = true;
+      state.lastActionAt = now;
+      try {
+        await manager?.injectRuntimeRecoveryMessage(sessionId!, '/compact');
+        log.warn(
+          `SpaceRuntime: injected /compact for overflowed execution ${execution.id} ` +
+            `(agent ${execution.agentName}, session ${sessionId}, attempt ${state.compactAttempts}/${MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS})`
+        );
+      } catch (err) {
+        log.warn(
+          `SpaceRuntime: failed to inject /compact for overflowed execution ${execution.id} ` +
+            `(session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return 'handled';
+    }
+
+    // Not prompt-too-long: if we were awaiting continue, compaction succeeded —
+    // send the resume nag. This is the shrinkage verification: the last message
+    // is no longer an overflow result, so the context is back under the limit.
+    if (state.awaitingContinue) {
+      state.awaitingContinue = false;
+      state.lastActionAt = now;
+      try {
+        await manager?.injectRuntimeRecoveryMessage(sessionId!, buildPromptTooLongContinueNag());
+        log.warn(
+          `SpaceRuntime: injected continue nag after compaction for execution ${execution.id} (agent ${execution.agentName}, session ${sessionId})`
+        );
+      } catch (err) {
+        log.warn(
+          `SpaceRuntime: failed to inject continue nag for execution ${execution.id} ` +
+            `(session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      return 'handled';
+    }
+
+    // No active recovery phase and not overflowing — nothing to do; the caller
+    // clears the state via the normal terminal-skip path.
+    this.promptTooLongRecovery.delete(key);
+    return 'handled';
   }
 
   private async handleAliveStuckExecutions(
@@ -6243,7 +6382,29 @@ export class SpaceRuntime {
       const classification = classifyLastMessageForIdleAgent(lastMessage);
       const key = `${runId}:${execution.id}`;
       if (classification.terminal) {
+        // Prompt-too-long overflow is a terminal result that the generic idle
+        // sweep would otherwise skip, leaving the execution stuck forever. Route
+        // it to compact-then-continue recovery BEFORE the normal terminal skip.
+        // The branch also fires while `awaitingContinue` is set so we can inject
+        // the resume nag after the compacted result lands (the last message is
+        // then no longer prompt-too-long).
+        const ptlState = this.promptTooLongRecovery.get(key);
+        if (isPromptTooLongResult(lastMessage) || ptlState?.awaitingContinue) {
+          const manager = tam ?? this.config.taskAgentManager;
+          const outcome = await this.recoverPromptTooLongIdleExecution(
+            runId,
+            spaceId,
+            canonicalTask,
+            execution,
+            lastMessage,
+            manager
+          );
+          if (outcome === 'blocked') return 'blocked';
+          preservedAny = true;
+          continue;
+        }
         this.nonTerminalIdleStates.delete(key);
+        this.promptTooLongRecovery.delete(key);
         continue;
       }
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -288,10 +288,13 @@ describe('QueryOptionsBuilder', () => {
       });
     });
 
-    it('should disable SDK auto-compaction when context window is unavailable', () => {
-      expect(buildProviderSettings('openrouter')).toEqual({
-        autoCompactEnabled: false,
-      });
+    it('should not disable SDK auto-compaction when context window is unavailable (avoid dead zone)', () => {
+      // Previously returned { autoCompactEnabled: false }, creating a dead zone
+      // with no compaction path (no SDK auto-compact, no NeoKai fallback) and
+      // guaranteeing context overflow. Returning undefined lets the SDK use its
+      // built-in auto-compact (enabled by default); the reactive prompt-too-long
+      // recovery handles any sub-200k mismatch.
+      expect(buildProviderSettings('openrouter')).toBeUndefined();
     });
 
     it('should use NeoKai fallback for both Kimi regions (SDK clamps every Kimi route to 200k)', () => {
@@ -367,16 +370,16 @@ describe('QueryOptionsBuilder', () => {
       });
     });
 
-    it('should disable SDK auto-compaction for OpenRouter when model is unknown', async () => {
+    it('should not disable SDK auto-compaction for OpenRouter when model is unknown (avoid dead zone)', async () => {
       registerOpenRouterProvider();
       // Empty cache — model not found
       setModelsCache(new Map());
       mockSession.config.provider = 'openrouter';
       mockSession.config.model = 'unknown-model';
       const options = await builder.build();
-      expect(options.settings).toEqual({
-        autoCompactEnabled: false,
-      });
+      // Returning undefined lets the SDK use its built-in auto-compact instead
+      // of creating a dead zone (no SDK compact, no NeoKai fallback).
+      expect(options.settings).toBeUndefined();
     });
 
     it('should leave settings undefined for native anthropic provider', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -460,21 +460,26 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
   });
 
   test('does not block a long-running worker whose compactions are productive', async () => {
-    // P2: compactAttempts resets on a productive resume, so a worker that
-    // legitimately re-fills context over time is not penalised for stale
-    // recovery history. Only CONSECUTIVE unproductive compactions escalate.
+    // A worker that compacts, makes real progress (a normal terminal result),
+    // and only later re-fills context must not be penalised: the progress result
+    // clears the recovery state via the terminal-skip path, so the next overflow
+    // starts fresh. Contrast with immediate re-overflow (no progress), which
+    // accumulates and escalates.
     const injections: Array<{ sessionId: string; message: string }> = [];
     const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
     const sessionId = 'session:long-running';
     const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
 
     const continueNag = buildPromptTooLongContinueNag();
-    // Three productive cycles: each /compact succeeds (context shrank) and the
-    // resume nag resets the counter. The worker must NOT be blocked.
+    // Three productive cycles. Between each, the resumed turn produces a normal
+    // success result (progress) which the terminal-skip path uses to clear state.
     for (let cycle = 0; cycle < 3; cycle++) {
-      await rt.executeTick(); // → /compact
+      await rt.executeTick(); // → /compact (fresh attempt, state was cleared)
+      saveResultMessage(sessionId, { promptTooLong: false }); // compact succeeded
+      await rt.executeTick(); // → continue nag
+      // Resumed turn completes normally — terminal-skip clears recovery state.
       saveResultMessage(sessionId, { promptTooLong: false });
-      await rt.executeTick(); // → continue nag (resets compactAttempts)
+      await rt.executeTick();
       saveResultMessage(sessionId, { promptTooLong: true }); // re-overflow later
     }
 
@@ -488,8 +493,34 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     ]);
     expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('idle');
     expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
-    // compactAttempts was reset by the last productive resume.
-    expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.compactAttempts).toBe(0);
+    // No lingering recovery state (cleared by the last progress result).
+    expect(promptTooLongRecoveryMap(rt).has(`${run.id}:${execution.id}`)).toBe(false);
+  });
+
+  test('blocks when compaction succeeds but the resume immediately re-overflows', async () => {
+    // The counter is NOT reset on nag delivery. If compaction succeeds but the
+    // resumed turn immediately re-overflows (no progress result in between),
+    // attempts accumulate and escalate — no infinite success→nag→overflow loop.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:edge-overflow';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    // Cycle 1: compact succeeds, continue nag, then immediate re-overflow.
+    await rt.executeTick(); // → /compact (attempt 1)
+    saveResultMessage(sessionId, { promptTooLong: false });
+    await rt.executeTick(); // → continue nag (attempts NOT reset)
+    saveResultMessage(sessionId, { promptTooLong: true }); // immediate re-overflow
+    // Cycle 2: attempts now 1 → /compact (attempt 2)
+    await rt.executeTick();
+    saveResultMessage(sessionId, { promptTooLong: false });
+    await rt.executeTick(); // → continue nag (attempts=2)
+    saveResultMessage(sessionId, { promptTooLong: true }); // immediate re-overflow
+    // Cycle 3: attempts=2 >= MAX → blocked
+    await rt.executeTick();
+
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
   });
 
   test('escalates to blocked when the /compact turn hangs (wait timeout)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -293,15 +293,23 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
   /** Save a result SDK message as the last message for a session. */
   function saveResultMessage(
     sessionId: string,
-    opts: { promptTooLong?: boolean; minutesAgo?: number }
+    opts: { promptTooLong?: boolean; nonOverflowError?: boolean; minutesAgo?: number }
   ): void {
     const message = {
       type: 'result',
-      subtype: opts.promptTooLong ? 'error_during_execution' : 'success',
-      is_error: !!opts.promptTooLong,
+      subtype: opts.promptTooLong
+        ? 'error_during_execution'
+        : opts.nonOverflowError
+          ? 'error_during_execution'
+          : 'success',
+      is_error: !!(opts.promptTooLong || opts.nonOverflowError),
       terminal_reason: opts.promptTooLong ? 'prompt_too_long' : 'completed',
-      errors: opts.promptTooLong ? ['prompt is too long: 205616 tokens > 200000 maximum'] : [],
-      result: opts.promptTooLong ? '' : 'ok',
+      errors: opts.promptTooLong
+        ? ['prompt is too long: 205616 tokens > 200000 maximum']
+        : opts.nonOverflowError
+          ? ['API Error: 500 Internal Server Error']
+          : [],
+      result: opts.promptTooLong || opts.nonOverflowError ? '' : 'ok',
     };
     sdkMessageRepo.saveSDKMessage(sessionId, message as never);
     const minutesAgo = opts.minutesAgo ?? 20;
@@ -547,5 +555,48 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
 
     expect(injections.filter((i) => i.message !== '/compact').length).toBeGreaterThanOrEqual(2);
     expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+  });
+
+  test('re-compacts instead of resuming when /compact errors (non-overflow)', async () => {
+    // P2: a non-overflow ERROR result (model/auth/rate-limit) means compaction
+    // failed — the recovery must NOT treat it as success and resume into an
+    // unchanged over-limit context. It re-compacts (counting as unproductive).
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:compact-error';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact (attempt 1)
+    // The /compact turn fails with a NON-overflow error.
+    saveResultMessage(sessionId, { nonOverflowError: true });
+    await rt.executeTick(); // → re-compact (attempt 2), NOT a continue nag
+    // Still failing → re-compact attempt 2 already used; another error escalates.
+    saveResultMessage(sessionId, { nonOverflowError: true });
+    await rt.executeTick(); // attempts exhausted → blocked
+
+    // No continue nag should ever have been sent (compaction never succeeded).
+    expect(injections.some((i) => i.message === buildPromptTooLongContinueNag())).toBe(false);
+    expect(injections.filter((i) => i.message === '/compact').length).toBeGreaterThanOrEqual(2);
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+  });
+
+  test('detaches the overflowed session when escalating to blocked', async () => {
+    // P2: escalation clears agentSessionId so the bounded blocked-run retry
+    // spawns fresh instead of resurrecting the terminal-overflow session.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:block-clear';
+    const { execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    // Force exhaustion: two unproductive compactions (fresh overflow each time).
+    await rt.executeTick(); // /compact 1
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick(); // /compact 2
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick(); // → blocked
+
+    const blocked = nodeExecutionRepo.getById(execution.id);
+    expect(blocked?.status).toBe('blocked');
+    expect(blocked?.agentSessionId).toBeNull();
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -116,8 +116,11 @@ function makeMockTaskAgentManager(
   const spawned: string[] = [];
   const defaultInject = async (sessionId: string, message: string): Promise<string> => {
     // Mirror production injectMessageIntoSession: persist the injected message
-    // so getLastSDKMessage advances to it, and return its dbId. This is what
-    // makes the message-advance detection in the recovery state machine work.
+    // with send_status='enqueued'. Critically, getLastSDKMessage EXCLUDES
+    // enqueued user messages (sdk-message-repository.ts:995), so the injected
+    // /compact is invisible to the idle sweep until the SDK consumes it —
+    // exactly like production. Simulating this is what makes the message-advance
+    // detection test meaningful.
     sdkMessages.saveSDKMessage(sessionId, {
       type: 'user',
       message: { role: 'user', content: message },
@@ -127,6 +130,7 @@ function makeMockTaskAgentManager(
         `SELECT id FROM sdk_messages WHERE session_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT 1`
       )
       .get(sessionId) as { id: string };
+    db.prepare(`UPDATE sdk_messages SET send_status = 'enqueued' WHERE id = ?`).run(row.id);
     return row.id;
   };
   const inject = options.injectThrows
@@ -332,8 +336,8 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     return makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, sdkMessageRepo, db, {
       inject: async (sessionId, message) => {
         injections.push({ sessionId, message });
-        // Mirror production: persist the injected message so getLastSDKMessage
-        // advances to it, and return its dbId.
+        // Mirror production: persist with send_status='enqueued' (excluded from
+        // getLastSDKMessage until consumed).
         sdkMessageRepo.saveSDKMessage(sessionId, {
           type: 'user',
           message: { role: 'user', content: message },
@@ -343,6 +347,7 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
             `SELECT id FROM sdk_messages WHERE session_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT 1`
           )
           .get(sessionId) as { id: string };
+        db.prepare(`UPDATE sdk_messages SET send_status = 'enqueued' WHERE id = ?`).run(row.id);
         return row.id;
       },
     });

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -523,6 +523,35 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
   });
 
+  test('preserves attempts while the resume nag is enqueued (no premature reset)', async () => {
+    // Round-7 regression: the continue nag is an enqueued user message invisible
+    // to getLastSDKMessage, so the sweep keeps seeing the compact-success result.
+    // Without the awaitingResume hold, the terminal-skip would clear the recovery
+    // state (resetting compactAttempts) before the resumed turn advances. Verify
+    // the state — and compactAttempts — survive ticks in that window.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:nag-enqueued';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact (attempt 1)
+    saveResultMessage(sessionId, { promptTooLong: false }); // compact success
+    await rt.executeTick(); // → continue nag delivered (awaitingResume=true)
+
+    // The nag is enqueued; getLastSDKMessage still returns the compact-success
+    // result. Multiple ticks must NOT clear/reset the state.
+    await rt.executeTick();
+    await rt.executeTick();
+    const preserved = promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`);
+    expect(preserved?.compactAttempts).toBe(1); // still preserved, not reset
+
+    // Now the resumed turn immediately re-overflows → re-compact with attempts
+    // preserved (attempt 2), not a fresh attempt 1.
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick();
+    expect(injections.filter((i) => i.message === '/compact').length).toBe(2);
+  });
+
   test('escalates to blocked when the /compact turn hangs (wait timeout)', async () => {
     // P2: if the /compact turn never produces a result, awaitingContinue must not
     // wait forever — the recovery escalates after COMPACT_RESULT_TIMEOUT_MS.

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -616,6 +616,34 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
   });
 
+  test('processes a resumed success past the timeout window instead of blocking', async () => {
+    // Round-10: a visible resumed-turn RESULT is processed BEFORE the timeout —
+    // a turn that took longer than the window but completed must not be mis-blocked.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:late-success';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact
+    saveResultMessage(sessionId, { promptTooLong: false }); // compact success
+    await rt.executeTick(); // → continue nag (awaitingResume=true)
+
+    // Simulate the tick loop being delayed past the timeout, but the resumed
+    // turn DID produce a (late) success result.
+    const states = (
+      rt as unknown as {
+        promptTooLongRecovery: Map<string, { awaitingResumeSince: number | null }>;
+      }
+    ).promptTooLongRecovery;
+    const state = states.get(`${run.id}:${execution.id}`);
+    state!.awaitingResumeSince = Date.now() - (COMPACT_RESULT_TIMEOUT_MS + 1000);
+    saveResultMessage(sessionId, { promptTooLong: false }); // resumed success
+
+    await rt.executeTick(); // → processes the result (productive), NOT blocked
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+  });
+
   test('re-compacts when the resumed turn errors (non-overflow), not silent clear', async () => {
     // P2: a non-overflow ERROR result from the resumed turn (auth/rate-limit) is
     // not "productive progress" — route it to re-compact/escalate instead of

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -589,6 +589,55 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(injections.filter((i) => i.message === '/compact').length).toBe(2);
   });
 
+  test('escalates to blocked when the resumed turn hangs (resume-wait timeout)', async () => {
+    // P2: if the resumed turn never produces a result after the continue nag,
+    // awaitingResume must not wait forever — escalate after COMPACT_RESULT_TIMEOUT_MS.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:hung-resume';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact
+    saveResultMessage(sessionId, { promptTooLong: false }); // compact success
+    await rt.executeTick(); // → continue nag (awaitingResume=true)
+
+    // Simulate the resumed turn hanging (no result ever lands).
+    const states = (
+      rt as unknown as {
+        promptTooLongRecovery: Map<string, { awaitingResumeSince: number | null }>;
+      }
+    ).promptTooLongRecovery;
+    const state = states.get(`${run.id}:${execution.id}`);
+    expect(state?.awaitingResumeSince).not.toBeNull();
+    state!.awaitingResumeSince = Date.now() - (COMPACT_RESULT_TIMEOUT_MS + 1000);
+
+    await rt.executeTick(); // → resume-wait timeout → blocked
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+  });
+
+  test('re-compacts when the resumed turn errors (non-overflow), not silent clear', async () => {
+    // P2: a non-overflow ERROR result from the resumed turn (auth/rate-limit) is
+    // not "productive progress" — route it to re-compact/escalate instead of
+    // silently clearing the recovery state and leaving the run idle.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:resume-error';
+    const { execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact (attempt 1)
+    saveResultMessage(sessionId, { promptTooLong: false }); // compact success
+    await rt.executeTick(); // → continue nag
+    // Resumed turn errors with a non-overflow error.
+    saveResultMessage(sessionId, { nonOverflowError: true });
+    await rt.executeTick(); // → re-compact (attempt 2, NOT a silent clear)
+
+    // No continue nag should have been sent for the errored resume, and a second
+    // /compact was injected (re-compact path, not productive clear).
+    expect(injections.some((i) => i.message === buildPromptTooLongContinueNag())).toBe(true); // the one productive nag after compact success
+    expect(injections.filter((i) => i.message === '/compact').length).toBe(2);
+  });
+
   test('escalates to blocked when the /compact turn hangs (wait timeout)', async () => {
     // P2: if the /compact turn never produces a result, awaitingContinue must not
     // wait forever — the recovery escalates after COMPACT_RESULT_TIMEOUT_MS.

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -104,9 +104,35 @@ function buildLinearWorkflow(
 function makeMockTaskAgentManager(
   taskRepo: SpaceTaskRepository,
   nodeExecutionRepo: NodeExecutionRepository,
-  inject: (sessionId: string, message: string) => Promise<string>
+  sdkMessages: SDKMessageRepository,
+  db: BunDatabase,
+  options: {
+    inject?: (sessionId: string, message: string) => Promise<string>;
+    /** Simulate a real injection that cannot deliver (throws). */
+    injectThrows?: boolean;
+  } = {}
 ) {
   const spawned: string[] = [];
+  const defaultInject = async (sessionId: string, message: string): Promise<string> => {
+    // Mirror production injectMessageIntoSession: persist the injected message
+    // so getLastSDKMessage advances to it, and return its dbId. This is what
+    // makes the message-advance detection in the recovery state machine work.
+    sdkMessages.saveSDKMessage(sessionId, {
+      type: 'user',
+      message: { role: 'user', content: message },
+    } as never);
+    const row = db
+      .prepare(
+        `SELECT id FROM sdk_messages WHERE session_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT 1`
+      )
+      .get(sessionId) as { id: string };
+    return row.id;
+  };
+  const inject = options.injectThrows
+    ? async (_sid: string, _msg: string) => {
+        throw new Error('session could not be rehydrated');
+      }
+    : (options.inject ?? defaultInject);
   return {
     isSpawning: () => false,
     isTaskAgentAlive: () => false,
@@ -282,11 +308,6 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     db.prepare(`UPDATE sdk_messages SET timestamp = ? WHERE session_id = ?`).run(ts, sessionId);
   }
 
-  /** Remove every SDK message for a session (used to swap the "last" message). */
-  function clearMessages(sessionId: string): void {
-    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(sessionId);
-  }
-
   function promptTooLongRecoveryMap(
     rt: SpaceRuntime
   ): Map<string, { compactAttempts: number; awaitingContinue: boolean }> {
@@ -297,25 +318,47 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     ).promptTooLongRecovery;
   }
 
-  test('compacts then continues when an idle execution overflows', async () => {
-    const injections: Array<{ sessionId: string; message: string }> = [];
-    const tam = makeMockTaskAgentManager(
-      taskRepo,
-      nodeExecutionRepo,
-      async (sessionId, message) => {
+  /** Build a TAM whose inject persists the message (like production) and records calls. */
+  function makeRecordingTam(injections: Array<{ sessionId: string; message: string }>): unknown {
+    return makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, sdkMessageRepo, db, {
+      inject: async (sessionId, message) => {
         injections.push({ sessionId, message });
-        return `injected:${injections.length}`;
-      }
-    );
-    const rt = new SpaceRuntime(buildConfig(tam));
+        // Mirror production: persist the injected message so getLastSDKMessage
+        // advances to it, and return its dbId.
+        sdkMessageRepo.saveSDKMessage(sessionId, {
+          type: 'user',
+          message: { role: 'user', content: message },
+        } as never);
+        const row = db
+          .prepare(
+            `SELECT id FROM sdk_messages WHERE session_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT 1`
+          )
+          .get(sessionId) as { id: string };
+        return row.id;
+      },
+    });
+  }
+
+  async function setupIdleOverflowExecution(
+    rt: SpaceRuntime,
+    sessionId: string,
+    promptTooLong = true
+  ): Promise<{ run: { id: string }; execution: { id: string } }> {
     const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
       { id: STEP_A, name: 'Work', agentId: AGENT },
     ]);
     const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
     const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
-    const sessionId = 'session:overflow';
     nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
-    saveResultMessage(sessionId, { promptTooLong: true });
+    saveResultMessage(sessionId, { promptTooLong });
+    return { run, execution };
+  }
+
+  test('compacts then continues when an idle execution overflows', async () => {
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:overflow';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
 
     // Tick 1: overflow detected → inject /compact FIRST.
     await rt.executeTick();
@@ -324,80 +367,113 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(state?.compactAttempts).toBe(1);
     expect(state?.awaitingContinue).toBe(true);
 
-    // Simulate compaction completing: replace the last message with a success result.
-    clearMessages(sessionId);
+    // Tick 2: the injected /compact is now the last (non-terminal) message — the
+    // recovery must still fire (it is not gated on classification.terminal) and
+    // wait, not re-inject.
+    await rt.executeTick();
+    expect(injections.map((i) => i.message)).toEqual(['/compact']);
+
+    // Simulate compaction completing: a success result lands (newer than /compact).
     saveResultMessage(sessionId, { promptTooLong: false });
 
-    // Tick 2: last message no longer overflow → inject the continue nag.
+    // Tick 3: last message advanced past /compact and is non-overflow → continue nag.
     await rt.executeTick();
     expect(injections.map((i) => i.message)).toEqual(['/compact', buildPromptTooLongContinueNag()]);
-    expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.awaitingContinue).toBe(
-      false
-    );
   });
 
   test('does not double-inject /compact while awaiting the compacted result', async () => {
-    const injections: string[] = [];
-    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, async (_sid, message) => {
-      injections.push(message);
-      return 'ok';
-    });
-    const rt = new SpaceRuntime(buildConfig(tam));
-    const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
-      { id: STEP_A, name: 'Work', agentId: AGENT },
-    ]);
-    const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-    const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
-    const sessionId = 'session:overflow2';
-    nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
-    saveResultMessage(sessionId, { promptTooLong: true });
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const { run, execution } = await setupIdleOverflowExecution(rt, 'session:overflow2', true);
 
+    await rt.executeTick(); // inject /compact
+    // The injected /compact is the last message; awaitingContinue is set. Two
+    // more ticks must NOT inject another /compact.
     await rt.executeTick();
-    // The last message is still the overflow result — a second tick must NOT
-    // inject another /compact (awaitingContinue guard).
     await rt.executeTick();
-    expect(injections).toEqual(['/compact']);
+    expect(injections.map((i) => i.message)).toEqual(['/compact']);
     expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.compactAttempts).toBe(1);
   });
 
-  test('escalates to blocked after MAX attempts when compaction cannot help', async () => {
-    const injections: string[] = [];
-    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, async (_sid, message) => {
-      injections.push(message);
-      return 'ok';
+  test('does not stall when a fresh overflow result follows the /compact', async () => {
+    // P1: if the /compact turn itself ends with another prompt-too-long result,
+    // the message-advance detection must clear the wait and escalate after MAX.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:fresh-overflow';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    // Tick 1: inject /compact (attempt 1).
+    await rt.executeTick();
+    // The /compact turn ends with ANOTHER overflow (compaction couldn't shrink).
+    saveResultMessage(sessionId, { promptTooLong: true });
+    // Tick 2: new overflow result → advance detection clears awaiting → attempt 2.
+    await rt.executeTick();
+    saveResultMessage(sessionId, { promptTooLong: true });
+    // Tick 3: attempts exhausted (2) → escalate to blocked.
+    await rt.executeTick();
+
+    expect(injections.map((i) => i.message)).toEqual(['/compact', '/compact']);
+    const updated = nodeExecutionRepo.getById(execution.id);
+    expect(updated?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+    expect(promptTooLongRecoveryMap(rt).has(`${run.id}:${execution.id}`)).toBe(false);
+  });
+
+  test('does not stall when /compact injection fails', async () => {
+    // P1: a thrown injectRuntimeRecoveryMessage must not leave awaitingContinue
+    // set; failed attempts count toward the cap and escalate instead of looping
+    // forever on the same overflow result.
+    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, sdkMessageRepo, db, {
+      injectThrows: true,
     });
     const rt = new SpaceRuntime(buildConfig(tam));
-    const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
-      { id: STEP_A, name: 'Work', agentId: AGENT },
-    ]);
-    const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-    const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+    const { run, execution } = await setupIdleOverflowExecution(rt, 'session:inject-fail', true);
+
+    // After at least one failed inject, awaitingContinue must NOT be set (the bug
+    // would leave it true and stall forever on subsequent ticks).
+    await rt.executeTick();
+    const stateAfterFail = promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`);
+    expect(stateAfterFail?.awaitingContinue).toBe(false);
+    expect(stateAfterFail?.compactAttempts).toBeGreaterThan(0);
+
+    // Keep ticking — failed attempts accumulate and escalate to blocked rather
+    // than retrying indefinitely.
+    for (let i = 0; i < 5 && nodeExecutionRepo.getById(execution.id)?.status !== 'blocked'; i++) {
+      await rt.executeTick();
+    }
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+  });
+
+  test('escalates to blocked after MAX attempts when compaction cannot help', async () => {
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
     const sessionId = 'session:unrecoverable';
-    nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
 
     const continueNag = buildPromptTooLongContinueNag();
     // Realistic "compaction can't help" cycle: each /compact shrinks context
     // (success result → continue nag), but the session re-overflows on the next
     // turn because a single message already exceeds the limit.
     // Cycle 1
-    saveResultMessage(sessionId, { promptTooLong: true });
     await rt.executeTick(); // → /compact (attempt 1)
-    clearMessages(sessionId);
     saveResultMessage(sessionId, { promptTooLong: false });
     await rt.executeTick(); // → continue nag
     // Cycle 2
-    clearMessages(sessionId);
     saveResultMessage(sessionId, { promptTooLong: true });
     await rt.executeTick(); // → /compact (attempt 2)
-    clearMessages(sessionId);
     saveResultMessage(sessionId, { promptTooLong: false });
     await rt.executeTick(); // → continue nag
     // Cycle 3: attempts exhausted → escalate to blocked
-    clearMessages(sessionId);
     saveResultMessage(sessionId, { promptTooLong: true });
     await rt.executeTick();
 
-    expect(injections).toEqual(['/compact', continueNag, '/compact', continueNag]);
+    expect(injections.map((i) => i.message)).toEqual([
+      '/compact',
+      continueNag,
+      '/compact',
+      continueNag,
+    ]);
     const updated = nodeExecutionRepo.getById(execution.id);
     expect(updated?.status).toBe('blocked');
     expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -28,6 +28,7 @@ import type { SpaceWorkflow } from '@neokai/shared';
 import {
   isPromptTooLongResult,
   buildPromptTooLongContinueNag,
+  COMPACT_RESULT_TIMEOUT_MS,
   MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS,
 } from '../../../../src/lib/space/runtime/prompt-too-long-recovery';
 
@@ -445,38 +446,106 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
   });
 
-  test('escalates to blocked after MAX attempts when compaction cannot help', async () => {
+  test('does not block a long-running worker whose compactions are productive', async () => {
+    // P2: compactAttempts resets on a productive resume, so a worker that
+    // legitimately re-fills context over time is not penalised for stale
+    // recovery history. Only CONSECUTIVE unproductive compactions escalate.
     const injections: Array<{ sessionId: string; message: string }> = [];
     const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
-    const sessionId = 'session:unrecoverable';
+    const sessionId = 'session:long-running';
     const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
 
     const continueNag = buildPromptTooLongContinueNag();
-    // Realistic "compaction can't help" cycle: each /compact shrinks context
-    // (success result → continue nag), but the session re-overflows on the next
-    // turn because a single message already exceeds the limit.
-    // Cycle 1
-    await rt.executeTick(); // → /compact (attempt 1)
-    saveResultMessage(sessionId, { promptTooLong: false });
-    await rt.executeTick(); // → continue nag
-    // Cycle 2
-    saveResultMessage(sessionId, { promptTooLong: true });
-    await rt.executeTick(); // → /compact (attempt 2)
-    saveResultMessage(sessionId, { promptTooLong: false });
-    await rt.executeTick(); // → continue nag
-    // Cycle 3: attempts exhausted → escalate to blocked
-    saveResultMessage(sessionId, { promptTooLong: true });
-    await rt.executeTick();
+    // Three productive cycles: each /compact succeeds (context shrank) and the
+    // resume nag resets the counter. The worker must NOT be blocked.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await rt.executeTick(); // → /compact
+      saveResultMessage(sessionId, { promptTooLong: false });
+      await rt.executeTick(); // → continue nag (resets compactAttempts)
+      saveResultMessage(sessionId, { promptTooLong: true }); // re-overflow later
+    }
 
     expect(injections.map((i) => i.message)).toEqual([
       '/compact',
       continueNag,
       '/compact',
       continueNag,
+      '/compact',
+      continueNag,
     ]);
-    const updated = nodeExecutionRepo.getById(execution.id);
-    expect(updated?.status).toBe('blocked');
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+    // compactAttempts was reset by the last productive resume.
+    expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.compactAttempts).toBe(0);
+  });
+
+  test('escalates to blocked when the /compact turn hangs (wait timeout)', async () => {
+    // P2: if the /compact turn never produces a result, awaitingContinue must not
+    // wait forever — the recovery escalates after COMPACT_RESULT_TIMEOUT_MS.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:hung-compact';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    // Tick 1: inject /compact. The turn "hangs" — no result lands.
+    await rt.executeTick();
+    expect(injections.map((i) => i.message)).toEqual(['/compact']);
+
+    // Simulate the timeout elapsing with no result (the /compact is still the
+    // last message, so the wait has not cleared).
+    const states = (
+      rt as unknown as {
+        promptTooLongRecovery: Map<string, { awaitingContinueSince: number | null }>;
+      }
+    ).promptTooLongRecovery;
+    const state = states.get(`${run.id}:${execution.id}`);
+    expect(state?.awaitingContinueSince).not.toBeNull();
+    state!.awaitingContinueSince = Date.now() - (COMPACT_RESULT_TIMEOUT_MS + 1000);
+
+    await rt.executeTick(); // → timeout → blocked
+
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
     expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
-    expect(promptTooLongRecoveryMap(rt).has(`${run.id}:${execution.id}`)).toBe(false);
+  });
+
+  test('retries then escalates when the resume nag cannot be delivered', async () => {
+    // P2: a failed continue-nag injection must not be silently swallowed — it
+    // retries and escalates to blocked if delivery keeps failing.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    // /compact succeeds, but the continue nag always fails.
+    let injectCallCount = 0;
+    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, sdkMessageRepo, db, {
+      inject: async (sessionId, message) => {
+        injectCallCount += 1;
+        if (message === '/compact') {
+          // /compact persists + returns dbId (success)
+          injections.push({ sessionId, message });
+          sdkMessageRepo.saveSDKMessage(sessionId, {
+            type: 'user',
+            message: { role: 'user', content: message },
+          } as never);
+          const row = db
+            .prepare(
+              `SELECT id FROM sdk_messages WHERE session_id = ? ORDER BY timestamp DESC, rowid DESC LIMIT 1`
+            )
+            .get(sessionId) as { id: string };
+          return row.id;
+        }
+        // continue nag always fails
+        injections.push({ sessionId, message });
+        throw new Error('session gone');
+      },
+    });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    const sessionId = 'session:nag-fail';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact (succeeds)
+    saveResultMessage(sessionId, { promptTooLong: false }); // compaction succeeded
+    await rt.executeTick(); // → continue nag (fails, attempt 1)
+    await rt.executeTick(); // → continue nag (fails, attempt 2) → blocked
+
+    expect(injections.filter((i) => i.message !== '/compact').length).toBeGreaterThanOrEqual(2);
+    expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Prompt-too-long recovery — unit + tick-loop integration tests.
+ *
+ * Covers:
+ *  - `isPromptTooLongResult` detection (terminal_reason + errors[] variants).
+ *  - The compact-then-continue state machine driven through the runtime tick:
+ *    overflow result → inject `/compact` → compacted result → continue nag.
+ *  - Bounded retries: repeated overflow escalates the execution to `blocked`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+import {
+  isPromptTooLongResult,
+  buildPromptTooLongContinueNag,
+  MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS,
+} from '../../../../src/lib/space/runtime/prompt-too-long-recovery';
+
+// ---------------------------------------------------------------------------
+// DB helpers (mirrors space-runtime-tick-loop.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+  const db = new BunDatabase(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db, () => {});
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS sdk_messages (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			message_type TEXT NOT NULL,
+			message_subtype TEXT,
+			sdk_message TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			send_status TEXT,
+			origin TEXT,
+			is_renderable INTEGER NOT NULL DEFAULT 1,
+			is_terminal INTEGER NOT NULL DEFAULT 0,
+			parent_tool_use_id TEXT,
+			task_id TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_sdk_messages_task_id ON sdk_messages(task_id);
+	`);
+  return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+  db.prepare(
+    `INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, max_concurrent_tasks, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', 1, ?, ?)`
+  ).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+  db.prepare(
+    `INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+  ).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+function buildLinearWorkflow(
+  spaceId: string,
+  workflowManager: SpaceWorkflowManager,
+  nodes: Array<{ id: string; name: string; agentId: string }>
+): SpaceWorkflow {
+  return workflowManager.createWorkflow({
+    spaceId,
+    name: `Test Workflow ${Date.now()}-${Math.random()}`,
+    description: 'Test',
+    nodes,
+    transitions: nodes.slice(0, -1).map((step, i) => ({
+      from: step.id,
+      to: nodes[i + 1].id,
+      condition: { type: 'always' as const },
+      order: 0,
+    })),
+    startNodeId: nodes[0].id,
+    rules: [],
+    tags: [],
+    completionAutonomyLevel: 3,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mock TaskAgentManager
+// ---------------------------------------------------------------------------
+
+function makeMockTaskAgentManager(
+  taskRepo: SpaceTaskRepository,
+  nodeExecutionRepo: NodeExecutionRepository,
+  inject: (sessionId: string, message: string) => Promise<string>
+) {
+  const spawned: string[] = [];
+  return {
+    isSpawning: () => false,
+    isTaskAgentAlive: () => false,
+    spawnWorkflowNodeAgent: async (task: unknown) => {
+      const t = task as { id: string };
+      spawned.push(t.id);
+      taskRepo.updateTask(t.id, { taskAgentSessionId: `session:${t.id}` });
+      return `session:${t.id}`;
+    },
+    isExecutionSpawning: () => false,
+    isSessionAlive: () => true,
+    spawnWorkflowNodeAgentForExecution: async (
+      task: unknown,
+      _space: unknown,
+      _workflow: unknown,
+      _run: unknown,
+      execution: unknown
+    ) => {
+      const e = execution as { id?: string };
+      const t = task as { id?: string };
+      const executionId = e.id ?? t.id ?? `exec-${Math.random().toString(36).slice(2)}`;
+      const sessionId = `session:${executionId}`;
+      spawned.push(t.id ?? executionId);
+      if (e.id) {
+        nodeExecutionRepo.update(e.id, {
+          status: 'in_progress',
+          agentSessionId: sessionId,
+          startedAt: Date.now(),
+          completedAt: null,
+        });
+      }
+      return sessionId;
+    },
+    rehydrate: async () => {},
+    cancelBySessionId: () => {},
+    interruptBySessionId: async () => {},
+    restartStuckSubSession: async () => {},
+    injectRuntimeRecoveryMessage: inject,
+    getAgentSessionById: () => ({ getProcessingState: () => ({ status: 'processing' }) }),
+    injectIntoTaskAgent: async () => ({ injected: false, reason: 'no-session' }),
+    _spawned: spawned,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isPromptTooLongResult', () => {
+  test('matches result with terminal_reason prompt_too_long', () => {
+    const msg = {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      terminal_reason: 'prompt_too_long',
+      errors: [],
+    };
+    expect(isPromptTooLongResult(msg as never)).toBe(true);
+  });
+
+  test('matches result with prompt-too-long error body (no terminal_reason)', () => {
+    const msg = {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      errors: ['prompt is too long: 205616 tokens > 200000 maximum'],
+    };
+    expect(isPromptTooLongResult(msg as never)).toBe(true);
+  });
+
+  test('matches prompt-too-long error body without N>M form', () => {
+    const msg = {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      errors: ['Prompt is too long'],
+    };
+    expect(isPromptTooLongResult(msg as never)).toBe(true);
+  });
+
+  test('rejects success result', () => {
+    const msg = { type: 'result', subtype: 'success', is_error: false, errors: [] };
+    expect(isPromptTooLongResult(msg as never)).toBe(false);
+  });
+
+  test('rejects max_turns error result', () => {
+    const msg = {
+      type: 'result',
+      subtype: 'error_max_turns',
+      is_error: true,
+      terminal_reason: 'max_turns',
+      errors: ['max_turns exceeded'],
+    };
+    expect(isPromptTooLongResult(msg as never)).toBe(false);
+  });
+
+  test('rejects non-result messages and null', () => {
+    expect(isPromptTooLongResult({ type: 'assistant' } as never)).toBe(false);
+    expect(isPromptTooLongResult(null)).toBe(false);
+    expect(isPromptTooLongResult(undefined)).toBe(false);
+  });
+});
+
+describe('SpaceRuntime — prompt-too-long recovery', () => {
+  let db: BunDatabase;
+  let workflowRunRepo: SpaceWorkflowRunRepository;
+  let taskRepo: SpaceTaskRepository;
+  let agentManager: SpaceAgentManager;
+  let workflowManager: SpaceWorkflowManager;
+  let spaceManager: SpaceManager;
+  let nodeExecutionRepo: NodeExecutionRepository;
+  let sdkMessageRepo: SDKMessageRepository;
+  let internalEventBus: InternalEventBus<DaemonInternalEventMap>;
+
+  const SPACE_ID = 'space-ptl';
+  const AGENT = 'agent-worker';
+  const STEP_A = 'step-a';
+
+  beforeEach(() => {
+    db = makeDb();
+    seedSpaceRow(db, SPACE_ID);
+    seedAgentRow(db, AGENT, SPACE_ID, 'Worker');
+    workflowRunRepo = new SpaceWorkflowRunRepository(db);
+    taskRepo = new SpaceTaskRepository(db);
+    nodeExecutionRepo = new NodeExecutionRepository(db);
+    sdkMessageRepo = new SDKMessageRepository(db);
+    agentManager = new SpaceAgentManager(new SpaceAgentRepository(db));
+    workflowManager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+    spaceManager = new SpaceManager(db);
+    internalEventBus = new InternalEventBus<DaemonInternalEventMap>();
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  function buildConfig(tam: unknown): SpaceRuntimeConfig {
+    return {
+      db,
+      spaceManager,
+      spaceAgentManager: agentManager,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      sdkMessageRepo,
+      internalEventBus,
+      taskAgentManager: tam as never,
+      agentNoProgressThresholdMs: 60_000,
+    };
+  }
+
+  /** Save a result SDK message as the last message for a session. */
+  function saveResultMessage(
+    sessionId: string,
+    opts: { promptTooLong?: boolean; minutesAgo?: number }
+  ): void {
+    const message = {
+      type: 'result',
+      subtype: opts.promptTooLong ? 'error_during_execution' : 'success',
+      is_error: !!opts.promptTooLong,
+      terminal_reason: opts.promptTooLong ? 'prompt_too_long' : 'completed',
+      errors: opts.promptTooLong ? ['prompt is too long: 205616 tokens > 200000 maximum'] : [],
+      result: opts.promptTooLong ? '' : 'ok',
+    };
+    sdkMessageRepo.saveSDKMessage(sessionId, message as never);
+    const minutesAgo = opts.minutesAgo ?? 20;
+    const ts = new Date(Date.now() - minutesAgo * 60_000).toISOString();
+    db.prepare(`UPDATE sdk_messages SET timestamp = ? WHERE session_id = ?`).run(ts, sessionId);
+  }
+
+  /** Remove every SDK message for a session (used to swap the "last" message). */
+  function clearMessages(sessionId: string): void {
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(sessionId);
+  }
+
+  function promptTooLongRecoveryMap(
+    rt: SpaceRuntime
+  ): Map<string, { compactAttempts: number; awaitingContinue: boolean }> {
+    return (
+      rt as unknown as {
+        promptTooLongRecovery: Map<string, { compactAttempts: number; awaitingContinue: boolean }>;
+      }
+    ).promptTooLongRecovery;
+  }
+
+  test('compacts then continues when an idle execution overflows', async () => {
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const tam = makeMockTaskAgentManager(
+      taskRepo,
+      nodeExecutionRepo,
+      async (sessionId, message) => {
+        injections.push({ sessionId, message });
+        return `injected:${injections.length}`;
+      }
+    );
+    const rt = new SpaceRuntime(buildConfig(tam));
+    const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+      { id: STEP_A, name: 'Work', agentId: AGENT },
+    ]);
+    const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+    const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+    const sessionId = 'session:overflow';
+    nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
+    saveResultMessage(sessionId, { promptTooLong: true });
+
+    // Tick 1: overflow detected → inject /compact FIRST.
+    await rt.executeTick();
+    expect(injections.map((i) => i.message)).toEqual(['/compact']);
+    const state = promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`);
+    expect(state?.compactAttempts).toBe(1);
+    expect(state?.awaitingContinue).toBe(true);
+
+    // Simulate compaction completing: replace the last message with a success result.
+    clearMessages(sessionId);
+    saveResultMessage(sessionId, { promptTooLong: false });
+
+    // Tick 2: last message no longer overflow → inject the continue nag.
+    await rt.executeTick();
+    expect(injections.map((i) => i.message)).toEqual(['/compact', buildPromptTooLongContinueNag()]);
+    expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.awaitingContinue).toBe(
+      false
+    );
+  });
+
+  test('does not double-inject /compact while awaiting the compacted result', async () => {
+    const injections: string[] = [];
+    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, async (_sid, message) => {
+      injections.push(message);
+      return 'ok';
+    });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+      { id: STEP_A, name: 'Work', agentId: AGENT },
+    ]);
+    const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+    const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+    const sessionId = 'session:overflow2';
+    nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
+    saveResultMessage(sessionId, { promptTooLong: true });
+
+    await rt.executeTick();
+    // The last message is still the overflow result — a second tick must NOT
+    // inject another /compact (awaitingContinue guard).
+    await rt.executeTick();
+    expect(injections).toEqual(['/compact']);
+    expect(promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`)?.compactAttempts).toBe(1);
+  });
+
+  test('escalates to blocked after MAX attempts when compaction cannot help', async () => {
+    const injections: string[] = [];
+    const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, async (_sid, message) => {
+      injections.push(message);
+      return 'ok';
+    });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+      { id: STEP_A, name: 'Work', agentId: AGENT },
+    ]);
+    const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+    const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+    const sessionId = 'session:unrecoverable';
+    nodeExecutionRepo.update(execution.id, { status: 'idle', agentSessionId: sessionId });
+
+    const continueNag = buildPromptTooLongContinueNag();
+    // Realistic "compaction can't help" cycle: each /compact shrinks context
+    // (success result → continue nag), but the session re-overflows on the next
+    // turn because a single message already exceeds the limit.
+    // Cycle 1
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick(); // → /compact (attempt 1)
+    clearMessages(sessionId);
+    saveResultMessage(sessionId, { promptTooLong: false });
+    await rt.executeTick(); // → continue nag
+    // Cycle 2
+    clearMessages(sessionId);
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick(); // → /compact (attempt 2)
+    clearMessages(sessionId);
+    saveResultMessage(sessionId, { promptTooLong: false });
+    await rt.executeTick(); // → continue nag
+    // Cycle 3: attempts exhausted → escalate to blocked
+    clearMessages(sessionId);
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick();
+
+    expect(injections).toEqual(['/compact', continueNag, '/compact', continueNag]);
+    const updated = nodeExecutionRepo.getById(execution.id);
+    expect(updated?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+    expect(promptTooLongRecoveryMap(rt).has(`${run.id}:${execution.id}`)).toBe(false);
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/prompt-too-long-recovery.test.ts
@@ -552,6 +552,43 @@ describe('SpaceRuntime — prompt-too-long recovery', () => {
     expect(injections.filter((i) => i.message === '/compact').length).toBe(2);
   });
 
+  test('preserves attempts even when the resume nag is consumed (visible)', async () => {
+    // Round-8 regression: production consumes the nag before
+    // injectRuntimeRecoveryMessage returns (enqueueWithId resolves after the SDK
+    // consumes it), so getLastSDKMessage INCLUDES the nag as a user message.
+    // awaitingResume must still wait for a resumed-turn RESULT, not clear on the
+    // consumed nag itself — otherwise attempts reset and the edge loop recurs.
+    const injections: Array<{ sessionId: string; message: string }> = [];
+    const rt = new SpaceRuntime(buildConfig(makeRecordingTam(injections)));
+    const sessionId = 'session:nag-consumed';
+    const { run, execution } = await setupIdleOverflowExecution(rt, sessionId, true);
+
+    await rt.executeTick(); // → /compact (attempt 1)
+    saveResultMessage(sessionId, { promptTooLong: false }); // compact success
+    await rt.executeTick(); // → continue nag delivered (awaitingResume=true)
+
+    // Simulate production: the nag is consumed (visible to getLastSDKMessage).
+    db.prepare(
+      `UPDATE sdk_messages SET send_status = 'consumed'
+       WHERE id = (
+         SELECT id FROM sdk_messages
+         WHERE session_id = ? AND message_type = 'user'
+         ORDER BY timestamp DESC, rowid DESC LIMIT 1
+       )`
+    ).run(sessionId);
+
+    // Tick with the consumed nag as the last message — must NOT clear the state
+    // (the nag is a user message, not a resumed-turn result).
+    await rt.executeTick();
+    const preserved = promptTooLongRecoveryMap(rt).get(`${run.id}:${execution.id}`);
+    expect(preserved?.compactAttempts).toBe(1);
+
+    // Resumed turn overflows → re-compact with attempts preserved (attempt 2).
+    saveResultMessage(sessionId, { promptTooLong: true });
+    await rt.executeTick();
+    expect(injections.filter((i) => i.message === '/compact').length).toBe(2);
+  });
+
   test('escalates to blocked when the /compact turn hangs (wait timeout)', async () => {
     // P2: if the /compact turn never produces a result, awaitingContinue must not
     // wait forever — the recovery escalates after COMPACT_RESULT_TIMEOUT_MS.


### PR DESCRIPTION
## What

Worker/node-agent sessions that overflow their context window receive a terminal `prompt_too_long` result. The idle sweep treated any result as a safe terminal point and skipped it, so the execution stuck forever — flagged Recoverable but **no recovery ran**. A naive auto-continue re-hits the same wall, so this recovery **compacts FIRST, then continues**.

## Changes

**Reactive recovery (core)**
- New `packages/daemon/src/lib/space/runtime/prompt-too-long-recovery.ts`:
  - `isPromptTooLongResult()` — detects the signature from a result message via `terminal_reason === 'prompt_too_long'` or `errors[]` matching `/prompt is too long/i`.
  - `buildPromptTooLongContinueNag()` + `MAX_PROMPT_TOO_LONG_RECOVERY_ATTEMPTS` (2).
- `SpaceRuntime.handleNonTerminalIdleExecutions` now intercepts a prompt-too-long terminal result **before** the terminal skip and runs a compact-then-continue state machine:
  1. overflow detected → inject `/compact` (reuses the existing messageQueue primitive from `sdk-message-handler.ts`)
  2. once the last message is no longer an overflow result (context dropped below the limit) → inject a "resume your work" nag
  3. `awaitingContinue` guard prevents double-`/compact` while the old result is still the last persisted message
  4. after `MAX` compactions that don't help → escalate execution + run to `blocked`

**Preventive (dead-zone elimination)**
- `buildProviderSettings()` no longer returns `{ autoCompactEnabled: false }` for a non-native provider with an unknown context window — that was a silent dead zone (no SDK compact, no NeoKai fallback) guaranteeing overflow. It now returns `undefined` so the SDK's built-in auto-compact (enabled by default) runs. Kimi's explicit disable + NeoKai fallback is unchanged.

## Why this is safe
- The continue nag fires **only** after compaction proves effective (last message is no longer prompt-too-long), so it never re-hits the wall.
- Shrinkage is self-verifying: a re-overflow after continue increments the attempt counter and escalates to `blocked`.
- Bounded retries (cap = 2).

## Tests
- `isPromptTooLongResult` unit tests (terminal_reason, errors variants, rejects success/max_turns).
- Tick-loop integration: overflow → `/compact` → continue nag; double-inject guard; escalation to `blocked`.
- Updated `buildProviderSettings` dead-zone test.
- All 1150 space-runtime tests + 158 query-options-builder tests pass; `bun run check` clean.

Closes #670