### PR TITLE
feat(space-runtime): auto-continue on terminal error results

### DIFF
--- a/packages/daemon/src/lib/space/runtime/constants.ts
+++ b/packages/daemon/src/lib/space/runtime/constants.ts
@@ -53,6 +53,20 @@ export const DEFAULT_TOOL_USE_ACTIVE_TTL_MS = 60 * 60 * 1000;
 export const MAX_AGENT_STUCK_RESTARTS = 1;
 
 /**
+ * Maximum number of automatic "continue" injections for a node-agent session
+ * that ended on a terminal error result (e.g. Codex 400, error_during_execution).
+ *
+ * A worker whose SDK stream terminates with an error subtype leaves the node
+ * idle with a *live* session and no recovery fires — this cap bounds the
+ * runtime's auto-continue before escalating to `blocked` (where
+ * `attemptBlockedRunRecovery`, capped by `MAX_BLOCKED_RUN_RETRIES`, takes over
+ * with a fresh re-spawn). Deterministic repeats (identical error signature) are
+ * escalated immediately regardless of this count, since a plain continue cannot
+ * fix them.
+ */
+export const MAX_TERMINAL_ERROR_CONTINUE_RETRIES = 2;
+
+/**
  * Maximum number of automatic recovery attempts for a blocked workflow run.
  *
  * When a workflow run enters `blocked` status (e.g. a node agent failed after

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7042,6 +7042,17 @@ export class SpaceRuntime {
       (execution) => execution.status === 'idle' && !!execution.agentSessionId
     );
 
+    // Index executions by session so per-session guards can be checked across
+    // EVERY row sharing a session (a reused agent can leave tool-continuation
+    // or #670 prompt-too-long state on a sibling idle row, not the newest one).
+    const executionsBySession = new Map<string, NodeExecution[]>();
+    for (const ex of allExecutions) {
+      if (!ex.agentSessionId) continue;
+      const list = executionsBySession.get(ex.agentSessionId);
+      if (list) list.push(ex);
+      else executionsBySession.set(ex.agentSessionId, [ex]);
+    }
+
     // A reused named-agent session can have a newer activation in_progress while
     // older rows remain idle. Skip any session that already has an active
     // (in_progress/pending) owner — that session is processing the new
@@ -7073,12 +7084,18 @@ export class SpaceRuntime {
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const key = `${runId}:${execution.id}`;
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
+      // Guards below are checked across EVERY row sharing this session: a reused
+      // agent can leave #670 prompt-too-long state or an active tool continuation
+      // on a sibling idle row, not the newest one selected here.
+      const sessionExecutions = executionsBySession.get(sessionId) ?? [execution];
 
-      // Deerring to #670: if its prompt-too-long state machine owns this
-      // execution it may be mid-compact even when the latest result is a
-      // non-overflow error_during_execution; a terminal-error continue here
-      // would race that recovery.
-      if (this.promptTooLongRecovery.has(key)) continue;
+      // Defer to #670: if its prompt-too-long state machine owns ANY execution for
+      // this session it may be mid-compact even when the latest result is a
+      // non-overflow error_during_execution; a terminal-error continue here would
+      // race that recovery.
+      if (sessionExecutions.some((e) => this.promptTooLongRecovery.has(`${runId}:${e.id}`))) {
+        continue;
+      }
       // Defer over-long-context results to #670 (compaction), not a plain
       // continue — continuing won't shrink the context.
       if (this.isPromptTooLongResultError(lastMessage)) continue;
@@ -7094,10 +7111,15 @@ export class SpaceRuntime {
 
       // Preserve executions with active tool continuations BEFORE the dead-session
       // reset — the pending tool_result is the next valid transcript item, and
-      // resetting/clearing the session here would orphan/409 it. Mirrors the
-      // guard in handleNonTerminalIdleExecutions.
-      if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id)) continue;
-      if (this.toolContinuationRepo.listPendingInboxForExecution(execution.id).length > 0) {
+      // resetting/clearing the session here would orphan/409 it. Checked across
+      // all rows sharing the session (mirrors handleNonTerminalIdleExecutions).
+      if (
+        sessionExecutions.some(
+          (e) =>
+            this.toolContinuationRepo.hasActiveToolUseForExecution(e.id) ||
+            this.toolContinuationRepo.listPendingInboxForExecution(e.id).length > 0
+        )
+      ) {
         continue;
       }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -60,6 +60,7 @@ import { ToolContinuationRecoveryRepository } from '../../../storage/repositorie
 import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import { Logger } from '../../logger';
+import { isSDKResultError } from '@neokai/shared/sdk';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceManager } from '../managers/space-manager';
 import { isValidSpaceTaskTransition, SpaceTaskManager } from '../managers/space-task-manager';
@@ -81,6 +82,7 @@ import {
   MAX_AGENT_STUCK_RESTARTS,
   MAX_BLOCKED_RUN_RETRIES,
   MAX_TASK_AGENT_CRASH_RETRIES,
+  MAX_TERMINAL_ERROR_CONTINUE_RETRIES,
 } from './constants';
 import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
@@ -426,6 +428,23 @@ interface NonTerminalIdleState {
   failedNudgeCount: number;
   lastNudgeAt: number | null;
   lastAttentionLogAt: number | null;
+}
+
+/**
+ * Recovery state for a node-agent session that ended on a terminal error
+ * result. Tracks the number of auto-continue injections and the normalized
+ * error signature of the last error we continued past, so a deterministic
+ * repeat (identical signature) can be escalated instead of looped on.
+ *
+ * `lastSessionId` detects a re-spawn (new session after `blocked` recovery):
+ * the count resets so a genuinely restarted session gets a fresh budget, while
+ * the total stays bounded by `MAX_BLOCKED_RUN_RETRIES`.
+ */
+interface TerminalErrorContinueState {
+  lastSessionId: string | null;
+  continueCount: number;
+  lastRetriedErrorSignature: string | null;
+  lastContinueAt: number | null;
 }
 
 const NON_TERMINAL_IDLE_FAILED_NUDGE_RETRY_MS = 60 * 1000;
@@ -982,6 +1001,15 @@ export class SpaceRuntime {
    * then repeated qualified idle is logged for human visibility.
    */
   private nonTerminalIdleStates = new Map<string, NonTerminalIdleState>();
+
+  /**
+   * In-memory recovery state keyed by `${runId}:${nodeExecutionId}` for
+   * node-agent sessions that ended on a terminal error result.
+   *
+   * Bounds auto-continue injections (`MAX_TERMINAL_ERROR_CONTINUE_RETRIES`)
+   * before escalating to `blocked`, and short-circuits deterministic repeats.
+   */
+  private terminalErrorContinueStates = new Map<string, TerminalErrorContinueState>();
 
   /**
    * In-memory Layer 1 recovery state keyed by `${runId}:${nodeExecutionId}`.
@@ -5186,6 +5214,11 @@ export class SpaceRuntime {
         this.promptTooLongRecovery.delete(key);
       }
     }
+    for (const key of this.terminalErrorContinueStates.keys()) {
+      if (key.startsWith(runId + ':')) {
+        this.terminalErrorContinueStates.delete(key);
+      }
+    }
   }
 
   private getAgentNoProgressThresholdMs(workflow: SpaceWorkflow, execution: NodeExecution): number {
@@ -6059,6 +6092,24 @@ export class SpaceRuntime {
       }
       nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
+      // Catch-all recovery: a node-agent session that ended on a terminal error
+      // result (e.g. Codex 400, error_during_execution) leaves the node idle
+      // with a *live* session that no other sweep recovers — the result is
+      // classified terminal so the non-terminal-idle and alive-stuck paths both
+      // bail. Auto-continue once/twice, then escalate to `blocked` so
+      // attemptBlockedRunRecovery takes over with its own bounded re-spawn.
+      const terminalErrorOutcome = await this.handleTerminalErrorIdleExecutions(
+        runId,
+        meta.spaceId,
+        canonicalTask,
+        tam,
+        space ?? null
+      );
+      if (terminalErrorOutcome === 'blocked') {
+        return;
+      }
+      nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+
       if (
         canonicalTask.status === 'done' ||
         canonicalTask.status === 'cancelled' ||
@@ -6922,6 +6973,264 @@ export class SpaceRuntime {
       }
     }
     return preservedAny ? 'preserved' : 'none';
+  }
+
+  /**
+   * Catch-all recovery for idle node-agent sessions that ended on a terminal
+   * error result (e.g. Codex 400, `error_during_execution`).
+   *
+   * The result is classified `terminal`, so neither `handleAliveStuckExecutions`
+   * nor `handleNonTerminalIdleExecutions` acts on it — the node silently goes
+   * idle with a live session and no recovery fires. This sweep injects a bounded
+   * number of "continue" messages via the same primitive a manual continue uses
+   * (`tam.injectRuntimeRecoveryMessage`), then escalates to `blocked` so
+   * `attemptBlockedRunRecovery` takes over with its own re-spawn cap.
+   *
+   * Guards (see task #673):
+   * - Only retryable subtypes (`error_during_execution`, `error_max_turns`).
+   *   Cost (`error_max_budget_usd`) and structured-output exhaustion are skipped.
+   * - Prompt-too-long results are skipped (deferred to #670 compaction).
+   * - Only when the task is `in_progress` with no `reportedStatus` and the
+   *   session is still alive.
+   * - Per-execution retry cap (`MAX_TERMINAL_ERROR_CONTINUE_RETRIES`).
+   * - Deterministic repeats (identical error signature) escalate immediately.
+   * - Grace cooldown between attempts (mirrors the alive-stuck nag grace).
+   */
+  private async handleTerminalErrorIdleExecutions(
+    runId: string,
+    spaceId: string,
+    canonicalTask: SpaceTask,
+    tam: TaskAgentManager,
+    space?: Space | null
+  ): Promise<'none' | 'continued' | 'blocked'> {
+    if (space?.paused || space?.stopped) return 'none';
+
+    // Explicit completion / review signals are authoritative — a final tool
+    // call may have parked the task even if the error result row persisted.
+    if (
+      canonicalTask.reportedStatus !== null ||
+      canonicalTask.status === 'review' ||
+      canonicalTask.status === 'approved' ||
+      canonicalTask.status === 'done' ||
+      canonicalTask.status === 'cancelled' ||
+      canonicalTask.status === 'archived'
+    ) {
+      return 'none';
+    }
+    if (canonicalTask.status !== 'in_progress') return 'none';
+
+    const graceMs = this.config.agentStuckNagGraceMs ?? DEFAULT_AGENT_STUCK_NAG_GRACE_MS;
+    const now = Date.now();
+
+    const idleExecutions = this.config.nodeExecutionRepo
+      .listByWorkflowRun(runId)
+      .filter((execution) => execution.status === 'idle' && !!execution.agentSessionId);
+
+    for (const execution of idleExecutions) {
+      const sessionId = execution.agentSessionId;
+      if (!sessionId) continue;
+
+      // Only recover live sessions — a dead session is owned by the crash-retry
+      // path in processRunTick (resetWorkflowNodeExecutionForSpawnRetry).
+      if (!tam.isSessionAlive(sessionId)) continue;
+
+      const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
+      if (!lastMessage || !isSDKResultError(lastMessage)) continue;
+
+      // Only retryable subtypes. Cost guard and structured-output exhaustion are
+      // non-retryable; auth errors arrive via session.error/blocked instead.
+      if (
+        lastMessage.subtype !== 'error_during_execution' &&
+        lastMessage.subtype !== 'error_max_turns'
+      ) {
+        continue;
+      }
+
+      // Defer over-long-context results to #670 (compaction), not a plain
+      // continue — continuing won't shrink the context.
+      if (this.isPromptTooLongResultError(lastMessage)) continue;
+
+      const key = `${runId}:${execution.id}`;
+      const state =
+        this.terminalErrorContinueStates.get(key) ??
+        ({
+          lastSessionId: sessionId,
+          continueCount: 0,
+          lastRetriedErrorSignature: null,
+          lastContinueAt: null,
+        } satisfies TerminalErrorContinueState);
+      this.terminalErrorContinueStates.set(key, state);
+
+      // A re-spawn (e.g. after blocked recovery) produces a new session id.
+      // Reset the budget so a genuinely restarted session gets a fresh chance;
+      // total attempts stay bounded by MAX_BLOCKED_RUN_RETRIES.
+      if (state.lastSessionId !== sessionId) {
+        state.lastSessionId = sessionId;
+        state.continueCount = 0;
+        state.lastRetriedErrorSignature = null;
+        state.lastContinueAt = null;
+      }
+
+      const signature = this.computeTerminalErrorSignature(lastMessage);
+
+      // Deterministic repeat: a plain continue already failed to clear this
+      // exact error, so looping again cannot help — escalate to blocked.
+      if (state.lastRetriedErrorSignature === signature) {
+        await this.escalateTerminalErrorToBlocked(
+          runId,
+          spaceId,
+          canonicalTask,
+          execution,
+          lastMessage,
+          `Terminal error recurred with an identical signature after a runtime continue (${signature})`
+        );
+        return 'blocked';
+      }
+
+      // Retry cap exhausted — escalate to blocked so attemptBlockedRunRecovery
+      // can attempt a single bounded re-spawn.
+      if (state.continueCount >= MAX_TERMINAL_ERROR_CONTINUE_RETRIES) {
+        await this.escalateTerminalErrorToBlocked(
+          runId,
+          spaceId,
+          canonicalTask,
+          execution,
+          lastMessage,
+          `Terminal error persisted after ${state.continueCount} runtime continue(s) (${signature})`
+        );
+        return 'blocked';
+      }
+
+      // Grace cooldown between attempts — give the agent time to reach a turn
+      // boundary and act on the previous continue before injecting another.
+      if (state.lastContinueAt !== null && now - state.lastContinueAt < graceMs) {
+        continue;
+      }
+
+      try {
+        await tam.injectRuntimeRecoveryMessage(
+          sessionId,
+          this.buildTerminalErrorContinueMessage(execution, lastMessage)
+        );
+        state.continueCount += 1;
+        state.lastContinueAt = now;
+        state.lastRetriedErrorSignature = signature;
+        log.warn(
+          `Node ${execution.workflowNodeId} ended idle on a terminal error result; ` +
+            `sent runtime continue ${state.continueCount}/${MAX_TERMINAL_ERROR_CONTINUE_RETRIES}: ` +
+            `execution=${execution.id} agent=${execution.agentName} session=${sessionId} ` +
+            `subtype=${lastMessage.subtype} signature=${signature}`
+        );
+      } catch (error) {
+        // Apply the grace cooldown even on failure so a transiently-failing
+        // injection (e.g. a rehydrate race) can't tight-loop every tick. The
+        // count/signature stay unset so a later success still counts correctly;
+        // a persistently-dead session is caught by the isSessionAlive guard.
+        state.lastContinueAt = now;
+        log.warn(
+          `Failed to send runtime continue for terminal-error idle node ${execution.workflowNodeId}; ` +
+            `needs attention: execution=${execution.id} agent=${execution.agentName} ` +
+            `session=${sessionId} signature=${signature}: ${formatCommandError(error)}`
+        );
+      }
+    }
+    return 'none';
+  }
+
+  /**
+   * Escalate a terminal-error-idle execution to `blocked`, mirroring the
+   * alive-stuck blocked path so `attemptBlockedRunRecovery` picks it up on the
+   * next tick with its own `MAX_BLOCKED_RUN_RETRIES` re-spawn cap.
+   */
+  private async escalateTerminalErrorToBlocked(
+    runId: string,
+    spaceId: string,
+    canonicalTask: SpaceTask,
+    execution: NodeExecution,
+    errorResult: { subtype: string; errors?: string[] },
+    detail: string
+  ): Promise<void> {
+    const errorSnippet = (errorResult.errors ?? []).join('; ').slice(0, 280);
+    const reason =
+      `Agent session ended on a terminal error result and exhausted runtime auto-continue recovery ` +
+      `(node ${execution.workflowNodeId}, agent ${execution.agentName}, subtype ${errorResult.subtype}): ` +
+      `${detail}${errorSnippet ? ` — ${errorSnippet}` : ''}`;
+    this.config.nodeExecutionRepo.update(execution.id, {
+      status: 'blocked',
+      result: reason,
+    });
+    await this.transitionRunStatusAndEmit(runId, 'blocked');
+    await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+      status: 'blocked',
+      result: reason,
+      blockReason: 'execution_failed',
+      completedAt: null,
+    });
+    const dedupKey = `${canonicalTask.id}:blocked`;
+    if (!this.notifiedTaskSet.has(dedupKey)) {
+      this.notifiedTaskSet.add(dedupKey);
+      await this.safeNotify({
+        kind: 'task_blocked',
+        spaceId,
+        taskId: canonicalTask.id,
+        reason,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    await this.safeNotify({
+      kind: 'workflow_run_blocked',
+      spaceId,
+      runId,
+      reason,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Normalized signature for a terminal error result, used to detect
+   * deterministic repeats (same subtype + terminal_reason + error strings).
+   */
+  private computeTerminalErrorSignature(message: {
+    subtype: string;
+    terminal_reason?: string;
+    errors?: string[];
+  }): string {
+    const terminalReason =
+      typeof message.terminal_reason === 'string' ? message.terminal_reason : '';
+    // Errors can be verbose; trim each so a recurring identical failure matches
+    // while an unrelated new error does not.
+    const errors = (message.errors ?? []).map((entry) => entry.trim().slice(0, 200));
+    return `${message.subtype}|${terminalReason}|${errors.join('\n')}`;
+  }
+
+  /**
+   * Whether a terminal error result represents an over-long-context failure.
+   * Such results must compact (#670) rather than receive a plain continue,
+   * which would only re-hit the same context limit.
+   */
+  private isPromptTooLongResultError(message: {
+    terminal_reason?: string;
+    errors?: string[];
+  }): boolean {
+    if (message.terminal_reason === 'prompt_too_long') return true;
+    return (message.errors ?? []).some((entry) => /prompt is too long/i.test(entry));
+  }
+
+  private buildTerminalErrorContinueMessage(
+    execution: NodeExecution,
+    errorResult: { subtype: string; errors?: string[] }
+  ): string {
+    const errorSummary = (errorResult.errors ?? []).join('; ').slice(0, 280);
+    return [
+      '[Runtime recovery — terminal error]',
+      '',
+      `Your previous turn ended with a terminal error result (${errorResult.subtype})` +
+        `${errorSummary ? `: ${errorSummary}` : ''}.`,
+      `The error appears transient. Resume your assigned task for node ${execution.workflowNodeId}` +
+        ` (agent ${execution.agentName}) from the current repository and workflow state.`,
+      'Inspect task/workflow status, recent messages, and any partial work before continuing.',
+      'If the same error recurs, report the blocker clearly through the available workflow tools.',
+    ].join('\n');
   }
 
   private async handleWaitingRebindExecutions(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7037,21 +7037,31 @@ export class SpaceRuntime {
     const graceMs = this.config.agentStuckNagGraceMs ?? DEFAULT_AGENT_STUCK_NAG_GRACE_MS;
     const now = Date.now();
 
-    const idleExecutions = this.config.nodeExecutionRepo
-      .listByWorkflowRun(runId)
-      .filter((execution) => execution.status === 'idle' && !!execution.agentSessionId);
+    const allExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+    const idleExecutions = allExecutions.filter(
+      (execution) => execution.status === 'idle' && !!execution.agentSessionId
+    );
 
-    // Sessions can be reused across node activations (createSubSession points
-    // multiple execution rows at the same agentSessionId), and createSubSession
-    // treats the NEWEST such row as the current execution for the session.
-    // listByWorkflowRun returns rows in created_at ASC, so a naive "first idle
-    // row wins" dedup would attach recovery/blocked-escalation to a STALE node.
-    // Group by session and keep only the newest execution per agentSessionId so
-    // recovery targets the current activation, and each shared session is
-    // processed at most once per tick (no double-injected continues).
+    // A reused named-agent session can have a newer activation in_progress while
+    // older rows remain idle. Skip any session that already has an active
+    // (in_progress/pending) owner — that session is processing the new
+    // activation and must not be recovered via the stale idle row.
+    const activeSessions = new Set<string>();
+    for (const ex of allExecutions) {
+      if (ex.agentSessionId && (ex.status === 'in_progress' || ex.status === 'pending')) {
+        activeSessions.add(ex.agentSessionId);
+      }
+    }
+
+    // createSubSession treats the NEWEST execution for a session as current
+    // (listByWorkflowRun is created_at ASC). Group by session, keep the newest
+    // idle row per session (excluding active-owner sessions), so recovery
+    // targets the current activation and each shared session is processed at
+    // most once per tick (no double-injected continues).
     const newestPerSession = new Map<string, NodeExecution>();
     for (const execution of idleExecutions) {
       const sid = execution.agentSessionId!;
+      if (activeSessions.has(sid)) continue;
       const existing = newestPerSession.get(sid);
       if (!existing || (execution.createdAt ?? 0) >= (existing.createdAt ?? 0)) {
         newestPerSession.set(sid, execution);
@@ -7064,6 +7074,11 @@ export class SpaceRuntime {
       const key = `${runId}:${execution.id}`;
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
 
+      // Deerring to #670: if its prompt-too-long state machine owns this
+      // execution it may be mid-compact even when the latest result is a
+      // non-overflow error_during_execution; a terminal-error continue here
+      // would race that recovery.
+      if (this.promptTooLongRecovery.has(key)) continue;
       // Defer over-long-context results to #670 (compaction), not a plain
       // continue — continuing won't shrink the context.
       if (this.isPromptTooLongResultError(lastMessage)) continue;
@@ -7074,6 +7089,15 @@ export class SpaceRuntime {
         lastMessage.subtype !== 'error_during_execution' &&
         lastMessage.subtype !== 'error_max_turns'
       ) {
+        continue;
+      }
+
+      // Preserve executions with active tool continuations BEFORE the dead-session
+      // reset — the pending tool_result is the next valid transcript item, and
+      // resetting/clearing the session here would orphan/409 it. Mirrors the
+      // guard in handleNonTerminalIdleExecutions.
+      if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id)) continue;
+      if (this.toolContinuationRepo.listPendingInboxForExecution(execution.id).length > 0) {
         continue;
       }
 
@@ -7109,22 +7133,13 @@ export class SpaceRuntime {
           );
           return 'blocked';
         }
-        // Clear the stale (dead, terminal-result-tainted) session id so the
-        // spawn loop creates a FRESH session. createSubSession reuses any prior
-        // execution row that still carries an agentSessionId (rehydrating it),
-        // which would resume from this terminal-error state instead of starting
-        // clean — defeating the re-spawn.
-        this.config.nodeExecutionRepo.update(execution.id, { agentSessionId: null });
+        // Clear the stale (dead, terminal-result-tainted) session id from EVERY
+        // row that references it so the spawn loop creates a FRESH session.
+        // createSubSession reuses the most recent execution that still carries
+        // an agentSessionId, so leaving sibling idle rows attached would
+        // resurrect this terminal-tainted session on re-spawn.
+        this.detachSessionFromAllExecutions(runId, sessionId);
         continue; // reset to pending; the spawn loop re-spawns a fresh session
-      }
-
-      // Preserve executions with active tool continuations — the next valid
-      // transcript item is the pending tool_result, and injecting a user
-      // continue here would race that delivery (orphan/409). Mirrors the guard
-      // in handleNonTerminalIdleExecutions.
-      if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id)) continue;
-      if (this.toolContinuationRepo.listPendingInboxForExecution(execution.id).length > 0) {
-        continue;
       }
 
       const state =
@@ -7256,6 +7271,21 @@ export class SpaceRuntime {
   }
 
   /**
+   * Clear an `agentSessionId` from every execution row in the run that currently
+   * references it. Used when tearing down a terminal-tainted session so that
+   * `createSubSession` (which reuses the most recent execution that still
+   * carries an agentSessionId) spawns a FRESH session instead of resurrecting
+   * the stale one via a sibling row.
+   */
+  private detachSessionFromAllExecutions(runId: string, sessionId: string): void {
+    for (const ex of this.config.nodeExecutionRepo.listByWorkflowRun(runId)) {
+      if (ex.agentSessionId === sessionId) {
+        this.config.nodeExecutionRepo.update(ex.id, { agentSessionId: null });
+      }
+    }
+  }
+
+  /**
    * Escalate a terminal-error-idle execution to `blocked`, mirroring the
    * alive-stuck blocked path so `attemptBlockedRunRecovery` picks it up on the
    * next tick with its own `MAX_BLOCKED_RUN_RETRIES` re-spawn cap.
@@ -7288,6 +7318,12 @@ export class SpaceRuntime {
           `SpaceRuntime: failed to cancel stale terminal-error session ${execution.agentSessionId} during block escalation: ${err instanceof Error ? err.message : String(err)}`
         );
       }
+      // Clear the session from EVERY row that references it. A reused named
+      // agent can have sibling idle rows pointing at the same agentSessionId;
+      // createSubSession reuses the most recent execution that still carries
+      // one, so leaving siblings attached would resurrect this terminal-tainted
+      // session on the next spawn instead of starting fresh.
+      this.detachSessionFromAllExecutions(runId, execution.agentSessionId);
     }
     this.config.nodeExecutionRepo.update(execution.id, {
       status: 'blocked',

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7049,11 +7049,27 @@ export class SpaceRuntime {
       const key = `${runId}:${execution.id}`;
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
 
+      // Defer over-long-context results to #670 (compaction), not a plain
+      // continue — continuing won't shrink the context.
+      if (this.isPromptTooLongResultError(lastMessage)) continue;
+
+      // Only retryable subtypes. Cost guard and structured-output exhaustion are
+      // non-retryable; auth errors arrive via session.error/blocked instead.
+      if (
+        lastMessage.subtype !== 'error_during_execution' &&
+        lastMessage.subtype !== 'error_max_turns'
+      ) {
+        continue;
+      }
+
       // A dead session cannot be continued. The liveness/crash-retry sweep
       // earlier in processRunTick only considers in_progress/pending rows, so
-      // an idle execution whose session died on a terminal error would
-      // otherwise sit unrecovered — reset it for a bounded re-spawn (or block
-      // if crash retries are exhausted).
+      // an idle execution whose session died on a retryable terminal error
+      // would otherwise sit unrecovered — reset it for a bounded re-spawn (or
+      // block if crash retries are exhausted). This runs AFTER the subtype
+      // guards above so non-retryable/cost-guarded subtypes are skipped
+      // consistently whether the session is live or dead (no wasteful
+      // guaranteed-to-re-fail re-spawns).
       if (!tam.isSessionAlive(sessionId)) {
         const crashExhausted = this.resetWorkflowNodeExecutionForSpawnRetry(
           runId,
@@ -7068,19 +7084,6 @@ export class SpaceRuntime {
           return 'blocked';
         }
         continue; // reset to pending; the spawn loop re-spawns a fresh session
-      }
-
-      // Defer over-long-context results to #670 (compaction), not a plain
-      // continue — continuing won't shrink the context.
-      if (this.isPromptTooLongResultError(lastMessage)) continue;
-
-      // Only retryable subtypes. Cost guard and structured-output exhaustion are
-      // non-retryable; auth errors arrive via session.error/blocked instead.
-      if (
-        lastMessage.subtype !== 'error_during_execution' &&
-        lastMessage.subtype !== 'error_max_turns'
-      ) {
-        continue;
       }
 
       const state =

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7083,7 +7083,22 @@ export class SpaceRuntime {
           ]);
           return 'blocked';
         }
+        // Clear the stale (dead, terminal-result-tainted) session id so the
+        // spawn loop creates a FRESH session. createSubSession reuses any prior
+        // execution row that still carries an agentSessionId (rehydrating it),
+        // which would resume from this terminal-error state instead of starting
+        // clean — defeating the re-spawn.
+        this.config.nodeExecutionRepo.update(execution.id, { agentSessionId: null });
         continue; // reset to pending; the spawn loop re-spawns a fresh session
+      }
+
+      // Preserve executions with active tool continuations — the next valid
+      // transcript item is the pending tool_result, and injecting a user
+      // continue here would race that delivery (orphan/409). Mirrors the guard
+      // in handleNonTerminalIdleExecutions.
+      if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id)) continue;
+      if (this.toolContinuationRepo.listPendingInboxForExecution(execution.id).length > 0) {
+        continue;
       }
 
       const state =
@@ -7137,9 +7152,16 @@ export class SpaceRuntime {
       }
 
       // Deterministic repeat (evaluated only after the grace window): a plain
-      // continue already failed to clear this exact error, so looping again
-      // cannot help — escalate to blocked.
-      if (state.lastRetriedErrorSignature === signature) {
+      // continue already failed to clear this exact error_during_execution, so
+      // looping again cannot help — escalate to blocked. error_max_turns is
+      // exempt: a same-signature max-turns result just means the agent hit the
+      // per-turn cap again (likely after making progress), not a deterministic
+      // failure, so it should consume the continueCount cap below rather than
+      // being short-circuited to a single continue.
+      if (
+        state.lastRetriedErrorSignature === signature &&
+        lastMessage.subtype === 'error_during_execution'
+      ) {
         await this.escalateTerminalErrorToBlocked(
           runId,
           spaceId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -445,6 +445,13 @@ interface TerminalErrorContinueState {
   continueCount: number;
   lastRetriedErrorSignature: string | null;
   lastContinueAt: number | null;
+  /**
+   * Consecutive failed `injectRuntimeRecoveryMessage` attempts. A live but
+   * wedged session whose injection keeps throwing would otherwise retry every
+   * grace interval forever; once this reaches the cap the execution escalates
+   * to `blocked`. Reset to 0 on any successful injection.
+   */
+  failedInjectionCount: number;
 }
 
 const NON_TERMINAL_IDLE_FAILED_NUDGE_RETRY_MS = 60 * 1000;
@@ -7058,6 +7065,7 @@ export class SpaceRuntime {
           continueCount: 0,
           lastRetriedErrorSignature: null,
           lastContinueAt: null,
+          failedInjectionCount: 0,
         } satisfies TerminalErrorContinueState);
       this.terminalErrorContinueStates.set(key, state);
 
@@ -7069,12 +7077,40 @@ export class SpaceRuntime {
         state.continueCount = 0;
         state.lastRetriedErrorSignature = null;
         state.lastContinueAt = null;
+        state.failedInjectionCount = 0;
       }
 
       const signature = this.computeTerminalErrorSignature(lastMessage);
 
-      // Deterministic repeat: a plain continue already failed to clear this
-      // exact error, so looping again cannot help — escalate to blocked.
+      // Grace cooldown FIRST. getLastSDKMessage skips user rows the SDK has not
+      // yet consumed, so immediately after a continue the last message is still
+      // the old terminal result. Evaluating the repeat/cap checks before the
+      // cooldown would block the run before the prior continue is even consumed.
+      // The grace window gives the injected continue time to take effect; only
+      // after it passes do we re-evaluate whether the error recurred.
+      if (state.lastContinueAt !== null && now - state.lastContinueAt < graceMs) {
+        continue;
+      }
+
+      // Bound persistently-failing injections: a live but wedged session whose
+      // injection keeps throwing would otherwise retry every grace interval
+      // forever. Escalate once consecutive failures reach the cap.
+      if (state.failedInjectionCount >= MAX_TERMINAL_ERROR_CONTINUE_RETRIES) {
+        await this.escalateTerminalErrorToBlocked(
+          runId,
+          spaceId,
+          canonicalTask,
+          execution,
+          lastMessage,
+          tam,
+          `runtime continue injection failed ${state.failedInjectionCount} consecutive time(s) for a live session (${signature})`
+        );
+        return 'blocked';
+      }
+
+      // Deterministic repeat (evaluated only after the grace window): a plain
+      // continue already failed to clear this exact error, so looping again
+      // cannot help — escalate to blocked.
       if (state.lastRetriedErrorSignature === signature) {
         await this.escalateTerminalErrorToBlocked(
           runId,
@@ -7082,6 +7118,7 @@ export class SpaceRuntime {
           canonicalTask,
           execution,
           lastMessage,
+          tam,
           `Terminal error recurred with an identical signature after a runtime continue (${signature})`
         );
         return 'blocked';
@@ -7096,15 +7133,10 @@ export class SpaceRuntime {
           canonicalTask,
           execution,
           lastMessage,
+          tam,
           `Terminal error persisted after ${state.continueCount} runtime continue(s) (${signature})`
         );
         return 'blocked';
-      }
-
-      // Grace cooldown between attempts — give the agent time to reach a turn
-      // boundary and act on the previous continue before injecting another.
-      if (state.lastContinueAt !== null && now - state.lastContinueAt < graceMs) {
-        continue;
       }
 
       try {
@@ -7115,6 +7147,13 @@ export class SpaceRuntime {
         state.continueCount += 1;
         state.lastContinueAt = now;
         state.lastRetriedErrorSignature = signature;
+        state.failedInjectionCount = 0;
+        // Mark the execution active so the resumed turn is monitored by the
+        // crash-retry and alive-stuck paths (which only scan in_progress). The
+        // normal sub-session completion callback returns it to `idle` when the
+        // resumed turn ends; without this, a session that hangs or dies after
+        // the injection would sit unmonitored as an idle execution.
+        this.config.nodeExecutionRepo.update(execution.id, { status: 'in_progress' });
         log.warn(
           `Node ${execution.workflowNodeId} ended idle on a terminal error result; ` +
             `sent runtime continue ${state.continueCount}/${MAX_TERMINAL_ERROR_CONTINUE_RETRIES}: ` +
@@ -7122,13 +7161,15 @@ export class SpaceRuntime {
             `subtype=${lastMessage.subtype} signature=${signature}`
         );
       } catch (error) {
-        // Apply the grace cooldown even on failure so a transiently-failing
-        // injection (e.g. a rehydrate race) can't tight-loop every tick. The
-        // count/signature stay unset so a later success still counts correctly;
-        // a persistently-dead session is caught by the isSessionAlive guard.
+        // Apply the grace cooldown on failure so a transiently-failing
+        // injection can't tight-loop every tick. The continue count/signature
+        // stay unset so a later success still counts correctly; consecutive
+        // failures are bounded by the failedInjectionCount check above.
         state.lastContinueAt = now;
+        state.failedInjectionCount += 1;
         log.warn(
-          `Failed to send runtime continue for terminal-error idle node ${execution.workflowNodeId}; ` +
+          `Failed to send runtime continue for terminal-error idle node ${execution.workflowNodeId} ` +
+            `(failure ${state.failedInjectionCount}/${MAX_TERMINAL_ERROR_CONTINUE_RETRIES}); ` +
             `needs attention: execution=${execution.id} agent=${execution.agentName} ` +
             `session=${sessionId} signature=${signature}: ${formatCommandError(error)}`
         );
@@ -7148,6 +7189,7 @@ export class SpaceRuntime {
     canonicalTask: SpaceTask,
     execution: NodeExecution,
     errorResult: { subtype: string; errors?: string[] },
+    tam: TaskAgentManager,
     detail: string
   ): Promise<void> {
     const errorSnippet = (errorResult.errors ?? []).join('; ').slice(0, 280);
@@ -7155,9 +7197,27 @@ export class SpaceRuntime {
       `Agent session ended on a terminal error result and exhausted runtime auto-continue recovery ` +
       `(node ${execution.workflowNodeId}, agent ${execution.agentName}, subtype ${errorResult.subtype}): ` +
       `${detail}${errorSnippet ? ` — ${errorSnippet}` : ''}`;
+    // Tear down the stale live session and clear the row's agentSessionId.
+    // attemptBlockedRunRecovery resets blocked executions to `pending` WITHOUT
+    // clearing agentSessionId, and the pending-repair loop re-promotes any
+    // pending execution whose agentSessionId is still alive back to
+    // in_progress — so leaving the live terminal session attached would skip
+    // the fresh re-spawn entirely and leave the run stuck on the same session.
+    if (execution.agentSessionId) {
+      try {
+        tam.cancelBySessionId(execution.agentSessionId);
+      } catch (err) {
+        log.warn(
+          `SpaceRuntime: failed to cancel stale terminal-error session ${execution.agentSessionId} during block escalation: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
     this.config.nodeExecutionRepo.update(execution.id, {
       status: 'blocked',
       result: reason,
+      agentSessionId: null,
+      startedAt: null,
+      completedAt: null,
     });
     await this.transitionRunStatusAndEmit(runId, 'blocked');
     await this.updateTaskAndEmit(spaceId, canonicalTask.id, {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7003,9 +7003,12 @@ export class SpaceRuntime {
    *   an idle dead terminal-error row would otherwise sit unrecovered).
    * - Per-execution retry cap (`MAX_TERMINAL_ERROR_CONTINUE_RETRIES`).
    * - Deterministic repeats (identical error signature) escalate immediately,
-   *   but only after the prior continue's grace window — and recovery state is
-   *   cleared once the execution observes a non-error result, so a later
-   *   recurrence in the same (reused) session gets a fresh budget.
+   *   but only after the prior continue's grace window. A genuinely recovered
+   *   session gets a fresh budget only via a re-spawn (new session id), which
+   *   `attemptBlockedRunRecovery` provides after a block — the state is NOT
+   *   reset on a non-error last message, because `getLastSDKMessage` returns
+   *   consumed user rows (e.g. the injected continue) that are not evidence of
+   *   real progress and would otherwise defeat the repeat/cap guards.
    * - Grace cooldown between attempts (mirrors the alive-stuck nag grace).
    */
   private async handleTerminalErrorIdleExecutions(
@@ -7044,20 +7047,6 @@ export class SpaceRuntime {
 
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const key = `${runId}:${execution.id}`;
-
-      // Reset recovery state once the execution has moved past the terminal
-      // error (progress / non-error result). Node-agent sessions are reused
-      // across later activations of the same task, so without this a
-      // recovered execution that later hits the same generic signature would
-      // be treated as a deterministic repeat from the earlier incident and
-      // blocked without its retry budget.
-      if (
-        this.terminalErrorContinueStates.has(key) &&
-        (!lastMessage || !isSDKResultError(lastMessage))
-      ) {
-        this.terminalErrorContinueStates.delete(key);
-      }
-
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
 
       // A dead session cannot be continued. The liveness/crash-retry sweep

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7089,6 +7089,11 @@ export class SpaceRuntime {
           sessionId
         );
         if (crashExhausted) {
+          // Clear the stale dead session on the exhausted path too, otherwise
+          // attemptBlockedRunRecovery's reset to `pending` leaves the dead
+          // agentSessionId attached and the spawn loop reuses/re-blocks it
+          // instead of trying a fresh session.
+          this.config.nodeExecutionRepo.update(execution.id, { agentSessionId: null });
           await this.blockRunForAgentCrash(runId, spaceId, canonicalTask, [
             this.config.nodeExecutionRepo.getById(execution.id) ?? execution,
           ]);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6994,13 +6994,18 @@ export class SpaceRuntime {
    * `attemptBlockedRunRecovery` takes over with its own re-spawn cap.
    *
    * Guards (see task #673):
-   * - Only retryable subtypes (`error_during_execution`, `error_max_turns`).
-   *   Cost (`error_max_budget_usd`) and structured-output exhaustion are skipped.
-   * - Prompt-too-long results are skipped (deferred to #670 compaction).
-   * - Only when the task is `in_progress` with no `reportedStatus` and the
-   *   session is still alive.
+   * - Only retryable subtypes (`error_during_execution`, `error_max_turns`) are
+   *   continued. Cost (`error_max_budget_usd`) and structured-output exhaustion
+   *   are skipped (non-retryable); prompt-too-long is deferred to #670.
+   * - Only when the task is `in_progress` with no `reportedStatus`.
+   * - A live session gets a bounded continue; a dead session is reset for a
+   *   bounded re-spawn (the crash-retry path only scans in_progress/pending, so
+   *   an idle dead terminal-error row would otherwise sit unrecovered).
    * - Per-execution retry cap (`MAX_TERMINAL_ERROR_CONTINUE_RETRIES`).
-   * - Deterministic repeats (identical error signature) escalate immediately.
+   * - Deterministic repeats (identical error signature) escalate immediately,
+   *   but only after the prior continue's grace window — and recovery state is
+   *   cleared once the execution observes a non-error result, so a later
+   *   recurrence in the same (reused) session gets a fresh budget.
    * - Grace cooldown between attempts (mirrors the alive-stuck nag grace).
    */
   private async handleTerminalErrorIdleExecutions(
@@ -7037,12 +7042,48 @@ export class SpaceRuntime {
       const sessionId = execution.agentSessionId;
       if (!sessionId) continue;
 
-      // Only recover live sessions — a dead session is owned by the crash-retry
-      // path in processRunTick (resetWorkflowNodeExecutionForSpawnRetry).
-      if (!tam.isSessionAlive(sessionId)) continue;
-
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
+      const key = `${runId}:${execution.id}`;
+
+      // Reset recovery state once the execution has moved past the terminal
+      // error (progress / non-error result). Node-agent sessions are reused
+      // across later activations of the same task, so without this a
+      // recovered execution that later hits the same generic signature would
+      // be treated as a deterministic repeat from the earlier incident and
+      // blocked without its retry budget.
+      if (
+        this.terminalErrorContinueStates.has(key) &&
+        (!lastMessage || !isSDKResultError(lastMessage))
+      ) {
+        this.terminalErrorContinueStates.delete(key);
+      }
+
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
+
+      // A dead session cannot be continued. The liveness/crash-retry sweep
+      // earlier in processRunTick only considers in_progress/pending rows, so
+      // an idle execution whose session died on a terminal error would
+      // otherwise sit unrecovered — reset it for a bounded re-spawn (or block
+      // if crash retries are exhausted).
+      if (!tam.isSessionAlive(sessionId)) {
+        const crashExhausted = this.resetWorkflowNodeExecutionForSpawnRetry(
+          runId,
+          execution,
+          `terminal-error session is no longer alive (subtype ${lastMessage.subtype})`,
+          sessionId
+        );
+        if (crashExhausted) {
+          await this.blockRunForAgentCrash(runId, spaceId, canonicalTask, [
+            this.config.nodeExecutionRepo.getById(execution.id) ?? execution,
+          ]);
+          return 'blocked';
+        }
+        continue; // reset to pending; the spawn loop re-spawns a fresh session
+      }
+
+      // Defer over-long-context results to #670 (compaction), not a plain
+      // continue — continuing won't shrink the context.
+      if (this.isPromptTooLongResultError(lastMessage)) continue;
 
       // Only retryable subtypes. Cost guard and structured-output exhaustion are
       // non-retryable; auth errors arrive via session.error/blocked instead.
@@ -7053,11 +7094,6 @@ export class SpaceRuntime {
         continue;
       }
 
-      // Defer over-long-context results to #670 (compaction), not a plain
-      // continue — continuing won't shrink the context.
-      if (this.isPromptTooLongResultError(lastMessage)) continue;
-
-      const key = `${runId}:${execution.id}`;
       const state =
         this.terminalErrorContinueStates.get(key) ??
         ({
@@ -7148,12 +7184,13 @@ export class SpaceRuntime {
         state.lastContinueAt = now;
         state.lastRetriedErrorSignature = signature;
         state.failedInjectionCount = 0;
-        // Mark the execution active so the resumed turn is monitored by the
-        // crash-retry and alive-stuck paths (which only scan in_progress). The
-        // normal sub-session completion callback returns it to `idle` when the
-        // resumed turn ends; without this, a session that hangs or dies after
-        // the injection would sit unmonitored as an idle execution.
-        this.config.nodeExecutionRepo.update(execution.id, { status: 'in_progress' });
+        // NB: the execution is intentionally left `idle`. The sweep re-evaluates
+        // idle rows every tick, so once the SDK writes the resumed turn's new
+        // last message the cooldown/repeat/cap logic re-applies naturally.
+        // Flipping to `in_progress` here would be a regression:
+        // handleSubSessionComplete is a one-shot callback that already fired for
+        // the original terminal error, so it would NOT re-fire to return the
+        // resumed turn to `idle`, leaving the row stuck in `in_progress`.
         log.warn(
           `Node ${execution.workflowNodeId} ended idle on a terminal error result; ` +
             `sent runtime continue ${state.continueCount}/${MAX_TERMINAL_ERROR_CONTINUE_RETRIES}: ` +

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7041,6 +7041,12 @@ export class SpaceRuntime {
       .listByWorkflowRun(runId)
       .filter((execution) => execution.status === 'idle' && !!execution.agentSessionId);
 
+    // Sessions can be reused across node activations (createSubSession points
+    // multiple execution rows at the same agentSessionId). Track sessions
+    // already evaluated this tick so a single terminal result on a shared
+    // session doesn't enqueue multiple continues (one per idle row).
+    const processedSessions = new Set<string>();
+
     for (const execution of idleExecutions) {
       const sessionId = execution.agentSessionId;
       if (!sessionId) continue;
@@ -7048,6 +7054,11 @@ export class SpaceRuntime {
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const key = `${runId}:${execution.id}`;
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
+      // A shared session yields the same last message for every idle row that
+      // references it — claim it on the first terminal-error match so sibling
+      // rows don't double-inject a continue in the same tick.
+      if (processedSessions.has(sessionId)) continue;
+      processedSessions.add(sessionId);
 
       // Defer over-long-context results to #670 (compaction), not a plain
       // continue — continuing won't shrink the context.

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7042,23 +7042,27 @@ export class SpaceRuntime {
       .filter((execution) => execution.status === 'idle' && !!execution.agentSessionId);
 
     // Sessions can be reused across node activations (createSubSession points
-    // multiple execution rows at the same agentSessionId). Track sessions
-    // already evaluated this tick so a single terminal result on a shared
-    // session doesn't enqueue multiple continues (one per idle row).
-    const processedSessions = new Set<string>();
-
+    // multiple execution rows at the same agentSessionId), and createSubSession
+    // treats the NEWEST such row as the current execution for the session.
+    // listByWorkflowRun returns rows in created_at ASC, so a naive "first idle
+    // row wins" dedup would attach recovery/blocked-escalation to a STALE node.
+    // Group by session and keep only the newest execution per agentSessionId so
+    // recovery targets the current activation, and each shared session is
+    // processed at most once per tick (no double-injected continues).
+    const newestPerSession = new Map<string, NodeExecution>();
     for (const execution of idleExecutions) {
-      const sessionId = execution.agentSessionId;
-      if (!sessionId) continue;
+      const sid = execution.agentSessionId!;
+      const existing = newestPerSession.get(sid);
+      if (!existing || (execution.createdAt ?? 0) >= (existing.createdAt ?? 0)) {
+        newestPerSession.set(sid, execution);
+      }
+    }
 
+    for (const execution of newestPerSession.values()) {
+      const sessionId = execution.agentSessionId!;
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const key = `${runId}:${execution.id}`;
       if (!lastMessage || !isSDKResultError(lastMessage)) continue;
-      // A shared session yields the same last message for every idle row that
-      // references it — claim it on the first terminal-error match so sibling
-      // rows don't double-inject a continue in the same tick.
-      if (processedSessions.has(sessionId)) continue;
-      processedSessions.add(sessionId);
 
       // Defer over-long-context results to #670 (compaction), not a plain
       // continue — continuing won't shrink the context.
@@ -7089,14 +7093,20 @@ export class SpaceRuntime {
           sessionId
         );
         if (crashExhausted) {
-          // Clear the stale dead session on the exhausted path too, otherwise
-          // attemptBlockedRunRecovery's reset to `pending` leaves the dead
-          // agentSessionId attached and the spawn loop reuses/re-blocks it
-          // instead of trying a fresh session.
-          this.config.nodeExecutionRepo.update(execution.id, { agentSessionId: null });
-          await this.blockRunForAgentCrash(runId, spaceId, canonicalTask, [
-            this.config.nodeExecutionRepo.getById(execution.id) ?? execution,
-          ]);
+          // Crash retries exhausted: escalate via the terminal-error path so the
+          // blockReason is 'execution_failed' (consistent with the alive-session
+          // escalation) and the stale dead session is cleared — letting the row
+          // fall to blockRunForAgentCrash would tag it 'agent_crashed' and leave
+          // agentSessionId attached for attemptBlockedRunRecovery to reuse.
+          await this.escalateTerminalErrorToBlocked(
+            runId,
+            spaceId,
+            canonicalTask,
+            execution,
+            lastMessage,
+            tam,
+            `terminal-error session died and crash-retries exhausted (subtype ${lastMessage.subtype}, signature ${this.computeTerminalErrorSignature(lastMessage)})`
+          );
           return 'blocked';
         }
         // Clear the stale (dead, terminal-result-tainted) session id so the

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -612,8 +612,8 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
   });
 
-  test('recovery state is cleared after progress so a later recurrence gets a fresh budget', async () => {
-    const { executionId } = seedIdleErrorRun({
+  test('a non-error last message (consumed continue / transient progress) does NOT reset the budget — same-signature recurrence is bounded', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['generic 400'],
     });
@@ -625,29 +625,36 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
 
-    // Simulate the continue succeeding: the agent made progress and the last
-    // message is no longer a terminal error result.
+    // Simulate the injected continue being consumed / the agent mid-turn: the
+    // last message is briefly a non-error (assistant) message. The recovery
+    // state must NOT be cleared here — getLastSDKMessage returns consumed user
+    // rows too, so resetting on any non-error message would defeat the
+    // repeat/cap guards (unbounded continues).
     db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
     sdkMessageRepo.saveSDKMessage(SESSION, {
       type: 'assistant',
       message: {
         role: 'assistant',
-        content: [{ type: 'text', text: 'done' }],
-        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'working...' }],
+        stop_reason: null,
       },
     } as never);
 
-    // Tick 2 → last message is non-error → recovery state cleared, no action.
+    // Tick 2 → non-error last message → execution skipped, no state change.
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
 
-    // The same (reused) session later hits the SAME generic terminal error.
+    // The resumed turn then fails with the SAME terminal error.
     db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
     saveResultError(SESSION, { subtype: 'error_during_execution', errors: ['generic 400'] });
 
-    // Tick 3 → state was cleared, so this is treated as a fresh incident and
-    // earns a continue (NOT an immediate deterministic-repeat block).
+    // Tick 3 → state was preserved → deterministic-repeat detected → blocked.
+    // (A fresh budget only comes from a re-spawn / new session id, not from a
+    // transient non-error last message.)
     await rt.executeTick();
-    expect(tam._injected).toHaveLength(2);
+    expect(tam._injected).toHaveLength(1);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -519,6 +519,43 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
   });
 
+  test('a shared session across idle rows injects only one continue per tick', async () => {
+    // Simulate a reused agent session: two idle node executions reference the
+    // SAME agentSessionId, both ending on the terminal error result for it.
+    const { runId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['shared-session error'],
+      sessionId: 'session:shared',
+    });
+    const second = nodeExecutionRepo.createOrIgnore({
+      workflowRunId: runId,
+      workflowNodeId: 'step-b',
+      agentName: 'Coder',
+      agentId: AGENT,
+      status: 'pending',
+    });
+    nodeExecutionRepo.update(second.id, {
+      status: 'idle',
+      agentSessionId: 'session:shared',
+      startedAt: Date.now() - 5 * 60_000,
+    });
+    expect(
+      nodeExecutionRepo
+        .listByWorkflowRun(runId)
+        .filter((e) => e.status === 'idle' && e.agentSessionId === 'session:shared')
+    ).toHaveLength(2);
+
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    // One continue for the shared session — not one per idle row.
+    expect(tam._injected).toHaveLength(1);
+    expect(tam._injected[0].sessionId).toBe('session:shared');
+  });
+
   test('task not in_progress is left alone', async () => {
     seedIdleErrorRun({ subtype: 'error_during_execution', taskStatus: 'done' });
     const tam = makeTam();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -395,8 +395,8 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
   });
 
-  test('prompt-too-long result is not continued (deferred to #670)', async () => {
-    const { executionId } = seedIdleErrorRun({
+  test('prompt-too-long result is not continued via the terminal-error sweep (deferred to #670)', async () => {
+    seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['prompt is too long: 205616 tokens > 200000 maximum'],
       terminalReason: 'prompt_too_long',
@@ -407,8 +407,11 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
 
     await rt.executeTick();
 
-    expect(tam._injected).toHaveLength(0);
-    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+    // #670 owns prompt-too-long recovery (it injects a /compact). This sweep
+    // must NOT inject its own terminal-error continue on top of it.
+    expect(
+      tam._injected.filter((m) => m.message.includes('[Runtime recovery — terminal error]'))
+    ).toHaveLength(0);
   });
 
   test('prompt-too-long detected via errors[] only (no terminal_reason) is also skipped', async () => {
@@ -422,7 +425,9 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
 
     await rt.executeTick();
 
-    expect(tam._injected).toHaveLength(0);
+    expect(
+      tam._injected.filter((m) => m.message.includes('[Runtime recovery — terminal error]'))
+    ).toHaveLength(0);
   });
 
   test('dead terminal-error session is reset for a FRESH re-spawn (stale session cleared)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -141,13 +141,16 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     } = {}
   ) {
     const injected: Array<{ sessionId: string; message: string }> = [];
+    const cancelled: string[] = [];
     return {
       isSessionAlive: overrides.isSessionAlive ?? (() => true),
       isExecutionSpawning: () => false,
       isSpawning: () => false,
       isTaskAgentAlive: () => true,
       rehydrate: async () => {},
-      cancelBySessionId: () => {},
+      cancelBySessionId: (sessionId: string) => {
+        cancelled.push(sessionId);
+      },
       interruptBySessionId: async () => {},
       restartStuckSubSession: async () => {},
       getAgentSessionById: () => null,
@@ -178,6 +181,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
         }),
       injectIntoTaskAgent: async () => ({ injected: false, reason: 'no-session' }),
       _injected: injected,
+      _cancelled: cancelled,
     };
   }
 
@@ -274,6 +278,27 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     return { runId: run.id, taskId: task.id, executionId: execution.id };
   }
 
+  /**
+   * Simulate `handleSubSessionComplete` returning a continued execution to
+   * `idle` after the resumed turn ends, optionally re-writing the persisted
+   * terminal result (e.g. to a different error signature). Production flips the
+   * execution to `in_progress` on a continue; tests must move it back to idle
+   * for the sweep to re-evaluate it on the next tick.
+   */
+  function resumeToIdle(
+    executionId: string,
+    opts: { subtype: string; errors?: string[]; terminalReason?: string }
+  ): void {
+    const execution = nodeExecutionRepo.getById(executionId);
+    const sessionId = execution?.agentSessionId ?? SESSION;
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(sessionId);
+    saveResultError(sessionId, opts);
+    nodeExecutionRepo.update(executionId, {
+      status: 'idle',
+      startedAt: Date.now() - 60_000,
+    });
+  }
+
   beforeEach(() => {
     db = makeDb();
     seedSpaceRow(db, SPACE_ID);
@@ -312,7 +337,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
   });
 
   test('error_during_execution on a live idle session injects one continue', async () => {
-    const { runId, taskId } = seedIdleErrorRun({
+    const { runId, taskId, executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['API Error: 400 {"type":"error","message":"Invalid request"}'],
     });
@@ -326,6 +351,9 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected[0].sessionId).toBe(SESSION);
     expect(tam._injected[0].message).toContain('[Runtime recovery — terminal error]');
     expect(tam._injected[0].message).toContain('error_during_execution');
+    // Execution flips to in_progress so the resumed turn is monitored by the
+    // crash-retry/alive-stuck paths; handleSubSessionComplete returns it to idle.
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('in_progress');
     // Run/task remain in_progress — recovery is a continue, not a block.
     expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
     expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
@@ -411,7 +439,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected).toHaveLength(0);
   });
 
-  test('retries up to the cap then escalates to blocked', async () => {
+  test('retries up to the cap then escalates to blocked (clearing the stale session)', async () => {
     const { runId, taskId, executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['transient hiccup A'],
@@ -420,14 +448,13 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     const rt = new SpaceRuntime(buildConfig(tam));
     (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
 
-    // First tick → continue #1 (signature A).
+    // First tick → continue #1 (signature A); execution flips to in_progress.
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
 
-    // Re-write the persisted result to a DIFFERENT error so the signature
-    // changes and the cap (not the repeat guard) is what trips.
-    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
-    saveResultError(SESSION, {
+    // Simulate the resumed turn ending back at idle with a DIFFERENT error so
+    // the signature changes and the cap (not the repeat guard) is what trips.
+    resumeToIdle(executionId, {
       subtype: 'error_during_execution',
       errors: ['transient hiccup B'],
     });
@@ -436,9 +463,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
     expect(tam._injected).toHaveLength(2);
 
-    // Re-write again to yet another distinct error.
-    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
-    saveResultError(SESSION, {
+    resumeToIdle(executionId, {
       subtype: 'error_during_execution',
       errors: ['transient hiccup C'],
     });
@@ -446,7 +471,12 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     // Third tick → cap (2) exhausted → blocked.
     await rt.executeTick();
 
-    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    const execution = nodeExecutionRepo.getById(executionId)!;
+    expect(execution.status).toBe('blocked');
+    // The stale live session is cancelled and cleared so attemptBlockedRunRecovery
+    // re-spawns a FRESH session instead of re-promoting this one.
+    expect(execution.agentSessionId).toBeNull();
+    expect(tam._cancelled).toContain(SESSION);
     expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.blockReason).toBe('execution_failed');
@@ -454,7 +484,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(notifications).toContainEqual(expect.objectContaining({ kind: 'workflow_run_blocked' }));
   });
 
-  test('deterministic repeat (identical signature) escalates to blocked immediately', async () => {
+  test('deterministic repeat (identical signature) escalates to blocked', async () => {
     const { runId, taskId, executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['Codex 400 invalid_request_error'],
@@ -467,17 +497,23 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
 
-    // The persisted result is unchanged → same signature next tick. A plain
-    // continue already failed to clear it, so escalate immediately.
+    // Resumed turn re-errored identically → same signature next evaluation.
+    resumeToIdle(executionId, {
+      subtype: 'error_during_execution',
+      errors: ['Codex 400 invalid_request_error'],
+    });
+
+    // Second tick → grace (0) passed, repeat detected → blocked, no 2nd continue.
     await rt.executeTick();
 
-    expect(tam._injected).toHaveLength(1); // no second continue
+    expect(tam._injected).toHaveLength(1);
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(nodeExecutionRepo.getById(executionId)?.agentSessionId).toBeNull();
     expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
   });
 
-  test('grace cooldown suppresses a second immediate continue', async () => {
+  test('grace cooldown suppresses a re-evaluation before the prior continue is consumed', async () => {
     const { executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       errors: ['hiccup'],
@@ -491,11 +527,15 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
 
-    // Replace with a distinct signature so only the cooldown could suppress it.
-    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
-    saveResultError(SESSION, { subtype: 'error_during_execution', errors: ['different'] });
+    // Resumed turn ends back at idle with a distinct signature. Even though the
+    // signature differs (so neither the repeat nor the cap would trip), the
+    // cooldown must give the prior continue its grace window before acting again.
+    resumeToIdle(executionId, {
+      subtype: 'error_during_execution',
+      errors: ['different'],
+    });
 
-    // Immediate second tick → within grace → no new continue, execution idle.
+    // Immediate second tick → within grace → no new continue.
     await rt.executeTick();
     expect(tam._injected).toHaveLength(1);
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
@@ -516,7 +556,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected).toHaveLength(1);
 
     // Simulate a blocked-recovery re-spawn: same execution, new session id,
-    // fresh error result.
+    // fresh error result, back to idle.
     nodeExecutionRepo.update(executionId, {
       status: 'idle',
       agentSessionId: 'session:gen-2',
@@ -531,5 +571,36 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     // Budget reset → a continue fires for the new session despite the prior one.
     expect(tam._injected).toHaveLength(2);
     expect(tam._injected[1].sessionId).toBe('session:gen-2');
+  });
+
+  test('persistently failing injection escalates to blocked (bounded, no infinite loop)', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['live-but-wedged'],
+    });
+    const tam = makeTam({
+      injectRuntimeRecoveryMessage: async () => {
+        throw new Error('rehydration index mismatch');
+      },
+    });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // First tick → injection fails (failure 1); execution stays idle.
+    await rt.executeTick();
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+
+    // Second tick → still within grace(0)? grace=0 means cooldown never blocks,
+    // but failedInjectionCount(1) < cap(2) → retry → fails again (failure 2).
+    await rt.executeTick();
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+
+    // Third tick → failedInjectionCount(2) >= cap → escalate to blocked.
+    await rt.executeTick();
+
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(nodeExecutionRepo.getById(executionId)?.agentSessionId).toBeNull();
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -32,6 +32,7 @@ import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
 import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
+import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -142,6 +143,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
   ) {
     const injected: Array<{ sessionId: string; message: string }> = [];
     const cancelled: string[] = [];
+    const spawnSnapshots: Array<{ agentSessionIdAtSpawn: string | null }> = [];
     return {
       isSessionAlive: overrides.isSessionAlive ?? (() => true),
       isExecutionSpawning: () => false,
@@ -164,6 +166,10 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       ) => {
         const exec = execution as { id?: string };
         if (exec.id) {
+          // Snapshot the DB state at spawn time so tests can verify the stale
+          // agentSessionId was cleared before the fresh session is assigned.
+          const current = nodeExecutionRepo.getById(exec.id);
+          spawnSnapshots.push({ agentSessionIdAtSpawn: current?.agentSessionId ?? null });
           nodeExecutionRepo.update(exec.id, {
             status: 'in_progress',
             agentSessionId: SESSION,
@@ -182,6 +188,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       injectIntoTaskAgent: async () => ({ injected: false, reason: 'no-session' }),
       _injected: injected,
       _cancelled: cancelled,
+      _spawnSnapshots: spawnSnapshots,
     };
   }
 
@@ -418,7 +425,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected).toHaveLength(0);
   });
 
-  test('dead terminal-error session is reset for re-spawn (not left stuck idle)', async () => {
+  test('dead terminal-error session is reset for a FRESH re-spawn (stale session cleared)', async () => {
     const { executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',
       sessionAlive: false,
@@ -431,9 +438,66 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
 
     // A dead session cannot be continued. The crash-retry path only scans
     // in_progress/pending, so this sweep resets the idle row for a bounded
-    // re-spawn instead of leaving it stuck idle.
+    // re-spawn. The stale (terminal-tainted) agentSessionId is cleared BEFORE
+    // the spawn so createSubSession spawns a fresh session instead of
+    // rehydrating/reusing the dead one.
     expect(tam._injected).toHaveLength(0);
-    expect(nodeExecutionRepo.getById(executionId)?.status).not.toBe('idle');
+    expect(tam._spawnSnapshots.length).toBeGreaterThanOrEqual(1);
+    expect(tam._spawnSnapshots[0].agentSessionIdAtSpawn).toBeNull();
+    // The spawn loop then re-spawns a fresh session.
+    const updated = nodeExecutionRepo.getById(executionId)!;
+    expect(updated.status).toBe('in_progress');
+  });
+
+  test('active tool continuation is preserved (no continue injected)', async () => {
+    const { runId, executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+    });
+    // Seed an active tool_use for this execution — the pending tool_result is
+    // the next valid transcript item; injecting a user continue would race it.
+    const toolRepo = new ToolContinuationRecoveryRepository(db);
+    toolRepo.ensureSchema();
+    toolRepo.recordToolUse({
+      toolUseId: 'tool-pending-1',
+      sessionId: SESSION,
+      ttlMs: 60_000,
+      owner: { executionId, workflowRunId: runId },
+    });
+    expect(toolRepo.hasActiveToolUseForExecution(executionId)).toBe(true);
+
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('error_max_turns consumes the full continue cap (not short-circuited by the repeat guard)', async () => {
+    const { executionId } = seedIdleErrorRun({ subtype: 'error_max_turns' });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // First tick → continue #1 (max-turns, signature stored).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Resumed turn hits max-turns AGAIN with the SAME (empty) signature.
+    resumeToIdle(executionId, { subtype: 'error_max_turns' });
+
+    // Second tick → max-turns is exempt from the deterministic-repeat shortcut,
+    // so it gets continue #2 (the cap), not an immediate block.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
+
+    // Third occurrence → cap (2) exhausted → blocked.
+    resumeToIdle(executionId, { subtype: 'error_max_turns' });
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
   });
 
   test('dead NON-retryable terminal-error session is skipped, not wastefully re-spawned', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -607,6 +607,10 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
 
     expect(tam._injected).toHaveLength(1); // no second continue
     expect(nodeExecutionRepo.getById(newest.id)?.status).toBe('blocked');
+    // The blocked escalation detaches the stale session from EVERY sibling row
+    // (createSubSession would otherwise resurrect it via the older idle row).
+    expect(nodeExecutionRepo.getById(newest.id)?.agentSessionId).toBeNull();
+    expect(nodeExecutionRepo.getById(oldestId)?.agentSessionId).toBeNull();
     expect(nodeExecutionRepo.getById(oldestId)?.status).toBe('idle');
   });
 
@@ -619,6 +623,43 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
 
     expect(tam._injected).toHaveLength(0);
+  });
+
+  test('a session already active (in_progress) on another execution is not recovered via the stale idle row', async () => {
+    // Reused agent session: older row idle on a terminal error, newer row
+    // in_progress on the same session (processing a new activation).
+    const { runId, executionId: idleId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['stale-row error'],
+      sessionId: 'session:reused',
+    });
+    const newer = nodeExecutionRepo.createOrIgnore({
+      workflowRunId: runId,
+      workflowNodeId: 'step-b',
+      agentName: 'Coder',
+      agentId: AGENT,
+      status: 'pending',
+    });
+    nodeExecutionRepo.update(newer.id, {
+      status: 'in_progress',
+      agentSessionId: 'session:reused',
+      startedAt: Date.now(),
+    });
+    db.prepare('UPDATE node_executions SET created_at = ? WHERE id = ?').run(
+      Date.now() + 60_000,
+      newer.id
+    );
+
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    // The session has an active owner; the stale idle row must not trigger a
+    // terminal-error continue that races the in-progress activation.
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(idleId)?.status).toBe('idle');
   });
 
   test('retries up to the cap then escalates to blocked (clearing the stale session)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -1,0 +1,535 @@
+/**
+ * SpaceRuntime — Terminal-Error Idle Recovery (Task #673)
+ *
+ * Catch-all recovery for node-agent sessions that end on a terminal error
+ * result (e.g. Codex 400, `error_during_execution`). Such a session leaves the
+ * node idle with a *live* session, and because the result is classified
+ * `terminal` no existing sweep recovers it — the worker is only revivable by a
+ * manual "continue".
+ *
+ * `handleTerminalErrorIdleExecutions` injects a bounded number of continues via
+ * the same primitive a manual continue uses, then escalates to `blocked`.
+ *
+ * Behaviour under test:
+ *   1. `error_during_execution` (alive session) → one continue injected.
+ *   2. `error_max_turns` is retryable → continue injected.
+ *   3. Grace cooldown suppresses an immediate second continue.
+ *   4. A different error signature earns a second continue (after cooldown).
+ *   5. Retry cap (2) exhausted → execution/run/task → `blocked`.
+ *   6. Deterministic repeat (identical signature) → blocked immediately.
+ *   7. `error_max_budget_usd` (cost guard) → no continue, no blocked.
+ *   8. Prompt-too-long result → no continue (deferred to #670 compaction).
+ *   9. Dead session → no continue (crash-retry path owns it).
+ *  10. Task not `in_progress` → no action.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+  const db = new BunDatabase(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db, () => {});
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS sdk_messages (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			message_type TEXT NOT NULL,
+			message_subtype TEXT,
+			sdk_message TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			send_status TEXT,
+			origin TEXT,
+			is_renderable INTEGER NOT NULL DEFAULT 1,
+			is_terminal INTEGER NOT NULL DEFAULT 0,
+			parent_tool_use_id TEXT,
+			task_id TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_sdk_messages_task_id ON sdk_messages(task_id);
+	`);
+  return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
+  db.prepare(
+    `INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, max_concurrent_tasks, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', 1, ?, ?)`
+  ).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+  db.prepare(
+    `INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+  ).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
+  let db: BunDatabase;
+  let workflowRunRepo: SpaceWorkflowRunRepository;
+  let taskRepo: SpaceTaskRepository;
+  let agentManager: SpaceAgentManager;
+  let workflowManager: SpaceWorkflowManager;
+  let spaceManager: SpaceManager;
+  let nodeExecutionRepo: NodeExecutionRepository;
+  let sdkMessageRepo: SDKMessageRepository;
+  let bus: InternalEventBus<DaemonInternalEventMap>;
+  let notifications: Array<{ kind: string; payload: Record<string, unknown> }>;
+
+  const SPACE_EVENT_MAP: Record<string, string> = {
+    'space.task.blocked': 'task_blocked',
+    'space.workflowRun.blocked': 'workflow_run_blocked',
+    'space.workflowRun.retry': 'task_retry',
+    'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
+  };
+
+  const SPACE_ID = 'space-terminal-err';
+  const AGENT = 'agent-coder';
+  const STEP_A = 'step-a';
+
+  const SESSION = 'session:terminal-err';
+
+  function buildConfig(
+    tam: unknown,
+    overrides: Partial<SpaceRuntimeConfig> = {}
+  ): SpaceRuntimeConfig {
+    return {
+      db,
+      spaceManager,
+      spaceAgentManager: agentManager,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      sdkMessageRepo,
+      internalEventBus: bus,
+      taskAgentManager: tam as never,
+      // Collapse the grace cooldown so cap/repeat tests can advance in
+      // successive ticks without waiting minutes.
+      agentStuckNagGraceMs: 0,
+      ...overrides,
+    };
+  }
+
+  function makeTam(
+    overrides: {
+      isSessionAlive?: (sessionId: string) => boolean;
+      injectRuntimeRecoveryMessage?: (sessionId: string, message: string) => Promise<string>;
+    } = {}
+  ) {
+    const injected: Array<{ sessionId: string; message: string }> = [];
+    return {
+      isSessionAlive: overrides.isSessionAlive ?? (() => true),
+      isExecutionSpawning: () => false,
+      isSpawning: () => false,
+      isTaskAgentAlive: () => true,
+      rehydrate: async () => {},
+      cancelBySessionId: () => {},
+      interruptBySessionId: async () => {},
+      restartStuckSubSession: async () => {},
+      getAgentSessionById: () => null,
+      spawnWorkflowNodeAgent: async () => SESSION,
+      spawnWorkflowNodeAgentForExecution: async (
+        _task: unknown,
+        _space: unknown,
+        _workflow: unknown,
+        _run: unknown,
+        execution: unknown
+      ) => {
+        const exec = execution as { id?: string };
+        if (exec.id) {
+          nodeExecutionRepo.update(exec.id, {
+            status: 'in_progress',
+            agentSessionId: SESSION,
+            startedAt: Date.now(),
+            completedAt: null,
+          });
+        }
+        return SESSION;
+      },
+      injectRuntimeRecoveryMessage:
+        overrides.injectRuntimeRecoveryMessage ??
+        (async (sessionId: string, message: string) => {
+          injected.push({ sessionId, message });
+          return `continue-msg:${injected.length}`;
+        }),
+      injectIntoTaskAgent: async () => ({ injected: false, reason: 'no-session' }),
+      _injected: injected,
+    };
+  }
+
+  /**
+   * Persist a terminal `result` message for a session via direct SQL so the
+   * subtype round-trips through `getLastSDKMessage` exactly.
+   */
+  function saveResultError(
+    sessionId: string,
+    opts: {
+      subtype: string;
+      errors?: string[];
+      terminalReason?: string;
+      minutesAgo?: number;
+    }
+  ): void {
+    const id = `${sessionId}-result-${Math.random().toString(36).slice(2)}`;
+    const message: Record<string, unknown> = {
+      type: 'result',
+      subtype: opts.subtype,
+      is_error: true,
+      num_turns: 1,
+      total_cost_usd: 0,
+      duration_ms: 1000,
+      duration_api_ms: 1000,
+      usage: { input_tokens: 1, output_tokens: 1 },
+      modelUsage: {},
+      permission_denials: [],
+      errors: opts.errors ?? [],
+      session_id: sessionId,
+      uuid: id,
+    };
+    if (opts.terminalReason) message.terminal_reason = opts.terminalReason;
+    const ts = new Date(Date.now() - (opts.minutesAgo ?? 0) * 60_000).toISOString();
+    db.prepare(
+      `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, is_renderable, is_terminal)
+       VALUES (?, ?, 'result', ?, ?, ?, 'consumed', 'sdk', 1, 1)`
+    ).run(id, sessionId, opts.subtype, JSON.stringify(message), ts);
+  }
+
+  /** Seed a single-node workflow run whose execution is idle on an error result. */
+  function seedIdleErrorRun(opts: {
+    subtype: string;
+    errors?: string[];
+    terminalReason?: string;
+    taskStatus?: string;
+    sessionAlive?: boolean;
+    sessionId?: string;
+  }): { runId: string; taskId: string; executionId: string } {
+    const workflow = workflowManager.createWorkflow({
+      spaceId: SPACE_ID,
+      name: `Terminal-error workflow ${Date.now()}-${Math.random()}`,
+      description: 'Test',
+      nodes: [{ id: STEP_A, name: 'Code', agentId: AGENT }],
+      transitions: [],
+      startNodeId: STEP_A,
+      endNodeId: STEP_A,
+      rules: [],
+      tags: [],
+      completionAutonomyLevel: 3,
+    });
+    const run = workflowRunRepo.createRun({
+      spaceId: SPACE_ID,
+      workflowId: workflow.id,
+      title: 'Terminal-error run',
+    });
+    workflowRunRepo.transitionStatus(run.id, 'in_progress');
+    const task = taskRepo.createTask({
+      spaceId: SPACE_ID,
+      title: 'Terminal-error task',
+      description: '',
+      workflowRunId: run.id,
+      workflowNodeId: STEP_A,
+      status: opts.taskStatus ?? 'in_progress',
+    });
+    const execution = nodeExecutionRepo.createOrIgnore({
+      workflowRunId: run.id,
+      workflowNodeId: STEP_A,
+      agentName: 'Coder',
+      agentId: AGENT,
+      status: 'pending',
+    });
+    const sessionId = opts.sessionId ?? SESSION;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: sessionId,
+      startedAt: Date.now() - 5 * 60_000,
+    });
+    saveResultError(sessionId, {
+      subtype: opts.subtype,
+      errors: opts.errors,
+      terminalReason: opts.terminalReason,
+    });
+    return { runId: run.id, taskId: task.id, executionId: execution.id };
+  }
+
+  beforeEach(() => {
+    db = makeDb();
+    seedSpaceRow(db, SPACE_ID);
+    seedAgentRow(db, AGENT, SPACE_ID, 'Coder');
+
+    workflowRunRepo = new SpaceWorkflowRunRepository(db);
+    taskRepo = new SpaceTaskRepository(db);
+    nodeExecutionRepo = new NodeExecutionRepository(db);
+    sdkMessageRepo = new SDKMessageRepository(db);
+
+    const agentRepo = new SpaceAgentRepository(db);
+    agentManager = new SpaceAgentManager(agentRepo);
+    const workflowRepo = new SpaceWorkflowRepository(db);
+    workflowManager = new SpaceWorkflowManager(workflowRepo);
+    spaceManager = new SpaceManager(db);
+    bus = new InternalEventBus<DaemonInternalEventMap>();
+
+    notifications = [];
+    for (const [eventName, kind] of Object.entries(SPACE_EVENT_MAP)) {
+      bus.subscribe(
+        eventName as keyof DaemonInternalEventMap,
+        (payload) => {
+          notifications.push({ kind, payload: payload as Record<string, unknown> });
+        },
+        { subscriberName: `test-terminal-err:${eventName}` }
+      );
+    }
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  test('error_during_execution on a live idle session injects one continue', async () => {
+    const { runId, taskId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['API Error: 400 {"type":"error","message":"Invalid request"}'],
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(tam._injected[0].sessionId).toBe(SESSION);
+    expect(tam._injected[0].message).toContain('[Runtime recovery — terminal error]');
+    expect(tam._injected[0].message).toContain('error_during_execution');
+    // Run/task remain in_progress — recovery is a continue, not a block.
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
+    expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
+  });
+
+  test('error_max_turns is retryable', async () => {
+    seedIdleErrorRun({ subtype: 'error_max_turns' });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+  });
+
+  test('error_max_budget_usd (cost guard) is never continued or blocked', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'error_max_budget_usd',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
+    expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
+    expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
+  });
+
+  test('prompt-too-long result is not continued (deferred to #670)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['prompt is too long: 205616 tokens > 200000 maximum'],
+      terminalReason: 'prompt_too_long',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('prompt-too-long detected via errors[] only (no terminal_reason) is also skipped', async () => {
+    seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['Error: prompt is too long'],
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+  });
+
+  test('dead session is not continued (crash-retry path owns it)', async () => {
+    seedIdleErrorRun({ subtype: 'error_during_execution', sessionAlive: false });
+    const tam = makeTam({ isSessionAlive: () => false });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+  });
+
+  test('task not in_progress is left alone', async () => {
+    seedIdleErrorRun({ subtype: 'error_during_execution', taskStatus: 'done' });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+  });
+
+  test('retries up to the cap then escalates to blocked', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['transient hiccup A'],
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // First tick → continue #1 (signature A).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Re-write the persisted result to a DIFFERENT error so the signature
+    // changes and the cap (not the repeat guard) is what trips.
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
+    saveResultError(SESSION, {
+      subtype: 'error_during_execution',
+      errors: ['transient hiccup B'],
+    });
+
+    // Second tick → continue #2 (signature B, under cap of 2).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
+
+    // Re-write again to yet another distinct error.
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
+    saveResultError(SESSION, {
+      subtype: 'error_during_execution',
+      errors: ['transient hiccup C'],
+    });
+
+    // Third tick → cap (2) exhausted → blocked.
+    await rt.executeTick();
+
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.blockReason).toBe('execution_failed');
+    expect(notifications).toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
+    expect(notifications).toContainEqual(expect.objectContaining({ kind: 'workflow_run_blocked' }));
+  });
+
+  test('deterministic repeat (identical signature) escalates to blocked immediately', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['Codex 400 invalid_request_error'],
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // First tick → continue #1, signature stored.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // The persisted result is unchanged → same signature next tick. A plain
+    // continue already failed to clear it, so escalate immediately.
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1); // no second continue
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+  });
+
+  test('grace cooldown suppresses a second immediate continue', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['hiccup'],
+    });
+    // Non-zero grace so the cooldown window is active.
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam, { agentStuckNagGraceMs: 60_000 }));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // First tick → continue #1.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Replace with a distinct signature so only the cooldown could suppress it.
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
+    saveResultError(SESSION, { subtype: 'error_during_execution', errors: ['different'] });
+
+    // Immediate second tick → within grace → no new continue, execution idle.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('a re-spawned session (new id) resets the continue budget', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['hiccup'],
+      sessionId: 'session:gen-1',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // Gen-1 session: continue once.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Simulate a blocked-recovery re-spawn: same execution, new session id,
+    // fresh error result.
+    nodeExecutionRepo.update(executionId, {
+      status: 'idle',
+      agentSessionId: 'session:gen-2',
+      startedAt: Date.now() - 60_000,
+    });
+    saveResultError('session:gen-2', {
+      subtype: 'error_during_execution',
+      errors: ['hiccup after respawn'],
+    });
+
+    await rt.executeTick();
+    // Budget reset → a continue fires for the new session despite the prior one.
+    expect(tam._injected).toHaveLength(2);
+    expect(tam._injected[1].sessionId).toBe('session:gen-2');
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -561,6 +561,55 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected[0].sessionId).toBe('session:shared');
   });
 
+  test('a shared session recovers via the NEWEST execution (not a stale node)', async () => {
+    // createSubSession treats the newest execution for a session as current.
+    // Two idle rows share a session; recovery must target the newest (step-b),
+    // so that a blocked escalation re-spawns the right workflow step.
+    const { runId, executionId: oldestId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['shared-session error'],
+      sessionId: 'session:shared',
+    });
+    const newest = nodeExecutionRepo.createOrIgnore({
+      workflowRunId: runId,
+      workflowNodeId: 'step-b',
+      agentName: 'Coder',
+      agentId: AGENT,
+      status: 'pending',
+    });
+    nodeExecutionRepo.update(newest.id, {
+      status: 'idle',
+      agentSessionId: 'session:shared',
+      startedAt: Date.now() - 5 * 60_000,
+    });
+    // Force step-b to be unambiguously newer than step-a (same-ms createdAt
+    // otherwise ties break by UUID, making "newest" non-deterministic in tests).
+    db.prepare('UPDATE node_executions SET created_at = ? WHERE id = ?').run(
+      Date.now() + 60_000,
+      newest.id
+    );
+
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // Tick 1 → continue #1 (targets the newest execution, step-b).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Resume the NEWEST execution to idle with the SAME signature → deterministic
+    // repeat on step-b → blocked. The oldest (step-a) must remain untouched.
+    resumeToIdle(newest.id, {
+      subtype: 'error_during_execution',
+      errors: ['shared-session error'],
+    });
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1); // no second continue
+    expect(nodeExecutionRepo.getById(newest.id)?.status).toBe('blocked');
+    expect(nodeExecutionRepo.getById(oldestId)?.status).toBe('idle');
+  });
+
   test('task not in_progress is left alone', async () => {
     seedIdleErrorRun({ subtype: 'error_during_execution', taskStatus: 'done' });
     const tam = makeTam();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -436,6 +436,25 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(nodeExecutionRepo.getById(executionId)?.status).not.toBe('idle');
   });
 
+  test('dead NON-retryable terminal-error session is skipped, not wastefully re-spawned', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_max_budget_usd',
+      sessionAlive: false,
+    });
+    const tam = makeTam({ isSessionAlive: () => false });
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    // A dead cost-guarded session is NOT re-spawned — the subtype guards run
+    // before the dead-session reset, so non-retryable subtypes are skipped
+    // consistently whether the session is live or dead (no guaranteed-to-re-fail
+    // re-spawns).
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
   test('task not in_progress is left alone', async () => {
     seedIdleErrorRun({ subtype: 'error_during_execution', taskStatus: 'done' });
     const tam = makeTam();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -351,9 +351,10 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected[0].sessionId).toBe(SESSION);
     expect(tam._injected[0].message).toContain('[Runtime recovery — terminal error]');
     expect(tam._injected[0].message).toContain('error_during_execution');
-    // Execution flips to in_progress so the resumed turn is monitored by the
-    // crash-retry/alive-stuck paths; handleSubSessionComplete returns it to idle.
-    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('in_progress');
+    // Execution stays idle: handleSubSessionComplete is a one-shot callback that
+    // already fired for the terminal error, so flipping to in_progress would
+    // leave it stuck. The sweep re-evaluates idle rows every tick instead.
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
     // Run/task remain in_progress — recovery is a continue, not a block.
     expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
     expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
@@ -417,15 +418,22 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._injected).toHaveLength(0);
   });
 
-  test('dead session is not continued (crash-retry path owns it)', async () => {
-    seedIdleErrorRun({ subtype: 'error_during_execution', sessionAlive: false });
+  test('dead terminal-error session is reset for re-spawn (not left stuck idle)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      sessionAlive: false,
+    });
     const tam = makeTam({ isSessionAlive: () => false });
     const rt = new SpaceRuntime(buildConfig(tam));
     (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
 
     await rt.executeTick();
 
+    // A dead session cannot be continued. The crash-retry path only scans
+    // in_progress/pending, so this sweep resets the idle row for a bounded
+    // re-spawn instead of leaving it stuck idle.
     expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).not.toBe('idle');
   });
 
   test('task not in_progress is left alone', async () => {
@@ -602,5 +610,44 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(nodeExecutionRepo.getById(executionId)?.agentSessionId).toBeNull();
     expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+  });
+
+  test('recovery state is cleared after progress so a later recurrence gets a fresh budget', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'error_during_execution',
+      errors: ['generic 400'],
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    // Tick 1 → continue #1 (signature stored).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // Simulate the continue succeeding: the agent made progress and the last
+    // message is no longer a terminal error result.
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
+    sdkMessageRepo.saveSDKMessage(SESSION, {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+      },
+    } as never);
+
+    // Tick 2 → last message is non-error → recovery state cleared, no action.
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    // The same (reused) session later hits the SAME generic terminal error.
+    db.prepare(`DELETE FROM sdk_messages WHERE session_id = ?`).run(SESSION);
+    saveResultError(SESSION, { subtype: 'error_during_execution', errors: ['generic 400'] });
+
+    // Tick 3 → state was cleared, so this is treated as a fresh incident and
+    // earns a continue (NOT an immediate deterministic-repeat block).
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What

Fixes the single highest-value stuck-worker gap (#673): a node-agent session that ends on a **terminal error result** (e.g. Codex 400, `error_during_execution`) left the node silently idle with a *live* session and **no recovery firing** — every `type:'result'` message is classified `terminal`, so the alive-stuck, non-terminal-idle, crash-retry, and blocked-run sweeps all bail. The worker was revivable only by a manual "continue".

## How

Add `handleTerminalErrorIdleExecutions` — a catch-all sweep wired into `processRunTick` right after `handleNonTerminalIdleExecutions`. It injects a bounded number of "continue" messages via the **same primitive a manual continue uses** (`tam.injectRuntimeRecoveryMessage`), then escalates to `blocked` so `attemptBlockedRunRecovery` takes over with its own `MAX_BLOCKED_RUN_RETRIES` re-spawn cap.

### Guards (per task spec)
- **Retryable subtypes only**: `error_during_execution`, `error_max_turns`. Cost (`error_max_budget_usd`) and structured-output exhaustion are skipped; auth errors arrive via `session.error`/blocked.
- **Prompt-too-long deferred to #670** — detected via `terminal_reason='prompt_too_long'` or the `errors[]` signature; a plain continue would just re-hit the context limit, so compaction must handle it.
- **Task `in_progress` + no `reportedStatus` + session alive** (dead sessions are owned by the crash-retry path).
- **Per-execution cap** `MAX_TERMINAL_ERROR_CONTINUE_RETRIES=2`, then `blocked`.
- **Deterministic repeats** (identical error signature) escalate immediately — a continue already failed to clear the exact error.
- **Grace cooldown** between attempts (mirrors `DEFAULT_AGENT_STUCK_NAG_GRACE_MS`); applied on failure too so a transiently-failing injection cannot tight-loop.
- **Re-spawn resets the budget** (new session id after blocked recovery) — total attempts stay bounded by `MAX_BLOCKED_RUN_RETRIES`.

Escalation mirrors `handleAliveStuckExecutions`' blocked path: execution/run/task → `blocked` with `blockReason: 'execution_failed'` + `task_blocked`/`workflow_run_blocked` notifications (deduplicated via `notifiedTaskSet`).

## Why the isolated sweep over the classifier one-liner

The alternative (make `classifyLastMessageForIdleAgent` return `{terminal:false}` for error subtypes) was rejected: it can't subtype-filter, has no cap→blocked escalation, reuses the generic non-terminal nudge instead of a targeted "continue after error", and widens the blast radius to both idle sweeps. The isolated sweep gives precise control over every guard.

## Imports
`isSDKResultError` from `@neokai/shared/sdk` (already exported, never previously imported in the daemon).

## Tests
New `space-runtime-terminal-error-recovery.test.ts` (11 cases): auto-continue, retryable subtype, cost-guard skip, prompt-too-long skip (both `terminal_reason` and `errors[]` detection), dead-session skip, non-`in_progress` skip, cap→blocked, deterministic repeat→blocked, grace cooldown, and re-spawn budget reset.

Full `5-space/runtime` shard: **1152 pass / 0 fail**.