### PR TITLE
fix(codex-bridge): log 4xx request bodies, stringify tool output, self-heal reasoning 400s

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -116,7 +116,11 @@ type ResponsesInputItem =
   | {
       type: 'function_call_output';
       call_id: string;
-      output: string | Array<ResponsesInputText | ResponsesInputImage>;
+      // The OpenAI Responses API documents function_call_output.output as a
+      // string. The ChatGPT Codex backend hard-rejects non-string shapes with
+      // `{"detail":"Unsupported content type"}`, so this is always stringified
+      // (see toolResultContent).
+      output: string;
     }
   | ResponsesReasoningItem;
 
@@ -272,15 +276,7 @@ const ESTIMATED_IMAGE_TOKENS = 300;
 
 function estimateResponsesContentTokens(item: ResponsesInputItem): number {
   if (item.type === 'function_call_output') {
-    if (typeof item.output === 'string') {
-      return estimateTextTokens(item.output);
-    }
-    return item.output.reduce((sum, block) => {
-      if (block.type === 'input_image') {
-        return sum + ESTIMATED_IMAGE_TOKENS;
-      }
-      return sum + estimateTextTokens(block.text);
-    }, 0);
+    return estimateTextTokens(item.output);
   }
   if (item.type === 'function_call') {
     return estimateTextTokens(item.name) + estimateTextTokens(item.arguments);
@@ -330,30 +326,33 @@ function estimateResponsesPayloadTokens(
   );
 }
 
-function toolResultContent(
-  content: AnthropicContentBlockToolResult['content']
-): string | Array<ResponsesInputText | ResponsesInputImage> {
+/**
+ * Convert an Anthropic tool_result `content` into the string expected by the
+ * OpenAI Responses API's `function_call_output.output` field.
+ *
+ * The Responses API documents `output` as a string; the ChatGPT Codex backend
+ * hard-rejects non-string shapes with `{"detail":"Unsupported content type"}`.
+ * Images cannot be carried in a string output, so non-text blocks are rendered
+ * as descriptive placeholders (the model still learns that media was returned).
+ */
+function toolResultContent(content: AnthropicContentBlockToolResult['content']): string {
   if (typeof content === 'string') return content;
-  const hasNonText = content.some((block) => block.type !== 'text');
-  if (!hasNonText) {
-    return content.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
-  }
-  const result: Array<ResponsesInputText | ResponsesInputImage> = [];
+  const parts: string[] = [];
   for (const block of content) {
     if (block.type === 'text') {
-      result.push({ type: 'input_text', text: block.text });
+      parts.push(block.text);
       continue;
     }
     if (block.type === 'image') {
-      result.push(imageBlockToInputImage(block));
+      const source = block.source as { type?: string; media_type?: string; url?: string };
+      parts.push(
+        `[image: ${source.type === 'url' ? (source.url ?? 'url') : (source.media_type ?? 'unknown')}]`
+      );
       continue;
     }
-    result.push({
-      type: 'input_text',
-      text: `[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`,
-    });
+    parts.push(`[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`);
   }
-  return result;
+  return parts.filter(Boolean).join('\n');
 }
 
 function appendInputMessage(
@@ -432,11 +431,7 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
       items.push({
         type: 'function_call_output',
         call_id: result.tool_use_id,
-        output: result.is_error
-          ? typeof output === 'string'
-            ? `[Tool error]\n${output}`
-            : [{ type: 'input_text' as const, text: `[Tool error]` }, ...output]
-          : output,
+        output: result.is_error ? `[Tool error]\n${output}` : output,
       });
       continue;
     }
@@ -744,6 +739,70 @@ function parseOpenAIError(status: number, text: string): string {
     if (typeof message === 'string' && message) return message;
   }
   return text || `OpenAI API request failed with status ${status}`;
+}
+
+/**
+ * Build a compact, payload-free summary of a Responses request body for
+ * diagnostic logging when the upstream rejects it (4xx).
+ *
+ * The ChatGPT Codex backend returns `{"detail":"Unsupported content type"}` on
+ * 400 without identifying which item it rejected. This summary captures, per
+ * input item: its `type`, the shapes most likely to trigger that error
+ * (function_call_output.output form, function_call.status presence, reasoning
+ * encrypted_content, message content block types) — without dumping potentially
+ * large or sensitive text payloads.
+ */
+function summarizeResponsesRequestFor4xx(body: ResponsesRequest): Record<string, unknown> {
+  const input = body.input.map((item) => {
+    if (item.type === 'function_call_output') {
+      return {
+        type: item.type,
+        call_id: item.call_id,
+        outputType: typeof item.output === 'string' ? 'string' : typeof item.output,
+      };
+    }
+    if (item.type === 'function_call') {
+      return {
+        type: item.type,
+        call_id: item.call_id,
+        name: item.name,
+        hasStatus: item.status !== undefined,
+      };
+    }
+    if (item.type === 'reasoning') {
+      return {
+        type: item.type,
+        encryptedContentLength: item.encrypted_content.length,
+      };
+    }
+    // message
+    return {
+      type: item.type,
+      role: item.role,
+      contentBlockTypes: item.content.map((block) => block.type),
+    };
+  });
+  return {
+    model: body.model,
+    inputItemCount: body.input.length,
+    inputItemTypes: body.input.map((i) => i.type),
+    input,
+    ...(body.previous_response_id ? { previous_response_id: body.previous_response_id } : {}),
+    ...(body.reasoning ? { reasoning: body.reasoning } : {}),
+    ...(body.include ? { include: body.include } : {}),
+    ...(body.tools ? { toolCount: body.tools.length } : {}),
+  };
+}
+
+/** Log a 4xx upstream rejection with the translated request body summary. */
+function logUpstream4xx(status: number, requestBody: ResponsesRequest, errorText: string): void {
+  // 4xx = client-side request problem (the body we built is rejected). 5xx is
+  // server-side, so the request-body summary is noise there.
+  if (status < 400 || status >= 500) return;
+  const summary = summarizeResponsesRequestFor4xx(requestBody);
+  logger.warn(
+    `openai-responses: upstream rejected request (HTTP ${status}): ${errorText.slice(0, 500)} | requestBodySummary=${JSON.stringify(summary)}`
+  );
 }
 
 function parseSSEBlock(block: string): OpenAIStreamEvent | null {
@@ -1401,12 +1460,45 @@ export function createOpenAIResponsesBridgeServer(
             });
             continuation = undefined;
           } else {
+            logUpstream4xx(openAIResponse.status, requestBody, errorText);
             return sendJsonError(
               openAIResponse.status,
               mapOpenAIStatusToAnthropicError(openAIResponse.status),
               parseOpenAIError(openAIResponse.status, errorText)
             );
           }
+        }
+        // Reasoning `encrypted_content` replay can trigger a 400
+        // "Unsupported content type" on the ChatGPT Codex backend when the
+        // encrypted blob is stale (e.g. after an SDK context rewrite). The
+        // error is terminal for the worker turn, so retry once without the
+        // replayed reasoning items so the turn completes. The streaming
+        // response refreshes/clears the per-session reasoning cache via
+        // onReasoningItems, so subsequent turns stop replaying the bad blob.
+        if (
+          !openAIResponse.ok &&
+          openAIResponse.status === 400 &&
+          requestBody.input.some((item) => item.type === 'reasoning')
+        ) {
+          const errorText = await openAIResponse.text();
+          logUpstream4xx(openAIResponse.status, requestBody, errorText);
+          logger.warn(
+            'openai-responses: 400 with replayed reasoning present — retrying once without reasoning items'
+          );
+          try {
+            requestBody = buildResponsesRequest(body, model, continuation, buildOpts, undefined);
+          } catch (err) {
+            return sendJsonError(
+              400,
+              'invalid_request_error',
+              err instanceof Error ? err.message : 'Bad Request'
+            );
+          }
+          openAIResponse = await fetchImpl(upstreamUrl, {
+            method: 'POST',
+            headers: buildOpenAIHeaders(config.auth, resolvedAuth),
+            body: JSON.stringify(requestBody),
+          });
         }
       } catch (err) {
         logger.warn('openai-responses: upstream request failed:', err);
@@ -1419,6 +1511,7 @@ export function createOpenAIResponsesBridgeServer(
 
       if (!openAIResponse.ok) {
         const text = await openAIResponse.text();
+        logUpstream4xx(openAIResponse.status, requestBody, text);
         return sendJsonError(
           openAIResponse.status,
           mapOpenAIStatusToAnthropicError(openAIResponse.status),

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { configureLogger, subscribeToStructuredLogs, LogLevel } from '@neokai/shared';
 import {
   _openAIResponsesBridgeServerTesting,
   anthropicMessagesToResponsesInput,
@@ -285,7 +286,7 @@ describe('openai-responses-bridge server', () => {
     ]);
   });
 
-  it('preserves non-text blocks in tool_result content as structured output', () => {
+  it('stringifies non-text tool_result content to a string (Codex rejects arrays)', () => {
     const input = anthropicMessagesToResponsesInput([
       {
         role: 'assistant',
@@ -320,10 +321,10 @@ describe('openai-responses-bridge server', () => {
       {
         type: 'function_call_output',
         call_id: 'call_1',
-        output: [
-          { type: 'input_text', text: 'Screenshot taken.' },
-          { type: 'input_image', image_url: 'data:image/png;base64,screendata' },
-        ],
+        // function_call_output.output must be a string on the Responses API;
+        // the ChatGPT Codex backend hard-rejects arrays with "Unsupported
+        // content type". Images become descriptive placeholders.
+        output: 'Screenshot taken.\n[image: image/png]',
       },
     ]);
   });
@@ -363,6 +364,41 @@ describe('openai-responses-bridge server', () => {
         output: 'Line 1\nLine 2',
       },
     ]);
+  });
+
+  it('stringifies is_error tool_result content with images to a string', () => {
+    const input = anthropicMessagesToResponsesInput([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'screenshot', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            is_error: true,
+            content: [
+              { type: 'text', text: 'Capture failed.' },
+              {
+                type: 'image',
+                source: { type: 'base64', media_type: 'image/png', data: 'screendata' },
+              },
+            ],
+          } as unknown as { type: 'tool_result'; tool_use_id: string; content: string },
+        ],
+      },
+    ]);
+
+    // is_error tool results are stringified too — no array output that Codex
+    // would reject.
+    const fnOutput = input.find((i) => i.type === 'function_call_output') as {
+      type: 'function_call_output';
+      output: unknown;
+    };
+    expect(typeof fnOutput.output).toBe('string');
+    expect(fnOutput.output).toBe('[Tool error]\nCapture failed.\n[image: image/png]');
   });
 
   it('throws on unsupported image source types', () => {
@@ -1613,6 +1649,355 @@ describe('openai-responses-bridge server', () => {
     expect(resp.status).toBe(529);
     expect(body.error.type).toBe('overloaded_error');
     expect(body.error.message).toBe('overloaded');
+  });
+
+  describe('4xx request diagnostics', () => {
+    let logEvents: Array<{ level: string; message: string }>;
+    let unsubscribe: () => void;
+
+    beforeEach(() => {
+      configureLogger({
+        level: LogLevel.WARN,
+        filter: ['kai:daemon:openai-responses-bridge-server'],
+      });
+      logEvents = [];
+      unsubscribe = subscribeToStructuredLogs((event) => {
+        logEvents.push({ level: event.level, message: event.message });
+      });
+    });
+
+    afterEach(() => {
+      unsubscribe();
+      configureLogger({ level: LogLevel.SILENT, filter: [] });
+    });
+
+    it('logs the translated request body summary when upstream returns 400 "Unsupported content type"', async () => {
+      server = createOpenAIResponsesBridgeServer({
+        auth: { source: 'api_key', apiKey: 'sk-test' },
+        models,
+        fetchImpl: async () =>
+          new Response('{"detail":"Unsupported content type"}', {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      });
+
+      const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'gpt-5.3-codex',
+          max_tokens: 128,
+          messages: [
+            { role: 'user', content: 'First.' },
+            {
+              role: 'assistant',
+              content: [
+                { type: 'text', text: 'Checking.' },
+                { type: 'tool_use', id: 'call_1', name: 'lookup', input: { q: 'codex' } },
+              ],
+            },
+            {
+              role: 'user',
+              content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'found' }],
+            },
+          ],
+        }),
+      });
+      await resp.text();
+
+      expect(resp.status).toBe(400);
+      // A single warn line capturing the upstream rejection + request body summary.
+      const rejectionLogs = logEvents.filter((e) =>
+        e.message.includes('upstream rejected request (HTTP 400)')
+      );
+      expect(rejectionLogs.length).toBe(1);
+      const summaryJson = rejectionLogs[0]!.message.slice(
+        rejectionLogs[0]!.message.indexOf('requestBodySummary=') + 'requestBodySummary='.length
+      );
+      const summary = JSON.parse(summaryJson) as Record<string, unknown>;
+      // Item types are enumerated so the rejected item can be identified.
+      expect(summary.inputItemTypes).toEqual([
+        'message',
+        'message',
+        'function_call',
+        'function_call_output',
+      ]);
+      // Shapes most likely to trigger "Unsupported content type" are captured.
+      const input = summary.input as Array<Record<string, unknown>>;
+      const fnOutput = input.find((i) => i.type === 'function_call_output');
+      expect(fnOutput?.outputType).toBe('string');
+      const fnCall = input.find((i) => i.type === 'function_call');
+      expect(fnCall?.hasStatus).toBe(true);
+    });
+
+    it('captures reasoning encrypted_content shape in the 4xx summary', async () => {
+      server = createOpenAIResponsesBridgeServer({
+        auth: { source: 'api_key', apiKey: 'sk-test' },
+        models,
+        fetchImpl: async (_url, init) => {
+          const reqBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          const input = reqBody.input as Array<Record<string, unknown>>;
+          // First request: succeed and return encrypted reasoning to be cached.
+          if (!input.some((i) => i.type === 'reasoning')) {
+            return sse([
+              {
+                event: 'response.output_text.delta',
+                data: { type: 'response.output_text.delta', delta: 'ok' },
+              },
+              {
+                event: 'response.completed',
+                data: {
+                  type: 'response.completed',
+                  response: {
+                    id: 'resp_1',
+                    usage: { input_tokens: 5, output_tokens: 1 },
+                    output: [{ type: 'reasoning', encrypted_content: 'enc_xyz' }],
+                  },
+                },
+              },
+            ]);
+          }
+          // Second request (carries replayed reasoning): rejected by upstream.
+          return new Response('{"detail":"Unsupported content type"}', {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      });
+
+      // First turn to populate the reasoning cache.
+      const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'gpt-5.3-codex',
+          max_tokens: 128,
+          messages: [{ role: 'user', content: 'First.' }],
+          thinking: { type: 'enabled', budget_tokens: 16000 },
+        }),
+      });
+      await readSSEEvents(first.body);
+
+      // Second turn replays the reasoning item; upstream rejects with 400.
+      const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'gpt-5.3-codex',
+          max_tokens: 128,
+          messages: [
+            { role: 'user', content: 'First.' },
+            { role: 'assistant', content: 'ok' },
+            { role: 'user', content: 'Second.' },
+          ],
+          thinking: { type: 'enabled', budget_tokens: 16000 },
+        }),
+      });
+      await second.text();
+
+      const rejectionLogs = logEvents.filter((e) =>
+        e.message.includes('upstream rejected request (HTTP 400)')
+      );
+      expect(rejectionLogs.length).toBe(1);
+      const summaryJson = rejectionLogs[0]!.message.slice(
+        rejectionLogs[0]!.message.indexOf('requestBodySummary=') + 'requestBodySummary='.length
+      );
+      const summary = JSON.parse(summaryJson) as Record<string, unknown>;
+      expect(summary.inputItemTypes).toContain('reasoning');
+      const reasoning = (summary.input as Array<Record<string, unknown>>).find(
+        (i) => i.type === 'reasoning'
+      );
+      // encrypted_content length is captured (not the payload itself).
+      expect(reasoning?.encryptedContentLength).toBe('enc_xyz'.length);
+    });
+
+    it('does not log request body summary for 5xx (server-side errors)', async () => {
+      server = createOpenAIResponsesBridgeServer({
+        auth: { source: 'api_key', apiKey: 'sk-test' },
+        models,
+        fetchImpl: async () =>
+          new Response('{"error":{"message":"internal"}}', {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      });
+
+      const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'gpt-5.3-codex',
+          max_tokens: 128,
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      });
+      await resp.text();
+
+      expect(resp.status).toBe(503);
+      // 5xx is server-side — no request-body summary is logged.
+      expect(logEvents.some((e) => e.message.includes('requestBodySummary='))).toBe(false);
+    });
+  });
+
+  it('self-heals: retries without reasoning on a 400 and completes the turn', async () => {
+    const capturedInputs: Array<Record<string, unknown>[]> = [];
+    server = createOpenAIResponsesBridgeServer({
+      auth: { source: 'api_key', apiKey: 'sk-test' },
+      models,
+      fetchImpl: async (_url, init) => {
+        const reqBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        const input = reqBody.input as Array<Record<string, unknown>>;
+        capturedInputs.push(input);
+        // Any request carrying a replayed reasoning item is rejected — this
+        // simulates the stale encrypted_content trigger (candidate 1).
+        if (input.some((i) => i.type === 'reasoning')) {
+          return new Response('{"detail":"Unsupported content type"}', {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        // Requests without reasoning succeed (including the self-healing retry).
+        // The first turn returns reasoning in its output so it gets cached for
+        // the session; the retry returns plain text.
+        const isFirstTurn =
+          input.length === 1 && (input[0] as Record<string, unknown>)?.type === 'message';
+        return sse([
+          ...(isFirstTurn
+            ? [
+                {
+                  event: 'response.completed',
+                  data: {
+                    type: 'response.completed',
+                    response: {
+                      id: 'resp_1',
+                      usage: { input_tokens: 5, output_tokens: 1 },
+                      output: [{ type: 'reasoning', encrypted_content: 'enc_cached' }],
+                    },
+                  },
+                },
+              ]
+            : [
+                {
+                  event: 'response.output_text.delta',
+                  data: { type: 'response.output_text.delta', delta: 'recovered' },
+                },
+                {
+                  event: 'response.completed',
+                  data: {
+                    type: 'response.completed',
+                    response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+                  },
+                },
+              ]),
+        ]);
+      },
+    });
+
+    // First turn: returns reasoning, which gets cached for the session.
+    const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [{ role: 'user', content: 'First.' }],
+        thinking: { type: 'enabled', budget_tokens: 16000 },
+      }),
+    });
+    await readSSEEvents(first.body);
+
+    // Second turn replays the cached reasoning; upstream 400s, then the bridge
+    // retries once without reasoning.
+    const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [
+          { role: 'user', content: 'First.' },
+          { role: 'assistant', content: 'recovered' },
+          { role: 'user', content: 'Second.' },
+        ],
+        thinking: { type: 'enabled', budget_tokens: 16000 },
+      }),
+    });
+    const events = await readSSEEvents(second.body);
+
+    // The turn completes (does not surface the terminal 400 to the SDK).
+    expect(second.status).toBe(200);
+    expect(textDeltaEvents(events).join('')).toBe('recovered');
+
+    // Two upstream calls for the second turn: first WITH reasoning (rejected),
+    // then the retry WITHOUT reasoning.
+    expect(capturedInputs.length).toBe(3);
+    expect(capturedInputs[1]!.some((i) => i.type === 'reasoning')).toBe(true);
+    expect(capturedInputs[2]!.some((i) => i.type === 'reasoning')).toBe(false);
+  });
+
+  it('surfaces the 400 when the reasoning-strip retry also fails', async () => {
+    server = createOpenAIResponsesBridgeServer({
+      auth: { source: 'api_key', apiKey: 'sk-test' },
+      models,
+      fetchImpl: async (_url, init) => {
+        const reqBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        const input = reqBody.input as Array<Record<string, unknown>>;
+        // First turn succeeds and returns reasoning.
+        if (!input.some((i) => i.type === 'reasoning') && input.length === 1) {
+          return sse([
+            {
+              event: 'response.completed',
+              data: {
+                type: 'response.completed',
+                response: {
+                  id: 'resp_1',
+                  usage: { input_tokens: 5, output_tokens: 1 },
+                  output: [{ type: 'reasoning', encrypted_content: 'enc_bad' }],
+                },
+              },
+            },
+          ]);
+        }
+        // Every multi-message request 400s — even the retry without reasoning.
+        return new Response('{"detail":"Unsupported content type"}', {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [{ role: 'user', content: 'First.' }],
+        thinking: { type: 'enabled', budget_tokens: 16000 },
+      }),
+    });
+    await readSSEEvents(first.body);
+
+    const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [
+          { role: 'user', content: 'First.' },
+          { role: 'assistant', content: 'ok' },
+          { role: 'user', content: 'Second.' },
+        ],
+        thinking: { type: 'enabled', budget_tokens: 16000 },
+      }),
+    });
+    const body = (await second.json()) as { error: { type: string; message: string } };
+
+    // When the retry also fails, the 400 surfaces to the SDK as before.
+    expect(second.status).toBe(400);
+    expect(body.error.message).toContain('Unsupported content type');
   });
 
   it('uses Codex ChatGPT OAuth endpoint and account header for OAuth auth', async () => {


### PR DESCRIPTION
## Summary

The Codex (gpt-5.5) bridge intermittently returns a terminal `400 {"detail":"Unsupported content type"}`, killing the worker turn (e.g. task `8d61e3d3`). The error originates upstream and the failing request body was never logged, so the rejected item could not be identified. This PR adds the missing diagnostics plus two defensive mitigations for the leading candidates.

## Changes

### 1. 4xx request diagnostics (highest priority)
Added `summarizeResponsesRequestFor4xx()` + `logUpstream4xx()`: when the upstream returns 4xx, log a payload-free summary of the translated request body — every input item's `type` plus the shapes most likely to trigger "Unsupported content type":
- `function_call_output.output` form (string vs other)
- `function_call.status` presence (candidate 2 verification)
- `reasoning` `encrypted_content` length (candidate 1)
- message content block types

This is what will pin the actual cause on the next occurrence. 5xx is intentionally skipped (server-side, the body isn't the problem). Example log line:
```
openai-responses: upstream rejected request (HTTP 400): {"detail":"Unsupported content type"} | requestBodySummary={"model":"gpt-5.5","inputItemCount":4,"inputItemTypes":["message","message","reasoning","message"],"input":[...],"include":["reasoning.encrypted_content"]}
```

### 2. Defensively stringify `function_call_output.output` (candidate 3)
`toolResultContent()` now always returns a string. Previously, non-text tool results (e.g. screenshots with images) were sent as an array of typed content blocks, which the ChatGPT Codex backend hard-rejects with "Unsupported content type". The Responses API documents `output` as a string; images become descriptive placeholders like `[image: image/png]`.

(The example run had all-string results, so this wasn't the trigger there — but it's a latent bug fixed defensively per the task plan.)

### 3. Self-healing reasoning replay 400 (candidate 1 — leading suspect)
Reasoning `encrypted_content` is cached per session and replayed before the current turn. A stale blob (e.g. after an SDK context rewrite/compaction) can trigger the 400 terminally. Following the existing `previous_response_id` retry pattern, the bridge now **retries once without reasoning items** when a 400 occurs with reasoning present, so the turn completes instead of dying. The streaming response refreshes/clears the per-session reasoning cache via `onReasoningItems`, so subsequent turns stop replaying the bad blob.

## Tests
67 bridge server tests (+6 new), covering:
- Stringified `function_call_output.output` (images → placeholder string, including `is_error` path)
- 4xx diagnostics: item types/shapes, reasoning capture, 5xx exclusion
- Reasoning retry: recovers the turn / still-failing surfaces the 400

## Acceptance status
- ✅ 4xx from Codex now logs the translated request body (item types + shapes)
- ✅ `function_call_output.output` is always a string on the Codex path (defensive)
- ⏳ Identifying the *exact* 8d61e3d3 trigger requires the log from the next live occurrence (no repro without live Codex creds); candidate 1 is mitigated by the self-healing retry, candidate 2 is observable in the new diagnostics (`hasStatus`)

## Notes
- The 4 pre-existing `ModelSwitchHandler` failures in `tests/unit/1-core/agent/` are unrelated (confirmed present on the base branch).