### PR TITLE
fix: map HTTP 529 to overloaded_error in all provider bridges

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
@@ -75,6 +75,7 @@ function mapUpstreamStatus(status: number): AnthropicErrorType {
   if (status === 404) return 'not_found_error';
   if (status === 413) return 'request_too_large';
   if (status === 429) return 'rate_limit_error';
+  if (status === 529) return 'overloaded_error';
   if (status >= 500) return 'api_error';
   return 'invalid_request_error';
 }

--- a/packages/daemon/src/lib/providers/ollama-bridge-server.ts
+++ b/packages/daemon/src/lib/providers/ollama-bridge-server.ts
@@ -112,6 +112,7 @@ function mapStatusToAnthropicError(status: number): AnthropicErrorType {
   if (status === 401 || status === 403) return 'authentication_error';
   if (status === 404) return 'not_found_error';
   if (status === 429) return 'rate_limit_error';
+  if (status === 529) return 'overloaded_error';
   if (status >= 500) return 'api_error';
   return 'invalid_request_error';
 }

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -188,6 +188,7 @@ function mapUpstreamStatus(status: number): AnthropicErrorType {
   if (status === 404) return 'not_found_error';
   if (status === 413) return 'request_too_large';
   if (status === 429) return 'rate_limit_error';
+  if (status === 529) return 'overloaded_error';
   if (status >= 500) return 'api_error';
   return 'invalid_request_error';
 }

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -237,6 +237,7 @@ function mapOpenAIStatusToAnthropicError(status: number): AnthropicErrorType {
   if (status === 404) return 'not_found_error';
   if (status === 413) return 'request_too_large';
   if (status === 429) return 'rate_limit_error';
+  if (status === 529) return 'overloaded_error';
   if (status >= 500) return 'api_error';
   return 'invalid_request_error';
 }

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge-server.test.ts
@@ -278,6 +278,23 @@ describe('AnthropicMessagesBridge', () => {
       const payload = (await response.json()) as { error: { type: string } };
       expect(payload.error.type).toBe('authentication_error');
     });
+
+    it('maps 529 to overloaded_error', async () => {
+      const fetchMock = mock(async () => new Response('overloaded', { status: 529 }));
+      const server = createAnthropicMessagesBridgeServer({
+        baseUrl: 'https://api.example.com',
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      servers.push(server);
+      const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'claude', messages: [], stream: true }),
+      });
+      expect(response.status).toBe(529);
+      const payload = (await response.json()) as { error: { type: string } };
+      expect(payload.error.type).toBe('overloaded_error');
+    });
   });
 
   describe('/v1/models with model metadata', () => {

--- a/packages/daemon/tests/unit/1-core/providers/ollama-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/ollama-bridge-server.test.ts
@@ -429,6 +429,30 @@ describe('Ollama Anthropic bridge server', () => {
     expect(body.error.message).toContain('Too Many Requests');
   });
 
+  it('maps upstream 529 to Anthropic overloaded_error', async () => {
+    const fetchMock = mock(async () => new Response('Overloaded', { status: 529 }));
+    const server = createOllamaAnthropicBridgeServer({
+      baseUrl: 'https://ollama.com',
+      apiKey: 'cloud-key',
+      fetchImpl: fetchMock as typeof fetch,
+    });
+    servers.push(server);
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-oss:120b-cloud',
+        messages: [{ role: 'user', content: 'Hi' }],
+      }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(529);
+    expect(body.error.type).toBe('overloaded_error');
+    expect(body.error.message).toContain('Overloaded');
+  });
+
   it('maps upstream failures to Anthropic JSON errors', async () => {
     const fetchMock = mock(async () => new Response('Unauthorized', { status: 401 }));
     const server = createOllamaAnthropicBridgeServer({

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge-server.test.ts
@@ -218,6 +218,35 @@ describe('OpenAI Chat Completions bridge server', () => {
     expect(body.error.type).toBe('authentication_error');
   });
 
+  it('maps upstream 529 to overloaded_error', async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({ error: { message: 'overloaded' } }), {
+          status: 529,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const server = createOpenAIChatBridgeServer({
+      baseUrl: 'http://upstream.test',
+      fetchImpl: fetchMock as typeof fetch,
+    });
+    servers.push(server);
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'm',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      }),
+    });
+    expect(response.status).toBe(529);
+    const body = (await response.json()) as { type: string; error: { type: string } };
+    expect(body.type).toBe('error');
+    expect(body.error.type).toBe('overloaded_error');
+  });
+
   it('does not crash when controller is already closed before upstream error', async () => {
     // Regression: catch-block `send()` calls used to throw TypeError when the
     // ReadableStreamDefaultController was already closed (client disconnect /

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1588,6 +1588,33 @@ describe('openai-responses-bridge server', () => {
     expect(body.error.message).toBe('slow down');
   });
 
+  it('maps upstream 529 responses to Anthropic overloaded_error', async () => {
+    server = createOpenAIResponsesBridgeServer({
+      auth: { source: 'api_key', apiKey: 'sk-test' },
+      models,
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: { message: 'overloaded' } }), {
+          status: 529,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+
+    const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+
+    const body = (await resp.json()) as { error: { type: string; message: string } };
+    expect(resp.status).toBe(529);
+    expect(body.error.type).toBe('overloaded_error');
+    expect(body.error.message).toBe('overloaded');
+  });
+
   it('uses Codex ChatGPT OAuth endpoint and account header for OAuth auth', async () => {
     let capturedUrl = '';
     let capturedHeaders: Headers | undefined;


### PR DESCRIPTION
## Summary

Maps upstream HTTP 529 to Anthropic `overloaded_error` in all three provider bridges. Today every bridge routes `status >= 500` to generic `api_error`, so 529 (overloaded) lands there and the `overloaded_error` type in `shared/error-envelope.ts` is never emitted.

The SDK retries `overloaded_error` with the correct retry-after cadence, whereas `api_error` retries with generic backoff.

## Changes

One-line addition before the `status >= 500` fallthrough in each bridge:

- `openai-responses-bridge/server.ts` — `mapOpenAIStatusToAnthropicError` (Codex/gpt-5.5 path)
- `openai-chat-bridge/server.ts` — `mapUpstreamStatus` (custom OpenAI endpoints)
- `anthropic-messages-bridge/server.ts` — `mapUpstreamStatus` (GLM/Kimi/OpenRouter pass-through)

## Test plan

- [x] Regression test added to each bridge verifying 529 → `overloaded_error`
- [x] `bun test` passes for all three bridge test files (123 tests, 0 fail)
- [x] Typecheck, lint, knip all clean