### PR TITLE
fix: classify GLM 1305 overload as retryable (multi-language provider codes)

### DIFF
--- a/packages/daemon/src/lib/agent/transient-error-patterns.ts
+++ b/packages/daemon/src/lib/agent/transient-error-patterns.ts
@@ -68,6 +68,16 @@ export const RETRYABLE_PROVIDER_ERROR_TEXT: readonly string[] = [
   'gateway timeout',
   'service unavailable',
   'temporarily unavailable',
+  // GLM (Zhipu) provider overload — code 1305 ("该模型当前访问量过大" = model traffic
+  // too high, try again later). The HTTP 529 transport status may not survive into the
+  // surfaced error string, so match the provider-specific signals directly. The code is
+  // matched in its bracketed payload shape `[1305]` (not as a bare number) so unrelated
+  // numerics (token counts, ports, request ids) cannot false-positive into a retry; the
+  // Chinese phrases are overload-specific descriptions ("access volume too high") that
+  // also catch the payload regardless of how the code is rendered.
+  '[1305]',
+  '访问量过大',
+  '当前访问量过大',
 ];
 
 /**

--- a/packages/daemon/tests/unit/1-core/agent/transient-error-patterns.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/transient-error-patterns.test.ts
@@ -185,4 +185,39 @@ describe('isRetryableProviderError', () => {
       expect(isRetryableProviderError('UNAUTHORIZED')).toBe(false);
     });
   });
+
+  describe('GLM (Zhipu) multi-language provider overload', () => {
+    // Acceptance case: a GLM 529 `[1305]` payload ("该模型当前访问量过大，请您稍后再试"
+    // — model traffic too high, try again later) must be retryable. The HTTP 529
+    // transport status may not appear in the surfaced string, so the provider-specific
+    // code/Chinese signals are matched directly.
+    it('classifies the full GLM 1305 payload as retryable', () => {
+      expect(isRetryableProviderError('[1305][该模型当前访问量过大，请您稍后再试]')).toBe(true);
+    });
+
+    // Each signal must independently classify as retryable (defence in depth).
+    const glmSignals = ['[1305]', '访问量过大', '当前访问量过大'];
+    for (const signal of glmSignals) {
+      it(`classifies GLM signal "${signal}" as retryable`, () => {
+        expect(isRetryableProviderError(signal)).toBe(true);
+      });
+    }
+
+    // The GLM code is matched in its bracketed payload shape only — a bare 1305
+    // (token count, port, request id) must NOT false-positive into a retry, and
+    // generic Chinese retry advice (稍后再试 = "try again later") must NOT either
+    // (it appears on localized terminal/validation errors).
+    const glmFalsePositives = [
+      'prompt is too long: 1305 tokens > 1000 maximum',
+      'request id: req_1305abc',
+      'ECONNREFUSED 127.0.0.1:1305',
+      '参数错误，请稍后再试',
+      '请稍后再试',
+    ];
+    for (const msg of glmFalsePositives) {
+      it(`does NOT classify as retryable: ${msg}`, () => {
+        expect(isRetryableProviderError(msg)).toBe(false);
+      });
+    }
+  });
 });


### PR DESCRIPTION
## What

GLM (Zhipu) 529 `[1305][该模型当前访问量过大，请您稍后再试]` ("model traffic too high, try again later") was still **terminal**: the HTTP 529 transport status often doesn't survive into the surfaced error string, and `RETRYABLE_PROVIDER_ERROR_TEXT` had no GLM-specific signals, so `isRetryableProviderError()` returned false and the bounded retry path (#2184) never fired.

## Change

Add GLM overload signals to `RETRYABLE_PROVIDER_ERROR_TEXT` in `transient-error-patterns.ts`:
- `[1305]` — bracketed payload shape only, so unrelated numerics (token counts, ports, request ids) can't false-positive into a retry.
- `访问量过大` / `当前访问量过大` — overload-specific Chinese descriptions ("access volume too high") that catch the payload regardless of how the code is rendered.

These feed `isRetryableProviderError()` → the existing bounded retry path with backoff (query-runner). Generic advice like `稍后再试` ("try again later") is intentionally excluded — it appears on localized terminal/validation errors too.

## Rebased onto dev
The generic 5xx / bridge-5xx / overload / case-insensitive handling landed in #2184 (`isRetryableProviderError` + word-boundary `HTTP_5XX_STATUS_RE` + bounded backoff retry + terminal guards). This PR is now the focused non-redundant delta: the **GLM multi-language/provider-code** signals that #2184 explicitly anticipated (`RETRYABLE_PROVIDER_ERROR_TEXT` comment: "provider-specific transient signals can be added here").

## Never-retry contract — preserved
`isRetryableProviderError()` already excludes 4xx/auth/quota/model_not_found/501. The GLM additions don't overlap any terminal guard (covered by tests).

## Test plan
`transient-error-patterns.test.ts`: GLM payload + each signal retryable; bare-numeric `1305` (token counts, ports, request ids) and generic `稍后再试` advice do NOT false-positive.

`bun run typecheck` ✅ · `oxlint` ✅ · `biome` ✅ · 229 affected tests pass.