### PR TITLE
feat(bridges): normalize body-embedded/mid-stream provider errors (GLM)

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
@@ -279,10 +279,12 @@ export function createAnthropicMessagesBridgeServer(
       // status gives the SDK nothing to retry on. When the body is not an event
       // stream, buffer it and inspect for a body-embedded transient error; if
       // found, re-emit as a retryable non-2xx response so the SDK retries. A
-      // genuine SSE stream is still passed through byte-for-byte below.
+      // genuine SSE stream is still passed through byte-for-byte below. Covers
+      // both /v1/messages and /v1/messages/count_tokens (GLM can return the
+      // same overload body for either).
       const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
       const isEventStream = upstreamContentType.includes('text/event-stream');
-      if (upstreamResponse.ok && !isEventStream && isMessages) {
+      if (upstreamResponse.ok && !isEventStream && (isMessages || isCountTokens)) {
         const bodyText = await upstreamResponse.text();
         const normalized = normalizeUpstreamError(bodyText, upstreamResponse.status);
         if (normalized) {

--- a/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
@@ -276,15 +276,15 @@ export function createAnthropicMessagesBridgeServer(
 
       // GLM and some Anthropic-compatible shims return 200 with a JSON error
       // body (content-type application/json) instead of an SSE stream — the
-      // status gives the SDK nothing to retry on. When the body is not an event
-      // stream, buffer it and inspect for a body-embedded transient error; if
-      // found, re-emit as a retryable non-2xx response so the SDK retries. A
-      // genuine SSE stream is still passed through byte-for-byte below. Covers
-      // both /v1/messages and /v1/messages/count_tokens (GLM can return the
-      // same overload body for either).
+      // status gives the SDK nothing to retry on. Only pre-buffer when the
+      // content-type explicitly says JSON, so a genuine SSE stream with a
+      // missing/mislabeled content-type still passes through byte-for-byte and
+      // isn't stalled waiting for the whole body. Covers both /v1/messages and
+      // /v1/messages/count_tokens (GLM can return the same overload body for
+      // either).
       const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
-      const isEventStream = upstreamContentType.includes('text/event-stream');
-      if (upstreamResponse.ok && !isEventStream && (isMessages || isCountTokens)) {
+      const isJsonBody = upstreamContentType.includes('application/json');
+      if (upstreamResponse.ok && isJsonBody && (isMessages || isCountTokens)) {
         const bodyText = await upstreamResponse.text();
         const normalized = normalizeUpstreamError(bodyText, upstreamResponse.status);
         if (normalized) {

--- a/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
@@ -22,7 +22,7 @@
  */
 
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
-import { normalizeUpstreamError } from '../shared/normalize-upstream-error.js';
+import { isJsonContentType, normalizeUpstreamError } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('anthropic-messages-bridge-server');
@@ -283,7 +283,7 @@ export function createAnthropicMessagesBridgeServer(
       // /v1/messages/count_tokens (GLM can return the same overload body for
       // either).
       const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
-      const isJsonBody = upstreamContentType.includes('application/json');
+      const isJsonBody = isJsonContentType(upstreamContentType);
       if (upstreamResponse.ok && isJsonBody && (isMessages || isCountTokens)) {
         const bodyText = await upstreamResponse.text();
         const normalized = normalizeUpstreamError(bodyText, upstreamResponse.status);

--- a/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-messages-bridge/server.ts
@@ -22,6 +22,7 @@
  */
 
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
+import { normalizeUpstreamError } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('anthropic-messages-bridge-server');
@@ -63,10 +64,30 @@ export type AnthropicMessagesBridgeConfig = {
   models?: AnthropicMessagesBridgeModel[];
 };
 
-function sendJsonError(status: number, type: AnthropicErrorType, message: string): Response {
+function sendJsonError(
+  status: number,
+  type: AnthropicErrorType,
+  message: string,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(createAnthropicErrorBody(type, message), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  });
+}
+
+/**
+ * Emit a normalized retryable upstream error. Sets `x-should-retry: true` so the
+ * retry intent is explicit (the Claude Agent SDK already retries on 429 / >=500
+ * status, and honours this header as a belt-and-braces override).
+ */
+function sendRetryableUpstreamError(normalized: {
+  type: AnthropicErrorType;
+  status: number;
+  message: string;
+}): Response {
+  return sendJsonError(normalized.status, normalized.type, normalized.message, {
+    'x-should-retry': 'true',
   });
 }
 
@@ -234,11 +255,52 @@ export function createAnthropicMessagesBridgeServer(
 
       if (!upstreamResponse.ok) {
         const text = await upstreamResponse.text();
+        // Inspect the BODY for provider-specific transient signals (GLM code
+        // 1305, 访问量过大, 稍后再试, …) that the status alone cannot convey. A
+        // 4xx carrying an overload code must be reclassified as retryable so the
+        // SDK retries instead of surfacing a terminal invalid_request_error.
+        const normalized = normalizeUpstreamError(text, upstreamResponse.status);
+        if (normalized) {
+          logger.warn(
+            `anthropic-messages-bridge: normalized upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
         return sendJsonError(
           upstreamResponse.status,
           mapUpstreamStatus(upstreamResponse.status),
           text || `Upstream returned HTTP ${upstreamResponse.status}`
         );
+      }
+
+      // GLM and some Anthropic-compatible shims return 200 with a JSON error
+      // body (content-type application/json) instead of an SSE stream — the
+      // status gives the SDK nothing to retry on. When the body is not an event
+      // stream, buffer it and inspect for a body-embedded transient error; if
+      // found, re-emit as a retryable non-2xx response so the SDK retries. A
+      // genuine SSE stream is still passed through byte-for-byte below.
+      const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
+      const isEventStream = upstreamContentType.includes('text/event-stream');
+      if (upstreamResponse.ok && !isEventStream && isMessages) {
+        const bodyText = await upstreamResponse.text();
+        const normalized = normalizeUpstreamError(bodyText, upstreamResponse.status);
+        if (normalized) {
+          logger.warn(
+            `anthropic-messages-bridge: normalized 200-with-body upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
+        // Not a recognized transient error. Re-wrap the buffered bytes unchanged
+        // so we neither break valid non-streaming responses nor hide unknown
+        // errors from the SDK.
+        return new Response(bodyText, {
+          status: upstreamResponse.status,
+          headers: {
+            'Content-Type': upstreamContentType || 'application/json',
+          },
+        });
       }
 
       // Pass the body stream through unchanged. The upstream is already

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -550,6 +550,35 @@ async function* readChatStream(
 }
 
 /**
+ * Extract a serialized `{error: ...}` body from a chat-stream chunk, for both
+ * the standard nested `chunk.error` shape and a FLAT payload.
+ *
+ * `readChatStream` discards the SSE `event:` line, so a flat `event: error`
+ * block like `data: {"type":"server_error","message":"overloaded"}` reaches the
+ * loop with no `error` wrapper. Without this, the flat error chunk has no
+ * choices, is skipped, and the bridge ends with a normal `end_turn` instead of
+ * surfacing the (retryable) error. A flat chunk is only treated as an error
+ * when it has no choices and no usage but carries error-like top-level fields.
+ */
+function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
+  if (chunk.error) return JSON.stringify({ error: chunk.error });
+  if (!chunk.choices?.length && !chunk.usage) {
+    const flat = chunk as Record<string, unknown>;
+    const message = typeof flat.message === 'string' ? flat.message : undefined;
+    const type = typeof flat.type === 'string' ? flat.type : undefined;
+    const code = typeof flat.code === 'string' ? flat.code : undefined;
+    if (message || type || code) {
+      const error: Record<string, unknown> = {};
+      if (message) error.message = message;
+      if (type) error.type = type;
+      if (code) error.code = code;
+      return JSON.stringify({ error });
+    }
+  }
+  return undefined;
+}
+
+/**
  * Translate the upstream OpenAI Chat Completions SSE stream into Anthropic
  * Messages SSE events. Handles incremental tool_calls accumulation.
  */
@@ -648,16 +677,23 @@ async function streamChatToAnthropic(params: {
     let sawAnyChunk = false;
     for await (const chunk of readChatStream(upstreamResponse.body)) {
       sawAnyChunk = true;
-      if (chunk.error?.message) {
-        // Carry the serialized chunk error so the catch handler can classify a
+      const errorBody = chatChunkErrorBody(chunk);
+      if (errorBody) {
+        // Carry the serialized error body so the catch handler can classify a
         // transient mid-stream error (rate_limit / overloaded) instead of
         // defaulting to a terminal api_error. The SDK cannot retry a stream it
         // has already started, so the correct type also lets the query-runner
-        // (B4) recognise and re-issue the whole query.
-        const streamErr = new Error(chunk.error.message);
-        (streamErr as { upstreamErrorBody?: string }).upstreamErrorBody = JSON.stringify({
-          error: chunk.error,
-        });
+        // (B4) recognise and re-issue the whole query. Handles both the nested
+        // `chunk.error` shape and flat payloads (see chatChunkErrorBody).
+        let errorMessage = 'OpenAI stream error';
+        try {
+          const err = (JSON.parse(errorBody).error ?? {}) as { message?: string };
+          if (typeof err.message === 'string' && err.message) errorMessage = err.message;
+        } catch {
+          // keep default
+        }
+        const streamErr = new Error(errorMessage);
+        (streamErr as { upstreamErrorBody?: string }).upstreamErrorBody = errorBody;
         throw streamErr;
       }
       if (chunk.usage) {

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -939,10 +939,13 @@ export function createOpenAIChatBridgeServer(
       }
 
       // Some OpenAI-compatible proxies return 200 with a JSON error body instead
-      // of an SSE stream. Buffer and classify before streaming so a transient
-      // body-embedded error can be re-emitted as a retryable non-2xx response.
+      // of an SSE stream. Only pre-buffer when the content-type explicitly says
+      // JSON — gating on "not event-stream" would also buffer endpoints that
+      // stream valid SSE with a missing/mislabeled content-type, waiting for the
+      // whole body and breaking incremental output. A real SSE stream (any other
+      // content-type, or none) flows straight through to readChatStream.
       const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
-      if (!upstreamContentType.includes('text/event-stream')) {
+      if (upstreamContentType.includes('application/json')) {
         const bodyText = await upstreamResponse.text();
         const normalized = normalizeOpenAiUpstreamError(bodyText, upstreamResponse.status);
         if (normalized) {
@@ -956,7 +959,7 @@ export function createOpenAIChatBridgeServer(
         // the non-SSE body exactly as before (terminal api_error for the user).
         upstreamResponse = new Response(bodyText, {
           status: upstreamResponse.status,
-          headers: { 'Content-Type': upstreamContentType || 'application/json' },
+          headers: { 'Content-Type': upstreamContentType },
         });
       }
 

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -38,6 +38,7 @@ import {
 } from '../provider-anthropic-compat/translator.js';
 import { estimateAnthropicInputTokens } from '../provider-anthropic-compat/token-estimator.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
+import { normalizeOpenAiUpstreamError } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('openai-chat-bridge-server');
@@ -176,10 +177,29 @@ type OpenAIChatStreamChunk = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sendJsonError(status: number, type: AnthropicErrorType, message: string): Response {
+function sendJsonError(
+  status: number,
+  type: AnthropicErrorType,
+  message: string,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(createAnthropicErrorBody(type, message), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  });
+}
+
+/**
+ * Emit a normalized retryable upstream error with `x-should-retry: true` so the
+ * Claude Agent SDK retries (it already retries on 429 / >=500 status).
+ */
+function sendRetryableUpstreamError(normalized: {
+  type: AnthropicErrorType;
+  status: number;
+  message: string;
+}): Response {
+  return sendJsonError(normalized.status, normalized.type, normalized.message, {
+    'x-should-retry': 'true',
   });
 }
 
@@ -625,7 +645,18 @@ async function streamChatToAnthropic(params: {
     let sawAnyChunk = false;
     for await (const chunk of readChatStream(upstreamResponse.body)) {
       sawAnyChunk = true;
-      if (chunk.error?.message) throw new Error(chunk.error.message);
+      if (chunk.error?.message) {
+        // Carry the serialized chunk error so the catch handler can classify a
+        // transient mid-stream error (rate_limit / overloaded) instead of
+        // defaulting to a terminal api_error. The SDK cannot retry a stream it
+        // has already started, so the correct type also lets the query-runner
+        // (B4) recognise and re-issue the whole query.
+        const streamErr = new Error(chunk.error.message);
+        (streamErr as { upstreamErrorBody?: string }).upstreamErrorBody = JSON.stringify({
+          error: chunk.error,
+        });
+        throw streamErr;
+      }
       if (chunk.usage) {
         finalPromptTokens = chunk.usage.prompt_tokens ?? finalPromptTokens;
         finalCompletionTokens = chunk.usage.completion_tokens ?? finalCompletionTokens;
@@ -743,8 +774,15 @@ async function streamChatToAnthropic(params: {
       'openai-chat-bridge: streaming failed:',
       error instanceof Error ? error.message : String(error)
     );
+    // Classify a transient mid-stream error body to the right Anthropic type so
+    // the SDK (and query-runner B4) can recognise it as retryable.
+    const upstreamErrorBody = (error as { upstreamErrorBody?: string }).upstreamErrorBody;
+    const normalized = upstreamErrorBody
+      ? normalizeOpenAiUpstreamError(upstreamErrorBody, 200)
+      : undefined;
+    const errorType: AnthropicErrorType = normalized?.type ?? 'api_error';
     try {
-      send(errorSSE('api_error', error instanceof Error ? error.message : 'OpenAI stream failed'));
+      send(errorSSE(errorType, error instanceof Error ? error.message : 'OpenAI stream failed'));
     } catch {
       // Controller already closed (client disconnect or upstream tear-down).
     }
@@ -881,11 +919,45 @@ export function createOpenAIChatBridgeServer(
 
       if (!upstreamResponse.ok) {
         const text = await upstreamResponse.text();
+        // Inspect the BODY for transient signals (rate_limit_exceeded /
+        // server_error / overload text) that the status alone misses — e.g. a
+        // 4xx carrying a rate-limit body, or a 5xx that should surface as
+        // overloaded_error. Reclassify so the SDK retries.
+        const normalized = normalizeOpenAiUpstreamError(text, upstreamResponse.status);
+        if (normalized) {
+          logger.warn(
+            `openai-chat-bridge: normalized upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
         return sendJsonError(
           upstreamResponse.status,
           mapUpstreamStatus(upstreamResponse.status),
           parseUpstreamError(upstreamResponse.status, text)
         );
+      }
+
+      // Some OpenAI-compatible proxies return 200 with a JSON error body instead
+      // of an SSE stream. Buffer and classify before streaming so a transient
+      // body-embedded error can be re-emitted as a retryable non-2xx response.
+      const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
+      if (!upstreamContentType.includes('text/event-stream')) {
+        const bodyText = await upstreamResponse.text();
+        const normalized = normalizeOpenAiUpstreamError(bodyText, upstreamResponse.status);
+        if (normalized) {
+          logger.warn(
+            `openai-chat-bridge: normalized 200-with-body upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
+        // Non-transient: reconstruct the response so the streaming path handles
+        // the non-SSE body exactly as before (terminal api_error for the user).
+        upstreamResponse = new Response(bodyText, {
+          status: upstreamResponse.status,
+          headers: { 'Content-Type': upstreamContentType || 'application/json' },
+        });
       }
 
       const stream = new ReadableStream<Uint8Array>({

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -566,8 +566,10 @@ function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
   if (!chunk.choices?.length && !chunk.usage) {
     const flat = chunk as Record<string, unknown>;
     const message = typeof flat.message === 'string' ? flat.message : undefined;
+    const detail = typeof flat.detail === 'string' ? flat.detail : undefined;
     const type = typeof flat.type === 'string' ? flat.type : undefined;
-    // Accept numeric codes (some gateways send {"code":429}) — coerce to string
+    // Accept numeric codes (some gateways send {"code":429}) and RFC 7807
+    // problem-detail fields (status→code, detail→message), coercing to strings
     // so the normalizer can classify them.
     const rawCode = flat.code;
     const code =
@@ -576,16 +578,29 @@ function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
         : typeof rawCode === 'number' && Number.isFinite(rawCode)
           ? String(rawCode)
           : undefined;
-    // Require an actual error signal: a message, a code, OR a `type` that is a
-    // recognized transient error type. A bare unknown `type` is treated as a
-    // heartbeat/metadata frame (e.g. `{"type":"ping"}`) and ignored so it
-    // doesn't abort a valid stream; a known type-only frame like
+    const rawStatus = flat.status;
+    const status =
+      typeof rawStatus === 'string'
+        ? rawStatus
+        : typeof rawStatus === 'number' && Number.isFinite(rawStatus)
+          ? String(rawStatus)
+          : undefined;
+    // Require an actual error signal: a message/detail, a code/status, OR a
+    // `type` that is a recognized transient error type. A bare unknown `type`
+    // is treated as a heartbeat/metadata frame (e.g. `{"type":"ping"}`) and
+    // ignored so it doesn't abort a valid stream; a known type-only frame like
     // `{"type":"server_error"}` is still admitted.
-    if (message || code || (type !== undefined && isOpenAiTransientErrorType(type))) {
+    if (
+      message ||
+      detail ||
+      code ||
+      status ||
+      (type !== undefined && isOpenAiTransientErrorType(type))
+    ) {
       const error: Record<string, unknown> = {};
-      if (message) error.message = message;
+      if (message ?? detail) error.message = message ?? detail;
       if (type) error.type = type;
-      if (code) error.code = code;
+      if (code ?? status) error.code = code ?? status;
       return JSON.stringify({ error });
     }
   }

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -38,7 +38,10 @@ import {
 } from '../provider-anthropic-compat/translator.js';
 import { estimateAnthropicInputTokens } from '../provider-anthropic-compat/token-estimator.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
-import { normalizeOpenAiUpstreamError } from '../shared/normalize-upstream-error.js';
+import {
+  isJsonContentType,
+  normalizeOpenAiUpstreamError,
+} from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('openai-chat-bridge-server');
@@ -945,7 +948,7 @@ export function createOpenAIChatBridgeServer(
       // whole body and breaking incremental output. A real SSE stream (any other
       // content-type, or none) flows straight through to readChatStream.
       const upstreamContentType = upstreamResponse.headers.get('content-type') ?? '';
-      if (upstreamContentType.includes('application/json')) {
+      if (isJsonContentType(upstreamContentType)) {
         const bodyText = await upstreamResponse.text();
         const normalized = normalizeOpenAiUpstreamError(bodyText, upstreamResponse.status);
         if (normalized) {

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -567,7 +567,15 @@ function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
     const flat = chunk as Record<string, unknown>;
     const message = typeof flat.message === 'string' ? flat.message : undefined;
     const type = typeof flat.type === 'string' ? flat.type : undefined;
-    const code = typeof flat.code === 'string' ? flat.code : undefined;
+    // Accept numeric codes (some gateways send {"code":429}) — coerce to string
+    // so the normalizer can classify them.
+    const rawCode = flat.code;
+    const code =
+      typeof rawCode === 'string'
+        ? rawCode
+        : typeof rawCode === 'number' && Number.isFinite(rawCode)
+          ? String(rawCode)
+          : undefined;
     // Require an actual error signal: a message, a code, OR a `type` that is a
     // recognized transient error type. A bare unknown `type` is treated as a
     // heartbeat/metadata frame (e.g. `{"type":"ping"}`) and ignored so it

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -567,7 +567,12 @@ function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
     const message = typeof flat.message === 'string' ? flat.message : undefined;
     const type = typeof flat.type === 'string' ? flat.type : undefined;
     const code = typeof flat.code === 'string' ? flat.code : undefined;
-    if (message || type || code) {
+    // Require an actual error signal (a message or a code) — NOT a bare `type`.
+    // Some OpenAI-compatible endpoints send JSON heartbeat/metadata frames like
+    // `{"type":"ping"}`; treating type-only frames as errors would abort a
+    // valid stream with a terminal api_error before later choices arrive.
+    // A `type` is still folded into the body for classification when present.
+    if (message || code) {
       const error: Record<string, unknown> = {};
       if (message) error.message = message;
       if (type) error.type = type;

--- a/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-chat-bridge/server.ts
@@ -40,6 +40,7 @@ import { estimateAnthropicInputTokens } from '../provider-anthropic-compat/token
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
 import {
   isJsonContentType,
+  isOpenAiTransientErrorType,
   normalizeOpenAiUpstreamError,
 } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
@@ -567,12 +568,12 @@ function chatChunkErrorBody(chunk: OpenAIChatStreamChunk): string | undefined {
     const message = typeof flat.message === 'string' ? flat.message : undefined;
     const type = typeof flat.type === 'string' ? flat.type : undefined;
     const code = typeof flat.code === 'string' ? flat.code : undefined;
-    // Require an actual error signal (a message or a code) — NOT a bare `type`.
-    // Some OpenAI-compatible endpoints send JSON heartbeat/metadata frames like
-    // `{"type":"ping"}`; treating type-only frames as errors would abort a
-    // valid stream with a terminal api_error before later choices arrive.
-    // A `type` is still folded into the body for classification when present.
-    if (message || code) {
+    // Require an actual error signal: a message, a code, OR a `type` that is a
+    // recognized transient error type. A bare unknown `type` is treated as a
+    // heartbeat/metadata frame (e.g. `{"type":"ping"}`) and ignored so it
+    // doesn't abort a valid stream; a known type-only frame like
+    // `{"type":"server_error"}` is still admitted.
+    if (message || code || (type !== undefined && isOpenAiTransientErrorType(type))) {
       const error: Record<string, unknown> = {};
       if (message) error.message = message;
       if (type) error.type = type;

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -1137,8 +1137,16 @@ async function streamResponsesToAnthropic({
         // already started, but the right type lets the query-runner (B4)
         // recognise and re-issue the whole query.
         const message = streamErrorMessage(event);
+        // `response.failed` carries the error under `event.response.error`; the
+        // `error` event carries it under `event.error`. Inspect whichever shape
+        // the upstream used so a transient `response.failed` is classified too.
+        const responseObject = event.response;
+        const responseError =
+          responseObject && typeof responseObject === 'object'
+            ? (responseObject as Record<string, unknown>).error
+            : undefined;
         const normalized = normalizeOpenAiUpstreamError(
-          JSON.stringify({ error: event.error ?? {} }),
+          JSON.stringify({ error: event.error ?? responseError ?? {} }),
           200
         );
         send(errorSSE(normalized?.type ?? 'api_error', message));
@@ -1490,6 +1498,17 @@ export function createOpenAIResponsesBridgeServer(
             continuation = undefined;
           } else {
             logUpstream4xx(openAIResponse.status, requestBody, errorText);
+            // The 400 isn't about previous_response_id — still inspect the body
+            // for a transient signal (a proxy may return 400 with a structured
+            // rate_limit/server body) before falling back to invalid_request.
+            const normalized = normalizeOpenAiUpstreamError(errorText, openAIResponse.status);
+            if (normalized) {
+              logger.warn(
+                `openai-responses: normalized continuation 400 to retryable ` +
+                  `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+              );
+              return sendRetryableUpstreamError(normalized);
+            }
             return sendJsonError(
               openAIResponse.status,
               mapOpenAIStatusToAnthropicError(openAIResponse.status),
@@ -1558,6 +1577,29 @@ export function createOpenAIResponsesBridgeServer(
           parseOpenAIError(openAIResponse.status, text)
         );
       }
+
+      // Some Responses-compatible proxies return 200 with a JSON error body
+      // instead of an SSE stream. With no SSE events the streamer below would
+      // emit a successful empty end_turn, hiding a body-embedded transient
+      // error. Buffer and classify before streaming (same as the chat bridge).
+      const upstreamContentType = openAIResponse.headers.get('content-type') ?? '';
+      if (openAIResponse.ok && !upstreamContentType.includes('text/event-stream')) {
+        const bodyText = await openAIResponse.text();
+        const normalized = normalizeOpenAiUpstreamError(bodyText, openAIResponse.status);
+        if (normalized) {
+          logger.warn(
+            `openai-responses: normalized 200-with-body upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
+        // Non-transient: reconstruct so the streaming path handles it as before.
+        openAIResponse = new Response(bodyText, {
+          status: openAIResponse.status,
+          headers: { 'Content-Type': upstreamContentType || 'application/json' },
+        });
+      }
+
       consumeContinuation(sessionId, resolvedContinuation);
 
       const estimatedInputTokens = continuation

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -29,7 +29,10 @@ import {
 } from '../provider-anthropic-compat/translator.js';
 import { getModelContextWindow as getCodexModelContextWindow } from '../codex-models.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
-import { normalizeOpenAiUpstreamError } from '../shared/normalize-upstream-error.js';
+import {
+  isJsonContentType,
+  normalizeOpenAiUpstreamError,
+} from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('openai-responses-bridge-server');
@@ -1543,6 +1546,21 @@ export function createOpenAIResponsesBridgeServer(
         ) {
           const errorText = await openAIResponse.text();
           logUpstream4xx(openAIResponse.status, requestBody, errorText);
+          // A transient 400 (rate_limit/overload in the body) is NOT a
+          // stale-reasoning failure. Normalize it to retryable so the SDK
+          // retries with backoff, instead of self-healing by dropping reasoning
+          // (which would mask the real rate-limit and skip the SDK retry path).
+          const reasoningNormalized = normalizeOpenAiUpstreamError(
+            errorText,
+            openAIResponse.status
+          );
+          if (reasoningNormalized) {
+            logger.warn(
+              `openai-responses: normalized reasoning 400 to retryable ` +
+                `${reasoningNormalized.type} (${reasoningNormalized.status}): ${reasoningNormalized.message.slice(0, 200)}`
+            );
+            return sendRetryableUpstreamError(reasoningNormalized);
+          }
           logger.warn(
             'openai-responses: 400 with replayed reasoning present — retrying once without reasoning items'
           );
@@ -1598,7 +1616,7 @@ export function createOpenAIResponsesBridgeServer(
       // real SSE stream with a missing/mislabeled content-type flows straight
       // through to the streamer.
       const upstreamContentType = openAIResponse.headers.get('content-type') ?? '';
-      if (openAIResponse.ok && upstreamContentType.includes('application/json')) {
+      if (openAIResponse.ok && isJsonContentType(upstreamContentType)) {
         const bodyText = await openAIResponse.text();
         const normalized = normalizeOpenAiUpstreamError(bodyText, openAIResponse.status);
         if (normalized) {

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -1136,20 +1136,33 @@ async function streamResponsesToAnthropic({
         // correct Anthropic type surfaces. The SDK cannot retry a stream it has
         // already started, but the right type lets the query-runner (B4)
         // recognise and re-issue the whole query.
-        const message = streamErrorMessage(event);
         // `response.failed` carries the error under `event.response.error`; the
-        // `error` event carries it under `event.error`. Inspect whichever shape
-        // the upstream used so a transient `response.failed` is classified too.
+        // `error` event under `event.error`; some upstreams put code/message at
+        // the event top level. Inspect whichever shape the upstream used.
         const responseObject = event.response;
         const responseError =
           responseObject && typeof responseObject === 'object'
             ? (responseObject as Record<string, unknown>).error
             : undefined;
+        const flatEvent = event as Record<string, unknown>;
+        const topLevelError: Record<string, unknown> = {};
+        if (typeof flatEvent.code === 'string') topLevelError.code = flatEvent.code;
+        if (typeof flatEvent.message === 'string') topLevelError.message = flatEvent.message;
+        if (typeof flatEvent.type === 'string' && flatEvent.type !== event.type)
+          topLevelError.type = flatEvent.type;
+        const errorBody =
+          event.error ??
+          responseError ??
+          (Object.keys(topLevelError).length > 0 ? topLevelError : undefined);
         const normalized = normalizeOpenAiUpstreamError(
-          JSON.stringify({ error: event.error ?? responseError ?? {} }),
+          JSON.stringify({ error: errorBody ?? {} }),
           200
         );
-        send(errorSSE(normalized?.type ?? 'api_error', message));
+        const bodyMessage =
+          errorBody && typeof (errorBody as Record<string, unknown>).message === 'string'
+            ? ((errorBody as Record<string, unknown>).message as string)
+            : undefined;
+        send(errorSSE(normalized?.type ?? 'api_error', bodyMessage ?? streamErrorMessage(event)));
         send(messageStopSSE());
         closeController();
         return;
@@ -1581,9 +1594,11 @@ export function createOpenAIResponsesBridgeServer(
       // Some Responses-compatible proxies return 200 with a JSON error body
       // instead of an SSE stream. With no SSE events the streamer below would
       // emit a successful empty end_turn, hiding a body-embedded transient
-      // error. Buffer and classify before streaming (same as the chat bridge).
+      // error. Only pre-buffer when the content-type explicitly says JSON — a
+      // real SSE stream with a missing/mislabeled content-type flows straight
+      // through to the streamer.
       const upstreamContentType = openAIResponse.headers.get('content-type') ?? '';
-      if (openAIResponse.ok && !upstreamContentType.includes('text/event-stream')) {
+      if (openAIResponse.ok && upstreamContentType.includes('application/json')) {
         const bodyText = await openAIResponse.text();
         const normalized = normalizeOpenAiUpstreamError(bodyText, openAIResponse.status);
         if (normalized) {
@@ -1596,7 +1611,7 @@ export function createOpenAIResponsesBridgeServer(
         // Non-transient: reconstruct so the streaming path handles it as before.
         openAIResponse = new Response(bodyText, {
           status: openAIResponse.status,
-          headers: { 'Content-Type': upstreamContentType || 'application/json' },
+          headers: { 'Content-Type': upstreamContentType },
         });
       }
 

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -31,6 +31,7 @@ import { getModelContextWindow as getCodexModelContextWindow } from '../codex-mo
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
 import {
   isJsonContentType,
+  isOpenAiTransientErrorType,
   normalizeOpenAiUpstreamError,
 } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
@@ -1141,14 +1142,15 @@ async function streamResponsesToAnthropic({
 
       const sseEvent = (event as { sseEvent?: string }).sseEvent;
       // An error frame is signalled by the payload type (`error` /
-      // `response.failed`) OR by the raw SSE `event:` name — a flat
-      // `event: error` block whose data type is the error category (e.g.
-      // {"type":"server_error"}) only carries the name in sseEvent.
+      // `response.failed`), the raw SSE `event:` name, OR a data-only frame
+      // whose payload type is a known transient error category (e.g.
+      // {"type":"server_error"} with no event line).
       if (
         event.type === 'response.failed' ||
         event.type === 'error' ||
         sseEvent === 'error' ||
-        sseEvent === 'response.failed'
+        sseEvent === 'response.failed' ||
+        (event.type !== undefined && isOpenAiTransientErrorType(event.type))
       ) {
         ensureStarted();
         closeThinkingBlock();
@@ -1167,14 +1169,16 @@ async function streamResponsesToAnthropic({
             : undefined;
         const flatEvent = event as Record<string, unknown>;
         const topLevelError: Record<string, unknown> = {};
-        if (typeof flatEvent.code === 'string') topLevelError.code = flatEvent.code;
+        // Accept numeric codes (e.g. {"code":429}) — coerce to string.
+        const rawCode = flatEvent.code;
+        if (typeof rawCode === 'string') topLevelError.code = rawCode;
+        else if (typeof rawCode === 'number' && Number.isFinite(rawCode))
+          topLevelError.code = String(rawCode);
         if (typeof flatEvent.message === 'string') topLevelError.message = flatEvent.message;
-        // The payload `type` is the error category when it differs from the SSE
-        // event discriminator (sseEvent / "error" / "response.failed").
-        const discriminant = sseEvent ?? event.type;
+        // The payload `type` is the error category when it is not the literal
+        // event discriminator ("error" / "response.failed").
         if (
           typeof flatEvent.type === 'string' &&
-          flatEvent.type !== discriminant &&
           flatEvent.type !== 'error' &&
           flatEvent.type !== 'response.failed'
         )

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -1169,12 +1169,20 @@ async function streamResponsesToAnthropic({
             : undefined;
         const flatEvent = event as Record<string, unknown>;
         const topLevelError: Record<string, unknown> = {};
-        // Accept numeric codes (e.g. {"code":429}) — coerce to string.
+        // Accept numeric codes (e.g. {"code":429}) and RFC 7807 problem-detail
+        // fields (status→code, detail→message), coercing to strings.
         const rawCode = flatEvent.code;
         if (typeof rawCode === 'string') topLevelError.code = rawCode;
         else if (typeof rawCode === 'number' && Number.isFinite(rawCode))
           topLevelError.code = String(rawCode);
+        else {
+          const rawStatus = flatEvent.status;
+          if (typeof rawStatus === 'string') topLevelError.code = rawStatus;
+          else if (typeof rawStatus === 'number' && Number.isFinite(rawStatus))
+            topLevelError.code = String(rawStatus);
+        }
         if (typeof flatEvent.message === 'string') topLevelError.message = flatEvent.message;
+        else if (typeof flatEvent.detail === 'string') topLevelError.message = flatEvent.detail;
         // The payload `type` is the error category when it is not the literal
         // event discriminator ("error" / "response.failed").
         if (

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -842,7 +842,15 @@ function parseSSEBlock(block: string): OpenAIStreamEvent | null {
   if (!data || data === '[DONE]') return null;
   const parsed = parseJsonObject(data);
   if (!parsed) return null;
-  return { type: eventType || (parsed.type as string | undefined), ...parsed };
+  return {
+    type: eventType || (parsed.type as string | undefined),
+    ...parsed,
+    // Preserve the raw SSE `event:` name. The spread above lets the payload
+    // `type` overwrite it, so a flat `event: error` block whose data has a
+    // different type (e.g. {"type":"server_error"}) would otherwise lose the
+    // fact that it was an error frame.
+    ...(eventType ? { sseEvent: eventType } : {}),
+  };
 }
 
 async function* readOpenAIStream(
@@ -1131,7 +1139,17 @@ async function streamResponsesToAnthropic({
         continue;
       }
 
-      if (event.type === 'response.failed' || event.type === 'error') {
+      const sseEvent = (event as { sseEvent?: string }).sseEvent;
+      // An error frame is signalled by the payload type (`error` /
+      // `response.failed`) OR by the raw SSE `event:` name — a flat
+      // `event: error` block whose data type is the error category (e.g.
+      // {"type":"server_error"}) only carries the name in sseEvent.
+      if (
+        event.type === 'response.failed' ||
+        event.type === 'error' ||
+        sseEvent === 'error' ||
+        sseEvent === 'response.failed'
+      ) {
         ensureStarted();
         closeThinkingBlock();
         closeTextBlock();
@@ -1151,7 +1169,15 @@ async function streamResponsesToAnthropic({
         const topLevelError: Record<string, unknown> = {};
         if (typeof flatEvent.code === 'string') topLevelError.code = flatEvent.code;
         if (typeof flatEvent.message === 'string') topLevelError.message = flatEvent.message;
-        if (typeof flatEvent.type === 'string' && flatEvent.type !== event.type)
+        // The payload `type` is the error category when it differs from the SSE
+        // event discriminator (sseEvent / "error" / "response.failed").
+        const discriminant = sseEvent ?? event.type;
+        if (
+          typeof flatEvent.type === 'string' &&
+          flatEvent.type !== discriminant &&
+          flatEvent.type !== 'error' &&
+          flatEvent.type !== 'response.failed'
+        )
           topLevelError.type = flatEvent.type;
         const errorBody =
           event.error ??

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -29,6 +29,7 @@ import {
 } from '../provider-anthropic-compat/translator.js';
 import { getModelContextWindow as getCodexModelContextWindow } from '../codex-models.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
+import { normalizeOpenAiUpstreamError } from '../shared/normalize-upstream-error.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('openai-responses-bridge-server');
@@ -228,10 +229,29 @@ function continuationKey(sessionId: string, callId: string): string {
   return `${sessionId}\u0000${callId}`;
 }
 
-function sendJsonError(status: number, type: AnthropicErrorType, message: string): Response {
+function sendJsonError(
+  status: number,
+  type: AnthropicErrorType,
+  message: string,
+  extraHeaders?: Record<string, string>
+): Response {
   return new Response(createAnthropicErrorBody(type, message), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  });
+}
+
+/**
+ * Emit a normalized retryable upstream error with `x-should-retry: true` so the
+ * Claude Agent SDK retries (it already retries on 429 / >=500 status).
+ */
+function sendRetryableUpstreamError(normalized: {
+  type: AnthropicErrorType;
+  status: number;
+  message: string;
+}): Response {
+  return sendJsonError(normalized.status, normalized.type, normalized.message, {
+    'x-should-retry': 'true',
   });
 }
 
@@ -1112,7 +1132,16 @@ async function streamResponsesToAnthropic({
         ensureStarted();
         closeThinkingBlock();
         closeTextBlock();
-        send(errorSSE('api_error', streamErrorMessage(event)));
+        // Classify a transient mid-stream error (rate_limit / overloaded) so the
+        // correct Anthropic type surfaces. The SDK cannot retry a stream it has
+        // already started, but the right type lets the query-runner (B4)
+        // recognise and re-issue the whole query.
+        const message = streamErrorMessage(event);
+        const normalized = normalizeOpenAiUpstreamError(
+          JSON.stringify({ error: event.error ?? {} }),
+          200
+        );
+        send(errorSSE(normalized?.type ?? 'api_error', message));
         send(messageStopSSE());
         closeController();
         return;
@@ -1512,6 +1541,17 @@ export function createOpenAIResponsesBridgeServer(
       if (!openAIResponse.ok) {
         const text = await openAIResponse.text();
         logUpstream4xx(openAIResponse.status, requestBody, text);
+        // Inspect the BODY for transient signals (rate_limit_exceeded /
+        // server_error / overload text) the status alone misses — e.g. a 4xx
+        // carrying a rate-limit body. Reclassify so the SDK retries.
+        const normalized = normalizeOpenAiUpstreamError(text, openAIResponse.status);
+        if (normalized) {
+          logger.warn(
+            `openai-responses: normalized upstream error to retryable ` +
+              `${normalized.type} (${normalized.status}): ${normalized.message.slice(0, 200)}`
+          );
+          return sendRetryableUpstreamError(normalized);
+        }
         return sendJsonError(
           openAIResponse.status,
           mapOpenAIStatusToAnthropicError(openAIResponse.status),

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -179,6 +179,18 @@ const TRANSIENT_RATE_LIMIT_TYPES = new Set(['rate_limit_exceeded', 'rate_limit_e
 const TRANSIENT_OVERLOAD_TYPES = new Set(['server_error', 'overloaded_error', '503', '529']);
 
 /**
+ * True if a string is a recognized transient error type/code — OpenAI
+ * (`rate_limit_exceeded`, `server_error`), Anthropic (`rate_limit_error`,
+ * `overloaded_error`), or an HTTP status code some gateways put in `code`
+ * (`429`, `503`, `529`). Used to admit type-only flat error frames while still
+ * ignoring unknown heartbeat/metadata frames (e.g. `{"type":"ping"}`).
+ */
+export function isOpenAiTransientErrorType(type: string): boolean {
+  const t = type.toLowerCase();
+  return TRANSIENT_RATE_LIMIT_TYPES.has(t) || TRANSIENT_OVERLOAD_TYPES.has(t);
+}
+
+/**
  * Inspect an OpenAI-compatible upstream response body for transient signals.
  * OpenAI / most proxies already convey transient failures via 429 / 5xx
  * statuses (which the SDK retries), so this primarily recovers the two cases

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -138,16 +138,22 @@ export function normalizeGlmUpstreamError(
       ? (parsed.error as Record<string, unknown>)
       : undefined;
   const codeField = readStringField(errorObj, 'code') ?? readStringField(parsed, 'code');
-  const messageField =
-    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message') ?? body;
+  // Message for substring matching — extracted error/message fields only, NOT
+  // the raw body (a valid JSON success response whose content mentions the GLM
+  // overload phrases must not be misclassified). The result message still falls
+  // back to the body for context.
+  const messageForMatching =
+    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message');
+  const messageField = messageForMatching ?? body;
 
   const isTransientCode = codeField === GLM_RATE_LIMIT_CODE;
-  // Match the GLM-specific Chinese substrings against both the raw body and the
-  // extracted message so we catch Anthropic-shaped envelopes that wrap the
-  // original GLM message in `error.message`.
-  const hasOverloadText =
-    containsAny(body, GLM_TRANSIENT_ERROR_SUBSTRINGS) ||
-    containsAny(messageField, GLM_TRANSIENT_ERROR_SUBSTRINGS);
+  // For JSON bodies, match ONLY against the extracted error/message fields. For
+  // non-JSON bodies (plain-text errors from proxies), fall back to scanning the
+  // raw text since there are no structured fields to read.
+  const hasOverloadText = parsed
+    ? messageForMatching !== undefined &&
+      containsAny(messageForMatching, GLM_TRANSIENT_ERROR_SUBSTRINGS)
+    : containsAny(body, GLM_TRANSIENT_ERROR_SUBSTRINGS);
 
   if (!isTransientCode && !hasOverloadText) return null;
 

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -138,12 +138,15 @@ export function normalizeGlmUpstreamError(
       ? (parsed.error as Record<string, unknown>)
       : undefined;
   const codeField = readStringField(errorObj, 'code') ?? readStringField(parsed, 'code');
-  // Message for substring matching — extracted error/message fields only, NOT
-  // the raw body (a valid JSON success response whose content mentions the GLM
-  // overload phrases must not be misclassified). The result message still falls
-  // back to the body for context.
+  // Message for substring matching — extracted error/message/detail fields only,
+  // NOT the raw body (a valid JSON success response whose content mentions the
+  // GLM overload phrases must not be misclassified). The result message still
+  // falls back to the body for context.
   const messageForMatching =
-    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message');
+    readStringField(errorObj, 'message') ??
+    readStringField(parsed, 'message') ??
+    readStringField(errorObj, 'detail') ??
+    readStringField(parsed, 'detail');
   const messageField = messageForMatching ?? body;
 
   const isTransientCode = codeField === GLM_RATE_LIMIT_CODE;
@@ -172,7 +175,7 @@ export function normalizeGlmUpstreamError(
 // a genuine 4xx invalid_request into a retryable error on weak evidence.
 const OPENAI_RATE_LIMIT_PATTERN = /rate_limit_exceeded|rate[ _-]?limit|too many requests/i;
 const OPENAI_OVERLOAD_PATTERN =
-  /overloaded|service unavailable|temporarily unavailable|try again (?:later|in)/i;
+  /overloaded|service unavailable|temporarily unavailable|try again (?:later|in)|internal server error|bad gateway|gateway timeout/i;
 /**
  * Structured `error.type`/`error.code` values that mark a transient fault.
  * Includes OpenAI values (`rate_limit_exceeded`, `server_error`), Anthropic
@@ -182,7 +185,15 @@ const OPENAI_OVERLOAD_PATTERN =
  * Anthropic-shaped body is the strongest possible structured signal.
  */
 const TRANSIENT_RATE_LIMIT_TYPES = new Set(['rate_limit_exceeded', 'rate_limit_error', '429']);
-const TRANSIENT_OVERLOAD_TYPES = new Set(['server_error', 'overloaded_error', '503', '529']);
+const TRANSIENT_OVERLOAD_TYPES = new Set([
+  'server_error',
+  'overloaded_error',
+  '500',
+  '502',
+  '503',
+  '504',
+  '529',
+]);
 
 /**
  * True if a string is a recognized transient error type/code — OpenAI
@@ -226,18 +237,25 @@ export function normalizeOpenAiUpstreamError(
   // top-level body — some upstreams emit a FLAT body like
   // `{"code":"rate_limit_exceeded","message":"slow down"}` with no `error`
   // wrapper, and those top-level fields are structured evidence too.
+  // Also accept RFC 7807 problem+json fields: `detail` (message) and `status`
+  // (HTTP status code), since the content-type gate already accepts
+  // `application/problem+json`.
   const typeField = (
     readStringField(errorObj, 'type') ?? readStringField(parsed, 'type')
   )?.toLowerCase();
   const codeField = (
-    readStringField(errorObj, 'code') ?? readStringField(parsed, 'code')
+    readStringField(errorObj, 'code') ??
+    readStringField(parsed, 'code') ??
+    readStringField(errorObj, 'status') ??
+    readStringField(parsed, 'status')
   )?.toLowerCase();
   // Message for substring matching — use ONLY the extracted error/top-level
-  // message, NOT the raw body. Scanning the whole body would misclassify a valid
-  // non-error JSON response (e.g. a non-streaming completion whose text mentions
-  // "rate limit" or "overloaded") as a retryable error.
+  // message (or problem+json `detail`), NOT the raw body.
   const messageForMatching =
-    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message');
+    readStringField(errorObj, 'message') ??
+    readStringField(parsed, 'message') ??
+    readStringField(errorObj, 'detail') ??
+    readStringField(parsed, 'detail');
   // Result message falls back to the body so the surfaced error has context.
   const messageField = messageForMatching ?? body;
 

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -238,12 +238,15 @@ export function normalizeOpenAiUpstreamError(
 
   if (!isRate && !isOverload) return null;
 
-  // A hard 4xx (other than 429) usually means a permanent client error
-  // (auth/not-found/bad-request). Only reclassify it when the body carries a
-  // strong STRUCTURED transient signal; otherwise leave it to the status-based
-  // mapping so we don't retry a genuine 401/404 indefinitely.
-  const isHard4xx = status >= 400 && status < 500 && status !== 429;
-  if (isHard4xx && !isRateType && !isServerType) return null;
+  // An explicit client-side status (4xx, including 429) is a trustworthy
+  // signal: a hard 4xx usually means a permanent client error
+  // (auth/not-found/bad-request), and a 429 is already a rate limit. Only let a
+  // STRONG STRUCTURED transient signal (error.type/error.code) override such a
+  // status — never loose message substrings. Otherwise we'd either retry a
+  // genuine 401/404 indefinitely, or let a "try again later" message override an
+  // explicit 429 and mislabel it as overloaded_error.
+  const isExplicitClientStatus = status >= 400 && status < 500;
+  if (isExplicitClientStatus && !isRateType && !isServerType) return null;
 
   // Structured type evidence wins over loose message substrings: a body whose
   // `type` is `rate_limit_exceeded` must classify as rate_limit_error (429) even

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -1,0 +1,227 @@
+/**
+ * Per-bridge upstream-error normalization.
+ *
+ * Bridges used to classify upstream errors by HTTP status only
+ * (`mapUpstreamStatus` / `mapOpenAIStatusToAnthropicError`). Many gateways —
+ * GLM (open.bigmodel.cn) especially — return transient errors embedded in the
+ * response BODY, not the status:
+ *
+ *   - 200-with-error-body: HTTP 200 but the body is a JSON error object instead
+ *     of an SSE stream. The pass-through bridge forwarded it verbatim, so the
+ *     SDK saw a 200 "success" and the error became terminal (no retry).
+ *   - non-2xx-with-error-body: the status (e.g. 400) implied a non-retryable
+ *     `invalid_request_error` even though the body carried an overload code.
+ *   - mid-stream error frame: a 200 SSE stream that emits an `event: error`
+ *     chunk mid-stream. The SDK cannot re-issue a started stream, so the
+ *     query-runner (B4) must re-run the whole query — these helpers classify
+ *     the body so that retry path can recognise it.
+ *
+ * `normalizeXxxUpstreamError(body, status)` inspects the BODY for
+ * provider-specific transient signals and emits the Anthropic retryable type
+ * (`overloaded_error` / `rate_limit_error`) plus a status the Claude Agent SDK
+ * actually retries. Verified against the SDK's `shouldRetry`: it retries on
+ * status 408, 409, 429 and any `>= 500`, and honours an `x-should-retry:
+ * true` header — so `429` (rate_limit_error) and `529` (overloaded_error) both
+ * trigger the SDK's built-in retry loop before the turn dies.
+ */
+
+import type { AnthropicErrorType } from './error-envelope.js';
+
+/**
+ * A normalized upstream error: the Anthropic error type to surface, the HTTP
+ * status to emit (chosen so the SDK retries transient classifications), and a
+ * human-readable message (usually the original provider message, preserved so
+ * the user sees the real reason).
+ */
+export type NormalizedUpstreamError = {
+  type: AnthropicErrorType;
+  status: number;
+  message: string;
+};
+
+/**
+ * GLM (Zhipu AI / open.bigmodel.cn) transient overload/rate-limit body signals.
+ *
+ * Exported so the query-runner (B4) can recognise mid-stream GLM overload
+ * errors that arrive as terminal in-stream SSE errors and re-issue the whole
+ * query — the SDK cannot retry a stream it has already started. These
+ * substrings are GLM-specific (Simplified Chinese) and safe to match against
+ * any error string without false positives on other providers.
+ */
+export const GLM_TRANSIENT_ERROR_SUBSTRINGS: readonly string[] = [
+  // "访问量过大" — GLM capacity/overload message.
+  '访问量过大',
+  // "稍后再试" — "please try again later"; generic transient retry message.
+  '稍后再试',
+];
+
+/**
+ * GLM transient error code for minute-level QPS / rate limiting. Delivered as
+ * `error.code` (or top-level `code`) in the response body, in either string
+ * ("1305") or numeric (1305) form.
+ */
+const GLM_RATE_LIMIT_CODE = '1305';
+
+function rateLimit(message: string): NormalizedUpstreamError {
+  return { type: 'rate_limit_error', status: 429, message };
+}
+
+function overloaded(message: string): NormalizedUpstreamError {
+  return { type: 'overloaded_error', status: 529, message };
+}
+
+/** Best-effort JSON object parse; returns undefined for non-JSON / non-object. */
+function tryParseJsonObject(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read a string field from a maybe-object, coercing numbers to string. */
+function readStringField(
+  obj: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = obj?.[key];
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+function containsAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+/**
+ * Inspect a GLM upstream response body for transient overload/rate-limit
+ * signals the HTTP status alone cannot convey. GLM frequently returns 200 with
+ * an error body (no SSE), or a 4xx carrying an overload code — both surface as
+ * terminal, non-retried errors without this normalization.
+ *
+ * Recognised GLM transient signals:
+ *   - error code `1305` (minute-level QPS / rate limiting) → rate_limit_error
+ *   - body/message containing `访问量过大` or `稍后再试` → overloaded_error
+ *
+ * @returns the retryable classification, or `null` when no transient signal is
+ *   found (caller falls back to status-based mapping).
+ */
+export function normalizeGlmUpstreamError(
+  body: string,
+  _status: number
+): NormalizedUpstreamError | null {
+  if (!body) return null;
+
+  // GLM emits errors in several shapes:
+  //   {"error":{"code":"1305","message":"访问量过大，请稍后再试"}}
+  //   {"code":"1305","message":"..."}                         (flat)
+  //   {"type":"error","error":{"type":"...","message":"..."}} (Anthropic-shaped)
+  const parsed = tryParseJsonObject(body);
+  const errorObj =
+    parsed?.error && typeof parsed.error === 'object' && !Array.isArray(parsed.error)
+      ? (parsed.error as Record<string, unknown>)
+      : undefined;
+  const codeField = readStringField(errorObj, 'code') ?? readStringField(parsed, 'code');
+  const messageField =
+    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message') ?? body;
+
+  const isTransientCode = codeField === GLM_RATE_LIMIT_CODE;
+  // Match the GLM-specific Chinese substrings against both the raw body and the
+  // extracted message so we catch Anthropic-shaped envelopes that wrap the
+  // original GLM message in `error.message`.
+  const hasOverloadText =
+    containsAny(body, GLM_TRANSIENT_ERROR_SUBSTRINGS) ||
+    containsAny(messageField, GLM_TRANSIENT_ERROR_SUBSTRINGS);
+
+  if (!isTransientCode && !hasOverloadText) return null;
+
+  // GLM code 1305 is a rate / QPS code → rate_limit_error. The capacity /
+  // overload messages (访问量过大 / 稍后再试) → overloaded_error. Both statuses
+  // are retried by the SDK (429 explicitly, 529 via >= 500).
+  if (isTransientCode) {
+    return rateLimit(messageField);
+  }
+  return overloaded(messageField);
+}
+
+// OpenAI-compatible transient body signals. Used by the chat and responses
+// bridges (custom OpenAI endpoints + Codex). Kept tight to avoid turning a
+// genuine 4xx invalid_request into a retryable error on weak evidence.
+const OPENAI_RATE_LIMIT_PATTERN = /rate_limit_exceeded|rate[ _-]?limit|too many requests/i;
+const OPENAI_OVERLOAD_PATTERN =
+  /overloaded|service unavailable|temporarily unavailable|try again (?:later|in)/i;
+/** OpenAI error `type`/`code` values that indicate a transient server fault. */
+const OPENAI_TRANSIENT_SERVER_TYPES = new Set(['server_error']);
+
+/**
+ * Inspect an OpenAI-compatible upstream response body for transient signals.
+ * OpenAI / most proxies already convey transient failures via 429 / 5xx
+ * statuses (which the SDK retries), so this primarily recovers the two cases
+ * the status misses: a 200-with-error-body and a mid-stream `error` chunk.
+ *
+ * On a hard 4xx (auth / not-found / bad-request) only a STRONG structured
+ * signal (`error.type`/`error.code` of `rate_limit_exceeded` or
+ * `server_error`) is trusted — a stray transient word in a 401 message must
+ * never become a retryable error. Message-substring evidence is honoured on
+ * 200-with-body and 5xx, where there is no trustworthy status to defer to.
+ *
+ * @returns the retryable classification, or `null` when no transient signal is
+ *   found.
+ */
+export function normalizeOpenAiUpstreamError(
+  body: string,
+  status: number
+): NormalizedUpstreamError | null {
+  if (!body) return null;
+
+  const parsed = tryParseJsonObject(body);
+  const errorObj =
+    parsed?.error && typeof parsed.error === 'object' && !Array.isArray(parsed.error)
+      ? (parsed.error as Record<string, unknown>)
+      : undefined;
+  const typeField = readStringField(errorObj, 'type')?.toLowerCase();
+  const codeField = readStringField(errorObj, 'code')?.toLowerCase();
+  const messageField = readStringField(errorObj, 'message') ?? body;
+
+  const structuredType = typeField ?? codeField;
+  const isRateType = structuredType === 'rate_limit_exceeded';
+  const isServerType =
+    structuredType !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(structuredType);
+
+  const isRateMessage = OPENAI_RATE_LIMIT_PATTERN.test(messageField);
+  const isOverloadMessage = OPENAI_OVERLOAD_PATTERN.test(messageField);
+
+  const isRate = isRateType || isRateMessage;
+  const isOverload = isServerType || isOverloadMessage;
+
+  if (!isRate && !isOverload) return null;
+
+  // A hard 4xx (other than 429) usually means a permanent client error
+  // (auth/not-found/bad-request). Only reclassify it when the body carries a
+  // strong STRUCTURED transient signal; otherwise leave it to the status-based
+  // mapping so we don't retry a genuine 401/404 indefinitely.
+  const isHard4xx = status >= 400 && status < 500 && status !== 429;
+  if (isHard4xx && !isRateType && !isServerType) return null;
+
+  if (isRate && !isOverload) {
+    return rateLimit(messageField);
+  }
+  return overloaded(messageField);
+}
+
+/**
+ * Combined helper for the generic Anthropic-messages pass-through bridge, which
+ * does not know which provider is upstream. Tries the GLM detector first (its
+ * signals are provider-specific and cannot false-positive), then the generic
+ * OpenAI detector for Anthropic-compatible shims that wrap OpenAI-style errors.
+ */
+export function normalizeUpstreamError(
+  body: string,
+  status: number
+): NormalizedUpstreamError | null {
+  return normalizeGlmUpstreamError(body, status) ?? normalizeOpenAiUpstreamError(body, status);
+}

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -226,8 +226,14 @@ export function normalizeOpenAiUpstreamError(
   const codeField = (
     readStringField(errorObj, 'code') ?? readStringField(parsed, 'code')
   )?.toLowerCase();
-  const messageField =
-    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message') ?? body;
+  // Message for substring matching — use ONLY the extracted error/top-level
+  // message, NOT the raw body. Scanning the whole body would misclassify a valid
+  // non-error JSON response (e.g. a non-streaming completion whose text mentions
+  // "rate limit" or "overloaded") as a retryable error.
+  const messageForMatching =
+    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message');
+  // Result message falls back to the body so the surfaced error has context.
+  const messageField = messageForMatching ?? body;
 
   // Inspect BOTH `type` and `code` independently. OpenAI-compatible payloads
   // sometimes set `error.type` to a broad category (e.g. "requests") while the
@@ -243,8 +249,10 @@ export function normalizeOpenAiUpstreamError(
     (typeField !== undefined && TRANSIENT_OVERLOAD_TYPES.has(typeField)) ||
     (codeField !== undefined && TRANSIENT_OVERLOAD_TYPES.has(codeField));
 
-  const isRateMessage = OPENAI_RATE_LIMIT_PATTERN.test(messageField);
-  const isOverloadMessage = OPENAI_OVERLOAD_PATTERN.test(messageField);
+  const isRateMessage =
+    messageForMatching !== undefined && OPENAI_RATE_LIMIT_PATTERN.test(messageForMatching);
+  const isOverloadMessage =
+    messageForMatching !== undefined && OPENAI_OVERLOAD_PATTERN.test(messageForMatching);
 
   const isRate = isRateType || isRateMessage;
   const isOverload = isServerType || isOverloadMessage;

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -169,13 +169,14 @@ const OPENAI_OVERLOAD_PATTERN =
   /overloaded|service unavailable|temporarily unavailable|try again (?:later|in)/i;
 /**
  * Structured `error.type`/`error.code` values that mark a transient fault.
- * Includes OpenAI values (`rate_limit_exceeded`, `server_error`) and Anthropic
- * values (`rate_limit_error`, `overloaded_error`) — the generic detector also
- * serves the Anthropic pass-through bridge, where an Anthropic-shaped body is
- * the strongest possible structured signal.
+ * Includes OpenAI values (`rate_limit_exceeded`, `server_error`), Anthropic
+ * values (`rate_limit_error`, `overloaded_error`), and the HTTP status codes
+ * some gateways put in `error.code` (e.g. `{"error":{"code":429}}` on a 400) —
+ * the generic detector also serves the Anthropic pass-through bridge, where an
+ * Anthropic-shaped body is the strongest possible structured signal.
  */
-const TRANSIENT_RATE_LIMIT_TYPES = new Set(['rate_limit_exceeded', 'rate_limit_error']);
-const TRANSIENT_OVERLOAD_TYPES = new Set(['server_error', 'overloaded_error']);
+const TRANSIENT_RATE_LIMIT_TYPES = new Set(['rate_limit_exceeded', 'rate_limit_error', '429']);
+const TRANSIENT_OVERLOAD_TYPES = new Set(['server_error', 'overloaded_error', '503', '529']);
 
 /**
  * Inspect an OpenAI-compatible upstream response body for transient signals.

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -148,14 +148,22 @@ export function normalizeGlmUpstreamError(
   return overloaded(messageField);
 }
 
-// OpenAI-compatible transient body signals. Used by the chat and responses
-// bridges (custom OpenAI endpoints + Codex). Kept tight to avoid turning a
-// genuine 4xx invalid_request into a retryable error on weak evidence.
+// Generic transient body signals. Used by the chat and responses bridges
+// (custom OpenAI endpoints + Codex) AND by the combined `normalizeUpstreamError`
+// the Anthropic-messages pass-through bridge calls. Kept tight to avoid turning
+// a genuine 4xx invalid_request into a retryable error on weak evidence.
 const OPENAI_RATE_LIMIT_PATTERN = /rate_limit_exceeded|rate[ _-]?limit|too many requests/i;
 const OPENAI_OVERLOAD_PATTERN =
   /overloaded|service unavailable|temporarily unavailable|try again (?:later|in)/i;
-/** OpenAI error `type`/`code` values that indicate a transient server fault. */
-const OPENAI_TRANSIENT_SERVER_TYPES = new Set(['server_error']);
+/**
+ * Structured `error.type`/`error.code` values that mark a transient fault.
+ * Includes OpenAI values (`rate_limit_exceeded`, `server_error`) and Anthropic
+ * values (`rate_limit_error`, `overloaded_error`) — the generic detector also
+ * serves the Anthropic pass-through bridge, where an Anthropic-shaped body is
+ * the strongest possible structured signal.
+ */
+const TRANSIENT_RATE_LIMIT_TYPES = new Set(['rate_limit_exceeded', 'rate_limit_error']);
+const TRANSIENT_OVERLOAD_TYPES = new Set(['server_error', 'overloaded_error']);
 
 /**
  * Inspect an OpenAI-compatible upstream response body for transient signals.
@@ -190,11 +198,16 @@ export function normalizeOpenAiUpstreamError(
   // Inspect BOTH `type` and `code` independently. OpenAI-compatible payloads
   // sometimes set `error.type` to a broad category (e.g. "requests") while the
   // actionable transient value lives in `error.code` (e.g. "rate_limit_exceeded").
-  // A `type ?? code` short-circuit would miss that combination.
-  const isRateType = typeField === 'rate_limit_exceeded' || codeField === 'rate_limit_exceeded';
+  // A `type ?? code` short-circuit would miss that combination. Recognise both
+  // OpenAI (`rate_limit_exceeded`/`server_error`) and Anthropic
+  // (`rate_limit_error`/`overloaded_error`) retryable type values — the latter is
+  // an explicit, unambiguous signal that always passes the hard-4xx guard.
+  const isRateType =
+    (typeField !== undefined && TRANSIENT_RATE_LIMIT_TYPES.has(typeField)) ||
+    (codeField !== undefined && TRANSIENT_RATE_LIMIT_TYPES.has(codeField));
   const isServerType =
-    (typeField !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(typeField)) ||
-    (codeField !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(codeField));
+    (typeField !== undefined && TRANSIENT_OVERLOAD_TYPES.has(typeField)) ||
+    (codeField !== undefined && TRANSIENT_OVERLOAD_TYPES.has(codeField));
 
   const isRateMessage = OPENAI_RATE_LIMIT_PATTERN.test(messageField);
   const isOverloadMessage = OPENAI_OVERLOAD_PATTERN.test(messageField);

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -229,10 +229,15 @@ export function normalizeOpenAiUpstreamError(
   if (!body) return null;
 
   const parsed = tryParseJsonObject(body);
+  const errorValue = parsed?.error;
   const errorObj =
-    parsed?.error && typeof parsed.error === 'object' && !Array.isArray(parsed.error)
-      ? (parsed.error as Record<string, unknown>)
+    errorValue && typeof errorValue === 'object' && !Array.isArray(errorValue)
+      ? (errorValue as Record<string, unknown>)
       : undefined;
+  // Some proxies return a STRING `error` value, e.g. `{"error":"Too Many
+  // Requests"}` or `{"error":"rate_limit_exceeded"}`. Treat it as message
+  // evidence, and — when it is a recognized transient type — as code evidence.
+  const errorString = typeof errorValue === 'string' ? errorValue : undefined;
   // Read structured fields from the nested `error` object, falling back to the
   // top-level body — some upstreams emit a FLAT body like
   // `{"code":"rate_limit_exceeded","message":"slow down"}` with no `error`
@@ -247,15 +252,17 @@ export function normalizeOpenAiUpstreamError(
     readStringField(errorObj, 'code') ??
     readStringField(parsed, 'code') ??
     readStringField(errorObj, 'status') ??
-    readStringField(parsed, 'status')
+    readStringField(parsed, 'status') ??
+    errorString
   )?.toLowerCase();
   // Message for substring matching — use ONLY the extracted error/top-level
-  // message (or problem+json `detail`), NOT the raw body.
+  // message (or problem+json `detail` / a string `error` value), NOT the raw body.
   const messageForMatching =
     readStringField(errorObj, 'message') ??
     readStringField(parsed, 'message') ??
     readStringField(errorObj, 'detail') ??
-    readStringField(parsed, 'detail');
+    readStringField(parsed, 'detail') ??
+    errorString;
   // Result message falls back to the body so the surfaced error has context.
   const messageField = messageForMatching ?? body;
 

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -187,10 +187,14 @@ export function normalizeOpenAiUpstreamError(
   const codeField = readStringField(errorObj, 'code')?.toLowerCase();
   const messageField = readStringField(errorObj, 'message') ?? body;
 
-  const structuredType = typeField ?? codeField;
-  const isRateType = structuredType === 'rate_limit_exceeded';
+  // Inspect BOTH `type` and `code` independently. OpenAI-compatible payloads
+  // sometimes set `error.type` to a broad category (e.g. "requests") while the
+  // actionable transient value lives in `error.code` (e.g. "rate_limit_exceeded").
+  // A `type ?? code` short-circuit would miss that combination.
+  const isRateType = typeField === 'rate_limit_exceeded' || codeField === 'rate_limit_exceeded';
   const isServerType =
-    structuredType !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(structuredType);
+    (typeField !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(typeField)) ||
+    (codeField !== undefined && OPENAI_TRANSIENT_SERVER_TYPES.has(codeField));
 
   const isRateMessage = OPENAI_RATE_LIMIT_PATTERN.test(messageField);
   const isOverloadMessage = OPENAI_OVERLOAD_PATTERN.test(messageField);

--- a/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
+++ b/packages/daemon/src/lib/providers/shared/normalize-upstream-error.ts
@@ -98,6 +98,18 @@ function containsAny(haystack: string, needles: readonly string[]): boolean {
 }
 
 /**
+ * True when a Content-Type value denotes a JSON body — `application/json`,
+ * `Application/JSON`, or any JSON-based media type such as
+ * `application/problem+json` (RFC 7807) or `application/vnd.api+json`. HTTP
+ * media types are case-insensitive, so the check is too. Used by the bridges to
+ * decide when a 200 response is a body-embedded JSON error worth buffering and
+ * normalizing (vs. a real SSE stream that must flow through unbuffered).
+ */
+export function isJsonContentType(contentType: string): boolean {
+  return /application\/(?:[\w.+-]+\+)?json/i.test(contentType);
+}
+
+/**
  * Inspect a GLM upstream response body for transient overload/rate-limit
  * signals the HTTP status alone cannot convey. GLM frequently returns 200 with
  * an error body (no SSE), or a 4xx carrying an overload code — both surface as
@@ -191,9 +203,18 @@ export function normalizeOpenAiUpstreamError(
     parsed?.error && typeof parsed.error === 'object' && !Array.isArray(parsed.error)
       ? (parsed.error as Record<string, unknown>)
       : undefined;
-  const typeField = readStringField(errorObj, 'type')?.toLowerCase();
-  const codeField = readStringField(errorObj, 'code')?.toLowerCase();
-  const messageField = readStringField(errorObj, 'message') ?? body;
+  // Read structured fields from the nested `error` object, falling back to the
+  // top-level body — some upstreams emit a FLAT body like
+  // `{"code":"rate_limit_exceeded","message":"slow down"}` with no `error`
+  // wrapper, and those top-level fields are structured evidence too.
+  const typeField = (
+    readStringField(errorObj, 'type') ?? readStringField(parsed, 'type')
+  )?.toLowerCase();
+  const codeField = (
+    readStringField(errorObj, 'code') ?? readStringField(parsed, 'code')
+  )?.toLowerCase();
+  const messageField =
+    readStringField(errorObj, 'message') ?? readStringField(parsed, 'message') ?? body;
 
   // Inspect BOTH `type` and `code` independently. OpenAI-compatible payloads
   // sometimes set `error.type` to a broad category (e.g. "requests") while the
@@ -224,9 +245,15 @@ export function normalizeOpenAiUpstreamError(
   const isHard4xx = status >= 400 && status < 500 && status !== 429;
   if (isHard4xx && !isRateType && !isServerType) return null;
 
-  if (isRate && !isOverload) {
-    return rateLimit(messageField);
-  }
+  // Structured type evidence wins over loose message substrings: a body whose
+  // `type` is `rate_limit_exceeded` must classify as rate_limit_error (429) even
+  // if its message also matches the overload regex (e.g. "...try again in 20s").
+  if (isRateType) return rateLimit(messageField);
+  if (isServerType) return overloaded(messageField);
+  // No structured signal — fall back to message evidence. This branch is only
+  // reached where message evidence is trusted (200-with-body / 5xx), since the
+  // hard-4xx guard above already returned for message-only hard-4xx matches.
+  if (isRateMessage) return rateLimit(messageField);
   return overloaded(messageField);
 }
 

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  createAnthropicMessagesBridgeServer,
+  type AnthropicMessagesBridgeServer,
+} from '../../../../../src/lib/providers/anthropic-messages-bridge/server';
+
+/**
+ * Acceptance test for task #676: a GLM overloaded error returned in the body
+ * (200-with-body or non-2xx-with-body) is normalized to a retryable Anthropic
+ * type (overloaded_error / rate_limit_error) with a status the Claude Agent SDK
+ * retries (429 / 529) and an `x-should-retry: true` header.
+ *
+ * GLM (open.bigmodel.cn) frequently returns 200 with a JSON error body instead
+ * of an SSE stream — there is no HTTP status for the SDK to retry on, so the
+ * error would otherwise surface as terminal.
+ */
+
+type FetchImpl = typeof fetch;
+
+function makeServer(upstream: FetchImpl): AnthropicMessagesBridgeServer {
+  return createAnthropicMessagesBridgeServer({
+    baseUrl: 'https://open.bigmodel.cn/api/anthropic',
+    apiKey: 'test-key',
+    fetchImpl: upstream,
+  });
+}
+
+async function postMessages(
+  port: number,
+  body: object = {
+    model: 'glm-5',
+    max_tokens: 16,
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  }
+): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('anthropic-messages-bridge: body-embedded upstream error normalization', () => {
+  let server: AnthropicMessagesBridgeServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  it('normalizes a 200-with-body GLM overloaded error to retryable overloaded_error', async () => {
+    // GLM returns 200 OK with a JSON error body (application/json), not an SSE
+    // stream. Without normalization the SDK sees a 200 "success".
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { code: '1303', message: '访问量过大，请稍后再试' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(529);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { type: string; error: { type: string; message: string } };
+    expect(json.type).toBe('error');
+    expect(json.error.type).toBe('overloaded_error');
+    expect(json.error.message).toContain('访问量过大');
+  });
+
+  it('normalizes a 200-with-body GLM rate-limit code to rate_limit_error', async () => {
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { code: '1305', message: '触发分钟级限流，请稍后再试' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('reclassifies a non-2xx GLM body carrying an overload code to retryable', async () => {
+    // GLM returns 400 but the body carries code 1305 — the status would map to
+    // invalid_request_error (non-retryable) without body inspection.
+    server = makeServer(
+      async () =>
+        new Response(JSON.stringify({ error: { code: '1305', message: '访问量过大' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('falls back to status-based mapping for non-transient error bodies', async () => {
+    server = makeServer(
+      async () =>
+        new Response(JSON.stringify({ error: { code: '1301', message: 'invalid argument' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(400);
+    expect(res.headers.get('x-should-retry')).toBeNull();
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('invalid_request_error');
+  });
+
+  it('passes a normal 200 SSE stream through byte-for-byte (regression)', async () => {
+    const sseBody =
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n' +
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/event-stream');
+    const text = await res.text();
+    expect(text).toBe(sseBody);
+  });
+
+  it('re-wraps a non-transient 200-with-body unchanged (does not hide unknown errors)', async () => {
+    const raw = JSON.stringify({ some: 'unexpected', body: true });
+    server = makeServer(
+      async () =>
+        new Response(raw, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const res = await postMessages(server.port);
+    // Not a recognized transient error → not reclassified. The buffered body is
+    // returned to the SDK unchanged so it isn't silently swallowed.
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(raw);
+  });
+});

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
@@ -41,6 +41,14 @@ async function postMessages(
   });
 }
 
+async function postCountTokens(port: number): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/v1/messages/count_tokens`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({ model: 'glm-5', messages: [{ role: 'user', content: 'hi' }] }),
+  });
+}
+
 describe('anthropic-messages-bridge: body-embedded upstream error normalization', () => {
   let server: AnthropicMessagesBridgeServer | undefined;
 
@@ -152,6 +160,36 @@ describe('anthropic-messages-bridge: body-embedded upstream error normalization'
     const res = await postMessages(server.port);
     // Not a recognized transient error → not reclassified. The buffered body is
     // returned to the SDK unchanged so it isn't silently swallowed.
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(raw);
+  });
+
+  it('normalizes a count_tokens 200-with-body GLM overload too', async () => {
+    // GLM can return the same overload body from /v1/messages/count_tokens; the
+    // normalization must not be gated to /v1/messages only.
+    server = makeServer(
+      async () =>
+        new Response(JSON.stringify({ error: { code: '1305', message: '访问量过大' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    const res = await postCountTokens(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('passes a normal count_tokens JSON response through unchanged', async () => {
+    const raw = JSON.stringify({ input_tokens: 42 });
+    server = makeServer(
+      async () =>
+        new Response(raw, { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const res = await postCountTokens(server.port);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe(raw);
   });

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-messages-bridge/server.test.ts
@@ -131,6 +131,28 @@ describe('anthropic-messages-bridge: body-embedded upstream error normalization'
     expect(json.error.type).toBe('invalid_request_error');
   });
 
+  it('recognizes an Anthropic-shaped rate_limit_error body (even on a hard 4xx)', async () => {
+    // The pass-through bridge serves Anthropic-compatible upstreams; an explicit
+    // Anthropic rate_limit_error is the strongest structured signal and must be
+    // retried even when the HTTP status is 400.
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            type: 'error',
+            error: { type: 'rate_limit_error', message: 'rate limit exceeded' },
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
   it('passes a normal 200 SSE stream through byte-for-byte (regression)', async () => {
     const sseBody =
       'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1"}}\n\n' +

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -208,6 +208,21 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
   });
 
+  it('admits a flat error frame with a numeric code (e.g. {"code":429})', async () => {
+    const sse = 'event: error\n' + 'data: {"code":429}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('rate_limit_error');
+  });
+
   it('streams a mislabeled-content-type SSE response without buffering or misclassifying it', async () => {
     // A proxy that streams valid SSE but sends Content-Type text/plain (or none)
     // must flow straight through to the streamer — NOT be buffered and matched

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -168,6 +168,28 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
   });
 
+  it('ignores type-only heartbeat frames (e.g. {"type":"ping"}) and streams normally', async () => {
+    // A bare top-level `type` with no message/code is a heartbeat/metadata
+    // frame, not an error — it must not abort the stream.
+    const sse =
+      'data: {"type":"ping"}\n\n' +
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n' +
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    expect(events.find((e) => e.event === 'error')).toBeUndefined();
+    const stop = events.find((e) => e.event === 'message_delta');
+    expect((stop?.data as { delta?: { stop_reason?: string } }).delta?.stop_reason).toBe(
+      'end_turn'
+    );
+  });
+
   it('streams a mislabeled-content-type SSE response without buffering or misclassifying it', async () => {
     // A proxy that streams valid SSE but sends Content-Type text/plain (or none)
     // must flow straight through to the streamer — NOT be buffered and matched

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -97,6 +97,26 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     expect(json.error.type).toBe('overloaded_error');
   });
 
+  it('recognizes non-canonical JSON content-types (application/problem+json, case-insensitive)', async () => {
+    // The gate must match the JSON media-type family case-insensitively,
+    // including RFC 7807 problem+json — otherwise these error bodies bypass
+    // normalization and the streamer emits an empty end_turn.
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'rate_limit_exceeded', message: 'Too Many Requests' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'Application/Problem+JSON; charset=utf-8' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
   it('classifies a mid-stream rate-limit chunk to rate_limit_error SSE (not api_error)', async () => {
     // Upstream returns a valid SSE stream that emits an `error` chunk mid-stream.
     const sse =

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -127,4 +127,28 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     const errorEvent = events.find((e) => e.event === 'error');
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('api_error');
   });
+
+  it('streams a mislabeled-content-type SSE response without buffering or misclassifying it', async () => {
+    // A proxy that streams valid SSE but sends Content-Type text/plain (or none)
+    // must flow straight through to the streamer — NOT be buffered and matched
+    // against the overload substring (which would misclassify a valid stream
+    // whose content happens to mention "overloaded" as a retryable error).
+    const sse =
+      'data: {"choices":[{"delta":{"content":"The server is overloaded but this is normal text"}}]}\n\n' +
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n';
+    server = makeServer(
+      async () => new Response(sse, { status: 200, headers: { 'Content-Type': 'text/plain' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    // It streamed normally: a text delta was emitted (not an error event).
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeUndefined();
+    const stop = events.find((e) => e.event === 'message_delta');
+    expect((stop?.data as { delta?: { stop_reason?: string } }).delta?.stop_reason).toBe(
+      'end_turn'
+    );
+  });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -208,6 +208,24 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
   });
 
+  it('admits a flat RFC 7807 problem-detail error frame (status/detail)', async () => {
+    // readChatStream discards `event: error`; a frame like
+    // {"status":429,"detail":"Too Many Requests"} has no message/code/known-type,
+    // so status→code and detail→message must be mapped before the guard.
+    const sse = 'event: error\n' + 'data: {"status":429,"detail":"Too Many Requests"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('rate_limit_error');
+  });
+
   it('admits a flat error frame with a numeric code (e.g. {"code":429})', async () => {
     const sse = 'event: error\n' + 'data: {"code":429}\n\n';
     server = makeServer(

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  createOpenAIChatBridgeServer,
+  type OpenAIChatBridgeServer,
+} from '../../../../../src/lib/providers/openai-chat-bridge/server';
+
+/**
+ * Task #676: the OpenAI chat bridge (custom endpoints) normalizes body-embedded
+ * and mid-stream provider errors to retryable Anthropic types. OpenAI-compatible
+ * proxies sometimes return 200 with a JSON error body, or a mid-stream `error`
+ * chunk — both would otherwise surface as a terminal api_error.
+ */
+
+function makeServer(upstream: typeof fetch): OpenAIChatBridgeServer {
+  return createOpenAIChatBridgeServer({
+    baseUrl: 'https://api.example.com/v1',
+    apiKey: 'test-key',
+    fetchImpl: upstream,
+    toolUseSupported: false,
+    visionSupported: false,
+    thinkingSupported: false,
+  });
+}
+
+async function postMessages(port: number): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: 'custom-model',
+      max_tokens: 16,
+      stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    }),
+  });
+}
+
+async function readSSEEventTypes(
+  body: ReadableStream<Uint8Array> | null
+): Promise<Array<{ event: string; data: Record<string, unknown> }>> {
+  if (!body) return [];
+  const text = await new Response(body).text();
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  for (const block of text.split('\n\n')) {
+    if (!block.trim()) continue;
+    const eventLine = block.split('\n').find((l) => l.startsWith('event: '));
+    const dataLine = block.split('\n').find((l) => l.startsWith('data: '));
+    if (!eventLine || !dataLine) continue;
+    events.push({
+      event: eventLine.slice('event: '.length),
+      data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,
+    });
+  }
+  return events;
+}
+
+describe('openai-chat-bridge: body-embedded / mid-stream error normalization', () => {
+  let server: OpenAIChatBridgeServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  it('normalizes a 200-with-body rate-limit error to retryable', async () => {
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'rate_limit_exceeded', message: 'Too Many Requests' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('reclassifies a 5xx overload body to overloaded_error', async () => {
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'server_error', message: 'engine overloaded, try again later' },
+          }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(529);
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('overloaded_error');
+  });
+
+  it('classifies a mid-stream rate-limit chunk to rate_limit_error SSE (not api_error)', async () => {
+    // Upstream returns a valid SSE stream that emits an `error` chunk mid-stream.
+    const sse =
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n' +
+      'data: {"error":{"message":"rate limit exceeded","type":"rate_limit_exceeded"}}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('rate_limit_error');
+  });
+
+  it('leaves a non-transient mid-stream chunk as api_error', async () => {
+    const sse = 'data: {"error":{"message":"invalid model","type":"invalid_request_error"}}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('api_error');
+  });
+});

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -190,6 +190,24 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     );
   });
 
+  it('admits a type-only flat error frame with a known transient type', async () => {
+    // A flat `event: error` block whose data is just {"type":"server_error"}
+    // (no message/code) is still a retryable error and must be surfaced, not
+    // ignored like a heartbeat.
+    const sse = 'event: error\n' + 'data: {"type":"server_error"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
   it('streams a mislabeled-content-type SSE response without buffering or misclassifying it', async () => {
     // A proxy that streams valid SSE but sends Content-Type text/plain (or none)
     // must flow straight through to the streamer — NOT be buffered and matched

--- a/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-chat-bridge/server.test.ts
@@ -148,6 +148,26 @@ describe('openai-chat-bridge: body-embedded / mid-stream error normalization', (
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('api_error');
   });
 
+  it('classifies a flat SSE error payload (event: error, top-level fields)', async () => {
+    // readChatStream drops the `event:` line; a flat payload like
+    // data: {"type":"server_error","message":"overloaded"} has no `error`
+    // wrapper and no choices, so it must be detected via the top-level fields
+    // (otherwise the bridge ends with a normal end_turn and hides the error).
+    const sse =
+      'event: error\n' + 'data: {"type":"server_error","message":"the engine is overloaded"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEventTypes(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
   it('streams a mislabeled-content-type SSE response without buffering or misclassifying it', async () => {
     // A proxy that streams valid SSE but sends Content-Type text/plain (or none)
     // must flow straight through to the streamer — NOT be buffered and matched

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -152,6 +152,31 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
   });
 
+  it('classifies a flat error event with top-level code/message', async () => {
+    // Some upstreams emit an `error` event with code/message at the top level
+    // (not nested under event.error). The bridge must read those fields too,
+    // classify the transient, and preserve the provider message.
+    const sse =
+      'event: error\n' +
+      'data: {"type":"error","code":"server_error","message":"the engine is overloaded"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string; message: string } }).error.type).toBe(
+      'overloaded_error'
+    );
+    expect((errorEvent?.data as { error: { message: string } }).error.message).toContain(
+      'the engine is overloaded'
+    );
+  });
+
   it('normalizes a 200-with-body rate-limit error before streaming', async () => {
     // A Responses-compatible proxy returns 200 with a JSON error body instead
     // of an SSE stream. Without normalization the streamer would emit a

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -177,6 +177,26 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     );
   });
 
+  it('classifies a flat error frame whose data type differs from the SSE event name', async () => {
+    // parseSSEBlock lets the payload `type` overwrite the SSE `event:` name, so
+    // a flat `event: error` block like data: {"type":"server_error",...} has
+    // event.type = "server_error" (not "error"). The bridge must still detect
+    // it as an error frame via the preserved SSE event name.
+    const sse =
+      'event: error\n' + 'data: {"type":"server_error","message":"the engine is overloaded"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
   it('normalizes a 200-with-body rate-limit error before streaming', async () => {
     // A Responses-compatible proxy returns 200 with a JSON error body instead
     // of an SSE stream. Without normalization the streamer would emit a

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -132,4 +132,119 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     const errorEvent = events.find((e) => e.event === 'error');
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('api_error');
   });
+
+  it('classifies a response.failed event whose error is under response.error', async () => {
+    // response.failed carries the failure under event.response.error (not
+    // event.error). The bridge must read that shape to classify the transient.
+    const sse =
+      'event: response.failed\n' +
+      'data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"overloaded"}}}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
+  it('normalizes a 200-with-body rate-limit error before streaming', async () => {
+    // A Responses-compatible proxy returns 200 with a JSON error body instead
+    // of an SSE stream. Without normalization the streamer would emit a
+    // successful empty end_turn.
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'rate_limit_exceeded', message: 'Too Many Requests' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('normalizes a transient body on a tool-continuation 400 before falling back', async () => {
+    // Continuation requests hit a dedicated 400 branch that returns immediately
+    // unless the body mentions previous_response_id. A structured transient 400
+    // (e.g. rate_limit_exceeded) must still be normalized before the
+    // invalid_request fallback so the SDK retries.
+    let call = 0;
+    server = makeServer(async () => {
+      call += 1;
+      if (call === 1) {
+        // First turn: emit a function call + response.completed so the bridge
+        // stores a continuation (call_abc -> resp_tool).
+        return new Response(
+          [
+            'event: response.function_call_arguments.done',
+            'data: {"type":"response.function_call_arguments.done","call_id":"call_abc","name":"lookup","arguments":"{\\"q\\":\\"weather\\"}"}',
+            '',
+            'event: response.completed',
+            'data: {"type":"response.completed","response":{"id":"resp_tool","usage":{"input_tokens":10,"output_tokens":4},"output":[]}}',
+            '',
+            '',
+          ].join('\n'),
+          { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+        );
+      }
+      // Continuation turn: upstream returns 400 with a transient body (no
+      // previous_response_id mention).
+      return new Response(
+        JSON.stringify({ error: { type: 'rate_limit_exceeded', message: 'slow down' } }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    // First request: primes the continuation.
+    const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [{ role: 'user', content: 'Use the tool.' }],
+        tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+      }),
+    });
+    await readSSEEvents(first.body);
+
+    // Continuation request: assistant tool_use + user tool_result for call_abc.
+    const res = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.3-codex',
+        max_tokens: 128,
+        messages: [
+          { role: 'user', content: 'Use the tool.' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'call_abc', name: 'lookup', input: { q: 'weather' } },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'call_abc', content: 'found' }],
+          },
+        ],
+        tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+      }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -177,6 +177,24 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     );
   });
 
+  it('classifies a flat RFC 7807 problem-detail error frame (status/detail)', async () => {
+    // A flat `event: error` frame whose data is {"status":429,"detail":"Too Many
+    // Requests"} — status→code and detail→message must be mapped before
+    // normalization so the retryable 429 classification is recovered.
+    const sse = 'event: error\n' + 'data: {"status":429,"detail":"Too Many Requests"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('rate_limit_error');
+  });
+
   it('classifies a flat error frame whose data type differs from the SSE event name', async () => {
     // parseSSEBlock lets the payload `type` overwrite the SSE `event:` name, so
     // a flat `event: error` block like data: {"type":"server_error",...} has

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -197,6 +197,38 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
   });
 
+  it('classifies a flat error frame with a numeric code (e.g. {"code":429})', async () => {
+    const sse = 'event: error\n' + 'data: {"code":429}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('rate_limit_error');
+  });
+
+  it('detects a data-only transient frame (no event line, known error type)', async () => {
+    // A frame with no `event:` line but a known transient payload type must be
+    // detected as an error frame via the payload type itself.
+    const sse = 'data: {"type":"server_error","message":"the engine is overloaded"}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
   it('normalizes a 200-with-body rate-limit error before streaming', async () => {
     // A Responses-compatible proxy returns 200 with a JSON error body instead
     // of an SSE stream. Without normalization the streamer would emit a

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  createOpenAIResponsesBridgeServer,
+  type OpenAIResponsesBridgeServer,
+} from '../../../../../src/lib/providers/openai-responses-bridge/server';
+
+/**
+ * Task #676: the OpenAI responses bridge (Codex / OpenRouter) normalizes
+ * body-embedded and mid-stream provider errors to retryable Anthropic types.
+ */
+
+function makeServer(upstream: typeof fetch): OpenAIResponsesBridgeServer {
+  return createOpenAIResponsesBridgeServer({
+    auth: { apiKey: 'test-key', source: 'api_key' },
+    models: [
+      {
+        id: 'gpt-5.3-codex',
+        display_name: 'GPT-5.3 Codex',
+        created_at: '2025-12-01T00:00:00Z',
+        context_window: 272000,
+      },
+    ],
+    fetchImpl: upstream,
+  });
+}
+
+async function postMessages(port: number): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: 'gpt-5.3-codex',
+      max_tokens: 16,
+      stream: true,
+      messages: [{ role: 'user', content: 'hi' }],
+    }),
+  });
+}
+
+async function readSSEEvents(
+  body: ReadableStream<Uint8Array> | null
+): Promise<Array<{ event: string; data: Record<string, unknown> }>> {
+  if (!body) return [];
+  const text = await new Response(body).text();
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  for (const block of text.split('\n\n')) {
+    if (!block.trim()) continue;
+    const eventLine = block.split('\n').find((l) => l.startsWith('event: '));
+    const dataLine = block.split('\n').find((l) => l.startsWith('data: '));
+    if (!eventLine || !dataLine) continue;
+    events.push({
+      event: eventLine.slice('event: '.length),
+      data: JSON.parse(dataLine.slice('data: '.length)) as Record<string, unknown>,
+    });
+  }
+  return events;
+}
+
+describe('openai-responses-bridge: body-embedded / mid-stream error normalization', () => {
+  let server: OpenAIResponsesBridgeServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  it('reclassifies a 5xx server_error body to overloaded_error (retryable)', async () => {
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'server_error', message: 'OpenAI is overloaded' },
+          }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(529);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('overloaded_error');
+  });
+
+  it('reclassifies a 4xx body with rate_limit_exceeded type to rate_limit_error', async () => {
+    server = makeServer(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { type: 'rate_limit_exceeded', message: 'slow down' },
+          }),
+          { status: 429, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
+
+  it('classifies a mid-stream error event to overloaded_error SSE (not api_error)', async () => {
+    // Upstream returns a valid SSE stream that emits an `error` event mid-stream
+    // with a server_error body.
+    const sse =
+      'event: error\n' +
+      'data: {"type":"error","error":{"type":"server_error","message":"overloaded"}}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(200);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('overloaded_error');
+  });
+
+  it('leaves a non-transient mid-stream error as api_error', async () => {
+    const sse =
+      'event: error\n' +
+      'data: {"type":"error","error":{"message":"bad request","code":"invalid_model"}}\n\n';
+    server = makeServer(
+      async () =>
+        new Response(sse, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    );
+
+    const res = await postMessages(server.port);
+    const events = await readSSEEvents(res.body);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect((errorEvent?.data as { error: { type: string } }).error.type).toBe('api_error');
+  });
+});

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/error-normalization.test.ts
@@ -272,4 +272,44 @@ describe('openai-responses-bridge: body-embedded / mid-stream error normalizatio
     const json = (await res.json()) as { error: { type: string } };
     expect(json.error.type).toBe('rate_limit_error');
   });
+
+  it('normalizes a transient 400 on a replayed-reasoning request before self-healing', async () => {
+    // A 400 with replayed reasoning present must be inspected for a transient
+    // body BEFORE the bridge self-heals by stripping reasoning — otherwise a
+    // rate-limit 400 is masked by a reasoning-stripped retry and the SDK never
+    // sees the retryable signal.
+    let call = 0;
+    server = makeServer(async () => {
+      call += 1;
+      if (call === 1) {
+        // First turn: emit reasoning so the bridge caches it for the session.
+        return new Response(
+          [
+            'event: response.completed',
+            'data: {"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":2},"output":[{"type":"reasoning","encrypted_content":"ENC_BLOB"}]}}',
+            '',
+            '',
+          ].join('\n'),
+          { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+        );
+      }
+      // Second turn: the bridge replays the cached reasoning item; upstream
+      // returns a rate-limit 400. Must be normalized, not reasoning-stripped.
+      return new Response(
+        JSON.stringify({ error: { type: 'rate_limit_exceeded', message: 'slow down' } }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    // Turn 1: primes the per-session reasoning cache.
+    const first = await postMessages(server.port);
+    await readSSEEvents(first.body);
+
+    // Turn 2: replayed reasoning + rate-limit 400 -> normalized to 429.
+    const res = await postMessages(server.port);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('x-should-retry')).toBe('true');
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe('rate_limit_error');
+  });
 });

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -282,6 +282,24 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.type).toBe('overloaded_error');
   });
 
+  it('treats a string error value as message evidence', () => {
+    // {"error":"Too Many Requests"} — the error value is a plain string, not
+    // an object. It must be read as the message so the rate-limit pattern matches.
+    const body = JSON.stringify({ error: 'Too Many Requests' });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('treats a string error value that is a known type as code evidence', () => {
+    // {"error":"rate_limit_exceeded"} — the string is a recognized transient
+    // type, so it must count as structured evidence (passes the hard-4xx guard).
+    const body = JSON.stringify({ error: 'rate_limit_exceeded' });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -199,6 +199,36 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.status).toBe(529);
   });
 
+  it('reads flat top-level code/type fields (no error wrapper) on a hard 4xx', () => {
+    // A flat body like {"code":"rate_limit_exceeded","message":"slow down"} has
+    // no nested `error` object; the top-level code is structured evidence that
+    // must pass the hard-4xx guard (message-only evidence is rejected there).
+    const body = JSON.stringify({ code: 'rate_limit_exceeded', message: 'slow down' });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('reads a flat top-level server_error type on a hard 4xx', () => {
+    const body = JSON.stringify({ type: 'server_error', message: 'down' });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
+  it('prefers the structured rate-limit type over overload retry text', () => {
+    // The message also matches the overload regex ("try again in"), but the
+    // structured type rate_limit_exceeded must win → rate_limit_error (429).
+    const body = JSON.stringify({
+      error: {
+        type: 'rate_limit_exceeded',
+        message: 'Rate limit reached. Please try again in 20s',
+      },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 429);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -157,6 +157,25 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.status).toBe(429);
   });
 
+  it('inspects error.code even when error.type is a non-transient category', () => {
+    // OpenAI-compatible payloads can set type to a broad category while the
+    // transient value lives in code. A `type ?? code` short-circuit would miss it.
+    const body = JSON.stringify({
+      error: { type: 'requests', code: 'rate_limit_exceeded', message: 'slow down' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('inspects error.code for server_error even when error.type is present', () => {
+    const body = JSON.stringify({
+      error: { type: 'requests', code: 'server_error', message: 'down' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 500);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -264,6 +264,24 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.type).toBe('overloaded_error');
   });
 
+  it('recognizes a 502 body code as overload', () => {
+    const body = JSON.stringify({ error: { code: 502, message: 'upstream failed' } });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
+  it('reads RFC 7807 problem+json detail/status fields', () => {
+    const body = JSON.stringify({ status: 429, detail: 'Too Many Requests' });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('rate_limit_error');
+  });
+
+  it('classifies standard 5xx reason phrases in error.message', () => {
+    const body = JSON.stringify({ error: { message: 'Internal Server Error' } });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  GLM_TRANSIENT_ERROR_SUBSTRINGS,
+  normalizeGlmUpstreamError,
+  normalizeOpenAiUpstreamError,
+  normalizeUpstreamError,
+} from '../../../../../src/lib/providers/shared/normalize-upstream-error';
+
+describe('normalizeGlmUpstreamError', () => {
+  describe('detects GLM transient overload signals', () => {
+    it('maps error code 1305 to rate_limit_error', () => {
+      const body = JSON.stringify({
+        error: { code: '1305', message: '当前分组上游负载过高，触发限流' },
+      });
+      const result = normalizeGlmUpstreamError(body, 200);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('rate_limit_error');
+      expect(result?.status).toBe(429);
+      expect(result?.message).toContain('触发限流');
+    });
+
+    it('maps numeric error code 1305 to rate_limit_error', () => {
+      const body = JSON.stringify({
+        error: { code: 1305, message: 'QPS exceeded' },
+      });
+      const result = normalizeGlmUpstreamError(body, 200);
+      expect(result?.type).toBe('rate_limit_error');
+      expect(result?.status).toBe(429);
+    });
+
+    it('maps flat-shape code 1305 to rate_limit_error', () => {
+      const body = JSON.stringify({ code: '1305', message: 'rate limited' });
+      const result = normalizeGlmUpstreamError(body, 400);
+      expect(result?.type).toBe('rate_limit_error');
+      expect(result?.status).toBe(429);
+    });
+
+    it('maps 访问量过大 to overloaded_error', () => {
+      const body = JSON.stringify({
+        type: 'error',
+        error: { type: 'api_error', message: '访问量过大，请稍后再试' },
+      });
+      const result = normalizeGlmUpstreamError(body, 200);
+      expect(result?.type).toBe('overloaded_error');
+      expect(result?.status).toBe(529);
+      expect(result?.message).toContain('访问量过大');
+    });
+
+    it('maps 稍后再试 substring to overloaded_error even in non-JSON body', () => {
+      const body = '服务繁忙，请稍后再试 (service busy)';
+      const result = normalizeGlmUpstreamError(body, 200);
+      expect(result?.type).toBe('overloaded_error');
+      expect(result?.status).toBe(529);
+    });
+
+    it('detects 访问量过大 via raw-body substring fallback', () => {
+      // Body where the GLM message is embedded but JSON.parse fails / is nested.
+      const body = 'upstream said: 访问量过大 oh no';
+      const result = normalizeGlmUpstreamError(body, 500);
+      expect(result?.type).toBe('overloaded_error');
+    });
+
+    it('prefers rate_limit_error when code 1305 accompanies overload text', () => {
+      const body = JSON.stringify({
+        error: { code: '1305', message: '访问量过大，请稍后再试' },
+      });
+      const result = normalizeGlmUpstreamError(body, 200);
+      expect(result?.type).toBe('rate_limit_error');
+      expect(result?.status).toBe(429);
+    });
+  });
+
+  describe('returns null for non-transient bodies', () => {
+    it('ignores a normal invalid_request error', () => {
+      const body = JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'missing field model' },
+      });
+      expect(normalizeGlmUpstreamError(body, 400)).toBeNull();
+    });
+
+    it('ignores an unrelated GLM error code', () => {
+      const body = JSON.stringify({
+        error: { code: '1301', message: 'invalid parameter' },
+      });
+      expect(normalizeGlmUpstreamError(body, 400)).toBeNull();
+    });
+
+    it('ignores empty body', () => {
+      expect(normalizeGlmUpstreamError('', 500)).toBeNull();
+    });
+
+    it('ignores a normal Anthropic-shaped success-ish body', () => {
+      const body = JSON.stringify({ type: 'message', id: 'msg_1' });
+      expect(normalizeGlmUpstreamError(body, 200)).toBeNull();
+    });
+  });
+
+  it('exposes GLM transient substrings for query-runner (B4) coordination', () => {
+    expect(GLM_TRANSIENT_ERROR_SUBSTRINGS).toContain('访问量过大');
+    expect(GLM_TRANSIENT_ERROR_SUBSTRINGS).toContain('稍后再试');
+  });
+});
+
+describe('normalizeOpenAiUpstreamError', () => {
+  it('maps rate_limit_exceeded type to rate_limit_error', () => {
+    const body = JSON.stringify({
+      error: { type: 'rate_limit_exceeded', message: 'You hit the limit' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 429);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('maps server_error type to overloaded_error', () => {
+    const body = JSON.stringify({
+      error: { type: 'server_error', message: 'Internal error' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 500);
+    expect(result?.type).toBe('overloaded_error');
+    expect(result?.status).toBe(529);
+  });
+
+  it('maps overload text in a 200-with-body to overloaded_error', () => {
+    const body = JSON.stringify({
+      error: { message: 'The engine is currently overloaded, try again later' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('overloaded_error');
+    expect(result?.status).toBe(529);
+  });
+
+  it('maps rate-limit message text to rate_limit_error', () => {
+    const body = JSON.stringify({
+      error: { message: 'Too Many Requests: rate limit reached' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 200);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('does NOT reclassify a hard 4xx on weak message evidence', () => {
+    // A 401 whose message happens to mention "rate limit" must stay
+    // non-retryable — only a structured signal overrides a hard 4xx.
+    const body = JSON.stringify({
+      error: { type: 'invalid_request_error', message: 'rate limit header missing' },
+    });
+    expect(normalizeOpenAiUpstreamError(body, 401)).toBeNull();
+  });
+
+  it('reclassifies a hard 4xx when the structured type is rate_limit_exceeded', () => {
+    const body = JSON.stringify({
+      error: { type: 'rate_limit_exceeded', message: 'quota hit' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('returns null for a normal invalid_request error', () => {
+    const body = JSON.stringify({
+      error: { type: 'invalid_request_error', message: 'bad model id' },
+    });
+    expect(normalizeOpenAiUpstreamError(body, 400)).toBeNull();
+  });
+});
+
+describe('normalizeUpstreamError (combined)', () => {
+  it('detects GLM signals first', () => {
+    const body = JSON.stringify({ error: { code: '1305', message: '访问量过大' } });
+    const result = normalizeUpstreamError(body, 200);
+    expect(result?.type).toBe('rate_limit_error');
+  });
+
+  it('falls through to the OpenAI detector for OpenAI-shaped errors', () => {
+    const body = JSON.stringify({
+      error: { type: 'server_error', message: 'down' },
+    });
+    const result = normalizeUpstreamError(body, 500);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
+  it('returns null when no detector matches', () => {
+    const body = JSON.stringify({ error: { message: 'not found' } });
+    expect(normalizeUpstreamError(body, 404)).toBeNull();
+  });
+});

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -94,6 +94,18 @@ describe('normalizeGlmUpstreamError', () => {
       const body = JSON.stringify({ type: 'message', id: 'msg_1' });
       expect(normalizeGlmUpstreamError(body, 200)).toBeNull();
     });
+
+    it('does NOT scan a JSON success body for GLM overload phrases', () => {
+      // A valid Anthropic-shaped message whose assistant content mentions
+      // "稍后再试" must not be misclassified as overloaded — only the extracted
+      // error.message / top-level message is matched for JSON bodies.
+      const body = JSON.stringify({
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: '请稍后再试，稍后重试。' }],
+      });
+      expect(normalizeGlmUpstreamError(body, 200)).toBeNull();
+    });
   });
 
   it('exposes GLM transient substrings for query-runner (B4) coordination', () => {

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -237,6 +237,21 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(normalizeOpenAiUpstreamError(body, 429)).toBeNull();
   });
 
+  it('recognizes a numeric HTTP status code in error.code (429 on a 400)', () => {
+    // Some gateways put the rate-limit status in the body as a numeric code
+    // while returning HTTP 400. readStringField coerces it to "429".
+    const body = JSON.stringify({ error: { code: 429, message: 'Too Many Requests' } });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('recognizes a numeric 503 code as overload', () => {
+    const body = JSON.stringify({ error: { code: 503, message: 'Service Unavailable' } });
+    const result = normalizeOpenAiUpstreamError(body, 500);
+    expect(result?.type).toBe('overloaded_error');
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -258,6 +258,18 @@ describe('normalizeOpenAiUpstreamError', () => {
     });
     expect(normalizeOpenAiUpstreamError(body, 400)).toBeNull();
   });
+
+  it('does NOT scan the whole body for retry words (success body false positive)', () => {
+    // A valid non-streaming JSON completion whose content mentions "rate limit"
+    // must NOT be classified as retryable — only the extracted error.message is
+    // matched, never the raw body.
+    const body = JSON.stringify({
+      id: 'chatcmpl-1',
+      object: 'chat.completion',
+      choices: [{ message: { content: 'The rate limit is 50 requests per minute.' } }],
+    });
+    expect(normalizeOpenAiUpstreamError(body, 200)).toBeNull();
+  });
 });
 
 describe('normalizeUpstreamError (combined)', () => {

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -229,6 +229,14 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.status).toBe(429);
   });
 
+  it('does not let weak "try again" text override an explicit HTTP 429', () => {
+    // A 429 is already a rate limit; a loose "Please try again later" message
+    // (which matches the overload regex) must NOT reclassify it as
+    // overloaded_error. Defer to the status-based mapping (rate_limit_error).
+    const body = JSON.stringify({ error: { message: 'Please try again later' } });
+    expect(normalizeOpenAiUpstreamError(body, 429)).toBeNull();
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },

--- a/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/shared/normalize-upstream-error.test.ts
@@ -176,6 +176,29 @@ describe('normalizeOpenAiUpstreamError', () => {
     expect(result?.type).toBe('overloaded_error');
   });
 
+  it('recognizes Anthropic rate_limit_error as a structured transient type', () => {
+    // The generic detector also serves the Anthropic pass-through bridge; an
+    // Anthropic-shaped body is an explicit, unambiguous signal that must pass
+    // the hard-4xx guard (a 400 carrying rate_limit_error should still retry).
+    const body = JSON.stringify({
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'rate limit exceeded' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('rate_limit_error');
+    expect(result?.status).toBe(429);
+  });
+
+  it('recognizes Anthropic overloaded_error as a structured transient type', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: { type: 'overloaded_error', message: 'Overloaded. Try again.' },
+    });
+    const result = normalizeOpenAiUpstreamError(body, 400);
+    expect(result?.type).toBe('overloaded_error');
+    expect(result?.status).toBe(529);
+  });
+
   it('returns null for a normal invalid_request error', () => {
     const body = JSON.stringify({
       error: { type: 'invalid_request_error', message: 'bad model id' },


### PR DESCRIPTION
## What

Today every provider bridge classifies upstream errors by **HTTP status only** (`mapUpstreamStatus` / `mapOpenAIStatusToAnthropicError`). Many gateways — **GLM (open.bigmodel.cn)** especially — return transient errors embedded in the response **body**, not the status:

- **200-with-error-body**: HTTP 200 but the body is a JSON error object instead of an SSE stream. The pass-through bridge forwarded it verbatim, so the SDK saw a 200 "success" and the error became terminal (**no retry**).
- **non-2xx-with-error-body**: a 4xx whose body carries an overload code — the status mapped to non-retryable `invalid_request_error` even though the error was transient.
- **mid-stream error frame**: a 200 SSE stream that emits an `event: error` chunk mid-stream. The SDK cannot re-issue a started stream.

## Change

Give each bridge a `normalizeUpstreamError(body, status)` that inspects the **body** for provider-specific transient signals and emits the Anthropic retryable type (`overloaded_error` / `rate_limit_error`) with a status the Claude Agent SDK actually retries.

Verified against the SDK's `shouldRetry`: it retries on status **429** and any **>= 500** (so 529 included), and honours an `x-should-retry: true` header — both 429 and 529 trigger the SDK's built-in retry loop before the turn dies.

### `shared/normalize-upstream-error.ts` (new)
- **GLM detector**: error code `1305` → `rate_limit_error`; `访问量过大` / `稍后再试` → `overloaded_error`. Handles nested (`error.code`), flat (`code`), numeric, and Anthropic-shaped envelopes, plus a raw-body substring fallback. GLM substrings are exported for query-runner (B4) coordination on mid-stream errors.
- **OpenAI-shape detector**: `rate_limit_exceeded` → `rate_limit_error`; `server_error` / overload text → `overloaded_error`. Conservative on hard 4xx (only trusts structured `type`/`code`, not loose message words, so a real 401 isn't retried).

### Bridge wiring
- **anthropic-messages-bridge (GLM — reported case)**: non-2xx + **200-with-body** normalization (buffers non-event-stream 200 bodies and inspects them). Genuine SSE streams still pass through byte-for-byte.
- **openai-chat-bridge (custom endpoints)**: non-2xx + 200-with-body + mid-stream chunk classification.
- **openai-responses-bridge (Codex)**: non-2xx + mid-stream event classification.

## Acceptance

A GLM overloaded error returned in the body (200-with-body **or** non-2xx-with-body) is normalized to a retryable Anthropic type and retried by the SDK, instead of killing the turn terminal. Covered by `anthropic-messages-bridge/server.test.ts`.

Mid-stream errors are classified to the correct type; the actual query-level retry of an already-started stream is coordinated with **B4** (query-runner) — the SDK can't retry a stream it has started.

## Composition with B1

Rebased on `dev`, which includes #B1 (`fix: map HTTP 529 to overloaded_error`). The two are complementary: a **plain HTTP 529** is caught by B1's status fallback; a **body-embedded overload** (200/4xx, no usable status) is caught here.

## Tests

- 22 unit tests for the normalizers (GLM + OpenAI detection, non-transient → null).
- 6 GLM-bridge integration tests (200-with-body, non-2xx-with-body, SSE pass-through regression, non-transient fallback).
- 4 chat-bridge + 4 responses-bridge tests (200-with-body, non-2xx, mid-stream classification).
- All 159 bridge tests pass post-rebase (incl. B1's existing tests).

Task #676.