### PR TITLE
fix(web): red error bubble for assistant error messages in MinimalThreadFeed

### DIFF
--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -54,6 +54,15 @@ function assistantText(uuid: string, text: string) {
   };
 }
 
+function assistantError(uuid: string, text: string, error = 'invalid_request') {
+  return {
+    type: 'assistant',
+    uuid,
+    error,
+    message: { content: [{ type: 'text', text }] },
+  };
+}
+
 function assistantToolUse(
   uuid: string,
   tools: Array<{ name: string; input: Record<string, unknown> }>
@@ -508,6 +517,70 @@ describe('MinimalThreadFeed', () => {
     });
     // Doesn't pick the earlier text once a later assistant text exists.
     expect(screen.queryByText('preliminary')).toBeNull();
+  });
+
+  it('renders an assistant error message as a red error bubble (not gray)', async () => {
+    const t = Date.now();
+    const rows = [
+      makeRow({
+        id: 'a1',
+        label: 'Coder Agent',
+        createdAt: t,
+        message: assistantError(
+          'a1',
+          'API Error: 400 {"type":"invalid_request_error","message":"messages must alternate"}'
+        ),
+      }),
+      makeRow({
+        id: 'r1',
+        label: 'Coder Agent',
+        createdAt: t + 1000,
+        message: resultMessage('r1'),
+      }),
+    ];
+
+    render(<MinimalThreadFeed parsedRows={rows} />);
+    const bubble = screen.getByTestId('minimal-thread-agent-bubble');
+    // The error flag flows through → red bubble + data attribute.
+    expect(bubble.getAttribute('data-has-error')).toBe('true');
+    expect(bubble.className).toContain('border-red-800');
+    expect(bubble.className).toContain('bg-red-900');
+    // Normal gray bubble classes are absent.
+    expect(bubble.className).not.toContain('bg-dark-800');
+    // "API Error" header label mirrors SDKAssistantMessage's hasError branch.
+    expect(bubble.textContent).toContain('API Error');
+    // The error text still renders as the bubble body.
+    await waitFor(() => {
+      expect(screen.getByTestId('md').textContent).toContain('API Error: 400');
+    });
+  });
+
+  it('renders a normal assistant reply without error styling', async () => {
+    const t = Date.now();
+    const rows = [
+      makeRow({
+        id: 'a1',
+        label: 'Coder Agent',
+        createdAt: t,
+        message: assistantText('a1', 'all good'),
+      }),
+      makeRow({
+        id: 'r1',
+        label: 'Coder Agent',
+        createdAt: t + 1000,
+        message: resultMessage('r1'),
+      }),
+    ];
+
+    render(<MinimalThreadFeed parsedRows={rows} />);
+    const bubble = screen.getByTestId('minimal-thread-agent-bubble');
+    expect(bubble.getAttribute('data-has-error')).toBeNull();
+    expect(bubble.className).not.toContain('border-red');
+    expect(bubble.className).toContain('bg-dark-800');
+    expect(bubble.textContent).not.toContain('API Error');
+    await waitFor(() => {
+      expect(screen.getByText('all good')).toBeTruthy();
+    });
   });
 
   it('keeps folded post-result task_notification rows from creating active rails', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -583,6 +583,44 @@ describe('MinimalThreadFeed', () => {
     });
   });
 
+  it('renders a recovered turn (error then success) as a gray bubble, not red', async () => {
+    // When an earlier assistant row carries a transient `error` (e.g. a 429
+    // the SDK retried) but a later assistant row produced a successful reply,
+    // the turn recovered. The surfaced reply is the successful one, so the
+    // bubble must stay gray — painting it red would show an "API Error" header
+    // over a successful reply body, which is misleading.
+    const t = Date.now();
+    const rows = [
+      makeRow({
+        id: 'err',
+        label: 'Coder Agent',
+        createdAt: t,
+        message: assistantError('err', 'API Error: 429 overloaded', 'overloaded_error'),
+      }),
+      makeRow({
+        id: 'ok',
+        label: 'Coder Agent',
+        createdAt: t + 1000,
+        message: assistantText('ok', 'Recovered — here is the fix'),
+      }),
+      makeRow({
+        id: 'r1',
+        label: 'Coder Agent',
+        createdAt: t + 2000,
+        message: resultMessage('r1'),
+      }),
+    ];
+
+    render(<MinimalThreadFeed parsedRows={rows} />);
+    const bubble = screen.getByTestId('minimal-thread-agent-bubble');
+    expect(bubble.getAttribute('data-has-error')).toBeNull();
+    expect(bubble.className).toContain('bg-dark-800');
+    expect(bubble.className).not.toContain('border-red');
+    await waitFor(() => {
+      expect(screen.getByText('Recovered — here is the fix')).toBeTruthy();
+    });
+  });
+
   it('keeps folded post-result task_notification rows from creating active rails', () => {
     const t = Date.now();
     const rows = [

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -190,6 +190,13 @@ interface CompletedFeedTurn {
   lastMessage: string;
   fallback: boolean;
   /**
+   * True when the surfaced assistant reply carries an SDK `error` field
+   * (e.g. `error: 'invalid_request'`). Renders the bubble with red error
+   * styling + an "API Error" header, mirroring SDKAssistantMessage's
+   * hasError branch, instead of the normal gray reply bubble.
+   */
+  hasError: boolean;
+  /**
    * Session id that produced this turn's reply text. Used by the
    * "open in session" affordance so clicking the button lands the user
    * on the right session even when multiple sessions are interleaved
@@ -557,8 +564,16 @@ function extractLastAssistantText(rows: ParsedThreadRow[]): {
   text: string;
   fallback: boolean;
   sourceRow: ParsedThreadRow | null;
+  /**
+   * True when the surfaced assistant reply (or any assistant row in the turn,
+   * when text came from a fallback) carries an SDK `error` field — e.g.
+   * `error: 'invalid_request'`. Drives the red error-bubble treatment in
+   * CompletedBody, mirroring SDKAssistantMessage's `hasError` branch.
+   */
+  hasError: boolean;
 } {
   let resultFallback: { text: string; sourceRow: ParsedThreadRow } | null = null;
+  let assistantHasError = false;
 
   for (let i = rows.length - 1; i >= 0; i--) {
     const row = rows[i];
@@ -578,6 +593,13 @@ function extractLastAssistantText(rows: ParsedThreadRow[]): {
     }
 
     if (!isSDKAssistantMessage(row.message)) continue;
+    // An assistant message may carry an `error` field (e.g. a 400
+    // invalid_request) alongside its text content. Track it so the reply
+    // bubble renders red instead of the normal gray, matching the chat
+    // transcript (SDKAssistantMessage detects the same field).
+    const hasError =
+      'error' in row.message && (row.message as { error?: unknown }).error !== undefined;
+    if (hasError) assistantHasError = true;
     const content = (row.message as { message?: { content?: unknown } }).message?.content;
     if (!Array.isArray(content)) continue;
     const texts = content
@@ -589,17 +611,23 @@ function extractLastAssistantText(rows: ParsedThreadRow[]): {
       )
       .map((block) => block.text.trim())
       .filter((s) => s.length > 0);
-    if (texts.length > 0) return { text: texts.join('\n\n'), fallback: false, sourceRow: row };
+    if (texts.length > 0)
+      return { text: texts.join('\n\n'), fallback: false, sourceRow: row, hasError };
   }
 
   // No assistant text anywhere in the turn — fall back to the result envelope.
   if (resultFallback) {
-    return { text: resultFallback.text, fallback: false, sourceRow: resultFallback.sourceRow };
+    return {
+      text: resultFallback.text,
+      fallback: false,
+      sourceRow: resultFallback.sourceRow,
+      hasError: assistantHasError,
+    };
   }
 
   const tail = rows[rows.length - 1] ?? null;
   const tailFallback = tail?.fallbackText ?? '';
-  return { text: tailFallback, fallback: true, sourceRow: tail };
+  return { text: tailFallback, fallback: true, sourceRow: tail, hasError: assistantHasError };
 }
 
 type TaskNotificationLite = {
@@ -696,7 +724,7 @@ function buildCompletedTurn(
   const endedAt = resultRow?.createdAt ?? lastRow.createdAt;
   const durationMs = Math.max(0, endedAt - startedAt);
   const durationSec = Math.max(1, Math.round(durationMs / 1000));
-  const { text, fallback, sourceRow } = extractLastAssistantText(rows);
+  const { text, fallback, sourceRow, hasError } = extractLastAssistantText(rows);
   const highlightSource = sourceRow ?? lastRow;
   const highlightUuid =
     highlightSource?.message &&
@@ -716,6 +744,7 @@ function buildCompletedTurn(
     messages: rows.length,
     lastMessage: text,
     fallback,
+    hasError,
     sessionId: highlightSource?.sessionId ?? lastRow.sessionId,
     highlightMessageUuid: highlightUuid,
     replacementStatus: sourceRow?.replacementStatus,
@@ -1842,10 +1871,34 @@ function CompletedBody({
   return (
     <div class={`mt-1.5 w-fit ${TASK_THREAD_AGENT_BUBBLE_WIDTH_CLASS}`}>
       <div
-        class="bg-dark-800 border border-dark-700 rounded-lg px-3 py-2"
+        class={
+          turn.hasError
+            ? 'bg-red-900/20 border border-red-800 rounded-lg px-3 py-2'
+            : 'bg-dark-800 border border-dark-700 rounded-lg px-3 py-2'
+        }
         data-testid="minimal-thread-agent-bubble"
+        data-has-error={turn.hasError || undefined}
       >
         <ReplacementBadge status={turn.replacementStatus} />
+        {turn.hasError ? (
+          <div class="flex items-center gap-2 text-red-400 text-sm font-medium mb-1">
+            <svg
+              class="w-4 h-4 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <span>API Error</span>
+          </div>
+        ) : null}
         {turn.roster.length > 0 ? (
           <div class="mb-2 space-y-0.5">
             {turn.roster.map((entry, i) => (
@@ -1854,7 +1907,13 @@ function CompletedBody({
           </div>
         ) : null}
         {turn.lastMessage ? (
-          <div class="text-sm text-gray-100 leading-relaxed [&_a]:text-blue-400">
+          <div
+            class={
+              turn.hasError
+                ? 'text-sm text-red-100 leading-relaxed [&_a]:text-red-300'
+                : 'text-sm text-gray-100 leading-relaxed [&_a]:text-blue-400'
+            }
+          >
             {turn.fallback ? (
               <p class="whitespace-pre-wrap break-words">{turn.lastMessage}</p>
             ) : (


### PR DESCRIPTION
## What

In the Space task thread, an assistant message carrying an SDK `error` field (e.g. `error: 'invalid_request'`, the "API Error: 400 …" text the user sees) rendered as a **normal gray reply bubble** — indistinguishable from a successful reply. The chat transcript already renders this correctly (`SDKAssistantMessage` detects `hasError` and swaps to a red bubble), but `MinimalThreadFeed` never inspected the `error` field.

## Change

- **`extractLastAssistantText`**: detect the assistant `error` flag (`'error' in message && error !== undefined`) on the surfaced assistant row, and track it across all assistant rows so the flag still propagates when text comes from a result/tail fallback. Returns a new `hasError` boolean.
- **`CompletedFeedTurn`**: carries the `hasError` flag.
- **`CompletedBody`**: when `hasError`, swaps the bubble to red (`bg-red-900/20 border-red-800`, matching the dark-mode palette of the always-dark thread feed) with an "API Error" header (warning icon + label), mirroring `SDKAssistantMessage`'s `hasError` branch. Body text uses `text-red-100`.

## Acceptance

A 400/invalid_request assistant message now shows a red error bubble in the space thread (not a gray reply), matching the chat transcript's styling.

## Test

- New: assistant error message renders a red bubble (`data-has-error`, `border-red-800`, `bg-red-900`, "API Error" header) with the error text as the body.
- New: normal assistant reply keeps the gray bubble (`bg-dark-800`, no error styling).
- All 65 tests in `MinimalThreadFeed.test.tsx` pass.