### PR TITLE
feat(web): surface terminal result errors inline in MinimalThreadFeed

### DIFF
--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -208,6 +208,38 @@ function errorResultMessage(uuid: string) {
   };
 }
 
+function budgetErrorResultMessage(uuid: string) {
+  return {
+    type: 'result',
+    uuid,
+    subtype: 'error_max_budget_usd',
+    is_error: true,
+    duration_ms: 1000,
+    duration_api_ms: 800,
+    num_turns: 1,
+    errors: ['Budget limit exceeded'],
+    stop_reason: null,
+    total_cost_usd: 0.5,
+    usage: { input_tokens: 50, output_tokens: 25 },
+  };
+}
+
+function errorResultMessageWithEmptyErrors(uuid: string) {
+  return {
+    type: 'result',
+    uuid,
+    subtype: 'error_during_execution',
+    is_error: true,
+    duration_ms: 1000,
+    duration_api_ms: 800,
+    num_turns: 1,
+    errors: [],
+    stop_reason: null,
+    total_cost_usd: 0.001,
+    usage: { input_tokens: 50, output_tokens: 25 },
+  };
+}
+
 describe('MinimalThreadFeed', () => {
   beforeEach(() => {
     cleanup();
@@ -2493,6 +2525,127 @@ describe('MinimalThreadFeed', () => {
       // `isError` flag wires the amber accent class onto the trigger so
       // failures surface in the actions row before the dropdown opens.
       expect(trigger?.className).toMatch(/amber/);
+    });
+  });
+
+  describe('Terminal result error inline surfacing', () => {
+    it('paints the completed turn bubble red and surfaces the error inline for error subtypes', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          message: assistantText('a1', 'attempting'),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: errorResultMessage('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      expect(bubble).not.toBeNull();
+      // Red bubble treatment — data attribute + red bg/border classes.
+      expect(bubble?.getAttribute('data-result-error')).toBe('true');
+      expect(bubble?.className).toMatch(/bg-red-900\/20/);
+      expect(bubble?.className).toMatch(/border-red-800/);
+      // Inline error summary surfaces the first error string without opening
+      // the dropdown.
+      const summary = container.querySelector(
+        '[data-testid="minimal-thread-result-error-summary"]'
+      );
+      expect(summary).not.toBeNull();
+      expect(summary?.textContent).toContain('something failed');
+    });
+
+    it('excludes error_max_budget_usd from the inline red treatment', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          message: assistantText('a1', 'ran out of budget'),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: budgetErrorResultMessage('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      expect(bubble).not.toBeNull();
+      // Budget cap is a deliberate cost guard, not an execution failure — no
+      // red bubble, no inline summary. It still gets the amber dropdown trigger.
+      expect(bubble?.getAttribute('data-result-error')).toBeNull();
+      expect(bubble?.className).not.toMatch(/bg-red-900/);
+      expect(
+        container.querySelector('[data-testid="minimal-thread-result-error-summary"]')
+      ).toBeNull();
+      expect(container.querySelector('button[title="Run result"]')).not.toBeNull();
+    });
+
+    it('does not paint the bubble red for successful results', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          message: assistantText('a1', 'all good'),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: resultMessage('r1', 'done'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      expect(bubble).not.toBeNull();
+      expect(bubble?.getAttribute('data-result-error')).toBeNull();
+      expect(bubble?.className).toMatch(/bg-dark-800/);
+      expect(
+        container.querySelector('[data-testid="minimal-thread-result-error-summary"]')
+      ).toBeNull();
+    });
+
+    it('falls back to a subtype label when errors[] is empty', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          message: assistantText('a1', 'attempting'),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: errorResultMessageWithEmptyErrors('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      expect(bubble?.getAttribute('data-result-error')).toBe('true');
+      const summary = container.querySelector(
+        '[data-testid="minimal-thread-result-error-summary"]'
+      );
+      expect(summary).not.toBeNull();
+      // No error string → humanized subtype label so the red bubble always
+      // carries an explanation.
+      expect(summary?.textContent).toContain('Error during execution');
     });
   });
 

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -2677,6 +2677,80 @@ describe('MinimalThreadFeed', () => {
       );
       expect(summary?.textContent).toContain('something failed');
     });
+
+    it('keeps a budget-cap turn visible even when the agent emitted no reply text', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          // tool_use only — no text before the budget-cap result
+          message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'echo test' } }]),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: budgetErrorResultMessage('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      // Budget-cap is excluded from the red-bubble treatment but the turn must
+      // still render so the amber result-info dropdown is accessible.
+      expect(bubble).not.toBeNull();
+      expect(bubble?.getAttribute('data-result-error')).toBeNull();
+      expect(bubble?.className).not.toMatch(/bg-red-900/);
+      expect(container.querySelector('button[title="Run result"]')).not.toBeNull();
+    });
+
+    it('folds post-result task_notification onto an error-only turn instead of duplicating', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          // tool_use only — no text assistant message before the error result
+          message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'bun test' } }]),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 100,
+          message: errorResultMessage('r1'),
+        }),
+        makeRow({
+          id: 'n1',
+          label: 'Coder Agent',
+          createdAt: t + 200,
+          messageType: 'system',
+          message: {
+            type: 'system',
+            subtype: 'task_notification',
+            task_id: 'task-x',
+            tool_use_id: 'tu-a1-0',
+            status: 'failed',
+            summary: 'tests failed',
+            output_file: '/tmp/o',
+          },
+        }),
+      ];
+
+      render(<MinimalThreadFeed parsedRows={rows} />);
+
+      // The error-only turn is visible with the red bubble.
+      const bubble = screen.getByTestId('minimal-thread-agent-bubble');
+      expect(bubble.getAttribute('data-result-error')).toBe('true');
+      // The task_notification folds onto the roster tool entry (no standalone
+      // system row duplicating it).
+      const entry = screen.getByTestId('minimal-thread-roster-entry');
+      expect(entry.dataset.taskStatus).toBe('failed');
+      expect(entry.textContent).toContain('tests failed');
+      expect(screen.queryByText('Task failed')).toBeNull();
+    });
   });
 
   it('caps the active roster at 8 most-recent entries even with mixed kinds', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -2767,9 +2767,10 @@ describe('MinimalThreadFeed', () => {
           label: 'Coder Agent',
           createdAt: t + 50,
           messageType: 'system',
-          message: operationalSystemMessage('s1', 'thinking_tokens', {
-            estimated_tokens: 5000,
-            estimated_tokens_delta: 100,
+          message: operationalSystemMessage('s1', 'model_refusal_fallback', {
+            content: 'Retried with fallback model',
+            original_model: 'claude-opus-4-5',
+            fallback_model: 'claude-sonnet-4-5',
           }),
         }),
         makeRow({
@@ -2796,14 +2797,20 @@ describe('MinimalThreadFeed', () => {
 
       render(<MinimalThreadFeed parsedRows={rows} />);
 
-      // The error bubble is visible with the red treatment.
-      const bubble = screen.getByTestId('minimal-thread-agent-bubble');
-      expect(bubble.getAttribute('data-result-error')).toBe('true');
-      // The tool_use survives the system-row split and appears in the roster
-      // with its folded task status.
-      const entry = screen.getByTestId('minimal-thread-roster-entry');
-      expect(entry.dataset.taskStatus).toBe('failed');
-      expect(entry.textContent).toContain('tests failed');
+      // The system-row split creates two completed turns in chronological
+      // order around the thinking_tokens card: a tool_use-only turn (kept by
+      // the roster-content filter from #2188) and the error turn.
+      const bubbles = screen.getAllByTestId('minimal-thread-agent-bubble');
+      expect(bubbles).toHaveLength(2);
+      // Turn 1 (tool_use): roster shows the folded task status.
+      const toolEntry = screen.getByTestId('minimal-thread-roster-entry');
+      expect(toolEntry.dataset.taskStatus).toBe('failed');
+      expect(toolEntry.textContent).toContain('tests failed');
+      // Turn 2 (error): red bubble + inline error summary.
+      const errorBubble = bubbles.find((b) => b.getAttribute('data-result-error') === 'true');
+      expect(errorBubble).toBeDefined();
+      const summary = screen.getByTestId('minimal-thread-result-error-summary');
+      expect(summary.textContent).toContain('something failed');
       // No standalone task_notification duplicating the roster.
       expect(screen.queryByText('Task failed')).toBeNull();
     });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -2751,6 +2751,62 @@ describe('MinimalThreadFeed', () => {
       expect(entry.textContent).toContain('tests failed');
       expect(screen.queryByText('Task failed')).toBeNull();
     });
+
+    it('keeps tool_use visible across operational system row splits in error-only turns', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          // tool_use only — no text before the system row and error result
+          message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'bun test' } }]),
+        }),
+        makeRow({
+          id: 's1',
+          label: 'Coder Agent',
+          createdAt: t + 50,
+          messageType: 'system',
+          message: operationalSystemMessage('s1', 'thinking_tokens', {
+            estimated_tokens: 5000,
+            estimated_tokens_delta: 100,
+          }),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 100,
+          message: errorResultMessage('r1'),
+        }),
+        makeRow({
+          id: 'n1',
+          label: 'Coder Agent',
+          createdAt: t + 200,
+          messageType: 'system',
+          message: {
+            type: 'system',
+            subtype: 'task_notification',
+            task_id: 'task-x',
+            tool_use_id: 'tu-a1-0',
+            status: 'failed',
+            summary: 'tests failed',
+          },
+        }),
+      ];
+
+      render(<MinimalThreadFeed parsedRows={rows} />);
+
+      // The error bubble is visible with the red treatment.
+      const bubble = screen.getByTestId('minimal-thread-agent-bubble');
+      expect(bubble.getAttribute('data-result-error')).toBe('true');
+      // The tool_use survives the system-row split and appears in the roster
+      // with its folded task status.
+      const entry = screen.getByTestId('minimal-thread-roster-entry');
+      expect(entry.dataset.taskStatus).toBe('failed');
+      expect(entry.textContent).toContain('tests failed');
+      // No standalone task_notification duplicating the roster.
+      expect(screen.queryByText('Task failed')).toBeNull();
+    });
   });
 
   it('caps the active roster at 8 most-recent entries even with mixed kinds', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -2647,6 +2647,36 @@ describe('MinimalThreadFeed', () => {
       // carries an explanation.
       expect(summary?.textContent).toContain('Error during execution');
     });
+
+    it('keeps a terminal-error turn visible even when the agent emitted no reply text', () => {
+      const t = Date.now();
+      const rows = [
+        makeRow({
+          id: 'a1',
+          label: 'Coder Agent',
+          createdAt: t,
+          // tool_use only — no text assistant message before the error result
+          message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'echo test' } }]),
+        }),
+        makeRow({
+          id: 'r1',
+          label: 'Coder Agent',
+          createdAt: t + 1000,
+          message: errorResultMessage('r1'),
+        }),
+      ];
+
+      const { container } = render(<MinimalThreadFeed parsedRows={rows} />);
+      const bubble = container.querySelector('[data-testid="minimal-thread-agent-bubble"]');
+      // Without the exemption from the empty-body filter, this turn would be
+      // dropped (empty lastMessage) and the red bubble would never render.
+      expect(bubble).not.toBeNull();
+      expect(bubble?.getAttribute('data-result-error')).toBe('true');
+      const summary = container.querySelector(
+        '[data-testid="minimal-thread-result-error-summary"]'
+      );
+      expect(summary?.textContent).toContain('something failed');
+    });
   });
 
   it('caps the active roster at 8 most-recent entries even with mixed kinds', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -1558,10 +1558,14 @@ function buildFeedTurns(
   // noise; the reply is rendered in the sibling that holds the result text.
   // A turn with no reply text but with roster content (tool calls / task
   // outcomes) is still meaningful — e.g. a killed task whose outcome lives in
-  // the roster — so keep it.
+  // the roster — so keep it. A turn that ended in a result error (any subtype)
+  // is also kept even with no text and no roster: the red bubble + inline
+  // error summary IS the visible content.
   return turns.filter((t) => {
     if (t.state !== 'completed') return true;
+    if (t.resultInfo && isSDKResultError(t.resultInfo)) return true;
     return t.lastMessage.length > 0 || t.roster.length > 0;
+  });
   });
 }
 

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -1402,11 +1402,7 @@ function buildFeedTurns(
         subtype !== 'task_notification' &&
         buildOperationalSystemTurn(row, false, rosteredActiveToolUseIds)
       ) {
-        // Mirror the main loop: only flush text-bearing slices so tool_use-only
-        // fragments aren't orphaned before the result arrives.
-        if (extractLastAssistantText(pendingAgentRows).text.length > 0) {
-          flush();
-        }
+        flush();
         continue;
       }
       pendingAgentRows.push(row);
@@ -1506,14 +1502,7 @@ function buildFeedTurns(
         rosteredToolUseIds
       );
       if (operationalSystemTurn) {
-        // Don't orphan tool_use-only fragments: only flush when the pending
-        // slice has reply text. A tool_use-only slice would be dropped by the
-        // empty-body filter, losing its tools from the eventual error turn's
-        // roster. Keeping it pending lets the tool_use fold into whatever
-        // segment comes next (error result, more assistant rows, etc.).
-        if (extractLastAssistantText(pendingAgentRows).text.length > 0) {
-          flushAgent();
-        }
+        flushAgent();
         turns.push(operationalSystemTurn);
         continue;
       }

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -1369,14 +1369,14 @@ function buildFeedTurns(
       sliceRows.some((r) => getToolUseContentBlocks(r).length > 0);
     const flush = (isFinal = false) => {
       if (
-        pendingAgentRows.length > 0 &&
-        !(isFinal && trailingBlockCanUpgradeToActive) &&
-        // Keep slices with text, tool_use content, OR any result error —
-        // error-only turns must be included so their tool_use_ids are collected
-        // into rosteredToolUseIds and post-result task_notifications fold onto
-        // the now-visible roster instead of duplicating as standalone rows.
-        sliceContributesToRoster(pendingAgentRows) ||
-          rowsContainResultError(pendingAgentRows)
+        (pendingAgentRows.length > 0 &&
+          !(isFinal && trailingBlockCanUpgradeToActive) &&
+          // Keep slices with text, tool_use content, OR any result error —
+          // error-only turns must be included so their tool_use_ids are collected
+          // into rosteredToolUseIds and post-result task_notifications fold onto
+          // the now-visible roster instead of duplicating as standalone rows.
+          sliceContributesToRoster(pendingAgentRows)) ||
+        rowsContainResultError(pendingAgentRows)
       ) {
         out.push(pendingAgentRows);
       }
@@ -1402,7 +1402,11 @@ function buildFeedTurns(
         subtype !== 'task_notification' &&
         buildOperationalSystemTurn(row, false, rosteredActiveToolUseIds)
       ) {
-        flush();
+        // Mirror the main loop: only flush text-bearing slices so tool_use-only
+        // fragments aren't orphaned before the result arrives.
+        if (extractLastAssistantText(pendingAgentRows).text.length > 0) {
+          flush();
+        }
         continue;
       }
       pendingAgentRows.push(row);
@@ -1502,7 +1506,14 @@ function buildFeedTurns(
         rosteredToolUseIds
       );
       if (operationalSystemTurn) {
-        flushAgent();
+        // Don't orphan tool_use-only fragments: only flush when the pending
+        // slice has reply text. A tool_use-only slice would be dropped by the
+        // empty-body filter, losing its tools from the eventual error turn's
+        // roster. Keeping it pending lets the tool_use fold into whatever
+        // segment comes next (error result, more assistant rows, etc.).
+        if (extractLastAssistantText(pendingAgentRows).text.length > 0) {
+          flushAgent();
+        }
         turns.push(operationalSystemTurn);
         continue;
       }
@@ -1581,7 +1592,6 @@ function buildFeedTurns(
     if (t.state !== 'completed') return true;
     if (t.resultInfo && isSDKResultError(t.resultInfo)) return true;
     return t.lastMessage.length > 0 || t.roster.length > 0;
-  });
   });
 }
 
@@ -2025,8 +2035,6 @@ function CompletedBody({
               />
             </svg>
             <span class="break-words line-clamp-2">{errorSummary}</span>
-          </div>
-        ) : null}
           </div>
         ) : null}
         {turn.roster.length > 0 ? (

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -549,6 +549,17 @@ function rowsContainResult(
   return resultInfo !== undefined && rows.some((row) => row.message === resultInfo);
 }
 
+/**
+ * Whether a row slice contains any non-success result message. Used to keep
+ * error-only turns (no assistant text) visible and to collect their
+ * tool_use_ids for task_notification folding — covering ALL error subtypes
+ * (including error_max_budget_usd), since visibility is separate from the
+ * narrower inline red-bubble treatment.
+ */
+function rowsContainResultError(rows: ParsedThreadRow[]): boolean {
+  return rows.some((row) => row.message && isSDKResultError(row.message));
+}
+
 function latestSessionId(rows: ParsedThreadRow[]): string | null {
   for (let i = rows.length - 1; i >= 0; i--) {
     if (rows[i].sessionId) return rows[i].sessionId;
@@ -1360,7 +1371,12 @@ function buildFeedTurns(
       if (
         pendingAgentRows.length > 0 &&
         !(isFinal && trailingBlockCanUpgradeToActive) &&
-        sliceContributesToRoster(pendingAgentRows)
+        // Keep slices with text, tool_use content, OR any result error —
+        // error-only turns must be included so their tool_use_ids are collected
+        // into rosteredToolUseIds and post-result task_notifications fold onto
+        // the now-visible roster instead of duplicating as standalone rows.
+        sliceContributesToRoster(pendingAgentRows) ||
+          rowsContainResultError(pendingAgentRows)
       ) {
         out.push(pendingAgentRows);
       }

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -29,6 +29,7 @@ import {
   isSDKCompactBoundary,
   isHiddenSystemSubtype,
   isConditionallyHiddenSystemMessage,
+  isSDKResultError,
   isSDKResultMessage,
   isSDKSystemInit,
   isToolUseBlock,
@@ -1872,6 +1873,45 @@ function RosterEntry({ entry, isLatest }: { entry: ActiveRosterEntry; isLatest: 
 }
 
 /**
+ * Terminal result subtypes surfaced inline as a red bubble in the minimal feed.
+ * `error_max_budget_usd` is intentionally excluded — hitting a budget cap is a
+ * deliberate cost guard, not an execution failure, so painting the whole turn
+ * red would mislead. It still gets the amber result-info dropdown trigger.
+ */
+const INLINE_RESULT_ERROR_SUBTYPES: ReadonlySet<string> = new Set([
+  'error_during_execution',
+  'error_max_turns',
+  'error_max_structured_output_retries',
+]);
+
+function isInlineTerminalResultError(result: ResultMessage | undefined): boolean {
+  if (!result || !isSDKResultError(result)) return false;
+  return INLINE_RESULT_ERROR_SUBTYPES.has(result.subtype);
+}
+
+const RESULT_ERROR_SUBTYPE_LABELS: Record<string, string> = {
+  error_during_execution: 'Error during execution',
+  error_max_turns: 'Max turns reached',
+  error_max_structured_output_retries: 'Max structured output retries reached',
+};
+
+/**
+ * First-line error summary for a terminal result error. Prefers the SDK's
+ * `errors[]` (the model/SDK's own failure message); falls back to a humanized
+ * subtype label so the red bubble always carries an explanation even when the
+ * errors array is empty/missing (defensive against bridge providers that omit
+ * it).
+ */
+function getResultErrorSummary(result: ResultMessage): string {
+  const errors = (result as { errors?: unknown }).errors;
+  if (Array.isArray(errors)) {
+    const first = errors.find((e): e is string => typeof e === 'string' && e.trim().length > 0);
+    if (first) return first.trim();
+  }
+  return RESULT_ERROR_SUBTYPE_LABELS[result.subtype] ?? 'Run failed';
+}
+
+/**
  * Body for a completed agent turn — wraps the meta-line + reply text in a
  * left-aligned chat bubble that sizes to content up to a max-width cap.
  *
@@ -1894,6 +1934,9 @@ function CompletedBody({
   turn: CompletedFeedTurn;
   overlayTaskId?: string;
 }) {
+  const isTerminalError = isInlineTerminalResultError(turn.resultInfo);
+  const errorSummary =
+    isTerminalError && turn.resultInfo ? getResultErrorSummary(turn.resultInfo) : null;
   const openSession = turn.sessionId
     ? () => {
         // `pushOverlayHistory` reads the highlight signal; passing the message
@@ -1909,15 +1952,17 @@ function CompletedBody({
         }
       }
     : undefined;
+  const isErrorBubble = isTerminalError || turn.hasError;
   return (
     <div class={`mt-1.5 w-fit ${TASK_THREAD_AGENT_BUBBLE_WIDTH_CLASS}`}>
       <div
-        class={
-          turn.hasError
-            ? 'bg-red-900/20 border border-red-800 rounded-lg px-3 py-2'
-            : 'bg-dark-800 border border-dark-700 rounded-lg px-3 py-2'
-        }
+        class={`rounded-lg px-3 py-2 ${
+          isErrorBubble
+            ? 'bg-red-900/20 border border-red-800'
+            : 'bg-dark-800 border border-dark-700'
+        }`}
         data-testid="minimal-thread-agent-bubble"
+        data-result-error={isTerminalError ? 'true' : undefined}
         data-has-error={turn.hasError || undefined}
       >
         <ReplacementBadge status={turn.replacementStatus} />
@@ -1938,6 +1983,30 @@ function CompletedBody({
               />
             </svg>
             <span>API Error</span>
+          </div>
+        ) : null}
+        {errorSummary ? (
+          <div
+            class="mb-2 flex items-start gap-1.5 text-xs text-red-300"
+            data-testid="minimal-thread-result-error-summary"
+          >
+            <svg
+              class="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01M5.07 19h13.86a2 2 0 001.74-3L13.74 4a2 2 0 00-3.48 0L3.33 16a2 2 0 001.74 3z"
+              />
+            </svg>
+            <span class="break-words line-clamp-2">{errorSummary}</span>
+          </div>
+        ) : null}
           </div>
         ) : null}
         {turn.roster.length > 0 ? (


### PR DESCRIPTION
## What

A completed Space task turn ending in a terminal result error (`error_during_execution` / `error_max_turns` / etc.) previously only surfaced the error behind the small amber `ResultInfoButton` dropdown — the turn bubble itself stayed `bg-dark-800` and the `errors[]` were hidden behind a click.

Now the `CompletedBody` bubble paints red and surfaces a one-line error summary inline at the top, so a terminal error is visible at a glance without opening the dropdown.

## Changes

- **`MinimalThreadFeed.tsx`** — `CompletedBody`:
  - When `resultInfo` is an inline-displayable error subtype, the bubble swaps to `bg-red-900/20 border-red-800` (matching the space-component error convention in SpaceForge/SpaceCreateDialog) and sets `data-result-error="true"`.
  - A flat one-line error summary (warning glyph + first error string, `text-red-300`) renders at the top of the bubble. Falls back to a humanized subtype label when `errors[]` is empty/missing.
- **`error_max_budget_usd` excluded** — hitting a budget cap is a deliberate cost guard, not an execution failure. It keeps the existing amber dropdown trigger but does not get the red bubble.

## Tests

4 new tests in `MinimalThreadFeed.test.tsx`:
- Red bubble + inline summary for `error_during_execution`
- `error_max_budget_usd` excluded from inline red treatment
- Successful result does not paint red
- Empty `errors[]` falls back to subtype label

```
cd packages/web && bunx vitest run src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
# 67 passed
```