### PR TITLE
fix: render api_retry/thinking_tokens/task_notification roster-only in the minimal feed

### DIFF
--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -302,17 +302,19 @@ describe('MinimalThreadFeed', () => {
     render(<MinimalThreadFeed parsedRows={rows} />);
 
     // Hidden subtypes (session_state_changed, commands_changed) are suppressed
-    // via isHiddenSystemSubtype; only thinking_tokens, model_fallback, and the
-    // warning notice render.
+    // via isHiddenSystemSubtype; thinking_tokens is roster-only. Only
+    // model_fallback and the warning notice render as system rows.
     const systemRows = screen.getAllByTestId('minimal-thread-system');
-    expect(systemRows).toHaveLength(3);
-    expect(systemRows[0].textContent).toContain('Thinking tokens');
-    expect(systemRows[0].textContent).toContain('1,250 estimated tokens (+25)');
-    expect(systemRows[1].textContent).toContain('Model fallback');
-    expect(systemRows[1].textContent).toContain('Retried with fallback model');
-    expect(systemRows[1].textContent).toContain('claude-opus-4-5 -> claude-sonnet-4-5');
-    expect(systemRows[2].textContent).toContain('Warning');
-    expect(systemRows[2].textContent).toContain('Hook warning shown to the user');
+    expect(systemRows).toHaveLength(2);
+    expect(systemRows[0].textContent).toContain('Model fallback');
+    expect(systemRows[0].textContent).toContain('Retried with fallback model');
+    expect(systemRows[0].textContent).toContain('claude-opus-4-5 -> claude-sonnet-4-5');
+    expect(systemRows[1].textContent).toContain('Warning');
+    expect(systemRows[1].textContent).toContain('Hook warning shown to the user');
+    // thinking_tokens is roster-only — never a main-thread system row.
+    expect(screen.getByTestId('space-task-event-feed-minimal').textContent).not.toContain(
+      'Thinking tokens'
+    );
   });
 
   it('renders worker shutdown rows only at the session tail', () => {
@@ -873,10 +875,15 @@ describe('MinimalThreadFeed', () => {
 
     render(<MinimalThreadFeed parsedRows={rows} />);
 
-    const feed = screen.getByTestId('space-task-event-feed-minimal');
-    expect(feed.textContent).toContain('Task completed');
-    expect(feed.textContent).toContain('first tool done');
-    expect(screen.queryAllByTestId('minimal-thread-roster-entry')).toHaveLength(0);
+    // tu-a1-0 is the oldest of 9 tools → capped out of the completed roster,
+    // so its outcome renders as a standalone roster entry (not a main-thread
+    // system row, and not folded — its tool card isn't in the roster).
+    const taskEntries = screen
+      .getAllByTestId('minimal-thread-roster-entry')
+      .filter((e) => (e as HTMLElement).dataset.rosterKind === 'task_notification');
+    expect(taskEntries).toHaveLength(1);
+    expect(taskEntries[0].textContent).toContain('Task completed');
+    expect(taskEntries[0].textContent).toContain('first tool done');
   });
 
   it('folds completed slices inside active blocks without suppressing the active tail', () => {
@@ -1142,7 +1149,7 @@ describe('MinimalThreadFeed', () => {
     expect(screen.getAllByText('API retry')).toHaveLength(1);
   });
 
-  it('falls back to a system row when api_retry is capped out of the active roster', () => {
+  it('does not render api_retry in the main thread when capped out of the active roster (roster-only)', () => {
     const t = Date.now();
     const rows = [
       makeRow({
@@ -1199,13 +1206,13 @@ describe('MinimalThreadFeed', () => {
       />
     );
 
+    // Capped out of the roster (8 newer text entries fill it) AND suppressed
+    // from the main thread — api_retry is roster-only, so it renders nowhere.
     const entries = screen.getAllByTestId('minimal-thread-roster-entry');
     expect(entries.some((entry) => entry.dataset.rosterKind === 'api_retry')).toBe(false);
     const feed = screen.getByTestId('space-task-event-feed-minimal');
-    expect(feed.textContent).toContain('API retry');
-    expect(feed.textContent).toContain('Attempt 1/3');
-    expect(feed.textContent).toContain('delay 1000ms');
-    expect(feed.textContent).toContain('status n/a');
+    expect(feed.textContent).not.toContain('API retry');
+    expect(feed.textContent).not.toContain('Attempt 1/3');
   });
 
   it('folds task_notification onto the roster entry when the tool_use is rostered', () => {
@@ -1520,11 +1527,12 @@ describe('MinimalThreadFeed', () => {
     expect(entries[1].textContent).not.toContain('secret');
   });
 
-  it('falls back to a system row for task_notification with no roster target (completed turn)', () => {
+  it('renders a standalone roster entry for task_notification with no roster target (completed turn)', () => {
     const t = Date.now();
     // More than ROSTER_MAX_ENTRIES tool_use blocks → the first tool is capped
-    // out of the completed roster. Its notification must remain standalone so
-    // terminal metadata is not lost.
+    // out of the completed roster. Its notification has no tool card to fold
+    // onto, so it renders as a standalone roster entry (terminal metadata not
+    // lost).
     const rows = [
       makeRow({
         id: 'a1',
@@ -1559,12 +1567,16 @@ describe('MinimalThreadFeed', () => {
 
     render(<MinimalThreadFeed parsedRows={rows} />);
 
-    // Capped out of the completed roster → notification renders as a row,
-    // preserving both summary and usage (terminal metadata not lost).
-    const feed = screen.getByTestId('space-task-event-feed-minimal');
-    expect(feed.textContent).toContain('Bash exited 1');
-    expect(feed.textContent).toContain('4,321 tokens');
-    expect(feed.textContent).toContain('3 tool uses');
+    // Capped out of the completed roster → standalone roster entry preserves
+    // status, summary, and usage (terminal metadata not lost).
+    const taskEntries = screen
+      .getAllByTestId('minimal-thread-roster-entry')
+      .filter((e) => (e as HTMLElement).dataset.rosterKind === 'task_notification');
+    expect(taskEntries).toHaveLength(1);
+    expect(taskEntries[0].textContent).toContain('Task failed');
+    expect(taskEntries[0].textContent).toContain('Bash exited 1');
+    expect(taskEntries[0].textContent).toContain('4,321 tok');
+    expect(taskEntries[0].textContent).toContain('3 tools');
   });
 
   it('falls back to a row when a stale summary lingers after the turn went terminal', () => {
@@ -1726,7 +1738,8 @@ describe('MinimalThreadFeed', () => {
     const feed = screen.getByTestId('space-task-event-feed-minimal');
     expect(feed.textContent).toContain('Task failed');
     expect(feed.textContent).toContain('second tool failed after retry');
-    expect(feed.textContent).toContain('1,234 tokens');
+    // Roster entry format uses the short "tok" suffix.
+    expect(feed.textContent).toContain('1,234 tok');
   });
 
   it('caps the active roster at 8 most-recent tool calls', () => {

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -1579,6 +1579,51 @@ describe('MinimalThreadFeed', () => {
     expect(taskEntries[0].textContent).toContain('3 tools');
   });
 
+  it('does not duplicate a task_notification that folds onto a rostered tool (roster-only turn)', () => {
+    const t = Date.now();
+    // Roster-only completed turn: a single tool (within cap) + result, no
+    // assistant reply text. The task_notification folds onto the tool card and
+    // must NOT also render as a standalone roster entry (the global pre-scan
+    // excludes text-less turns, so the within-turn roster must gate standalone).
+    const rows = [
+      makeRow({
+        id: 'a1',
+        label: 'Coder Agent',
+        createdAt: t,
+        message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'bun test' } }]),
+      }),
+      makeRow({ id: 'r1', label: 'Coder Agent', createdAt: t + 100, message: resultMessage('r1') }),
+      makeRow({
+        id: 'n1',
+        label: 'Coder Agent',
+        createdAt: t + 200,
+        messageType: 'system',
+        message: {
+          type: 'system',
+          subtype: 'task_notification',
+          task_id: 't',
+          tool_use_id: 'tu-a1-0',
+          status: 'completed',
+          summary: 'all tests passed',
+          output_file: '/tmp/o',
+          usage: { total_tokens: 500, tool_uses: 1, duration_ms: 1200 },
+        },
+      }),
+    ];
+
+    render(<MinimalThreadFeed parsedRows={rows} />);
+
+    // Outcome folds onto the Bash tool card exactly once — never standalone.
+    const standalone = screen
+      .getAllByTestId('minimal-thread-roster-entry')
+      .filter((e) => (e as HTMLElement).dataset.rosterKind === 'task_notification');
+    expect(standalone).toHaveLength(0);
+    const toolEntries = screen
+      .getAllByTestId('minimal-thread-roster-entry')
+      .filter((e) => (e as HTMLElement).dataset.rosterKind === 'tool');
+    expect(toolEntries.some((e) => e.textContent?.includes('all tests passed'))).toBe(true);
+  });
+
   it('falls back to a row when a stale summary lingers after the turn went terminal', () => {
     const t = Date.now();
     // Tool_use + result → terminal turn, but the active-turn LiveQuery still

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -743,7 +743,13 @@ function buildCompletedTurn(
         taskNotificationsByToolUseId,
         indexCompletedFoldableToolUseIds(rows)
       );
-      return [...base, ...standaloneTaskNotificationEntries(rows, globalRosteredToolUseIds)];
+      // Suppress standalone entries for outcomes already folded onto a tool
+      // card in THIS turn (the global pre-scan misses roster-only turns).
+      const rostered = new Set([
+        ...globalRosteredToolUseIds,
+        ...rosteredToolUseIdsFromRoster(base),
+      ]);
+      return [...base, ...standaloneTaskNotificationEntries(rows, rostered)];
     })(),
   };
 }
@@ -810,6 +816,23 @@ function standaloneTaskNotificationEntries(
 }
 
 /**
+ * tool_use_ids whose tool cards are present in a given roster. Combined with
+ * the global rostered set to gate standalone task_notification entries: a
+ * notification must NOT emit a standalone roster entry if its outcome already
+ * folds onto a tool card in THIS turn's roster — otherwise roster-only turns
+ * (no assistant text, kept only for their roster) would show the outcome twice
+ * (once folded, once standalone), since the global pre-scan excludes those
+ * text-less turns and so omits their tool ids.
+ */
+function rosteredToolUseIdsFromRoster(roster: ActiveRosterEntry[]): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of roster) {
+    if (entry.kind === 'tool' && entry.toolUseId) ids.add(entry.toolUseId);
+  }
+  return ids;
+}
+
+/**
  * Collect the tool_use_ids that have a rendered active-roster target — i.e.
  * tool_use entries that survive the ROSTER_MAX_ENTRIES cap in a summary whose
  * session actually renders an active roster. A summary only renders an active
@@ -862,11 +885,13 @@ function buildActiveTurn(
   });
   // Append standalone outcome entries for task_notifications whose tool_use
   // isn't rostered in any turn (capped out / orphan). Folded ones are already
-  // on their tool card; checking the global set prevents cross-turn duplication.
-  const roster = [
-    ...baseRoster,
-    ...standaloneTaskNotificationEntries(rows, globalRosteredToolUseIds),
-  ];
+  // on their tool card; checking the global set + this turn's roster prevents
+  // both cross-turn and within-turn duplication.
+  const rostered = new Set([
+    ...globalRosteredToolUseIds,
+    ...rosteredToolUseIdsFromRoster(baseRoster),
+  ]);
+  const roster = [...baseRoster, ...standaloneTaskNotificationEntries(rows, rostered)];
   return {
     state: 'active',
     id: turnId,
@@ -1293,11 +1318,19 @@ function buildFeedTurns(
     const blockKey = normalizeAgentKey(block.agentLabel);
     const trailingBlockCanUpgradeToActive = normalisedActive.has(blockKey) && !block.isTerminal;
     let pendingAgentRows: ParsedThreadRow[] = [];
+    // A completed slice contributes to the rostered-tool pre-scan when it has
+    // an assistant reply OR tool_use content. Including tool-only slices
+    // (no reply text — e.g. a background task turn) means their tool ids enter
+    // the global rostered set, so a task_notification that folds onto one of
+    // those tools isn't duplicated as a standalone roster entry elsewhere.
+    const sliceContributesToRoster = (sliceRows: ParsedThreadRow[]) =>
+      extractLastAssistantText(sliceRows).text.length > 0 ||
+      sliceRows.some((r) => getToolUseContentBlocks(r).length > 0);
     const flush = (isFinal = false) => {
       if (
         pendingAgentRows.length > 0 &&
         !(isFinal && trailingBlockCanUpgradeToActive) &&
-        extractLastAssistantText(pendingAgentRows).text.length > 0
+        sliceContributesToRoster(pendingAgentRows)
       ) {
         out.push(pendingAgentRows);
       }

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -164,6 +164,21 @@ interface RosterApiRetryEntry {
   ts: number;
   uuid: string;
 }
+/**
+ * Standalone task outcome entry — rendered directly in the roster (chat-
+ * container style: ✓/■/✗ + summary + usage) for task_notifications whose
+ * originating tool_use is NOT in the roster (capped out / orphan / completed
+ * turn). When the tool_use IS rostered, the outcome folds onto its tool card
+ * instead (see foldTaskNotification) so these two never duplicate.
+ */
+interface RosterTaskNotificationEntry {
+  kind: 'task_notification';
+  status: 'completed' | 'failed' | 'stopped';
+  summary?: string;
+  usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
+  ts: number;
+  toolUseId?: string;
+}
 type ActiveRosterEntry =
   | RosterToolEntry
   | RosterMessageEntry
@@ -171,7 +186,8 @@ type ActiveRosterEntry =
   | RosterUserEntry
   | RosterHandoffEntry
   | RosterHookEntry
-  | RosterApiRetryEntry;
+  | RosterApiRetryEntry
+  | RosterTaskNotificationEntry;
 
 const TASK_THREAD_MESSAGE_BUBBLE_WIDTH_CLASS = 'max-w-[85%] md:max-w-[86%]';
 const TASK_THREAD_AGENT_BUBBLE_WIDTH_CLASS = 'max-w-full md:max-w-[86%]';
@@ -688,6 +704,7 @@ function buildCompletedTurn(
   turnId: string,
   resultInfo: ResultMessage | undefined,
   taskNotificationsByToolUseId: Map<string, TaskNotificationLite>,
+  globalRosteredToolUseIds: Set<string>,
   transitionSummary: ActiveTurnSummary | undefined = undefined
 ): CompletedFeedTurn {
   const startedAt = rows[0].createdAt;
@@ -720,11 +737,14 @@ function buildCompletedTurn(
     highlightMessageUuid: highlightUuid,
     replacementStatus: sourceRow?.replacementStatus,
     resultInfo,
-    roster: completedRosterEntries(
-      rows,
-      taskNotificationsByToolUseId,
-      indexCompletedFoldableToolUseIds(rows)
-    ),
+    roster: (() => {
+      const base = completedRosterEntries(
+        rows,
+        taskNotificationsByToolUseId,
+        indexCompletedFoldableToolUseIds(rows)
+      );
+      return [...base, ...standaloneTaskNotificationEntries(rows, globalRosteredToolUseIds)];
+    })(),
   };
 }
 
@@ -753,6 +773,43 @@ function indexTaskNotifications(rows: ParsedThreadRow[]): Map<string, TaskNotifi
 }
 
 /**
+ * Build standalone roster entries for task_notifications whose originating
+ * tool_use is NOT rendered in the roster (capped out / orphan / completed
+ * turn). These have no tool card to fold onto, so they get their own
+ * chat-container-style outcome line. Entries whose tool_use IS rostered are
+ * skipped — their outcome folds onto that tool card (foldTaskNotification),
+ * so the two paths never duplicate.
+ */
+function standaloneTaskNotificationEntries(
+  rows: ParsedThreadRow[],
+  rosteredToolUseIds: Set<string>
+): RosterTaskNotificationEntry[] {
+  const out: RosterTaskNotificationEntry[] = [];
+  for (const row of rows) {
+    const msg = row.message;
+    if (!msg || msg.type !== 'system') continue;
+    if ((msg as { subtype?: string }).subtype !== 'task_notification') continue;
+    const n = msg as {
+      tool_use_id?: string;
+      status?: 'completed' | 'failed' | 'stopped';
+      summary?: string;
+      usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
+    };
+    if (!n.status) continue;
+    if (n.tool_use_id && rosteredToolUseIds.has(n.tool_use_id)) continue;
+    out.push({
+      kind: 'task_notification',
+      status: n.status,
+      ts: row.createdAt,
+      ...(n.summary ? { summary: n.summary } : {}),
+      ...(n.usage ? { usage: n.usage } : {}),
+      ...(n.tool_use_id ? { toolUseId: n.tool_use_id } : {}),
+    });
+  }
+  return out;
+}
+
+/**
  * Collect the tool_use_ids that have a rendered active-roster target — i.e.
  * tool_use entries that survive the ROSTER_MAX_ENTRIES cap in a summary whose
  * session actually renders an active roster. A summary only renders an active
@@ -778,20 +835,6 @@ function collectActiveRosteredToolUseIds(
   return ids;
 }
 
-function collectRosteredApiRetryUuids(
-  summaries: ActiveTurnSummary[],
-  renderedTurnKeys: Set<string>
-): Set<string> {
-  const uuids = new Set<string>();
-  for (const summary of summaries) {
-    if (!renderedTurnKeys.has(`${summary.sessionId}:${summary.turnIndex}`)) continue;
-    for (const entry of rosterEntriesFromSummary(summary, ROSTER_MAX_ENTRIES)) {
-      if (entry.kind === 'api_retry') uuids.add(entry.uuid);
-    }
-  }
-  return uuids;
-}
-
 function collectRosteredToolUseIds(
   summaries: ActiveTurnSummary[],
   renderedTurnKeys: Set<string>,
@@ -810,12 +853,20 @@ function buildActiveTurn(
   turnId: string,
   summary: ActiveTurnSummary | undefined,
   sessionId: string | null,
-  taskNotificationsByToolUseId: Map<string, TaskNotificationLite>
+  taskNotificationsByToolUseId: Map<string, TaskNotificationLite>,
+  globalRosteredToolUseIds: Set<string>
 ): ActiveFeedTurn {
-  const roster = rosterEntriesFromSummary(summary, ROSTER_MAX_ENTRIES).map((entry) => {
+  const baseRoster = rosterEntriesFromSummary(summary, ROSTER_MAX_ENTRIES).map((entry) => {
     if (entry.kind !== 'tool') return entry;
     return foldTaskNotification(entry, taskNotificationsByToolUseId);
   });
+  // Append standalone outcome entries for task_notifications whose tool_use
+  // isn't rostered in any turn (capped out / orphan). Folded ones are already
+  // on their tool card; checking the global set prevents cross-turn duplication.
+  const roster = [
+    ...baseRoster,
+    ...standaloneTaskNotificationEntries(rows, globalRosteredToolUseIds),
+  ];
   return {
     state: 'active',
     id: turnId,
@@ -946,8 +997,7 @@ function isFoldedTaskNotification(row: ParsedThreadRow, rosteredToolUseIds: Set<
 function buildOperationalSystemTurn(
   row: ParsedThreadRow,
   isSessionTail: boolean,
-  rosteredToolUseIds: Set<string>,
-  rosteredApiRetryUuids: Set<string>
+  rosteredToolUseIds: Set<string>
 ): SystemFeedTurn | null {
   const message = row.message;
   if (!message || message.type !== 'system') return null;
@@ -968,10 +1018,18 @@ function buildOperationalSystemTurn(
   // system turn so the terminal summary/usage/failure is not silently lost.
   // True orphans (no tool_use_id) also fall through.
   if (isFoldedTaskNotification(row, rosteredToolUseIds)) return null;
-  if (subtype === 'api_retry') {
-    const uuid = (message as { uuid?: unknown }).uuid;
-    if (typeof uuid === 'string' && rosteredApiRetryUuids.has(uuid)) return null;
-  }
+  // These subtypes surface ONLY as roster entries in the minimal feed (like
+  // hooks) — never as standalone system cards in the main thread, even when
+  // capped out of the roster:
+  //   - api_retry: roster `api_retry` entry. (The chat transcript still
+  //     renders api_retry via SDKSystemMessage.)
+  //   - thinking_tokens: roster `thinking` entries carry the content; the
+  //     numeric token estimate is dropped (it's excluded from the chat
+  //     transcript pagination too).
+  //   - task_notification: folds onto its roster tool card when the tool is
+  //     rostered, otherwise a standalone roster entry. Never a main-thread card.
+  if (subtype === 'api_retry' || subtype === 'thinking_tokens' || subtype === 'task_notification')
+    return null;
   // Honor the centralized hidden-subtype contract so Space task threads
   // don't surface noisy rows the main transcript already hides.
   if (isHiddenSystemSubtype(subtype)) return null;
@@ -986,78 +1044,6 @@ function buildOperationalSystemTurn(
     typeof (message as { uuid?: unknown }).uuid === 'string'
       ? ((message as { uuid: string }).uuid as string)
       : undefined;
-
-  if (subtype === 'thinking_tokens') {
-    const estimatedTokens = (message as { estimated_tokens?: unknown }).estimated_tokens;
-    const delta = (message as { estimated_tokens_delta?: unknown }).estimated_tokens_delta;
-    const tokenText =
-      typeof estimatedTokens === 'number' ? estimatedTokens.toLocaleString() : 'unknown';
-    const deltaText =
-      typeof delta === 'number' ? ` (${delta >= 0 ? '+' : ''}${delta.toLocaleString()})` : '';
-    return {
-      state: 'system',
-      id: `system-${String(row.id)}`,
-      agent: row.label,
-      agentKind: row.kind,
-      agentRole: row.role,
-      agentNodeExecutionId: row.nodeExecutionId ?? null,
-      createdAt: row.createdAt,
-      title: 'Thinking tokens',
-      body: `${tokenText} estimated tokens${deltaText}`,
-      sessionId: row.sessionId,
-      highlightMessageUuid: highlightUuid,
-      replacementStatus: row.replacementStatus,
-    };
-  }
-
-  // task_notification fallback: only reached when there is no roster target
-  // (completed turn / missing/stale summary / capped-out tool). Surface the
-  // terminal status + summary + usage so failures aren't silently lost — this
-  // row is the only remaining place to show the terminal metadata, matching
-  // what the roster and the full chat notification renderer display.
-  if (subtype === 'task_notification') {
-    const status = (message as { status?: string }).status;
-    const summary = (message as { summary?: unknown }).summary;
-    const usage = (
-      message as {
-        usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number };
-      }
-    ).usage;
-    const title =
-      status === 'completed'
-        ? 'Task completed'
-        : status === 'failed'
-          ? 'Task failed'
-          : status === 'stopped'
-            ? 'Task stopped'
-            : 'Task notification';
-    const parts: string[] = [];
-    if (typeof summary === 'string' && summary.trim()) parts.push(summary.trim());
-    else if (typeof status === 'string') parts.push(status);
-    if (usage) {
-      const segs: string[] = [];
-      if (typeof usage.total_tokens === 'number')
-        segs.push(`${usage.total_tokens.toLocaleString()} tokens`);
-      if (typeof usage.tool_uses === 'number') segs.push(`${usage.tool_uses} tool uses`);
-      if (typeof usage.duration_ms === 'number')
-        segs.push(`${(usage.duration_ms / 1000).toFixed(1)}s`);
-      if (segs.length > 0) parts.push(segs.join(' · '));
-    }
-    return {
-      state: 'system',
-      id: `system-${String(row.id)}`,
-      agent: row.label,
-      agentKind: row.kind,
-      agentRole: row.role,
-      agentNodeExecutionId: row.nodeExecutionId ?? null,
-      createdAt: row.createdAt,
-      title,
-      body: parts.join('\n'),
-      sessionId: row.sessionId,
-      highlightMessageUuid: highlightUuid,
-      replacementStatus: row.replacementStatus,
-    };
-  }
 
   if (subtype === 'session_state_changed') {
     const state = (message as { state?: unknown }).state;
@@ -1090,33 +1076,6 @@ function buildOperationalSystemTurn(
       createdAt: row.createdAt,
       title: 'Commands changed',
       body: `${count.toLocaleString()} slash commands available`,
-      sessionId: row.sessionId,
-      highlightMessageUuid: highlightUuid,
-      replacementStatus: row.replacementStatus,
-    };
-  }
-
-  if (subtype === 'api_retry') {
-    const retry = message as {
-      attempt?: unknown;
-      max_retries?: unknown;
-      retry_delay_ms?: unknown;
-      error_status?: unknown;
-    };
-    const attempt = finiteNumber(retry.attempt, 1);
-    const maxRetries = finiteNumber(retry.max_retries);
-    const retryDelayMs = finiteNumber(retry.retry_delay_ms);
-    const status = retry.error_status === null ? 'n/a' : String(finiteNumber(retry.error_status));
-    return {
-      state: 'system',
-      id: `system-${String(row.id)}`,
-      agent: row.label,
-      agentKind: row.kind,
-      agentRole: row.role,
-      agentNodeExecutionId: row.nodeExecutionId ?? null,
-      createdAt: row.createdAt,
-      title: 'API retry',
-      body: `Attempt ${attempt}/${maxRetries}, delay ${retryDelayMs}ms, status ${status}`,
       sessionId: row.sessionId,
       highlightMessageUuid: highlightUuid,
       replacementStatus: row.replacementStatus,
@@ -1328,7 +1287,6 @@ function buildFeedTurns(
     activeTurnSummaries,
     renderedTurnKeys
   );
-  const rosteredApiRetryUuids = collectRosteredApiRetryUuids(activeTurnSummaries, renderedTurnKeys);
 
   const completedRows = blocks.flatMap((block) => {
     const out: ParsedThreadRow[][] = [];
@@ -1363,7 +1321,7 @@ function buildFeedTurns(
       }
       if (
         subtype !== 'task_notification' &&
-        buildOperationalSystemTurn(row, false, rosteredActiveToolUseIds, rosteredApiRetryUuids)
+        buildOperationalSystemTurn(row, false, rosteredActiveToolUseIds)
       ) {
         flush();
         continue;
@@ -1440,6 +1398,7 @@ function buildFeedTurns(
           turnId,
           resultInfo,
           taskNotificationsByToolUseId,
+          rosteredToolUseIds,
           transitionSummary
         )
       );
@@ -1461,8 +1420,7 @@ function buildFeedTurns(
       const operationalSystemTurn = buildOperationalSystemTurn(
         row,
         row.sessionId ? latestRowIdBySession.get(row.sessionId) === String(row.id) : false,
-        rosteredToolUseIds,
-        rosteredApiRetryUuids
+        rosteredToolUseIds
       );
       if (operationalSystemTurn) {
         flushAgent();
@@ -1522,7 +1480,8 @@ function buildFeedTurns(
         completed.id,
         summary,
         sessionId,
-        taskNotificationsByToolUseId
+        taskNotificationsByToolUseId,
+        rosteredToolUseIds
       );
     }
   }
@@ -1534,9 +1493,12 @@ function buildFeedTurns(
   // turn from the same agent. Showing the fragment as its own header-only row
   // (e.g. "REVIEWER 12:29 PM · 3 messages · 9s" with nothing under it) is
   // noise; the reply is rendered in the sibling that holds the result text.
+  // A turn with no reply text but with roster content (tool calls / task
+  // outcomes) is still meaningful — e.g. a killed task whose outcome lives in
+  // the roster — so keep it.
   return turns.filter((t) => {
     if (t.state !== 'completed') return true;
-    return t.lastMessage.length > 0;
+    return t.lastMessage.length > 0 || t.roster.length > 0;
   });
 }
 
@@ -1683,6 +1645,52 @@ function RosterEntry({ entry, isLatest }: { entry: ActiveRosterEntry; isLatest: 
             attempt {entry.attempt}/{entry.maxRetries} · status {status} · delay{' '}
             {entry.retryDelayMs}ms
           </span>
+        </span>
+      </div>
+    );
+  }
+
+  if (entry.kind === 'task_notification') {
+    const isSuccess = entry.status === 'completed';
+    const isStopped = entry.status === 'stopped';
+    const statusLabel = isSuccess ? 'Task completed' : isStopped ? 'Task stopped' : 'Task failed';
+    const statusColor = isSuccess
+      ? 'text-green-400'
+      : isStopped
+        ? 'text-amber-300'
+        : 'text-red-400';
+    return (
+      <div
+        class={`flex items-start gap-2 font-mono text-xs leading-5 ${fadeClass}`}
+        data-testid="minimal-thread-roster-entry"
+        data-roster-kind="task_notification"
+        data-task-status={entry.status}
+      >
+        <span class="mt-0.5 shrink-0" aria-hidden="true">
+          {isSuccess ? (
+            <span class="text-green-400">✓</span>
+          ) : isStopped ? (
+            <span class="text-amber-300">■</span>
+          ) : (
+            <span class="text-red-400">✗</span>
+          )}
+        </span>
+        <span class="min-w-0 truncate">
+          <span class={`font-semibold ${statusColor}`}>{statusLabel}</span>
+          {entry.summary ? (
+            <>
+              <span class="text-gray-400"> — </span>
+              <span class={bodyClass}>{entry.summary}</span>
+            </>
+          ) : null}
+          {entry.usage ? (
+            <span class="text-gray-500">
+              {' '}
+              · {entry.usage.total_tokens.toLocaleString()} tok · {entry.usage.tool_uses} tool
+              {entry.usage.tool_uses === 1 ? '' : 's'} ·{' '}
+              {(entry.usage.duration_ms / 1000).toFixed(1)}s
+            </span>
+          ) : null}
         </span>
       </div>
     );


### PR DESCRIPTION
## What

The minimal feed (Space task thread) has two surfaces with distinct jobs: the **main thread body** is the readable multi-agent *conversation*; the **roster** is the dedicated *operational-status* surface. Operational metadata was leaking into the main thread as cards, duplicating the roster. This moves three system subtypes to **roster-only** in `MinimalThreadFeed`.

The **chat container** (`SDKMessageRenderer`) is unchanged — it still renders all three as before.

## Changes (`MinimalThreadFeed.tsx`)

| Subtype | Before | After |
|---|---|---|
| `api_retry` | main-thread system card + roster entry | roster-only (existing `api_retry` entry) |
| `thinking_tokens` | main-thread system card | roster-only (existing `thinking` entries) |
| `task_notification` | folded on roster tool card **or** main-thread fallback card | folded on roster tool card when the tool is within the 8-entry cap; otherwise a **new standalone roster entry** (chat-container style: ✓/■/✗ + summary + usage) |

### task_notification detail
- `task_notification` has no standalone server roster kind — it folds client-side onto a `tool` card only when that tool is within the roster cap.
- **Fold** when rostered → one attributable line (outcome on the action that produced it); better UX than a standalone duplicate.
- **Standalone** `RosterTaskNotificationEntry` when the tool is capped-out / orphan / completed-turn, so terminal outcomes (incl. failures + usage) are never lost.
- Standalone suppression uses the **global** `rosteredToolUseIds` set to avoid cross-turn duplication (fold in one turn + standalone in another).
- Removed the main-thread fallback card from `buildOperationalSystemTurn`.
- The drop-empty-turns filter now keeps turns with roster content, so a degenerate turn (e.g. a killed task with no reply text) isn't dropped along with its outcome.

### Cleanup
- Removed dead `api_retry` / `thinking_tokens` system-turn builders.
- Removed orphaned `collectRosteredApiRetryUuids` (the "suppress only if rostered" logic is gone — api_retry is always roster-only now).

## Tests
`MinimalThreadFeed.test.tsx`: updated 4 task_notification tests + 1 thinking_tokens test + 1 api_retry test for the new roster-only behavior; the standalone entry, the fold, and the drop-logic are all covered.

```
cd packages/web && bunx vitest run src/components/space/ src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
# 69 files, 1622 passed
```

`bun run check` green. Render-side only; no query/wire change. Do not merge — dev protected.