### PR TITLE
fix(external-events): dedupe polled PR metadata on head sha, not updated_at

### DIFF
--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -221,8 +221,16 @@ export function normalizeGitHubPollingRow(
   if (endpointKey === 'review_comments') eventType = 'pull_request_review_comment';
   const id = getNumber(obj.id) || prNumber;
   const updatedAt = parseGitHubTimestamp(obj.updated_at ?? obj.created_at);
+  // `pulls` rows bump updated_at on every comment/check/push, so keying the
+  // dedupe on updated_at re-fires the same PR metadata every cycle. Re-emit
+  // only when the head actually changes (a real push); comments/checks already
+  // arrive via their own dedicated events. Fall back to updatedAt only when the
+  // head is missing (deleted-head PRs) so the row still dedupes within a cycle.
+  const headSha = endpointKey === 'pulls' ? getString(asObject(obj.head).sha) : '';
   const dedupeVersion =
-    endpointKey === 'pulls' ? String(updatedAt) : getString(obj.updated_at ?? obj.created_at);
+    endpointKey === 'pulls'
+      ? headSha || String(updatedAt)
+      : getString(obj.updated_at ?? obj.created_at);
   const dedupeSuffix = dedupeVersion ? `:${dedupeVersion}` : '';
   const canonicalOwner = watched.owner.toLowerCase();
   const canonicalRepo = watched.repo.toLowerCase();

--- a/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  normalizeGitHubPollingRow,
+  type GitHubPollingRepo,
+} from '../../../../src/lib/external-events/github/github-normalizer';
+
+// ============================================================================
+// Factory for GitHub `/repos/{owner}/{repo}/pulls` rows.
+// ============================================================================
+
+const watched: GitHubPollingRepo = { owner: 'Acme', repo: 'Widgets' };
+const HEAD_SHA_INITIAL = 'aaa111bbb222ccc333';
+const HEAD_SHA_PUSHED = 'ddd444eee555fff666';
+
+function makePullRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1001,
+    number: 42,
+    url: 'https://api.github.com/repos/Acme/Widgets/pulls/42',
+    html_url: 'https://github.com/Acme/Widgets/pull/42',
+    title: 'Add polling support',
+    body: 'Adds polling support for GitHub PRs',
+    user: { login: 'lsm', type: 'User' },
+    head: { sha: HEAD_SHA_INITIAL, ref: 'feature/polling' },
+    created_at: '2026-06-24T10:00:00Z',
+    updated_at: '2026-06-24T14:24:20Z',
+    ...overrides,
+  };
+}
+
+describe('normalizeGitHubPollingRow — pulls dedupe key', () => {
+  it('keys the dedupe suffix on the head sha, not the volatile updated_at', () => {
+    const event = normalizeGitHubPollingRow(watched, makePullRow(), 'pulls')!;
+    expect(event).not.toBeNull();
+    // eventType for the pulls endpoint is `pull_request`; owner/repo lowercased.
+    expect(event.dedupeKey).toBe(`acme/widgets:pull_request:1001:${HEAD_SHA_INITIAL}`);
+    expect(event.deliveryId).toBe(`poll:pull_request:1001:${HEAD_SHA_INITIAL}`);
+    expect(event.externalId).toBe(`pull_request:1001:${HEAD_SHA_INITIAL}`);
+  });
+
+  it('keeps the same dedupeKey when only updated_at advanced (e.g. a comment/check)', () => {
+    const first = normalizeGitHubPollingRow(watched, makePullRow(), 'pulls');
+    // A comment or check_run bumped updated_at but did NOT push a new commit.
+    const second = normalizeGitHubPollingRow(
+      watched,
+      makePullRow({ updated_at: '2026-06-24T15:10:00Z' }),
+      'pulls'
+    );
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    // Same dedupe key → the store collapses both rows, no duplicate delivery.
+    expect(second!.dedupeKey).toBe(first!.dedupeKey);
+    expect(second!.deliveryId).toBe(first!.deliveryId);
+    expect(second!.externalId).toBe(first!.externalId);
+    // occurredAt still reflects the (advanced) updated_at.
+    expect(second!.occurredAt).toBeGreaterThan(first!.occurredAt);
+  });
+
+  it('changes the dedupeKey when the head sha changes (a real push)', () => {
+    const first = normalizeGitHubPollingRow(watched, makePullRow(), 'pulls');
+    const second = normalizeGitHubPollingRow(
+      watched,
+      makePullRow({ head: { sha: HEAD_SHA_PUSHED, ref: 'feature/polling' } }),
+      'pulls'
+    );
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(second!.dedupeKey).not.toBe(first!.dedupeKey);
+    expect(second!.dedupeKey).toBe(`acme/widgets:pull_request:1001:${HEAD_SHA_PUSHED}`);
+  });
+
+  it('falls back to updatedAt when head.sha is missing (deleted-head PR)', () => {
+    const row = makePullRow({ head: {} });
+    const first = normalizeGitHubPollingRow(watched, row, 'pulls');
+    // Within a single cycle the identical row dedupes against itself.
+    const secondSame = normalizeGitHubPollingRow(watched, row, 'pulls');
+
+    expect(first).not.toBeNull();
+    expect(secondSame!.dedupeKey).toBe(first!.dedupeKey);
+    // When updated_at advances, the fallback key advances (no stale head to pin).
+    const advanced = normalizeGitHubPollingRow(
+      watched,
+      makePullRow({ head: {}, updated_at: '2026-06-24T15:10:00Z' }),
+      'pulls'
+    );
+    expect(advanced!.dedupeKey).not.toBe(first!.dedupeKey);
+  });
+});


### PR DESCRIPTION
## Problem

Polling re-delivered the same GitHub PR metadata event on **every** poll cycle in which the PR was touched, producing duplicate `pull_request` messages to subscribers (e.g. a reviewer got re-activated ~8 times just to re-ack the same PR).

## Root cause

In `normalizeGitHubPollingRow`, the `pulls` endpoint keyed its dedupe suffix on the PR's `updated_at`:

```ts
const dedupeVersion = endpointKey === 'pulls' ? String(updatedAt) : ...;
```

GitHub bumps a PR's `updated_at` on **every** touch — a new comment, a push, a `check_run`, a review. So during a review storm the `updated_at` advances nearly every poll → the dedupe suffix changes → the dedupe key changes → the deduper never collapses it → the same PR metadata is re-published as a "new" event every cycle. The volatile `updated_at` also fed `deliveryId` and `externalId`.

`review_comments` / `issue_comments` were **not** affected (comments are immutable, so `updated_at` == `created_at` is stable).

## Fix

Stop keying the `pulls` dedupe on the volatile `updated_at`. Re-emit a PR metadata event only when the PR **head** actually changes (a real push); comments/checks already arrive via their own dedicated polling events.

```ts
const headSha = endpointKey === 'pulls' ? getString(asObject(obj.head).sha) : '';
const dedupeVersion =
  endpointKey === 'pulls'
    ? headSha || String(updatedAt)   // fallback for deleted-head PRs
    : getString(obj.updated_at ?? obj.created_at);
```

- `occurredAt` stays `updatedAt` — only the dedupe key changes.
- Deleted-head PRs (no `head.sha`) fall back to `updatedAt` so they still dedupe within a cycle.
- `issue_comments` / `review_comments` branches untouched.

## Tests

New `github-normalizer.test.ts` covering `normalizeGitHubPollingRow` for `pulls`:
1. Same PR polled twice, only a comment bumped `updated_at` (head sha unchanged) → same `dedupeKey` (collapsed by the store).
2. Same PR polled after a push (new `head.sha`) → `dedupeKey` changes (re-emitted once).
3. Deleted-head PR (no `head.sha`) → falls back to `updatedAt` so it still dedupes within a cycle.

## Verification

- `cd packages/daemon && bun test tests/unit/2-handlers/github/github-normalizer.test.ts` → 4 pass
- Full `tests/unit/2-handlers/github/` suite → 377 pass
- `bun run check` (lint + typecheck + knip + guards) green

## Out of scope

- Webhook+polling dedupe-key unification.
- The delivery bug where events only reach a reviewer that is subscribed but doesn't receive (execution-status gating) — separate task.
- The `ensurePrSubscriptionForNode` emitter-binding cleanup — separate task.

Fixes #671