### PR TITLE
feat(space): rate-limit cooldown + re-auth banners in task thread (#680)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -577,7 +577,8 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       db,
       internalEventBus,
       undefined,
-      credentialManager
+      credentialManager,
+      reactiveDb
     );
 
     // Initialize ClientEventBridge — forwards selected InternalEventBus events to

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -418,9 +418,34 @@ function mapSpaceTaskActivityRow(row: Record<string, unknown>): Record<string, u
     typeof row.role === 'string' ? row.role : kind === 'task_agent' ? 'task-agent' : kind;
   const rawLabel = typeof row.label === 'string' ? row.label : rawRole;
 
+  // Rate-limit cooldown details. Only present when the session's
+  // processing_state.status is 'rate_limit_cooldown'; the three sibling fields
+  // are extracted from the same JSON column. Surface as a single object so the
+  // renderer can hand them straight to RateLimitCooldownBanner.
+  const rateLimitCooldown =
+    row.processingStatus === 'rate_limit_cooldown'
+      ? buildRateLimitCooldown(row.retryCount, row.maxRetries, row.retryAt)
+      : null;
+
+  // Persisted structured session error snapshot (see StateProjectionService).
+  const sessionError = parseSessionError(row.sessionError);
+
+  // Strip the raw extracted keys so the member shape stays clean — the grouped
+  // objects above are the canonical surface.
+  const {
+    retryCount: _retryCount,
+    maxRetries: _maxRetries,
+    retryAt: _retryAt,
+    sessionError: _sessionErrorRaw,
+    completionSummary: _completionSummary,
+    ...rest
+  } = row;
+
   return {
-    ...row,
+    ...rest,
     kind,
+    rateLimitCooldown,
+    sessionError,
     nodeExecution:
       kind === 'node_agent'
         ? {
@@ -440,6 +465,61 @@ function mapSpaceTaskActivityRow(row: Record<string, unknown>): Record<string, u
     role: rawRole,
     messageCount: Number(row.messageCount ?? 0),
   };
+}
+
+/**
+ * Build the `rateLimitCooldown` object from the raw JSON-extracted values.
+ * Returns null unless all three fields are present and parse to finite numbers
+ * — a partial snapshot (e.g. missing retryAt) can't drive the countdown UI and
+ * would only confuse the renderer. `json_extract` yields SQL NULL (→ JS null)
+ * for absent JSON keys, so an explicit null guard is required: `Number(null)`
+ * coerces to 0 which is otherwise indistinguishable from a real zero.
+ */
+function buildRateLimitCooldown(
+  retryCount: unknown,
+  maxRetries: unknown,
+  retryAt: unknown
+): { retryCount: number; maxRetries: number; retryAt: number } | null {
+  const rc = toFiniteNumber(retryCount);
+  const mr = toFiniteNumber(maxRetries);
+  const at = toFiniteNumber(retryAt);
+  if (rc === null || mr === null || at === null) return null;
+  return { retryCount: rc, maxRetries: mr, retryAt: at };
+}
+
+/** Coerce a `json_extract` result to a finite number, or null if absent/invalid. */
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Parse the persisted `sessions.last_error` JSON snapshot into the member's
+ * `sessionError` object. Returns null for missing/unparseable rows so the
+ * renderer treats "no error" and "malformed error" identically.
+ */
+function parseSessionError(value: unknown): {
+  category: string;
+  message: string;
+  providerId?: string | null;
+} | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  try {
+    const parsed = JSON.parse(value) as {
+      category?: unknown;
+      message?: unknown;
+      providerId?: unknown;
+    };
+    if (typeof parsed.category !== 'string' || !parsed.category) return null;
+    return {
+      category: parsed.category,
+      message: typeof parsed.message === 'string' ? parsed.message : '',
+      ...(typeof parsed.providerId === 'string' ? { providerId: parsed.providerId } : {}),
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -1122,6 +1202,10 @@ SELECT
   END AS state,
   json_extract(s.processing_state, '$.status') AS processingStatus,
   json_extract(s.processing_state, '$.phase') AS processingPhase,
+  json_extract(s.processing_state, '$.retryCount') AS retryCount,
+  json_extract(s.processing_state, '$.maxRetries') AS maxRetries,
+  json_extract(s.processing_state, '$.retryAt') AS retryAt,
+  s.last_error AS sessionError,
   COALESCE(ms.messageCount, 0) AS messageCount,
   ase.task_id AS taskId,
   ase.task_title AS taskTitle,
@@ -1131,7 +1215,6 @@ SELECT
   ase.agent_name AS agentName,
   ase.execution_result AS executionResult,
   ase.task_id AS currentStep,
-  NULL AS error,
   NULL AS completionSummary,
   CAST(
     MAX(

--- a/packages/daemon/src/lib/state-projection-service.ts
+++ b/packages/daemon/src/lib/state-projection-service.ts
@@ -236,6 +236,12 @@ export class StateProjectionService {
           details,
           occurredAt: Date.now(),
         });
+        // Persist a small snapshot to the session row so DB-backed read models
+        // (the Space task thread's activity LiveQuery) can surface actionable
+        // errors — e.g. a re-authenticate affordance for PROVIDER_AUTH_ERROR —
+        // without a separate per-session subscription. Mirrors the in-memory
+        // cache lifecycle (cleared on `session.errorClear`).
+        this.persistSessionError(sessionId, details);
       },
       { subscriberName: 'StateProjectionService.sessionError' }
     );
@@ -246,9 +252,54 @@ export class StateProjectionService {
       (data) => {
         const { sessionId } = data as unknown as { sessionId: string };
         this.errorCache.set(sessionId, null);
+        this.persistSessionError(sessionId, null);
       },
       { subscriberName: 'StateProjectionService.sessionErrorClear' }
     );
+  }
+
+  /**
+   * Persist (or clear) the active session error snapshot on the session row.
+   *
+   * Writes a small JSON snapshot `{ category, message, providerId? }` derived
+   * from the structured error so DB-backed read models (the Space task thread
+   * activity LiveQuery) can surface actionable errors reactively. Passing
+   * `null` clears the column (mirrors `session.errorClear`).
+   *
+   * Best-effort: a DB write failure must never break the in-memory cache
+   * update or the subsequent state broadcast — every path is guarded and
+   * logs at most a warning.
+   */
+  private persistSessionError(sessionId: string, details: unknown): void {
+    if (!this.db) return;
+    try {
+      const db = this.db.getDatabase();
+      if (!details) {
+        db.prepare('UPDATE sessions SET last_error = NULL WHERE id = ?').run(sessionId);
+        return;
+      }
+      const err = details as {
+        category?: unknown;
+        userMessage?: unknown;
+        message?: unknown;
+        metadata?: Record<string, unknown> | undefined;
+      };
+      const category = typeof err.category === 'string' ? err.category : null;
+      if (!category) return;
+      const message =
+        (typeof err.userMessage === 'string' && err.userMessage) ||
+        (typeof err.message === 'string' && err.message) ||
+        '';
+      const providerIdRaw = err.metadata?.providerId;
+      const snapshot: Record<string, unknown> = { category, message };
+      if (typeof providerIdRaw === 'string') snapshot.providerId = providerIdRaw;
+      db.prepare('UPDATE sessions SET last_error = ? WHERE id = ?').run(
+        JSON.stringify(snapshot),
+        sessionId
+      );
+    } catch (err) {
+      this.logger.warn(`Failed to persist session error for ${sessionId}:`, err);
+    }
   }
 
   /**

--- a/packages/daemon/src/lib/state-projection-service.ts
+++ b/packages/daemon/src/lib/state-projection-service.ts
@@ -24,6 +24,7 @@ import type { SettingsManager } from './settings-manager';
 import type { ProviderCredentialManager } from './credentials/provider-credential-manager';
 import type { Config } from '../config';
 import type { Database } from '../storage/database';
+import type { ReactiveDatabase } from '../storage/reactive-database';
 import { Logger } from './logger';
 import type {
   SessionsState,
@@ -89,7 +90,8 @@ export class StateProjectionService {
     private db?: Database,
     private internalEventBus?: InternalEventBus<DaemonInternalEventMap>,
     clientEvents?: IClientEventGateway,
-    private credentialManager?: ProviderCredentialManager
+    private credentialManager?: ProviderCredentialManager,
+    private reactiveDb?: ReactiveDatabase
   ) {
     this.clientEvents = clientEvents ?? new ClientEventGateway({ hub: messageHub });
     this.setupHandlers();
@@ -276,6 +278,10 @@ export class StateProjectionService {
       const db = this.db.getDatabase();
       if (!details) {
         db.prepare('UPDATE sessions SET last_error = NULL WHERE id = ?').run(sessionId);
+        // The write bypasses the ReactiveDatabase proxy, so notify explicitly
+        // — otherwise the activity LiveQuery wouldn't re-evaluate on a clear
+        // that isn't accompanied by a state-machine transition.
+        this.reactiveDb?.notifyChange('sessions');
         return;
       }
       const err = details as {
@@ -297,6 +303,8 @@ export class StateProjectionService {
         JSON.stringify(snapshot),
         sessionId
       );
+      // See above: bypasses the proxy, so notify the LiveQuery engine directly.
+      this.reactiveDb?.notifyChange('sessions');
     } catch (err) {
       this.logger.warn(`Failed to persist session error for ${sessionId}:`, err);
     }

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -153,6 +153,7 @@ export function createTables(db: BunDatabase): void {
         sdk_origin_path TEXT,
         available_commands TEXT,
         processing_state TEXT,
+        last_error TEXT,
         archived_at TEXT,
         parent_id TEXT,
         type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat')),

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -725,6 +725,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
   // Migration 160: Backfill friction_digest evidence kind for databases that already ran migration 159.
   run(migrationMarkerKey(160), () => runMigration160(db));
+
+  // Migration 161: Persist the active session error snapshot (sessions.last_error).
+  run(migrationMarkerKey(161), () => runMigration161(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -10878,4 +10881,23 @@ export function runMigration159(db: BunDatabase): void {
 
 export function runMigration160(db: BunDatabase): void {
   widenEvolutionEvidenceKinds(db);
+}
+
+/**
+ * Migration 161: Add `sessions.last_error` for persisting the active session
+ * error snapshot.
+ *
+ * The structured session error (ErrorManager → StateProjectionService
+ * `errorCache`) was previously in-memory only and therefore invisible to the
+ * DB-backed activity LiveQuery. Persisting it as a small JSON snapshot
+ * ({ category, message, providerId }) lets the Space task thread surface a
+ * re-authenticate affordance (PROVIDER_AUTH_ERROR) reactively through the
+ * existing activity subscription, without forcing the user into the chat
+ * container. Cleared on `session.errorClear`, mirroring the in-memory cache.
+ */
+export function runMigration161(db: BunDatabase): void {
+  if (!tableExists(db, 'sessions')) return;
+  if (!tableHasColumn(db, 'sessions', 'last_error')) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN last_error TEXT`);
+  }
 }

--- a/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
@@ -7,7 +7,9 @@
  */
 
 import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
 import { StateProjectionService } from '../../../../src/lib/state-projection-service';
+import type { Database } from '../../../../src/storage';
 import type { Session, GlobalSettings, AgentProcessingState } from '@neokai/shared';
 import { STATE_CHANNELS, DEFAULT_GLOBAL_SETTINGS } from '@neokai/shared';
 import type {
@@ -518,5 +520,102 @@ describe('StateProjectionService', () => {
         expect(state.apiConnection.status).toBe('disconnected');
       });
     });
+  });
+});
+
+/**
+ * Real-DB coverage for the `sessions.last_error` persistence that shadows the
+ * in-memory errorCache. The mock-based suite above can't assert column writes,
+ * so this block wires a genuine in-memory SQLite database through the service.
+ */
+describe('StateProjectionService — session error persistence', () => {
+  let service: StateProjectionService;
+  let memDb: BunDatabase;
+  let eventSubscribers: Map<string, Function[]>;
+
+  beforeEach(() => {
+    memDb = new BunDatabase(':memory:');
+    memDb.exec(`CREATE TABLE sessions (id TEXT PRIMARY KEY, last_error TEXT)`);
+    memDb.prepare('INSERT INTO sessions (id) VALUES (?)').run('sess-cooldown-1');
+
+    eventSubscribers = new Map();
+    const mockInternalEventBus = {
+      subscribe: mock((event: string, handler: Function) => {
+        const existing = eventSubscribers.get(event) || [];
+        existing.push(handler);
+        eventSubscribers.set(event, existing);
+        return () => {};
+      }),
+      publish: mock(async () => ({ delivered: 0, failures: [] })),
+      publishAsync: mock(() => {}),
+    } as unknown as InternalEventBus<DaemonInternalEventMap>;
+
+    // `Database` facade stand-in — only `getDatabase()` is exercised by the
+    // persistence path, so a minimal mock over the real in-memory DB suffices.
+    const dbFacade = { getDatabase: () => memDb } as unknown as Database;
+
+    service = new StateProjectionService(
+      { event: mock(async () => {}), onRequest: mock(() => () => {}) } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      dbFacade,
+      mockInternalEventBus
+    );
+  });
+
+  function lastError(sessionId: string): string | null {
+    const row = memDb.prepare('SELECT last_error FROM sessions WHERE id = ?').get(sessionId) as {
+      last_error: string | null;
+    };
+    return row.last_error;
+  }
+
+  it('persists a structured provider auth error to sessions.last_error', async () => {
+    const handler = eventSubscribers.get('session.error')?.[0];
+    await handler!({
+      sessionId: 'sess-cooldown-1',
+      error: 'Anthropic authentication failed.',
+      details: {
+        category: 'provider_auth_error',
+        userMessage: 'Anthropic authentication failed.',
+        message: '401 invalid_api_key',
+        metadata: { providerId: 'anthropic' },
+      },
+    });
+
+    const stored = lastError('sess-cooldown-1');
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({
+      category: 'provider_auth_error',
+      message: 'Anthropic authentication failed.',
+      providerId: 'anthropic',
+    });
+  });
+
+  it('clears sessions.last_error on session.errorClear', async () => {
+    const errorHandler = eventSubscribers.get('session.error')?.[0];
+    await errorHandler!({
+      sessionId: 'sess-cooldown-1',
+      error: 'boom',
+      details: { category: 'provider_auth_error', userMessage: 'boom', metadata: {} },
+    });
+    expect(lastError('sess-cooldown-1')).not.toBeNull();
+
+    const clearHandler = eventSubscribers.get('session.errorClear')?.[0];
+    await clearHandler!({ sessionId: 'sess-cooldown-1' });
+    expect(lastError('sess-cooldown-1')).toBeNull();
+  });
+
+  it('ignores error events without a structured category', async () => {
+    const handler = eventSubscribers.get('session.error')?.[0];
+    await handler!({
+      sessionId: 'sess-cooldown-1',
+      error: 'plain string error',
+      details: { code: 'ERR_001' },
+    });
+    // No category → nothing persisted (column stays NULL).
+    expect(lastError('sess-cooldown-1')).toBeNull();
   });
 });

--- a/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/state-projection-service.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, beforeEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { StateProjectionService } from '../../../../src/lib/state-projection-service';
 import type { Database } from '../../../../src/storage';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
 import type { Session, GlobalSettings, AgentProcessingState } from '@neokai/shared';
 import { STATE_CHANNELS, DEFAULT_GLOBAL_SETTINGS } from '@neokai/shared';
 import type {
@@ -532,6 +533,7 @@ describe('StateProjectionService — session error persistence', () => {
   let service: StateProjectionService;
   let memDb: BunDatabase;
   let eventSubscribers: Map<string, Function[]>;
+  let notifyChange: ReturnType<typeof mock>;
 
   beforeEach(() => {
     memDb = new BunDatabase(':memory:');
@@ -539,6 +541,7 @@ describe('StateProjectionService — session error persistence', () => {
     memDb.prepare('INSERT INTO sessions (id) VALUES (?)').run('sess-cooldown-1');
 
     eventSubscribers = new Map();
+    notifyChange = mock(() => {});
     const mockInternalEventBus = {
       subscribe: mock((event: string, handler: Function) => {
         const existing = eventSubscribers.get(event) || [];
@@ -553,6 +556,10 @@ describe('StateProjectionService — session error persistence', () => {
     // `Database` facade stand-in — only `getDatabase()` is exercised by the
     // persistence path, so a minimal mock over the real in-memory DB suffices.
     const dbFacade = { getDatabase: () => memDb } as unknown as Database;
+    // ReactiveDatabase stand-in — `notifyChange` is spied so the test asserts
+    // the LiveQuery engine is told the sessions table changed (the write
+    // bypasses the reactive proxy, so an explicit notify is required).
+    const reactiveDb = { notifyChange } as unknown as ReactiveDatabase;
 
     service = new StateProjectionService(
       { event: mock(async () => {}), onRequest: mock(() => () => {}) } as never,
@@ -561,7 +568,10 @@ describe('StateProjectionService — session error persistence', () => {
       {} as never,
       {} as never,
       dbFacade,
-      mockInternalEventBus
+      mockInternalEventBus,
+      undefined,
+      undefined,
+      reactiveDb
     );
   });
 
@@ -592,6 +602,9 @@ describe('StateProjectionService — session error persistence', () => {
       message: 'Anthropic authentication failed.',
       providerId: 'anthropic',
     });
+    // The write bypasses the reactive proxy, so the LiveQuery engine must be
+    // notified explicitly that the sessions table changed.
+    expect(notifyChange).toHaveBeenCalledWith('sessions');
   });
 
   it('clears sessions.last_error on session.errorClear', async () => {
@@ -603,9 +616,11 @@ describe('StateProjectionService — session error persistence', () => {
     });
     expect(lastError('sess-cooldown-1')).not.toBeNull();
 
+    notifyChange.mockClear();
     const clearHandler = eventSubscribers.get('session.errorClear')?.[0];
     await clearHandler!({ sessionId: 'sess-cooldown-1' });
     expect(lastError('sess-cooldown-1')).toBeNull();
+    expect(notifyChange).toHaveBeenCalledWith('sessions');
   });
 
   it('ignores error events without a structured category', async () => {
@@ -615,7 +630,8 @@ describe('StateProjectionService — session error persistence', () => {
       error: 'plain string error',
       details: { code: 'ERR_001' },
     });
-    // No category → nothing persisted (column stays NULL).
+    // No category → nothing persisted (column stays NULL) and no notify fired.
     expect(lastError('sess-cooldown-1')).toBeNull();
+    expect(notifyChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -323,16 +323,19 @@ describe('NAMED_QUERY_REGISTRY', () => {
       id: string,
       type: string,
       processingState: string,
-      sessionContext?: string
+      sessionContext?: string,
+      lastError?: string
     ): void {
       db.exec(`
 				INSERT INTO sessions (
 					id, title, workspace_path, created_at, last_active_at, status, config, metadata,
 					is_worktree, worktree_path, main_repo_path, worktree_branch, git_branch, sdk_session_id,
-					available_commands, processing_state, archived_at, type, session_context
+					available_commands, processing_state, last_error, archived_at, type, session_context
 				) VALUES (
 					'${id}', 'Session', '/tmp/test-space', '${nowIso}', '${nowIso}', 'active', '{}', '{}',
-					0, NULL, NULL, NULL, NULL, NULL, NULL, '${processingState}', NULL, '${type}', '${sessionContext ?? '{}'}'
+					0, NULL, NULL, NULL, NULL, NULL, NULL, '${processingState}', ${
+            lastError ? `'${lastError}'` : 'NULL'
+          }, NULL, '${type}', '${sessionContext ?? '{}'}'
 				)
 			`);
     }
@@ -445,6 +448,65 @@ describe('NAMED_QUERY_REGISTRY', () => {
       expect(row.messageCount).toBe(2);
       expect(row.taskId).toBe(taskId);
       expect(row.taskTitle).toBe('Ship UI review');
+    });
+
+    test('surfaces rate-limit cooldown details from processing_state', () => {
+      const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+      const retryAt = now + 60_000;
+      insertSession(
+        sessionId,
+        'space_task_agent',
+        `{"status":"rate_limit_cooldown","retryCount":2,"maxRetries":5,"retryAt":${retryAt}}`
+      );
+
+      const [row] = queryAndMap(taskId);
+      expect(row.processingStatus).toBe('rate_limit_cooldown');
+      expect(row.state).toBe('cooldown');
+      expect(row.rateLimitCooldown).toEqual({
+        retryCount: 2,
+        maxRetries: 5,
+        retryAt,
+      });
+      // Raw extracted keys are stripped from the mapped member shape.
+      expect(row.retryCount).toBeUndefined();
+      expect(row.maxRetries).toBeUndefined();
+      expect(row.retryAt).toBeUndefined();
+    });
+
+    test('rateLimitCooldown is null when cooldown fields are missing', () => {
+      const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+      // status is rate_limit_cooldown but the sibling fields are absent
+      insertSession(sessionId, 'space_task_agent', '{"status":"rate_limit_cooldown"}');
+
+      const [row] = queryAndMap(taskId);
+      expect(row.processingStatus).toBe('rate_limit_cooldown');
+      expect(row.rateLimitCooldown).toBeNull();
+    });
+
+    test('surfaces persisted provider auth error from sessions.last_error', () => {
+      const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+      insertSession(
+        sessionId,
+        'space_task_agent',
+        '{"status":"interrupted"}',
+        undefined,
+        '{"category":"provider_auth_error","message":"Anthropic authentication failed.","providerId":"anthropic"}'
+      );
+
+      const [row] = queryAndMap(taskId);
+      expect(row.sessionError).toEqual({
+        category: 'provider_auth_error',
+        message: 'Anthropic authentication failed.',
+        providerId: 'anthropic',
+      });
+    });
+
+    test('sessionError is null when last_error is absent', () => {
+      const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+      insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+      const [row] = queryAndMap(taskId);
+      expect(row.sessionError).toBeNull();
     });
 
     test('returns unified task message rows with label and task metadata', () => {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -496,6 +496,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			sdk_origin_path TEXT,
 			available_commands TEXT,
 			processing_state TEXT,
+			last_error TEXT,
 			archived_at TEXT,
 			parent_id TEXT,
 			type TEXT DEFAULT 'worker' CHECK(type IN ('worker', 'room_chat', 'planner', 'coder', 'leader', 'general', 'lobby', 'spaces_global', 'space_task_agent', 'space_chat')),

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -859,6 +859,28 @@ export interface SpaceTaskActivityMember {
     | null;
   /** Raw processing phase when the session is actively processing */
   processingPhase?: 'initializing' | 'thinking' | 'streaming' | 'finalizing' | null;
+  /**
+   * Rate-limit cooldown details. Present (non-null) only when
+   * `processingStatus === 'rate_limit_cooldown'`. Extracted from the same
+   * `processing_state` JSON column the activity query reads, so the value
+   * stays reactive without a separate subscription. Surfaces the countdown +
+   * Retry/Cancel affordance in the Space task thread without forcing the
+   * user into the chat container.
+   */
+  rateLimitCooldown?: { retryCount: number; maxRetries: number; retryAt: number } | null;
+  /**
+   * Active structured session error snapshot (persisted on the session row),
+   * or null when the session has no active error. Mirrors the in-memory
+   * `errorCache` lifecycle (set on `session.error`, cleared on
+   * `session.errorClear`). `category` matches the daemon `ErrorCategory`
+   * union (e.g. `'provider_auth_error'`). `providerId` is present for
+   * provider errors so the task thread can render a re-authenticate affordance.
+   */
+  sessionError?: {
+    category: string;
+    message: string;
+    providerId?: string | null;
+  } | null;
   /** Number of persisted SDK messages seen in the backing session */
   messageCount: number;
   /** Linked SpaceTask when this member corresponds to a persisted step task */

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -463,6 +463,35 @@ export function SpaceTaskPane({
     }
     return labels;
   }, [activityMembers]);
+  // Worker members in rate-limit cooldown / provider auth error, for the pinned
+  // banners above the feed. Derived from the same activity subscription that
+  // drives the live rails so the banners appear/disappear reactively as the
+  // session transitions in and out of cooldown / error state.
+  const cooldownBannerMembers = useMemo(
+    () =>
+      activityMembers
+        .filter((m) => m.rateLimitCooldown && m.sessionId)
+        .map((m) => ({
+          sessionId: m.sessionId,
+          label: m.label,
+          retryCount: m.rateLimitCooldown!.retryCount,
+          maxRetries: m.rateLimitCooldown!.maxRetries,
+          retryAt: m.rateLimitCooldown!.retryAt,
+        })),
+    [activityMembers]
+  );
+  const authErrorBannerMembers = useMemo(
+    () =>
+      activityMembers
+        .filter((m) => m.sessionId && m.sessionError?.category === 'provider_auth_error')
+        .map((m) => ({
+          sessionId: m.sessionId,
+          label: m.label,
+          message: m.sessionError?.message ?? '',
+          providerId: m.sessionError?.providerId ?? null,
+        })),
+    [activityMembers]
+  );
   const hasUnifiedWorkflowThread =
     !!task.workflowRunId || !!agentSessionId || activityMembers.length > 0;
   const showInlineComposer = !isTerminalTask;
@@ -1069,6 +1098,8 @@ export function SpaceTaskPane({
                   bottomInsetPx={taskComposerPaddingPx}
                   activeAgentLabels={activeAgentLabels}
                   overlayTaskId={task.id}
+                  cooldownBannerMembers={cooldownBannerMembers}
+                  authErrorBannerMembers={authErrorBannerMembers}
                   autoScrollEnabled={autoScrollEnabled}
                   onShowScrollButtonChange={setShowScrollButton}
                   onScrollToBottomChange={(scrollToBottom) => {

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -1,8 +1,37 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
+import { getProviderLabel } from '../../hooks/useModelSwitcher';
+import { navigateToSettings } from '../../lib/router';
 import { MinimalThreadFeed } from './thread/minimal/MinimalThreadFeed';
 import { parseThreadRow } from './thread/space-task-thread-events';
+import { RateLimitCooldownBanner } from '../sdk/RateLimitCooldownBanner';
+
+/**
+ * A worker whose session is in rate-limit cooldown. Surfaced as a pinned
+ * banner above the feed (countdown + Retry/Cancel) so the user can act on it
+ * without opening the session in the chat container. Mirrors the
+ * RateLimitCooldownBanner placement in ChatContainer.
+ */
+export interface CooldownBannerMember {
+  sessionId: string;
+  label: string;
+  retryCount: number;
+  maxRetries: number;
+  retryAt: number;
+}
+
+/**
+ * A worker whose session has an active provider auth error. Surfaced as a
+ * pinned banner above the feed with a re-authenticate affordance — same action
+ * wiring as ChatContainer's structured-error action button.
+ */
+export interface AuthErrorBannerMember {
+  sessionId: string;
+  label: string;
+  message: string;
+  providerId?: string | null;
+}
 
 interface SpaceTaskUnifiedThreadProps {
   taskId: string;
@@ -26,6 +55,16 @@ interface SpaceTaskUnifiedThreadProps {
   activeAgentLabels?: ReadonlySet<string>;
   /** Task id forwarded to overlay open affordances for node-agent send routing. */
   overlayTaskId?: string;
+  /**
+   * Worker members currently in rate-limit cooldown. Each renders a pinned
+   * countdown + Retry/Cancel banner above the feed.
+   */
+  cooldownBannerMembers?: CooldownBannerMember[];
+  /**
+   * Worker members with an active provider auth error. Each renders a pinned
+   * re-authenticate banner above the feed.
+   */
+  authErrorBannerMembers?: AuthErrorBannerMember[];
   autoScrollEnabled?: boolean;
   onShowScrollButtonChange?: (showScrollButton: boolean) => void;
   onScrollToBottomChange?: (scrollToBottom: ((smooth?: boolean) => void) | null) => void;
@@ -40,6 +79,8 @@ export function SpaceTaskUnifiedThread({
   topInsetClass = '',
   activeAgentLabels,
   overlayTaskId,
+  cooldownBannerMembers = [],
+  authErrorBannerMembers = [],
   autoScrollEnabled = true,
   onShowScrollButtonChange,
   onScrollToBottomChange,
@@ -114,8 +155,30 @@ export function SpaceTaskUnifiedThread({
   const bottomInsetClasses =
     bottomInsetPx === undefined ? `${bottomInsetClass} ${bottomScrollPaddingClass}` : '';
 
+  const hasBanners = cooldownBannerMembers.length > 0 || authErrorBannerMembers.length > 0;
+
   return (
     <div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
+      {hasBanners && (
+        <div class="flex-shrink-0 px-4 pt-3 space-y-2" data-testid="space-task-thread-banner-stack">
+          {cooldownBannerMembers.map((m) => (
+            <div key={`cooldown-${m.sessionId}`} data-testid="space-thread-cooldown-banner">
+              <div class="mb-1 text-[11px] font-medium uppercase tracking-wide text-amber-300/80">
+                {m.label}
+              </div>
+              <RateLimitCooldownBanner
+                sessionId={m.sessionId}
+                retryCount={m.retryCount}
+                maxRetries={m.maxRetries}
+                retryAt={m.retryAt}
+              />
+            </div>
+          ))}
+          {authErrorBannerMembers.map((m) => (
+            <ProviderAuthErrorBanner key={`auth-${m.sessionId}`} member={m} />
+          ))}
+        </div>
+      )}
       <div
         ref={containerRef}
         class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClasses}`}
@@ -131,6 +194,50 @@ export function SpaceTaskUnifiedThread({
           <div ref={messagesEndRef} />
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Pinned provider auth-error banner for the Space task thread. Surfaces the
+ * agent label, the error message, and a "Re-authenticate {Provider}" action
+ * that routes to Settings → Providers — the same wiring ChatContainer uses
+ * for its structured-error action button.
+ */
+function ProviderAuthErrorBanner({ member }: { member: AuthErrorBannerMember }) {
+  const providerLabel = member.providerId ? getProviderLabel(member.providerId) : 'Provider';
+  return (
+    <div
+      class="flex items-center gap-2 px-3 py-2 rounded border bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800 text-red-900 dark:text-red-100"
+      data-testid="space-thread-auth-error-banner"
+    >
+      <svg
+        class="w-3.5 h-3.5 shrink-0 text-red-600 dark:text-red-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width={2}
+          d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z"
+        />
+      </svg>
+      <span class="text-xs flex-1 min-w-0">
+        <span class="font-medium text-red-300/80 uppercase tracking-wide mr-1">{member.label}</span>
+        <span class="break-words">
+          {member.message || `${providerLabel} authentication failed.`}
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={() => navigateToSettings('providers')}
+        class="text-xs font-medium px-2 py-0.5 rounded bg-red-600 hover:bg-red-700 text-white transition-colors shrink-0"
+      >
+        Re-authenticate {providerLabel}
+      </button>
     </div>
   );
 }

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -138,4 +138,62 @@ describe('SpaceTaskUnifiedThread', () => {
     render(<SpaceTaskUnifiedThread taskId="task-1" />);
     expect(screen.getByText('No task-agent activity yet.')).toBeTruthy();
   });
+
+  describe('rate-limit cooldown banner', () => {
+    it('renders a pinned countdown + Retry/Cancel banner per cooldown member', () => {
+      const retryAt = Date.now() + 60_000;
+      render(
+        <SpaceTaskUnifiedThread
+          taskId="task-1"
+          cooldownBannerMembers={[
+            {
+              sessionId: 'worker-1',
+              label: 'Coder Agent',
+              retryCount: 2,
+              maxRetries: 5,
+              retryAt,
+            },
+          ]}
+        />
+      );
+
+      const banner = screen.getByTestId('space-thread-cooldown-banner');
+      expect(banner).toBeTruthy();
+      // Agent label is surfaced so the user knows which worker is throttled.
+      expect(banner.textContent).toContain('Coder Agent');
+      // RateLimitCooldownBanner renders the manual-override actions.
+      expect(screen.getByText('Retry Now')).toBeTruthy();
+      expect(screen.getByText('Cancel')).toBeTruthy();
+    });
+
+    it('does not render the banner stack when there are no cooldown members', () => {
+      render(<SpaceTaskUnifiedThread taskId="task-1" />);
+      expect(screen.queryByTestId('space-task-thread-banner-stack')).toBeNull();
+    });
+  });
+
+  describe('provider auth-error banner', () => {
+    it('renders a re-authenticate affordance per auth-error member', () => {
+      render(
+        <SpaceTaskUnifiedThread
+          taskId="task-1"
+          authErrorBannerMembers={[
+            {
+              sessionId: 'worker-1',
+              label: 'Coder Agent',
+              message: 'Anthropic authentication failed.',
+              providerId: 'anthropic',
+            },
+          ]}
+        />
+      );
+
+      const banner = screen.getByTestId('space-thread-auth-error-banner');
+      expect(banner).toBeTruthy();
+      expect(banner.textContent).toContain('Coder Agent');
+      expect(banner.textContent).toContain('Anthropic authentication failed.');
+      // Provider label is resolved via getProviderLabel → "Anthropic".
+      expect(screen.getByText('Re-authenticate Anthropic')).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## What

The Space task thread (`MinimalThreadFeed`) had **no rate-limit cooldown or provider auth-error surfaces** — a worker hitting `rate_limit_cooldown` or a `PROVIDER_AUTH_ERROR` showed nothing actionable unless the user opened the session in the chat container.

This adds both as **pinned banners above the feed**, reactive through the existing activity subscription (no new client subscription, no opening the chat container).

## Changes

**Rate-limit cooldown** (`agentState.status === 'rate_limit_cooldown'`)
- Extract `retryCount`/`maxRetries`/`retryAt` from the `processing_state` JSON the activity LiveQuery already reads → new `SpaceTaskActivityMember.rateLimitCooldown`.
- Render a per-worker countdown + **Retry/Cancel** by reusing the existing `RateLimitCooldownBanner` (session-scoped, self-contained).

**Provider auth error** (`PROVIDER_AUTH_ERROR`)
- The structured error was in-memory only (`StateProjectionService.errorCache`), invisible to the DB-backed activity LiveQuery. Persist a small snapshot (`{ category, message, providerId }`) to a new `sessions.last_error` column — set on `session.error`, cleared on `session.errorClear`, mirroring the in-memory cache lifecycle exactly.
- Surface it in the activity LiveQuery → `SpaceTaskActivityMember.sessionError`.
- Render a **Re-authenticate {Provider}** affordance reusing ChatContainer's action wiring (`navigateToSettings('providers')` + `getProviderLabel`).

**Placement:** pane-level banner in `SpaceTaskUnifiedThread` (matches how `ChatContainer` pins it). `MinimalThreadFeed` is unchanged — it stays focused on turn rendering.

**Other:**
- Migration 161 (`sessions.last_error`) + fresh-schema column.
- `SpaceTaskPane` derives `cooldownBannerMembers` / `authErrorBannerMembers` from the activity members it already holds.

## Tests
- Daemon: activity LiveQuery maps cooldown details + persisted error (incl. null/missing-field guards); `StateProjectionService` writes/clears `last_error` on the real session row.
- Web: `SpaceTaskUnifiedThread` renders the cooldown countdown (Retry/Cancel) and the re-authenticate button per affected member; banner stack absent when no members qualify.
- `bun run check`, `check:db-schema-parity`, daemon shards (1-core, 0-shared-handlers-workflow, 4-space-migrations-*), and the affected web vitest suites all green.

## Coordination
The cooldown surface remains the **manual-override UI** even after the auto-retry work (#673-677) lands; this PR only adds the surface, not retry logic. Persisting `last_error` is additive and idempotent with the in-memory `errorCache` — ChatContainer behaviour is unchanged.

Closes #680.