### PR TITLE
feat: add get_external_event MCP tool for on-demand raw event fetch

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -992,6 +992,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     memoryRepo: deps.db.agentMemory,
     goalService: spaceGoalService,
     evolutionScopeService,
+    externalEventStore: deps.externalEventStore,
   });
 
   deps.commandBus.register('agent.message.inject', async (command) => {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -876,6 +876,7 @@ export class SpaceRuntimeService {
       replyRoutingRegistry: this.config.replyRoutingRegistry,
       messageResolver: this.createMessageResolver(space.id),
       longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
+      externalEventStore: this.config.externalEventStore,
     });
   }
 
@@ -1505,6 +1506,7 @@ export class SpaceRuntimeService {
       replyRoutingRegistry: this.config.replyRoutingRegistry,
       messageResolver: this.createMessageResolver(space.id),
       longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
+      externalEventStore: this.config.externalEventStore,
     });
 
     const additional: Record<string, McpServerConfig> = {
@@ -1634,6 +1636,7 @@ export class SpaceRuntimeService {
       replyRoutingRegistry: this.config.replyRoutingRegistry,
       messageResolver: this.createMessageResolver(space.id),
       longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
+      externalEventStore: this.config.externalEventStore,
     });
 
     // Create a space-scoped db-query server if dbPath is configured.

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2812,19 +2812,18 @@ export class SpaceRuntime {
     const occurredAtValues = items.map((item) => item.event.occurredAt);
     const oldest = new Date(Math.min(...occurredAtValues)).toISOString();
     const newest = new Date(Math.max(...occurredAtValues)).toISOString();
-    // Include the coalesced event ids so the agent can actually call
-    // get_external_event(eventId) — without them the digest points at a tool
-    // the agent has no argument for. Cap the inline list to keep the injected
-    // message bounded when many events coalesce into one rate-limit digest.
-    const DIGEST_EVENT_ID_CAP = 10;
-    const eventIds = items.map((item) => item.event.eventId);
-    const shown = eventIds.slice(0, DIGEST_EVENT_ID_CAP);
-    const remaining = eventIds.length - shown.length;
-    const eventIdList = shown.join(', ') + (remaining > 0 ? `, … (${remaining} more)` : '');
+    // Include every coalesced event id so the agent can fetch any of them via
+    // get_external_event(eventId). deliverDigestToSession marks ALL coalesced
+    // deliveries as delivered after injecting this single message, so hiding
+    // any id (e.g. via a cap) would leave delivered-but-unreachable events.
+    // Rate-limit digests are small in practice, and even a large burst stays
+    // well within an injected-message budget (UUIDs are compact), so we list
+    // all ids rather than truncate.
+    const eventIds = items.map((item) => item.event.eventId).join(', ');
     return (
       `${items.length} events received for topics: ${topics.join(', ')} ` +
       `(oldest: ${oldest}, newest: ${newest}). ` +
-      `Event IDs: ${eventIdList}. ` +
+      `Event IDs: ${eventIds}. ` +
       `Use get_external_event(eventId) for full details.`
     );
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2814,7 +2814,7 @@ export class SpaceRuntime {
     const newest = new Date(Math.max(...occurredAtValues)).toISOString();
     return `${items.length} events received for topics: ${topics.join(
       ', '
-    )} (oldest: ${oldest}, newest: ${newest}). Use subscribe_external_event to get details.`;
+    )} (oldest: ${oldest}, newest: ${newest}). Use get_external_event(eventId) for full details.`;
   }
 
   /**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2812,9 +2812,21 @@ export class SpaceRuntime {
     const occurredAtValues = items.map((item) => item.event.occurredAt);
     const oldest = new Date(Math.min(...occurredAtValues)).toISOString();
     const newest = new Date(Math.max(...occurredAtValues)).toISOString();
-    return `${items.length} events received for topics: ${topics.join(
-      ', '
-    )} (oldest: ${oldest}, newest: ${newest}). Use get_external_event(eventId) for full details.`;
+    // Include the coalesced event ids so the agent can actually call
+    // get_external_event(eventId) — without them the digest points at a tool
+    // the agent has no argument for. Cap the inline list to keep the injected
+    // message bounded when many events coalesce into one rate-limit digest.
+    const DIGEST_EVENT_ID_CAP = 10;
+    const eventIds = items.map((item) => item.event.eventId);
+    const shown = eventIds.slice(0, DIGEST_EVENT_ID_CAP);
+    const remaining = eventIds.length - shown.length;
+    const eventIdList = shown.join(', ') + (remaining > 0 ? `, … (${remaining} more)` : '');
+    return (
+      `${items.length} events received for topics: ${topics.join(', ')} ` +
+      `(oldest: ${oldest}, newest: ${newest}). ` +
+      `Event IDs: ${eventIdList}. ` +
+      `Use get_external_event(eventId) for full details.`
+    );
   }
 
   /**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -347,6 +347,12 @@ export interface TaskAgentManagerConfig {
   goalService?: import('../goals/goal-service').SpaceGoalService;
   /** Evolution scope service for scoped lesson injection. */
   evolutionScopeService?: EvolutionScopeService;
+  /**
+   * External event store, plumbed into node-agent tools so sub-sessions can
+   * call `get_external_event` for on-demand raw event fetch. Optional — when
+   * absent, the tool is not registered on node-agent sessions.
+   */
+  externalEventStore?: import('../../external-events/external-event-store').ExternalEventStore;
 }
 
 // ---------------------------------------------------------------------------
@@ -4017,6 +4023,7 @@ export class TaskAgentManager {
       artifactRepo: this.config.artifactRepo,
       taskRepo: this.config.taskRepo,
       auditLogRepo: this.auditLogRepo,
+      externalEventStore: this.config.externalEventStore,
       getSpaceAutonomyLevel: async (sid) => {
         const s = await spaceManager.getSpace(sid);
         return s?.autonomyLevel ?? 1;

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -124,6 +124,28 @@ export const SubscribePrEventsSchema = z.object({
 export type SubscribePrEventsInput = z.infer<typeof SubscribePrEventsSchema>;
 
 // ---------------------------------------------------------------------------
+// get_external_event
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `get_external_event` input.
+ *
+ * Fetches the full raw record for a single external event by its id — the
+ * on-demand deep-dive counterpart to the lean "essence" injected into sessions
+ * as a message. Use this for the rare (~1%) case where the digested summary is
+ * not enough and you need the complete payload (incl. `rawPayload`, `body`,
+ * `actor`, `eventType`, source-native fields, etc.).
+ */
+export const GetExternalEventSchema = z.object({
+  eventId: z
+    .string()
+    .min(1)
+    .describe('The id of the external event to fetch (as carried in injected event digests)'),
+});
+
+export type GetExternalEventInput = z.infer<typeof GetExternalEventSchema>;
+
+// ---------------------------------------------------------------------------
 // save_artifact
 // ---------------------------------------------------------------------------
 
@@ -489,6 +511,7 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
   subscribe_external_event: SubscribeExternalEventSchema,
   unsubscribe_external_event: UnsubscribeExternalEventSchema,
   subscribe_pr_events: SubscribePrEventsSchema,
+  get_external_event: GetExternalEventSchema,
   restore_node_agent: RestoreNodeAgentSchema,
   list_tasks: ListTasksSchema,
   get_task: GetTaskSchema,

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -75,6 +75,7 @@ import {
   SubscribeExternalEventSchema,
   UnsubscribeExternalEventSchema,
   SubscribePrEventsSchema,
+  GetExternalEventSchema,
 } from './node-agent-tool-schemas';
 import type {
   ListPeersInput,
@@ -95,10 +96,12 @@ import type {
   SubscribeExternalEventInput,
   UnsubscribeExternalEventInput,
   SubscribePrEventsInput,
+  GetExternalEventInput,
 } from './node-agent-tool-schemas';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceTask } from '@neokai/shared';
 import type { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
+import type { ExternalEventStore } from '../../external-events/external-event-store';
 import { parseAddress } from '../../../../../messaging/src/address';
 import { translateLegacyNodeTargets } from '../messaging-adapter';
 import { getEffectiveGate, hasInjectedGateFeature } from '../runtime/gate-features';
@@ -439,6 +442,12 @@ export interface NodeAgentToolsConfig {
    * Optional — when absent, no audit entries are written.
    */
   auditLogRepo?: McpAuditLogRepository;
+  /**
+   * External event store for the `get_external_event` on-demand fetch tool.
+   * Optional — when absent, the tool is not registered. Reads are scoped to
+   * the current space so events never leak across spaces.
+   */
+  externalEventStore?: ExternalEventStore;
   /**
    * Optional callback invoked when the agent calls `restore_node_agent`.
    *
@@ -1689,6 +1698,38 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
       return result;
     },
 
+    /**
+     * Fetch the full raw record for a single external event by id.
+     *
+     * On-demand counterpart to the lean "essence" injected into sessions as a
+     * message: use this for the rare deep-dive case where the digested summary
+     * is not enough and you need the complete payload (incl. `rawPayload`,
+     * `body`, `actor`, `eventType`, source-native fields, etc.).
+     *
+     * Returns a clear not-found result for unknown ids. Reads are scoped to the
+     * current space — an id that resolves to an event in another space is
+     * treated as not-found so events never leak across spaces.
+     */
+    async get_external_event(args: GetExternalEventInput): Promise<ToolResult> {
+      const { externalEventStore } = config;
+      if (!externalEventStore) {
+        return jsonResult({
+          success: false,
+          error: 'External event lookup is not available.',
+        });
+      }
+      const record = externalEventStore.getById(args.eventId);
+      // Scope by space: getById resolves by id only, so an id belonging to
+      // another space must be treated as not-found.
+      if (!record || record.event.spaceId !== spaceId) {
+        return jsonResult({
+          success: false,
+          error: `External event not found: ${args.eventId}`,
+        });
+      }
+      return jsonResult({ success: true, event: record.event, state: record.state });
+    },
+
     async approve_task(args: ApproveTaskInput): Promise<ToolResult> {
       if (!config.onApproveTask) {
         return jsonResult({
@@ -2048,6 +2089,20 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
               'Events are delivered to this node-agent session as messages. The coder node typically calls this.',
             SubscribePrEventsSchema.shape,
             (args) => handlers.subscribe_pr_events(args)
+          ),
+        ]
+      : []),
+    ...(config.externalEventStore
+      ? [
+          tool(
+            'get_external_event',
+            'Fetch the full raw record for a single external event by id — the on-demand deep-dive counterpart to ' +
+              'the lean event summary injected into your session as a message. Use this for the rare case where the ' +
+              'summary is not enough and you need the complete payload (incl. `rawPayload`, `body`, `actor`, ' +
+              '`eventType`, source-native fields such as review `state`, check-run `conclusion`, diff `path`/`line`, etc.). ' +
+              'Returns a not-found result for unknown ids.',
+            GetExternalEventSchema.shape,
+            (args) => handlers.get_external_event(args)
           ),
         ]
       : []),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -75,6 +75,7 @@ import { canTransition } from '../runtime/workflow-run-status-machine';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
 import { validateGlobPattern } from '../../external-events/topic-validator';
+import type { ExternalEventStore } from '../../external-events/external-event-store';
 import { getAvailableModels, getModelInfoUnfiltered, isValidModel } from '../../model-service';
 import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 import { RESERVED_SPACE_AGENT_HANDLES, slugifyWithinLimit } from '../slug';
@@ -439,6 +440,12 @@ export interface SpaceAgentToolsConfig {
       message: MessageRecord
     ) => Promise<string | null | undefined>;
   };
+  /**
+   * External event store for the `get_external_event` on-demand fetch tool.
+   * Optional — when absent, the tool is not registered. Reads are scoped to
+   * the current space so events never leak across spaces.
+   */
+  externalEventStore?: ExternalEventStore;
 }
 
 // ---------------------------------------------------------------------------
@@ -1461,6 +1468,32 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ success: false, error: message });
       }
+    },
+
+    /**
+     * Fetch the full raw record for a single external event by id.
+     *
+     * On-demand counterpart to the lean "essence" injected into sessions as a
+     * message: use this for the rare deep-dive case where the digested summary
+     * is not enough and you need the complete payload (incl. `rawPayload`,
+     * `body`, `actor`, `eventType`, source-native fields, etc.).
+     *
+     * Returns a clear not-found result for unknown ids. Reads are scoped to the
+     * current space — an id that resolves to an event in another space is
+     * treated as not-found so events never leak across spaces.
+     */
+    async get_external_event(args: { eventId: string }): Promise<ToolResult> {
+      const store = config.externalEventStore;
+      if (!store) {
+        return jsonResult({ success: false, error: 'External event lookup is not available.' });
+      }
+      const record = store.getById(args.eventId);
+      // Scope by space: getById resolves by id only, so an id belonging to
+      // another space must be treated as not-found.
+      if (!record || record.event.spaceId !== spaceId) {
+        return jsonResult({ success: false, error: `External event not found: ${args.eventId}` });
+      }
+      return jsonResult({ success: true, event: record.event, state: record.state });
     },
 
     /**
@@ -4116,6 +4149,22 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
         'List external-event subscriptions for a long-horizon Space agent.',
         { agent_id: z.string().describe('Long-horizon agent ID') },
         (args) => handlers.list_agent_event_subscriptions(args)
+      )
+    );
+  }
+
+  // External event on-demand fetch — only registered when the store is provided.
+  if (config.externalEventStore) {
+    tools.push(
+      tool(
+        'get_external_event',
+        'Fetch the full raw record for a single external event by id — the on-demand deep-dive counterpart to ' +
+          'the lean event summary injected into a session as a message. Use this for the rare case where the summary ' +
+          'is not enough and you need the complete payload (incl. `rawPayload`, `body`, `actor`, `eventType`, ' +
+          'source-native fields such as review `state`, check-run `conclusion`, diff `path`/`line`, etc.). ' +
+          'Returns a not-found result for unknown ids.',
+        { eventId: z.string().min(1).describe('The id of the external event to fetch') },
+        (args) => handlers.get_external_event(args)
       )
     );
   }

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -31,6 +31,8 @@ import { AgentMessageRouter } from '../../../../src/lib/space/runtime/agent-mess
 import { ChannelResolver } from '../../../../src/lib/space/runtime/channel-resolver.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { McpAuditLogRepository } from '../../../../src/storage/repositories/mcp-audit-log-repository.ts';
+import { ExternalEventStore } from '../../../../src/lib/external-events/external-event-store.ts';
+import type { ExternalEvent } from '../../../../src/lib/external-events/types.ts';
 import { jsonResult } from '../../../../src/lib/space/tools/tool-result.ts';
 import type { SubscribeExternalEventInput } from '../../../../src/lib/space/tools/node-agent-tool-schemas.ts';
 import { registerGateFeature } from '../../../../src/lib/space/runtime/gate-features.ts';
@@ -2474,6 +2476,147 @@ describe('node-agent-tools: external event subscriptions', () => {
     );
     expect(withRegistered).toContain('subscribe_external_event');
     expect(withRegistered).toContain('unsubscribe_external_event');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: get_external_event
+// ---------------------------------------------------------------------------
+
+function makeGitHubEvent(overrides: Partial<ExternalEvent> = {}): ExternalEvent {
+  return {
+    id: crypto.randomUUID(),
+    spaceId: 'space-node-tools-test',
+    source: 'github',
+    topic: 'github/owner/repo/pull_request_review_comment/42.created',
+    occurredAt: Date.now(),
+    ingestedAt: Date.now(),
+    summary: 'review comment on PR #42',
+    dedupeKey: `dedupe-${Math.random().toString(36).slice(2)}`,
+    externalUrl: 'https://github.com/owner/repo/pull/42#discussion_r1',
+    payload: {
+      eventType: 'pull_request_review_comment',
+      action: 'created',
+      actor: 'octocat',
+      actorType: 'User',
+      body: 'nit: prefer const',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      entityId: '42',
+      repoOwner: 'owner',
+      repoName: 'repo',
+      deliveryId: 'delivery-1',
+      externalId: 'ext-1',
+      source: 'webhook',
+      rawPayload: {
+        comment: {
+          id: 1,
+          node_id: 'PRRC_node1',
+          body: 'nit: prefer const',
+          path: 'src/index.ts',
+          line: 10,
+          side: 'RIGHT',
+          in_reply_to_id: null,
+          html_url: 'https://github.com/owner/repo/pull/42#discussion_r1',
+          pull_request_url: 'https://github.com/owner/repo/pull/42',
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('node-agent-tools: get_external_event', () => {
+  let ctx: TestCtx;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  afterEach(() => {
+    ctx.db.close();
+  });
+
+  test('returns the full record (incl. rawPayload) for a known eventId', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    const event = makeGitHubEvent({ spaceId: ctx.spaceId });
+    store.store(event);
+
+    const handlers = createNodeAgentToolHandlers(makeConfig(ctx, { externalEventStore: store }));
+    const result = await handlers.get_external_event({ eventId: event.id });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(true);
+    expect(data.event.id).toBe(event.id);
+    expect(data.event.topic).toBe(event.topic);
+    expect(data.event.summary).toBe(event.summary);
+    expect(data.event.externalUrl).toBe(event.externalUrl);
+    // The complete source payload — including the nested rawPayload — is present.
+    expect(data.event.payload.body).toBe('nit: prefer const');
+    expect(data.event.payload.rawPayload.comment.node_id).toBe('PRRC_node1');
+    expect(data.event.payload.rawPayload.comment.path).toBe('src/index.ts');
+    expect(data.event.payload.actor).toBe('octocat');
+    expect(data.event.payload.eventType).toBe('pull_request_review_comment');
+  });
+
+  test('returns a not-found result for an unknown eventId', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    const handlers = createNodeAgentToolHandlers(makeConfig(ctx, { externalEventStore: store }));
+    const result = await handlers.get_external_event({ eventId: 'does-not-exist' });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not found');
+  });
+
+  test('treats an event in another space as not-found (no cross-space leak)', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    // Seed the foreign-space row so the event FK is satisfied; the lookup must
+    // still reject it because the caller's space differs. Use a distinct
+    // workspace_path — the column is UNIQUE and the default helper hardcodes /tmp.
+    ctx.db
+      .prepare(
+        `INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+         allowed_models, session_ids, slug, status, created_at, updated_at)
+         VALUES (?, '/tmp/space-other', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+      )
+      .run('space-other', 'Space other', 'space-other', Date.now(), Date.now());
+    const event = makeGitHubEvent({ spaceId: 'space-other' });
+    store.store(event);
+
+    const handlers = createNodeAgentToolHandlers(makeConfig(ctx, { externalEventStore: store }));
+    const result = await handlers.get_external_event({ eventId: event.id });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not found');
+  });
+
+  test('returns unavailable when the store is not wired', async () => {
+    const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
+    const result = await handlers.get_external_event({ eventId: 'any' });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not available');
+  });
+
+  test('createNodeAgentMcpServer registers get_external_event only when the store is wired', () => {
+    const store = new ExternalEventStore(ctx.db);
+
+    const withoutStore = createNodeAgentMcpServer(makeConfig(ctx));
+    const withoutRegistered = Object.keys(
+      (withoutStore as unknown as { instance: { _registeredTools: Record<string, unknown> } })
+        .instance._registeredTools
+    );
+    expect(withoutRegistered).not.toContain('get_external_event');
+
+    const withStore = createNodeAgentMcpServer(makeConfig(ctx, { externalEventStore: store }));
+    const withRegistered = Object.keys(
+      (withStore as unknown as { instance: { _registeredTools: Record<string, unknown> } }).instance
+        ._registeredTools
+    );
+    expect(withRegistered).toContain('get_external_event');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -40,6 +40,8 @@ import {
   createSpaceAgentMcpServer,
   createSpaceAgentToolHandlers,
 } from '../../../../src/lib/space/tools/space-agent-tools.ts';
+import { ExternalEventStore } from '../../../../src/lib/external-events/external-event-store.ts';
+import type { ExternalEvent } from '../../../../src/lib/external-events/types.ts';
 import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { formatAgentMessage } from '../../../../src/lib/space/agent-message-envelope.ts';
@@ -6007,5 +6009,132 @@ describe('cancel_task on draft — error message consistency', () => {
     // Should mention what transitions ARE allowed from draft
     expect(parsed.error).toContain('open');
     expect(parsed.error).toContain('archived');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_external_event (LH-agent / space-agent surface)
+// ---------------------------------------------------------------------------
+
+function makeGitHubExternalEvent(overrides: Partial<ExternalEvent> = {}): ExternalEvent {
+  return {
+    id: crypto.randomUUID(),
+    spaceId: 'space-tools-test',
+    source: 'github',
+    topic: 'github/owner/repo/pull_request/42.closed',
+    occurredAt: Date.now(),
+    ingestedAt: Date.now(),
+    summary: 'PR #42 closed',
+    dedupeKey: `dedupe-${Math.random().toString(36).slice(2)}`,
+    externalUrl: 'https://github.com/owner/repo/pull/42',
+    payload: {
+      eventType: 'pull_request',
+      action: 'closed',
+      actor: 'octocat',
+      actorType: 'User',
+      body: 'merging this',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      entityId: '42',
+      repoOwner: 'owner',
+      repoName: 'repo',
+      deliveryId: 'delivery-1',
+      externalId: 'ext-1',
+      source: 'webhook',
+      rawPayload: {
+        pull_request: {
+          id: 1,
+          node_id: 'PR_node1',
+          number: 42,
+          html_url: 'https://github.com/owner/repo/pull/42',
+          merged: true,
+          state: 'closed',
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('space-agent-tools: get_external_event', () => {
+  let ctx: TestCtx;
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+  afterEach(() => {
+    ctx.db.close();
+  });
+
+  test('returns the full record (incl. rawPayload) for a known eventId', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    const event = makeGitHubExternalEvent({ spaceId: ctx.spaceId });
+    store.store(event);
+
+    const handlers = makeHandlers(ctx, { externalEventStore: store });
+    const result = await handlers.get_external_event({ eventId: event.id });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(true);
+    expect(data.event.id).toBe(event.id);
+    expect(data.event.payload.body).toBe('merging this');
+    expect(data.event.payload.rawPayload.pull_request.node_id).toBe('PR_node1');
+    expect(data.event.payload.actor).toBe('octocat');
+    expect(data.event.payload.eventType).toBe('pull_request');
+  });
+
+  test('returns a not-found result for an unknown eventId', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    const handlers = makeHandlers(ctx, { externalEventStore: store });
+    const result = await handlers.get_external_event({ eventId: 'nope' });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not found');
+  });
+
+  test('treats an event in another space as not-found (no cross-space leak)', async () => {
+    const store = new ExternalEventStore(ctx.db);
+    // Seed the foreign-space row so the event FK is satisfied; the lookup must
+    // still reject it because the caller's space differs. Use a distinct
+    // workspace_path — the column is UNIQUE.
+    seedSpaceRow(ctx.db, 'space-other', '/tmp/space-other');
+    const event = makeGitHubExternalEvent({ spaceId: 'space-other' });
+    store.store(event);
+
+    const handlers = makeHandlers(ctx, { externalEventStore: store });
+    const result = await handlers.get_external_event({ eventId: event.id });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not found');
+  });
+
+  test('createSpaceAgentMcpServer registers get_external_event only when the store is wired', () => {
+    const store = new ExternalEventStore(ctx.db);
+
+    const withoutStore = createSpaceAgentMcpServer({
+      spaceId: ctx.spaceId,
+      runtime: ctx.runtime,
+      workflowManager: ctx.workflowManager,
+      taskRepo: ctx.taskRepo,
+      nodeExecutionRepo: ctx.nodeExecutionRepo,
+      workflowRunRepo: ctx.workflowRunRepo,
+      taskManager: ctx.taskManager,
+      spaceAgentManager: ctx.agentManager,
+    });
+    expect(getRegisteredToolNames(withoutStore)).not.toContain('get_external_event');
+
+    const withStore = createSpaceAgentMcpServer({
+      spaceId: ctx.spaceId,
+      runtime: ctx.runtime,
+      workflowManager: ctx.workflowManager,
+      taskRepo: ctx.taskRepo,
+      nodeExecutionRepo: ctx.nodeExecutionRepo,
+      workflowRunRepo: ctx.workflowRunRepo,
+      taskManager: ctx.taskManager,
+      spaceAgentManager: ctx.agentManager,
+      externalEventStore: store,
+    });
+    expect(getRegisteredToolNames(withStore)).toContain('get_external_event');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -2145,6 +2145,12 @@ describe('SpaceRuntime external event subscriptions', () => {
       '40 events received for topics: github/lsm/neokai/pull_request/42.review_submitted'
     );
     expect(injected.some((item) => item.message.includes(events[0]!.id))).toBe(false);
+    // The digest must list EVERY coalesced id (no cap/truncation) so every
+    // delivered event remains fetchable via get_external_event(eventId).
+    // events[1..40] are in the digest; verify an id well past the old 10-cap.
+    expect(injected[10]!.message).toContain(events[30]!.id);
+    expect(injected[10]!.message).toContain(events[40]!.id);
+    expect(injected[10]!.message).not.toContain('more)`');
   });
 
   test('persists pending delivery when target execution is not active', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1164,7 +1164,7 @@ describe('SpaceRuntime external event subscriptions', () => {
       events.slice(0, 10).map((event) => event.id)
     );
     expect(injected[10]!.message).toBe(
-      '5 events received for topics: github/lsm/neokai/pull_request/42.review_comment, github/lsm/neokai/pull_request/42.review_submitted (oldest: 2023-11-14T22:13:20.010Z, newest: 2023-11-14T22:13:20.014Z). Use subscribe_external_event to get details.'
+      '5 events received for topics: github/lsm/neokai/pull_request/42.review_comment, github/lsm/neokai/pull_request/42.review_submitted (oldest: 2023-11-14T22:13:20.010Z, newest: 2023-11-14T22:13:20.014Z). Use get_external_event(eventId) for full details.'
     );
     for (const event of events) {
       expect(eventStore.getById(event.id)?.state).toBe('delivered');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1163,9 +1163,20 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected.slice(0, 10).map((item) => JSON.parse(item.message).eventId)).toEqual(
       events.slice(0, 10).map((event) => event.id)
     );
-    expect(injected[10]!.message).toBe(
-      '5 events received for topics: github/lsm/neokai/pull_request/42.review_comment, github/lsm/neokai/pull_request/42.review_submitted (oldest: 2023-11-14T22:13:20.010Z, newest: 2023-11-14T22:13:20.014Z). Use get_external_event(eventId) for full details.'
+    expect(injected[10]!.message).toContain(
+      '5 events received for topics: github/lsm/neokai/pull_request/42.review_comment, github/lsm/neokai/pull_request/42.review_submitted'
     );
+    expect(injected[10]!.message).toContain(
+      '(oldest: 2023-11-14T22:13:20.010Z, newest: 2023-11-14T22:13:20.014Z)'
+    );
+    expect(injected[10]!.message).toContain('Use get_external_event(eventId) for full details.');
+    // The digest must carry the coalesced event ids so the agent can fetch the
+    // full record via get_external_event(eventId) — otherwise the pointer is
+    // unusable. The 5 coalesced events are evt-rate-limit-10..14.
+    for (const id of ['evt-rate-limit-10', 'evt-rate-limit-14']) {
+      expect(injected[10]!.message).toContain(`Event IDs: `);
+      expect(injected[10]!.message).toContain(id);
+    }
     for (const event of events) {
       expect(eventStore.getById(event.id)?.state).toBe('delivered');
       expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');


### PR DESCRIPTION
## What

Adds a new `get_external_event({ eventId })` MCP tool that returns the **full raw external-event record** (summary, body, payload, `rawPayload`, actor, eventType, externalUrl, …) via `externalEventStore.getById(eventId)`. This is the on-demand deep-dive counterpart to the lean event "essence" that a companion task will inject into sessions — agents need a fetch path *before* the injected message is slimmed. Non-breaking / additive; ships first.

Also fixes a stale reference: the rate-limit digest message told agents to "Use `subscribe_external_event` to get details" — that's the *subscribe* tool, not a fetch. Now points at `get_external_event(eventId)`.

## GitHub event field catalog (verified against docs)

Per the official [Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads), the normalized payloads NeoKai stores expose these genuinely useful fields (all reachable via the returned `payload`, incl. nested `rawPayload`):

| Event | Key fields available |
|---|---|
| `pull_request_review_comment` | `comment.{node_id, body, path, line, side, in_reply_to_id, commit_id, html_url, pull_request_url}` |
| `issue_comment` | `comment.{node_id, body, html_url, issue_url}` + `issue.pull_request` (PR vs issue) |
| `pull_request_review` | `review.{node_id, body, state, html_url, pull_request_url, submitted_at, commit_id}` |
| `pull_request` | `pull_request.{node_id, number, html_url, body, state, merged, head, base}` |
| `check_run` | `check_run.{node_id, head_sha, status, conclusion, name, html_url, check_suite, started_at, completed_at}` |

This catalog drives both this fetch task and the companion "essence" slimming task.

## Scope

1. **New tool `get_external_event({ eventId })`** → returns full record; clear not-found for unknown ids; **scoped to the caller's space** so events never leak across spaces.
2. **Both tool surfaces:**
   - Node-agent: `node-agent-tools.ts` + schema `node-agent-tool-schemas.ts`; store wired through `task-agent-manager.ts` + `rpc-handlers/index.ts`.
   - LH-agent / space-agent: `space-agent-tools.ts`; store wired to all three `createSpaceAgentMcpServer` sites in `space-runtime-service.ts`.
3. **Digest fix:** `formatExternalEventDigestMessage` → "Use `get_external_event(eventId)` for full details."

## Tests

- `get_external_event` with a known `eventId` → full record incl. `rawPayload` + node_id (both surfaces).
- Unknown `eventId` → not-found result.
- Event in another space → treated as not-found (no cross-space leak).
- Tool registers only when `externalEventStore` is wired (both surfaces).
- Updated the existing digest-message assertion.

`cd packages/daemon && bun test` for the tool/store/runtime test files — all green. `bun run check` green.

## Out of scope

- Slimming the injected message + node_id extraction — companion task (blocked on this one).
- Changing what's persisted (already stored fully).