### PR TITLE
fix(space-runtime): activate subscribed agents for external events

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -32,9 +32,16 @@ export class SpaceManager {
    * runtime (resume from paused or start from stopped). Used to re-seed task
    * schedules whose fire jobs were skipped during the inactive window so they
    * can resume firing without a daemon restart. Multiple callbacks are allowed.
+   *
+   * Returns an unsubscribe function that removes the callback; runtimes should
+   * call it on stop() to avoid stale callbacks dispatching through a stopped
+   * instance.
    */
-  onSpaceResumedRegister(cb: (spaceId: string) => void): void {
+  onSpaceResumedRegister(cb: (spaceId: string) => void): () => void {
     this.onSpaceResumedCallbacks.push(cb);
+    return () => {
+      this.onSpaceResumedCallbacks = this.onSpaceResumedCallbacks.filter((c) => c !== cb);
+    };
   }
 
   /**

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -21,7 +21,7 @@ const log = new Logger('SpaceManager');
 
 export class SpaceManager {
   private spaceRepo: SpaceRepository;
-  private onSpaceResumed: ((spaceId: string) => void) | null = null;
+  private onSpaceResumedCallbacks: Array<(spaceId: string) => void> = [];
 
   constructor(private db: BunDatabase) {
     this.spaceRepo = new SpaceRepository(db);
@@ -31,10 +31,10 @@ export class SpaceManager {
    * Register a callback invoked after a space transitions back to an active
    * runtime (resume from paused or start from stopped). Used to re-seed task
    * schedules whose fire jobs were skipped during the inactive window so they
-   * can resume firing without a daemon restart.
+   * can resume firing without a daemon restart. Multiple callbacks are allowed.
    */
   onSpaceResumedRegister(cb: (spaceId: string) => void): void {
-    this.onSpaceResumed = cb;
+    this.onSpaceResumedCallbacks.push(cb);
   }
 
   /**
@@ -132,10 +132,12 @@ export class SpaceManager {
 
     // Re-seed any active schedules whose fire jobs were skipped while the
     // space was paused so they pick up forward progress.
-    try {
-      this.onSpaceResumed?.(id);
-    } catch (err) {
-      log.error('resumeSpace: schedule recovery hook failed (non-fatal)', err);
+    for (const cb of this.onSpaceResumedCallbacks) {
+      try {
+        cb(id);
+      } catch (err) {
+        log.error('resumeSpace: schedule recovery hook failed (non-fatal)', err);
+      }
     }
 
     return resumed;
@@ -174,10 +176,12 @@ export class SpaceManager {
       throw new Error(`Failed to start space: ${id}`);
     }
 
-    try {
-      this.onSpaceResumed?.(id);
-    } catch (err) {
-      log.error('startSpace: schedule recovery hook failed (non-fatal)', err);
+    for (const cb of this.onSpaceResumedCallbacks) {
+      try {
+        cb(id);
+      } catch (err) {
+        log.error('startSpace: schedule recovery hook failed (non-fatal)', err);
+      }
     }
 
     return started;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1008,6 +1008,7 @@ export class SpaceRuntime {
   private unsubscribeExternalEventPublished?: () => void;
   private unsubscribeSdkToolUseCreated?: () => void;
   private unsubscribeSdkToolUseConsumed?: () => void;
+  private unsubscribeSpaceResumed?: () => void;
   private acceptingExternalEvents = false;
 
   constructor(private config: SpaceRuntimeConfig) {
@@ -1020,7 +1021,9 @@ export class SpaceRuntime {
     }
     this.subscribeExternalEventPublished();
     this.subscribeSdkToolUseCreated();
-    this.config.spaceManager.onSpaceResumedRegister?.((spaceId) => this.onSpaceResumed(spaceId));
+    this.unsubscribeSpaceResumed = this.config.spaceManager.onSpaceResumedRegister?.((spaceId) =>
+      this.onSpaceResumed(spaceId)
+    );
   }
 
   private subscribeSdkToolUseCreated(): void {
@@ -1954,11 +1957,21 @@ export class SpaceRuntime {
         });
         store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
       } else if (resolved.sessionId && this.isTargetSessionLive(resolved.sessionId)) {
+        await this.flushPendingNodeQueueAsync(resolved, deliveryKey);
         await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'immediate');
       } else if (resolved.sessionId) {
+        await this.flushPendingNodeQueueAsync(resolved, deliveryKey);
         await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'defer');
       } else if (this.isPending(resolved)) {
         this.queueForPendingNode(resolved, payload, deliveryKey);
+        // The execution is already pending (e.g. activateNode reset it or a
+        // background spawn is still running). Keep a retry alive so the event
+        // is delivered as soon as the spawn completes, without burning the
+        // bounded attempt count while we are simply waiting.
+        this.scheduleActivationRetry(resolved, payload, deliveryKey, 'node_execution_pending', {
+          preserveAttemptCount: true,
+          markFailure: false,
+        });
       } else {
         let activatedTarget: WorkflowSubscriptionTarget | null = null;
         try {
@@ -2514,15 +2527,21 @@ export class SpaceRuntime {
     target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
     deliveryKey: string,
-    failureReason: string
+    failureReason: string,
+    options: { preserveAttemptCount?: boolean; markFailure?: boolean } = {}
   ): void {
     if (this.externalEventRetryTimers.has(deliveryKey)) return;
-    const attempts = (this.externalEventRetryCounts.get(deliveryKey) ?? 0) + 1;
-    this.externalEventRetryCounts.set(deliveryKey, attempts);
-    this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
-      terminal: attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS,
-      reason: failureReason,
-    });
+    let attempts = this.externalEventRetryCounts.get(deliveryKey) ?? 0;
+    if (!options.preserveAttemptCount) {
+      attempts += 1;
+      this.externalEventRetryCounts.set(deliveryKey, attempts);
+    }
+    if (options.markFailure !== false) {
+      this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
+        terminal: attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS,
+        reason: failureReason,
+      });
+    }
     if (attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS) {
       this.config.externalEventStore?.markEventFailedIfAllDeliveriesTerminal(event.eventId);
       this.clearExternalEventRetry(deliveryKey);
@@ -3897,6 +3916,12 @@ export class SpaceRuntime {
     this.subscribeSdkToolUseCreated();
     this.acceptingExternalEvents = this.rehydrated;
     this.rescheduleQueuedExternalEventRetries();
+    // Re-seed sessionless activation retries after a stop->start of the same
+    // runtime instance. On first start this is a no-op because rehydrate will
+    // run inside executeTick and call requeuePersistedPendingDeliveries.
+    if (this.rehydrated) {
+      this.requeuePersistedPendingDeliveries();
+    }
     // Sweep events that arrived while stopped. On first start this is a
     // no-op (sweep runs inside executeTick after rehydrate). On
     // stop→start of the same runtime instance, it catches events that
@@ -3932,6 +3957,8 @@ export class SpaceRuntime {
     this.unsubscribeSdkToolUseCreated = undefined;
     this.unsubscribeSdkToolUseConsumed?.();
     this.unsubscribeSdkToolUseConsumed = undefined;
+    this.unsubscribeSpaceResumed?.();
+    this.unsubscribeSpaceResumed = undefined;
     for (const timer of this.externalEventRetryTimers.values()) {
       clearTimeout(timer);
     }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1980,7 +1980,7 @@ export class SpaceRuntime {
         await this.flushPendingNodeQueueAsync(resolved, deliveryKey, {
           event: payload,
           deliveryKey,
-          deliveryMode: 'immediate',
+          deliveryMode: this.resolveIncludeCurrentDeliveryMode(resolved, payload, deliveryKey),
           createdAt: eventRecord?.createdAt ?? Date.now(),
         });
       } else if (resolved.sessionId) {
@@ -1992,7 +1992,14 @@ export class SpaceRuntime {
           createdAt: eventRecord?.createdAt ?? Date.now(),
         });
       } else if (this.isPending(resolved)) {
-        this.queueForPendingNode(resolved, payload, deliveryKey);
+        const eventRecord = store.getById(payload.eventId);
+        this.queueForPendingNode(
+          resolved,
+          payload,
+          deliveryKey,
+          'immediate',
+          eventRecord?.createdAt ?? Date.now()
+        );
         // The execution is already pending (e.g. activateNode reset it or a
         // background spawn is still running). Keep a retry alive so the event
         // is delivered as soon as the spawn completes, without burning the
@@ -2007,7 +2014,14 @@ export class SpaceRuntime {
           activatedTarget = await this.activateSubscribedTargetForExternalEvent(resolved);
         } catch (err) {
           const failureReason = err instanceof Error ? err.message : String(err);
-          this.queueForPendingNode(resolved, payload, deliveryKey);
+          const eventRecord = store.getById(payload.eventId);
+          this.queueForPendingNode(
+            resolved,
+            payload,
+            deliveryKey,
+            'immediate',
+            eventRecord?.createdAt ?? Date.now()
+          );
           this.scheduleActivationRetry(
             resolved,
             payload,
@@ -2021,7 +2035,11 @@ export class SpaceRuntime {
           await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey, {
             event: payload,
             deliveryKey,
-            deliveryMode: 'immediate',
+            deliveryMode: this.resolveIncludeCurrentDeliveryMode(
+              activatedTarget,
+              payload,
+              deliveryKey
+            ),
             createdAt: eventRecord?.createdAt ?? Date.now(),
           });
         } else if (activatedTarget?.sessionId) {
@@ -2589,14 +2607,22 @@ export class SpaceRuntime {
         this.clearExternalEventRetry(deliveryKey);
         return;
       }
+      const eventRecord = this.config.externalEventStore?.getById(event.eventId);
       const queuedItem = this.getQueuedDelivery(target, deliveryKey) ?? {
         event,
         deliveryKey,
         deliveryMode: 'immediate',
-        createdAt: this.config.externalEventStore?.getById(event.eventId)?.createdAt ?? Date.now(),
+        createdAt: eventRecord?.createdAt ?? Date.now(),
       };
-      if (this.isQueuedExternalEventExpired(queuedItem)) {
-        this.failQueuedDeliveryForTtl(queuedItem, this.buildQueueKey(target));
+      // The event record is the authoritative TTL anchor; a queued item created
+      // before the event was backdated (or with a stale clock) must still expire
+      // when the underlying event is older than the TTL window.
+      const ttlAnchor = eventRecord?.createdAt ?? queuedItem.createdAt;
+      if (this.isQueuedExternalEventExpired({ ...queuedItem, createdAt: ttlAnchor })) {
+        this.failQueuedDeliveryForTtl(
+          { ...queuedItem, createdAt: ttlAnchor },
+          this.buildQueueKey(target)
+        );
         return;
       }
       // Re-check run deliverability before dispatching — activation retries
@@ -2677,15 +2703,22 @@ export class SpaceRuntime {
         });
         return;
       }
+      const eventRecord = this.config.externalEventStore?.getById(event.eventId);
       const queued = this.getQueuedDelivery(target, deliveryKey);
       const queuedItem = queued ?? {
         event,
         deliveryKey,
         deliveryMode,
-        createdAt: options.createdAt ?? Date.now(),
+        createdAt: eventRecord?.createdAt ?? options.createdAt ?? Date.now(),
       };
-      if (this.isQueuedExternalEventExpired(queuedItem)) {
-        this.failQueuedDeliveryForTtl(queuedItem, this.buildQueueKey(target));
+      // The event record is the authoritative TTL anchor; prefer it over an
+      // in-memory queued item that may carry a stale queue-time timestamp.
+      const ttlAnchor = eventRecord?.createdAt ?? queuedItem.createdAt;
+      if (this.isQueuedExternalEventExpired({ ...queuedItem, createdAt: ttlAnchor })) {
+        this.failQueuedDeliveryForTtl(
+          { ...queuedItem, createdAt: ttlAnchor },
+          this.buildQueueKey(target)
+        );
         return;
       }
       // Re-check run deliverability before dispatching — the run may have
@@ -2744,6 +2777,25 @@ export class SpaceRuntime {
     return this.pendingExternalEventQueue
       .get(this.buildQueueKey(target))
       ?.find((item) => item.deliveryKey === deliveryKey);
+  }
+
+  /**
+   * Recover the delivery mode for the current event/deliveryKey when it is
+   * being included in an ordered pending-node drain. The in-memory queued item
+   * is authoritative; otherwise recover from the persisted delivery's failure
+   * reason; default to immediate for fresh deliveries.
+   */
+  private resolveIncludeCurrentDeliveryMode(
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>,
+    event: ExternalEventPublishedPayload,
+    deliveryKey: string
+  ): 'immediate' | 'defer' {
+    const queued = this.getQueuedDelivery(target, deliveryKey);
+    if (queued) return queued.deliveryMode;
+    const store = this.config.externalEventStore;
+    if (!store) return 'immediate';
+    const delivery = store.getDelivery(event.eventId, deliveryKey);
+    return deliveryModeFromFailureReason(delivery?.failureReason);
   }
 
   private clearQueuedDelivery(target: WorkflowSubscriptionTarget, deliveryKey: string): void {
@@ -4697,6 +4749,24 @@ export class SpaceRuntime {
   onSpaceResumed(spaceId: string): void {
     const store = this.config.externalEventStore;
     if (!store) return;
+
+    // Rebuild PR auto-subscriptions for blocked runs in this space before
+    // evaluating pending deliveries. The startup rehydrate skips paused spaces,
+    // so a resumed space's blocked runs may have no trie entry yet; without
+    // rebuilding first, valid pending PR deliveries would be incorrectly
+    // terminalized as subscription_no_longer_active.
+    const blockedRuns = this.config.workflowRunRepo
+      .listBySpace(spaceId)
+      .filter((run) => run.status === 'blocked');
+    for (const run of blockedRuns) {
+      try {
+        this.notifyRunBlocked(run.id);
+      } catch (err) {
+        log.warn(
+          `SpaceRuntime: failed to rebuild PR subscription for blocked run ${run.id} on resume: ${formatCommandError(err)}`
+        );
+      }
+    }
 
     for (const delivery of store.listPendingDeliveries()) {
       const task = this.config.taskRepo.getTask(delivery.taskId);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1607,11 +1607,20 @@ export class SpaceRuntime {
 
   private async flushPendingNodeQueueAsync(
     target: WorkflowSubscriptionTarget,
-    excludeDeliveryKey?: string
+    excludeDeliveryKey?: string,
+    includeCurrent?: PendingExternalEvent
   ): Promise<void> {
     const prepared = this.preparePendingNodeQueueDispatchable(target, excludeDeliveryKey);
     if (!prepared) return;
     const { targetWithExecution, dispatchable } = prepared;
+
+    if (includeCurrent) {
+      dispatchable.push(includeCurrent);
+    }
+
+    if (dispatchable.length > 1) {
+      dispatchable.sort((a, b) => a.createdAt - b.createdAt);
+    }
 
     for (const item of dispatchable) {
       this.clearExternalEventRetry(item.deliveryKey);
@@ -1899,93 +1908,123 @@ export class SpaceRuntime {
     }
 
     for (const { target, deliveryKey } of workflowDeliveries.values()) {
-      try {
-        if (
-          store.isDeliveryTerminal(payload.eventId, deliveryKey) ||
-          this.externalEventDeliveriesInFlight.has(deliveryKey)
-        ) {
-          continue;
-        }
+      await this.deliverExternalEventToWorkflowTarget(target, payload, deliveryKey);
+    }
+  }
 
-        if (this.isTargetTaskTerminal(target.taskId)) {
-          store.markDeliveryFailed(payload.eventId, deliveryKey, {
-            terminal: true,
-            reason: 'target_task_terminal',
-          });
-          store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
-        } else if (target.sessionId && this.isTargetSessionLive(target.sessionId)) {
-          await this.enqueueDeliverableExternalEvent(target, payload, deliveryKey, 'immediate');
-        } else if (target.sessionId) {
-          await this.enqueueDeliverableExternalEvent(target, payload, deliveryKey, 'defer');
-        } else if (this.isPending(target)) {
-          this.queueForPendingNode(target, payload, deliveryKey);
-        } else {
-          let activatedTarget: WorkflowSubscriptionTarget | null = null;
-          try {
-            activatedTarget = await this.activateSubscribedTargetForExternalEvent(target);
-          } catch (err) {
-            const failureReason = err instanceof Error ? err.message : String(err);
-            this.queueForPendingNode(target, payload, deliveryKey);
-            this.scheduleActivationRetry(
-              target,
-              payload,
-              deliveryKey,
-              `activation_failed; ${failureReason}`
-            );
-            continue;
-          }
-          if (activatedTarget?.sessionId && this.isTargetSessionLive(activatedTarget.sessionId)) {
-            await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey);
-            await this.enqueueDeliverableExternalEvent(
-              activatedTarget,
-              payload,
-              deliveryKey,
-              'immediate'
-            );
-          } else if (activatedTarget?.sessionId) {
-            await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey);
-            await this.enqueueDeliverableExternalEvent(
-              activatedTarget,
-              payload,
-              deliveryKey,
-              'defer'
-            );
-          } else if (activatedTarget) {
-            store.markDeliveryFailed(payload.eventId, deliveryKey, {
-              terminal: false,
-              reason: 'node_execution_not_active',
-            });
-            // The persisted retryable delivery plus the activation retry timer
-            // are sufficient; do not duplicate it in the in-memory queue.
-            // In-memory items use queue-time ordering, which would break the
-            // chronological ordering between persisted pending deliveries.
-            if (!(await this.isTargetSpacePausedOrStopped(activatedTarget))) {
-              this.scheduleActivationRetry(
-                activatedTarget,
-                payload,
-                deliveryKey,
-                'node_execution_not_active'
-              );
-            }
-          } else if (
-            this.hasActiveExecutionForRun(target.workflowRunId) &&
-            !this.hasTerminalExecutionForTarget(target)
-          ) {
-            this.queueForPendingNode(target, payload, deliveryKey);
-          } else {
-            this.clearExternalEventRetry(deliveryKey);
-            store.markDeliveryFailed(payload.eventId, deliveryKey, {
-              terminal: false,
-              reason: 'node_execution_not_active',
-            });
-          }
-        }
-      } catch (err) {
-        log.warn(
-          `SpaceRuntime: failed to process external event ${payload.eventId} for ` +
-            `${target.workflowRunId}/${target.nodeId}/${target.agentName}: ${formatCommandError(err)}`
-        );
+  /**
+   * Deliver (or queue/retry) a single external-event payload to a specific
+   * workflow subscription target. This is the per-target logic extracted from
+   * handleExternalEvent so activation retries can be scoped to the original
+   * delivery instead of replaying the entire event and re-computing matches.
+   */
+  private async deliverExternalEventToWorkflowTarget(
+    target: WorkflowSubscriptionTarget,
+    payload: ExternalEventPublishedPayload,
+    deliveryKey: string
+  ): Promise<void> {
+    const store = this.config.externalEventStore;
+    if (!store) return;
+    // Re-resolve the target at retry/delivery time so a session that appeared
+    // since the delivery was registered is picked up.
+    const resolved = this.resolveSubscriptionTarget(target);
+    try {
+      if (
+        store.isDeliveryTerminal(payload.eventId, deliveryKey) ||
+        this.externalEventDeliveriesInFlight.has(deliveryKey)
+      ) {
+        return;
       }
+
+      if (!this.isTargetStillSubscribed(resolved, payload.topic)) {
+        store.markDeliveryFailed(payload.eventId, deliveryKey, {
+          terminal: true,
+          reason: 'subscription_no_longer_active',
+        });
+        store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
+        this.clearExternalEventRetry(deliveryKey);
+        this.clearQueuedDelivery(resolved, deliveryKey);
+        return;
+      }
+
+      if (this.isTargetTaskTerminal(resolved.taskId)) {
+        store.markDeliveryFailed(payload.eventId, deliveryKey, {
+          terminal: true,
+          reason: 'target_task_terminal',
+        });
+        store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
+      } else if (resolved.sessionId && this.isTargetSessionLive(resolved.sessionId)) {
+        await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'immediate');
+      } else if (resolved.sessionId) {
+        await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'defer');
+      } else if (this.isPending(resolved)) {
+        this.queueForPendingNode(resolved, payload, deliveryKey);
+      } else {
+        let activatedTarget: WorkflowSubscriptionTarget | null = null;
+        try {
+          activatedTarget = await this.activateSubscribedTargetForExternalEvent(resolved);
+        } catch (err) {
+          const failureReason = err instanceof Error ? err.message : String(err);
+          this.queueForPendingNode(resolved, payload, deliveryKey);
+          this.scheduleActivationRetry(
+            resolved,
+            payload,
+            deliveryKey,
+            `activation_failed; ${failureReason}`
+          );
+          return;
+        }
+        if (activatedTarget?.sessionId && this.isTargetSessionLive(activatedTarget.sessionId)) {
+          const eventRecord = store.getById(payload.eventId);
+          await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey, {
+            event: payload,
+            deliveryKey,
+            deliveryMode: 'immediate',
+            createdAt: eventRecord?.createdAt ?? Date.now(),
+          });
+        } else if (activatedTarget?.sessionId) {
+          const eventRecord = store.getById(payload.eventId);
+          await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey, {
+            event: payload,
+            deliveryKey,
+            deliveryMode: 'defer',
+            createdAt: eventRecord?.createdAt ?? Date.now(),
+          });
+        } else if (activatedTarget) {
+          store.markDeliveryFailed(payload.eventId, deliveryKey, {
+            terminal: false,
+            reason: 'node_execution_not_active',
+          });
+          // The persisted retryable delivery plus the activation retry timer
+          // are sufficient; do not duplicate it in the in-memory queue.
+          // In-memory items use queue-time ordering, which would break the
+          // chronological ordering between persisted pending deliveries.
+          if (!(await this.isTargetSpacePausedOrStopped(activatedTarget))) {
+            this.scheduleActivationRetry(
+              activatedTarget,
+              payload,
+              deliveryKey,
+              'node_execution_not_active'
+            );
+          }
+        } else if (
+          this.hasActiveExecutionForRun(resolved.workflowRunId) &&
+          !this.hasTerminalExecutionForTarget(resolved)
+        ) {
+          this.queueForPendingNode(resolved, payload, deliveryKey);
+        } else {
+          this.clearExternalEventRetry(deliveryKey);
+          store.markDeliveryFailed(payload.eventId, deliveryKey, {
+            terminal: false,
+            reason: 'node_execution_not_active',
+          });
+        }
+      }
+    } catch (err) {
+      log.warn(
+        `SpaceRuntime: failed to process external event ${payload.eventId} for ` +
+          `${resolved.workflowRunId}/${resolved.nodeId}/${resolved.agentName}: ${formatCommandError(err)}`
+      );
     }
   }
 
@@ -2066,7 +2105,9 @@ export class SpaceRuntime {
     if (this.isTargetTaskTerminal(target.taskId)) return null;
     if (this.hasTerminalExecutionForTarget(target)) return null;
     const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
-    if (!run || !isExternallyDeliverableRun(run.status)) return null;
+    // Blocked runs have their own gate/recovery path; do not spawn subscribers
+    // directly while the run is blocked.
+    if (!run || run.status !== 'in_progress') return null;
     const task = this.config.taskRepo.getTask(target.taskId);
     if (!task) return null;
     // Static subscriptions can match workflow agents that have not been spawned
@@ -2494,7 +2535,7 @@ export class SpaceRuntime {
         this.clearExternalEventRetry(deliveryKey);
         return;
       }
-      void this.handleExternalEvent(event);
+      void this.deliverExternalEventToWorkflowTarget(target, event, deliveryKey);
     }, EXTERNAL_EVENT_RETRY_DELAY_MS);
     this.externalEventRetryTimers.set(deliveryKey, timer);
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1020,6 +1020,7 @@ export class SpaceRuntime {
     }
     this.subscribeExternalEventPublished();
     this.subscribeSdkToolUseCreated();
+    this.config.spaceManager.onSpaceResumedRegister?.((spaceId) => this.onSpaceResumed(spaceId));
   }
 
   private subscribeSdkToolUseCreated(): void {
@@ -1586,39 +1587,10 @@ export class SpaceRuntime {
     return false;
   }
 
-  flushPendingNodeQueue(target: WorkflowSubscriptionTarget): void {
-    if (!target.sessionId) return;
-    const targetWithExecution = this.resolveSubscriptionTarget(target);
-    const key = this.buildQueueKey(target);
-    const queued = this.pendingExternalEventQueue.get(key);
-    const inMemoryDeliveryKeys = new Set(queued?.map((item) => item.deliveryKey) ?? []);
-
-    // Collect dispatchable items from both in-memory queue and DB-persisted
-    // pending deliveries into a single list so they can be sorted and
-    // dispatched in chronological order.
-    const dispatchable: PendingExternalEvent[] = [];
-
-    if (queued) {
-      this.pendingExternalEventQueue.delete(key);
-      const now = Date.now();
-      for (const item of queued) {
-        if (this.isQueuedExternalEventExpired(item, now)) {
-          this.failQueuedDeliveryForTtl(item, key);
-          continue;
-        }
-        dispatchable.push(item);
-      }
-    }
-
-    this.collectPersistedPendingDeliveries(targetWithExecution, inMemoryDeliveryKeys, dispatchable);
-
-    if (dispatchable.length === 0) return;
-
-    // Sort by createdAt so events from both sources are dispatched in
-    // chronological order regardless of which queue held them. Uses stable
-    // sort (default in modern JS engines) so items with the same createdAt
-    // preserve their insertion order (FIFO from the in-memory queue).
-    dispatchable.sort((a, b) => a.createdAt - b.createdAt);
+  flushPendingNodeQueue(target: WorkflowSubscriptionTarget, excludeDeliveryKey?: string): void {
+    const prepared = this.preparePendingNodeQueueDispatchable(target, excludeDeliveryKey);
+    if (!prepared) return;
+    const { targetWithExecution, dispatchable } = prepared;
 
     for (const item of dispatchable) {
       this.clearExternalEventRetry(item.deliveryKey);
@@ -1633,10 +1605,81 @@ export class SpaceRuntime {
     }
   }
 
+  private async flushPendingNodeQueueAsync(
+    target: WorkflowSubscriptionTarget,
+    excludeDeliveryKey?: string
+  ): Promise<void> {
+    const prepared = this.preparePendingNodeQueueDispatchable(target, excludeDeliveryKey);
+    if (!prepared) return;
+    const { targetWithExecution, dispatchable } = prepared;
+
+    for (const item of dispatchable) {
+      this.clearExternalEventRetry(item.deliveryKey);
+      await this.enqueueDeliverableExternalEvent(
+        targetWithExecution,
+        item.event,
+        item.deliveryKey,
+        item.deliveryMode,
+        item.createdAt,
+        true
+      );
+    }
+  }
+
+  private preparePendingNodeQueueDispatchable(
+    target: WorkflowSubscriptionTarget,
+    excludeDeliveryKey?: string
+  ): {
+    targetWithExecution: WorkflowSubscriptionTarget;
+    dispatchable: PendingExternalEvent[];
+  } | null {
+    if (!target.sessionId) return null;
+    const targetWithExecution = this.resolveSubscriptionTarget(target);
+    const key = this.buildQueueKey(target);
+    const queued = this.pendingExternalEventQueue.get(key);
+    const inMemoryDeliveryKeys = new Set(queued?.map((item) => item.deliveryKey) ?? []);
+
+    // Collect dispatchable items from both in-memory queue and DB-persisted
+    // pending deliveries into a single list so they can be sorted and
+    // dispatched in chronological order.
+    const dispatchable: PendingExternalEvent[] = [];
+
+    if (queued) {
+      this.pendingExternalEventQueue.delete(key);
+      const now = Date.now();
+      for (const item of queued) {
+        if (item.deliveryKey === excludeDeliveryKey) continue;
+        if (this.isQueuedExternalEventExpired(item, now)) {
+          this.failQueuedDeliveryForTtl(item, key);
+          continue;
+        }
+        dispatchable.push(item);
+      }
+    }
+
+    this.collectPersistedPendingDeliveries(
+      targetWithExecution,
+      inMemoryDeliveryKeys,
+      dispatchable,
+      excludeDeliveryKey
+    );
+
+    if (dispatchable.length === 0) return { targetWithExecution, dispatchable };
+
+    // Sort by createdAt so events from both sources are dispatched in
+    // chronological order regardless of which queue held them. Uses stable
+    // sort (default in modern JS engines) so items with the same createdAt
+    // preserve their insertion order (FIFO from the in-memory queue).
+    dispatchable.sort((a, b) => a.createdAt - b.createdAt);
+
+    return { targetWithExecution, dispatchable };
+  }
+
   private collectPersistedPendingDeliveries(
     target: WorkflowSubscriptionTarget,
     skipDeliveryKeys: Set<string>,
-    dispatchable: PendingExternalEvent[]
+    dispatchable: PendingExternalEvent[],
+    excludeDeliveryKey?: string
   ): void {
     const store = this.config.externalEventStore;
     if (!store || !target.sessionId) return;
@@ -1648,6 +1691,7 @@ export class SpaceRuntime {
           delivery.taskId === target.taskId &&
           delivery.nodeId === target.nodeId &&
           delivery.agentName === target.agentName &&
+          delivery.deliveryKey !== excludeDeliveryKey &&
           !skipDeliveryKeys.has(delivery.deliveryKey) &&
           // Only flush deliveries that carry an explicit retryable
           // failureReason (e.g. `node_execution_not_active`). A `pending` row
@@ -1891,7 +1935,7 @@ export class SpaceRuntime {
             continue;
           }
           if (activatedTarget?.sessionId && this.isTargetSessionLive(activatedTarget.sessionId)) {
-            this.flushPendingNodeQueue(activatedTarget);
+            await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey);
             await this.enqueueDeliverableExternalEvent(
               activatedTarget,
               payload,
@@ -1899,7 +1943,7 @@ export class SpaceRuntime {
               'immediate'
             );
           } else if (activatedTarget?.sessionId) {
-            this.flushPendingNodeQueue(activatedTarget);
+            await this.flushPendingNodeQueueAsync(activatedTarget, deliveryKey);
             await this.enqueueDeliverableExternalEvent(
               activatedTarget,
               payload,
@@ -4495,7 +4539,55 @@ export class SpaceRuntime {
           delivery.failureReason ?? `deliveryMode:${mode}; retry requeued after runtime rehydrate`,
           { preserveAttemptCount: true, createdAt: eventRecord.createdAt }
         );
+      } else {
+        // Sessionless pending rows (e.g. activation timeout/empty result) need
+        // an activation retry rather than a normal delivery retry, because
+        // delivery requires the node agent to be activated first.
+        this.scheduleActivationRetry(
+          target,
+          eventPayload,
+          delivery.deliveryKey,
+          delivery.failureReason ?? 'node_execution_not_active'
+        );
       }
+    }
+  }
+
+  /**
+   * Called when a paused/stopped space resumes. Re-schedules activation retries
+   * for sessionless pending deliveries in that space so idle subscribed targets
+   * are not stranded until an unrelated activation or restart happens.
+   */
+  onSpaceResumed(spaceId: string): void {
+    const store = this.config.externalEventStore;
+    if (!store) return;
+
+    for (const delivery of store.listPendingDeliveries()) {
+      const task = this.config.taskRepo.getTask(delivery.taskId);
+      if (!task || task.spaceId !== spaceId) continue;
+
+      const target = {
+        workflowRunId: delivery.workflowRunId,
+        taskId: delivery.taskId,
+        nodeId: delivery.nodeId,
+        agentName: delivery.agentName,
+      };
+      // Only wake deliveries that still need activation. If a live session is
+      // already resolved, the normal delivery retry path already handles it.
+      const resolved = this.resolveSubscriptionTarget(target);
+      if (resolved.sessionId) continue;
+
+      const eventRecord = store.getById(delivery.eventId);
+      if (!eventRecord || eventRecord.state !== 'published') continue;
+      if (!this.isTargetStillSubscribed(target, eventRecord.event.topic)) continue;
+
+      const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
+      this.scheduleActivationRetry(
+        target,
+        eventPayload,
+        delivery.deliveryKey,
+        delivery.failureReason ?? 'node_execution_not_active'
+      );
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1957,11 +1957,21 @@ export class SpaceRuntime {
         });
         store.markEventFailedIfAllDeliveriesTerminal(payload.eventId);
       } else if (resolved.sessionId && this.isTargetSessionLive(resolved.sessionId)) {
-        await this.flushPendingNodeQueueAsync(resolved, deliveryKey);
-        await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'immediate');
+        const eventRecord = store.getById(payload.eventId);
+        await this.flushPendingNodeQueueAsync(resolved, deliveryKey, {
+          event: payload,
+          deliveryKey,
+          deliveryMode: 'immediate',
+          createdAt: eventRecord?.createdAt ?? Date.now(),
+        });
       } else if (resolved.sessionId) {
-        await this.flushPendingNodeQueueAsync(resolved, deliveryKey);
-        await this.enqueueDeliverableExternalEvent(resolved, payload, deliveryKey, 'defer');
+        const eventRecord = store.getById(payload.eventId);
+        await this.flushPendingNodeQueueAsync(resolved, deliveryKey, {
+          event: payload,
+          deliveryKey,
+          deliveryMode: 'defer',
+          createdAt: eventRecord?.createdAt ?? Date.now(),
+        });
       } else if (this.isPending(resolved)) {
         this.queueForPendingNode(resolved, payload, deliveryKey);
         // The execution is already pending (e.g. activateNode reset it or a
@@ -2117,6 +2127,12 @@ export class SpaceRuntime {
   ): Promise<WorkflowSubscriptionTarget | null> {
     if (this.isTargetTaskTerminal(target.taskId)) return null;
     if (this.hasTerminalExecutionForTarget(target)) return null;
+    const currentExecution = this.getCurrentQueueableOrActiveExecution(target);
+    if (currentExecution?.status === 'blocked') {
+      // Blocked executions are recovered through the blocked-run external-event
+      // hook, not by subscriber activation. Keep them on that path.
+      return null;
+    }
     const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
     // Blocked runs have their own gate/recovery path; do not spawn subscribers
     // directly while the run is blocked.
@@ -2552,6 +2568,16 @@ export class SpaceRuntime {
       this.externalEventRetryTimers.delete(deliveryKey);
       if (this.config.externalEventStore?.isDeliveryTerminal(event.eventId, deliveryKey)) {
         this.clearExternalEventRetry(deliveryKey);
+        return;
+      }
+      const queuedItem = this.getQueuedDelivery(target, deliveryKey) ?? {
+        event,
+        deliveryKey,
+        deliveryMode: 'immediate',
+        createdAt: this.config.externalEventStore?.getById(event.eventId)?.createdAt ?? Date.now(),
+      };
+      if (this.isQueuedExternalEventExpired(queuedItem)) {
+        this.failQueuedDeliveryForTtl(queuedItem, this.buildQueueKey(target));
         return;
       }
       void this.deliverExternalEventToWorkflowTarget(target, event, deliveryKey);
@@ -3914,6 +3940,11 @@ export class SpaceRuntime {
 
     this.subscribeExternalEventPublished();
     this.subscribeSdkToolUseCreated();
+    // Re-register the space-resume hook after a stop->start cycle; stop()
+    // unsubscribes it to avoid stale callbacks, so start() must restore it.
+    this.unsubscribeSpaceResumed ??= this.config.spaceManager.onSpaceResumedRegister?.((spaceId) =>
+      this.onSpaceResumed(spaceId)
+    );
     this.acceptingExternalEvents = this.rehydrated;
     this.rescheduleQueuedExternalEventRetries();
     // Re-seed sessionless activation retries after a stop->start of the same
@@ -4647,7 +4678,14 @@ export class SpaceRuntime {
 
       const eventRecord = store.getById(delivery.eventId);
       if (!eventRecord || eventRecord.state !== 'published') continue;
-      if (!this.isTargetStillSubscribed(target, eventRecord.event.topic)) continue;
+      if (!this.isTargetStillSubscribed(target, eventRecord.event.topic)) {
+        store.markDeliveryFailed(delivery.eventId, delivery.deliveryKey, {
+          terminal: true,
+          reason: 'subscription_no_longer_active',
+        });
+        store.markEventFailedIfAllDeliveriesTerminal(delivery.eventId);
+        continue;
+      }
 
       const eventPayload = this.externalEventPayloadFromRecord(eventRecord.event);
       this.scheduleActivationRetry(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1875,17 +1875,61 @@ export class SpaceRuntime {
           await this.enqueueDeliverableExternalEvent(target, payload, deliveryKey, 'defer');
         } else if (this.isPending(target)) {
           this.queueForPendingNode(target, payload, deliveryKey);
-        } else if (
-          this.hasActiveExecutionForRun(target.workflowRunId) &&
-          !this.hasTerminalExecutionForTarget(target)
-        ) {
-          this.queueForPendingNode(target, payload, deliveryKey);
         } else {
-          this.clearExternalEventRetry(deliveryKey);
-          store.markDeliveryFailed(payload.eventId, deliveryKey, {
-            terminal: false,
-            reason: 'node_execution_not_active',
-          });
+          let activatedTarget: WorkflowSubscriptionTarget | null = null;
+          try {
+            activatedTarget = await this.activateSubscribedTargetForExternalEvent(target);
+          } catch (err) {
+            const failureReason = err instanceof Error ? err.message : String(err);
+            this.queueForPendingNode(target, payload, deliveryKey);
+            this.scheduleActivationRetry(
+              target,
+              payload,
+              deliveryKey,
+              `activation_failed; ${failureReason}`
+            );
+            continue;
+          }
+          if (activatedTarget?.sessionId && this.isTargetSessionLive(activatedTarget.sessionId)) {
+            await this.enqueueDeliverableExternalEvent(
+              activatedTarget,
+              payload,
+              deliveryKey,
+              'immediate'
+            );
+          } else if (activatedTarget?.sessionId) {
+            await this.enqueueDeliverableExternalEvent(
+              activatedTarget,
+              payload,
+              deliveryKey,
+              'defer'
+            );
+          } else if (activatedTarget) {
+            store.markDeliveryFailed(payload.eventId, deliveryKey, {
+              terminal: false,
+              reason: 'node_execution_not_active',
+            });
+            this.queueForPendingNode(activatedTarget, payload, deliveryKey);
+            if (!(await this.isTargetSpacePausedOrStopped(activatedTarget))) {
+              this.scheduleActivationRetry(
+                activatedTarget,
+                payload,
+                deliveryKey,
+                'activation did not produce a live session'
+              );
+            }
+          } else if (
+            this.hasActiveExecutionForRun(target.workflowRunId) &&
+            !this.hasTerminalExecutionForTarget(target)
+          ) {
+            this.queueForPendingNode(target, payload, deliveryKey);
+          } else {
+            this.clearExternalEventRetry(deliveryKey);
+            store.markDeliveryFailed(payload.eventId, deliveryKey, {
+              terminal: false,
+              reason: 'node_execution_not_active',
+            });
+          }
         }
       } catch (err) {
         log.warn(
@@ -1958,6 +2002,44 @@ export class SpaceRuntime {
       anyRetryScheduled = anyRetryScheduled || results.some((value) => value === 'retry');
     }
     return { firedRunIds, anyGateOpened, anyRetryScheduled };
+  }
+
+  private async isTargetSpacePausedOrStopped(target: WorkflowSubscriptionTarget): Promise<boolean> {
+    const task = this.config.taskRepo.getTask(target.taskId);
+    if (!task) return true;
+    const space = await this.config.spaceManager.getSpace(task.spaceId);
+    return !space || space.paused || space.stopped;
+  }
+
+  private async activateSubscribedTargetForExternalEvent(
+    target: WorkflowSubscriptionTarget
+  ): Promise<WorkflowSubscriptionTarget | null> {
+    if (this.isTargetTaskTerminal(target.taskId)) return null;
+    if (this.hasTerminalExecutionForTarget(target)) return null;
+    const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
+    if (!run || !isExternallyDeliverableRun(run.status)) return null;
+    const task = this.config.taskRepo.getTask(target.taskId);
+    if (!task) return null;
+    const space = await this.config.spaceManager.getSpace(task.spaceId);
+    if (!space || space.paused || space.stopped)
+      return this.hasAnyExecutionForTarget(target) ? target : null;
+    const activate = this.config.taskAgentManager?.activateTargetSessionsForMessage;
+    if (!activate) return null;
+
+    const activated = await activate.call(
+      this.config.taskAgentManager,
+      target.taskId,
+      target.workflowRunId,
+      target.agentName,
+      {
+        reopenReason: `external event delivery to subscribed agent "${target.agentName}"`,
+        reopenBy: 'external-event',
+        workflowNodeId: target.nodeId,
+      }
+    );
+    if (activated.length === 0) return null;
+
+    return this.resolveSubscriptionTarget(target);
   }
 
   private async deliverToLongHorizonAgent(
@@ -2330,6 +2412,36 @@ export class SpaceRuntime {
     }
   }
 
+  private scheduleActivationRetry(
+    target: WorkflowSubscriptionTarget,
+    event: ExternalEventPublishedPayload,
+    deliveryKey: string,
+    failureReason: string
+  ): void {
+    if (this.externalEventRetryTimers.has(deliveryKey)) return;
+    const attempts = (this.externalEventRetryCounts.get(deliveryKey) ?? 0) + 1;
+    this.externalEventRetryCounts.set(deliveryKey, attempts);
+    this.config.externalEventStore?.markDeliveryFailed(event.eventId, deliveryKey, {
+      terminal: attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS,
+      reason: failureReason,
+    });
+    if (attempts > EXTERNAL_EVENT_RETRY_MAX_ATTEMPTS) {
+      this.config.externalEventStore?.markEventFailedIfAllDeliveriesTerminal(event.eventId);
+      this.clearExternalEventRetry(deliveryKey);
+      this.clearQueuedDelivery(target, deliveryKey);
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.externalEventRetryTimers.delete(deliveryKey);
+      if (this.config.externalEventStore?.isDeliveryTerminal(event.eventId, deliveryKey)) {
+        this.clearExternalEventRetry(deliveryKey);
+        return;
+      }
+      void this.handleExternalEvent(event);
+    }, EXTERNAL_EVENT_RETRY_DELAY_MS);
+    this.externalEventRetryTimers.set(deliveryKey, timer);
+  }
+
   private queueForRetry(
     target: WorkflowSubscriptionTarget,
     event: ExternalEventPublishedPayload,
@@ -2682,6 +2794,14 @@ export class SpaceRuntime {
       .some(
         (execution) => execution.agentName === target.agentName && execution.status === 'cancelled'
       );
+  }
+
+  private hasAnyExecutionForTarget(
+    target: Pick<WorkflowSubscriptionTarget, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>
+  ): boolean {
+    return this.config.nodeExecutionRepo
+      .listByNode(target.workflowRunId, target.nodeId)
+      .some((execution) => execution.agentName === target.agentName);
   }
 
   private isTargetTaskTerminal(taskId: string): boolean {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1596,6 +1596,15 @@ export class SpaceRuntime {
     const { targetWithExecution, dispatchable } = prepared;
 
     for (const item of dispatchable) {
+      // A concurrent cleanup may have marked this delivery terminal while the
+      // batch was being prepared. Skip dispatch rather than injecting into a
+      // target that is no longer eligible.
+      if (
+        this.config.externalEventStore?.isDeliveryTerminal(item.event.eventId, item.deliveryKey)
+      ) {
+        this.clearExternalEventRetry(item.deliveryKey);
+        continue;
+      }
       this.clearExternalEventRetry(item.deliveryKey);
       void this.enqueueDeliverableExternalEvent(
         targetWithExecution,
@@ -1626,6 +1635,16 @@ export class SpaceRuntime {
     }
 
     for (const item of dispatchable) {
+      // A concurrent cleanup (unregisterExecution, subscription removal, or
+      // run terminalization) may have marked this delivery terminal while the
+      // ordered batch was being prepared. Skip dispatch rather than injecting
+      // an event into a target that is no longer eligible.
+      if (
+        this.config.externalEventStore?.isDeliveryTerminal(item.event.eventId, item.deliveryKey)
+      ) {
+        this.clearExternalEventRetry(item.deliveryKey);
+        continue;
+      }
       this.clearExternalEventRetry(item.deliveryKey);
       await this.enqueueDeliverableExternalEvent(
         targetWithExecution,
@@ -2578,6 +2597,24 @@ export class SpaceRuntime {
       };
       if (this.isQueuedExternalEventExpired(queuedItem)) {
         this.failQueuedDeliveryForTtl(queuedItem, this.buildQueueKey(target));
+        return;
+      }
+      // Re-check run deliverability before dispatching — activation retries
+      // bypass the normal retry-path guard, so a run that became cancelled,
+      // done, or blocked-without-active-execution while the timer was pending
+      // must be failed terminally instead of recording a non-terminal
+      // node_execution_not_active and leaving the delivery stranded.
+      const run = this.config.workflowRunRepo.getRun(target.workflowRunId);
+      const blockedNoExec = run?.status === 'blocked' && !this.hasActiveExecutionForRun(run.id);
+      const store = this.config.externalEventStore;
+      if (!run || !isExternallyDeliverableRun(run.status) || blockedNoExec) {
+        store?.markDeliveryFailed(event.eventId, deliveryKey, {
+          terminal: true,
+          reason: 'run_not_externally_deliverable',
+        });
+        this.clearExternalEventRetry(deliveryKey);
+        this.clearQueuedDelivery(target, deliveryKey);
+        store?.markEventFailedIfAllDeliveriesTerminal(event.eventId);
         return;
       }
       void this.deliverExternalEventToWorkflowTarget(target, event, deliveryKey);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4755,10 +4755,24 @@ export class SpaceRuntime {
     // so a resumed space's blocked runs may have no trie entry yet; without
     // rebuilding first, valid pending PR deliveries would be incorrectly
     // terminalized as subscription_no_longer_active.
+    //
+    // Only rebuild missing auto subscriptions: if the run already has one,
+    // re-entering registerPrEventSubscriptionForRun would clear it and
+    // failQueuedDeliveriesForTarget would terminally mark the pending PR
+    // delivery as auto_pr_subscription_cleared before the same subscription
+    // is reinserted.
     const blockedRuns = this.config.workflowRunRepo
       .listBySpace(spaceId)
       .filter((run) => run.status === 'blocked');
     for (const run of blockedRuns) {
+      const hasAutoSubscription =
+        this.topicTrie.count(
+          (target) =>
+            isWorkflowSubscriptionTarget(target) &&
+            target.workflowRunId === run.id &&
+            target.subscriptionKind === 'auto'
+        ) > 0;
+      if (hasAutoSubscription) continue;
       try {
         this.notifyRunBlocked(run.id);
       } catch (err) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1891,6 +1891,7 @@ export class SpaceRuntime {
             continue;
           }
           if (activatedTarget?.sessionId && this.isTargetSessionLive(activatedTarget.sessionId)) {
+            this.flushPendingNodeQueue(activatedTarget);
             await this.enqueueDeliverableExternalEvent(
               activatedTarget,
               payload,
@@ -1898,6 +1899,7 @@ export class SpaceRuntime {
               'immediate'
             );
           } else if (activatedTarget?.sessionId) {
+            this.flushPendingNodeQueue(activatedTarget);
             await this.enqueueDeliverableExternalEvent(
               activatedTarget,
               payload,
@@ -1909,13 +1911,16 @@ export class SpaceRuntime {
               terminal: false,
               reason: 'node_execution_not_active',
             });
-            this.queueForPendingNode(activatedTarget, payload, deliveryKey);
+            // The persisted retryable delivery plus the activation retry timer
+            // are sufficient; do not duplicate it in the in-memory queue.
+            // In-memory items use queue-time ordering, which would break the
+            // chronological ordering between persisted pending deliveries.
             if (!(await this.isTargetSpacePausedOrStopped(activatedTarget))) {
               this.scheduleActivationRetry(
                 activatedTarget,
                 payload,
                 deliveryKey,
-                'activation did not produce a live session'
+                'node_execution_not_active'
               );
             }
           } else if (
@@ -2020,9 +2025,13 @@ export class SpaceRuntime {
     if (!run || !isExternallyDeliverableRun(run.status)) return null;
     const task = this.config.taskRepo.getTask(target.taskId);
     if (!task) return null;
+    // Static subscriptions can match workflow agents that have not been spawned
+    // yet. Only lazily activate when there is already a node execution for this
+    // target; otherwise queue for the active run and wait for normal workflow
+    // progression to create the execution.
+    if (!this.hasAnyExecutionForTarget(target)) return null;
     const space = await this.config.spaceManager.getSpace(task.spaceId);
-    if (!space || space.paused || space.stopped)
-      return this.hasAnyExecutionForTarget(target) ? target : null;
+    if (!space || space.paused || space.stopped) return target;
     const activate = this.config.taskAgentManager?.activateTargetSessionsForMessage;
     if (!activate) return null;
 
@@ -2037,7 +2046,11 @@ export class SpaceRuntime {
         workflowNodeId: target.nodeId,
       }
     );
-    if (activated.length === 0) return null;
+    // If activation timed out or could not produce a session, return the target
+    // so the caller queues the event and schedules a bounded activation retry.
+    // Returning null here would strand the event in the pending queue with no
+    // retry timer.
+    if (activated.length === 0) return target;
 
     return this.resolveSubscriptionTarget(target);
   }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1561,14 +1561,17 @@ export class TaskAgentManager {
     taskId: string,
     workflowRunId: string,
     agentName: string,
-    options?: { reopenReason?: string; reopenBy?: string }
+    options?: { reopenReason?: string; reopenBy?: string; workflowNodeId?: string }
   ): Promise<Array<{ agentName: string; sessionId: string }>> {
     await this.tryResumeNodeAgentSession(workflowRunId, agentName);
+    const matchesNode = (workflowNodeId: string) =>
+      !options?.workflowNodeId || workflowNodeId === options.workflowNodeId;
     const existing = this.config.nodeExecutionRepo
       .listByWorkflowRun(workflowRunId)
       .filter(
         (execution) =>
           execution.agentName === agentName &&
+          matchesNode(execution.workflowNodeId) &&
           (execution.status === 'in_progress' || execution.status === 'blocked')
       )
       .at(-1);
@@ -1586,7 +1589,21 @@ export class TaskAgentManager {
       });
     }
 
-    await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
+    if (options?.workflowNodeId) {
+      const task = this.config.taskRepo.getTask(taskId);
+      if (task?.workflowRunId) {
+        const run = this.config.workflowRunRepo.getRun(task.workflowRunId);
+        if (run?.workflowId) {
+          const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
+          const node = workflow?.nodes.find((candidate) => candidate.id === options.workflowNodeId);
+          const slots = node ? resolveNodeAgents(node) : [];
+          if (!slots.some((slot) => slot.name === agentName)) return [];
+        }
+      }
+      await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
+    } else {
+      await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
+    }
 
     const task = this.config.taskRepo.getTask(taskId);
     const run = this.config.workflowRunRepo.getRun(workflowRunId);
@@ -1598,7 +1615,9 @@ export class TaskAgentManager {
 
     const execution = this.config.nodeExecutionRepo
       .listByWorkflowRun(workflowRunId)
-      .find((candidate) => candidate.agentName === agentName);
+      .find(
+        (candidate) => candidate.agentName === agentName && matchesNode(candidate.workflowNodeId)
+      );
     if (!execution) return [];
 
     const spawnPromise = this.spawnWorkflowNodeAgentForExecution(
@@ -1625,7 +1644,7 @@ export class TaskAgentManager {
   async ensureWorkflowNodeActivationForAgent(
     taskId: string,
     agentName: string,
-    options?: { reopenReason?: string; reopenBy?: string }
+    options?: { reopenReason?: string; reopenBy?: string; workflowNodeId?: string }
   ): Promise<boolean> {
     try {
       const task = this.config.taskRepo.getTask(taskId);
@@ -1648,6 +1667,7 @@ export class TaskAgentManager {
           continue;
         }
         if (slots.some((slot) => slot.name === agentName)) {
+          if (options?.workflowNodeId && node.id !== options.workflowNodeId) continue;
           targetNodeId = node.id;
           break;
         }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1274,13 +1274,24 @@ export class TaskAgentManager {
    * is left intact for the next activation (e.g. when `createSubSession` spawns/reuses
    * the session and calls `flushPendingMessagesForTarget`).
    */
-  async tryResumeNodeAgentSession(workflowRunId: string, agentName: string): Promise<void> {
+  async tryResumeNodeAgentSession(
+    workflowRunId: string,
+    agentName: string,
+    workflowNodeId?: string
+  ): Promise<void> {
     const repo = this.config.pendingMessageRepo;
     if (!repo) return;
 
     const executions = this.config.nodeExecutionRepo.listByWorkflowRun(workflowRunId);
-    const exec = executions.filter((e) => e.agentName === agentName && e.agentSessionId).at(-1);
-    if (!exec?.agentSessionId) return; // No known session for this agent — wait for spawn.
+    const exec = executions
+      .filter(
+        (e) =>
+          e.agentName === agentName &&
+          e.agentSessionId &&
+          (!workflowNodeId || e.workflowNodeId === workflowNodeId)
+      )
+      .at(-1);
+    if (!exec?.agentSessionId) return; // No known session for this agent/node — wait for spawn.
 
     const sessionId = exec.agentSessionId;
 
@@ -1563,7 +1574,7 @@ export class TaskAgentManager {
     agentName: string,
     options?: { reopenReason?: string; reopenBy?: string; workflowNodeId?: string }
   ): Promise<Array<{ agentName: string; sessionId: string }>> {
-    await this.tryResumeNodeAgentSession(workflowRunId, agentName);
+    await this.tryResumeNodeAgentSession(workflowRunId, agentName, options?.workflowNodeId);
     const matchesNode = (workflowNodeId: string) =>
       !options?.workflowNodeId || workflowNodeId === options.workflowNodeId;
     const existing = this.config.nodeExecutionRepo

--- a/packages/daemon/tests/unit/1-core/lib/space-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-manager.test.ts
@@ -224,20 +224,31 @@ describe('SpaceManager', () => {
     });
   });
 
-  describe('addSession / removeSession', () => {
-    it('adds and removes sessions', async () => {
+  describe('onSpaceResumedRegister', () => {
+    it('invokes registered callbacks on resume and start', async () => {
       const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+      const calls: string[] = [];
+      manager.onSpaceResumedRegister((spaceId) => calls.push(spaceId));
 
-      const withSession = await manager.addSession(space.id, 'sess-1');
-      expect(withSession.sessionIds).toContain('sess-1');
+      await manager.pauseSpace(space.id);
+      await manager.resumeSpace(space.id);
+      expect(calls).toContain(space.id);
 
-      const without = await manager.removeSession(space.id, 'sess-1');
-      expect(without.sessionIds).not.toContain('sess-1');
+      calls.length = 0;
+      await manager.stopSpace(space.id);
+      await manager.startSpace(space.id);
+      expect(calls).toContain(space.id);
     });
 
-    it('throws for unknown space', async () => {
-      await expect(manager.addSession('nonexistent', 's1')).rejects.toThrow('not found');
-      await expect(manager.removeSession('nonexistent', 's1')).rejects.toThrow('not found');
+    it('returns an unsubscribe that removes the callback', async () => {
+      const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+      const calls: string[] = [];
+      const unsubscribe = manager.onSpaceResumedRegister((spaceId) => calls.push(spaceId));
+
+      unsubscribe();
+      await manager.pauseSpace(space.id);
+      await manager.resumeSpace(space.id);
+      expect(calls).toHaveLength(0);
     });
   });
 });

--- a/packages/daemon/tests/unit/1-core/lib/space-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-manager.test.ts
@@ -224,6 +224,23 @@ describe('SpaceManager', () => {
     });
   });
 
+  describe('addSession / removeSession', () => {
+    it('adds and removes sessions', async () => {
+      const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });
+
+      const withSession = await manager.addSession(space.id, 'sess-1');
+      expect(withSession.sessionIds).toContain('sess-1');
+
+      const without = await manager.removeSession(space.id, 'sess-1');
+      expect(without.sessionIds).not.toContain('sess-1');
+    });
+
+    it('throws for unknown space', async () => {
+      await expect(manager.addSession('nonexistent', 's1')).rejects.toThrow('not found');
+      await expect(manager.removeSession('nonexistent', 's1')).rejects.toThrow('not found');
+    });
+  });
+
   describe('onSpaceResumedRegister', () => {
     it('invokes registered callbacks on resume and start', async () => {
       const space = await manager.createSpace({ workspacePath: tmpDir, name: 'A' });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -169,6 +169,7 @@ describe('SpaceRuntime external event subscriptions', () => {
   let longHorizonMessages: Array<{ agentId: string; message: string; idempotencyKey?: string }>;
   let tam: MockTaskAgentManager;
   let bus: ReturnType<typeof createDaemonInternalEventBus>;
+  let spaceManager: SpaceManager;
 
   function createWorkflow(
     nodeId = 'code',
@@ -245,9 +246,10 @@ describe('SpaceRuntime external event subscriptions', () => {
     });
     tam = new MockTaskAgentManager();
     artifactRepo = new WorkflowRunArtifactRepository(db);
+    spaceManager = new SpaceManager(db);
     runtime = new SpaceRuntime({
       db,
-      spaceManager: new SpaceManager(db),
+      spaceManager,
       spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
       spaceWorkflowManager: workflowManager,
       workflowRunRepo,
@@ -4969,6 +4971,237 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(older.id)?.state).toBe('delivered');
     expect(eventStore.getById(newer.id)?.state).toBe('delivered');
     expect(eventStore.getById(current.id)?.state).toBe('delivered');
+  });
+
+  test('awaits queued flush before delivering activating event', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const older = makeEvent({
+      id: 'evt-older-async-flush',
+      dedupeKey: 'dedupe-older-async-flush',
+      occurredAt: 1_700_000_000_000,
+    });
+    await eventService.publish(older);
+    expect(eventStore.listDeliveries(older.id)[0]!.state).toBe('pending');
+
+    // Rebuild runtime with an awaitable inject so we can observe ordering.
+    await runtime.stop();
+    let releaseFirstInject!: () => void;
+    const firstInjectStarted = Promise.withResolvers<void>();
+    const commandBus = createInternalCommandBus();
+    commandBus.register('agent.message.inject', async (command) => {
+      injected.push({
+        sessionId: command.sessionId,
+        message: command.message,
+        deliveryMode: command.deliveryMode,
+      });
+      if (injected.length === 1) {
+        firstInjectStarted.resolve();
+        await new Promise<void>((resolve) => {
+          releaseFirstInject = resolve;
+        });
+      }
+      return { ok: true };
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager,
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    runtime.registerSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+
+    // Activate the node: the next event triggers a flush of the older pending
+    // delivery, then delivers itself. The async flush must complete the older
+    // inject before the current event is injected.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      completedAt: null,
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-async-flush' }];
+    tam.alive.add('session-async-flush');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-async-flush',
+      });
+    };
+
+    const current = makeEvent({
+      id: 'evt-current-async-flush',
+      dedupeKey: 'dedupe-current-async-flush',
+      occurredAt: 1_700_000_000_100,
+    });
+    const publishPromise = eventService.publish(current);
+    await firstInjectStarted.promise;
+    expect(injected).toHaveLength(1);
+    expect(JSON.parse(injected[0]!.message).eventId).toBe(older.id);
+    releaseFirstInject();
+    await publishPromise;
+
+    expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([
+      older.id,
+      current.id,
+    ]);
+    expect(eventStore.getById(older.id)?.state).toBe('delivered');
+    expect(eventStore.getById(current.id)?.state).toBe('delivered');
+  });
+
+  test('reschedules paused-space deliveries after resume', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+
+    tam.activationResult = [];
+    const event = makeEvent({ id: 'evt-paused-resume' });
+    await eventService.publish(event);
+
+    expect(tam.activationCalls).toHaveLength(0);
+    const pending = eventStore.listDeliveries(event.id)[0]!;
+    expect(pending.state).toBe('pending');
+    expect(pending.failureReason).toBe('node_execution_not_active');
+
+    // Resume the space. The runtime's onSpaceResumed hook must schedule an
+    // activation retry for the sessionless pending delivery.
+    db.prepare(`UPDATE spaces SET paused = 0 WHERE id = ?`).run(SPACE_ID);
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      completedAt: null,
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-resume' }];
+    tam.alive.add('session-resume');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-resume',
+      });
+    };
+    runtime.start();
+    await spaceManager.resumeSpace(SPACE_ID);
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(tam.activationCalls.length).toBeGreaterThanOrEqual(1);
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-resume');
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+  });
+
+  test('excludes retried delivery from activation flush drain', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-exclude-retry' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe('node_execution_not_active');
+
+    // Before the activation retry fires, make activation succeed. The retry
+    // calls flushPendingNodeQueueAsync with the current deliveryKey excluded;
+    // without that exclusion the DB-persisted pending row would be delivered
+    // twice (once by the flush and once by the post-flush enqueue).
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      completedAt: null,
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-exclude-retry' }];
+    tam.alive.add('session-exclude-retry');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-exclude-retry',
+      });
+    };
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected).toHaveLength(1);
+    expect(JSON.parse(injected[0]!.message).eventId).toBe(event.id);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+  });
+
+  test('rehydrates sessionless activation retries after restart', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-sessionless-rehydrate' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe('node_execution_not_active');
+    await runtime.stop();
+
+    const commandBus = createInternalCommandBus();
+    commandBus.register('agent.message.inject', async (command) => {
+      injected.push({
+        sessionId: command.sessionId,
+        message: command.message,
+        deliveryMode: command.deliveryMode,
+      });
+      return { ok: true };
+    });
+    runtime = new SpaceRuntime({
+      db,
+      spaceManager,
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    runtime.registerSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+
+    // Activation should succeed when the rehydrated retry fires.
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-rehydrated-retry' }];
+    tam.alive.add('session-rehydrated-retry');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-rehydrated-retry',
+      });
+    };
+
+    // Reset call tracking so we only measure what happens after rehydrate.
+    tam.activationCalls = [];
+    injected = [];
+
+    await runtime.rehydrateExecutors();
+    expect(tam.activationCalls).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(tam.activationCalls.length).toBeGreaterThanOrEqual(1);
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-rehydrated-retry');
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import { ExternalEventService } from '../../../../src/lib/external-events/external-event-service';
@@ -21,6 +21,8 @@ import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/sp
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
 import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository';
 import { createSpaceTables } from '../../helpers/space-test-db';
+
+setDefaultTimeout(10_000);
 
 const SPACE_ID = 'space-runtime-events';
 const AGENT_ID = 'agent-runtime-events';
@@ -82,6 +84,10 @@ function makeEvent(overrides: Partial<ExternalEvent> = {}): ExternalEvent {
 class MockTaskAgentManager {
   alive = new Set<string>();
   spawned: string[] = [];
+  activationCalls: Array<{ taskId: string; workflowRunId: string; agentName: string }> = [];
+  activationResult: Array<{ agentName: string; sessionId: string }> = [];
+  activationError: Error | null = null;
+  onActivate: (() => void) | null = null;
 
   isSessionAlive(sessionId: string): boolean {
     return this.alive.has(sessionId);
@@ -108,6 +114,20 @@ class MockTaskAgentManager {
   }
 
   async flushPendingMessagesForTarget(): Promise<void> {}
+
+  async activateTargetSessionsForMessage(
+    taskId: string,
+    workflowRunId: string,
+    agentName: string
+  ): Promise<Array<{ agentName: string; sessionId: string }>> {
+    this.activationCalls.push({ taskId, workflowRunId, agentName });
+    if (this.activationError) throw this.activationError;
+    this.onActivate?.();
+    for (const result of this.activationResult) {
+      this.alive.add(result.sessionId);
+    }
+    return this.activationResult;
+  }
 
   async spawnWorkflowNodeAgentForExecution(
     _task: unknown,
@@ -2136,8 +2156,8 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected.some((item) => item.message.includes(events[0]!.id))).toBe(false);
   });
 
-  test('persists pending delivery when target execution is not active', async () => {
-    const { workflow, run, task } = await startRunWithSubscription();
+  test('does not activate cancelled target executions', async () => {
+    const { run } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
     nodeExecutionRepo.update(execution.id, {
       status: 'cancelled',
@@ -2149,12 +2169,180 @@ describe('SpaceRuntime external event subscriptions', () => {
     const event = makeEvent();
     await eventService.publish(event);
 
+    expect(tam.activationCalls).toHaveLength(0);
     expect(injected).toHaveLength(0);
     const delivery = eventStore.listDeliveries(event.id)[0]!;
     expect(delivery.state).toBe('pending');
     expect(delivery.failureReason).toBe('node_execution_not_active');
     expect(eventStore.listPendingDeliveries()).toContainEqual(delivery);
     expect(eventStore.getById(event.id)?.state).toBe('published');
+  });
+
+  test('activates idle subscribed targets instead of failing node_execution_not_active', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-activated-event' }];
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        status: 'in_progress',
+        agentSessionId: 'session-activated-event',
+        completedAt: null,
+      });
+    };
+
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(tam.activationCalls).toEqual([
+      { taskId: task.id, workflowRunId: run.id, agentName: 'coder' },
+    ]);
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-activated-event');
+    expect(JSON.parse(injected[0]!.message).eventId).toBe(event.id);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('delivered');
+    expect(delivery.failureReason).toBeNull();
+  });
+
+  test('queues external events when activation starts without a ready session', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-starting-event' }];
+
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(tam.activationCalls).toEqual([
+      { taskId: task.id, workflowRunId: run.id, agentName: 'coder' },
+    ]);
+    expect(injected).toHaveLength(0);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-starting-event',
+      completedAt: null,
+    });
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-starting-event',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-starting-event');
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+  });
+
+  test('activation failures schedule bounded retries and terminalize', async () => {
+    const { run } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationError = new Error('spawn failed');
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe(
+      'activation_failed; spawn failed'
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 5_600));
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('activation_failed; spawn failed');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(tam.activationCalls.length).toBeGreaterThanOrEqual(5);
+    expect(tam.activationCalls.length).toBeLessThanOrEqual(6);
+  });
+
+  test('paused spaces keep external events queued without terminal retry burn', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    await new Promise((resolve) => setTimeout(resolve, 5_600));
+
+    expect(tam.activationCalls).toHaveLength(0);
+    const pending = eventStore.listDeliveries(event.id)[0]!;
+    expect(pending.state).toBe('pending');
+    expect(pending.failureReason).toBe('node_execution_not_active');
+
+    db.prepare(`UPDATE spaces SET paused = 0 WHERE id = ?`).run(SPACE_ID);
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-after-pause',
+      completedAt: null,
+    });
+    tam.alive.add('session-after-pause');
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-after-pause',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-after-pause');
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
+  });
+
+  test('activation retry does not double-deliver after pending flush wins', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-race' }];
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-race',
+      completedAt: null,
+    });
+    tam.alive.add('session-race');
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-race',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-race');
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
   });
 
   test('delivers immediately for idle executions with retained live sessions', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -84,7 +84,12 @@ function makeEvent(overrides: Partial<ExternalEvent> = {}): ExternalEvent {
 class MockTaskAgentManager {
   alive = new Set<string>();
   spawned: string[] = [];
-  activationCalls: Array<{ taskId: string; workflowRunId: string; agentName: string }> = [];
+  activationCalls: Array<{
+    taskId: string;
+    workflowRunId: string;
+    agentName: string;
+    options?: { workflowNodeId?: string };
+  }> = [];
   activationResult: Array<{ agentName: string; sessionId: string }> = [];
   activationError: Error | null = null;
   onActivate: (() => void) | null = null;
@@ -118,9 +123,15 @@ class MockTaskAgentManager {
   async activateTargetSessionsForMessage(
     taskId: string,
     workflowRunId: string,
-    agentName: string
+    agentName: string,
+    options?: { workflowNodeId?: string }
   ): Promise<Array<{ agentName: string; sessionId: string }>> {
-    this.activationCalls.push({ taskId, workflowRunId, agentName });
+    this.activationCalls.push({
+      taskId,
+      workflowRunId,
+      agentName,
+      options: options?.workflowNodeId ? { workflowNodeId: options.workflowNodeId } : undefined,
+    });
     if (this.activationError) throw this.activationError;
     this.onActivate?.();
     for (const result of this.activationResult) {
@@ -2199,7 +2210,12 @@ describe('SpaceRuntime external event subscriptions', () => {
     await eventService.publish(event);
 
     expect(tam.activationCalls).toEqual([
-      { taskId: task.id, workflowRunId: run.id, agentName: 'coder' },
+      {
+        taskId: task.id,
+        workflowRunId: run.id,
+        agentName: 'coder',
+        options: { workflowNodeId: 'code' },
+      },
     ]);
     expect(injected).toHaveLength(1);
     expect(injected[0]!.sessionId).toBe('session-activated-event');
@@ -2223,7 +2239,12 @@ describe('SpaceRuntime external event subscriptions', () => {
     await eventService.publish(event);
 
     expect(tam.activationCalls).toEqual([
-      { taskId: task.id, workflowRunId: run.id, agentName: 'coder' },
+      {
+        taskId: task.id,
+        workflowRunId: run.id,
+        agentName: 'coder',
+        options: { workflowNodeId: 'code' },
+      },
     ]);
     expect(injected).toHaveLength(0);
     expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
@@ -4826,6 +4847,129 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected[0]!.deliveryMode).toBe('defer');
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
+
+  test('activation timeout schedules bounded retries and terminalizes', async () => {
+    const { run } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    // Empty result simulates activateTargetSessionsForMessage timing out.
+    tam.activationResult = [];
+
+    const event = makeEvent();
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.failureReason).toBe('node_execution_not_active');
+
+    await new Promise((resolve) => setTimeout(resolve, 5_600));
+
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('node_execution_not_active');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+    expect(tam.activationCalls.length).toBeGreaterThanOrEqual(5);
+    expect(tam.activationCalls.length).toBeLessThanOrEqual(6);
+  });
+
+  test('static subscription without node execution does not activate future nodes', async () => {
+    const workflow = workflowManager.createWorkflow({
+      spaceId: SPACE_ID,
+      name: 'Two-node workflow',
+      description: '',
+      nodes: [
+        {
+          id: 'start',
+          name: 'Start',
+          agents: [{ agentId: AGENT_ID, name: 'coder' }],
+        },
+        {
+          id: 'future',
+          name: 'Future',
+          agents: [{ agentId: AGENT_ID, name: 'reviewer' }],
+        },
+      ],
+      transitions: [],
+      startNodeId: 'start',
+      rules: [],
+      tags: [],
+    });
+    const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+    const task = tasks[0]!;
+    // Only the start node has an execution; subscribe to the future node.
+    runtime.registerSubscription(run.id, task.id, 'future', 'reviewer', DEFAULT_TOPIC, {
+      subscriptionKind: 'static',
+    });
+
+    const event = makeEvent();
+    await eventService.publish(event);
+
+    expect(tam.activationCalls).toHaveLength(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+    expect(eventStore.getById(event.id)?.state).toBe('published');
+  });
+
+  test('successful activation drains older queued events before current', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    // Activation returns empty while the worker is idle, so older events persist
+    // as retryable pending deliveries.
+    tam.activationResult = [];
+
+    const older = makeEvent({
+      id: 'evt-older-queued',
+      dedupeKey: 'dedupe-older-queued',
+      occurredAt: 1_700_000_000_000,
+    });
+    const newer = makeEvent({
+      id: 'evt-newer-queued',
+      dedupeKey: 'dedupe-newer-queued',
+      occurredAt: 1_700_000_000_100,
+    });
+    await eventService.publish(older);
+    await eventService.publish(newer);
+    expect(eventStore.listDeliveries(older.id)[0]!.state).toBe('pending');
+    expect(eventStore.listDeliveries(newer.id)[0]!.state).toBe('pending');
+
+    // The third event arrives while the worker is activating: the execution is
+    // in_progress but has no sessionId yet, so activation kicks in and flushes
+    // the older persisted pending deliveries before delivering the current one.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      completedAt: null,
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-activated' }];
+    tam.alive.add('session-activated');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-activated',
+      });
+    };
+
+    const current = makeEvent({
+      id: 'evt-current-activating',
+      dedupeKey: 'dedupe-current-activating',
+      occurredAt: 1_700_000_000_200,
+    });
+    await eventService.publish(current);
+
+    expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([
+      older.id,
+      newer.id,
+      current.id,
+    ]);
+    expect(eventStore.getById(older.id)?.state).toBe('delivered');
+    expect(eventStore.getById(newer.id)?.state).toBe('delivered');
+    expect(eventStore.getById(current.id)?.state).toBe('delivered');
+  });
 });
 
 describe('SpaceRuntime event-driven gate evaluation', () => {
@@ -5180,41 +5324,6 @@ describe('SpaceRuntime event-driven gate evaluation', () => {
     const event = makePrEvent();
     await eventService.publish(event);
     // Agent-owned dynamic subscription still matches.
-    expect(injected).toHaveLength(1);
-  });
-
-  test('registerPrEventSubscriptionForRun drops the prior auto-subscription when the PR URL changes', async () => {
-    const { run } = await startRun();
-    const first = runtime.registerPrEventSubscriptionForRun(
-      run.id,
-      'https://github.com/lsm/neokai/pull/42'
-    );
-    expect(first.success).toBe(true);
-    expect(first.topicPattern).toBe('github/lsm/neokai/pull_request/42.*');
-
-    // Swap to a different PR — the old auto-subscription for PR #42 must be
-    // removed so obsolete events stop matching.
-    const second = runtime.registerPrEventSubscriptionForRun(
-      run.id,
-      'https://github.com/lsm/neokai/pull/99'
-    );
-    expect(second.success).toBe(true);
-    expect(second.topicPattern).toBe('github/lsm/neokai/pull_request/99.*');
-
-    // Event for the old PR — should NOT deliver.
-    const staleEvent = makePrEvent({
-      topic: 'github/lsm/neokai/pull_request/42.review_submitted',
-      dedupeKey: 'dedupe-stale-42',
-    });
-    await eventService.publish(staleEvent);
-    expect(injected).toHaveLength(0);
-
-    // Event for the new PR — SHOULD deliver.
-    const freshEvent = makePrEvent({
-      topic: 'github/lsm/neokai/pull_request/99.review_submitted',
-      dedupeKey: 'dedupe-fresh-99',
-    });
-    await eventService.publish(freshEvent);
     expect(injected).toHaveLength(1);
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -5374,7 +5374,7 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('delivered');
   });
 
-  test('drains older pending rows before live-session delivery', async () => {
+  test('orders older retry before newer pending rows in resolved-session drain', async () => {
     const { run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
     nodeExecutionRepo.update(execution.id, {
@@ -5385,30 +5385,143 @@ describe('SpaceRuntime external event subscriptions', () => {
     tam.activationResult = [];
 
     const older = makeEvent({
-      id: 'evt-older-pending-live',
-      dedupeKey: 'dedupe-older-pending-live',
+      id: 'evt-older-retry-live',
+      dedupeKey: 'dedupe-older-retry-live',
       occurredAt: 1_700_000_000_000,
     });
-    await eventService.publish(older);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Make the session live before the newer event arrives.
-    nodeExecutionRepo.update(execution.id, {
-      status: 'in_progress',
-      agentSessionId: 'session-live-drain',
-    });
-    tam.alive.add('session-live-drain');
-
     const newer = makeEvent({
-      id: 'evt-newer-pending-live',
-      dedupeKey: 'dedupe-newer-pending-live',
+      id: 'evt-newer-retry-live',
+      dedupeKey: 'dedupe-newer-retry-live',
       occurredAt: 1_700_000_000_100,
     });
+
+    await eventService.publish(older);
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await eventService.publish(newer);
 
+    expect(eventStore.listDeliveries(older.id)[0]!.state).toBe('pending');
+    expect(eventStore.listDeliveries(newer.id)[0]!.state).toBe('pending');
+
+    // Make the session live; the older retry fires first and the drain must
+    // include the current (older) event in the sorted batch so A is delivered
+    // before B, even though B is already persisted as a pending row.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-retry-drain-order',
+    });
+    tam.alive.add('session-retry-drain-order');
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
     expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([older.id, newer.id]);
     expect(eventStore.getById(older.id)?.state).toBe('delivered');
     expect(eventStore.getById(newer.id)?.state).toBe('delivered');
+  });
+
+  test('re-registers space-resume hook on start after stop', async () => {
+    const manager = spaceManager;
+    const before = (manager as unknown as { onSpaceResumedCallbacks: unknown[] })
+      .onSpaceResumedCallbacks.length;
+    const runtime2 = new SpaceRuntime({
+      db,
+      spaceManager: manager,
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus: (runtime as unknown as { config: { commandBus: unknown } }).config.commandBus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    const afterRegister = (manager as unknown as { onSpaceResumedCallbacks: unknown[] })
+      .onSpaceResumedCallbacks.length;
+    expect(afterRegister).toBe(before + 1);
+
+    await runtime2.stop();
+    expect(
+      (manager as unknown as { onSpaceResumedCallbacks: unknown[] }).onSpaceResumedCallbacks
+    ).toHaveLength(before);
+
+    runtime2.start();
+    expect(
+      (manager as unknown as { onSpaceResumedCallbacks: unknown[] }).onSpaceResumedCallbacks
+    ).toHaveLength(before + 1);
+
+    await runtime2.stop();
+  });
+
+  test('terminalizes resumed deliveries whose subscription was removed', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-resume-subscription-removed' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    await spaceManager.pauseSpace(SPACE_ID);
+    runtime.unregisterSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+    await spaceManager.resumeSpace(SPACE_ID);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('subscription_no_longer_active');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
+  test('does not activate blocked executions so they stay on the blocked-run recovery path', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'blocked',
+      agentSessionId: null,
+      startedAt: null,
+      completedAt: null,
+    });
+
+    const event = makeEvent({ id: 'evt-blocked-exec' });
+    await eventService.publish(event);
+
+    // Activation should not have been attempted for a blocked execution.
+    expect(tam.activationCalls).toHaveLength(0);
+    // The delivery stays pending/queued for the recovery path rather than
+    // being terminally failed.
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+  });
+
+  test('expires activation retry instead of redispatching stale event', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-activation-ttl' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Backdate the event past the TTL window before the activation retry fires.
+    db.prepare(`UPDATE space_external_events SET created_at = ? WHERE id = ?`).run(
+      Date.now() - 301_000,
+      event.id
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('ttl_expired');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -5647,6 +5647,38 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(delivery.failureReason).not.toBe('subscription_no_longer_active');
   });
 
+  test('does not clear existing PR auto-subscription deliveries on resume', async () => {
+    const { run, task } = await startRunWithSubscription();
+    workflowRunRepo.updateRun(run.id, { status: 'blocked', failureReason: 'manual block' });
+    artifactRepo.upsert({
+      id: 'art-resume-existing',
+      runId: run.id,
+      nodeId: 'code',
+      artifactType: 'pr_url',
+      artifactKey: 'pr_url',
+      data: { prUrl: 'https://github.com/lsm/neokai/pull/99' },
+    });
+
+    // Establish the auto-subscription and create a pending PR delivery.
+    runtime.notifyRunBlocked(run.id);
+    const prTopic = 'github/lsm/neokai/pull_request/99.review_submitted';
+    const event = makeEvent({ id: 'evt-resume-existing-subscription', topic: prTopic });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Resume the space. onSpaceResumed must not re-enter
+    // registerPrEventSubscriptionForRun for a run that already has an auto
+    // subscription, because that would clear the existing subscription and
+    // terminally fail the pending delivery as auto_pr_subscription_cleared.
+    runtime.onSpaceResumed(SPACE_ID);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(runtime.lookupSubscriptionTargets(prTopic).length).toBeGreaterThan(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).not.toBe('failed');
+    expect(delivery.failureReason).not.toBe('auto_pr_subscription_cleared');
+  });
+
   test('preserves event age when requeueing activation retries for pending executions', async () => {
     const { run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -5203,6 +5203,103 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(injected[0]!.sessionId).toBe('session-rehydrated-retry');
     expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('delivered');
   });
+
+  test('preserves chronological order when older activation retry activates first', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const older = makeEvent({
+      id: 'evt-older-retry-first',
+      dedupeKey: 'dedupe-older-retry-first',
+      occurredAt: 1_700_000_000_000,
+    });
+    const newer = makeEvent({
+      id: 'evt-newer-retry-first',
+      dedupeKey: 'dedupe-newer-retry-first',
+      occurredAt: 1_700_000_000_100,
+    });
+    await eventService.publish(older);
+    // Stagger ingestion so the DB `created_at` ordering matches the intended
+    // chronological order; without a gap both rows may share the same ms.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await eventService.publish(newer);
+    expect(eventStore.listDeliveries(older.id)[0]!.state).toBe('pending');
+    expect(eventStore.listDeliveries(newer.id)[0]!.state).toBe('pending');
+
+    // The older event's retry fires first and activates the agent. The drain
+    // includes the older event in the sorted batch so it is delivered before
+    // the newer pending row, regardless of which retry timer fires first.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      completedAt: null,
+    });
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-retry-order' }];
+    tam.alive.add('session-retry-order');
+    tam.onActivate = () => {
+      nodeExecutionRepo.update(execution.id, {
+        agentSessionId: 'session-retry-order',
+      });
+    };
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([older.id, newer.id]);
+    expect(eventStore.getById(older.id)?.state).toBe('delivered');
+    expect(eventStore.getById(newer.id)?.state).toBe('delivered');
+  });
+
+  test('scopes activation retry to original delivery when subscription is removed', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-subscription-removed' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Remove the subscription before the retry fires.
+    runtime.unregisterSubscription(run.id, task.id, 'code', 'coder', DEFAULT_TOPIC);
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    // The retry targets the specific delivery and terminalizes it, instead of
+    // replaying the whole event and marking it ignored while the row stays pending.
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('subscription_no_longer_active');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
+  test('does not activate subscribers while the workflow run is blocked', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    // Blocked run with an active execution that has no live session.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: null,
+      startedAt: Date.now(),
+      completedAt: null,
+    });
+    workflowRunRepo.updateRun(run.id, { status: 'blocked', failureReason: 'agentCrash' });
+
+    const event = makeEvent({ id: 'evt-blocked-run' });
+    await eventService.publish(event);
+
+    expect(tam.activationCalls).toHaveLength(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+    expect(delivery.failureReason).toBeNull();
+  });
 });
 
 describe('SpaceRuntime event-driven gate evaluation', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -5523,6 +5523,76 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(delivery.failureReason).toBe('ttl_expired');
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
+
+  test('terminalizes activation retry when run becomes undeliverable', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-activation-run-shutdown' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Run becomes cancelled before the activation retry fires.
+    workflowRunRepo.updateRun(run.id, { status: 'cancelled' });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('run_not_externally_deliverable');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
+  test('ordered dispatch skips delivery terminalized while batch was prepared', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+
+    const earlier = makeEvent({ id: 'evt-terminalized-early' });
+    const later = makeEvent({ id: 'evt-terminalized-late' });
+    await eventService.publish(earlier);
+    await eventService.publish(later);
+    expect(eventStore.listDeliveries(earlier.id)[0]!.state).toBe('pending');
+    expect(eventStore.listDeliveries(later.id)[0]!.state).toBe('pending');
+
+    // Activate the node so the flush will dispatch both queued items.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-terminalized-dispatch',
+      completedAt: null,
+    });
+    tam.alive.add('session-terminalized-dispatch');
+
+    // Simulate a concurrent cleanup terminalizing the earlier delivery before
+    // the ordered dispatch loop reaches it.
+    const earlierDelivery = eventStore.listDeliveries(earlier.id)[0]!;
+    eventStore.markDeliveryFailed(earlier.id, earlierDelivery.deliveryKey, {
+      terminal: true,
+      reason: 'subscription_no_longer_active',
+    });
+
+    runtime.flushPendingNodeQueue({
+      workflowRunId: run.id,
+      taskId: task.id,
+      nodeId: 'code',
+      agentName: 'coder',
+      sessionId: 'session-terminalized-dispatch',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([later.id]);
+    expect(eventStore.listDeliveries(earlier.id)[0]!.state).toBe('failed');
+    expect(eventStore.listDeliveries(later.id)[0]!.state).toBe('delivered');
+  });
 });
 
 describe('SpaceRuntime event-driven gate evaluation', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -4277,21 +4277,28 @@ describe('SpaceRuntime external event subscriptions', () => {
     try {
       for (const event of events) {
         await eventService.publish(event);
-        fakeNow += 61_000;
+        fakeNow += 100;
       }
     } finally {
       Date.now = originalNow;
     }
 
-    const droppedDelivery = eventStore.listDeliveries(events[0]!.id)[0]!;
-    expect(droppedDelivery.state).toBe('failed');
-    expect(droppedDelivery.failureReason).toBe('pending_node_queue_overflow');
+    // Let the rate-limit digest timer flush; the batched digest items are
+    // requeued as pending deliveries, and the oldest one is dropped with the
+    // overflow reason once the queue reaches its limit.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const droppedDelivery = events
+      .map((event) => eventStore.listDeliveries(event.id)[0]!)
+      .find((delivery) => delivery.failureReason === 'pending_node_queue_overflow');
+    expect(droppedDelivery).toBeDefined();
+    expect(droppedDelivery!.state).toBe('failed');
     const retryState = runtime as unknown as {
       externalEventRetryTimers: Map<string, unknown>;
       externalEventRetryCounts: Map<string, number>;
     };
-    expect(retryState.externalEventRetryTimers.has(droppedDelivery.deliveryKey)).toBe(false);
-    expect(retryState.externalEventRetryCounts.has(droppedDelivery.deliveryKey)).toBe(false);
+    expect(retryState.externalEventRetryTimers.has(droppedDelivery!.deliveryKey)).toBe(false);
+    expect(retryState.externalEventRetryCounts.has(droppedDelivery!.deliveryKey)).toBe(false);
   });
 
   test('fails delivery terminally when injection command handler is missing', async () => {
@@ -5280,25 +5287,128 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.getById(event.id)?.state).toBe('failed');
   });
 
-  test('does not activate subscribers while the workflow run is blocked', async () => {
+  test('unregisters space-resume hook on stop', async () => {
+    const manager = spaceManager;
+    const before = (manager as unknown as { onSpaceResumedCallbacks: unknown[] })
+      .onSpaceResumedCallbacks.length;
+    const runtime2 = new SpaceRuntime({
+      db,
+      spaceManager: manager,
+      spaceAgentManager: new SpaceAgentManager(new SpaceAgentRepository(db)),
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+      commandBus: (runtime as unknown as { config: { commandBus: unknown } }).config.commandBus,
+      externalEventStore: eventStore,
+      taskAgentManager: tam as never,
+    });
+    const afterRegister = (manager as unknown as { onSpaceResumedCallbacks: unknown[] })
+      .onSpaceResumedCallbacks.length;
+    expect(afterRegister).toBe(before + 1);
+
+    await runtime2.stop();
+    const afterStop = (manager as unknown as { onSpaceResumedCallbacks: unknown[] })
+      .onSpaceResumedCallbacks.length;
+    expect(afterStop).toBe(before);
+  });
+
+  test('rehydrates sessionless activation timers after stop-start', async () => {
     const { run, task } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
-    // Blocked run with an active execution that has no live session.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-stop-start-retry' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    await runtime.stop();
+
+    tam.activationResult = [{ agentName: 'coder', sessionId: 'session-stop-start' }];
+    tam.alive.add('session-stop-start');
     nodeExecutionRepo.update(execution.id, {
       status: 'in_progress',
-      agentSessionId: null,
+      agentSessionId: 'session-stop-start',
       startedAt: Date.now(),
+    });
+
+    runtime.start();
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-stop-start');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+
+    await runtime.stop();
+  });
+
+  test('keeps activation retries alive while spawn is pending', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'pending',
+      agentSessionId: null,
       completedAt: null,
     });
-    workflowRunRepo.updateRun(run.id, { status: 'blocked', failureReason: 'agentCrash' });
 
-    const event = makeEvent({ id: 'evt-blocked-run' });
+    const event = makeEvent({ id: 'evt-pending-spawn' });
     await eventService.publish(event);
-
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
     expect(tam.activationCalls).toHaveLength(0);
-    const delivery = eventStore.listDeliveries(event.id)[0]!;
-    expect(delivery.state).toBe('pending');
-    expect(delivery.failureReason).toBeNull();
+
+    // Simulate the background spawn completing before the retry fires.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-pending-spawn',
+    });
+    tam.alive.add('session-pending-spawn');
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-pending-spawn');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
+
+  test('drains older pending rows before live-session delivery', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const older = makeEvent({
+      id: 'evt-older-pending-live',
+      dedupeKey: 'dedupe-older-pending-live',
+      occurredAt: 1_700_000_000_000,
+    });
+    await eventService.publish(older);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Make the session live before the newer event arrives.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-live-drain',
+    });
+    tam.alive.add('session-live-drain');
+
+    const newer = makeEvent({
+      id: 'evt-newer-pending-live',
+      dedupeKey: 'dedupe-newer-pending-live',
+      occurredAt: 1_700_000_000_100,
+    });
+    await eventService.publish(newer);
+
+    expect(injected.map((item) => JSON.parse(item.message).eventId)).toEqual([older.id, newer.id]);
+    expect(eventStore.getById(older.id)?.state).toBe('delivered');
+    expect(eventStore.getById(newer.id)?.state).toBe('delivered');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -5593,6 +5593,122 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(eventStore.listDeliveries(earlier.id)[0]!.state).toBe('failed');
     expect(eventStore.listDeliveries(later.id)[0]!.state).toBe('delivered');
   });
+
+  test('rebuilds blocked-run PR subscriptions on resume before terminalizing pending deliveries', async () => {
+    const { run, task } = await startRunWithSubscription();
+    workflowRunRepo.updateRun(run.id, { status: 'blocked', failureReason: 'manual block' });
+    artifactRepo.upsert({
+      id: 'art-resume-subscription',
+      runId: run.id,
+      nodeId: 'code',
+      artifactType: 'pr_url',
+      artifactKey: 'pr_url',
+      data: { prUrl: 'https://github.com/lsm/neokai/pull/99' },
+    });
+
+    // Establish the auto-subscription and create a pending PR delivery.
+    runtime.notifyRunBlocked(run.id);
+    const prTopic = 'github/lsm/neokai/pull_request/99.review_submitted';
+    const event = makeEvent({ id: 'evt-resume-subscription-rebuild', topic: prTopic });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Simulate startup skipping the paused space: drop the auto-subscription
+    // from the trie without failing queued deliveries. Use the trie directly
+    // (not lookupSubscriptionTargets) because the latter also matches the
+    // legacy four-segment topic form and would still find the dynamic
+    // subscription registered by startRunWithSubscription.
+    const trie = (
+      runtime as unknown as {
+        topicTrie: {
+          remove: (predicate: (target: unknown) => boolean) => void;
+          lookup: (topic: string) => unknown[];
+        };
+      }
+    ).topicTrie;
+    trie.remove((target) => {
+      const t = target as { workflowRunId?: string; subscriptionKind?: string };
+      return t.workflowRunId === run.id && t.subscriptionKind === 'auto';
+    });
+    expect(
+      trie
+        .lookup(prTopic)
+        .filter((target) => (target as { subscriptionKind?: string }).subscriptionKind === 'auto')
+    ).toHaveLength(0);
+
+    // Resume the space. onSpaceResumed must rebuild the PR subscription before
+    // the subscription check, so the pending delivery is not terminalized.
+    runtime.onSpaceResumed(SPACE_ID);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(runtime.lookupSubscriptionTargets(prTopic).length).toBeGreaterThan(0);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).not.toBe('failed');
+    expect(delivery.failureReason).not.toBe('subscription_no_longer_active');
+  });
+
+  test('preserves event age when requeueing activation retries for pending executions', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'pending',
+      agentSessionId: null,
+      completedAt: null,
+    });
+
+    const event = makeEvent({ id: 'evt-pending-activation-age' });
+    await eventService.publish(event);
+    expect(eventStore.listDeliveries(event.id)[0]!.state).toBe('pending');
+
+    // Backdate the event past the TTL window. The pending-execution queueing
+    // must carry the original createdAt so the activation retry TTL check
+    // expires the stale event instead of redispatching it after spawn.
+    db.prepare(`UPDATE space_external_events SET created_at = ? WHERE id = ?`).run(
+      Date.now() - 301_000,
+      event.id
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('failed');
+    expect(delivery.failureReason).toBe('ttl_expired');
+    expect(eventStore.getById(event.id)?.state).toBe('failed');
+  });
+
+  test('preserves deferred mode when activation retry reaches a live session', async () => {
+    const { run, task } = await startRunWithSubscription();
+    const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;
+    nodeExecutionRepo.update(execution.id, {
+      status: 'idle',
+      agentSessionId: null,
+      completedAt: Date.now(),
+    });
+    tam.activationResult = [];
+
+    const event = makeEvent({ id: 'evt-activation-defer-mode' });
+    await eventService.publish(event);
+    const delivery = eventStore.listDeliveries(event.id)[0]!;
+    expect(delivery.state).toBe('pending');
+
+    // Simulate a rehydrated/sessionless retry whose pending row encoded defer mode.
+    eventStore.markDeliveryFailed(event.id, delivery.deliveryKey, {
+      terminal: false,
+      reason: 'deliveryMode:defer; digest pending during session loss',
+    });
+
+    // Now make the session live and trigger the activation retry.
+    nodeExecutionRepo.update(execution.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-activation-defer',
+    });
+    tam.alive.add('session-activation-defer');
+
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+    expect(injected).toHaveLength(1);
+    expect(injected[0]!.sessionId).toBe('session-activation-defer');
+    expect(injected[0]!.deliveryMode).toBe('defer');
+    expect(eventStore.getById(event.id)?.state).toBe('delivered');
+  });
 });
 
 describe('SpaceRuntime event-driven gate evaluation', () => {


### PR DESCRIPTION
## Summary
- reuse TaskAgentManager activation semantics when external events target subscribed idle node agents
- queue events for activation-started targets and keep cancelled executions from being revived
- add runtime coverage for activation, queue flush, and terminal target behavior

## Tests
- cd packages/daemon && bun test tests/unit/5-space/runtime/space-runtime-external-events.test.ts
- ./scripts/test-daemon.sh 5-space-runtime-a
- bun run check