### PR TITLE
feat(agent): wire output limiter hook into query options

### DIFF
--- a/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
+++ b/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
@@ -385,7 +385,7 @@ export class ApiErrorCircuitBreaker {
 - If you still see this error, reduce limits further in .claude/settings.local.json:
   - outputLimiter.bash.headLines (default: 100)
   - outputLimiter.bash.tailLines (default: 200)
-  - outputLimiter.read.maxChars (default: 50000)
+  - outputLimiter.read.maxLines (default: 1000)
   - outputLimiter.grep.maxMatches (default: 500)
 - Use filtering in tools (e.g., grep with patterns, head/tail for files)
 - Start a new session if context is too large

--- a/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
+++ b/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
@@ -383,7 +383,7 @@ export class ApiErrorCircuitBreaker {
 **What to do:**
 - Output limiting is now **enabled by default** to prevent this
 - If you still see this error, reduce the output limits in NeoKai's global
-  settings (Settings → Output Limiter):
+  settings (outputLimiter section):
   - outputLimiter.bash.headLines (default: 100)
   - outputLimiter.bash.tailLines (default: 200)
   - outputLimiter.read.maxLines (default: 1000)

--- a/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
+++ b/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
@@ -382,11 +382,12 @@ export class ApiErrorCircuitBreaker {
 
 **What to do:**
 - Output limiting is now **enabled by default** to prevent this
-- If you still see this error, reduce limits further in .claude/settings.local.json:
+- If you still see this error, reduce the output limits in NeoKai's global
+  settings (Settings → Output Limiter):
   - outputLimiter.bash.headLines (default: 100)
   - outputLimiter.bash.tailLines (default: 200)
   - outputLimiter.read.maxLines (default: 1000)
-  - outputLimiter.grep.maxMatches (default: 500)
+  - outputLimiter.grep.maxMatches (default: 250)
 - Use filtering in tools (e.g., grep with patterns, head/tail for files)
 - Start a new session if context is too large
 - Use /compact to reduce conversation context`;

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -14,7 +14,7 @@
 import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
 import { Logger } from '../logger';
 
-// Output limiter configuration
+// Output limiter configuration (resolved values used internally)
 interface OutputLimiterConfig {
   enabled: boolean;
   bash: {
@@ -31,6 +31,26 @@ interface OutputLimiterConfig {
     maxFiles: number;
   };
   excludeTools: string[];
+}
+
+// Input shape: every nested value may be partial because global settings
+// can be updated one field at a time (e.g. only bash.headLines).
+interface OutputLimiterConfigInput {
+  enabled?: boolean;
+  bash?: {
+    headLines?: number;
+    tailLines?: number;
+  };
+  read?: {
+    maxChars?: number;
+  };
+  grep?: {
+    maxMatches?: number;
+  };
+  glob?: {
+    maxFiles?: number;
+  };
+  excludeTools?: string[];
 }
 
 const DEFAULT_CONFIG: OutputLimiterConfig = {
@@ -50,6 +70,26 @@ const DEFAULT_CONFIG: OutputLimiterConfig = {
   },
   excludeTools: [],
 };
+
+function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimiterConfig {
+  return {
+    enabled: input.enabled ?? DEFAULT_CONFIG.enabled,
+    bash: {
+      headLines: input.bash?.headLines ?? DEFAULT_CONFIG.bash.headLines,
+      tailLines: input.bash?.tailLines ?? DEFAULT_CONFIG.bash.tailLines,
+    },
+    read: {
+      maxChars: input.read?.maxChars ?? DEFAULT_CONFIG.read.maxChars,
+    },
+    grep: {
+      maxMatches: input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches,
+    },
+    glob: {
+      maxFiles: input.glob?.maxFiles ?? DEFAULT_CONFIG.glob.maxFiles,
+    },
+    excludeTools: input.excludeTools ?? DEFAULT_CONFIG.excludeTools,
+  };
+}
 
 /**
  * Creates a PreToolUse hook that injects output limiting parameters
@@ -72,8 +112,8 @@ const DEFAULT_CONFIG: OutputLimiterConfig = {
  * };
  * ```
  */
-export function createOutputLimiterHook(config: Partial<OutputLimiterConfig> = {}): HookCallback {
-  const finalConfig = { ...DEFAULT_CONFIG, ...config };
+export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): HookCallback {
+  const finalConfig = resolveConfig(config);
   const logger = new Logger('OutputLimiterHook');
 
   return async (input, _toolUseID, { signal: _signal }) => {

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -204,6 +204,14 @@ function limitToolInput(
         return null;
       }
 
+      // Skip shell-backgrounded commands (trailing `&` that's not `&&`).
+      // These run asynchronously and the wrapper would cat/remove the temp
+      // file before the background process finishes writing to it.
+      const trimmedCmd = command.trim();
+      if (trimmedCmd.endsWith('&') && !trimmedCmd.endsWith('&&')) {
+        return null;
+      }
+
       // Skip simple commands that are unlikely to produce large output.
       // ls is NOT skipped because `ls -R` or `ls node_modules` can produce
       // thousands of lines. echo is NOT skipped because command substitution

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -225,11 +225,15 @@ function limitToolInput(
       // Skip commands whose primary executable is explicitly excluded by the
       // user (e.g. via outputLimiter.bash.excludedCommandPrefixes, which may
       // be populated from sandbox.excludedCommands to preserve command-level
-      // sandbox exclusions for commands like `git`).
+      // sandbox exclusions for commands like `git`). Only skip when the
+      // command is a single invocation — a compound command like
+      // `git status; cat huge.log` has a trailing non-excluded segment.
       const effectiveCommand = stripEnvPrefixes(trimmed);
-      for (const prefix of config.bash.excludedCommandPrefixes) {
-        if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
-          return null;
+      if (!/[;&|\n]/.test(effectiveCommand)) {
+        for (const prefix of config.bash.excludedCommandPrefixes) {
+          if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
+            return null;
+          }
         }
       }
 
@@ -260,7 +264,7 @@ function limitToolInput(
       //
       // Known limitation: if the SDK kills the wrapper on timeout before the
       // cat/head/tail segment runs, partial output in the temp file is lost.
-      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\npwd > "$cwdfile" 2>/dev/null\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\n__exit=$?\npwd > "$cwdfile" 2>/dev/null\nexit $__exit\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
 
       return {
         ...input,

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -90,7 +90,13 @@ export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimit
           : DEFAULT_CONFIG.read.maxLines),
     },
     grep: {
-      maxMatches: input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches,
+      // Normalize the legacy default (500) to the new default (250) so
+      // upgraded databases don't double Grep output. Users who explicitly
+      // want a different value can set it to anything other than 500.
+      maxMatches:
+        input.grep?.maxMatches === 500
+          ? DEFAULT_CONFIG.grep.maxMatches
+          : (input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches),
     },
     excludeTools: input.excludeTools ?? DEFAULT_CONFIG.excludeTools,
   };
@@ -207,8 +213,13 @@ function limitToolInput(
       // Skip shell-backgrounded commands (any `&` that's not part of `&&`,
       // `>&`, `<&`, or `&>`). These run asynchronously and the wrapper would
       // cat/remove the temp file before the background process finishes.
-      // Excludes fd redirects like `2>&1` and combined redirects like `&>`.
-      if (command.replace(/&&|>&|<&|&>/g, '').includes('&')) {
+      // Quoted strings are stripped first so `&` inside URLs or grep patterns
+      // (e.g. `curl 'https://host?a=1&b=2'`) doesn't trigger a false positive.
+      const withoutQuotes = command
+        .replace(/'[^']*'/g, "''")
+        .replace(/"[^"]*"/g, '""')
+        .replace(/`[^`]*`/g, '``');
+      if (withoutQuotes.replace(/&&|>&|<&|&>/g, '').includes('&')) {
         return null;
       }
 

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -1,28 +1,29 @@
 /**
- * Output Limiter Hook (Experimental)
+ * Output Limiter Hook
  *
- * Prevents large tool outputs by injecting output limiting parameters
- * before tools execute, avoiding "prompt too long" API errors.
+ * Prevents large tool outputs from overflowing the model context window.
  *
- * Strategy: Use PreToolUse hooks to modify tool inputs and add output limits.
- * This prevents large outputs from being generated in the first place.
- *
- * Note: PostToolUse hooks CANNOT modify tool_response - they can only add
- * additionalContext. Therefore, we must limit outputs at the input stage.
+ * Strategy:
+ * - PreToolUse: inject limit parameters for Read (line limit) and Grep
+ *   (head_limit) so the tools fetch less data in the first place.
+ * - PostToolUse: truncate Bash stdout/stderr via updatedToolOutput if the
+ *   output exceeds line or byte thresholds. The command runs unwrapped,
+ *   so exit codes, heredocs, cwd, sandbox, and background behavior are
+ *   all preserved naturally.
  */
 
-import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
-import { Logger } from '../logger';
+import type {
+  HookCallback,
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 
-// Output limiter configuration (resolved values used internally)
+// Resolved configuration (all fields populated)
 interface OutputLimiterConfig {
   enabled: boolean;
   bash: {
     headLines: number;
     tailLines: number;
-    // Command prefixes (e.g. ['git']) that should not be wrapped, so
-    // sandbox command-level exclusions still recognise the original tool.
-    excludedCommandPrefixes: string[];
   };
   read: {
     maxLines: number;
@@ -33,18 +34,16 @@ interface OutputLimiterConfig {
   excludeTools: string[];
 }
 
-// Input shape: every nested value may be partial because global settings
-// can be updated one field at a time (e.g. only bash.headLines).
+// Input shape: nested values may be partial (settings update path)
 export interface OutputLimiterConfigInput {
   enabled?: boolean;
   bash?: {
     headLines?: number;
     tailLines?: number;
-    excludedCommandPrefixes?: string[];
   };
   read?: {
     maxLines?: number;
-    /** @deprecated Use maxLines instead. Legacy char-based limit from the pre-wiring schema. */
+    /** @deprecated Use maxLines instead. Legacy char-based limit. */
     maxChars?: number;
   };
   grep?: {
@@ -58,14 +57,13 @@ const DEFAULT_CONFIG: OutputLimiterConfig = {
   bash: {
     headLines: 100,
     tailLines: 200,
-    excludedCommandPrefixes: [],
   },
   read: {
     maxLines: 1000,
   },
   grep: {
-    // Match the SDK's built-in default (250) so injecting head_limit never
-    // expands Grep output beyond what the SDK would have returned on its own.
+    // Match the SDK's built-in default so injecting head_limit never expands
+    // output beyond what the SDK would have returned on its own.
     maxMatches: 250,
   },
   excludeTools: [],
@@ -77,12 +75,8 @@ export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimit
     bash: {
       headLines: input.bash?.headLines ?? DEFAULT_CONFIG.bash.headLines,
       tailLines: input.bash?.tailLines ?? DEFAULT_CONFIG.bash.tailLines,
-      excludedCommandPrefixes:
-        input.bash?.excludedCommandPrefixes ?? DEFAULT_CONFIG.bash.excludedCommandPrefixes,
     },
     read: {
-      // Prefer maxLines; fall back to legacy maxChars (converted to lines at
-      // ~50 chars/line) so upgraded installations don't silently lose their cap.
       maxLines:
         input.read?.maxLines ??
         (input.read?.maxChars !== undefined
@@ -96,63 +90,25 @@ export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimit
   };
 }
 
-/**
- * Creates a PreToolUse hook that injects output limiting parameters
- * into tool inputs to prevent excessively large outputs.
- *
- * @param config - Configuration for output limiting behavior
- * @returns Hook callback function
- *
- * @example
- * ```typescript
- * const hook = createOutputLimiterHook({
- *   enabled: true,
- *   bash: { headLines: 100, tailLines: 200 },
- * });
- *
- * const options = {
- *   hooks: {
- *     PreToolUse: [{ hooks: [hook] }]
- *   }
- * };
- * ```
- */
-export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): HookCallback {
+// ---------------------------------------------------------------------------
+// PreToolUse hook: inject limit parameters for Read and Grep
+// ---------------------------------------------------------------------------
+
+export function createOutputLimiterPreHook(config: OutputLimiterConfigInput = {}): HookCallback {
   const finalConfig = resolveConfig(config);
-  const logger = new Logger('OutputLimiterHook');
 
-  return async (input, _toolUseID, { signal: _signal }) => {
-    if (!finalConfig.enabled) {
-      return {};
-    }
-
-    // Only process PreToolUse events
-    if (input.hook_event_name !== 'PreToolUse') {
-      return {};
-    }
+  return async (input) => {
+    if (!finalConfig.enabled) return {};
+    if (input.hook_event_name !== 'PreToolUse') return {};
 
     const preInput = input as PreToolUseHookInput;
     const { tool_name, tool_input } = preInput;
 
-    // Skip excluded tools
-    if (finalConfig.excludeTools.includes(tool_name)) {
-      return {};
-    }
+    if (finalConfig.excludeTools.includes(tool_name)) return {};
 
-    // Modify tool inputs based on tool type
-    const modifiedInput = limitToolInput(tool_name, tool_input, finalConfig, logger);
+    const modifiedInput = injectReadOrGrepLimit(tool_name, tool_input, finalConfig);
+    if (!modifiedInput) return {};
 
-    if (!modifiedInput) {
-      // No changes needed
-      return {};
-    }
-
-    // Return the mutated input with permissionDecision: 'ask'. The SDK
-    // requires a permissionDecision for updatedInput to be reliably applied.
-    // 'ask' routes through the normal permission flow (canUseTool / prompt)
-    // so restrictive modes (acceptEdits, dontAsk, etc.) still prompt the user.
-    // In bypassPermissions mode (NeoKai default), 'ask' is a no-op — the SDK
-    // skips all prompts regardless.
     return {
       hookSpecificOutput: {
         hookEventName: input.hook_event_name,
@@ -163,157 +119,24 @@ export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): 
   };
 }
 
-/**
- * Strip leading env var assignments and `env`/`command` prefixes from a
- * command so the primary executable is visible for exclusion checks.
- * Handles quoted values: `GIT_SSH_COMMAND='ssh -i key' git fetch` → `git fetch`.
- */
-function stripEnvPrefixes(command: string): string {
-  // Match repeated groups of:
-  //   ENV_VAR=value   (value is \S+ or "..." or '...')
-  //   env             (bare env prefix)
-  //   command         (command bypass)
-  return command.replace(
-    /^((?:env\s+|command\s+)?(?:(?:[A-Za-z_]\w*=(?:[^\s'"\\]+|"[^"]*"|'[^']*'))\s+|env\s+|command\s+))*/,
-    ''
-  );
-}
-
-/**
- * Inject output limiting parameters into tool inputs
- * Returns modified input if changes were made, null otherwise
- */
-function limitToolInput(
+function injectReadOrGrepLimit(
   toolName: string,
   toolInput: unknown,
-  config: OutputLimiterConfig,
-  _logger: Logger
+  config: OutputLimiterConfig
 ): Record<string, unknown> | null {
   const input = toolInput as Record<string, unknown>;
 
   switch (toolName) {
-    case 'Bash': {
-      // Smart output limiting: capture both start and end of output
-      const command = input.command as string | undefined;
-      if (!command) return null;
-
-      // Skip background commands — the wrapper captures output to a temp file
-      // and only prints it after the command exits, which breaks streaming for
-      // long-lived background processes (dev servers, watchers, etc.).
-      if (input.run_in_background === true) {
-        return null;
-      }
-
-      // Skip shell-backgrounded commands (any `&` that's not part of `&&`,
-      // `>&`, `<&`, or `&>`). These run asynchronously and the wrapper would
-      // cat/remove the temp file before the background process finishes.
-      // Quoted strings are stripped first so `&` inside URLs or grep patterns
-      // (e.g. `curl 'https://host?a=1&b=2'`) doesn't trigger a false positive.
-      const withoutQuotes = command
-        .replace(/'[^']*'/g, "''")
-        .replace(/"[^"]*"/g, '""')
-        .replace(/`[^`]*`/g, '``');
-      if (withoutQuotes.replace(/&&|>&|<&|&>/g, '').includes('&')) {
-        return null;
-      }
-
-      // Skip simple commands that are unlikely to produce large output.
-      // ls is NOT skipped because `ls -R` or `ls node_modules` can produce
-      // thousands of lines. echo is NOT skipped because command substitution
-      // (`echo "$(cat huge.log)"`) can expand to large output.
-      const simpleCommands = /^(pwd|which|whoami)$/;
-      if (simpleCommands.test(command.trim())) {
-        return null;
-      }
-
-      // Skip pure directory-changing commands (no compound operators). `cd
-      // <dir>` inside a subshell does not change the SDK's persistent cwd.
-      // Compound commands like `cd pkg && bun test` or `cd pkg\nbun test` are
-      // still wrapped because the trailing command produces output.
-      const trimmed = command.trim();
-      if (/^cd(\s|$)/.test(trimmed) && !/[;&|\n]/.test(trimmed)) {
-        return null;
-      }
-
-      // Skip commands whose primary executable is explicitly excluded by the
-      // user (e.g. via outputLimiter.bash.excludedCommandPrefixes, which may
-      // be populated from sandbox.excludedCommands to preserve command-level
-      // sandbox exclusions for commands like `git`). Only skip when the
-      // command is a single invocation — a compound command like
-      // `git status; cat huge.log` has a trailing non-excluded segment.
-      const effectiveCommand = stripEnvPrefixes(trimmed);
-      // Check for compound operators outside quoted strings so commands like
-      // `git push origin 'HEAD:refs/heads/foo;bar'` are still recognised as
-      // single git invocations.
-      const effectiveNoQuotes = effectiveCommand
-        .replace(/'[^']*'/g, "''")
-        .replace(/"[^"]*"/g, '""')
-        .replace(/`[^`]*`/g, '``');
-      if (!/[;&|\n]/.test(effectiveNoQuotes)) {
-        for (const prefix of config.bash.excludedCommandPrefixes) {
-          if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
-            return null;
-          }
-        }
-      }
-
-      const headLines = config.bash.headLines;
-      const tailLines = config.bash.tailLines;
-      // Byte caps enforce a hard limit even when output has few but very long
-      // lines (minified JSON, base64, \r-progress streams).
-      const headBytes = headLines * 200;
-      const tailBytes = tailLines * 200;
-      const maxBytes = headBytes + tailBytes;
-
-      // Create smart truncation command:
-      //
-      // A subshell `(...)` is used so that `exit` and `set -e` inside the
-      // user command only terminate the subshell, not the wrapper shell.
-      // This ensures the cat/head/tail/cleanup path always runs.
-      //
-      // To preserve cwd changes (which a subshell would normally discard),
-      // the subshell writes its final `pwd` to a temp file. After truncation,
-      // the wrapper replays the cwd change in the parent shell with `cd`.
-      // If the command calls `exit` early, `pwd` never runs and the cwd file
-      // is empty — matching the behavior of the unwrapped command.
-      //
-      // stderr is always captured: the subshell redirects both streams into
-      // the temp file (`> "$tmpfile" 2>&1`). Commands that already pipe
-      // stdout through `| head` are still wrapped because their stderr stream
-      // remains uncapped without the wrapper.
-      //
-      // Known limitation: if the SDK kills the wrapper on timeout before the
-      // cat/head/tail segment runs, partial output in the temp file is lost.
-      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\n__exit=$?\npwd >| "$cwdfile" 2>/dev/null\nexit $__exit\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
-
-      return {
-        ...input,
-        command: limitedCommand,
-        description: `${input.description || 'Execute command'} (output: first ${headLines} + last ${tailLines} lines)`,
-      };
-    }
-
     case 'Read': {
       const maxLines = config.read.maxLines;
-
-      // If an explicit limit is already within the cap (and not 0 which the
-      // SDK treats as unlimited for some tools), leave it alone.
       if (typeof input.limit === 'number' && input.limit > 0 && input.limit <= maxLines) {
         return null;
       }
-
-      // Otherwise inject or clamp to the configured cap.
-      return {
-        ...input,
-        limit: maxLines,
-      };
+      return { ...input, limit: maxLines };
     }
 
     case 'Grep': {
       const maxMatches = config.grep.maxMatches;
-
-      // head_limit: 0 means unlimited in the SDK, so treat it as uncapped.
-      // Only skip when the explicit value is positive and within the cap.
       if (
         typeof input.head_limit === 'number' &&
         input.head_limit > 0 &&
@@ -321,15 +144,74 @@ function limitToolInput(
       ) {
         return null;
       }
-
-      return {
-        ...input,
-        head_limit: maxMatches,
-      };
+      return { ...input, head_limit: maxMatches };
     }
 
     default:
-      // No limiting strategy for this tool
       return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// PostToolUse hook: truncate large Bash output via updatedToolOutput
+// ---------------------------------------------------------------------------
+
+export function createOutputLimiterPostHook(config: OutputLimiterConfigInput = {}): HookCallback {
+  const finalConfig = resolveConfig(config);
+
+  return async (input) => {
+    if (!finalConfig.enabled) return {};
+    if (input.hook_event_name !== 'PostToolUse') return {};
+
+    const postInput = input as PostToolUseHookInput;
+    const { tool_name, tool_response } = postInput;
+
+    if (tool_name !== 'Bash') return {};
+
+    const response = tool_response as { stdout?: string; stderr?: string } | null;
+    if (!response || typeof response !== 'object') return {};
+
+    const stdout = typeof response.stdout === 'string' ? response.stdout : '';
+    const stderr = typeof response.stderr === 'string' ? response.stderr : '';
+
+    const headLines = finalConfig.bash.headLines;
+    const tailLines = finalConfig.bash.tailLines;
+    const maxBytes = (headLines + tailLines) * 200;
+
+    const stdoutLines = stdout.split('\n');
+    const stderrLines = stderr.split('\n');
+    const totalLines = stdoutLines.length + stderrLines.length;
+    const totalBytes = stdout.length + stderr.length;
+
+    if (totalLines <= headLines + tailLines && totalBytes <= maxBytes) {
+      return {}; // Within limits
+    }
+
+    const truncated: Record<string, unknown> = { ...response };
+    truncated.stdout = truncateOutput(stdout, headLines, tailLines);
+    truncated.stderr = truncateOutput(stderr, headLines, tailLines);
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: input.hook_event_name,
+        updatedToolOutput: truncated,
+      },
+    };
+  };
+}
+
+/**
+ * Truncate a string to the first `headLines` + last `tailLines` lines.
+ * If the string has fewer lines than the threshold, it is returned unchanged.
+ */
+function truncateOutput(str: string, headLines: number, tailLines: number): string {
+  if (!str) return str;
+  const lines = str.split('\n');
+  if (lines.length <= headLines + tailLines) return str;
+
+  const head = lines.slice(0, headLines).join('\n');
+  const tail = lines.slice(-tailLines).join('\n');
+  const omitted = lines.length - headLines - tailLines;
+
+  return `${head}\n\n... [Truncated ${omitted} lines — showing first ${headLines} and last ${tailLines} lines] ...\n\n${tail}`;
 }

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -147,16 +147,16 @@ export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): 
       return {};
     }
 
-    // Return the mutated input with permissionDecision: 'allow'. The SDK
+    // Return the mutated input with permissionDecision: 'ask'. The SDK
     // requires a permissionDecision for updatedInput to be reliably applied.
-    // NeoKai defaults to bypassPermissions where 'allow' is a no-op; in
-    // restrictive modes this auto-approves the call, which is an accepted
-    // trade-off — the alternative is the limiter's mutations being silently
-    // dropped and large outputs running uncapped.
+    // 'ask' routes through the normal permission flow (canUseTool / prompt)
+    // so restrictive modes (acceptEdits, dontAsk, etc.) still prompt the user.
+    // In bypassPermissions mode (NeoKai default), 'ask' is a no-op — the SDK
+    // skips all prompts regardless.
     return {
       hookSpecificOutput: {
         hookEventName: input.hook_event_name,
-        permissionDecision: 'allow' as const,
+        permissionDecision: 'ask' as const,
         updatedInput: modifiedInput,
       },
     };

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -173,14 +173,24 @@ function limitToolInput(
       }
 
       // Skip simple commands that are unlikely to produce large output
-      // (pwd, cd, echo simple strings, etc.)
-      const simpleCommands = /^(pwd|cd|echo\s+"[^"]{0,50}"|ls(\s+-\w+)?(\s+\S+)?|which|whoami)$/;
+      // (pwd, echo simple strings, ls, which, whoami).
+      const simpleCommands = /^(pwd|echo\s+"[^"]{0,50}"|ls(\s+-\w+)?(\s+\S+)?|which|whoami)$/;
       if (simpleCommands.test(command.trim())) {
         return null;
       }
 
-      // Skip commands whose primary executable is sandbox-excluded (e.g. git),
-      // so command-level sandbox exclusions still see the original command.
+      // Skip directory-changing commands. `cd <dir>` inside a subshell does
+      // not change the SDK's persistent cwd, so wrapping it would silently
+      // break relative-path commands that follow.
+      if (/^cd(\s|$)/.test(command.trim())) {
+        return null;
+      }
+
+      // Skip commands whose primary executable is explicitly excluded by the
+      // user (e.g. via outputLimiter.bash.excludedCommandPrefixes). This is
+      // NOT auto-populated from sandbox.excludedCommands — those are about
+      // sandbox routing, not output limiting, and blanket-excluding git would
+      // leave high-volume commands like `git diff` uncapped.
       const trimmed = command.trim();
       for (const prefix of config.bash.excludedCommandPrefixes) {
         if (trimmed === prefix || trimmed.startsWith(`${prefix} `)) {
@@ -190,17 +200,20 @@ function limitToolInput(
 
       const headLines = config.bash.headLines;
       const tailLines = config.bash.tailLines;
+      // Secondary byte cap so a single very long line (minified JSON, base64,
+      // progress with \r) doesn't bypass the line-based threshold.
+      const maxBytes = (headLines + tailLines) * 200;
 
       // Create smart truncation command:
       // 1. Save stdout AND stderr to temp file, preserving the original exit status.
-      // 2. If output exceeds limit: show first N + truncation message + last N.
+      // 2. If output exceeds the line OR byte limit: show first N + message + last N.
       // 3. Otherwise: show all output.
       // 4. Clean up temp file and exit with the original status.
       //
       // A newline is inserted before the closing `)` of the subshell so that
       // commands whose last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`)
       // keep their delimiter on its own line and are parsed correctly.
-      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ]; then head -n ${headLines} "$tmpfile"; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile"; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile"; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile"; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
 
       return {
         ...input,

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -62,7 +62,9 @@ const DEFAULT_CONFIG: OutputLimiterConfig = {
     maxLines: 1000,
   },
   grep: {
-    maxMatches: 500,
+    // Match the SDK's built-in default (250) so injecting head_limit never
+    // expands Grep output beyond what the SDK would have returned on its own.
+    maxMatches: 250,
   },
   excludeTools: [],
 };
@@ -167,6 +169,13 @@ function limitToolInput(
       const command = input.command as string | undefined;
       if (!command) return null;
 
+      // Skip background commands — the wrapper captures output to a temp file
+      // and only prints it after the command exits, which breaks streaming for
+      // long-lived background processes (dev servers, watchers, etc.).
+      if (input.run_in_background === true) {
+        return null;
+      }
+
       // Skip if already has head/tail limiting
       if (/\|\s*(head|tail)/.test(command)) {
         return null;
@@ -179,19 +188,19 @@ function limitToolInput(
         return null;
       }
 
-      // Skip directory-changing commands. `cd <dir>` inside a subshell does
-      // not change the SDK's persistent cwd, so wrapping it would silently
-      // break relative-path commands that follow.
-      if (/^cd(\s|$)/.test(command.trim())) {
+      // Skip pure directory-changing commands (no compound operators). `cd
+      // <dir>` inside a subshell does not change the SDK's persistent cwd.
+      // Compound commands like `cd pkg && bun test` are still wrapped because
+      // the trailing command produces output.
+      const trimmed = command.trim();
+      if (/^cd(\s|$)/.test(trimmed) && !/[;&|]/.test(trimmed)) {
         return null;
       }
 
       // Skip commands whose primary executable is explicitly excluded by the
-      // user (e.g. via outputLimiter.bash.excludedCommandPrefixes). This is
-      // NOT auto-populated from sandbox.excludedCommands — those are about
-      // sandbox routing, not output limiting, and blanket-excluding git would
-      // leave high-volume commands like `git diff` uncapped.
-      const trimmed = command.trim();
+      // user (e.g. via outputLimiter.bash.excludedCommandPrefixes, which may
+      // be populated from sandbox.excludedCommands to preserve command-level
+      // sandbox exclusions for commands like `git`).
       for (const prefix of config.bash.excludedCommandPrefixes) {
         if (trimmed === prefix || trimmed.startsWith(`${prefix} `)) {
           return null;
@@ -200,20 +209,24 @@ function limitToolInput(
 
       const headLines = config.bash.headLines;
       const tailLines = config.bash.tailLines;
-      // Secondary byte cap so a single very long line (minified JSON, base64,
-      // progress with \r) doesn't bypass the line-based threshold.
-      const maxBytes = (headLines + tailLines) * 200;
+      // Byte caps enforce a hard limit even when output has few but very long
+      // lines (minified JSON, base64, \r-progress streams).
+      const headBytes = headLines * 200;
+      const tailBytes = tailLines * 200;
+      const maxBytes = headBytes + tailBytes;
 
       // Create smart truncation command:
       // 1. Save stdout AND stderr to temp file, preserving the original exit status.
-      // 2. If output exceeds the line OR byte limit: show first N + message + last N.
+      // 2. If output exceeds the line OR byte limit: show first N + message + last N,
+      //    piping each through head -c / tail -c to enforce the byte cap on
+      //    individual long lines.
       // 3. Otherwise: show all output.
       // 4. Clean up temp file and exit with the original status.
       //
       // A newline is inserted before the closing `)` of the subshell so that
       // commands whose last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`)
       // keep their delimiter on its own line and are parsed correctly.
-      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile"; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile"; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
 
       return {
         ...input,

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -44,6 +44,8 @@ export interface OutputLimiterConfigInput {
   };
   read?: {
     maxLines?: number;
+    /** @deprecated Use maxLines instead. Legacy char-based limit from the pre-wiring schema. */
+    maxChars?: number;
   };
   grep?: {
     maxMatches?: number;
@@ -79,7 +81,13 @@ export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimit
         input.bash?.excludedCommandPrefixes ?? DEFAULT_CONFIG.bash.excludedCommandPrefixes,
     },
     read: {
-      maxLines: input.read?.maxLines ?? DEFAULT_CONFIG.read.maxLines,
+      // Prefer maxLines; fall back to legacy maxChars (converted to lines at
+      // ~50 chars/line) so upgraded installations don't silently lose their cap.
+      maxLines:
+        input.read?.maxLines ??
+        (input.read?.maxChars !== undefined
+          ? Math.floor(input.read.maxChars / 50)
+          : DEFAULT_CONFIG.read.maxLines),
     },
     grep: {
       maxMatches: input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches,
@@ -176,14 +184,17 @@ function limitToolInput(
         return null;
       }
 
-      // Skip if already has head/tail limiting
-      if (/\|\s*(head|tail)/.test(command)) {
+      // Skip if already has head/tail limiting — but only when there are no
+      // compound operators (`;`, `&&`, `||`). A compound command like
+      // `grep foo | head; cat huge.log` has an unbounded trailing segment.
+      if (/\|\s*(head|tail)/.test(command) && !/;\s|&&|\|\|/.test(command)) {
         return null;
       }
 
       // Skip simple commands that are unlikely to produce large output
-      // (pwd, echo simple strings, ls, which, whoami).
-      const simpleCommands = /^(pwd|echo\s+"[^"]{0,50}"|ls(\s+-\w+)?(\s+\S+)?|which|whoami)$/;
+      // (pwd, echo simple strings, which, whoami). ls is NOT skipped because
+      // `ls -R` or `ls node_modules` can produce thousands of lines.
+      const simpleCommands = /^(pwd|echo\s+"[^"]{0,50}"|which|whoami)$/;
       if (simpleCommands.test(command.trim())) {
         return null;
       }

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -246,15 +246,17 @@ function limitToolInput(
       // 3. Otherwise: show all output.
       // 4. Clean up temp file and exit with the original status.
       //
+      // A command group `{ ... }` is used instead of a subshell `(...)` so that
+      // side effects like `cd` persist to the SDK's shell — wrapping
+      // `cd pkg && bun test` in a subshell would leave the session cwd unchanged.
+      //
+      // A newline is inserted before the closing `}` so that commands whose
+      // last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`) keep their
+      // delimiter on its own line and are parsed correctly.
+      //
       // Known limitation: if the SDK kills the wrapper on timeout before the
       // cat/head/tail segment runs, partial output in the temp file is lost.
-      // This is an accepted trade-off — the primary goal is preventing context
-      // overflow, not preserving timeout diagnostics.
-      //
-      // A newline is inserted before the closing `)` of the subshell so that
-      // commands whose last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`)
-      // keep their delimiter on its own line and are parsed correctly.
-      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); {\n${command}\n} > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
 
       return {
         ...input,
@@ -264,13 +266,14 @@ function limitToolInput(
     }
 
     case 'Read': {
-      // Inject limit parameter if not present
-      if (typeof input.limit === 'number') {
-        return null; // Already has limit
-      }
-
       const maxLines = config.read.maxLines;
 
+      // If an explicit limit is already within the cap, leave it alone.
+      if (typeof input.limit === 'number' && input.limit <= maxLines) {
+        return null;
+      }
+
+      // Otherwise inject or clamp to the configured cap.
       return {
         ...input,
         limit: maxLines,
@@ -278,12 +281,12 @@ function limitToolInput(
     }
 
     case 'Grep': {
-      // Inject head_limit parameter if not present
-      if (typeof input.head_limit === 'number') {
-        return null; // Already has limit
-      }
-
       const maxMatches = config.grep.maxMatches;
+
+      // If an explicit head_limit is already within the cap, leave it alone.
+      if (typeof input.head_limit === 'number' && input.head_limit <= maxMatches) {
+        return null;
+      }
 
       return {
         ...input,

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -112,7 +112,7 @@ export function createOutputLimiterPreHook(config: OutputLimiterConfigInput = {}
     return {
       hookSpecificOutput: {
         hookEventName: input.hook_event_name,
-        permissionDecision: 'ask' as const,
+        permissionDecision: 'allow' as const,
         updatedInput: modifiedInput,
       },
     };
@@ -167,6 +167,7 @@ export function createOutputLimiterPostHook(config: OutputLimiterConfigInput = {
     const { tool_name, tool_response } = postInput;
 
     if (tool_name !== 'Bash') return {};
+    if (finalConfig.excludeTools.includes(tool_name)) return {};
 
     const response = tool_response as { stdout?: string; stderr?: string } | null;
     if (!response || typeof response !== 'object') return {};
@@ -178,18 +179,21 @@ export function createOutputLimiterPostHook(config: OutputLimiterConfigInput = {
     const tailLines = finalConfig.bash.tailLines;
     const maxBytes = (headLines + tailLines) * 200;
 
-    const stdoutLines = stdout.split('\n');
-    const stderrLines = stderr.split('\n');
-    const totalLines = stdoutLines.length + stderrLines.length;
+    const totalLines = stdout.split('\n').length + stderr.split('\n').length;
     const totalBytes = stdout.length + stderr.length;
 
     if (totalLines <= headLines + tailLines && totalBytes <= maxBytes) {
       return {}; // Within limits
     }
 
+    // Split the line budget across stdout and stderr proportionally so the
+    // combined output stays within the configured cap.
+    const stdoutTruncated = truncateOutput(stdout, headLines, tailLines, maxBytes);
+    const stderrTruncated = truncateOutput(stderr, headLines, tailLines, maxBytes);
+
     const truncated: Record<string, unknown> = { ...response };
-    truncated.stdout = truncateOutput(stdout, headLines, tailLines);
-    truncated.stderr = truncateOutput(stderr, headLines, tailLines);
+    truncated.stdout = stdoutTruncated;
+    truncated.stderr = stderrTruncated;
 
     return {
       hookSpecificOutput: {
@@ -202,16 +206,32 @@ export function createOutputLimiterPostHook(config: OutputLimiterConfigInput = {
 
 /**
  * Truncate a string to the first `headLines` + last `tailLines` lines.
- * If the string has fewer lines than the threshold, it is returned unchanged.
+ * Also enforces a byte cap for strings with very long individual lines.
+ * Returns the original string if within both limits.
  */
-function truncateOutput(str: string, headLines: number, tailLines: number): string {
+function truncateOutput(
+  str: string,
+  headLines: number,
+  tailLines: number,
+  maxBytes: number
+): string {
   if (!str) return str;
+
+  // Byte cap for very long single lines (minified JSON, base64).
+  if (str.length > maxBytes) {
+    const halfBytes = Math.floor(maxBytes / 2);
+    return `${str.slice(0, halfBytes)}\n\n... [Truncated ${str.length - maxBytes} bytes] ...\n\n${str.slice(-halfBytes)}`;
+  }
+
   const lines = str.split('\n');
-  if (lines.length <= headLines + tailLines) return str;
+  const threshold = headLines + tailLines;
+  if (lines.length <= threshold) return str;
 
   const head = lines.slice(0, headLines).join('\n');
-  const tail = lines.slice(-tailLines).join('\n');
+  const tail = tailLines > 0 ? lines.slice(-tailLines).join('\n') : '';
   const omitted = lines.length - headLines - tailLines;
 
-  return `${head}\n\n... [Truncated ${omitted} lines — showing first ${headLines} and last ${tailLines} lines] ...\n\n${tail}`;
+  return tail
+    ? `${head}\n\n... [Truncated ${omitted} lines — showing first ${headLines} and last ${tailLines} lines] ...\n\n${tail}`
+    : `${head}\n\n... [Truncated ${omitted} lines — showing first ${headLines} lines] ...`;
 }

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -20,35 +20,33 @@ interface OutputLimiterConfig {
   bash: {
     headLines: number;
     tailLines: number;
+    // Command prefixes (e.g. ['git']) that should not be wrapped, so
+    // sandbox command-level exclusions still recognise the original tool.
+    excludedCommandPrefixes: string[];
   };
   read: {
-    maxChars: number;
+    maxLines: number;
   };
   grep: {
     maxMatches: number;
-  };
-  glob: {
-    maxFiles: number;
   };
   excludeTools: string[];
 }
 
 // Input shape: every nested value may be partial because global settings
 // can be updated one field at a time (e.g. only bash.headLines).
-interface OutputLimiterConfigInput {
+export interface OutputLimiterConfigInput {
   enabled?: boolean;
   bash?: {
     headLines?: number;
     tailLines?: number;
+    excludedCommandPrefixes?: string[];
   };
   read?: {
-    maxChars?: number;
+    maxLines?: number;
   };
   grep?: {
     maxMatches?: number;
-  };
-  glob?: {
-    maxFiles?: number;
   };
   excludeTools?: string[];
 }
@@ -58,34 +56,31 @@ const DEFAULT_CONFIG: OutputLimiterConfig = {
   bash: {
     headLines: 100,
     tailLines: 200,
+    excludedCommandPrefixes: [],
   },
   read: {
-    maxChars: 50000,
+    maxLines: 1000,
   },
   grep: {
     maxMatches: 500,
   },
-  glob: {
-    maxFiles: 1000,
-  },
   excludeTools: [],
 };
 
-function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimiterConfig {
+export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimiterConfig {
   return {
     enabled: input.enabled ?? DEFAULT_CONFIG.enabled,
     bash: {
       headLines: input.bash?.headLines ?? DEFAULT_CONFIG.bash.headLines,
       tailLines: input.bash?.tailLines ?? DEFAULT_CONFIG.bash.tailLines,
+      excludedCommandPrefixes:
+        input.bash?.excludedCommandPrefixes ?? DEFAULT_CONFIG.bash.excludedCommandPrefixes,
     },
     read: {
-      maxChars: input.read?.maxChars ?? DEFAULT_CONFIG.read.maxChars,
+      maxLines: input.read?.maxLines ?? DEFAULT_CONFIG.read.maxLines,
     },
     grep: {
       maxMatches: input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches,
-    },
-    glob: {
-      maxFiles: input.glob?.maxFiles ?? DEFAULT_CONFIG.glob.maxFiles,
     },
     excludeTools: input.excludeTools ?? DEFAULT_CONFIG.excludeTools,
   };
@@ -102,7 +97,7 @@ function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimiterConfi
  * ```typescript
  * const hook = createOutputLimiterHook({
  *   enabled: true,
- *   limits: { BASH_MAX_LINES: 500 }
+ *   bash: { headLines: 100, tailLines: 200 },
  * });
  *
  * const options = {
@@ -142,11 +137,12 @@ export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): 
       return {};
     }
 
-    // Return modified input with allow decision
+    // Return only the input mutation. We intentionally do NOT emit a
+    // permissionDecision here; output limiting should not grant permission
+    // on its own in restrictive permission modes.
     return {
       hookSpecificOutput: {
         hookEventName: input.hook_event_name,
-        permissionDecision: 'allow' as const,
         updatedInput: modifiedInput,
       },
     };
@@ -183,15 +179,28 @@ function limitToolInput(
         return null;
       }
 
+      // Skip commands whose primary executable is sandbox-excluded (e.g. git),
+      // so command-level sandbox exclusions still see the original command.
+      const trimmed = command.trim();
+      for (const prefix of config.bash.excludedCommandPrefixes) {
+        if (trimmed === prefix || trimmed.startsWith(`${prefix} `)) {
+          return null;
+        }
+      }
+
       const headLines = config.bash.headLines;
       const tailLines = config.bash.tailLines;
 
       // Create smart truncation command:
-      // 1. Save output to temp file
-      // 2. If output exceeds limit: show first N + truncation message + last N
-      // 3. Otherwise: show all output
-      // 4. Clean up temp file
-      const limitedCommand = `tmpfile=$(mktemp); (${command}) 2>&1 > "$tmpfile"; total_lines=$(wc -l < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ]; then head -n ${headLines} "$tmpfile"; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile"; else cat "$tmpfile"; fi; rm -f "$tmpfile"`;
+      // 1. Save stdout AND stderr to temp file, preserving the original exit status.
+      // 2. If output exceeds limit: show first N + truncation message + last N.
+      // 3. Otherwise: show all output.
+      // 4. Clean up temp file and exit with the original status.
+      //
+      // A newline is inserted before the closing `)` of the subshell so that
+      // commands whose last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`)
+      // keep their delimiter on its own line and are parsed correctly.
+      const limitedCommand = `tmpfile=$(mktemp); (\n${command}\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ]; then head -n ${headLines} "$tmpfile"; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile"; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
 
       return {
         ...input,
@@ -206,12 +215,11 @@ function limitToolInput(
         return null; // Already has limit
       }
 
-      const maxChars = config.read.maxChars;
+      const maxLines = config.read.maxLines;
 
       return {
         ...input,
-        // Convert char limit to line limit (assume ~50 chars per line)
-        limit: Math.floor(maxChars / 50),
+        limit: maxLines,
       };
     }
 
@@ -226,22 +234,6 @@ function limitToolInput(
       return {
         ...input,
         head_limit: maxMatches,
-      };
-    }
-
-    case 'Glob': {
-      // Glob can return huge lists of files
-      // Add a reasonable limit if not present
-      const head_limit = input.head_limit as number | undefined;
-      if (typeof head_limit === 'number') {
-        return null;
-      }
-
-      const maxFiles = config.glob.maxFiles;
-
-      return {
-        ...input,
-        head_limit: maxFiles,
       };
     }
 

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -147,12 +147,16 @@ export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): 
       return {};
     }
 
-    // Return only the input mutation. We intentionally do NOT emit a
-    // permissionDecision here; output limiting should not grant permission
-    // on its own in restrictive permission modes.
+    // Return the mutated input with permissionDecision: 'allow'. The SDK
+    // requires a permissionDecision for updatedInput to be reliably applied.
+    // NeoKai defaults to bypassPermissions where 'allow' is a no-op; in
+    // restrictive modes this auto-approves the call, which is an accepted
+    // trade-off — the alternative is the limiter's mutations being silently
+    // dropped and large outputs running uncapped.
     return {
       hookSpecificOutput: {
         hookEventName: input.hook_event_name,
+        permissionDecision: 'allow' as const,
         updatedInput: modifiedInput,
       },
     };
@@ -185,9 +189,10 @@ function limitToolInput(
       }
 
       // Skip if already has head/tail limiting — but only when there are no
-      // compound operators (`;`, `&&`, `||`). A compound command like
-      // `grep foo | head; cat huge.log` has an unbounded trailing segment.
-      if (/\|\s*(head|tail)/.test(command) && !/;\s|&&|\|\|/.test(command)) {
+      // compound operators (`;`, `&&`, `||`, newline). A compound command like
+      // `grep foo | head; cat huge.log` or `grep | head\ncat huge.log` has an
+      // unbounded trailing segment.
+      if (/\|\s*(head|tail)/.test(command) && !/;\s|&&|\|\||\n/.test(command)) {
         return null;
       }
 
@@ -233,6 +238,11 @@ function limitToolInput(
       //    individual long lines.
       // 3. Otherwise: show all output.
       // 4. Clean up temp file and exit with the original status.
+      //
+      // Known limitation: if the SDK kills the wrapper on timeout before the
+      // cat/head/tail segment runs, partial output in the temp file is lost.
+      // This is an accepted trade-off — the primary goal is preventing context
+      // overflow, not preserving timeout diagnostics.
       //
       // A newline is inserted before the closing `)` of the subshell so that
       // commands whose last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`)

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -164,6 +164,22 @@ export function createOutputLimiterHook(config: OutputLimiterConfigInput = {}): 
 }
 
 /**
+ * Strip leading env var assignments and `env`/`command` prefixes from a
+ * command so the primary executable is visible for exclusion checks.
+ * Handles quoted values: `GIT_SSH_COMMAND='ssh -i key' git fetch` → `git fetch`.
+ */
+function stripEnvPrefixes(command: string): string {
+  // Match repeated groups of:
+  //   ENV_VAR=value   (value is \S+ or "..." or '...')
+  //   env             (bare env prefix)
+  //   command         (command bypass)
+  return command.replace(
+    /^((?:env\s+|command\s+)?(?:(?:[A-Za-z_]\w*=(?:[^\s'"\\]+|"[^"]*"|'[^']*'))\s+|env\s+|command\s+))*/,
+    ''
+  );
+}
+
+/**
  * Inject output limiting parameters into tool inputs
  * Returns modified input if changes were made, null otherwise
  */
@@ -188,19 +204,11 @@ function limitToolInput(
         return null;
       }
 
-      // Skip if already has head/tail limiting — but only when there are no
-      // compound operators (`;`, `&&`, `||`, newline). A compound command like
-      // `grep foo | head; cat huge.log` or `grep | head\ncat huge.log` has an
-      // unbounded trailing segment. Semicolons are matched regardless of
-      // trailing whitespace (`head;cat` is still compound).
-      if (/\|\s*(head|tail)/.test(command) && !/;|&&|\|\||\n/.test(command)) {
-        return null;
-      }
-
-      // Skip simple commands that are unlikely to produce large output
-      // (pwd, echo simple strings, which, whoami). ls is NOT skipped because
-      // `ls -R` or `ls node_modules` can produce thousands of lines.
-      const simpleCommands = /^(pwd|echo\s+"[^"]{0,50}"|which|whoami)$/;
+      // Skip simple commands that are unlikely to produce large output.
+      // ls is NOT skipped because `ls -R` or `ls node_modules` can produce
+      // thousands of lines. echo is NOT skipped because command substitution
+      // (`echo "$(cat huge.log)"`) can expand to large output.
+      const simpleCommands = /^(pwd|which|whoami)$/;
       if (simpleCommands.test(command.trim())) {
         return null;
       }
@@ -217,13 +225,8 @@ function limitToolInput(
       // Skip commands whose primary executable is explicitly excluded by the
       // user (e.g. via outputLimiter.bash.excludedCommandPrefixes, which may
       // be populated from sandbox.excludedCommands to preserve command-level
-      // sandbox exclusions for commands like `git`). Strip leading env var
-      // assignments and `env`/`command` prefixes so `GIT_SSH_COMMAND=... git`
-      // and `env git` are still recognised.
-      const effectiveCommand = trimmed.replace(
-        /^((?:env\s+)?(?:[A-Za-z_]\w*=\S+\s+|command\s+))*/,
-        ''
-      );
+      // sandbox exclusions for commands like `git`).
+      const effectiveCommand = stripEnvPrefixes(trimmed);
       for (const prefix of config.bash.excludedCommandPrefixes) {
         if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
           return null;
@@ -239,24 +242,25 @@ function limitToolInput(
       const maxBytes = headBytes + tailBytes;
 
       // Create smart truncation command:
-      // 1. Save stdout AND stderr to temp file, preserving the original exit status.
-      // 2. If output exceeds the line OR byte limit: show first N + message + last N,
-      //    piping each through head -c / tail -c to enforce the byte cap on
-      //    individual long lines.
-      // 3. Otherwise: show all output.
-      // 4. Clean up temp file and exit with the original status.
       //
-      // A command group `{ ... }` is used instead of a subshell `(...)` so that
-      // side effects like `cd` persist to the SDK's shell — wrapping
-      // `cd pkg && bun test` in a subshell would leave the session cwd unchanged.
+      // A subshell `(...)` is used so that `exit` and `set -e` inside the
+      // user command only terminate the subshell, not the wrapper shell.
+      // This ensures the cat/head/tail/cleanup path always runs.
       //
-      // A newline is inserted before the closing `}` so that commands whose
-      // last line is a heredoc delimiter (e.g. `cat <<'EOF' … EOF`) keep their
-      // delimiter on its own line and are parsed correctly.
+      // To preserve cwd changes (which a subshell would normally discard),
+      // the subshell writes its final `pwd` to a temp file. After truncation,
+      // the wrapper replays the cwd change in the parent shell with `cd`.
+      // If the command calls `exit` early, `pwd` never runs and the cwd file
+      // is empty — matching the behavior of the unwrapped command.
+      //
+      // stderr is always captured: the subshell redirects both streams into
+      // the temp file (`> "$tmpfile" 2>&1`). Commands that already pipe
+      // stdout through `| head` are still wrapped because their stderr stream
+      // remains uncapped without the wrapper.
       //
       // Known limitation: if the SDK kills the wrapper on timeout before the
       // cat/head/tail segment runs, partial output in the temp file is lost.
-      const limitedCommand = `tmpfile=$(mktemp); {\n${command}\n} > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; rm -f "$tmpfile"; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\npwd > "$cwdfile" 2>/dev/null\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
 
       return {
         ...input,
@@ -268,8 +272,9 @@ function limitToolInput(
     case 'Read': {
       const maxLines = config.read.maxLines;
 
-      // If an explicit limit is already within the cap, leave it alone.
-      if (typeof input.limit === 'number' && input.limit <= maxLines) {
+      // If an explicit limit is already within the cap (and not 0 which the
+      // SDK treats as unlimited for some tools), leave it alone.
+      if (typeof input.limit === 'number' && input.limit > 0 && input.limit <= maxLines) {
         return null;
       }
 
@@ -283,8 +288,13 @@ function limitToolInput(
     case 'Grep': {
       const maxMatches = config.grep.maxMatches;
 
-      // If an explicit head_limit is already within the cap, leave it alone.
-      if (typeof input.head_limit === 'number' && input.head_limit <= maxMatches) {
+      // head_limit: 0 means unlimited in the SDK, so treat it as uncapped.
+      // Only skip when the explicit value is positive and within the cap.
+      if (
+        typeof input.head_limit === 'number' &&
+        input.head_limit > 0 &&
+        input.head_limit <= maxMatches
+      ) {
         return null;
       }
 

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -90,13 +90,7 @@ export function resolveConfig(input: OutputLimiterConfigInput = {}): OutputLimit
           : DEFAULT_CONFIG.read.maxLines),
     },
     grep: {
-      // Normalize the legacy default (500) to the new default (250) so
-      // upgraded databases don't double Grep output. Users who explicitly
-      // want a different value can set it to anything other than 500.
-      maxMatches:
-        input.grep?.maxMatches === 500
-          ? DEFAULT_CONFIG.grep.maxMatches
-          : (input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches),
+      maxMatches: input.grep?.maxMatches ?? DEFAULT_CONFIG.grep.maxMatches,
     },
     excludeTools: input.excludeTools ?? DEFAULT_CONFIG.excludeTools,
   };
@@ -248,7 +242,14 @@ function limitToolInput(
       // command is a single invocation — a compound command like
       // `git status; cat huge.log` has a trailing non-excluded segment.
       const effectiveCommand = stripEnvPrefixes(trimmed);
-      if (!/[;&|\n]/.test(effectiveCommand)) {
+      // Check for compound operators outside quoted strings so commands like
+      // `git push origin 'HEAD:refs/heads/foo;bar'` are still recognised as
+      // single git invocations.
+      const effectiveNoQuotes = effectiveCommand
+        .replace(/'[^']*'/g, "''")
+        .replace(/"[^"]*"/g, '""')
+        .replace(/`[^`]*`/g, '``');
+      if (!/[;&|\n]/.test(effectiveNoQuotes)) {
         for (const prefix of config.bash.excludedCommandPrefixes) {
           if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
             return null;
@@ -283,7 +284,7 @@ function limitToolInput(
       //
       // Known limitation: if the SDK kills the wrapper on timeout before the
       // cat/head/tail segment runs, partial output in the temp file is lost.
-      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\n__exit=$?\npwd > "$cwdfile" 2>/dev/null\nexit $__exit\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
+      const limitedCommand = `tmpfile=$(mktemp); cwdfile=$(mktemp); (\n${command}\n__exit=$?\npwd >| "$cwdfile" 2>/dev/null\nexit $__exit\n) > "$tmpfile" 2>&1; exit_code=$?; total_lines=$(wc -l < "$tmpfile"); total_bytes=$(wc -c < "$tmpfile"); if [ "$total_lines" -gt ${headLines + tailLines} ] || [ "$total_bytes" -gt ${maxBytes} ]; then head -n ${headLines} "$tmpfile" | head -c ${headBytes}; echo ""; echo "... [Truncated $(($total_lines - ${headLines + tailLines})) lines / $(($total_bytes - ${maxBytes})) bytes - showing first ${headLines} and last ${tailLines} lines] ..."; echo ""; tail -n ${tailLines} "$tmpfile" | tail -c ${tailBytes}; else cat "$tmpfile"; fi; newcwd=$(cat "$cwdfile" 2>/dev/null); rm -f "$tmpfile" "$cwdfile"; [ -n "$newcwd" ] && cd "$newcwd" 2>/dev/null; exit $exit_code`;
 
       return {
         ...input,

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -204,11 +204,11 @@ function limitToolInput(
         return null;
       }
 
-      // Skip shell-backgrounded commands (any `&` that's not part of `&&`).
-      // These run asynchronously and the wrapper would cat/remove the temp
-      // file before the background process finishes writing to it. Covers
-      // `cmd &`, `cmd & cleanup`, and `nohup cmd &`.
-      if (command.replace(/&&/g, '').includes('&')) {
+      // Skip shell-backgrounded commands (any `&` that's not part of `&&`,
+      // `>&`, `<&`, or `&>`). These run asynchronously and the wrapper would
+      // cat/remove the temp file before the background process finishes.
+      // Excludes fd redirects like `2>&1` and combined redirects like `&>`.
+      if (command.replace(/&&|>&|<&|&>/g, '').includes('&')) {
         return null;
       }
 

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -191,8 +191,9 @@ function limitToolInput(
       // Skip if already has head/tail limiting — but only when there are no
       // compound operators (`;`, `&&`, `||`, newline). A compound command like
       // `grep foo | head; cat huge.log` or `grep | head\ncat huge.log` has an
-      // unbounded trailing segment.
-      if (/\|\s*(head|tail)/.test(command) && !/;\s|&&|\|\||\n/.test(command)) {
+      // unbounded trailing segment. Semicolons are matched regardless of
+      // trailing whitespace (`head;cat` is still compound).
+      if (/\|\s*(head|tail)/.test(command) && !/;|&&|\|\||\n/.test(command)) {
         return null;
       }
 
@@ -216,9 +217,15 @@ function limitToolInput(
       // Skip commands whose primary executable is explicitly excluded by the
       // user (e.g. via outputLimiter.bash.excludedCommandPrefixes, which may
       // be populated from sandbox.excludedCommands to preserve command-level
-      // sandbox exclusions for commands like `git`).
+      // sandbox exclusions for commands like `git`). Strip leading env var
+      // assignments and `env`/`command` prefixes so `GIT_SSH_COMMAND=... git`
+      // and `env git` are still recognised.
+      const effectiveCommand = trimmed.replace(
+        /^((?:env\s+)?(?:[A-Za-z_]\w*=\S+\s+|command\s+))*/,
+        ''
+      );
       for (const prefix of config.bash.excludedCommandPrefixes) {
-        if (trimmed === prefix || trimmed.startsWith(`${prefix} `)) {
+        if (effectiveCommand === prefix || effectiveCommand.startsWith(`${prefix} `)) {
           return null;
         }
       }

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -204,11 +204,11 @@ function limitToolInput(
         return null;
       }
 
-      // Skip shell-backgrounded commands (trailing `&` that's not `&&`).
+      // Skip shell-backgrounded commands (any `&` that's not part of `&&`).
       // These run asynchronously and the wrapper would cat/remove the temp
-      // file before the background process finishes writing to it.
-      const trimmedCmd = command.trim();
-      if (trimmedCmd.endsWith('&') && !trimmedCmd.endsWith('&&')) {
+      // file before the background process finishes writing to it. Covers
+      // `cmd &`, `cmd & cleanup`, and `nohup cmd &`.
+      if (command.replace(/&&/g, '').includes('&')) {
         return null;
       }
 

--- a/packages/daemon/src/lib/agent/output-limiter-hook.ts
+++ b/packages/daemon/src/lib/agent/output-limiter-hook.ts
@@ -206,10 +206,10 @@ function limitToolInput(
 
       // Skip pure directory-changing commands (no compound operators). `cd
       // <dir>` inside a subshell does not change the SDK's persistent cwd.
-      // Compound commands like `cd pkg && bun test` are still wrapped because
-      // the trailing command produces output.
+      // Compound commands like `cd pkg && bun test` or `cd pkg\nbun test` are
+      // still wrapped because the trailing command produces output.
       const trimmed = command.trim();
-      if (/^cd(\s|$)/.test(trimmed) && !/[;&|]/.test(trimmed)) {
+      if (/^cd(\s|$)/.test(trimmed) && !/[;&|\n]/.test(trimmed)) {
         return null;
       }
 

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -63,7 +63,11 @@ import {
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
 import { createLoopDetectorHooks } from './loop-detector-hook';
-import { createOutputLimiterHook, resolveConfig } from './output-limiter-hook';
+import {
+  createOutputLimiterPostHook,
+  createOutputLimiterPreHook,
+  resolveConfig,
+} from './output-limiter-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 /**
@@ -1237,64 +1241,35 @@ CRITICAL RULES:
       }
     }
 
-    // Output limiter: cap the size of Bash/Read/Grep outputs before the
-    // tool runs. Loaded from global settings; defaults to enabled when
-    // settings include outputLimiter (matching DEFAULT_GLOBAL_SETTINGS), and
-    // stays off when settings omit the key entirely. The hook only mutates
-    // input and does not emit a permission decision.
-    //
-    // sandbox.excludedCommands (e.g. ['git']) are passed as
-    // bash.excludedCommandPrefixes so wrapping does not hide the original
-    // command from the sandbox's command-level exclusion classifier — git
-    // over SSH/LFS still bypasses the sandbox as intended. Only done when
-    // sandbox is actually enabled; in bypassPermissions mode the sandbox is
-    // inactive and all commands (including git) are wrapped for limiting.
-    //
-    // Note on loop detection: the loop detector runs BEFORE this hook, so its
-    // PreToolUse fingerprint uses the original command. The PostToolUse event
-    // sees the wrapped command. The streak-based deny path (consecutive
-    // identical calls) is unaffected because it keys on the original command
-    // in the pre hook. The Bash failure-aware deny path correlates pre/post
-    // keys, so its ring may not accumulate for wrapped Bash commands; this is
-    // an accepted trade-off — the streak path still catches dead loops.
+    // Output limiter (PreToolUse): inject limit parameters for Read and Grep
+    // so the tools fetch less data. Bash is NOT handled here — it is truncated
+    // post-execution via updatedToolOutput in the PostToolUse hook below.
     const globalSettings = this.ctx.settingsManager.getGlobalSettings();
     const outputLimiterSettings = globalSettings.outputLimiter;
-    if (outputLimiterSettings) {
-      const resolvedOutputLimiter = resolveConfig(outputLimiterSettings);
-      if (resolvedOutputLimiter.enabled) {
-        // Derive excludedCommands from the session sandbox config only — this
-        // is the same config the SDK receives via `sandbox: config.sandbox`.
-        // Falling back to global defaults would create a mismatch: the limiter
-        // would skip wrapping git while the SDK's sandbox (which only sees
-        // session config) would not exclude it.
-        const sessionSandbox = this.ctx.session.config.sandbox;
-        const sandboxEnabled = sessionSandbox?.enabled;
-        const sandboxExcluded = sandboxEnabled ? (sessionSandbox?.excludedCommands ?? []) : [];
-        // Merge user-configured limiter exclusions with sandbox exclusions
-        // instead of overwriting one with the other.
-        const userExcluded = outputLimiterSettings.bash?.excludedCommandPrefixes ?? [];
-        const excludedCommandPrefixes = [...new Set([...userExcluded, ...sandboxExcluded])];
-        preToolUse.push({
-          hooks: [
-            createOutputLimiterHook({
-              ...outputLimiterSettings,
-              bash: {
-                ...outputLimiterSettings.bash,
-                ...(excludedCommandPrefixes.length > 0 ? { excludedCommandPrefixes } : {}),
-              },
-            }),
-          ],
-        });
-      }
+    const outputLimiterEnabled =
+      outputLimiterSettings && resolveConfig(outputLimiterSettings).enabled;
+    if (outputLimiterEnabled) {
+      preToolUse.push({
+        hooks: [createOutputLimiterPreHook(outputLimiterSettings)],
+      });
     }
 
     if (preToolUse.length > 0) {
       hooks.PreToolUse = preToolUse;
     }
-    // PostToolUse + PostToolUseFailure observers feed the Bash detector's
-    // outcome ring. Installed unconditionally — they early-out on
-    // non-Bash tools and when bash.enabled is false.
-    hooks.PostToolUse = [{ hooks: [loopDetectorHooks.postToolUse] }];
+
+    // PostToolUse: loop detector (failure ring) + output limiter (Bash
+    // truncation via updatedToolOutput). Commands run unwrapped, so exit
+    // codes, heredocs, cwd, and sandbox behavior are all preserved.
+    const postHooks: NonNullable<Options['hooks']>['PostToolUse'] = [
+      { hooks: [loopDetectorHooks.postToolUse] },
+    ];
+    if (outputLimiterEnabled) {
+      postHooks.push({ hooks: [createOutputLimiterPostHook(outputLimiterSettings)] });
+    }
+    hooks.PostToolUse = postHooks;
+
+    // PostToolUseFailure observer feeds the Bash detector's outcome ring.
     hooks.PostToolUseFailure = [{ hooks: [loopDetectorHooks.postToolUseFailure] }];
     return hooks;
   }

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1264,16 +1264,20 @@ CRITICAL RULES:
       if (resolvedOutputLimiter.enabled) {
         const sessionSandbox = this.ctx.session.config.sandbox;
         const sandboxEnabled = sessionSandbox?.enabled ?? globalSettings.sandbox?.enabled;
-        const excludedCommandPrefixes = sandboxEnabled
-          ? (sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands)
-          : undefined;
+        const sandboxExcluded = sandboxEnabled
+          ? (sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands ?? [])
+          : [];
+        // Merge user-configured limiter exclusions with sandbox exclusions
+        // instead of overwriting one with the other.
+        const userExcluded = outputLimiterSettings.bash?.excludedCommandPrefixes ?? [];
+        const excludedCommandPrefixes = [...new Set([...userExcluded, ...sandboxExcluded])];
         preToolUse.push({
           hooks: [
             createOutputLimiterHook({
               ...outputLimiterSettings,
               bash: {
                 ...outputLimiterSettings.bash,
-                ...(excludedCommandPrefixes ? { excludedCommandPrefixes } : {}),
+                ...(excludedCommandPrefixes.length > 0 ? { excludedCommandPrefixes } : {}),
               },
             }),
           ],

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -63,6 +63,7 @@ import {
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
 import { createLoopDetectorHooks } from './loop-detector-hook';
+import { createOutputLimiterHook } from './output-limiter-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 /**
@@ -1175,8 +1176,15 @@ CRITICAL RULES:
    * The PostToolUse + PostToolUseFailure hooks observe Bash outcomes for
    * the failure-aware Bash dead-loop detector. The PreToolUse hook itself
    * filters internally on `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds` and the
-   * Bash sub-config. Tool guards from the workflow definition are appended
-   * on top of the PreToolUse chain.
+   * Bash sub-config.
+   *
+   * The output-limiter hook is added next when enabled in global settings;
+   * it mutates tool inputs (Bash/Read/Grep/Glob) to cap output size before
+   * the tool runs, preventing a single large output from overflowing the
+   * model context window.
+   *
+   * Tool guards from the workflow definition are appended on top of the
+   * PreToolUse chain.
    */
   private buildHooks(): Options['hooks'] {
     const hooks: NonNullable<Options['hooks']> = {};
@@ -1201,6 +1209,18 @@ CRITICAL RULES:
     preToolUse.push({
       hooks: [loopDetectorHooks.preToolUse],
     });
+
+    // Output limiter: cap the size of Bash/Read/Grep/Glob outputs before
+    // the tool runs. Loaded from global settings; only installed when
+    // explicitly enabled so existing sessions without the setting stay
+    // unchanged. The hook itself is a no-op for non-limited tools and for
+    // inputs that already specify limits.
+    const outputLimiterSettings = this.ctx.settingsManager.getGlobalSettings().outputLimiter;
+    if (outputLimiterSettings?.enabled) {
+      preToolUse.push({
+        hooks: [createOutputLimiterHook(outputLimiterSettings)],
+      });
+    }
 
     // Workflow tool guards (declarative deny/allow rules) layered on top.
     const guards = this.ctx.toolGuards;

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -63,7 +63,7 @@ import {
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
 import { createLoopDetectorHooks } from './loop-detector-hook';
-import { createOutputLimiterHook } from './output-limiter-hook';
+import { createOutputLimiterHook, resolveConfig } from './output-limiter-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 /**
@@ -1178,13 +1178,16 @@ CRITICAL RULES:
    * filters internally on `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds` and the
    * Bash sub-config.
    *
-   * The output-limiter hook is added next when enabled in global settings;
-   * it mutates tool inputs (Bash/Read/Grep/Glob) to cap output size before
-   * the tool runs, preventing a single large output from overflowing the
-   * model context window.
+   * Workflow tool guards (declarative deny/allow rules) run next so they
+   * evaluate the original tool input, before the output-limiter hook mutates
+   * Bash commands into a truncation wrapper.
    *
-   * Tool guards from the workflow definition are appended on top of the
-   * PreToolUse chain.
+   * The output-limiter hook is added last in the PreToolUse chain when
+   * enabled in global settings. It mutates Bash/Read/Grep inputs to cap
+   * output size before the tool runs, preventing a single large output from
+   * overflowing the model context window. It only mutates input and does
+   * not emit a permission decision, so it cannot bypass restrictive
+   * permission modes.
    */
   private buildHooks(): Options['hooks'] {
     const hooks: NonNullable<Options['hooks']> = {};
@@ -1210,19 +1213,9 @@ CRITICAL RULES:
       hooks: [loopDetectorHooks.preToolUse],
     });
 
-    // Output limiter: cap the size of Bash/Read/Grep/Glob outputs before
-    // the tool runs. Loaded from global settings; only installed when
-    // explicitly enabled so existing sessions without the setting stay
-    // unchanged. The hook itself is a no-op for non-limited tools and for
-    // inputs that already specify limits.
-    const outputLimiterSettings = this.ctx.settingsManager.getGlobalSettings().outputLimiter;
-    if (outputLimiterSettings?.enabled) {
-      preToolUse.push({
-        hooks: [createOutputLimiterHook(outputLimiterSettings)],
-      });
-    }
-
-    // Workflow tool guards (declarative deny/allow rules) layered on top.
+    // Workflow tool guards (declarative deny/allow rules). These run
+    // before the output-limiter mutation so regexes match the original
+    // command shape (e.g. `^rm\s+-rf`).
     const guards = this.ctx.toolGuards;
     if (guards?.length) {
       // Group guards by matcher (tool name) to create one matcher entry per tool.
@@ -1240,6 +1233,33 @@ CRITICAL RULES:
         preToolUse.push({
           matcher,
           hooks: matcherGuards.map(compileToolGuard),
+        });
+      }
+    }
+
+    // Output limiter: cap the size of Bash/Read/Grep outputs before the
+    // tool runs. Loaded from global settings; defaults to enabled when
+    // settings include outputLimiter (matching DEFAULT_GLOBAL_SETTINGS), and
+    // stays off when settings omit the key entirely. The hook only mutates
+    // input and does not emit a permission decision.
+    const globalSettings = this.ctx.settingsManager.getGlobalSettings();
+    const outputLimiterSettings = globalSettings.outputLimiter;
+    if (outputLimiterSettings) {
+      const resolvedOutputLimiter = resolveConfig(outputLimiterSettings);
+      if (resolvedOutputLimiter.enabled) {
+        const sessionSandbox = this.ctx.session.config.sandbox;
+        const excludedCommandPrefixes =
+          sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands;
+        preToolUse.push({
+          hooks: [
+            createOutputLimiterHook({
+              ...outputLimiterSettings,
+              bash: {
+                ...outputLimiterSettings.bash,
+                excludedCommandPrefixes,
+              },
+            }),
+          ],
         });
       }
     }

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1262,11 +1262,14 @@ CRITICAL RULES:
     if (outputLimiterSettings) {
       const resolvedOutputLimiter = resolveConfig(outputLimiterSettings);
       if (resolvedOutputLimiter.enabled) {
+        // Derive excludedCommands from the session sandbox config only — this
+        // is the same config the SDK receives via `sandbox: config.sandbox`.
+        // Falling back to global defaults would create a mismatch: the limiter
+        // would skip wrapping git while the SDK's sandbox (which only sees
+        // session config) would not exclude it.
         const sessionSandbox = this.ctx.session.config.sandbox;
-        const sandboxEnabled = sessionSandbox?.enabled ?? globalSettings.sandbox?.enabled;
-        const sandboxExcluded = sandboxEnabled
-          ? (sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands ?? [])
-          : [];
+        const sandboxEnabled = sessionSandbox?.enabled;
+        const sandboxExcluded = sandboxEnabled ? (sessionSandbox?.excludedCommands ?? []) : [];
         // Merge user-configured limiter exclusions with sandbox exclusions
         // instead of overwriting one with the other.
         const userExcluded = outputLimiterSettings.bash?.excludedCommandPrefixes ?? [];

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1243,12 +1243,12 @@ CRITICAL RULES:
     // stays off when settings omit the key entirely. The hook only mutates
     // input and does not emit a permission decision.
     //
-    // We do NOT auto-populate bash.excludedCommandPrefixes from
-    // sandbox.excludedCommands — those control sandbox routing, not output
-    // limiting, and blanket-excluding git would leave high-volume commands
-    // like `git diff` uncapped. Users who need to exclude specific commands
-    // from output limiting can set outputLimiter.bash.excludedCommandPrefixes
-    // explicitly.
+    // sandbox.excludedCommands (e.g. ['git']) are passed as
+    // bash.excludedCommandPrefixes so wrapping does not hide the original
+    // command from the sandbox's command-level exclusion classifier — git
+    // over SSH/LFS still bypasses the sandbox as intended. Only done when
+    // sandbox is actually enabled; in bypassPermissions mode the sandbox is
+    // inactive and all commands (including git) are wrapped for limiting.
     //
     // Note on loop detection: the loop detector runs BEFORE this hook, so its
     // PreToolUse fingerprint uses the original command. The PostToolUse event
@@ -1262,8 +1262,21 @@ CRITICAL RULES:
     if (outputLimiterSettings) {
       const resolvedOutputLimiter = resolveConfig(outputLimiterSettings);
       if (resolvedOutputLimiter.enabled) {
+        const sessionSandbox = this.ctx.session.config.sandbox;
+        const sandboxEnabled = sessionSandbox?.enabled ?? globalSettings.sandbox?.enabled;
+        const excludedCommandPrefixes = sandboxEnabled
+          ? (sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands)
+          : undefined;
         preToolUse.push({
-          hooks: [createOutputLimiterHook(outputLimiterSettings)],
+          hooks: [
+            createOutputLimiterHook({
+              ...outputLimiterSettings,
+              bash: {
+                ...outputLimiterSettings.bash,
+                ...(excludedCommandPrefixes ? { excludedCommandPrefixes } : {}),
+              },
+            }),
+          ],
         });
       }
     }

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1242,24 +1242,28 @@ CRITICAL RULES:
     // settings include outputLimiter (matching DEFAULT_GLOBAL_SETTINGS), and
     // stays off when settings omit the key entirely. The hook only mutates
     // input and does not emit a permission decision.
+    //
+    // We do NOT auto-populate bash.excludedCommandPrefixes from
+    // sandbox.excludedCommands — those control sandbox routing, not output
+    // limiting, and blanket-excluding git would leave high-volume commands
+    // like `git diff` uncapped. Users who need to exclude specific commands
+    // from output limiting can set outputLimiter.bash.excludedCommandPrefixes
+    // explicitly.
+    //
+    // Note on loop detection: the loop detector runs BEFORE this hook, so its
+    // PreToolUse fingerprint uses the original command. The PostToolUse event
+    // sees the wrapped command. The streak-based deny path (consecutive
+    // identical calls) is unaffected because it keys on the original command
+    // in the pre hook. The Bash failure-aware deny path correlates pre/post
+    // keys, so its ring may not accumulate for wrapped Bash commands; this is
+    // an accepted trade-off — the streak path still catches dead loops.
     const globalSettings = this.ctx.settingsManager.getGlobalSettings();
     const outputLimiterSettings = globalSettings.outputLimiter;
     if (outputLimiterSettings) {
       const resolvedOutputLimiter = resolveConfig(outputLimiterSettings);
       if (resolvedOutputLimiter.enabled) {
-        const sessionSandbox = this.ctx.session.config.sandbox;
-        const excludedCommandPrefixes =
-          sessionSandbox?.excludedCommands ?? globalSettings.sandbox?.excludedCommands;
         preToolUse.push({
-          hooks: [
-            createOutputLimiterHook({
-              ...outputLimiterSettings,
-              bash: {
-                ...outputLimiterSettings.bash,
-                excludedCommandPrefixes,
-              },
-            }),
-          ],
+          hooks: [createOutputLimiterHook(outputLimiterSettings)],
         });
       }
     }

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -27,7 +27,6 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      // Verify the command has smart truncation
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
         const updatedInput = (
           result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
@@ -37,27 +36,17 @@ describe('OutputLimiterHook', () => {
         expect(updatedInput.command).toContain('tail -n 200');
         expect(updatedInput.command).toContain('Truncated');
         expect(updatedInput.command).toContain('rm -f "$tmpfile"');
-
-        // Verify description
         expect(updatedInput.description).toContain('first 100 + last 200 lines');
       } else {
         throw new Error('Expected hookSpecificOutput in result');
       }
-
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-        },
-      });
     });
 
     it('should preserve the original exit status when wrapping Bash commands', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git diff HEAD~1',
-        },
+        tool_input: { command: 'git diff HEAD~1' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -67,15 +56,10 @@ describe('OutputLimiterHook', () => {
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as unknown as {
-            updatedInput: Record<string, unknown>;
-          }
-        ).updatedInput;
-        expect(updatedInput.command).toContain('exit_code=$?');
-        expect(updatedInput.command).toContain('exit $exit_code');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        expect(cmd).toContain('exit_code=$?');
+        expect(cmd).toContain('exit $exit_code');
       }
     });
 
@@ -83,9 +67,7 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git diff HEAD~1',
-        },
+        tool_input: { command: 'git diff HEAD~1' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -95,26 +77,17 @@ describe('OutputLimiterHook', () => {
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as unknown as {
-            updatedInput: Record<string, unknown>;
-          }
-        ).updatedInput;
-        // Redirect both stdout and stderr into the temp file, not stderr to original stdout.
-        expect(updatedInput.command).toContain('> "$tmpfile" 2>&1');
-        expect(updatedInput.command).not.toMatch(/\)\s*2>&1\s*>\s*"\$tmpfile"/);
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        expect(cmd).toContain('> "$tmpfile" 2>&1');
       }
     });
 
-    it('should not modify commands that already have head limiting', async () => {
+    it('should use a subshell to isolate exit/set -e from the wrapper', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git log | head -n 100',
-        },
+        tool_input: { command: 'echo before; set -e; false' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -123,16 +96,22 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toEqual({});
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        // Subshell so exit/set -e only kills the subshell, not the wrapper
+        expect(cmd).toContain('(\n');
+        expect(cmd).toContain('\n) > "$tmpfile" 2>&1');
+        // Cleanup runs after the subshell
+        expect(cmd).toContain('rm -f "$tmpfile"');
+      }
     });
 
-    it('should not modify short commands', async () => {
+    it('should capture and replay cwd changes from the subshell', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'pwd',
-        },
+        tool_input: { command: 'cd packages/daemon && bun test' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -141,16 +120,78 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toEqual({});
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        // Subshell writes pwd to cwdfile
+        expect(cmd).toContain('pwd > "$cwdfile"');
+        // Wrapper replays cwd after truncation
+        expect(cmd).toContain('newcwd=$(cat "$cwdfile"');
+        expect(cmd).toContain('cd "$newcwd"');
+      }
+    });
+
+    it('should wrap commands that already have head/tail (stderr still uncapped)', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'git log | head -n 100' },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      // No longer skipped — stderr from `git log` can still overflow
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
+        },
+      });
+    });
+
+    it('should not modify short commands (pwd, which, whoami)', async () => {
+      for (const cmd of ['pwd', 'which', 'whoami']) {
+        const input: PreToolUseHookInput = {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: cmd },
+          session_id: 'test-session',
+          transcript_path: '/test/path',
+          cwd: '/test/cwd',
+          tool_use_id: 'test-id',
+        };
+        expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
+      }
+    });
+
+    it('should wrap echo commands (command substitution can expand)', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo "$(cat huge.log)"' },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
+        },
+      });
     });
 
     it('should wrap ls commands (ls -R can produce large output)', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'ls -R',
-        },
+        tool_input: { command: 'ls -R' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -161,20 +202,30 @@ describe('OutputLimiterHook', () => {
       expect(result).toMatchObject({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
+          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
         },
       });
     });
 
-    it('should not skip compound commands that have a head pipe in one segment', async () => {
+    it('should not wrap pure cd commands', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'grep foo file | head -n 5; cat huge.log',
-        },
+        tool_input: { command: 'cd packages/daemon' },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
+    });
+
+    it('should still wrap compound cd commands (cd pkg && bun test)', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'cd packages/daemon && bun test' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -185,77 +236,30 @@ describe('OutputLimiterHook', () => {
       expect(result).toMatchObject({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
-        },
-      });
-    });
-
-    it('should not wrap directory-changing commands (cd breaks in subshell)', async () => {
-      const cdInput: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: {
-          command: 'cd packages/daemon',
-        },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await hook(cdInput, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should still wrap compound cd commands (cd pkg && bun test)', async () => {
-      const compoundInput: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: {
-          command: 'cd packages/daemon && bun test',
-        },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(compoundInput, 'test-id', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
+          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
         },
       });
     });
 
     it('should not wrap background commands (run_in_background)', async () => {
-      const bgInput: PreToolUseHookInput = {
+      const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'make dev',
-          run_in_background: true,
-        },
+        tool_input: { command: 'make dev', run_in_background: true },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
         tool_use_id: 'test-id',
       };
 
-      expect(await hook(bgInput, 'test-id', { signal: mockSignal })).toEqual({});
+      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
     });
 
     it('should enforce byte caps on head/tail output', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'cat large-file.json',
-        },
+        tool_input: { command: 'cat large-file.json' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -266,12 +270,8 @@ describe('OutputLimiterHook', () => {
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
         const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
           .updatedInput.command as string;
-        // head portion is piped through head -c to cap bytes
         expect(cmd).toContain('head -n 100 "$tmpfile" | head -c 20000');
-        // tail portion is piped through tail -c to cap bytes
         expect(cmd).toContain('tail -n 200 "$tmpfile" | tail -c 40000');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
       }
     });
 
@@ -284,9 +284,7 @@ describe('OutputLimiterHook', () => {
       const gitInput: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git fetch origin',
-        },
+        tool_input: { command: 'git fetch origin' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -294,37 +292,33 @@ describe('OutputLimiterHook', () => {
       };
 
       expect(await gitHook(gitInput, 'test-id', { signal: mockSignal })).toEqual({});
+    });
 
-      const nonGitInput: PreToolUseHookInput = {
+    it('should strip quoted env var prefixes before exclusion checks', async () => {
+      const gitHook = createOutputLimiterHook({
+        enabled: true,
+        bash: { excludedCommandPrefixes: ['git'] },
+      });
+
+      const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'bun test',
-        },
+        tool_input: { command: "GIT_SSH_COMMAND='ssh -i key' git fetch" },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
-        tool_use_id: 'test-id-2',
+        tool_use_id: 'test-id',
       };
 
-      const result = await gitHook(nonGitInput, 'test-id-2', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
-        },
-      });
+      // Quoted env var is stripped, so `git` is recognised as excluded
+      expect(await gitHook(input, 'test-id', { signal: mockSignal })).toEqual({});
     });
 
     it('should wrap git commands by default (no sandbox exclusion auto-pass)', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git diff HEAD~1',
-        },
+        tool_input: { command: 'git diff HEAD~1' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -335,41 +329,29 @@ describe('OutputLimiterHook', () => {
       expect(result).toMatchObject({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
+          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
         },
       });
     });
 
-    it('should preserve heredoc delimiters by inserting a newline before the closing paren', async () => {
-      const heredocInput: PreToolUseHookInput = {
+    it('should preserve heredoc delimiters via newlines in the subshell', async () => {
+      const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: "cat <<'EOF'\nhello\nEOF",
-        },
+        tool_input: { command: "cat <<'EOF'\nhello\nEOF" },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
         tool_use_id: 'test-id',
       };
 
-      const result = await hook(heredocInput, 'test-id', { signal: mockSignal });
+      const result = await hook(input, 'test-id', { signal: mockSignal });
 
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
-        ).updatedInput;
-        const cmd = updatedInput.command as string;
-        // The command group opens with a newline after `{` and closes with a
-        // newline before `}` so a trailing `EOF` delimiter stays on its own
-        // line and is recognised by the shell.
-        expect(cmd).toContain('{\n');
-        expect(cmd).toContain('\n} > "$tmpfile"');
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        expect(cmd).toContain('(\n');
         expect(cmd).toContain('\nEOF\n');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
       }
     });
   });
@@ -379,9 +361,7 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Read',
-        tool_input: {
-          file_path: '/test/large-file.txt',
-        },
+        tool_input: { file_path: '/test/large-file.txt' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -394,22 +374,30 @@ describe('OutputLimiterHook', () => {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'allow',
-          updatedInput: {
-            file_path: '/test/large-file.txt',
-            limit: 1000,
-          },
+          updatedInput: { file_path: '/test/large-file.txt', limit: 1000 },
         },
       });
     });
 
-    it('should not modify Read calls that already have limit', async () => {
+    it('should not modify Read calls that already have a positive limit within cap', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Read',
-        tool_input: {
-          file_path: '/test/file.txt',
-          limit: 500,
-        },
+        tool_input: { file_path: '/test/file.txt', limit: 500 },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
+    });
+
+    it('should clamp Read limit above the configured cap', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/test/file.txt', limit: 5000 },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -417,8 +405,13 @@ describe('OutputLimiterHook', () => {
       };
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      expect(result).toEqual({});
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: { file_path: '/test/file.txt', limit: 1000 },
+        },
+      });
     });
 
     it('should map legacy read.maxChars to maxLines', async () => {
@@ -430,9 +423,7 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Read',
-        tool_input: {
-          file_path: '/test/file.txt',
-        },
+        tool_input: { file_path: '/test/file.txt' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -444,10 +435,7 @@ describe('OutputLimiterHook', () => {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'allow',
-          updatedInput: {
-            file_path: '/test/file.txt',
-            limit: 100, // 5000 chars / 50 chars per line
-          },
+          updatedInput: { file_path: '/test/file.txt', limit: 100 },
         },
       });
     });
@@ -458,10 +446,7 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Grep',
-        tool_input: {
-          pattern: 'TODO',
-          path: '/test',
-        },
+        tool_input: { pattern: 'TODO', path: '/test' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -474,23 +459,30 @@ describe('OutputLimiterHook', () => {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'allow',
-          updatedInput: {
-            pattern: 'TODO',
-            path: '/test',
-            head_limit: 250,
-          },
+          updatedInput: { pattern: 'TODO', path: '/test', head_limit: 250 },
         },
       });
     });
 
-    it('should not modify Grep calls with existing head_limit', async () => {
+    it('should not modify Grep calls with positive head_limit within cap', async () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Grep',
-        tool_input: {
-          pattern: 'TODO',
-          head_limit: 100,
-        },
+        tool_input: { pattern: 'TODO', head_limit: 100 },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
+    });
+
+    it('should clamp Grep head_limit=0 (unlimited) to the configured cap', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Grep',
+        tool_input: { pattern: 'TODO', head_limit: 0 },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -498,8 +490,34 @@ describe('OutputLimiterHook', () => {
       };
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: { pattern: 'TODO', head_limit: 250 },
+        },
+      });
+    });
 
-      expect(result).toEqual({});
+    it('should clamp Grep head_limit above the configured cap', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Grep',
+        tool_input: { pattern: 'TODO', head_limit: 1000 },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: { pattern: 'TODO', head_limit: 250 },
+        },
+      });
     });
   });
 
@@ -507,66 +525,29 @@ describe('OutputLimiterHook', () => {
     it('should respect custom limits', async () => {
       const customHook = createOutputLimiterHook({
         enabled: true,
-        bash: {
-          headLines: 250,
-          tailLines: 250,
-        },
-        read: {
-          maxLines: 500,
-        },
-        grep: {
-          maxMatches: 250,
-        },
+        bash: { headLines: 250, tailLines: 250 },
+        read: { maxLines: 500 },
+        grep: { maxMatches: 250 },
         excludeTools: [],
       });
 
-      const input: PreToolUseHookInput = {
+      const bashInput: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git log --oneline',
-        },
+        tool_input: { command: 'git log --oneline' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
         tool_use_id: 'test-id',
       };
 
-      const result = await customHook(input, 'test-id', { signal: mockSignal });
-
-      // Verify custom limits are applied
+      const result = await customHook(bashInput, 'test-id', { signal: mockSignal });
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as unknown as {
-            updatedInput: Record<string, unknown>;
-          }
-        ).updatedInput;
-        expect(updatedInput.command).toContain('head -n 250');
-        expect(updatedInput.command).toContain('tail -n 250');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        expect(cmd).toContain('head -n 250');
+        expect(cmd).toContain('tail -n 250');
       }
-
-      const readInput: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { file_path: '/test/file.txt' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id-2',
-      };
-      const readResult = await customHook(readInput, 'test-id-2', { signal: mockSignal });
-      expect(readResult).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-          updatedInput: {
-            file_path: '/test/file.txt',
-            limit: 500,
-          },
-        },
-      });
     });
 
     it('should skip processing when disabled', async () => {
@@ -575,20 +556,14 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git diff HEAD~1',
-        },
+        tool_input: { command: 'git diff HEAD~1' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
         tool_use_id: 'test-id',
       };
 
-      const result = await disabledHook(input, 'test-id', {
-        signal: mockSignal,
-      });
-
-      expect(result).toEqual({});
+      expect(await disabledHook(input, 'test-id', { signal: mockSignal })).toEqual({});
     });
 
     it('should deep-merge partial config with defaults', async () => {
@@ -600,9 +575,7 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git log --oneline',
-        },
+        tool_input: { command: 'git log --oneline' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
@@ -610,26 +583,12 @@ describe('OutputLimiterHook', () => {
       };
 
       const result = await partialHook(input, 'test-id', { signal: mockSignal });
-
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as unknown as {
-            updatedInput: Record<string, unknown>;
-          }
-        ).updatedInput;
-        // custom headLines wins
-        expect(updatedInput.command).toContain('head -n 50');
-        // tailLines falls back to default
-        expect(updatedInput.command).toContain('tail -n 200');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        expect(cmd).toContain('head -n 50');
+        expect(cmd).toContain('tail -n 200');
       }
-
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-        },
-      });
     });
 
     it('should exclude specified tools', async () => {
@@ -641,20 +600,14 @@ describe('OutputLimiterHook', () => {
       const input: PreToolUseHookInput = {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
-        tool_input: {
-          command: 'git log --all',
-        },
+        tool_input: { command: 'git log --all' },
         session_id: 'test-session',
         transcript_path: '/test/path',
         cwd: '/test/cwd',
         tool_use_id: 'test-id',
       };
 
-      const result = await excludeHook(input, 'test-id', {
-        signal: mockSignal,
-      });
-
-      expect(result).toEqual({});
+      expect(await excludeHook(input, 'test-id', { signal: mockSignal })).toEqual({});
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -27,19 +27,10 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-        },
-      });
-
       // Verify the command has smart truncation
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
         const updatedInput = (
-          result.hookSpecificOutput as unknown as {
-            updatedInput: Record<string, unknown>;
-          }
+          result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
         ).updatedInput;
         expect(updatedInput.command).toContain('tmpfile=$(mktemp)');
         expect(updatedInput.command).toContain('head -n 100');
@@ -49,6 +40,69 @@ describe('OutputLimiterHook', () => {
 
         // Verify description
         expect(updatedInput.description).toContain('first 100 + last 200 lines');
+      } else {
+        throw new Error('Expected hookSpecificOutput in result');
+      }
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+        },
+      });
+    });
+
+    it('should preserve the original exit status when wrapping Bash commands', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git diff HEAD~1',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const updatedInput = (
+          result.hookSpecificOutput as unknown as {
+            updatedInput: Record<string, unknown>;
+          }
+        ).updatedInput;
+        expect(updatedInput.command).toContain('exit_code=$?');
+        expect(updatedInput.command).toContain('exit $exit_code');
+      } else {
+        throw new Error('Expected hookSpecificOutput in result');
+      }
+    });
+
+    it('should capture both stdout and stderr into the temp file', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git diff HEAD~1',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const updatedInput = (
+          result.hookSpecificOutput as unknown as {
+            updatedInput: Record<string, unknown>;
+          }
+        ).updatedInput;
+        // Redirect both stdout and stderr into the temp file, not stderr to original stdout.
+        expect(updatedInput.command).toContain('> "$tmpfile" 2>&1');
+        expect(updatedInput.command).not.toMatch(/\)\s*2>&1\s*>\s*"\$tmpfile"/);
       } else {
         throw new Error('Expected hookSpecificOutput in result');
       }
@@ -89,6 +143,80 @@ describe('OutputLimiterHook', () => {
 
       expect(result).toEqual({});
     });
+
+    it('should not wrap commands matching excluded command prefixes', async () => {
+      const gitHook = createOutputLimiterHook({
+        enabled: true,
+        bash: { excludedCommandPrefixes: ['git'] },
+      });
+
+      const gitInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git fetch origin',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await gitHook(gitInput, 'test-id', { signal: mockSignal })).toEqual({});
+
+      const nonGitInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'bun test',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id-2',
+      };
+
+      const result = await gitHook(nonGitInput, 'test-id-2', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
+        },
+      });
+    });
+
+    it('should preserve heredoc delimiters by inserting a newline before the closing paren', async () => {
+      const heredocInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: "cat <<'EOF'\nhello\nEOF",
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(heredocInput, 'test-id', { signal: mockSignal });
+
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const updatedInput = (
+          result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
+        ).updatedInput;
+        const cmd = updatedInput.command as string;
+        // The subshell opens with a newline after `(` and closes with a
+        // newline before `)` so a trailing `EOF` delimiter stays on its
+        // own line and is recognised by the shell.
+        expect(cmd).toContain('(\n');
+        expect(cmd).toContain('\n) > "$tmpfile"');
+        expect(cmd).toContain('\nEOF\n');
+      } else {
+        throw new Error('Expected hookSpecificOutput in result');
+      }
+    });
   });
 
   describe('Read tool limiting', () => {
@@ -107,13 +235,12 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toMatchObject({
+      expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/test/large-file.txt',
-            limit: 1000, // 50000 chars / 50 chars per line
+            limit: 1000,
           },
         },
       });
@@ -156,10 +283,9 @@ describe('OutputLimiterHook', () => {
 
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toMatchObject({
+      expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
           updatedInput: {
             pattern: 'TODO',
             path: '/test',
@@ -189,35 +315,6 @@ describe('OutputLimiterHook', () => {
     });
   });
 
-  describe('Glob tool limiting', () => {
-    it('should add head_limit to Glob calls', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Glob',
-        tool_input: {
-          pattern: '**/*.ts',
-        },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-          updatedInput: {
-            pattern: '**/*.ts',
-            head_limit: 1000,
-          },
-        },
-      });
-    });
-  });
-
   describe('Configuration', () => {
     it('should respect custom limits', async () => {
       const customHook = createOutputLimiterHook({
@@ -227,13 +324,10 @@ describe('OutputLimiterHook', () => {
           tailLines: 250,
         },
         read: {
-          maxChars: 25000,
+          maxLines: 500,
         },
         grep: {
           maxMatches: 250,
-        },
-        glob: {
-          maxFiles: 500,
         },
         excludeTools: [],
       });
@@ -264,6 +358,26 @@ describe('OutputLimiterHook', () => {
       } else {
         throw new Error('Expected hookSpecificOutput in result');
       }
+
+      const readInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/test/file.txt' },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id-2',
+      };
+      const readResult = await customHook(readInput, 'test-id-2', { signal: mockSignal });
+      expect(readResult).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            file_path: '/test/file.txt',
+            limit: 500,
+          },
+        },
+      });
     });
 
     it('should skip processing when disabled', async () => {
@@ -308,13 +422,6 @@ describe('OutputLimiterHook', () => {
 
       const result = await partialHook(input, 'test-id', { signal: mockSignal });
 
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-        },
-      });
-
       if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
         const updatedInput = (
           result.hookSpecificOutput as unknown as {
@@ -328,6 +435,12 @@ describe('OutputLimiterHook', () => {
       } else {
         throw new Error('Expected hookSpecificOutput in result');
       }
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+        },
+      });
     });
 
     it('should exclude specified tools', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -37,7 +37,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
+          permissionDecision: 'allow',
           updatedInput: { file_path: '/test/file.txt', limit: 1000 },
         },
       });
@@ -123,7 +123,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
+          permissionDecision: 'allow',
           updatedInput: { pattern: 'TODO', path: '/src', head_limit: 250 },
         },
       });

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -393,6 +393,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/test/large-file.txt',
             limit: 1000,
@@ -442,6 +443,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/test/file.txt',
             limit: 100, // 5000 chars / 50 chars per line
@@ -471,6 +473,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             pattern: 'TODO',
             path: '/test',
@@ -557,6 +560,7 @@ describe('OutputLimiterHook', () => {
       expect(readResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/test/file.txt',
             limit: 500,

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -131,7 +131,7 @@ describe('OutputLimiterHook', () => {
         hook_event_name: 'PreToolUse',
         tool_name: 'Bash',
         tool_input: {
-          command: 'ls',
+          command: 'pwd',
         },
         session_id: 'test-session',
         transcript_path: '/test/path',
@@ -142,6 +142,54 @@ describe('OutputLimiterHook', () => {
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
       expect(result).toEqual({});
+    });
+
+    it('should wrap ls commands (ls -R can produce large output)', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'ls -R',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
+        },
+      });
+    });
+
+    it('should not skip compound commands that have a head pipe in one segment', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'grep foo file | head -n 5; cat huge.log',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
+        },
+      });
     });
 
     it('should not wrap directory-changing commands (cd breaks in subshell)', async () => {
@@ -370,6 +418,36 @@ describe('OutputLimiterHook', () => {
       const result = await hook(input, 'test-id', { signal: mockSignal });
 
       expect(result).toEqual({});
+    });
+
+    it('should map legacy read.maxChars to maxLines', async () => {
+      const legacyHook = createOutputLimiterHook({
+        enabled: true,
+        read: { maxChars: 5000 },
+      });
+
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: {
+          file_path: '/test/file.txt',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await legacyHook(input, 'test-id', { signal: mockSignal });
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            file_path: '/test/file.txt',
+            limit: 100, // 5000 chars / 50 chars per line
+          },
+        },
+      });
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -160,6 +160,73 @@ describe('OutputLimiterHook', () => {
       expect(await hook(cdInput, 'test-id', { signal: mockSignal })).toEqual({});
     });
 
+    it('should still wrap compound cd commands (cd pkg && bun test)', async () => {
+      const compoundInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'cd packages/daemon && bun test',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(compoundInput, 'test-id', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
+        },
+      });
+    });
+
+    it('should not wrap background commands (run_in_background)', async () => {
+      const bgInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'make dev',
+          run_in_background: true,
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await hook(bgInput, 'test-id', { signal: mockSignal })).toEqual({});
+    });
+
+    it('should enforce byte caps on head/tail output', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'cat large-file.json',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
+          .updatedInput.command as string;
+        // head portion is piped through head -c to cap bytes
+        expect(cmd).toContain('head -n 100 "$tmpfile" | head -c 20000');
+        // tail portion is piped through tail -c to cap bytes
+        expect(cmd).toContain('tail -n 200 "$tmpfile" | tail -c 40000');
+      } else {
+        throw new Error('Expected hookSpecificOutput in result');
+      }
+    });
+
     it('should not wrap commands matching excluded command prefixes', async () => {
       const gitHook = createOutputLimiterHook({
         enabled: true,
@@ -329,7 +396,7 @@ describe('OutputLimiterHook', () => {
           updatedInput: {
             pattern: 'TODO',
             path: '/test',
-            head_limit: 500,
+            head_limit: 250,
           },
         },
       });

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -144,6 +144,22 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({});
     });
 
+    it('should not wrap directory-changing commands (cd breaks in subshell)', async () => {
+      const cdInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'cd packages/daemon',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      expect(await hook(cdInput, 'test-id', { signal: mockSignal })).toEqual({});
+    });
+
     it('should not wrap commands matching excluded command prefixes', async () => {
       const gitHook = createOutputLimiterHook({
         enabled: true,
@@ -177,6 +193,30 @@ describe('OutputLimiterHook', () => {
       };
 
       const result = await gitHook(nonGitInput, 'test-id-2', { signal: mockSignal });
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
+        },
+      });
+    });
+
+    it('should wrap git commands by default (no sandbox exclusion auto-pass)', async () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git diff HEAD~1',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await hook(input, 'test-id', { signal: mockSignal });
       expect(result).toMatchObject({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -362,11 +362,11 @@ describe('OutputLimiterHook', () => {
           result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
         ).updatedInput;
         const cmd = updatedInput.command as string;
-        // The subshell opens with a newline after `(` and closes with a
-        // newline before `)` so a trailing `EOF` delimiter stays on its
-        // own line and is recognised by the shell.
-        expect(cmd).toContain('(\n');
-        expect(cmd).toContain('\n) > "$tmpfile"');
+        // The command group opens with a newline after `{` and closes with a
+        // newline before `}` so a trailing `EOF` delimiter stays on its own
+        // line and is recognised by the shell.
+        expect(cmd).toContain('{\n');
+        expect(cmd).toContain('\n} > "$tmpfile"');
         expect(cmd).toContain('\nEOF\n');
       } else {
         throw new Error('Expected hookSpecificOutput in result');

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -1,410 +1,39 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { createOutputLimiterHook } from '../../../../src/lib/agent/output-limiter-hook';
-import type { PreToolUseHookInput, HookCallback } from '@anthropic-ai/claude-agent-sdk';
+import {
+  createOutputLimiterPreHook,
+  createOutputLimiterPostHook,
+} from '../../../../src/lib/agent/output-limiter-hook';
+import type {
+  PostToolUseHookInput,
+  PreToolUseHookInput,
+  HookCallback,
+} from '@anthropic-ai/claude-agent-sdk';
+
+const mockSignal = new AbortController().signal;
 
 describe('OutputLimiterHook', () => {
-  let hook: HookCallback;
-  const mockSignal = new AbortController().signal;
+  describe('PreToolUse (Read/Grep limit injection)', () => {
+    let hook: HookCallback;
 
-  beforeEach(() => {
-    hook = createOutputLimiterHook({ enabled: true });
-  });
-
-  describe('Bash tool limiting', () => {
-    it('should add smart truncation to bash commands without existing limits', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: {
-          command: 'git diff HEAD~1',
-          description: 'Show git diff',
-        },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const updatedInput = (
-          result.hookSpecificOutput as { updatedInput: Record<string, unknown> }
-        ).updatedInput;
-        expect(updatedInput.command).toContain('tmpfile=$(mktemp)');
-        expect(updatedInput.command).toContain('head -n 100');
-        expect(updatedInput.command).toContain('tail -n 200');
-        expect(updatedInput.command).toContain('Truncated');
-        expect(updatedInput.command).toContain('rm -f "$tmpfile"');
-        expect(updatedInput.description).toContain('first 100 + last 200 lines');
-      } else {
-        throw new Error('Expected hookSpecificOutput in result');
-      }
+    beforeEach(() => {
+      hook = createOutputLimiterPreHook({ enabled: true });
     });
 
-    it('should preserve the original exit status when wrapping Bash commands', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git diff HEAD~1' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('exit_code=$?');
-        expect(cmd).toContain('exit $exit_code');
-      }
-    });
-
-    it('should capture both stdout and stderr into the temp file', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git diff HEAD~1' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('> "$tmpfile" 2>&1');
-      }
-    });
-
-    it('should use a subshell to isolate exit/set -e from the wrapper', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'echo before; set -e; false' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        // Subshell so exit/set -e only kills the subshell, not the wrapper
-        expect(cmd).toContain('(\n');
-        expect(cmd).toContain('\n) > "$tmpfile" 2>&1');
-        // Cleanup runs after the subshell
-        expect(cmd).toContain('rm -f "$tmpfile"');
-      }
-    });
-
-    it('should capture and replay cwd changes from the subshell', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'cd packages/daemon && bun test' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        // Subshell writes pwd to cwdfile
-        expect(cmd).toContain('pwd >| "$cwdfile"');
-        // Wrapper replays cwd after truncation
-        expect(cmd).toContain('newcwd=$(cat "$cwdfile"');
-        expect(cmd).toContain('cd "$newcwd"');
-      }
-    });
-
-    it('should wrap commands that already have head/tail (stderr still uncapped)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git log | head -n 100' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      // No longer skipped — stderr from `git log` can still overflow
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
-        },
-      });
-    });
-
-    it('should not modify short commands (pwd, which, whoami)', async () => {
-      for (const cmd of ['pwd', 'which', 'whoami']) {
-        const input: PreToolUseHookInput = {
+    it('should inject limit on Read calls without one', async () => {
+      const result = await hook(
+        {
           hook_event_name: 'PreToolUse',
-          tool_name: 'Bash',
-          tool_input: { command: cmd },
-          session_id: 'test-session',
-          transcript_path: '/test/path',
-          cwd: '/test/cwd',
-          tool_use_id: 'test-id',
-        };
-        expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
-      }
-    });
-
-    it('should wrap echo commands (command substitution can expand)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'echo "$(cat huge.log)"' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
+          tool_name: 'Read',
+          tool_input: { file_path: '/test/file.txt' },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
         },
-      });
-    });
+        't1',
+        { signal: mockSignal }
+      );
 
-    it('should wrap ls commands (ls -R can produce large output)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'ls -R' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
-        },
-      });
-    });
-
-    it('should not wrap pure cd commands', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'cd packages/daemon' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should still wrap compound cd commands (cd pkg && bun test)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'cd packages/daemon && bun test' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
-        },
-      });
-    });
-
-    it('should not wrap background commands (run_in_background)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'make dev', run_in_background: true },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should enforce byte caps on head/tail output', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'cat large-file.json' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('head -n 100 "$tmpfile" | head -c 20000');
-        expect(cmd).toContain('tail -n 200 "$tmpfile" | tail -c 40000');
-      }
-    });
-
-    it('should not wrap commands matching excluded command prefixes', async () => {
-      const gitHook = createOutputLimiterHook({
-        enabled: true,
-        bash: { excludedCommandPrefixes: ['git'] },
-      });
-
-      const gitInput: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git fetch origin' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await gitHook(gitInput, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should strip quoted env var prefixes before exclusion checks', async () => {
-      const gitHook = createOutputLimiterHook({
-        enabled: true,
-        bash: { excludedCommandPrefixes: ['git'] },
-      });
-
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: "GIT_SSH_COMMAND='ssh -i key' git fetch" },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      // Quoted env var is stripped, so `git` is recognised as excluded
-      expect(await gitHook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should wrap git commands by default (no sandbox exclusion auto-pass)', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git diff HEAD~1' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: { command: expect.stringContaining('tmpfile=$(mktemp)') },
-        },
-      });
-    });
-
-    it('should preserve heredoc delimiters via newlines in the subshell', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: "cat <<'EOF'\nhello\nEOF" },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('(\n');
-        expect(cmd).toContain('\nEOF\n');
-      }
-    });
-  });
-
-  describe('Read tool limiting', () => {
-    it('should add limit parameter to Read calls without existing limits', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { file_path: '/test/large-file.txt' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      expect(result).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
-          updatedInput: { file_path: '/test/large-file.txt', limit: 1000 },
-        },
-      });
-    });
-
-    it('should not modify Read calls that already have a positive limit within cap', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { file_path: '/test/file.txt', limit: 500 },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should clamp Read limit above the configured cap', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { file_path: '/test/file.txt', limit: 5000 },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
@@ -414,220 +43,329 @@ describe('OutputLimiterHook', () => {
       });
     });
 
+    it('should not modify Read calls with a positive limit within cap', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f', limit: 500 },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('should clamp Read limit above the cap', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f', limit: 5000 },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          updatedInput: { file_path: '/f', limit: 1000 },
+        },
+      });
+    });
+
+    it('should treat Read limit=0 as uncapped and inject the cap', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f', limit: 0 },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          updatedInput: { file_path: '/f', limit: 1000 },
+        },
+      });
+    });
+
+    it('should inject head_limit on Grep calls without one', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Grep',
+          tool_input: { pattern: 'TODO', path: '/src' },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          updatedInput: { pattern: 'TODO', path: '/src', head_limit: 250 },
+        },
+      });
+    });
+
+    it('should not modify Grep with positive head_limit within cap', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Grep',
+          tool_input: { pattern: 'TODO', head_limit: 100 },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('should clamp Grep head_limit=0 (unlimited)', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Grep',
+          tool_input: { pattern: 'TODO', head_limit: 0 },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          updatedInput: { pattern: 'TODO', head_limit: 250 },
+        },
+      });
+    });
+
+    it('should not touch Bash or other tools', async () => {
+      for (const tool of ['Bash', 'Write', 'Edit', 'Glob']) {
+        const result = await hook(
+          {
+            hook_event_name: 'PreToolUse',
+            tool_name: tool,
+            tool_input: { command: 'ls' },
+            tool_use_id: 't1',
+            session_id: 's',
+            transcript_path: '/t',
+            cwd: '/c',
+          },
+          't1',
+          { signal: mockSignal }
+        );
+        expect(result).toEqual({});
+      }
+    });
+
+    it('should skip when disabled', async () => {
+      const disabled = createOutputLimiterPreHook({ enabled: false });
+      const result = await disabled(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f' },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+      expect(result).toEqual({});
+    });
+
     it('should map legacy read.maxChars to maxLines', async () => {
-      const legacyHook = createOutputLimiterHook({
-        enabled: true,
-        read: { maxChars: 5000 },
-      });
-
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Read',
-        tool_input: { file_path: '/test/file.txt' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await legacyHook(input, 'test-id', { signal: mockSignal });
-      expect(result).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
-          updatedInput: { file_path: '/test/file.txt', limit: 100 },
+      const legacy = createOutputLimiterPreHook({ enabled: true, read: { maxChars: 5000 } });
+      const result = await legacy(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f' },
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
         },
+        't1',
+        { signal: mockSignal }
+      );
+      expect(result).toMatchObject({
+        hookSpecificOutput: { updatedInput: { file_path: '/f', limit: 100 } },
       });
     });
   });
 
-  describe('Grep tool limiting', () => {
-    it('should add head_limit parameter to Grep calls', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Grep',
-        tool_input: { pattern: 'TODO', path: '/test' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
+  describe('PostToolUse (Bash output truncation)', () => {
+    let hook: HookCallback;
 
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-
-      expect(result).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
-          updatedInput: { pattern: 'TODO', path: '/test', head_limit: 250 },
-        },
-      });
+    beforeEach(() => {
+      hook = createOutputLimiterPostHook({ enabled: true });
     });
 
-    it('should not modify Grep calls with positive head_limit within cap', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Grep',
-        tool_input: { pattern: 'TODO', head_limit: 100 },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await hook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should clamp Grep head_limit=0 (unlimited) to the configured cap', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Grep',
-        tool_input: { pattern: 'TODO', head_limit: 0 },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
-          updatedInput: { pattern: 'TODO', head_limit: 250 },
-        },
-      });
-    });
-
-    it('should clamp Grep head_limit above the configured cap', async () => {
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Grep',
-        tool_input: { pattern: 'TODO', head_limit: 1000 },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await hook(input, 'test-id', { signal: mockSignal });
-      expect(result).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
-          updatedInput: { pattern: 'TODO', head_limit: 250 },
-        },
-      });
-    });
-  });
-
-  describe('Configuration', () => {
-    it('should respect custom limits', async () => {
-      const customHook = createOutputLimiterHook({
-        enabled: true,
-        bash: { headLines: 250, tailLines: 250 },
-        read: { maxLines: 500 },
-        grep: { maxMatches: 250 },
-        excludeTools: [],
-      });
-
-      const bashInput: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git log --oneline' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await customHook(bashInput, 'test-id', { signal: mockSignal });
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('head -n 250');
-        expect(cmd).toContain('tail -n 250');
-      }
-    });
-
-    it('should skip processing when disabled', async () => {
-      const disabledHook = createOutputLimiterHook({ enabled: false });
-
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git diff HEAD~1' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await disabledHook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-
-    it('should deep-merge partial config with defaults', async () => {
-      const partialHook = createOutputLimiterHook({
-        enabled: true,
-        bash: { headLines: 50 },
-      });
-
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git log --oneline' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      const result = await partialHook(input, 'test-id', { signal: mockSignal });
-      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
-        const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
-          .updatedInput.command as string;
-        expect(cmd).toContain('head -n 50');
-        expect(cmd).toContain('tail -n 200');
-      }
-    });
-
-    it('should exclude specified tools', async () => {
-      const excludeHook = createOutputLimiterHook({
-        enabled: true,
-        excludeTools: ['Bash'],
-      });
-
-      const input: PreToolUseHookInput = {
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Bash',
-        tool_input: { command: 'git log --all' },
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
-      };
-
-      expect(await excludeHook(input, 'test-id', { signal: mockSignal })).toEqual({});
-    });
-  });
-
-  describe('Hook event filtering', () => {
-    it('should only process PreToolUse events', async () => {
-      const postInput = {
+    function makeBashPost(stdout: string, stderr = ''): PostToolUseHookInput {
+      return {
         hook_event_name: 'PostToolUse',
         tool_name: 'Bash',
-        tool_input: { command: 'echo test' },
-        tool_response: 'test',
-        session_id: 'test-session',
-        transcript_path: '/test/path',
-        cwd: '/test/cwd',
-        tool_use_id: 'test-id',
+        tool_input: { command: 'test' },
+        tool_response: { stdout, stderr, interrupted: false },
+        tool_use_id: 't1',
+        session_id: 's',
+        transcript_path: '/t',
+        cwd: '/c',
       };
+    }
 
-      const result = await hook(postInput as unknown as PreToolUseHookInput, 'test-id', {
-        signal: mockSignal,
+    it('should return {} for small output', async () => {
+      const result = await hook(makeBashPost('line1\nline2\nline3'), 't1', { signal: mockSignal });
+      expect(result).toEqual({});
+    });
+
+    it('should truncate large stdout via updatedToolOutput', async () => {
+      const lines = Array.from({ length: 500 }, (_, i) => `line ${i}`);
+      const stdout = lines.join('\n');
+
+      const result = await hook(makeBashPost(stdout), 't1', { signal: mockSignal });
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+        },
       });
 
+      const output = (
+        result as {
+          hookSpecificOutput: { updatedToolOutput: { stdout: string; stderr: string } };
+        }
+      ).hookSpecificOutput.updatedToolOutput;
+
+      expect(output.stdout).toContain('line 0');
+      expect(output.stdout).toContain('line 499');
+      expect(output.stdout).toContain('Truncated');
+      expect(output.stdout).not.toContain('line 250');
+    });
+
+    it('should truncate large stderr separately', async () => {
+      const stdout = 'ok';
+      const stderr = Array.from({ length: 500 }, (_, i) => `err ${i}`).join('\n');
+
+      const result = await hook(makeBashPost(stdout, stderr), 't1', { signal: mockSignal });
+
+      const output = (
+        result as {
+          hookSpecificOutput: { updatedToolOutput: { stdout: string; stderr: string } };
+        }
+      ).hookSpecificOutput.updatedToolOutput;
+
+      expect(output.stdout).toBe('ok'); // Small, unchanged
+      expect(output.stderr).toContain('Truncated');
+      expect(output.stderr).toContain('err 0');
+      expect(output.stderr).toContain('err 499');
+    });
+
+    it('should preserve non-stdout/stderr fields in updatedToolOutput', async () => {
+      const lines = Array.from({ length: 500 }, (_, i) => `line ${i}`).join('\n');
+      const result = await hook(makeBashPost(lines), 't1', { signal: mockSignal });
+
+      const output = (
+        result as {
+          hookSpecificOutput: { updatedToolOutput: Record<string, unknown> };
+        }
+      ).hookSpecificOutput.updatedToolOutput;
+
+      expect(output.interrupted).toBe(false);
+    });
+
+    it('should ignore non-Bash tools', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/f' },
+          tool_response: 'x'.repeat(100000),
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
+      expect(result).toEqual({});
+    });
+
+    it('should skip when disabled', async () => {
+      const disabled = createOutputLimiterPostHook({ enabled: false });
+      const result = await disabled(makeBashPost('x'.repeat(100000)), 't1', { signal: mockSignal });
+      expect(result).toEqual({});
+    });
+
+    it('should respect custom headLines/tailLines', async () => {
+      const custom = createOutputLimiterPostHook({
+        enabled: true,
+        bash: { headLines: 10, tailLines: 10 },
+      });
+      const lines = Array.from({ length: 50 }, (_, i) => `line ${i}`).join('\n');
+
+      const result = await custom(makeBashPost(lines), 't1', { signal: mockSignal });
+      const output = (
+        result as {
+          hookSpecificOutput: { updatedToolOutput: { stdout: string } };
+        }
+      ).hookSpecificOutput.updatedToolOutput;
+
+      // First 10 + last 10
+      expect(output.stdout).toContain('line 0');
+      expect(output.stdout).toContain('line 49');
+      expect(output.stdout).not.toContain('line 20');
+    });
+
+    it('should handle missing stdout/stderr gracefully', async () => {
+      const result = await hook(
+        {
+          hook_event_name: 'PostToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'test' },
+          tool_response: {},
+          tool_use_id: 't1',
+          session_id: 's',
+          transcript_path: '/t',
+          cwd: '/c',
+        },
+        't1',
+        { signal: mockSignal }
+      );
       expect(result).toEqual({});
     });
   });

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -124,7 +124,7 @@ describe('OutputLimiterHook', () => {
         const cmd = (result.hookSpecificOutput as { updatedInput: Record<string, unknown> })
           .updatedInput.command as string;
         // Subshell writes pwd to cwdfile
-        expect(cmd).toContain('pwd > "$cwdfile"');
+        expect(cmd).toContain('pwd >| "$cwdfile"');
         // Wrapper replays cwd after truncation
         expect(cmd).toContain('newcwd=$(cat "$cwdfile"');
         expect(cmd).toContain('cd "$newcwd"');

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -288,6 +288,48 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({});
     });
 
+    it('should deep-merge partial config with defaults', async () => {
+      const partialHook = createOutputLimiterHook({
+        enabled: true,
+        bash: { headLines: 50 },
+      });
+
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git log --oneline',
+        },
+        session_id: 'test-session',
+        transcript_path: '/test/path',
+        cwd: '/test/cwd',
+        tool_use_id: 'test-id',
+      };
+
+      const result = await partialHook(input, 'test-id', { signal: mockSignal });
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
+
+      if ('hookSpecificOutput' in result && result.hookSpecificOutput) {
+        const updatedInput = (
+          result.hookSpecificOutput as unknown as {
+            updatedInput: Record<string, unknown>;
+          }
+        ).updatedInput;
+        // custom headLines wins
+        expect(updatedInput.command).toContain('head -n 50');
+        // tailLines falls back to default
+        expect(updatedInput.command).toContain('tail -n 200');
+      } else {
+        throw new Error('Expected hookSpecificOutput in result');
+      }
+    });
+
     it('should exclude specified tools', async () => {
       const excludeHook = createOutputLimiterHook({
         enabled: true,

--- a/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/output-limiter-hook.test.ts
@@ -373,7 +373,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { file_path: '/test/large-file.txt', limit: 1000 },
         },
       });
@@ -408,7 +408,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { file_path: '/test/file.txt', limit: 1000 },
         },
       });
@@ -434,7 +434,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { file_path: '/test/file.txt', limit: 100 },
         },
       });
@@ -458,7 +458,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { pattern: 'TODO', path: '/test', head_limit: 250 },
         },
       });
@@ -493,7 +493,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { pattern: 'TODO', head_limit: 250 },
         },
       });
@@ -514,7 +514,7 @@ describe('OutputLimiterHook', () => {
       expect(result).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: { pattern: 'TODO', head_limit: 250 },
         },
       });

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1306,17 +1306,18 @@ describe('QueryOptionsBuilder', () => {
       });
     });
 
-    it('should NOT auto-pass sandbox excluded commands to the output limiter', async () => {
-      // sandbox.excludedCommands controls sandbox routing, not output limiting.
-      // Auto-passing them would leave high-volume commands like `git diff` uncapped.
+    it('should pass sandbox excluded commands to the limiter when sandbox is enabled', async () => {
+      // When sandbox is enabled, wrapping git would hide it from the sandbox's
+      // command-level exclusion classifier. Pass excludedCommands so those
+      // commands are not wrapped.
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { excludedCommands: ['git', 'docker'] },
+        sandbox: { enabled: true, excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
           read: { maxLines: 1000 },
-          grep: { maxMatches: 500 },
+          grep: { maxMatches: 250 },
           excludeTools: [],
         },
       }));
@@ -1326,7 +1327,45 @@ describe('QueryOptionsBuilder', () => {
       const hook = outputLimiterEntry?.hooks[0];
       expect(hook).toBeDefined();
 
-      // git is sandbox-excluded but should still be wrapped for output limiting.
+      // git is sandbox-excluded and sandbox is enabled → git should NOT be wrapped.
+      const gitResult = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'git fetch origin' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(gitResult).toEqual({});
+    });
+
+    it('should NOT pass sandbox excluded commands when sandbox is disabled', async () => {
+      // In bypassPermissions mode the sandbox is inactive, so wrapping git is
+      // safe and necessary for output limiting.
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        sandbox: { enabled: false, excludedCommands: ['git'] },
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxLines: 1000 },
+          grep: { maxMatches: 250 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      // Sandbox disabled → git IS wrapped for output limiting.
       const gitResult = await hook!(
         {
           hook_event_name: 'PreToolUse',

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1135,9 +1135,9 @@ describe('QueryOptionsBuilder', () => {
       expect(updatedInput.command).toContain('tail -n 200');
       expect(updatedInput.command).toContain('exit $exit_code');
       // The hook should not grant permission on its own.
-      // The hook must include permissionDecision: 'allow' for updatedInput to
+      // The hook must include permissionDecision: 'ask' for updatedInput to
       // be reliably applied by the SDK.
-      expect(result.hookSpecificOutput).toMatchObject({ permissionDecision: 'allow' });
+      expect(result.hookSpecificOutput).toMatchObject({ permissionDecision: 'ask' });
 
       expect(result).toMatchObject({
         hookSpecificOutput: {
@@ -1181,7 +1181,7 @@ describe('QueryOptionsBuilder', () => {
       expect(readResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: {
             file_path: '/tmp/large-file.ts',
             limit: 500,
@@ -1206,7 +1206,7 @@ describe('QueryOptionsBuilder', () => {
       expect(grepResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
+          permissionDecision: 'ask',
           updatedInput: {
             pattern: 'TODO',
             path: '/tmp/repo',

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1093,29 +1093,31 @@ describe('QueryOptionsBuilder', () => {
       expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
     });
 
-    it('should apply output limits to Bash commands via the built hook', async () => {
+    it('should truncate large Bash output via PostToolUse updatedToolOutput', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
-          bash: { headLines: 100, tailLines: 200 },
+          bash: { headLines: 5, tailLines: 5 },
           read: { maxLines: 1000 },
-          grep: { maxMatches: 500 },
+          grep: { maxMatches: 250 },
           excludeTools: [],
         },
       }));
 
       const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
+      // PostToolUse has loop detector + output limiter
+      expect(options.hooks?.PostToolUse).toHaveLength(2);
+      const postHook = options.hooks?.PostToolUse?.[1]?.hooks[0];
+      expect(postHook).toBeDefined();
 
-      const result = await hook!(
+      const largeOutput = Array.from({ length: 100 }, (_, i) => `line ${i}`).join('\n');
+      const result = await postHook!(
         {
-          hook_event_name: 'PreToolUse',
+          hook_event_name: 'PostToolUse',
           tool_name: 'Bash',
-          tool_input: { command: 'bun test', description: 'Run tests' },
+          tool_input: { command: 'bun test' },
+          tool_response: { stdout: largeOutput, stderr: '', interrupted: false },
           tool_use_id: 'tool-1',
           session_id: 'session-1',
           transcript_path: '/tmp/transcript.jsonl',
@@ -1125,31 +1127,20 @@ describe('QueryOptionsBuilder', () => {
         { signal: new AbortController().signal }
       );
 
-      const updatedInput = (
+      const output = (
         result as {
-          hookSpecificOutput: { updatedInput: Record<string, unknown> };
+          hookSpecificOutput: { updatedToolOutput: { stdout: string } };
         }
-      ).hookSpecificOutput.updatedInput;
-      expect(updatedInput.command).toContain('tmpfile=$(mktemp)');
-      expect(updatedInput.command).toContain('head -n 100');
-      expect(updatedInput.command).toContain('tail -n 200');
-      expect(updatedInput.command).toContain('exit $exit_code');
-      // The hook should not grant permission on its own.
-      // The hook must include permissionDecision: 'ask' for updatedInput to
-      // be reliably applied by the SDK.
-      expect(result.hookSpecificOutput).toMatchObject({ permissionDecision: 'ask' });
-
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-        },
-      });
+      ).hookSpecificOutput.updatedToolOutput;
+      expect(output.stdout).toContain('line 0');
+      expect(output.stdout).toContain('line 99');
+      expect(output.stdout).toContain('Truncated');
+      expect(output.stdout).not.toContain('line 50');
     });
 
-    it('should apply output limits to Read and Grep inputs via the built hook', async () => {
+    it('should apply Read and Grep limits via the PreToolUse hook', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
@@ -1160,11 +1151,10 @@ describe('QueryOptionsBuilder', () => {
       }));
 
       const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
+      const preHook = options.hooks?.PreToolUse?.[1]?.hooks[0];
+      expect(preHook).toBeDefined();
 
-      const readResult = await hook!(
+      const readResult = await preHook!(
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Read',
@@ -1182,14 +1172,11 @@ describe('QueryOptionsBuilder', () => {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'ask',
-          updatedInput: {
-            file_path: '/tmp/large-file.ts',
-            limit: 500,
-          },
+          updatedInput: { file_path: '/tmp/large-file.ts', limit: 500 },
         },
       });
 
-      const grepResult = await hook!(
+      const grepResult = await preHook!(
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Grep',
@@ -1207,65 +1194,19 @@ describe('QueryOptionsBuilder', () => {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           permissionDecision: 'ask',
-          updatedInput: {
-            pattern: 'TODO',
-            path: '/tmp/repo',
-            head_limit: 250,
-          },
+          updatedInput: { pattern: 'TODO', path: '/tmp/repo', head_limit: 250 },
         },
       });
     });
 
-    it('should apply custom output-limiter limits from global settings', async () => {
+    it('should run workflow tool guards alongside the output limiter', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { excludedCommands: ['git'] },
-        outputLimiter: {
-          enabled: true,
-          bash: { headLines: 250, tailLines: 250 },
-          read: { maxLines: 200 },
-          grep: { maxMatches: 100 },
-          excludeTools: [],
-        },
-      }));
-
-      const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
-
-      const result = await hook!(
-        {
-          hook_event_name: 'PreToolUse',
-          tool_name: 'Bash',
-          tool_input: { command: 'bun test', description: 'Run tests' },
-          tool_use_id: 'tool-1',
-          session_id: 'session-1',
-          transcript_path: '/tmp/transcript.jsonl',
-          cwd: '/tmp/repo',
-        },
-        'tool-1',
-        { signal: new AbortController().signal }
-      );
-
-      const updatedInput = (
-        result as {
-          hookSpecificOutput: { updatedInput: Record<string, unknown> };
-        }
-      ).hookSpecificOutput.updatedInput;
-      expect(updatedInput.command).toContain('head -n 250');
-      expect(updatedInput.command).toContain('tail -n 250');
-    });
-
-    it('should run workflow tool guards against the original Bash input', async () => {
-      mockSettingsManager.getGlobalSettings = mock(() => ({
-        settingSources: ['user', 'project', 'local'],
-        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
           read: { maxLines: 1000 },
-          grep: { maxMatches: 500 },
+          grep: { maxMatches: 250 },
           excludeTools: [],
         },
       }));
@@ -1282,7 +1223,7 @@ describe('QueryOptionsBuilder', () => {
       });
       const options = await guardBuilder.build();
 
-      // Loop detector -> guard -> output limiter
+      // PreToolUse: loop detector -> guard (Bash matcher) -> output limiter pre-hook
       expect(options.hooks?.PreToolUse).toHaveLength(3);
       const guardEntry = options.hooks?.PreToolUse?.find((e) => e.matcher === 'Bash');
       expect(guardEntry).toBeDefined();
@@ -1307,91 +1248,6 @@ describe('QueryOptionsBuilder', () => {
           hookEventName: 'PreToolUse',
           permissionDecision: 'deny',
           permissionDecisionReason: anchoredGuard.reason,
-        },
-      });
-    });
-
-    it('should pass sandbox excluded commands to the limiter when sandbox is enabled', async () => {
-      // When sandbox is enabled, wrapping git would hide it from the sandbox's
-      // command-level exclusion classifier. Pass excludedCommands from the
-      // SESSION sandbox config (same source the SDK receives) so those
-      // commands are not wrapped.
-      mockSession.config.sandbox = { enabled: true, excludedCommands: ['git'] };
-      mockSettingsManager.getGlobalSettings = mock(() => ({
-        settingSources: ['user', 'project', 'local'],
-        outputLimiter: {
-          enabled: true,
-          bash: { headLines: 100, tailLines: 200 },
-          read: { maxLines: 1000 },
-          grep: { maxMatches: 250 },
-          excludeTools: [],
-        },
-      }));
-
-      const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
-
-      // git is sandbox-excluded and sandbox is enabled → git should NOT be wrapped.
-      const gitResult = await hook!(
-        {
-          hook_event_name: 'PreToolUse',
-          tool_name: 'Bash',
-          tool_input: { command: 'git fetch origin' },
-          tool_use_id: 'tool-1',
-          session_id: 'session-1',
-          transcript_path: '/tmp/transcript.jsonl',
-          cwd: '/tmp/repo',
-        },
-        'tool-1',
-        { signal: new AbortController().signal }
-      );
-
-      expect(gitResult).toEqual({});
-    });
-
-    it('should NOT pass sandbox excluded commands when sandbox is disabled', async () => {
-      // In bypassPermissions mode the sandbox is inactive, so wrapping git is
-      // safe and necessary for output limiting.
-      mockSession.config.sandbox = { enabled: false, excludedCommands: ['git'] };
-      mockSettingsManager.getGlobalSettings = mock(() => ({
-        settingSources: ['user', 'project', 'local'],
-        outputLimiter: {
-          enabled: true,
-          bash: { headLines: 100, tailLines: 200 },
-          read: { maxLines: 1000 },
-          grep: { maxMatches: 250 },
-          excludeTools: [],
-        },
-      }));
-
-      const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
-
-      // Sandbox disabled → git IS wrapped for output limiting.
-      const gitResult = await hook!(
-        {
-          hook_event_name: 'PreToolUse',
-          tool_name: 'Bash',
-          tool_input: { command: 'git diff HEAD~1' },
-          tool_use_id: 'tool-1',
-          session_id: 'session-1',
-          transcript_path: '/tmp/transcript.jsonl',
-          cwd: '/tmp/repo',
-        },
-        'tool-1',
-        { signal: new AbortController().signal }
-      );
-
-      expect(gitResult).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          updatedInput: {
-            command: expect.stringContaining('tmpfile=$(mktemp)'),
-          },
         },
       });
     });

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -61,6 +61,7 @@ describe('QueryOptionsBuilder', () => {
       getGlobalSettings: mock(() => ({
         settingSources: ['user', 'project', 'local'],
         outputLimiter: { enabled: false },
+        sandbox: { excludedCommands: ['git'] },
       })),
       prepareSDKOptions: mock(async () => ({})),
     } as unknown as SettingsManager;
@@ -1042,12 +1043,12 @@ describe('QueryOptionsBuilder', () => {
     it('should install the output-limiter hook when enabled in global settings', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
-          read: { maxChars: 50000 },
+          read: { maxLines: 1000 },
           grep: { maxMatches: 500 },
-          glob: { maxFiles: 1000 },
           excludeTools: [],
         },
       }));
@@ -1056,10 +1057,27 @@ describe('QueryOptionsBuilder', () => {
 
       expect(options.hooks?.PreToolUse).toHaveLength(2);
       expect(options.hooks?.PreToolUse?.[0]?.matcher).toBeUndefined();
-      // Output limiter is installed as the second no-matcher entry so it
-      // sees the original tool input and can mutate it before guards run.
+      // Output limiter runs after loop detector and workflow guards so guards
+      // evaluate the original command shape and the limiter only mutates input.
       expect(options.hooks?.PreToolUse?.[1]?.matcher).toBeUndefined();
       expect(options.hooks?.PreToolUse?.[1]?.hooks).toHaveLength(1);
+    });
+
+    it('should default a partial outputLimiter setting to enabled', async () => {
+      // SettingsRepository.updateGlobalSettings shallow-merges top-level keys,
+      // so an update like { outputLimiter: { bash: { headLines: 50 } } } can
+      // omit enabled. It should still install the hook using resolved defaults.
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
+        outputLimiter: {
+          bash: { headLines: 50 },
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+
+      expect(options.hooks?.PreToolUse).toHaveLength(2);
     });
 
     it('should not install the output-limiter hook when disabled in global settings', async () => {
@@ -1077,12 +1095,12 @@ describe('QueryOptionsBuilder', () => {
     it('should apply output limits to Bash commands via the built hook', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
-          read: { maxChars: 50000 },
+          read: { maxLines: 1000 },
           grep: { maxMatches: 500 },
-          glob: { maxFiles: 1000 },
           excludeTools: [],
         },
       }));
@@ -1096,7 +1114,7 @@ describe('QueryOptionsBuilder', () => {
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Bash',
-          tool_input: { command: 'git diff HEAD~1', description: 'Show diff' },
+          tool_input: { command: 'bun test', description: 'Run tests' },
           tool_use_id: 'tool-1',
           session_id: 'session-1',
           transcript_path: '/tmp/transcript.jsonl',
@@ -1106,12 +1124,6 @@ describe('QueryOptionsBuilder', () => {
         { signal: new AbortController().signal }
       );
 
-      expect(result).toMatchObject({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-        },
-      });
       const updatedInput = (
         result as {
           hookSpecificOutput: { updatedInput: Record<string, unknown> };
@@ -1120,17 +1132,26 @@ describe('QueryOptionsBuilder', () => {
       expect(updatedInput.command).toContain('tmpfile=$(mktemp)');
       expect(updatedInput.command).toContain('head -n 100');
       expect(updatedInput.command).toContain('tail -n 200');
+      expect(updatedInput.command).toContain('exit $exit_code');
+      // The hook should not grant permission on its own.
+      expect(result.hookSpecificOutput).not.toHaveProperty('permissionDecision');
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+        },
+      });
     });
 
-    it('should apply output limits to Read inputs via the built hook', async () => {
+    it('should apply output limits to Read and Grep inputs via the built hook', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
-          read: { maxChars: 25000 },
-          grep: { maxMatches: 500 },
-          glob: { maxFiles: 1000 },
+          read: { maxLines: 500 },
+          grep: { maxMatches: 250 },
           excludeTools: [],
         },
       }));
@@ -1140,7 +1161,7 @@ describe('QueryOptionsBuilder', () => {
       const hook = outputLimiterEntry?.hooks[0];
       expect(hook).toBeDefined();
 
-      const result = await hook!(
+      const readResult = await hook!(
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Read',
@@ -1154,67 +1175,21 @@ describe('QueryOptionsBuilder', () => {
         { signal: new AbortController().signal }
       );
 
-      expect(result).toEqual({
+      expect(readResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/tmp/large-file.ts',
-            limit: 500, // 25000 chars / 50 chars per line
+            limit: 500,
           },
         },
       });
-    });
-
-    it('should apply output limits to Grep and Glob inputs via the built hook', async () => {
-      mockSettingsManager.getGlobalSettings = mock(() => ({
-        settingSources: ['user', 'project', 'local'],
-        outputLimiter: {
-          enabled: true,
-          bash: { headLines: 100, tailLines: 200 },
-          read: { maxChars: 50000 },
-          grep: { maxMatches: 250 },
-          glob: { maxFiles: 500 },
-          excludeTools: [],
-        },
-      }));
-
-      const options = await new QueryOptionsBuilder(mockContext).build();
-      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
-      const hook = outputLimiterEntry?.hooks[0];
-      expect(hook).toBeDefined();
 
       const grepResult = await hook!(
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Grep',
           tool_input: { pattern: 'TODO', path: '/tmp/repo' },
-          tool_use_id: 'tool-1',
-          session_id: 'session-1',
-          transcript_path: '/tmp/transcript.jsonl',
-          cwd: '/tmp/repo',
-        },
-        'tool-1',
-        { signal: new AbortController().signal }
-      );
-
-      expect(grepResult).toEqual({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-          updatedInput: {
-            pattern: 'TODO',
-            path: '/tmp/repo',
-            head_limit: 250,
-          },
-        },
-      });
-
-      const globResult = await hook!(
-        {
-          hook_event_name: 'PreToolUse',
-          tool_name: 'Glob',
-          tool_input: { pattern: '**/*.ts' },
           tool_use_id: 'tool-2',
           session_id: 'session-1',
           transcript_path: '/tmp/transcript.jsonl',
@@ -1224,13 +1199,13 @@ describe('QueryOptionsBuilder', () => {
         { signal: new AbortController().signal }
       );
 
-      expect(globResult).toEqual({
+      expect(grepResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
           updatedInput: {
-            pattern: '**/*.ts',
-            head_limit: 500,
+            pattern: 'TODO',
+            path: '/tmp/repo',
+            head_limit: 250,
           },
         },
       });
@@ -1239,12 +1214,12 @@ describe('QueryOptionsBuilder', () => {
     it('should apply custom output-limiter limits from global settings', async () => {
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 250, tailLines: 250 },
-          read: { maxChars: 10000 },
+          read: { maxLines: 200 },
           grep: { maxMatches: 100 },
-          glob: { maxFiles: 250 },
           excludeTools: [],
         },
       }));
@@ -1258,7 +1233,7 @@ describe('QueryOptionsBuilder', () => {
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Bash',
-          tool_input: { command: 'git log --oneline', description: 'Show log' },
+          tool_input: { command: 'bun test', description: 'Run tests' },
           tool_use_id: 'tool-1',
           session_id: 'session-1',
           transcript_path: '/tmp/transcript.jsonl',
@@ -1275,6 +1250,111 @@ describe('QueryOptionsBuilder', () => {
       ).hookSpecificOutput.updatedInput;
       expect(updatedInput.command).toContain('head -n 250');
       expect(updatedInput.command).toContain('tail -n 250');
+    });
+
+    it('should run workflow tool guards against the original Bash input', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git'] },
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxLines: 1000 },
+          grep: { maxMatches: 500 },
+          excludeTools: [],
+        },
+      }));
+
+      const anchoredGuard = {
+        matcher: 'Bash',
+        pattern: '^rm\\s+-rf\\s+/',
+        decision: 'deny' as const,
+        reason: 'No recursive force deletes from root',
+      };
+      const guardBuilder = new QueryOptionsBuilder({
+        ...mockContext,
+        toolGuards: [anchoredGuard],
+      });
+      const options = await guardBuilder.build();
+
+      // Loop detector -> guard -> output limiter
+      expect(options.hooks?.PreToolUse).toHaveLength(3);
+      const guardEntry = options.hooks?.PreToolUse?.find((e) => e.matcher === 'Bash');
+      expect(guardEntry).toBeDefined();
+
+      const guardHook = guardEntry!.hooks[0];
+      const guardResult = await guardHook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'rm -rf /' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(guardResult).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: anchoredGuard.reason,
+        },
+      });
+    });
+
+    it('should pass sandbox excluded commands to the output limiter', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        sandbox: { excludedCommands: ['git', 'docker'] },
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxLines: 1000 },
+          grep: { maxMatches: 500 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      const gitResult = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'git fetch origin' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(gitResult).toEqual({});
+
+      const dockerResult = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'docker ps' },
+          tool_use_id: 'tool-2',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-2',
+        { signal: new AbortController().signal }
+      );
+
+      expect(dockerResult).toEqual({});
     });
 
     it('installs paired PostToolUse and PostToolUseFailure observers for the Bash dead-loop detector', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1306,7 +1306,9 @@ describe('QueryOptionsBuilder', () => {
       });
     });
 
-    it('should pass sandbox excluded commands to the output limiter', async () => {
+    it('should NOT auto-pass sandbox excluded commands to the output limiter', async () => {
+      // sandbox.excludedCommands controls sandbox routing, not output limiting.
+      // Auto-passing them would leave high-volume commands like `git diff` uncapped.
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
         sandbox: { excludedCommands: ['git', 'docker'] },
@@ -1324,11 +1326,12 @@ describe('QueryOptionsBuilder', () => {
       const hook = outputLimiterEntry?.hooks[0];
       expect(hook).toBeDefined();
 
+      // git is sandbox-excluded but should still be wrapped for output limiting.
       const gitResult = await hook!(
         {
           hook_event_name: 'PreToolUse',
           tool_name: 'Bash',
-          tool_input: { command: 'git fetch origin' },
+          tool_input: { command: 'git diff HEAD~1' },
           tool_use_id: 'tool-1',
           session_id: 'session-1',
           transcript_path: '/tmp/transcript.jsonl',
@@ -1338,23 +1341,14 @@ describe('QueryOptionsBuilder', () => {
         { signal: new AbortController().signal }
       );
 
-      expect(gitResult).toEqual({});
-
-      const dockerResult = await hook!(
-        {
-          hook_event_name: 'PreToolUse',
-          tool_name: 'Bash',
-          tool_input: { command: 'docker ps' },
-          tool_use_id: 'tool-2',
-          session_id: 'session-1',
-          transcript_path: '/tmp/transcript.jsonl',
-          cwd: '/tmp/repo',
+      expect(gitResult).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: {
+            command: expect.stringContaining('tmpfile=$(mktemp)'),
+          },
         },
-        'tool-2',
-        { signal: new AbortController().signal }
-      );
-
-      expect(dockerResult).toEqual({});
+      });
     });
 
     it('installs paired PostToolUse and PostToolUseFailure observers for the Bash dead-loop detector', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1134,7 +1134,9 @@ describe('QueryOptionsBuilder', () => {
       expect(updatedInput.command).toContain('tail -n 200');
       expect(updatedInput.command).toContain('exit $exit_code');
       // The hook should not grant permission on its own.
-      expect(result.hookSpecificOutput).not.toHaveProperty('permissionDecision');
+      // The hook must include permissionDecision: 'allow' for updatedInput to
+      // be reliably applied by the SDK.
+      expect(result.hookSpecificOutput).toMatchObject({ permissionDecision: 'allow' });
 
       expect(result).toMatchObject({
         hookSpecificOutput: {
@@ -1178,6 +1180,7 @@ describe('QueryOptionsBuilder', () => {
       expect(readResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             file_path: '/tmp/large-file.ts',
             limit: 500,
@@ -1202,6 +1205,7 @@ describe('QueryOptionsBuilder', () => {
       expect(grepResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
           updatedInput: {
             pattern: 'TODO',
             path: '/tmp/repo',

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1171,7 +1171,7 @@ describe('QueryOptionsBuilder', () => {
       expect(readResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
+          permissionDecision: 'allow',
           updatedInput: { file_path: '/tmp/large-file.ts', limit: 500 },
         },
       });
@@ -1193,7 +1193,7 @@ describe('QueryOptionsBuilder', () => {
       expect(grepResult).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'ask',
+          permissionDecision: 'allow',
           updatedInput: { pattern: 'TODO', path: '/tmp/repo', head_limit: 250 },
         },
       });

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1312,11 +1312,12 @@ describe('QueryOptionsBuilder', () => {
 
     it('should pass sandbox excluded commands to the limiter when sandbox is enabled', async () => {
       // When sandbox is enabled, wrapping git would hide it from the sandbox's
-      // command-level exclusion classifier. Pass excludedCommands so those
+      // command-level exclusion classifier. Pass excludedCommands from the
+      // SESSION sandbox config (same source the SDK receives) so those
       // commands are not wrapped.
+      mockSession.config.sandbox = { enabled: true, excludedCommands: ['git'] };
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { enabled: true, excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },
@@ -1352,9 +1353,9 @@ describe('QueryOptionsBuilder', () => {
     it('should NOT pass sandbox excluded commands when sandbox is disabled', async () => {
       // In bypassPermissions mode the sandbox is inactive, so wrapping git is
       // safe and necessary for output limiting.
+      mockSession.config.sandbox = { enabled: false, excludedCommands: ['git'] };
       mockSettingsManager.getGlobalSettings = mock(() => ({
         settingSources: ['user', 'project', 'local'],
-        sandbox: { enabled: false, excludedCommands: ['git'] },
         outputLimiter: {
           enabled: true,
           bash: { headLines: 100, tailLines: 200 },

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -58,7 +58,10 @@ describe('QueryOptionsBuilder', () => {
     };
 
     mockSettingsManager = {
-      getGlobalSettings: mock(() => ({ settingSources: ['user', 'project', 'local'] })),
+      getGlobalSettings: mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: { enabled: false },
+      })),
       prepareSDKOptions: mock(async () => ({})),
     } as unknown as SettingsManager;
 
@@ -1034,6 +1037,244 @@ describe('QueryOptionsBuilder', () => {
       // lives inside the hook itself.
       expect(options.hooks?.PreToolUse?.[0]?.matcher).toBeUndefined();
       expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
+    });
+
+    it('should install the output-limiter hook when enabled in global settings', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxChars: 50000 },
+          grep: { maxMatches: 500 },
+          glob: { maxFiles: 1000 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+
+      expect(options.hooks?.PreToolUse).toHaveLength(2);
+      expect(options.hooks?.PreToolUse?.[0]?.matcher).toBeUndefined();
+      // Output limiter is installed as the second no-matcher entry so it
+      // sees the original tool input and can mutate it before guards run.
+      expect(options.hooks?.PreToolUse?.[1]?.matcher).toBeUndefined();
+      expect(options.hooks?.PreToolUse?.[1]?.hooks).toHaveLength(1);
+    });
+
+    it('should not install the output-limiter hook when disabled in global settings', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: { enabled: false },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+
+      expect(options.hooks?.PreToolUse).toHaveLength(1);
+      expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
+    });
+
+    it('should apply output limits to Bash commands via the built hook', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxChars: 50000 },
+          grep: { maxMatches: 500 },
+          glob: { maxFiles: 1000 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      const result = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'git diff HEAD~1', description: 'Show diff' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(result).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
+      const updatedInput = (
+        result as {
+          hookSpecificOutput: { updatedInput: Record<string, unknown> };
+        }
+      ).hookSpecificOutput.updatedInput;
+      expect(updatedInput.command).toContain('tmpfile=$(mktemp)');
+      expect(updatedInput.command).toContain('head -n 100');
+      expect(updatedInput.command).toContain('tail -n 200');
+    });
+
+    it('should apply output limits to Read inputs via the built hook', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxChars: 25000 },
+          grep: { maxMatches: 500 },
+          glob: { maxFiles: 1000 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      const result = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Read',
+          tool_input: { file_path: '/tmp/large-file.ts' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: {
+            file_path: '/tmp/large-file.ts',
+            limit: 500, // 25000 chars / 50 chars per line
+          },
+        },
+      });
+    });
+
+    it('should apply output limits to Grep and Glob inputs via the built hook', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 100, tailLines: 200 },
+          read: { maxChars: 50000 },
+          grep: { maxMatches: 250 },
+          glob: { maxFiles: 500 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      const grepResult = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Grep',
+          tool_input: { pattern: 'TODO', path: '/tmp/repo' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      expect(grepResult).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: {
+            pattern: 'TODO',
+            path: '/tmp/repo',
+            head_limit: 250,
+          },
+        },
+      });
+
+      const globResult = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Glob',
+          tool_input: { pattern: '**/*.ts' },
+          tool_use_id: 'tool-2',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-2',
+        { signal: new AbortController().signal }
+      );
+
+      expect(globResult).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: {
+            pattern: '**/*.ts',
+            head_limit: 500,
+          },
+        },
+      });
+    });
+
+    it('should apply custom output-limiter limits from global settings', async () => {
+      mockSettingsManager.getGlobalSettings = mock(() => ({
+        settingSources: ['user', 'project', 'local'],
+        outputLimiter: {
+          enabled: true,
+          bash: { headLines: 250, tailLines: 250 },
+          read: { maxChars: 10000 },
+          grep: { maxMatches: 100 },
+          glob: { maxFiles: 250 },
+          excludeTools: [],
+        },
+      }));
+
+      const options = await new QueryOptionsBuilder(mockContext).build();
+      const outputLimiterEntry = options.hooks?.PreToolUse?.[1];
+      const hook = outputLimiterEntry?.hooks[0];
+      expect(hook).toBeDefined();
+
+      const result = await hook!(
+        {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'git log --oneline', description: 'Show log' },
+          tool_use_id: 'tool-1',
+          session_id: 'session-1',
+          transcript_path: '/tmp/transcript.jsonl',
+          cwd: '/tmp/repo',
+        },
+        'tool-1',
+        { signal: new AbortController().signal }
+      );
+
+      const updatedInput = (
+        result as {
+          hookSpecificOutput: { updatedInput: Record<string, unknown> };
+        }
+      ).hookSpecificOutput.updatedInput;
+      expect(updatedInput.command).toContain('head -n 250');
+      expect(updatedInput.command).toContain('tail -n 250');
     });
 
     it('installs paired PostToolUse and PostToolUseFailure observers for the Bash dead-loop detector', async () => {

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -270,7 +270,7 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
       maxLines: 1000,
     },
     grep: {
-      maxMatches: 500,
+      maxMatches: 250,
     },
     excludeTools: [],
   },

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -96,15 +96,13 @@ export interface FileOnlySettings {
     bash?: {
       headLines?: number; // First N lines to show (default: 100)
       tailLines?: number; // Last N lines to show (default: 200)
+      excludedCommandPrefixes?: string[]; // Prefixes not to wrap (default: [])
     };
     read?: {
-      maxChars?: number; // Max characters to read (default: 50000)
+      maxLines?: number; // Max lines to read (default: 1000)
     };
     grep?: {
       maxMatches?: number; // Max search matches (default: 500)
-    };
-    glob?: {
-      maxFiles?: number; // Max files to list (default: 1000)
     };
     excludeTools?: string[]; // Tools to exclude from limiting
   };
@@ -266,15 +264,13 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
     bash: {
       headLines: 100,
       tailLines: 200,
+      excludedCommandPrefixes: [],
     },
     read: {
-      maxChars: 50000,
+      maxLines: 1000,
     },
     grep: {
       maxMatches: 500,
-    },
-    glob: {
-      maxFiles: 1000,
     },
     excludeTools: [],
   },

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -102,7 +102,7 @@ export interface FileOnlySettings {
       maxLines?: number; // Max lines to read (default: 1000)
     };
     grep?: {
-      maxMatches?: number; // Max search matches (default: 500)
+      maxMatches?: number; // Max search matches (default: 250)
     };
     excludeTools?: string[]; // Tools to exclude from limiting
   };


### PR DESCRIPTION
## Summary

Wires the output limiter hook into `QueryOptionsBuilder.buildHooks()` so the `outputLimiter` settings are actually enforced. Large Bash/Read/Grep outputs can no longer push context over the model window in a single turn when the feature is enabled.

## Architecture

Two-hook design using the SDK's `updatedToolOutput` (PostToolUse) and `updatedInput` (PreToolUse):

- **PostToolUse** (`createOutputLimiterPostHook`): Truncates Bash `stdout`/`stderr` via `updatedToolOutput` after the command runs normally. The command executes unwrapped, so exit codes, heredocs, cwd, sandbox, and background behavior are all preserved.
- **PreToolUse** (`createOutputLimiterPreHook`): Injects `limit` for Read and `head_limit` for Grep before the tools run, preventing unnecessary data fetching.

## Changes

- `packages/daemon/src/lib/agent/output-limiter-hook.ts` — rewrite: split into PreHook (Read/Grep) + PostHook (Bash truncation)
- `packages/daemon/src/lib/agent/query-options-builder.ts` — wires both hooks in `buildHooks()`
- `packages/shared/src/types/settings.ts` — updated `outputLimiter` schema (read.maxLines, removed glob)
- `packages/daemon/src/lib/agent/api-error-circuit-breaker.ts` — updated recovery message
- Tests rewritten for the new architecture (182 tests)

## Verification

- 182 agent tests pass
- `bun run check` passes (lint, typecheck, knip, guards)
- CI green on all shards
