### PR TITLE
fix(release): restore @neokai/cli-* npm scope for v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to HyperNeo will be documented in this file.
 
+## [0.39.1] - 2026-07-03
+
+### Fixed
+
+- **npm publishing**: Reverted CLI platform package scope from `@hyperneo/cli-*` to `@neokai/cli-*` so v0.39.1 can publish using the existing npm scope and Trusted Publishing configuration. The user-facing package name (`hyperneo`), CLI binary (`hyperneo`), and HyperNeo branding are unchanged.
+
 ## [0.39.0] - 2026-07-03
 
 Project-wide rebrand from NeoKai to HyperNeo: packages, imports, environment variables, data directory, CLI binary, and npm packages renamed. Space runtime PR-event subscription hardened across three fixes, worker agent tool profiles aligned with runtime inheritance, provider logos branded in the model picker and composer pill, and Kimi/OpenAI bridge resilience improved. 15 commits since v0.38.0.

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@hyperneo/cli",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "bin": {
         "hyperneo": "./main.ts",
       },
@@ -32,7 +32,7 @@
     },
     "packages/daemon": {
       "name": "@hyperneo/daemon",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.179",
         "@anthropic-ai/sdk": "0.93.0",
@@ -50,11 +50,11 @@
     },
     "packages/desktop": {
       "name": "@hyperneo/desktop",
-      "version": "0.39.0",
+      "version": "0.39.1",
     },
     "packages/e2e": {
       "name": "@hyperneo/e2e",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hyperneo/shared",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
@@ -97,7 +97,7 @@
     },
     "packages/web": {
       "name": "@hyperneo/web",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "dependencies": {
         "@preact/signals": "2.9.1",
         "clsx": "2.1.1",
@@ -919,7 +919,7 @@
 
     "eight-colors": ["eight-colors@1.3.3", "", {}, "sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.385", "", {}, "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.386", "", {}, "sha512-f9yJE+9dJy+B4QC1iTu+mVP/KWLZviG5u/qtRwdBF0zPt3etWa1HSY1lMuWw0Nt8/KpLCY6ok+XlKHOs6ZhxSA=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -1063,7 +1063,7 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 

--- a/npm/hyperneo/bin/hyperneo.js
+++ b/npm/hyperneo/bin/hyperneo.js
@@ -3,16 +3,16 @@
 /**
  * HyperNeo CLI launcher.
  * Detects the current platform and spawns the correct compiled binary
- * from the matching @hyperneo/cli-{platform} optional dependency.
+ * from the matching @neokai/cli-{platform} optional dependency.
  */
 
 const { spawnSync } = require('child_process');
 
 const PLATFORM_MAP = {
-  'darwin-arm64': '@hyperneo/cli-darwin-arm64',
-  'darwin-x64': '@hyperneo/cli-darwin-x64',
-  'linux-x64': '@hyperneo/cli-linux-x64',
-  'linux-arm64': '@hyperneo/cli-linux-arm64',
+  'darwin-arm64': '@neokai/cli-darwin-arm64',
+  'darwin-x64': '@neokai/cli-darwin-x64',
+  'linux-x64': '@neokai/cli-linux-x64',
+  'linux-arm64': '@neokai/cli-linux-arm64',
 };
 
 const platformKey = `${process.platform}-${process.arch}`;

--- a/npm/hyperneo/package.json
+++ b/npm/hyperneo/package.json
@@ -1,15 +1,15 @@
 {
   "name": "hyperneo",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "HyperNeo - Claude Agent SDK Web Interface",
   "bin": {
     "hyperneo": "bin/hyperneo.js"
   },
   "optionalDependencies": {
-    "@hyperneo/cli-darwin-arm64": "0.39.0",
-    "@hyperneo/cli-darwin-x64": "0.39.0",
-    "@hyperneo/cli-linux-x64": "0.39.0",
-    "@hyperneo/cli-linux-arm64": "0.39.0"
+    "@neokai/cli-darwin-arm64": "0.39.1",
+    "@neokai/cli-darwin-x64": "0.39.1",
+    "@neokai/cli-linux-x64": "0.39.1",
+    "@neokai/cli-linux-arm64": "0.39.1"
   },
   "files": [
     "bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/cli",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/daemon",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/desktop",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "private": true,
   "description": "Kai Desktop App - Tauri wrapper bundling the HyperNeo daemon as a sidecar",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "neokai-desktop"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "dirs",
  "log",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokai-desktop"
-version = "0.39.0"
+version = "0.39.1"
 description = "Kai - AI Assistant Desktop App"
 authors = ["HyperNeo contributors"]
 license = "Apache-2.0"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kai",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "identifier": "io.neokai.kai",
   "build": {
     "frontendDist": "loading",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/e2e",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/shared",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "license": "Apache-2.0",
   "main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/web",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/scripts/package-npm.ts
+++ b/scripts/package-npm.ts
@@ -30,7 +30,7 @@ console.log(`Packaging npm packages (version ${VERSION})...\n`);
 
 // 1. Create platform-specific packages
 for (const { target, os, cpu } of PLATFORMS) {
-  const pkgName = `@hyperneo/cli-${target}`;
+  const pkgName = `@neokai/cli-${target}`;
   const pkgDir = join(NPM_DIR, `cli-${target}`);
   const binDir = join(pkgDir, 'bin');
 
@@ -86,7 +86,7 @@ chmodSync(join(mainBinDir, 'hyperneo.js'), 0o755);
 // Write main package.json
 const optionalDeps: Record<string, string> = {};
 for (const { target } of PLATFORMS) {
-  optionalDeps[`@hyperneo/cli-${target}`] = VERSION;
+  optionalDeps[`@neokai/cli-${target}`] = VERSION;
 }
 
 writeFileSync(


### PR DESCRIPTION
Restores the CLI platform package scope from @hyperneo/cli-* to @neokai/cli-* so v0.39.1 can publish using the existing npm scope and Trusted Publishing config.