### PR TITLE
Release v0.39.5: complete HyperNeo rebrand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,17 +333,17 @@ jobs:
 
           for dmg in "$BUNDLE_ROOT"/dmg/*.dmg; do
             [ -e "$dmg" ] || continue
-            cp "$dmg" "$ARTIFACT_DIR/Kai_${VERSION}_${{ matrix.arch }}.dmg"
+            cp "$dmg" "$ARTIFACT_DIR/HyperNeo_${VERSION}_${{ matrix.arch }}.dmg"
           done
 
           for deb in "$BUNDLE_ROOT"/deb/*.deb; do
             [ -e "$deb" ] || continue
-            cp "$deb" "$ARTIFACT_DIR/Kai_${VERSION}_${{ matrix.arch }}.deb"
+            cp "$deb" "$ARTIFACT_DIR/HyperNeo_${VERSION}_${{ matrix.arch }}.deb"
           done
 
           for rpm in "$BUNDLE_ROOT"/rpm/*.rpm; do
             [ -e "$rpm" ] || continue
-            cp "$rpm" "$ARTIFACT_DIR/Kai_${VERSION}_${{ matrix.arch }}.rpm"
+            cp "$rpm" "$ARTIFACT_DIR/HyperNeo_${VERSION}_${{ matrix.arch }}.rpm"
           done
 
           if [ -d "$BUNDLE_ROOT/macos" ]; then
@@ -352,7 +352,7 @@ jobs:
             APP_PATH=""
           fi
           if [ -n "$APP_PATH" ]; then
-            ditto -c -k --keepParent "$APP_PATH" "$ARTIFACT_DIR/Kai_${VERSION}_${{ matrix.arch }}.app.zip"
+            ditto -c -k --keepParent "$APP_PATH" "$ARTIFACT_DIR/HyperNeo_${VERSION}_${{ matrix.arch }}.app.zip"
           fi
 
           if ! compgen -G "$ARTIFACT_DIR/*" > /dev/null; then
@@ -361,9 +361,9 @@ jobs:
           fi
 
           if command -v sha256sum >/dev/null 2>&1; then
-            (cd "$ARTIFACT_DIR" && sha256sum * > "Kai_${VERSION}_${{ matrix.arch }}_SHA256SUMS.txt")
+            (cd "$ARTIFACT_DIR" && sha256sum * > "HyperNeo_${VERSION}_${{ matrix.arch }}_SHA256SUMS.txt")
           else
-            (cd "$ARTIFACT_DIR" && shasum -a 256 * > "Kai_${VERSION}_${{ matrix.arch }}_SHA256SUMS.txt")
+            (cd "$ARTIFACT_DIR" && shasum -a 256 * > "HyperNeo_${VERSION}_${{ matrix.arch }}_SHA256SUMS.txt")
           fi
 
       - name: Upload desktop artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to HyperNeo will be documented in this file.
 
+## [0.39.5] - 2026-07-04
+
+### Changed
+
+- **npm publishing**: Restored platform-specific optional dependencies to the `@hyperneo/cli-*` scope now that the packages have been manually published and Trusted Publishing for `lsm/HyperNeo` is configured. The install package remains `hyperneo`.
+- **Desktop release assets**: Renamed desktop installer filenames from `Kai_*` to `HyperNeo_*` to match the HyperNeo rebrand.
+
 ## [0.39.4] - 2026-07-04
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@hyperneo/cli",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "bin": {
         "hyperneo": "./main.ts",
       },
@@ -32,7 +32,7 @@
     },
     "packages/daemon": {
       "name": "@hyperneo/daemon",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.179",
         "@anthropic-ai/sdk": "0.93.0",
@@ -50,11 +50,11 @@
     },
     "packages/desktop": {
       "name": "@hyperneo/desktop",
-      "version": "0.39.4",
+      "version": "0.39.5",
     },
     "packages/e2e": {
       "name": "@hyperneo/e2e",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.8.0",
@@ -70,7 +70,7 @@
     },
     "packages/shared": {
       "name": "@hyperneo/shared",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
@@ -97,7 +97,7 @@
     },
     "packages/web": {
       "name": "@hyperneo/web",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "dependencies": {
         "@preact/signals": "2.9.1",
         "clsx": "2.1.1",
@@ -731,7 +731,7 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.41", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
@@ -777,7 +777,7 @@
 
     "console-grid": ["console-grid@2.2.4", "", {}, "sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -1690,6 +1690,8 @@
     "http-assert/http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
 
     "koa/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "koa/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "koa/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 

--- a/npm/hyperneo/bin/hyperneo.js
+++ b/npm/hyperneo/bin/hyperneo.js
@@ -3,16 +3,16 @@
 /**
  * HyperNeo CLI launcher.
  * Detects the current platform and spawns the correct compiled binary
- * from the matching @neokai/cli-{platform} optional dependency.
+ * from the matching @hyperneo/cli-{platform} optional dependency.
  */
 
 const { spawnSync } = require('child_process');
 
 const PLATFORM_MAP = {
-  'darwin-arm64': '@neokai/cli-darwin-arm64',
-  'darwin-x64': '@neokai/cli-darwin-x64',
-  'linux-x64': '@neokai/cli-linux-x64',
-  'linux-arm64': '@neokai/cli-linux-arm64',
+  'darwin-arm64': '@hyperneo/cli-darwin-arm64',
+  'darwin-x64': '@hyperneo/cli-darwin-x64',
+  'linux-x64': '@hyperneo/cli-linux-x64',
+  'linux-arm64': '@hyperneo/cli-linux-arm64',
 };
 
 const platformKey = `${process.platform}-${process.arch}`;

--- a/npm/hyperneo/package.json
+++ b/npm/hyperneo/package.json
@@ -1,15 +1,15 @@
 {
   "name": "hyperneo",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "description": "HyperNeo - Claude Agent SDK Web Interface",
   "bin": {
     "hyperneo": "bin/hyperneo.js"
   },
   "optionalDependencies": {
-    "@neokai/cli-darwin-arm64": "0.39.4",
-    "@neokai/cli-darwin-x64": "0.39.4",
-    "@neokai/cli-linux-x64": "0.39.4",
-    "@neokai/cli-linux-arm64": "0.39.4"
+    "@hyperneo/cli-darwin-arm64": "0.39.5",
+    "@hyperneo/cli-darwin-x64": "0.39.5",
+    "@hyperneo/cli-linux-x64": "0.39.5",
+    "@hyperneo/cli-linux-arm64": "0.39.5"
   },
   "files": [
     "bin/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/cli",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/daemon",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "type": "module",
   "license": "Apache-2.0",
   "main": "main.ts",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/desktop",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "private": true,
   "description": "Kai Desktop App - Tauri wrapper bundling the HyperNeo daemon as a sidecar",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "neokai-desktop"
-version = "0.39.4"
+version = "0.39.5"
 dependencies = [
  "dirs",
  "log",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neokai-desktop"
-version = "0.39.4"
-description = "Kai - AI Assistant Desktop App"
+version = "0.39.5"
+description = "HyperNeo - AI Assistant Desktop App"
 authors = ["HyperNeo contributors"]
 license = "Apache-2.0"
 repository = "https://github.com/lsm/dev-neokai"

--- a/packages/desktop/src-tauri/loading/index.html
+++ b/packages/desktop/src-tauri/loading/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kai - Loading</title>
+    <title>HyperNeo - Loading</title>
     <style>
         * {
             margin: 0;
@@ -53,7 +53,7 @@
 </head>
 <body>
     <div class="container">
-        <div class="logo">Kai</div>
+        <div class="logo">HyperNeo</div>
         <div class="spinner"></div>
         <div class="status">Starting AI assistant...</div>
     </div>

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -46,8 +46,8 @@ pub fn run() {
 			)?;
 
 			// System tray menu.
-			let show_item = MenuItem::with_id(app, "show", "Show Kai", true, None::<&str>)?;
-			let hide_item = MenuItem::with_id(app, "hide", "Hide Kai", true, None::<&str>)?;
+			let show_item = MenuItem::with_id(app, "show", "Show HyperNeo", true, None::<&str>)?;
+			let hide_item = MenuItem::with_id(app, "hide", "Hide HyperNeo", true, None::<&str>)?;
 			let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
 			let menu = Menu::with_items(app, &[&show_item, &hide_item, &quit_item])?;
@@ -174,7 +174,7 @@ pub fn run() {
 					}
 				});
 
-				log::info!("Kai desktop app started with neokai daemon");
+				log::info!("HyperNeo desktop app started with neokai daemon");
 
 				// Poll the daemon's health endpoint, then navigate the webview off
 				// the loading splash and onto the live UI.

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Kai",
-  "version": "0.39.4",
+  "productName": "HyperNeo",
+  "version": "0.39.5",
   "identifier": "io.neokai.kai",
   "build": {
     "frontendDist": "loading",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Kai",
+        "title": "HyperNeo",
         "url": "loading/index.html",
         "width": 1200,
         "height": 800,
@@ -51,7 +51,7 @@
       "icons/icon.ico"
     ],
     "shortDescription": "AI Assistant Desktop App",
-    "longDescription": "Kai - A powerful AI assistant for developers",
+    "longDescription": "HyperNeo - A powerful AI assistant for developers",
     "category": "DeveloperTool",
     "macOS": {
       "minimumSystemVersion": "10.13",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/e2e",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/shared",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "type": "module",
   "license": "Apache-2.0",
   "main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperneo/web",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/scripts/package-npm.ts
+++ b/scripts/package-npm.ts
@@ -30,7 +30,7 @@ console.log(`Packaging npm packages (version ${VERSION})...\n`);
 
 // 1. Create platform-specific packages
 for (const { target, os, cpu } of PLATFORMS) {
-  const pkgName = `@neokai/cli-${target}`;
+  const pkgName = `@hyperneo/cli-${target}`;
   const pkgDir = join(NPM_DIR, `cli-${target}`);
   const binDir = join(pkgDir, 'bin');
 
@@ -86,7 +86,7 @@ chmodSync(join(mainBinDir, 'hyperneo.js'), 0o755);
 // Write main package.json
 const optionalDeps: Record<string, string> = {};
 for (const { target } of PLATFORMS) {
-  optionalDeps[`@neokai/cli-${target}`] = VERSION;
+  optionalDeps[`@hyperneo/cli-${target}`] = VERSION;
 }
 
 writeFileSync(


### PR DESCRIPTION
## Summary

Bumps the release to v0.39.5 and completes the HyperNeo npm/desktop rebrand.

### Changes

- Switches npm platform optional dependencies from `@neokai/cli-*` back to `@hyperneo/cli-*`.
- Bumps all workspace packages and the desktop bundle version to `0.39.5`.
- Renames GitHub Release desktop assets from `Kai_*` to `HyperNeo_*`.
- Updates desktop app productName, window title, and menu/loading branding to HyperNeo.
- Regenerates `bun.lock` and `Cargo.lock`.

### Release notes

See `CHANGELOG.md` for the full v0.39.5 entry.

### Post-merge

After this PR merges, tag `v0.39.5` on `dev` and push the tag to trigger the Release workflow. The workflow will publish `hyperneo@0.39.5` and `@hyperneo/cli-*@0.39.5` via Trusted Publishing.

> ⚠️ Ensure the `hyperneo` and `@hyperneo/cli-*` packages on npm have `lsm/HyperNeo` / `.github/workflows/release.yml` configured as a Trusted Publisher before pushing the tag.
