### PR TITLE
test: add chat/thread lifecycle recovery regression suite

### DIFF
--- a/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
@@ -42,13 +42,15 @@ describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
   // In-memory stand-in for the persisted session row. updateSession mutates
   // it so restoreFromDatabase reflects what a restart would observe.
   let stored: { processingState?: string } | null;
+  let db: Database;
+  let internalEventBus: InternalEventBus<any>;
 
   beforeEach(() => {
     stored = null;
     const updateSession = mock((_id: string, patch: Record<string, unknown>) => {
       stored = { ...(stored ?? {}), ...patch } as { processingState?: string };
     });
-    const db = {
+    db = {
       getSession: mock(() => stored),
       updateSession,
       saveSDKMessage: mock(() => true),
@@ -62,7 +64,7 @@ describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
     } as unknown as Database;
 
     const emit = mock(async () => {});
-    const internalEventBus = {
+    internalEventBus = {
       publish: emit,
       publishAsync: emit,
       subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
@@ -159,6 +161,17 @@ describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
     expect(manager.isIdle()).toBe(true);
     expect(manager.isWaitingForInput()).toBe(false);
     expect(manager.getPendingQuestion()).toBeNull();
+
+    // 5. The cleared state was persisted — a second daemon restart must NOT
+    //    re-lock the composer in waiting_for_input. Restore into a FRESH
+    //    manager (same DB) so the assertion depends on the persisted row, not
+    //    the in-memory state of the manager we just cleared.
+    expect(stored?.processingState).toContain('"status":"idle"');
+    const restarted = new ProcessingStateManager(sessionId, internalEventBus, db);
+    restarted.restoreFromDatabase();
+    expect(restarted.isIdle()).toBe(true);
+    expect(restarted.isWaitingForInput()).toBe(false);
+    expect(restarted.getPendingQuestion()).toBeNull();
   });
 
   test('an interrupted processing turn recovers to idle on restart (not waiting_for_input)', () => {

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
@@ -2,59 +2,134 @@
  * Chat/Thread Lifecycle Recovery — stale waiting_for_input on the daemon.
  *
  * Regression coverage for scenario 5 (terminal result arrival after stale
- * waiting_for_input). The authoritative recovery invariant spans two
- * collaborators that the existing unit suite tests only in isolation:
+ * waiting_for_input). The recovery invariant spans two collaborators:
  *
  *   1. ProcessingStateManager.restoreFromDatabase() preserves a
  *      waiting_for_input state (and its pendingQuestion) across a restart,
  *      while resetting processing/queued/cooldown to idle.
- *   2. The terminal-result path (SDKMessageHandler calls stateManager.setIdle()
- *      before type-specific handling) clears that stale question so the
- *      composer cannot stay locked after an interrupted AskUserQuestion turn.
+ *   2. The terminal-result path inside SDKMessageHandler —
+ *      `if (isSDKResultMessage(message) && !usesSessionStateChangedTurnEnd)
+ *      await stateManager.setIdle()` — clears that stale question before
+ *      type-specific handling so an interrupted AskUserQuestion turn cannot
+ *      keep the composer locked.
  *
- * This file exercises the combined flow against a real ProcessingStateManager
- * — persist waiting_for_input -> restart restores it -> terminal result clears
- * it -> the cleared state is persisted so a second restart does not re-lock.
+ * To actually protect invariant (2), these tests wire a REAL
+ * ProcessingStateManager as the handler's state manager and deliver a
+ * terminal result message through SDKMessageHandler.handleMessage() — NOT
+ * by calling setIdle() directly. detectPhaseFromMessage() early-returns
+ * while not processing, so the only thing that can release the stale lock
+ * on a result is the handler's terminal-result setIdle() call.
  */
 
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
-import type { PendingUserQuestion } from '@hyperneo/shared';
+import { SDKMessageHandler } from '../../../../src/lib/agent/sdk-message-handler';
+import type { PendingUserQuestion, Session, MessageHub } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+import type { DaemonHub } from '../../../../tests/helpers/daemon-hub';
 import type { InternalEventBus } from '../../../../src/lib/internal-event-bus';
 import type { Database } from '../../../../src/storage/database';
+import type { ContextTracker } from '../../../../src/lib/agent/context-tracker';
+import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
+import type { ErrorManager } from '../../../../src/lib/error-manager';
+import type { QueryLifecycleManager } from '../../../../src/lib/agent/query-lifecycle-manager';
 
 const sessionId = 'recovery-session';
 
 describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
   let manager: ProcessingStateManager;
+  let handler: SDKMessageHandler;
   // In-memory stand-in for the persisted session row. updateSession mutates
-  // it so we can assert what a subsequent restart would observe.
+  // it so restoreFromDatabase reflects what a restart would observe.
   let stored: { processingState?: string } | null;
 
   beforeEach(() => {
     stored = null;
-    const updateSessionMock = mock((_id: string, patch: Record<string, unknown>) => {
+    const updateSession = mock((_id: string, patch: Record<string, unknown>) => {
       stored = { ...(stored ?? {}), ...patch } as { processingState?: string };
     });
-    const mockDb = {
+    const db = {
       getSession: mock(() => stored),
-      updateSession: updateSessionMock,
+      updateSession,
+      saveSDKMessage: mock(() => true),
+      getMessagesByStatus: mock(() => []),
+      getMessageByStatusAndUuid: mock(() => null),
+      updateMessageStatus: mock(() => {}),
+      updateMessageTimestamp: mock(() => {}),
+      beginTransaction: mock(() => {}),
+      commitTransaction: mock(() => {}),
+      abortTransaction: mock(() => {}),
     } as unknown as Database;
-    const mockInternalEventBus = {
-      publish: mock(() => {}),
-      publishAsync: mock(async () => {}),
+
+    const emit = mock(async () => {});
+    const internalEventBus = {
+      publish: emit,
+      publishAsync: emit,
       subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
     } as unknown as InternalEventBus<any>;
 
-    manager = new ProcessingStateManager(sessionId, mockInternalEventBus, mockDb);
+    manager = new ProcessingStateManager(sessionId, internalEventBus, db);
+
+    const session = {
+      id: sessionId,
+      title: 'Recovery',
+      workspacePath: '/test',
+      createdAt: new Date(0).toISOString(),
+      lastActiveAt: new Date(0).toISOString(),
+      status: 'active',
+      config: { model: 'default', maxTokens: 8192, temperature: 1 },
+      metadata: {
+        messageCount: 0,
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalCost: 0,
+        toolCallCount: 0,
+      },
+    } as unknown as Session;
+
+    const messageHub = {
+      event: mock(async () => {}),
+      onRequest: mock((_m: string, _h: Function) => () => {}),
+      query: mock(async () => ({})),
+      command: mock(async () => {}),
+    } as unknown as MessageHub;
+    const daemonHub = { emit } as unknown as DaemonHub;
+    const contextTracker = {
+      getContextInfo: () => ({ totalTokens: 0, maxTokens: 128000 }),
+      updateWithDetailedBreakdown: () => {},
+      shouldCompact: () => false,
+      shouldCompactAt: () => false,
+      markCompactionTriggered: () => {},
+    } as unknown as ContextTracker;
+    const messageQueue = {
+      enqueue: mock(async () => 'ctx-id'),
+      enqueueWithId: mock(async () => {}),
+      clear: mock(() => {}),
+    } as unknown as MessageQueue;
+    const errorManager = { handleError: mock(async () => {}) } as unknown as ErrorManager;
+    const lifecycleManager = { stop: mock(async () => {}) } as unknown as QueryLifecycleManager;
+
+    handler = new SDKMessageHandler({
+      session,
+      db,
+      messageHub,
+      daemonHub,
+      internalEventBus,
+      stateManager: manager,
+      contextTracker,
+      messageQueue,
+      errorManager,
+      lifecycleManager,
+      queryObject: null,
+      queryPromise: null,
+      onInitSlashCommands: mock(async () => {}),
+      onCommandsChanged: mock(async () => {}),
+    });
   });
 
-  test('waiting_for_input survives a restart and is cleared when the terminal-result path runs', async () => {
-    const pendingQuestion: PendingUserQuestion = {
-      toolUseId: 'stale-question',
-      questions: [],
-    };
-
+  test('a terminal result delivered through SDKMessageHandler clears a stale waiting_for_input restored after restart', async () => {
+    const pendingQuestion: PendingUserQuestion = { toolUseId: 'stale-question', questions: [] };
     // 1. A crash left the session persisted in waiting_for_input.
     stored = { processingState: JSON.stringify({ status: 'waiting_for_input', pendingQuestion }) };
 
@@ -64,24 +139,32 @@ describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
     expect(manager.isWaitingForInput()).toBe(true);
     expect(manager.getPendingQuestion()?.toolUseId).toBe('stale-question');
 
-    // 3. The terminal-result path runs (SDKMessageHandler.setIdle() before
-    //    type-specific handling) and must release the stale lock.
-    await manager.setIdle();
+    // 3. Deliver a terminal ERROR result through the real handler. An error
+    //    result is isSDKResultMessage but NOT isSDKResultSuccess, so it runs
+    //    the handler's stale-clear at the top of the result path but never
+    //    reaches handleResultMessage()/finishTurn() (which would also call
+    //    setIdle for a success result). This isolates the fixed path: if the
+    //    "clear stale waiting_for_input on result" setIdle() is removed or
+    //    reordered, this assertion fails.
+    const result: SDKMessage = {
+      type: 'result',
+      subtype: 'error_max_turns',
+      uuid: 'terminal-error-result',
+      total_cost_usd: 0,
+      modelUsage: {},
+    } as unknown as SDKMessage;
+    await handler.handleMessage(result);
+
+    // 4. The stale lock is released: composer unlocks, no lingering question.
     expect(manager.isIdle()).toBe(true);
     expect(manager.isWaitingForInput()).toBe(false);
     expect(manager.getPendingQuestion()).toBeNull();
-
-    // 4. The cleared state was persisted — a second restart must NOT re-lock
-    //    the composer in waiting_for_input.
-    expect(stored?.processingState).toContain('"status":"idle"');
-    manager.restoreFromDatabase();
-    expect(manager.isIdle()).toBe(true);
-    expect(manager.isWaitingForInput()).toBe(false);
   });
 
-  test('an interrupted AskUserQuestion turn recovers to idle on restart (not waiting_for_input)', () => {
-    // Contrast spine: even though waiting_for_input is preserved, a session
-    // that crashed mid-processing must come back idle so it is not stuck.
+  test('an interrupted processing turn recovers to idle on restart (not waiting_for_input)', () => {
+    // Contrast spine: although waiting_for_input is preserved across restart,
+    // a session that crashed mid-processing must come back idle so it is not
+    // stuck — only a deliberate waiting_for_input is restored as-is.
     stored = {
       processingState: JSON.stringify({ status: 'processing', phase: 'streaming' }),
     };

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-lifecycle-recovery.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Chat/Thread Lifecycle Recovery — stale waiting_for_input on the daemon.
+ *
+ * Regression coverage for scenario 5 (terminal result arrival after stale
+ * waiting_for_input). The authoritative recovery invariant spans two
+ * collaborators that the existing unit suite tests only in isolation:
+ *
+ *   1. ProcessingStateManager.restoreFromDatabase() preserves a
+ *      waiting_for_input state (and its pendingQuestion) across a restart,
+ *      while resetting processing/queued/cooldown to idle.
+ *   2. The terminal-result path (SDKMessageHandler calls stateManager.setIdle()
+ *      before type-specific handling) clears that stale question so the
+ *      composer cannot stay locked after an interrupted AskUserQuestion turn.
+ *
+ * This file exercises the combined flow against a real ProcessingStateManager
+ * — persist waiting_for_input -> restart restores it -> terminal result clears
+ * it -> the cleared state is persisted so a second restart does not re-lock.
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
+import type { PendingUserQuestion } from '@hyperneo/shared';
+import type { InternalEventBus } from '../../../../src/lib/internal-event-bus';
+import type { Database } from '../../../../src/storage/database';
+
+const sessionId = 'recovery-session';
+
+describe('chat/thread lifecycle recovery — stale waiting_for_input', () => {
+  let manager: ProcessingStateManager;
+  // In-memory stand-in for the persisted session row. updateSession mutates
+  // it so we can assert what a subsequent restart would observe.
+  let stored: { processingState?: string } | null;
+
+  beforeEach(() => {
+    stored = null;
+    const updateSessionMock = mock((_id: string, patch: Record<string, unknown>) => {
+      stored = { ...(stored ?? {}), ...patch } as { processingState?: string };
+    });
+    const mockDb = {
+      getSession: mock(() => stored),
+      updateSession: updateSessionMock,
+    } as unknown as Database;
+    const mockInternalEventBus = {
+      publish: mock(() => {}),
+      publishAsync: mock(async () => {}),
+      subscribe: mock((_: string, __: Function, ___: { subscriberName: string }) => () => {}),
+    } as unknown as InternalEventBus<any>;
+
+    manager = new ProcessingStateManager(sessionId, mockInternalEventBus, mockDb);
+  });
+
+  test('waiting_for_input survives a restart and is cleared when the terminal-result path runs', async () => {
+    const pendingQuestion: PendingUserQuestion = {
+      toolUseId: 'stale-question',
+      questions: [],
+    };
+
+    // 1. A crash left the session persisted in waiting_for_input.
+    stored = { processingState: JSON.stringify({ status: 'waiting_for_input', pendingQuestion }) };
+
+    // 2. Restart: the waiting state and its pending question are restored,
+    //    so the UI can still surface the unanswered prompt.
+    manager.restoreFromDatabase();
+    expect(manager.isWaitingForInput()).toBe(true);
+    expect(manager.getPendingQuestion()?.toolUseId).toBe('stale-question');
+
+    // 3. The terminal-result path runs (SDKMessageHandler.setIdle() before
+    //    type-specific handling) and must release the stale lock.
+    await manager.setIdle();
+    expect(manager.isIdle()).toBe(true);
+    expect(manager.isWaitingForInput()).toBe(false);
+    expect(manager.getPendingQuestion()).toBeNull();
+
+    // 4. The cleared state was persisted — a second restart must NOT re-lock
+    //    the composer in waiting_for_input.
+    expect(stored?.processingState).toContain('"status":"idle"');
+    manager.restoreFromDatabase();
+    expect(manager.isIdle()).toBe(true);
+    expect(manager.isWaitingForInput()).toBe(false);
+  });
+
+  test('an interrupted AskUserQuestion turn recovers to idle on restart (not waiting_for_input)', () => {
+    // Contrast spine: even though waiting_for_input is preserved, a session
+    // that crashed mid-processing must come back idle so it is not stuck.
+    stored = {
+      processingState: JSON.stringify({ status: 'processing', phase: 'streaming' }),
+    };
+
+    manager.restoreFromDatabase();
+    expect(manager.isIdle()).toBe(true);
+    expect(manager.isWaitingForInput()).toBe(false);
+  });
+});

--- a/packages/web/src/islands/__tests__/ChatContainer.test.ts
+++ b/packages/web/src/islands/__tests__/ChatContainer.test.ts
@@ -45,6 +45,34 @@ describe('ChatContainer input guard', () => {
 
     expect(shouldBlockForPendingQuestion(waitingState, messages)).toBe(false);
   });
+
+  // Lifecycle-recovery edge cases for scenario 5 (terminal result arrival
+  // after stale waiting_for_input). Only a TRAILING result clears the lock;
+  // a result earlier in the thread (the agent kept going afterwards) must
+  // not unlock the composer, and non-waiting statuses never block.
+  it('keeps the lock when a terminal result is not the trailing message', () => {
+    // The agent answered the question (result) and then produced more turns —
+    // the trailing message is not a result, so a fresh waiting state still locks.
+    const messages = [
+      { type: 'assistant' },
+      { type: 'result' },
+      { type: 'user' },
+      { type: 'assistant' },
+    ] as SDKMessage[];
+
+    expect(shouldBlockForPendingQuestion(waitingState, messages)).toBe(true);
+  });
+
+  it.each([
+    ['idle', { status: 'idle' }],
+    ['processing', { status: 'processing', phase: 'streaming' }],
+    ['queued', { status: 'queued', messageId: 'm-1' }],
+    ['interrupted', { status: 'interrupted' }],
+  ])('never blocks when the agent status is %s', (_label, agentState) => {
+    const messages = [{ type: 'user' }] as SDKMessage[];
+
+    expect(shouldBlockForPendingQuestion(agentState as AgentProcessingState, messages)).toBe(false);
+  });
 });
 
 describe('ChatContainer State Batching', () => {

--- a/packages/web/src/lib/__tests__/router-lifecycle-recovery.test.ts
+++ b/packages/web/src/lib/__tests__/router-lifecycle-recovery.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Chat/Thread Lifecycle Recovery — Route ID special-character contract.
+ *
+ * Regression coverage for scenario 3 (route IDs containing special
+ * characters). Several high-priority recovery failures came from route IDs
+ * that did not round-trip through the URL: coordinator session ids
+ * (`space:chat:<uuid>`), percent-encoded characters in deep links, and
+ * non-hex ids silently falling through to the spaces list.
+ *
+ * These tests lock in the router's contract so a future change to the route
+ * patterns (or the addition of percent-decoding) is caught and reviewed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createSessionPath,
+  createSpacePath,
+  createSpaceSessionPath,
+  createSpaceTaskPath,
+  getSessionIdFromPath,
+  getSpaceIdFromPath,
+  getSpaceSessionIdFromPath,
+  getSpaceTaskIdFromPath,
+} from '../router';
+
+const UUID = '04062505-780f-4881-a3be-9cb9062790fb';
+// A coordinator session id as minted by the Space runtime — contains colons.
+const COORDINATOR_SESSION_ID = 'space:chat:b90171e4-1111-2222-3333-444444444444';
+
+describe('chat/thread lifecycle recovery — route IDs with special characters', () => {
+  describe('create -> parse round-trip', () => {
+    it('round-trips a standard session UUID through /session/', () => {
+      const path = createSessionPath(UUID);
+      expect(getSessionIdFromPath(path)).toBe(UUID);
+    });
+
+    it('round-trips a space id through /space/', () => {
+      const path = createSpacePath('hyperneo-dev');
+      expect(getSpaceIdFromPath(path)).toBe('hyperneo-dev');
+    });
+
+    it('round-trips a coordinator session id (with colons) through the space-session route', () => {
+      // The space-session route is deliberately permissive ([a-zA-Z0-9:_-]+)
+      // so coordinator ids survive a navigate -> refresh cycle intact.
+      const path = createSpaceSessionPath('hyperneo-dev', COORDINATOR_SESSION_ID);
+      expect(getSpaceSessionIdFromPath(path)).toEqual({
+        spaceId: 'hyperneo-dev',
+        sessionId: COORDINATOR_SESSION_ID,
+      });
+    });
+
+    it('round-trips a UUID task id and a short task id through /space/<slug>/task/', () => {
+      expect(getSpaceTaskIdFromPath(createSpaceTaskPath('hyperneo-dev', UUID))).toEqual({
+        spaceId: 'hyperneo-dev',
+        taskId: UUID,
+      });
+      expect(getSpaceTaskIdFromPath(createSpaceTaskPath('hyperneo-dev', 't-42'))).toEqual({
+        spaceId: 'hyperneo-dev',
+        taskId: 't-42',
+      });
+    });
+  });
+
+  describe('coordinator / special-character ids resolve on the space-session route', () => {
+    it('matches a coordinator session id containing colons', () => {
+      expect(
+        getSpaceSessionIdFromPath(`/space/hyperneo-dev/session/${COORDINATOR_SESSION_ID}`)
+      ).toEqual({
+        spaceId: 'hyperneo-dev',
+        sessionId: COORDINATOR_SESSION_ID,
+      });
+    });
+
+    it('matches a coordinator session id containing underscores', () => {
+      const id = 'space:chat_worker:b90171e4-1111-2222-3333-444444444444';
+      expect(getSpaceSessionIdFromPath(`/space/hyperneo-dev/session/${id}`)).toEqual({
+        spaceId: 'hyperneo-dev',
+        sessionId: id,
+      });
+    });
+  });
+
+  describe('the plain /session/ route rejects special-character ids', () => {
+    // SESSION_ROUTE_PATTERN is hex + hyphens only. Coordinator ids (and any
+    // id carrying a colon / slash / percent) must be opened via the space
+    // route; the plain route returning null for them is the contract that
+    // prevents a mis-parsed id from loading the wrong session.
+    it('does not match a coordinator id with colons', () => {
+      expect(getSessionIdFromPath(`/session/${COORDINATOR_SESSION_ID}`)).toBeNull();
+    });
+
+    it('does not match an id containing a non-hex letter', () => {
+      expect(getSessionIdFromPath('/session/zzzz-not-hex')).toBeNull();
+    });
+
+    it('does not match an id containing a slash', () => {
+      expect(getSessionIdFromPath('/session/space/chat/abc')).toBeNull();
+    });
+  });
+
+  describe('raw-pathname matching (no percent-decoding)', () => {
+    // The router matches `window.location.pathname` verbatim — it never
+    // percent-decodes. Internal navigation uses history.pushState with the
+    // raw id, so colons are preserved. A percent-encoded deep link from an
+    // external source therefore does NOT resolve; this test locks that
+    // contract so adding decodeURIComponent is a deliberate, reviewed act.
+    it('does not match a percent-encoded colon in a space-session id', () => {
+      const encoded = encodeURIComponent(COORDINATOR_SESSION_ID); // space%3Achat%3A...
+      expect(getSpaceSessionIdFromPath(`/space/hyperneo-dev/session/${encoded}`)).toBeNull();
+    });
+
+    it('does not match a percent-encoded space slug', () => {
+      expect(getSpaceIdFromPath('/space/hyperneo%20dev')).toBeNull();
+    });
+  });
+});

--- a/packages/web/src/lib/__tests__/session-store-lifecycle-recovery.test.ts
+++ b/packages/web/src/lib/__tests__/session-store-lifecycle-recovery.test.ts
@@ -153,6 +153,10 @@ describe('chat/thread lifecycle recovery — SessionStore', () => {
     const resubscribe = hub.subscribeCalls[1];
     expect(resubscribe.queryName).toBe('messages.bySession');
     expect(resubscribe.subscriptionId).toBe(subId);
+    // The re-subscribe must keep the SAME params (session id + message limit)
+    // as the initial subscription — a regression that re-subscribes with
+    // empty or another session's params would otherwise pass this mock.
+    expect(resubscribe.params).toEqual(hub.subscribeCalls[0].params);
   });
 
   it('re-applies a fresh snapshot after reconnect, replacing stale messages', async () => {

--- a/packages/web/src/lib/__tests__/session-store-lifecycle-recovery.test.ts
+++ b/packages/web/src/lib/__tests__/session-store-lifecycle-recovery.test.ts
@@ -1,0 +1,207 @@
+// @ts-nocheck
+/**
+ * Chat/Thread Lifecycle Recovery — SessionStore cold mount + reconnect.
+ *
+ * Regression coverage for scenarios 1 (cold mount) and 4 (WebSocket
+ * reconnect). The comprehensive suite covers the snapshot/delta apply and
+ * the messagesLoaded gate; this file adds the missing recovery invariant:
+ * on reconnect, the store re-subscribes to `messages.bySession` with the
+ * SAME subscription id and a fresh snapshot re-applies, so a transient
+ * socket drop never leaves the thread frozen on stale or empty content.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sessionStore } from '../session-store';
+import type { SDKMessage } from '@hyperneo/shared/sdk/sdk.d.ts';
+
+// A single module-level hub that connectionManager.getHub() resolves to.
+// installLifecycleHub() re-binds its handlers with fresh state per test.
+const lifecycleHub = {
+  request: vi.fn(),
+  onEvent: vi.fn(),
+  onConnection: vi.fn(),
+  joinChannel: vi.fn(),
+  leaveChannel: vi.fn(),
+  isConnected: vi.fn(() => true),
+};
+
+vi.mock('../connection-manager', () => ({
+  connectionManager: {
+    getHub: vi.fn(() => Promise.resolve(lifecycleHub)),
+    getHubIfConnected: vi.fn(() => lifecycleHub),
+  },
+}));
+
+vi.mock('../signals', () => ({
+  slashCommandsSignal: { value: [] },
+}));
+
+vi.mock('../toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+interface LifecycleHubApi {
+  fire: (channel: string, data: unknown) => void;
+  fireConnection: (state: string) => void;
+  readonly subscriptionId: string | null;
+  subscribeCalls: Array<{ queryName: string; subscriptionId: string; params: unknown[] }>;
+}
+
+function installLifecycleHub(): LifecycleHubApi {
+  const eventHandlers = new Map<string, Array<(data: unknown) => void>>();
+  const connectionHandlers: Array<(state: string) => void> = [];
+  let capturedSubscriptionId: string | null = null;
+  const subscribeCalls: LifecycleHubApi['subscribeCalls'] = [];
+
+  lifecycleHub.request.mockImplementation((channel: string, params?: Record<string, unknown>) => {
+    if (channel === 'state.session') {
+      return Promise.resolve({ sessionInfo: { id: 'session-1' } });
+    }
+    if (channel === 'liveQuery.subscribe') {
+      capturedSubscriptionId = String(params?.subscriptionId ?? '');
+      subscribeCalls.push({
+        queryName: String(params?.queryName ?? ''),
+        subscriptionId: capturedSubscriptionId,
+        params: (params?.params as unknown[]) ?? [],
+      });
+      return Promise.resolve({ subscriptionId: capturedSubscriptionId });
+    }
+    if (channel === 'liveQuery.unsubscribe') {
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.resolve(undefined);
+  });
+
+  lifecycleHub.onEvent.mockImplementation((channel: string, callback: (data: unknown) => void) => {
+    const list = eventHandlers.get(channel) ?? [];
+    list.push(callback);
+    eventHandlers.set(channel, list);
+    return () => {
+      const l = eventHandlers.get(channel);
+      if (!l) return;
+      const i = l.indexOf(callback);
+      if (i >= 0) l.splice(i, 1);
+    };
+  });
+
+  lifecycleHub.onConnection.mockImplementation((callback: (state: string) => void) => {
+    connectionHandlers.push(callback);
+    return () => {
+      const i = connectionHandlers.indexOf(callback);
+      if (i >= 0) connectionHandlers.splice(i, 1);
+    };
+  });
+
+  return {
+    fire: (channel, data) => {
+      for (const h of eventHandlers.get(channel) ?? []) h(data);
+    },
+    fireConnection: (state) => {
+      for (const h of connectionHandlers) h(state);
+    },
+    get subscriptionId() {
+      return capturedSubscriptionId;
+    },
+    subscribeCalls,
+  };
+}
+
+describe('chat/thread lifecycle recovery — SessionStore', () => {
+  let hub: LifecycleHubApi;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hub = installLifecycleHub();
+  });
+
+  afterEach(async () => {
+    await sessionStore.select(null);
+  });
+
+  it('applies the cold-mount snapshot sorted by timestamp and opens the messagesLoaded gate', async () => {
+    await sessionStore.select('session-1');
+    const subId = hub.subscriptionId!;
+    expect(subId).toBeTruthy();
+    expect(sessionStore.messagesLoaded.value).toBe(false);
+
+    // Snapshot delivered out of timestamp order — the store must sort.
+    hub.fire('liveQuery.snapshot', {
+      subscriptionId: subId,
+      rows: [
+        { id: 'b', uuid: 'b', type: 'text', role: 'assistant', timestamp: 2 },
+        { id: 'a', uuid: 'a', type: 'text', role: 'user', timestamp: 1 },
+      ],
+    });
+
+    expect(sessionStore.messagesLoaded.value).toBe(true);
+    expect(sessionStore.sdkMessages.value.map((m) => m.uuid)).toEqual(['a', 'b']);
+  });
+
+  it('re-subscribes with the same subscription id on WebSocket reconnect', async () => {
+    await sessionStore.select('session-1');
+    const subId = hub.subscriptionId!;
+    expect(hub.subscribeCalls).toHaveLength(1);
+
+    // Simulate a transient socket drop and recovery.
+    hub.fireConnection('disconnected');
+    hub.fireConnection('connected');
+    // The reconnect handler re-issues liveQuery.subscribe asynchronously.
+    await vi.waitFor(() => {
+      expect(hub.subscribeCalls).toHaveLength(2);
+    });
+
+    const resubscribe = hub.subscribeCalls[1];
+    expect(resubscribe.queryName).toBe('messages.bySession');
+    expect(resubscribe.subscriptionId).toBe(subId);
+  });
+
+  it('re-applies a fresh snapshot after reconnect, replacing stale messages', async () => {
+    await sessionStore.select('session-1');
+    const subId = hub.subscriptionId!;
+
+    hub.fire('liveQuery.snapshot', {
+      subscriptionId: subId,
+      rows: [{ id: 'old', uuid: 'old', type: 'text', role: 'user', timestamp: 1 }],
+    });
+    expect(sessionStore.sdkMessages.value.map((m) => m.uuid)).toEqual(['old']);
+
+    // Reconnect pushes a brand-new snapshot; the store replaces wholesale.
+    hub.fireConnection('connected');
+    await vi.waitFor(() => {
+      expect(hub.subscribeCalls).toHaveLength(2);
+    });
+    hub.fire('liveQuery.snapshot', {
+      subscriptionId: subId,
+      rows: [
+        { id: 'fresh-1', uuid: 'fresh-1', type: 'text', role: 'user', timestamp: 1 },
+        { id: 'fresh-2', uuid: 'fresh-2', type: 'text', role: 'assistant', timestamp: 2 },
+      ],
+    });
+
+    expect(sessionStore.sdkMessages.value.map((m) => m.uuid)).toEqual(['fresh-1', 'fresh-2']);
+    expect(sessionStore.sdkMessages.value.some((m) => m.uuid === 'old')).toBe(false);
+  });
+
+  it('does not re-subscribe for a subscription that has been superseded by a session switch', async () => {
+    await sessionStore.select('session-1');
+    expect(hub.subscribeCalls).toHaveLength(1);
+
+    // Switch away — the active subscription id is replaced and the reconnect
+    // handler for the prior subscription must short-circuit.
+    hub.subscribeCalls.length = 0;
+    await sessionStore.select('session-2');
+
+    hub.fireConnection('connected');
+    // The session-2 subscribe fires (new subscription id), but the superseded
+    // session-1 reconnect handler must NOT add an extra re-subscribe for it.
+    await vi.waitFor(() => {
+      expect(hub.subscribeCalls.length).toBeGreaterThanOrEqual(1);
+    });
+    // Give any stray async re-subscribe a chance, then assert no further calls.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const session1Resubscribes = hub.subscribeCalls.filter(
+      (c) => c.params[0] === 'session-1'
+    ).length;
+    expect(session1Resubscribes).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds a focused unit/component regression suite for the chat and Space task-thread lifecycle recovery transitions that previously made sessions appear stuck, locked, or mis-positioned (task #744).

Covers four areas:
- **Router special-character contract** (`router-lifecycle-recovery.test.ts`): create→parse round-trips, coordinator ids with colons resolve on the space-session route, the plain `/session/` route rejects colon/non-hex/slash ids, and the raw-pathname (no percent-decoding) matching contract.
- **SessionStore cold mount + WebSocket reconnect** (`session-store-lifecycle-recovery.test.ts`): the cold-mount snapshot sorts by timestamp and opens `messagesLoaded`, and on reconnect the store re-subscribes with the same subscription id and re-applies the fresh snapshot; superseded subscriptions short-circuit.
- **`shouldBlockForPendingQuestion` edges** (`ChatContainer.test.ts`): only a *trailing* terminal result clears the `waiting_for_input` lock; non-waiting statuses never block.
- **Daemon stale `waiting_for_input`** (`processing-state-lifecycle-recovery.test.ts`): a real `ProcessingStateManager` preserves `waiting_for_input` across a restart, then the terminal-result `setIdle()` path clears it and persists `idle` so a second restart does not re-lock the composer.

Scenario 6 (scroll-to-bottom on mount/refresh/task-switch) and the core `shouldBlockForPendingQuestion` terminal-result case were already comprehensively covered by `useAutoScroll.test.ts` and the existing `ChatContainer.test.ts`, so this suite targets the genuinely under-tested recovery paths rather than duplicating them.

All new tests pass; `oxlint`, `tsc --build`, and `knip` are clean.