### PR TITLE
Add GPT-5.6 Codex models

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -218,7 +218,7 @@ export function ensureAgentTools(
  * anthropic-copilot — Copilot bridge still routes to Anthropic API.
  * anthropic-codex  — Codex bridge uses real Codex model IDs (gpt-5.6-sol,
  *                   gpt-5.6-terra, etc.) with preferContextWindowMetadata=true,
- *                   so SDK reads the correct 1.05M/272k/128k windows from
+ *                   so SDK reads the correct 372k/272k/128k windows from
  *                   /v1/models metadata instead of its hardcoded database.
  *                   CLAUDE_CODE_AUTO_COMPACT_WINDOW is set
  *                   explicitly so auto-compact fires at the correct threshold.

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -218,7 +218,7 @@ export function ensureAgentTools(
  * anthropic-copilot — Copilot bridge still routes to Anthropic API.
  * anthropic-codex  — Codex bridge uses real Codex model IDs (gpt-5.6-sol,
  *                   gpt-5.6-terra, etc.) with preferContextWindowMetadata=true,
- *                   so SDK reads the correct 372k/272k/128k windows from
+ *                   so SDK reads the correct 1.05M/272k/128k windows from
  *                   /v1/models metadata instead of its hardcoded database.
  *                   CLAUDE_CODE_AUTO_COMPACT_WINDOW is set
  *                   explicitly so auto-compact fires at the correct threshold.

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -216,10 +216,11 @@ export function ensureAgentTools(
  *
  * anthropic        — native Anthropic API, SDK knows all model context windows.
  * anthropic-copilot — Copilot bridge still routes to Anthropic API.
- * anthropic-codex  — Codex bridge uses real Codex model IDs (gpt-5.5, gpt-5.4-mini,
- *                   etc.) with preferContextWindowMetadata=true, so SDK reads the
- *                   correct 272k/128k windows from /v1/models metadata instead of
- *                   its hardcoded database. CLAUDE_CODE_AUTO_COMPACT_WINDOW is set
+ * anthropic-codex  — Codex bridge uses real Codex model IDs (gpt-5.6-sol,
+ *                   gpt-5.6-terra, etc.) with preferContextWindowMetadata=true,
+ *                   so SDK reads the correct 1.05M/272k/128k windows from
+ *                   /v1/models metadata instead of its hardcoded database.
+ *                   CLAUDE_CODE_AUTO_COMPACT_WINDOW is set
  *                   explicitly so auto-compact fires at the correct threshold.
  * glm              — Sets CLAUDE_CODE_AUTO_COMPACT_WINDOW per model (1M for
  *                   glm-5.2[1m], 200k for the rest). The `[1m]` suffix is
@@ -285,9 +286,9 @@ export function shouldUseHyperNeoCompactFallback(providerId: string): boolean {
   // below the rejection point — the SDK keeps context < 167k and Kimi always
   // accepts. The cost is compacting ~62k earlier than the unreachable 262k ideal;
   // the win is no more overflow (runtime or resume). This is the same tradeoff
-  // every non-`[1m]` non-Anthropic model already accepts. Codex avoids it only
-  // because its bridge routes `gpt-5.5[1m]` — the `[1m]` suffix grants an honest
-  // 1M belief (gpt-5.5 truly supports ~1M). Kimi has no `[1m]` analog (262k ≠ 1M).
+  // every non-`[1m]` non-Anthropic model already accepts. Codex avoids it because
+  // its bridge advertises the selected model's real context window through
+  // `/v1/models` metadata. Kimi has no equivalent SDK-visible metadata path.
   return PROVIDER_NO_SDK_AUTO_COMPACT.has(providerId);
 }
 

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -121,6 +121,21 @@ const STATIC_MODEL_METADATA: ModelInfo[] = [
   ...KimiProvider.MODELS,
 ];
 const CODEX_STATIC_MODEL_METADATA = getCodexBridgeModelInfos();
+const COPILOT_LEGACY_CODEX_STATIC_METADATA: ModelInfo[] = [
+  {
+    id: 'gpt-5.1-codex-mini',
+    name: 'GPT-5.1 Codex Mini',
+    alias: 'codex-5.1-mini',
+    providerAliases: ['gpt-5.1-mini'],
+    family: 'gpt',
+    provider: 'anthropic-copilot',
+    contextWindow: 128000,
+    preferContextWindowMetadata: true,
+    description: 'GPT-5.1 Codex Mini via GitHub Copilot',
+    releaseDate: '2025-12-01',
+    available: true,
+  },
+];
 
 /**
  * Merge provider-loaded models with FALLBACK_MODELS.
@@ -597,7 +612,8 @@ function overlayCodexStaticMetadata(model: ModelInfo): ModelInfo {
     resolveCodexBridgeModelId(model.id) ?? resolveCodexBridgeModelId(model.alias);
   const staticModel = resolvedCodexId
     ? findInModels(CODEX_STATIC_MODEL_METADATA, resolvedCodexId)
-    : undefined;
+    : (findInModels(COPILOT_LEGACY_CODEX_STATIC_METADATA, model.id) ??
+      findInModels(COPILOT_LEGACY_CODEX_STATIC_METADATA, model.alias));
   return staticModel
     ? {
         ...model,

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -170,11 +170,11 @@ export class AnthropicToCodexBridgeProvider implements Provider {
   get capabilities(): ProviderCapabilities {
     return {
       streaming: true,
-      // GPT-5.5 supports reasoning.effort via the OpenAI Responses API; the bridge
+      // GPT-5.6 supports reasoning.effort via the OpenAI Responses API; the bridge
       // translates OpenAI reasoning events to Anthropic thinking SSE blocks.
       extendedThinking: true,
       thinkingModes: 'granular',
-      maxContextWindow: 272000,
+      maxContextWindow: 1050000,
       functionCalling: true,
       vision: true,
     };
@@ -424,9 +424,10 @@ export class AnthropicToCodexBridgeProvider implements Provider {
   private modelAliases(): Record<string, string> {
     // User-facing aliases (e.g. 'codex' → 'gpt-5.3-codex')
     const userAliases = Object.fromEntries(
-      ANTHROPIC_CODEX_MODELS.flatMap((model) =>
-        model.alias ? [[model.alias, model.id] as const] : []
-      )
+      ANTHROPIC_CODEX_MODELS.flatMap((model) => [
+        ...(model.alias ? [[model.alias, model.id] as const] : []),
+        ...(model.providerAliases?.map((alias) => [alias, model.id] as const) ?? []),
+      ])
     );
     return userAliases;
   }
@@ -437,7 +438,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
       display_name: model.name,
       created_at: `${model.releaseDate ?? '2026-01-01'}T00:00:00Z`,
       context_window: model.contextWindow,
-      max_tokens: 16384,
+      max_tokens: model.id.startsWith('gpt-5.6-') ? 128000 : 16384,
     }));
     return codexModels;
   }
@@ -627,7 +628,9 @@ export class AnthropicToCodexBridgeProvider implements Provider {
   ownsModel(modelId: string): boolean {
     // Only claim model IDs that are explicitly listed in our catalogue.
     // This avoids hijacking other providers' models (e.g. gpt-4, gpt-4o).
-    return ANTHROPIC_CODEX_MODELS.some((m) => m.id === modelId || m.alias === modelId);
+    return ANTHROPIC_CODEX_MODELS.some(
+      (m) => m.id === modelId || m.alias === modelId || m.providerAliases?.includes(modelId)
+    );
   }
 
   translateModelIdForSdk(_modelId: string): string {
@@ -638,15 +641,15 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 
   getModelForTier(tier: ModelTier): string | undefined {
     // Routing policy:
-    //   opus    → gpt-5.5           (latest frontier, matches ANTHROPIC_DEFAULT_OPUS_MODEL)
-    //   sonnet  → gpt-5.3-codex     (primary Codex model, matches ANTHROPIC_DEFAULT_SONNET_MODEL)
-    //   haiku   → gpt-5.4-mini       (fast/cheap, matches ANTHROPIC_DEFAULT_HAIKU_MODEL)
-    //   default → gpt-5.3-codex     (same as sonnet; no separate env var needed)
+    //   opus    → gpt-5.6-sol       (latest flagship, matches ANTHROPIC_DEFAULT_OPUS_MODEL)
+    //   sonnet  → gpt-5.6-terra     (balanced model, matches ANTHROPIC_DEFAULT_SONNET_MODEL)
+    //   haiku   → gpt-5.6-luna      (fast/cheap, matches ANTHROPIC_DEFAULT_HAIKU_MODEL)
+    //   default → gpt-5.6-terra     (same as sonnet; no separate env var needed)
     const map: Record<ModelTier, string> = {
-      opus: 'gpt-5.5',
-      sonnet: 'gpt-5.3-codex',
-      haiku: 'gpt-5.4-mini',
-      default: 'gpt-5.3-codex',
+      opus: 'gpt-5.6-sol',
+      sonnet: 'gpt-5.6-terra',
+      haiku: 'gpt-5.6-luna',
+      default: 'gpt-5.6-terra',
     };
     return map[tier];
   }
@@ -677,7 +680,9 @@ export class AnthropicToCodexBridgeProvider implements Provider {
     }
     // Resolve alias (e.g. 'codex' → 'gpt-5.3-codex') so ANTHROPIC_DEFAULT_*_MODEL
     // receives real OpenAI model IDs that the bridge can forward upstream.
-    const entry = ANTHROPIC_CODEX_MODELS.find((m) => m.alias === modelId || m.id === modelId);
+    const entry = ANTHROPIC_CODEX_MODELS.find(
+      (m) => m.alias === modelId || m.id === modelId || m.providerAliases?.includes(modelId)
+    );
     if (!entry) {
       throw new Error(`Unknown Codex model: ${modelId}`);
     }
@@ -723,9 +728,9 @@ export class AnthropicToCodexBridgeProvider implements Provider {
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
         // Route all tiers to real Codex model IDs. SDK uses these for sub-agent
         // selection and fallback. Context window comes from /v1/models metadata.
-        ANTHROPIC_DEFAULT_OPUS_MODEL: CODEX_TO_SDK_MODEL['gpt-5.5'],
+        ANTHROPIC_DEFAULT_OPUS_MODEL: CODEX_TO_SDK_MODEL['gpt-5.6-sol'],
         ANTHROPIC_DEFAULT_SONNET_MODEL: sdkModelId,
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: CODEX_TO_SDK_MODEL['gpt-5.4-mini'],
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: CODEX_TO_SDK_MODEL['gpt-5.6-luna'],
       },
       isAnthropicCompatible: true,
       apiVersion: 'v1',

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -174,7 +174,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
       // translates OpenAI reasoning events to Anthropic thinking SSE blocks.
       extendedThinking: true,
       thinkingModes: 'granular',
-      maxContextWindow: 372000,
+      maxContextWindow: 1050000,
       functionCalling: true,
       vision: true,
     };

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -174,7 +174,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
       // translates OpenAI reasoning events to Anthropic thinking SSE blocks.
       extendedThinking: true,
       thinkingModes: 'granular',
-      maxContextWindow: 1050000,
+      maxContextWindow: 372000,
       functionCalling: true,
       vision: true,
     };

--- a/packages/daemon/src/lib/providers/codex-models.ts
+++ b/packages/daemon/src/lib/providers/codex-models.ts
@@ -1,9 +1,9 @@
 import type { ModelInfo } from '@hyperneo/shared';
 
 export const MODEL_CONTEXT_WINDOWS = {
-  'gpt-5.6-sol': 372000,
-  'gpt-5.6-terra': 372000,
-  'gpt-5.6-luna': 372000,
+  'gpt-5.6-sol': 1050000,
+  'gpt-5.6-terra': 1050000,
+  'gpt-5.6-luna': 1050000,
   'gpt-5.5': 272000,
   'gpt-5.3-codex': 272000,
   'gpt-5.4': 272000,

--- a/packages/daemon/src/lib/providers/codex-models.ts
+++ b/packages/daemon/src/lib/providers/codex-models.ts
@@ -1,11 +1,13 @@
 import type { ModelInfo } from '@hyperneo/shared';
 
 export const MODEL_CONTEXT_WINDOWS = {
+  'gpt-5.6-sol': 1050000,
+  'gpt-5.6-terra': 1050000,
+  'gpt-5.6-luna': 1050000,
+  'gpt-5.5': 272000,
   'gpt-5.3-codex': 272000,
   'gpt-5.4': 272000,
-  'gpt-5.5': 272000,
   'gpt-5.4-mini': 128000,
-  'gpt-5.1-codex-mini': 128000,
 } as const;
 
 export type CodexBridgeModelId = keyof typeof MODEL_CONTEXT_WINDOWS;
@@ -13,13 +15,41 @@ export type CodexBridgeModelId = keyof typeof MODEL_CONTEXT_WINDOWS;
 const CODEX_MODEL_ALIASES = {
   codex: 'gpt-5.3-codex',
   'codex-5.4': 'gpt-5.4',
-  'codex-latest': 'gpt-5.5',
-  'codex-mini': 'gpt-5.4-mini',
-  'gpt-5.1-mini': 'gpt-5.1-codex-mini',
-  'codex-5.1-mini': 'gpt-5.1-codex-mini',
+  'codex-5.5': 'gpt-5.5',
+  'codex-latest': 'gpt-5.6-sol',
+  'codex-5.6': 'gpt-5.6-sol',
+  'codex-5.6-sol': 'gpt-5.6-sol',
+  'codex-5.6-terra': 'gpt-5.6-terra',
+  'codex-5.6-luna': 'gpt-5.6-luna',
+  'codex-mini': 'gpt-5.6-luna',
+  'codex-5.4-mini': 'gpt-5.4-mini',
 } as const satisfies Record<string, CodexBridgeModelId>;
 
 const CODEX_MODEL_DETAILS = {
+  'gpt-5.6-sol': {
+    name: 'GPT-5.6 Sol',
+    alias: 'codex-latest',
+    description: 'GPT-5.6 Sol · Flagship reasoning/coding model with Ultra mode',
+    releaseDate: '2026-07-09',
+  },
+  'gpt-5.6-terra': {
+    name: 'GPT-5.6 Terra',
+    alias: 'codex-5.6-terra',
+    description: 'GPT-5.6 Terra · Balanced GPT-5.5-level coding model',
+    releaseDate: '2026-07-09',
+  },
+  'gpt-5.6-luna': {
+    name: 'GPT-5.6 Luna',
+    alias: 'codex-mini',
+    description: 'GPT-5.6 Luna · Fast and efficient for high-volume workloads',
+    releaseDate: '2026-07-09',
+  },
+  'gpt-5.5': {
+    name: 'GPT-5.5',
+    alias: 'codex-5.5',
+    description: 'GPT-5.5 · Frontier agentic coding model',
+    releaseDate: '2026-04-01',
+  },
   'gpt-5.3-codex': {
     name: 'GPT-5.3 Codex',
     alias: 'codex',
@@ -32,22 +62,10 @@ const CODEX_MODEL_DETAILS = {
     description: 'GPT-5.4 · Frontier agentic coding model',
     releaseDate: '2026-01-01',
   },
-  'gpt-5.5': {
-    name: 'GPT-5.5',
-    alias: 'codex-latest',
-    description: 'GPT-5.5 · Latest frontier agentic coding model',
-    releaseDate: '2026-04-01',
-  },
   'gpt-5.4-mini': {
     name: 'GPT-5.4 Mini',
-    alias: 'codex-mini',
+    alias: 'codex-5.4-mini',
     description: 'GPT-5.4 Mini · Fast and efficient for simpler tasks',
-    releaseDate: '2026-01-01',
-  },
-  'gpt-5.1-codex-mini': {
-    name: 'GPT-5.1 Codex Mini',
-    alias: 'codex-5.1-mini',
-    description: 'GPT-5.1 Codex Mini · Fast and efficient for simpler tasks',
     releaseDate: '2026-01-01',
   },
 } as const satisfies Record<
@@ -69,6 +87,13 @@ export function getModelContextWindow(modelId: string): number | undefined {
   return resolved ? MODEL_CONTEXT_WINDOWS[resolved] : undefined;
 }
 
+function getProviderAliases(id: CodexBridgeModelId, primaryAlias: string): string[] {
+  return Object.entries(CODEX_MODEL_ALIASES)
+    .filter(([, target]) => target === id)
+    .map(([alias]) => alias)
+    .filter((alias) => alias !== primaryAlias);
+}
+
 /**
  * Codex model IDs for SDK routing.
  *
@@ -85,21 +110,25 @@ export function getModelContextWindow(modelId: string): number | undefined {
  * model ID is preserved when the SDK sends requests.
  */
 export const CODEX_TO_SDK_MODEL: Record<CodexBridgeModelId, string> = {
+  'gpt-5.6-sol': 'gpt-5.6-sol',
+  'gpt-5.6-terra': 'gpt-5.6-terra',
+  'gpt-5.6-luna': 'gpt-5.6-luna',
   'gpt-5.5': 'gpt-5.5',
   'gpt-5.3-codex': 'gpt-5.3-codex',
   'gpt-5.4': 'gpt-5.4',
   'gpt-5.4-mini': 'gpt-5.4-mini',
-  'gpt-5.1-codex-mini': 'gpt-5.1-codex-mini',
 };
 
 export function getCodexBridgeModelInfos(): ModelInfo[] {
   return (Object.keys(MODEL_CONTEXT_WINDOWS) as CodexBridgeModelId[]).map((id) => {
     const details = CODEX_MODEL_DETAILS[id];
+    const providerAliases = getProviderAliases(id, details.alias);
     return {
       id,
       name: details.name,
       alias: details.alias,
       sdkModelIds: [CODEX_TO_SDK_MODEL[id]].filter(Boolean),
+      ...(providerAliases.length > 0 ? { providerAliases } : {}),
       family: 'gpt',
       provider: 'anthropic-codex',
       contextWindow: MODEL_CONTEXT_WINDOWS[id],

--- a/packages/daemon/src/lib/providers/codex-models.ts
+++ b/packages/daemon/src/lib/providers/codex-models.ts
@@ -1,9 +1,9 @@
 import type { ModelInfo } from '@hyperneo/shared';
 
 export const MODEL_CONTEXT_WINDOWS = {
-  'gpt-5.6-sol': 1050000,
-  'gpt-5.6-terra': 1050000,
-  'gpt-5.6-luna': 1050000,
+  'gpt-5.6-sol': 372000,
+  'gpt-5.6-terra': 372000,
+  'gpt-5.6-luna': 372000,
   'gpt-5.5': 272000,
   'gpt-5.3-codex': 272000,
   'gpt-5.4': 272000,

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -582,11 +582,12 @@ function toolChoiceToResponsesToolChoice(
 }
 
 /**
- * Models known to support reasoning.effort="xhigh". Mini variants reject
- * xhigh with a 400 error; keep newly added models conservative unless verified.
+ * Models known to support reasoning.effort="xhigh".
  */
 const MODELS_SUPPORTING_XHIGH_REASONING = new Set([
   'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.3-codex',
   'gpt-5.4',
   'gpt-5.5',

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -582,10 +582,15 @@ function toolChoiceToResponsesToolChoice(
 }
 
 /**
- * Models known to support reasoning.effort="xhigh". Mini and older
- * variants (e.g. gpt-5.1-codex-mini) reject xhigh with a 400 error.
+ * Models known to support reasoning.effort="xhigh". Mini variants reject
+ * xhigh with a 400 error; keep newly added models conservative unless verified.
  */
-const MODELS_SUPPORTING_XHIGH_REASONING = new Set(['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5']);
+const MODELS_SUPPORTING_XHIGH_REASONING = new Set([
+  'gpt-5.6-sol',
+  'gpt-5.3-codex',
+  'gpt-5.4',
+  'gpt-5.5',
+]);
 
 /**
  * Map Anthropic SDK thinking config (budget_tokens) to OpenAI reasoning.effort.

--- a/packages/daemon/tests/online/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -152,7 +152,7 @@ async function callBridge(
   bridgeUrl: string,
   messages: BridgeMessage[],
   tools: BridgeTool[] = [],
-  model = 'gpt-5.1-codex-mini',
+  model = 'gpt-5.4-mini',
   system?: string
 ): Promise<SseEvent[]> {
   const reqBody: Record<string, unknown> = {
@@ -220,7 +220,7 @@ describe('Codex Bridge (Online)', () => {
       );
     }
 
-    const cfg = provider.buildSdkConfig('gpt-5.1-codex-mini', { workspacePath: process.cwd() });
+    const cfg = provider.buildSdkConfig('gpt-5.4-mini', { workspacePath: process.cwd() });
     bridgeUrl = cfg.envVars.ANTHROPIC_BASE_URL as string;
 
     // Start a daemon server for provider-session and daemon-level tests.
@@ -256,8 +256,8 @@ describe('Codex Bridge (Online)', () => {
   // Test 2: Tool use round-trip
   // -------------------------------------------------------------------------
   test('tool use: bridge routes tool call and model uses result in reply', async () => {
-    // Use gpt-5.1-codex-mini for tool-use tests — confirmed to support dynamic tools.
-    const TOOL_MODEL = 'gpt-5.1-codex-mini';
+    // Use the established mini tier for tool-use tests to avoid depending on newly released models.
+    const TOOL_MODEL = 'gpt-5.4-mini';
     // System prompt that forces tool use even with models that prefer self-answering.
     const TOOL_SYSTEM =
       'When the user asks you to call a tool, you MUST call that tool. ' +
@@ -349,8 +349,8 @@ describe('Codex Bridge (Online)', () => {
   // Test 3: MCP-style tool (in-process mock MCP server)
   // -------------------------------------------------------------------------
   test('mcp tool: bridge handles MCP-style tool naming and call round-trip', async () => {
-    // Use gpt-5.1-codex-mini for tool-use tests — confirmed to support dynamic tools.
-    const TOOL_MODEL = 'gpt-5.1-codex-mini';
+    // Use the established mini tier for tool-use tests to avoid depending on newly released models.
+    const TOOL_MODEL = 'gpt-5.4-mini';
     const TOOL_SYSTEM =
       'When the user asks you to call a tool, you MUST call that tool. ' +
       'Never answer the question yourself without first calling the requested tool.';
@@ -452,7 +452,7 @@ describe('Codex Bridge (Online)', () => {
         workspacePath,
         title: 'Codex Explicit Provider Test',
         config: {
-          model: 'gpt-5.1-codex-mini',
+          model: 'gpt-5.4-mini',
           provider: 'anthropic-codex',
           permissionMode: 'acceptEdits',
         },

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -385,27 +385,27 @@ describe('ContextFetcher.toContextInfo', () => {
 
   it('matches GPT-5.6 Sol SDK model names to Codex metadata aliases', () => {
     const response = baseResponse({
-      totalTokens: 186000,
+      totalTokens: 525000,
       maxTokens: 200000,
       rawMaxTokens: 200000,
-      percentage: 93,
+      percentage: 262.5,
       model: 'gpt-5.6-sol',
       autoCompactThreshold: 180000,
       isAutoCompactEnabled: true,
-      categories: [{ name: 'Messages', tokens: 186000, color: 'blue' }],
+      categories: [{ name: 'Messages', tokens: 525000, color: 'blue' }],
     });
 
     const info = ContextFetcher.toContextInfo(response, {
       id: 'gpt-5.6-sol',
       alias: 'codex-latest',
-      contextWindow: 372000,
+      contextWindow: 1050000,
       preferContextWindowMetadata: true,
     });
 
-    expect(info.totalCapacity).toBe(372000);
+    expect(info.totalCapacity).toBe(1050000);
     expect(info.percentUsed).toBe(50);
-    expect(info.breakdown.Messages).toEqual({ tokens: 186000, percent: 50 });
-    expect(info.autoCompactThreshold).toBe(334800);
+    expect(info.breakdown.Messages).toEqual({ tokens: 525000, percent: 50 });
+    expect(info.autoCompactThreshold).toBe(945000);
   });
 
   it('prefers SDK capacity over session metadata for fallback model usage', () => {

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -219,7 +219,7 @@ describe('ContextFetcher.toContextInfo', () => {
 
     const info = ContextFetcher.toContextInfo(response, {
       id: 'gpt-5.5',
-      alias: 'codex-latest',
+      alias: 'codex-5.5',
       sdkModelIds: ['gpt-5.5'],
       contextWindow: 272000,
       preferContextWindowMetadata: true,
@@ -372,7 +372,7 @@ describe('ContextFetcher.toContextInfo', () => {
 
     const info = ContextFetcher.toContextInfo(response, {
       id: 'gpt-5.5',
-      alias: 'codex-latest',
+      alias: 'codex-5.5',
       contextWindow: 272000,
       preferContextWindowMetadata: true,
     });
@@ -383,29 +383,29 @@ describe('ContextFetcher.toContextInfo', () => {
     expect(info.autoCompactThreshold).toBe(244800);
   });
 
-  it('matches GPT-5.1 mini SDK model names to Codex metadata aliases', () => {
+  it('matches GPT-5.6 Sol SDK model names to Codex metadata aliases', () => {
     const response = baseResponse({
-      totalTokens: 64000,
+      totalTokens: 525000,
       maxTokens: 200000,
       rawMaxTokens: 200000,
-      percentage: 32,
-      model: 'gpt-5.1-mini',
+      percentage: 262.5,
+      model: 'gpt-5.6-sol',
       autoCompactThreshold: 180000,
       isAutoCompactEnabled: true,
-      categories: [{ name: 'Messages', tokens: 64000, color: 'blue' }],
+      categories: [{ name: 'Messages', tokens: 525000, color: 'blue' }],
     });
 
     const info = ContextFetcher.toContextInfo(response, {
-      id: 'gpt-5.1-mini',
-      alias: 'copilot-gpt-5-1-mini',
-      contextWindow: 128000,
+      id: 'gpt-5.6-sol',
+      alias: 'codex-latest',
+      contextWindow: 1050000,
       preferContextWindowMetadata: true,
     });
 
-    expect(info.totalCapacity).toBe(128000);
+    expect(info.totalCapacity).toBe(1050000);
     expect(info.percentUsed).toBe(50);
-    expect(info.breakdown.Messages).toEqual({ tokens: 64000, percent: 50 });
-    expect(info.autoCompactThreshold).toBe(115200);
+    expect(info.breakdown.Messages).toEqual({ tokens: 525000, percent: 50 });
+    expect(info.autoCompactThreshold).toBe(945000);
   });
 
   it('prefers SDK capacity over session metadata for fallback model usage', () => {

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -385,27 +385,27 @@ describe('ContextFetcher.toContextInfo', () => {
 
   it('matches GPT-5.6 Sol SDK model names to Codex metadata aliases', () => {
     const response = baseResponse({
-      totalTokens: 525000,
+      totalTokens: 186000,
       maxTokens: 200000,
       rawMaxTokens: 200000,
-      percentage: 262.5,
+      percentage: 93,
       model: 'gpt-5.6-sol',
       autoCompactThreshold: 180000,
       isAutoCompactEnabled: true,
-      categories: [{ name: 'Messages', tokens: 525000, color: 'blue' }],
+      categories: [{ name: 'Messages', tokens: 186000, color: 'blue' }],
     });
 
     const info = ContextFetcher.toContextInfo(response, {
       id: 'gpt-5.6-sol',
       alias: 'codex-latest',
-      contextWindow: 1050000,
+      contextWindow: 372000,
       preferContextWindowMetadata: true,
     });
 
-    expect(info.totalCapacity).toBe(1050000);
+    expect(info.totalCapacity).toBe(372000);
     expect(info.percentUsed).toBe(50);
-    expect(info.breakdown.Messages).toEqual({ tokens: 525000, percent: 50 });
-    expect(info.autoCompactThreshold).toBe(945000);
+    expect(info.breakdown.Messages).toEqual({ tokens: 186000, percent: 50 });
+    expect(info.autoCompactThreshold).toBe(334800);
   });
 
   it('prefers SDK capacity over session metadata for fallback model usage', () => {

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -195,7 +195,7 @@ describe('Model Service', () => {
 
       expect(model).not.toBeNull();
       expect(model?.provider).toBe('anthropic-codex');
-      expect(model?.contextWindow).toBe(372000);
+      expect(model?.contextWindow).toBe(1050000);
       expect(model?.preferContextWindowMetadata).toBe(true);
     });
 
@@ -206,7 +206,7 @@ describe('Model Service', () => {
 
       expect(model).not.toBeNull();
       expect(model?.id).toBe('gpt-5.6-sol');
-      expect(model?.contextWindow).toBe(372000);
+      expect(model?.contextWindow).toBe(1050000);
     });
 
     it('should overlay Codex metadata for matching Copilot OpenAI models', async () => {
@@ -355,7 +355,7 @@ describe('Model Service', () => {
       } as ProviderLike);
 
       const modelInfo = await getModelInfo('gpt-5.6-sol', 'global', 'anthropic-codex');
-      expect(modelInfo?.contextWindow).toBe(372000);
+      expect(modelInfo?.contextWindow).toBe(1050000);
       expect(await isValidModel('gpt-5.6-sol', 'global', 'anthropic-codex')).toBe(false);
     });
 
@@ -697,7 +697,7 @@ describe('Model Service', () => {
       } as any);
 
       expect(model?.id).toBe('gpt-5.6-sol');
-      expect(model?.contextWindow).toBe(372000);
+      expect(model?.contextWindow).toBe(1050000);
     });
 
     it('should return null when the session provider is missing', async () => {

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -195,7 +195,7 @@ describe('Model Service', () => {
 
       expect(model).not.toBeNull();
       expect(model?.provider).toBe('anthropic-codex');
-      expect(model?.contextWindow).toBe(1050000);
+      expect(model?.contextWindow).toBe(372000);
       expect(model?.preferContextWindowMetadata).toBe(true);
     });
 
@@ -206,7 +206,7 @@ describe('Model Service', () => {
 
       expect(model).not.toBeNull();
       expect(model?.id).toBe('gpt-5.6-sol');
-      expect(model?.contextWindow).toBe(1050000);
+      expect(model?.contextWindow).toBe(372000);
     });
 
     it('should overlay Codex metadata for matching Copilot OpenAI models', async () => {
@@ -237,6 +237,28 @@ describe('Model Service', () => {
                 releaseDate: '2026-01-01',
                 available: true,
               },
+              {
+                id: 'gpt-5.1-codex-mini',
+                name: 'GPT-5.1 Codex Mini (Copilot API)',
+                alias: 'copilot-gpt-5-1-codex-mini',
+                family: 'gpt',
+                provider: 'anthropic-copilot',
+                contextWindow: 200000,
+                description: 'GPT-5.1 Codex Mini via GitHub Copilot',
+                releaseDate: '2025-12-01',
+                available: true,
+              },
+              {
+                id: 'gpt-5.1-mini',
+                name: 'GPT-5.1 Mini (Copilot API)',
+                alias: 'copilot-gpt-5-1-mini',
+                family: 'gpt',
+                provider: 'anthropic-copilot',
+                contextWindow: 200000,
+                description: 'GPT-5.1 Mini via GitHub Copilot',
+                releaseDate: '2025-12-01',
+                available: true,
+              },
             ],
           ],
         ])
@@ -244,12 +266,18 @@ describe('Model Service', () => {
 
       const full = await getModelInfo('gpt-5.5', 'global', 'anthropic-copilot');
       const mini = await getModelInfo('gpt-5.4-mini', 'global', 'anthropic-copilot');
+      const legacyMini = await getModelInfo('gpt-5.1-codex-mini', 'global', 'anthropic-copilot');
+      const legacyAliasMini = await getModelInfo('gpt-5.1-mini', 'global', 'anthropic-copilot');
 
       expect(full?.contextWindow).toBe(272000);
       expect(full?.preferContextWindowMetadata).toBe(true);
       expect(mini?.id).toBe('gpt-5.4-mini');
       expect(mini?.contextWindow).toBe(128000);
       expect(mini?.preferContextWindowMetadata).toBe(true);
+      expect(legacyMini?.contextWindow).toBe(128000);
+      expect(legacyMini?.preferContextWindowMetadata).toBe(true);
+      expect(legacyAliasMini?.contextWindow).toBe(128000);
+      expect(legacyAliasMini?.preferContextWindowMetadata).toBe(true);
     });
 
     it('should not resolve unknown Codex models to fallback metadata', async () => {
@@ -327,7 +355,7 @@ describe('Model Service', () => {
       } as ProviderLike);
 
       const modelInfo = await getModelInfo('gpt-5.6-sol', 'global', 'anthropic-codex');
-      expect(modelInfo?.contextWindow).toBe(1050000);
+      expect(modelInfo?.contextWindow).toBe(372000);
       expect(await isValidModel('gpt-5.6-sol', 'global', 'anthropic-codex')).toBe(false);
     });
 
@@ -669,7 +697,7 @@ describe('Model Service', () => {
       } as any);
 
       expect(model?.id).toBe('gpt-5.6-sol');
-      expect(model?.contextWindow).toBe(1050000);
+      expect(model?.contextWindow).toBe(372000);
     });
 
     it('should return null when the session provider is missing', async () => {

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -191,11 +191,11 @@ describe('Model Service', () => {
     it('should resolve Codex static metadata when provider cache is unavailable', async () => {
       clearModelsCache();
 
-      const model = await getModelInfo('gpt-5.5', 'global', 'anthropic-codex');
+      const model = await getModelInfo('gpt-5.6-sol', 'global', 'anthropic-codex');
 
       expect(model).not.toBeNull();
       expect(model?.provider).toBe('anthropic-codex');
-      expect(model?.contextWindow).toBe(272000);
+      expect(model?.contextWindow).toBe(1050000);
       expect(model?.preferContextWindowMetadata).toBe(true);
     });
 
@@ -205,8 +205,8 @@ describe('Model Service', () => {
       const model = await getModelInfo('codex-latest', 'global', 'anthropic-codex');
 
       expect(model).not.toBeNull();
-      expect(model?.id).toBe('gpt-5.5');
-      expect(model?.contextWindow).toBe(272000);
+      expect(model?.id).toBe('gpt-5.6-sol');
+      expect(model?.contextWindow).toBe(1050000);
     });
 
     it('should overlay Codex metadata for matching Copilot OpenAI models', async () => {
@@ -227,13 +227,13 @@ describe('Model Service', () => {
                 available: true,
               },
               {
-                id: 'gpt-5.1-mini',
-                name: 'GPT-5.1 Mini (Copilot API)',
-                alias: 'copilot-gpt-5-1-mini',
+                id: 'gpt-5.4-mini',
+                name: 'GPT-5.4 Mini (Copilot API)',
+                alias: 'copilot-gpt-5-4-mini',
                 family: 'gpt',
                 provider: 'anthropic-copilot',
                 contextWindow: 200000,
-                description: 'GPT-5.1 Mini via GitHub Copilot',
+                description: 'GPT-5.4 Mini via GitHub Copilot',
                 releaseDate: '2026-01-01',
                 available: true,
               },
@@ -243,11 +243,11 @@ describe('Model Service', () => {
       );
 
       const full = await getModelInfo('gpt-5.5', 'global', 'anthropic-copilot');
-      const mini = await getModelInfo('gpt-5.1-mini', 'global', 'anthropic-copilot');
+      const mini = await getModelInfo('gpt-5.4-mini', 'global', 'anthropic-copilot');
 
       expect(full?.contextWindow).toBe(272000);
       expect(full?.preferContextWindowMetadata).toBe(true);
-      expect(mini?.id).toBe('gpt-5.1-mini');
+      expect(mini?.id).toBe('gpt-5.4-mini');
       expect(mini?.contextWindow).toBe(128000);
       expect(mini?.preferContextWindowMetadata).toBe(true);
     });
@@ -326,9 +326,9 @@ describe('Model Service', () => {
         isAvailable: async () => false,
       } as ProviderLike);
 
-      const modelInfo = await getModelInfo('gpt-5.5', 'global', 'anthropic-codex');
-      expect(modelInfo?.contextWindow).toBe(272000);
-      expect(await isValidModel('gpt-5.5', 'global', 'anthropic-codex')).toBe(false);
+      const modelInfo = await getModelInfo('gpt-5.6-sol', 'global', 'anthropic-codex');
+      expect(modelInfo?.contextWindow).toBe(1050000);
+      expect(await isValidModel('gpt-5.6-sol', 'global', 'anthropic-codex')).toBe(false);
     });
 
     it('should validate Codex static metadata only when the provider is available', async () => {
@@ -343,7 +343,7 @@ describe('Model Service', () => {
         isAvailable: async () => true,
       } as ProviderLike);
 
-      expect(await isValidModel('gpt-5.5', 'global', 'anthropic-codex')).toBe(true);
+      expect(await isValidModel('gpt-5.6-sol', 'global', 'anthropic-codex')).toBe(true);
       expect(await isValidModel('gpt-unknown', 'global', 'anthropic-codex')).toBe(false);
     });
   });
@@ -663,13 +663,13 @@ describe('Model Service', () => {
 
       const model = await getSessionModelInfo({
         config: {
-          model: 'gpt-5.5',
+          model: 'gpt-5.6-sol',
           provider: 'anthropic-codex',
         },
       } as any);
 
-      expect(model?.id).toBe('gpt-5.5');
-      expect(model?.contextWindow).toBe(272000);
+      expect(model?.id).toBe('gpt-5.6-sol');
+      expect(model?.contextWindow).toBe(1050000);
     });
 
     it('should return null when the session provider is missing', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -155,7 +155,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
     });
 
     it('reports the maximum Codex context window', () => {
-      expect(provider.capabilities.maxContextWindow).toBe(1050000);
+      expect(provider.capabilities.maxContextWindow).toBe(372000);
     });
 
     it('advertises thinking when the Responses adapter is active', () => {
@@ -695,7 +695,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
       expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-terra');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.6-sol');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('372000');
     });
 
     it('routes GPT-5.6 Sol using real Codex ID with context metadata', async () => {
@@ -705,7 +705,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
       const models = await provider.getModels();
       const sol = models.find((model) => model.id === 'gpt-5.6-sol');
-      expect(sol?.contextWindow).toBe(1_050_000);
+      expect(sol?.contextWindow).toBe(372_000);
       expect(sol?.preferContextWindowMetadata).toBe(true);
       expect(sol?.sdkModelIds).toContain('gpt-5.6-sol');
     });
@@ -720,7 +720,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const cfg = provider.buildSdkConfig('codex-mini', { workspacePath: '/tmp/ws-mini' });
       expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-luna');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('372000');
     });
 
     it('keeps cross-tier fallback registrations isolated by SDK alias', async () => {
@@ -819,9 +819,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       };
       const byId = new Map(body.data.map((m) => [m.id, m.context_window]));
       // Real Codex models advertise their actual context windows.
-      expect(byId.get('gpt-5.6-sol')).toBe(1_050_000);
-      expect(byId.get('gpt-5.6-terra')).toBe(1_050_000);
-      expect(byId.get('gpt-5.6-luna')).toBe(1_050_000);
+      expect(byId.get('gpt-5.6-sol')).toBe(372_000);
+      expect(byId.get('gpt-5.6-terra')).toBe(372_000);
+      expect(byId.get('gpt-5.6-luna')).toBe(372_000);
       expect(byId.get('gpt-5.5')).toBe(272_000);
       expect(byId.get('gpt-5.4-mini')).toBe(128_000);
       // No Anthropic alias models should be present.
@@ -865,6 +865,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       expect(provider.ownsModel('o1-preview')).toBe(false);
       expect(provider.ownsModel('o3-mini')).toBe(false);
       expect(provider.ownsModel('gpt-5-mini')).toBe(false);
+      expect(provider.ownsModel('gpt-5.1-codex-mini')).toBe(false);
+      expect(provider.ownsModel('gpt-5.1-mini')).toBe(false);
+      expect(provider.ownsModel('codex-5.1-mini')).toBe(false);
       // GPT-4 models the bridge cannot serve
       expect(provider.ownsModel('gpt-4o')).toBe(false);
       expect(provider.ownsModel('gpt-4')).toBe(false);
@@ -918,9 +921,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const models = await provider.getModels();
       const contextWindows = new Map(models.map((model) => [model.id, model.contextWindow]));
 
-      expect(contextWindows.get('gpt-5.6-sol')).toBe(1050000);
-      expect(contextWindows.get('gpt-5.6-terra')).toBe(1050000);
-      expect(contextWindows.get('gpt-5.6-luna')).toBe(1050000);
+      expect(contextWindows.get('gpt-5.6-sol')).toBe(372000);
+      expect(contextWindows.get('gpt-5.6-terra')).toBe(372000);
+      expect(contextWindows.get('gpt-5.6-luna')).toBe(372000);
       expect(contextWindows.get('gpt-5.3-codex')).toBe(272000);
       expect(contextWindows.get('gpt-5.4')).toBe(272000);
       expect(contextWindows.get('gpt-5.5')).toBe(272000);

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -155,7 +155,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
     });
 
     it('reports the maximum Codex context window', () => {
-      expect(provider.capabilities.maxContextWindow).toBe(272000);
+      expect(provider.capabilities.maxContextWindow).toBe(1050000);
     });
 
     it('advertises thinking when the Responses adapter is active', () => {
@@ -691,23 +691,23 @@ describe('AnthropicToCodexBridgeProvider', () => {
       // Following the GLM/Kimi pattern, we use real Codex model IDs directly.
       // The SDK reads context window from /v1/models metadata (preferContextWindowMetadata: true)
       // instead of its hardcoded database, avoiding token counting mismatch.
-      const cfg = provider.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-model' });
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini');
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.5');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('272000');
+      const cfg = provider.buildSdkConfig('gpt-5.6-terra', { workspacePath: '/tmp/ws-model' });
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-terra');
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.6-sol');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
     });
 
-    it('routes GPT-5.5 using real Codex ID with context metadata', async () => {
-      const cfg = provider.buildSdkConfig('gpt-5.5', { workspacePath: '/tmp/ws-gpt-55' });
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.5');
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.5');
+    it('routes GPT-5.6 Sol using real Codex ID with context metadata', async () => {
+      const cfg = provider.buildSdkConfig('gpt-5.6-sol', { workspacePath: '/tmp/ws-gpt-56-sol' });
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-sol');
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.6-sol');
 
       const models = await provider.getModels();
-      const gpt55 = models.find((model) => model.id === 'gpt-5.5');
-      expect(gpt55?.contextWindow).toBe(272_000);
-      expect(gpt55?.preferContextWindowMetadata).toBe(true);
-      expect(gpt55?.sdkModelIds).toContain('gpt-5.5');
+      const sol = models.find((model) => model.id === 'gpt-5.6-sol');
+      expect(sol?.contextWindow).toBe(1_050_000);
+      expect(sol?.preferContextWindowMetadata).toBe(true);
+      expect(sol?.sdkModelIds).toContain('gpt-5.6-sol');
     });
 
     it('resolves model alias to real Codex ID in ANTHROPIC_DEFAULT_SONNET_MODEL', () => {
@@ -716,17 +716,11 @@ describe('AnthropicToCodexBridgeProvider', () => {
       expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
     });
 
-    it('keeps the SDK sonnet tier on the mini Anthropic ID for mini Codex sessions', () => {
+    it('keeps the SDK sonnet tier on Luna for mini Codex sessions', () => {
       const cfg = provider.buildSdkConfig('codex-mini', { workspacePath: '/tmp/ws-mini' });
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4-mini');
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('128000');
-    });
-
-    it('uses real Codex mini model IDs for GPT-5.1 mini sessions', () => {
-      const cfg = provider.buildSdkConfig('codex-5.1-mini', { workspacePath: '/tmp/ws-51-mini' });
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.1-codex-mini');
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini');
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-luna');
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
     });
 
     it('keeps cross-tier fallback registrations isolated by SDK alias', async () => {
@@ -751,36 +745,36 @@ describe('AnthropicToCodexBridgeProvider', () => {
           }
         );
 
-        const miniSession = { sessionId: 'mini-with-frontier-fallback', workspacePath: '/tmp/ws' };
-        const miniPrimary = provider.buildSdkConfig('codex-mini', miniSession);
-        provider.buildSdkConfig('gpt-5.5', miniSession);
-        await originalFetch(`${miniPrimary.envVars.ANTHROPIC_BASE_URL}/v1/messages`, {
+        const lunaSession = { sessionId: 'luna-with-frontier-fallback', workspacePath: '/tmp/ws' };
+        const lunaPrimary = provider.buildSdkConfig('gpt-5.6-luna', lunaSession);
+        provider.buildSdkConfig('gpt-5.6-sol', lunaSession);
+        await originalFetch(`${lunaPrimary.envVars.ANTHROPIC_BASE_URL}/v1/messages`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: 'gpt-5.4-mini',
+            model: 'gpt-5.6-luna',
             max_tokens: 128,
             messages: [{ role: 'user', content: 'hi' }],
           }),
         });
 
         const frontierSession = {
-          sessionId: 'frontier-with-mini-fallback',
+          sessionId: 'frontier-with-luna-fallback',
           workspacePath: '/tmp/ws',
         };
-        const frontierPrimary = provider.buildSdkConfig('gpt-5.5', frontierSession);
-        provider.buildSdkConfig('codex-mini', frontierSession);
+        const frontierPrimary = provider.buildSdkConfig('gpt-5.6-sol', frontierSession);
+        provider.buildSdkConfig('gpt-5.6-luna', frontierSession);
         await originalFetch(`${frontierPrimary.envVars.ANTHROPIC_BASE_URL}/v1/messages`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            model: 'gpt-5.5',
+            model: 'gpt-5.6-sol',
             max_tokens: 128,
             messages: [{ role: 'user', content: 'hi' }],
           }),
         });
 
-        expect(capturedModels).toEqual(['gpt-5.4-mini', 'gpt-5.5']);
+        expect(capturedModels).toEqual(['gpt-5.6-luna', 'gpt-5.6-sol']);
       } finally {
         fetchSpy?.mockRestore();
       }
@@ -788,8 +782,8 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
     it('resolves codex-latest alias to real Codex ID', () => {
       const cfg = provider.buildSdkConfig('codex-latest', { workspacePath: '/tmp/ws-latest' });
-      // 'codex-latest' is an alias for 'gpt-5.5', now uses real Codex ID
-      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.5');
+      // 'codex-latest' is an alias for 'gpt-5.6-sol', now uses real Codex ID
+      expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-sol');
     });
 
     it('resolves gpt-5.4 alias to real Codex ID', () => {
@@ -825,6 +819,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       };
       const byId = new Map(body.data.map((m) => [m.id, m.context_window]));
       // Real Codex models advertise their actual context windows.
+      expect(byId.get('gpt-5.6-sol')).toBe(1_050_000);
+      expect(byId.get('gpt-5.6-terra')).toBe(1_050_000);
+      expect(byId.get('gpt-5.6-luna')).toBe(1_050_000);
       expect(byId.get('gpt-5.5')).toBe(272_000);
       expect(byId.get('gpt-5.4-mini')).toBe(128_000);
       // No Anthropic alias models should be present.
@@ -843,16 +840,21 @@ describe('AnthropicToCodexBridgeProvider', () => {
     });
 
     it('owns models explicitly listed in the catalogue', () => {
+      expect(provider.ownsModel('gpt-5.6-sol')).toBe(true);
+      expect(provider.ownsModel('gpt-5.6-terra')).toBe(true);
+      expect(provider.ownsModel('gpt-5.6-luna')).toBe(true);
       expect(provider.ownsModel('gpt-5.3-codex')).toBe(true);
       expect(provider.ownsModel('gpt-5.4')).toBe(true);
       expect(provider.ownsModel('gpt-5.5')).toBe(true);
       expect(provider.ownsModel('gpt-5.4-mini')).toBe(true);
-      expect(provider.ownsModel('gpt-5.1-codex-mini')).toBe(true);
       // Aliases also owned
       expect(provider.ownsModel('codex')).toBe(true);
       expect(provider.ownsModel('codex-5.4')).toBe(true);
+      expect(provider.ownsModel('codex-5.5')).toBe(true);
+      expect(provider.ownsModel('codex-5.6')).toBe(true);
+      expect(provider.ownsModel('codex-5.6-terra')).toBe(true);
+      expect(provider.ownsModel('codex-5.6-luna')).toBe(true);
       expect(provider.ownsModel('codex-mini')).toBe(true);
-      expect(provider.ownsModel('codex-5.1-mini')).toBe(true);
       expect(provider.ownsModel('codex-latest')).toBe(true);
     });
 
@@ -874,7 +876,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
       // env vars to route to real Codex model IDs. Context window comes from /v1/models metadata.
       expect(provider.translateModelIdForSdk('codex-latest')).toBe('default');
       expect(provider.translateModelIdForSdk('codex-mini')).toBe('default');
-      expect(provider.translateModelIdForSdk('codex-5.1-mini')).toBe('default');
+      expect(provider.translateModelIdForSdk('codex-5.6-terra')).toBe('default');
       expect(provider.translateModelIdForSdk('gpt-5.5')).toBe('default');
       expect(provider.translateModelIdForSdk('unknown-model')).toBe('default');
     });
@@ -916,11 +918,13 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const models = await provider.getModels();
       const contextWindows = new Map(models.map((model) => [model.id, model.contextWindow]));
 
+      expect(contextWindows.get('gpt-5.6-sol')).toBe(1050000);
+      expect(contextWindows.get('gpt-5.6-terra')).toBe(1050000);
+      expect(contextWindows.get('gpt-5.6-luna')).toBe(1050000);
       expect(contextWindows.get('gpt-5.3-codex')).toBe(272000);
       expect(contextWindows.get('gpt-5.4')).toBe(272000);
       expect(contextWindows.get('gpt-5.5')).toBe(272000);
       expect(contextWindows.get('gpt-5.4-mini')).toBe(128000);
-      expect(contextWindows.get('gpt-5.1-codex-mini')).toBe(128000);
     });
 
     it('advertises real Codex model IDs in sdkModelIds', async () => {
@@ -928,11 +932,13 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const models = await provider.getModels();
       const sdkIds = new Map(models.map((model) => [model.id, model.sdkModelIds]));
 
+      expect(sdkIds.get('gpt-5.6-sol')).toContain('gpt-5.6-sol');
+      expect(sdkIds.get('gpt-5.6-terra')).toContain('gpt-5.6-terra');
+      expect(sdkIds.get('gpt-5.6-luna')).toContain('gpt-5.6-luna');
       expect(sdkIds.get('gpt-5.5')).toContain('gpt-5.5');
       expect(sdkIds.get('gpt-5.3-codex')).toContain('gpt-5.3-codex');
       expect(sdkIds.get('gpt-5.4')).toContain('gpt-5.4');
       expect(sdkIds.get('gpt-5.4-mini')).toContain('gpt-5.4-mini');
-      expect(sdkIds.get('gpt-5.1-codex-mini')).toContain('gpt-5.1-codex-mini');
     });
 
     it('sets thinkingModes to granular when Responses adapter is active', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -155,7 +155,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
     });
 
     it('reports the maximum Codex context window', () => {
-      expect(provider.capabilities.maxContextWindow).toBe(372000);
+      expect(provider.capabilities.maxContextWindow).toBe(1050000);
     });
 
     it('advertises thinking when the Responses adapter is active', () => {
@@ -695,7 +695,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
       expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-terra');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.6-sol');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('372000');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
     });
 
     it('routes GPT-5.6 Sol using real Codex ID with context metadata', async () => {
@@ -705,7 +705,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 
       const models = await provider.getModels();
       const sol = models.find((model) => model.id === 'gpt-5.6-sol');
-      expect(sol?.contextWindow).toBe(372_000);
+      expect(sol?.contextWindow).toBe(1_050_000);
       expect(sol?.preferContextWindowMetadata).toBe(true);
       expect(sol?.sdkModelIds).toContain('gpt-5.6-sol');
     });
@@ -720,7 +720,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const cfg = provider.buildSdkConfig('codex-mini', { workspacePath: '/tmp/ws-mini' });
       expect(cfg.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.6-luna');
       expect(cfg.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.6-luna');
-      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('372000');
+      expect(cfg.envVars.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1050000');
     });
 
     it('keeps cross-tier fallback registrations isolated by SDK alias', async () => {
@@ -819,9 +819,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       };
       const byId = new Map(body.data.map((m) => [m.id, m.context_window]));
       // Real Codex models advertise their actual context windows.
-      expect(byId.get('gpt-5.6-sol')).toBe(372_000);
-      expect(byId.get('gpt-5.6-terra')).toBe(372_000);
-      expect(byId.get('gpt-5.6-luna')).toBe(372_000);
+      expect(byId.get('gpt-5.6-sol')).toBe(1_050_000);
+      expect(byId.get('gpt-5.6-terra')).toBe(1_050_000);
+      expect(byId.get('gpt-5.6-luna')).toBe(1_050_000);
       expect(byId.get('gpt-5.5')).toBe(272_000);
       expect(byId.get('gpt-5.4-mini')).toBe(128_000);
       // No Anthropic alias models should be present.
@@ -921,9 +921,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
       const models = await provider.getModels();
       const contextWindows = new Map(models.map((model) => [model.id, model.contextWindow]));
 
-      expect(contextWindows.get('gpt-5.6-sol')).toBe(372000);
-      expect(contextWindows.get('gpt-5.6-terra')).toBe(372000);
-      expect(contextWindows.get('gpt-5.6-luna')).toBe(372000);
+      expect(contextWindows.get('gpt-5.6-sol')).toBe(1050000);
+      expect(contextWindows.get('gpt-5.6-terra')).toBe(1050000);
+      expect(contextWindows.get('gpt-5.6-luna')).toBe(1050000);
       expect(contextWindows.get('gpt-5.3-codex')).toBe(272000);
       expect(contextWindows.get('gpt-5.4')).toBe(272000);
       expect(contextWindows.get('gpt-5.5')).toBe(272000);

--- a/packages/daemon/tests/unit/1-core/providers/context-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/context-manager.test.ts
@@ -1056,9 +1056,7 @@ describe('ProviderContextManager', () => {
       };
 
       // Same provider → no restart
-      expect(manager.requiresQueryRestart(session, 'gpt-5.3-codex-mini', 'anthropic-codex')).toBe(
-        false
-      );
+      expect(manager.requiresQueryRestart(session, 'gpt-5.6-luna', 'anthropic-codex')).toBe(false);
     });
   });
 
@@ -1117,24 +1115,24 @@ describe('sdk-model-id-aliasing invariant — real provider buildSdkConfig()', (
     codexProvider = undefined;
   });
 
-  it('Codex provider: ANTHROPIC_DEFAULT_HAIKU_MODEL uses real Codex mini model ID', () => {
+  it('Codex provider: ANTHROPIC_DEFAULT_HAIKU_MODEL uses real Codex Luna model ID', () => {
     codexProvider = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
-    const cfg = codexProvider.buildSdkConfig('gpt-5.3-codex', {
+    const cfg = codexProvider.buildSdkConfig('gpt-5.6-terra', {
       workspacePath: '/tmp/ws-codex-leak',
     });
-    expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5.4-mini');
+    expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5.6-luna');
   });
 
   it('Codex provider: all three DEFAULT_*_MODEL slots use real Codex model IDs', () => {
     codexProvider = new AnthropicToCodexBridgeProvider({ OPENAI_API_KEY: 'sk-test' });
-    const cfg = codexProvider.buildSdkConfig('gpt-5.3-codex', {
+    const cfg = codexProvider.buildSdkConfig('gpt-5.6-terra', {
       workspacePath: '/tmp/ws-codex-all',
     });
-    // Haiku slot uses the Codex mini model ID
-    expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5.4-mini');
-    // Sonnet and Opus slots use the selected Codex model ID
-    expect(cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']).toBe('gpt-5.3-codex');
-    expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).toBe('gpt-5.5');
+    // Haiku slot uses the Codex Luna model ID
+    expect(cfg.envVars['ANTHROPIC_DEFAULT_HAIKU_MODEL']).toBe('gpt-5.6-luna');
+    // Sonnet uses the selected Codex model ID; Opus uses the flagship model
+    expect(cfg.envVars['ANTHROPIC_DEFAULT_SONNET_MODEL']).toBe('gpt-5.6-terra');
+    expect(cfg.envVars['ANTHROPIC_DEFAULT_OPUS_MODEL']).toBe('gpt-5.6-sol');
   });
 
   it('Copilot provider: all three DEFAULT_*_MODEL slots are set to the resolved model ID', () => {

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -2780,7 +2780,7 @@ describe('openai-responses-bridge server', () => {
           id: 'gpt-5.6-sol',
           display_name: 'GPT-5.6 Sol',
           created_at: '2026-07-09T00:00:00Z',
-          context_window: 1050000,
+          context_window: 372000,
         },
       ],
       fetchImpl: async (_url, init) => {
@@ -2802,6 +2802,47 @@ describe('openai-responses-bridge server', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         model: 'gpt-5.6-sol',
+        max_tokens: 128,
+        messages: [{ role: 'user', content: 'Think deeply.' }],
+        thinking: { type: 'enabled', budget_tokens: 32000 },
+      }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(capturedBody?.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' });
+  });
+
+  it('maps think32k to xhigh on GPT-5.6 Terra', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    server = createOpenAIResponsesBridgeServer({
+      auth: { source: 'api_key', apiKey: 'sk-test' },
+      models: [
+        {
+          id: 'gpt-5.6-terra',
+          display_name: 'GPT-5.6 Terra',
+          created_at: '2026-07-09T00:00:00Z',
+          context_window: 372000,
+        },
+      ],
+      fetchImpl: async (_url, init) => {
+        capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return sse([
+          {
+            event: 'response.completed',
+            data: {
+              type: 'response.completed',
+              response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+            },
+          },
+        ]);
+      },
+    });
+
+    const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gpt-5.6-terra',
         max_tokens: 128,
         messages: [{ role: 'user', content: 'Think deeply.' }],
         thinking: { type: 'enabled', budget_tokens: 32000 },
@@ -2847,7 +2888,7 @@ describe('openai-responses-bridge server', () => {
     expect(capturedBody?.include).toEqual(['reasoning.encrypted_content']);
   });
 
-  it('caps think32k to high on models that do not support xhigh', async () => {
+  it('maps think32k to xhigh on GPT-5.6 Luna', async () => {
     let capturedBody: Record<string, unknown> | undefined;
     server = createOpenAIResponsesBridgeServer({
       auth: { source: 'api_key', apiKey: 'sk-test' },
@@ -2856,7 +2897,7 @@ describe('openai-responses-bridge server', () => {
           id: 'gpt-5.6-luna',
           display_name: 'GPT-5.6 Luna',
           created_at: '2026-07-09T00:00:00Z',
-          context_window: 1050000,
+          context_window: 372000,
         },
       ],
       fetchImpl: async (_url, init) => {
@@ -2885,7 +2926,7 @@ describe('openai-responses-bridge server', () => {
     });
 
     expect(resp.status).toBe(200);
-    expect(capturedBody?.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+    expect(capturedBody?.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' });
   });
   it('omits reasoning when thinking is off', async () => {
     let capturedBody: Record<string, unknown> | undefined;

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -643,33 +643,33 @@ describe('openai-responses-bridge server', () => {
     });
 
     // Primary model registration
-    server.setSessionModelConfig?.('session-a', 'gpt-5.5', 'gpt-5.3-codex');
+    server.setSessionModelConfig?.('session-a', 'gpt-5.6-sol', 'gpt-5.6-sol');
     // Fallback model registration (same session, different alias)
-    server.setSessionModelConfig?.('session-a', 'gpt-5.4-mini', 'gpt-5.1-codex-mini');
+    server.setSessionModelConfig?.('session-a', 'gpt-5.6-luna', 'gpt-5.6-luna');
 
-    // Primary request — should still resolve to gpt-5.3-codex
+    // Primary request — should still resolve to gpt-5.6-sol
     await fetch(`${server.baseUrlForSession?.('session-a')}/v1/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gpt-5.5',
+        model: 'gpt-5.6-sol',
         max_tokens: 128,
         messages: [{ role: 'user', content: 'primary' }],
       }),
     });
-    expect(capturedBody?.model).toBe('gpt-5.3-codex');
+    expect(capturedBody?.model).toBe('gpt-5.6-sol');
 
-    // Fallback request — should resolve to gpt-5.1-codex-mini
+    // Fallback request — should resolve to gpt-5.6-luna
     await fetch(`${server.baseUrlForSession?.('session-a')}/v1/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gpt-5.4-mini',
+        model: 'gpt-5.6-luna',
         max_tokens: 128,
         messages: [{ role: 'user', content: 'fallback' }],
       }),
     });
-    expect(capturedBody?.model).toBe('gpt-5.1-codex-mini');
+    expect(capturedBody?.model).toBe('gpt-5.6-luna');
   });
 
   it('uses last-registered model when same-tier models share alias (last-wins)', async () => {
@@ -2771,11 +2771,18 @@ describe('openai-responses-bridge server', () => {
     ]);
   });
 
-  it('maps think32k to xhigh on frontier models that support it', async () => {
+  it('maps think32k to xhigh on GPT-5.6 models that support it', async () => {
     let capturedBody: Record<string, unknown> | undefined;
     server = createOpenAIResponsesBridgeServer({
       auth: { source: 'api_key', apiKey: 'sk-test' },
-      models,
+      models: [
+        {
+          id: 'gpt-5.6-sol',
+          display_name: 'GPT-5.6 Sol',
+          created_at: '2026-07-09T00:00:00Z',
+          context_window: 1050000,
+        },
+      ],
       fetchImpl: async (_url, init) => {
         capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
         return sse([
@@ -2794,7 +2801,7 @@ describe('openai-responses-bridge server', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gpt-5.3-codex',
+        model: 'gpt-5.6-sol',
         max_tokens: 128,
         messages: [{ role: 'user', content: 'Think deeply.' }],
         thinking: { type: 'enabled', budget_tokens: 32000 },
@@ -2846,10 +2853,10 @@ describe('openai-responses-bridge server', () => {
       auth: { source: 'api_key', apiKey: 'sk-test' },
       models: [
         {
-          id: 'gpt-5.1-codex-mini',
-          display_name: 'GPT-5.1 Codex Mini',
-          created_at: '2026-01-01T00:00:00Z',
-          context_window: 128000,
+          id: 'gpt-5.6-luna',
+          display_name: 'GPT-5.6 Luna',
+          created_at: '2026-07-09T00:00:00Z',
+          context_window: 1050000,
         },
       ],
       fetchImpl: async (_url, init) => {
@@ -2870,7 +2877,7 @@ describe('openai-responses-bridge server', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gpt-5.1-codex-mini',
+        model: 'gpt-5.6-luna',
         max_tokens: 128,
         messages: [{ role: 'user', content: 'Think deeply.' }],
         thinking: { type: 'enabled', budget_tokens: 32000 },

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -2780,7 +2780,7 @@ describe('openai-responses-bridge server', () => {
           id: 'gpt-5.6-sol',
           display_name: 'GPT-5.6 Sol',
           created_at: '2026-07-09T00:00:00Z',
-          context_window: 372000,
+          context_window: 1050000,
         },
       ],
       fetchImpl: async (_url, init) => {
@@ -2821,7 +2821,7 @@ describe('openai-responses-bridge server', () => {
           id: 'gpt-5.6-terra',
           display_name: 'GPT-5.6 Terra',
           created_at: '2026-07-09T00:00:00Z',
-          context_window: 372000,
+          context_window: 1050000,
         },
       ],
       fetchImpl: async (_url, init) => {
@@ -2897,7 +2897,7 @@ describe('openai-responses-bridge server', () => {
           id: 'gpt-5.6-luna',
           display_name: 'GPT-5.6 Luna',
           created_at: '2026-07-09T00:00:00Z',
-          context_window: 372000,
+          context_window: 1050000,
         },
       ],
       fetchImpl: async (_url, init) => {

--- a/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
+++ b/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
@@ -322,7 +322,7 @@ describe('ContextUsageBar', () => {
         totalUsed: 64000,
         totalCapacity: 128000,
         percentUsed: 50,
-        model: 'gpt-5.1-mini',
+        model: 'gpt-5.4-mini',
       };
       const { container } = render(
         <ContextUsageBar contextUsage={codexUsage} maxContextTokens={200000} />


### PR DESCRIPTION
Adds GPT-5.6 Sol, Terra, and Luna to the Codex/OpenAI registry, points Codex aliases/default tiers at the new family, and removes GPT-5.1 Codex Mini metadata and aliases. Also updates reasoning support and affected tests for the new model set.

Verified with `bun run check`, focused daemon unit tests, and the updated ContextUsageBar test.
