### PR TITLE
refactor(web): apply unified indicators to plain chat sessions

### DIFF
--- a/packages/web/src/components/ConnectionStatus.tsx
+++ b/packages/web/src/components/ConnectionStatus.tsx
@@ -1,12 +1,21 @@
 /**
  * ConnectionStatus Component
  *
- * Shows daemon connection and processing status:
- * - Connecting: Yellow dot + "Connecting..."
- * - Connected + idle: Green dot + "Ready"
- * - Disconnected: Gray dot + "Offline"
- * - Processing: Pulsing dot + dynamic action (e.g., "Reading files...", "Thinking...")
+ * Shows daemon connection and processing status, with all tones derived from
+ * the unified indicator foundation so colors stay consistent across the UI:
+ * - Connecting/Reconnecting: pulsing progress dot
+ * - Connected + idle: static success dot + "Ready"
+ * - Disconnected: static neutral dot + "Offline"
+ * - Failed/Error: static danger dot + "Connection Failed"
+ * - Processing: pulsing phase-colored dot + dynamic action
  */
+
+import { INDICATOR_TONES, type IndicatorTone } from '../lib/indicator-tokens.ts';
+import {
+  SESSION_PROCESSING_PHASE_CONFIG,
+  SESSION_PROCESSING_STATUS_CONFIG,
+} from '../lib/session-processing-phase.ts';
+import { StatusDot } from './ui/StatusDot.tsx';
 
 interface ConnectionStatusProps {
   connectionState:
@@ -21,94 +30,64 @@ interface ConnectionStatusProps {
   streamingPhase?: 'initializing' | 'thinking' | 'streaming' | 'finalizing' | null;
 }
 
+interface StatusResult {
+  tone: IndicatorTone;
+  pulse: boolean;
+  text: string;
+}
+
+/**
+ * Resolve the connection/processing state into a foundation tone + label.
+ * Processing takes priority over the connection state; a known streaming phase
+ * uses its phase tone, and a null/unknown phase falls back to the generic
+ * 'processing' tone (info) from the foundation.
+ */
+function resolveStatus({
+  connectionState,
+  isProcessing,
+  currentAction,
+  streamingPhase,
+}: ConnectionStatusProps): StatusResult {
+  // Processing takes priority with phase-specific tones.
+  if (isProcessing && currentAction) {
+    const config = streamingPhase
+      ? SESSION_PROCESSING_PHASE_CONFIG[streamingPhase]
+      : SESSION_PROCESSING_STATUS_CONFIG.processing;
+    return { tone: config.tone, pulse: true, text: currentAction };
+  }
+
+  switch (connectionState) {
+    case 'connected':
+      return { tone: 'success', pulse: false, text: 'Ready' };
+    case 'connecting':
+      return { tone: 'progress', pulse: true, text: 'Connecting...' };
+    case 'reconnecting':
+      return { tone: 'progress', pulse: true, text: 'Reconnecting...' };
+    case 'failed':
+    case 'error':
+      return { tone: 'danger', pulse: false, text: 'Connection Failed' };
+    default:
+      // disconnected
+      return { tone: 'neutral', pulse: false, text: 'Offline' };
+  }
+}
+
 export default function ConnectionStatus({
   connectionState,
   isProcessing,
   currentAction,
   streamingPhase,
 }: ConnectionStatusProps) {
-  const getStatus = () => {
-    // Processing state takes priority with phase-specific colors
-    if (isProcessing && currentAction) {
-      // Phase-specific color coding
-      let dotClass = 'bg-purple-500 animate-pulse';
-      let textClass = 'text-purple-400';
-
-      if (streamingPhase) {
-        switch (streamingPhase) {
-          case 'initializing':
-            dotClass = 'bg-yellow-500 animate-pulse';
-            textClass = 'text-yellow-400';
-            break;
-          case 'thinking':
-            dotClass = 'bg-blue-500 animate-pulse';
-            textClass = 'text-blue-400';
-            break;
-          case 'streaming':
-            dotClass = 'bg-green-500 animate-pulse';
-            textClass = 'text-green-400';
-            break;
-          case 'finalizing':
-            dotClass = 'bg-purple-500 animate-pulse';
-            textClass = 'text-purple-400';
-            break;
-        }
-      }
-
-      return {
-        dotClass,
-        text: currentAction,
-        textClass,
-      };
-    }
-
-    // Connection states
-    if (connectionState === 'connected') {
-      return {
-        dotClass: 'bg-green-500',
-        text: 'Ready',
-        textClass: 'text-green-400',
-      };
-    }
-
-    if (connectionState === 'connecting') {
-      return {
-        dotClass: 'bg-yellow-500 animate-pulse',
-        text: 'Connecting...',
-        textClass: 'text-yellow-400',
-      };
-    }
-
-    if (connectionState === 'reconnecting') {
-      return {
-        dotClass: 'bg-yellow-500 animate-pulse',
-        text: 'Reconnecting...',
-        textClass: 'text-yellow-400',
-      };
-    }
-
-    if (connectionState === 'failed' || connectionState === 'error') {
-      return {
-        dotClass: 'bg-red-500',
-        text: 'Connection Failed',
-        textClass: 'text-red-400',
-      };
-    }
-
-    // disconnected
-    return {
-      dotClass: 'bg-gray-500',
-      text: 'Offline',
-      textClass: 'text-gray-500',
-    };
-  };
-
-  const status = getStatus();
+  const status = resolveStatus({ connectionState, isProcessing, currentAction, streamingPhase });
 
   return (
     <div class="flex items-center gap-2">
-      <div class={`w-2 h-2 rounded-full ${status.dotClass}`} />
-      {status.text && <span class={`text-xs font-medium ${status.textClass}`}>{status.text}</span>}
+      <StatusDot tone={status.tone} pulse={status.pulse} />
+      {status.text && (
+        <span class={`text-xs font-medium ${INDICATOR_TONES[status.tone].text}`}>
+          {status.text}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/ConnectionStatus.tsx
+++ b/packages/web/src/components/ConnectionStatus.tsx
@@ -14,6 +14,7 @@ import { INDICATOR_TONES, type IndicatorTone } from '../lib/indicator-tokens.ts'
 import {
   SESSION_PROCESSING_PHASE_CONFIG,
   SESSION_PROCESSING_STATUS_CONFIG,
+  type SessionProcessingConfig,
 } from '../lib/session-processing-phase.ts';
 import { StatusDot } from './ui/StatusDot.tsx';
 
@@ -50,9 +51,15 @@ function resolveStatus({
 }: ConnectionStatusProps): StatusResult {
   // Processing takes priority with phase-specific tones.
   if (isProcessing && currentAction) {
-    const config = streamingPhase
-      ? SESSION_PROCESSING_PHASE_CONFIG[streamingPhase]
-      : SESSION_PROCESSING_STATUS_CONFIG.processing;
+    // Persisted phase values are only cast to the union at the type level, so
+    // an unrecognized phase can reach here at runtime. Look it up via a Partial
+    // map and fall back to the generic 'processing' tone — the same defensive
+    // pattern getAgentProcessingStateConfig uses — so a future/malformed phase
+    // never crashes the render with an undefined config.
+    const byPhase = SESSION_PROCESSING_PHASE_CONFIG as Partial<
+      Record<string, SessionProcessingConfig>
+    >;
+    const config = byPhase[streamingPhase ?? ''] ?? SESSION_PROCESSING_STATUS_CONFIG.processing;
     return { tone: config.tone, pulse: true, text: currentAction };
   }
 

--- a/packages/web/src/components/SessionListItem.tsx
+++ b/packages/web/src/components/SessionListItem.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'preact/hooks';
 import type { Session } from '@hyperneo/shared';
-import { currentSessionIdSignal } from '../lib/signals.ts';
-import { allSessionStatuses, getProcessingPhaseColor } from '../lib/session-status.ts';
+import { useState } from 'preact/hooks';
 import { useSessionRename } from '../hooks/useSessionRename';
-import { RenameIcon } from './icons/RenameIcon';
+import { getSessionLifecycleStatusConfig } from '../lib/session-lifecycle-status.ts';
+import { getAgentProcessingStateConfig } from '../lib/session-processing-phase.ts';
+import { allSessionStatuses } from '../lib/session-status.ts';
+import { currentSessionIdSignal } from '../lib/signals.ts';
 import { cn } from '../lib/utils.ts';
+import { RenameIcon } from './icons/RenameIcon';
+import { StatusDot } from './ui/StatusDot.tsx';
+import { UnreadBadge } from './ui/UnreadBadge.tsx';
 
 interface SessionListItemProps {
   session: Session;
@@ -15,38 +19,38 @@ interface SessionListItemProps {
 
 /**
  * Status Indicator Component
- * Shows processing state (pulsing) or unread state (static)
+ *
+ * Renders the unified indicator for a sidebar row:
+ * - Actively processing → pulsing phase-colored dot
+ * - Unseen messages → blue unread badge (count)
+ * - Otherwise (at rest) → static lifecycle-colored dot
+ *
+ * Tones are derived from the indicator foundation so colors stay consistent
+ * across the app. Processing takes priority over unread; idle/interrupted are
+ * treated as "at rest" (no pulse), matching the legacy indicator behavior.
  */
-function StatusIndicator({ sessionId }: { sessionId: string }) {
-  const statuses = allSessionStatuses.value;
-  const status = statuses.get(sessionId);
+function StatusIndicator({ session, sessionId }: { session: Session; sessionId: string }) {
+  const status = allSessionStatuses.value.get(sessionId);
 
   if (!status) return null;
 
-  const { processingState, hasUnread } = status;
-  const phaseColors = getProcessingPhaseColor(processingState);
+  const { processingState, unreadCount } = status;
 
-  // Processing state takes priority - show pulsing indicator
-  if (phaseColors) {
-    return (
-      <div class="relative flex-shrink-0 w-2 h-2">
-        <span class={`absolute inset-0 rounded-full ${phaseColors.dot} animate-pulse`} />
-        <span class={`absolute inset-0 rounded-full ${phaseColors.dot} animate-ping opacity-50`} />
-      </div>
-    );
+  // Actively processing (queued / processing / waiting / rate-limited) pulses.
+  // idle and interrupted are "at rest" and fall through to the dot/badge below.
+  if (processingState.status !== 'idle' && processingState.status !== 'interrupted') {
+    const config = getAgentProcessingStateConfig(processingState);
+    return <StatusDot tone={config.tone} pulse aria-label={config.label} />;
   }
 
-  // Unread state - show static blue dot
-  if (hasUnread) {
-    return (
-      <div class="flex-shrink-0 w-2 h-2">
-        <span class="block w-full h-full rounded-full bg-blue-500" />
-      </div>
-    );
+  // Unseen messages — blue numeric badge.
+  if (unreadCount > 0) {
+    return <UnreadBadge count={unreadCount} />;
   }
 
-  // Idle and read - no indicator needed
-  return null;
+  // At rest — static lifecycle-colored dot.
+  const lifecycle = getSessionLifecycleStatusConfig(session.status);
+  return <StatusDot tone={lifecycle.tone} aria-label={lifecycle.label} />;
 }
 
 function WorktreeBranchIcon() {
@@ -139,7 +143,7 @@ export default function SessionListItem({
               isActive ? 'text-gray-100' : 'text-gray-400 group-hover/row:text-gray-200'
             )}
           >
-            <StatusIndicator sessionId={session.id} />
+            <StatusIndicator session={session} sessionId={session.id} />
             <h3
               class={cn('flex-1 min-w-0 truncate text-sm', isActive && 'font-medium')}
               onDblClick={startEditing}

--- a/packages/web/src/components/SessionListItem.tsx
+++ b/packages/web/src/components/SessionListItem.tsx
@@ -18,6 +18,20 @@ interface SessionListItemProps {
 }
 
 /**
+ * Known agent statuses that count as "actively processing" and should pulse.
+ * idle/interrupted are at rest, and — because persisted processingState is only
+ * cast to the union at the type level — any unrecognized/legacy status also
+ * falls through to the at-rest path, matching the foundation's own
+ * unknown-status → idle fallback.
+ */
+const ACTIVE_PROCESSING_STATUSES = new Set([
+  'queued',
+  'processing',
+  'waiting_for_input',
+  'rate_limit_cooldown',
+]);
+
+/**
  * Status Indicator Component
  *
  * Renders the unified indicator for a sidebar row:
@@ -26,8 +40,8 @@ interface SessionListItemProps {
  * - Otherwise (at rest) → static lifecycle-colored dot
  *
  * Tones are derived from the indicator foundation so colors stay consistent
- * across the app. Processing takes priority over unread; idle/interrupted are
- * treated as "at rest" (no pulse), matching the legacy indicator behavior.
+ * across the app. Processing takes priority over unread; idle, interrupted,
+ * and unrecognized statuses are treated as "at rest" (no pulse).
  */
 function StatusIndicator({ session, sessionId }: { session: Session; sessionId: string }) {
   const status = allSessionStatuses.value.get(sessionId);
@@ -36,9 +50,8 @@ function StatusIndicator({ session, sessionId }: { session: Session; sessionId: 
 
   const { processingState, unreadCount } = status;
 
-  // Actively processing (queued / processing / waiting / rate-limited) pulses.
-  // idle and interrupted are "at rest" and fall through to the dot/badge below.
-  if (processingState.status !== 'idle' && processingState.status !== 'interrupted') {
+  // Actively processing → pulsing phase-colored dot.
+  if (ACTIVE_PROCESSING_STATUSES.has(processingState.status)) {
     const config = getAgentProcessingStateConfig(processingState);
     return <StatusDot tone={config.tone} pulse aria-label={config.label} />;
   }

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -12,34 +12,36 @@
  * Uses the global connectionState signal directly for guaranteed reactivity.
  */
 
-import { useSignalEffect } from '@preact/signals';
-import { useState, useCallback, useEffect, useRef } from 'preact/hooks';
 import type { ContextInfo, ModelInfo, ThinkingLevel } from '@hyperneo/shared';
+import { getThinkingOptionsForProvider, THINKING_LEVEL_LABELS } from '@hyperneo/shared';
 import type { ProviderAuthStatus } from '@hyperneo/shared/provider';
-import { THINKING_LEVEL_LABELS, getThinkingOptionsForProvider } from '@hyperneo/shared';
-import { connectionState, type ConnectionState } from '../lib/state.ts';
-import { connectionManager } from '../lib/connection-manager.ts';
-import ConnectionStatus from './ConnectionStatus.tsx';
-import ContextUsageBar from './ContextUsageBar.tsx';
-import { ContentContainer } from './ui/ContentContainer.tsx';
+import { useSignalEffect } from '@preact/signals';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import {
-  useModal,
-  useClickOutside,
   getProviderLabel,
   groupModelsByProvider,
+  useClickOutside,
   useFilteredModelsForPicker,
   useMessageHub,
+  useModal,
 } from '../hooks';
-import { Spinner } from './ui/Spinner.tsx';
-import { Tooltip } from './ui/Tooltip.tsx';
+import { connectionManager } from '../lib/connection-manager.ts';
 import { borderColors } from '../lib/design-tokens.ts';
-import { ProviderLogo } from './ProviderLogo.tsx';
+import type { IndicatorTone } from '../lib/indicator-tokens.ts';
 import {
-  providerPillStyle,
-  providerLogoColor,
   providerHeaderStyle,
+  providerLogoColor,
+  providerPillStyle,
   shortenModelName,
 } from '../lib/provider-brand.ts';
+import { type ConnectionState, connectionState } from '../lib/state.ts';
+import ConnectionStatus from './ConnectionStatus.tsx';
+import ContextUsageBar from './ContextUsageBar.tsx';
+import { ProviderLogo } from './ProviderLogo.tsx';
+import { ContentContainer } from './ui/ContentContainer.tsx';
+import { Spinner } from './ui/Spinner.tsx';
+import { StatusDot } from './ui/StatusDot.tsx';
+import { Tooltip } from './ui/Tooltip.tsx';
 
 // Provider brand colors + logos live in lib/provider-brand.ts and
 // components/ProviderLogo.tsx (shared with the model picker).
@@ -453,15 +455,17 @@ export default function SessionStatusBar({
                       const authStatus = providerAuthStatuses.get(provider);
                       const isAuthenticated = authStatus?.isAuthenticated;
                       const needsRefresh = authStatus?.needsRefresh ?? false;
-                      // Dot: gray = unknown, green = ok, yellow = expiring, red = unauthenticated (only current shown)
-                      const dotClass =
+                      // Availability dot tone: neutral = unknown, success = ok,
+                      // warning = expiring, danger = unauthenticated. Drives the
+                      // dot from the unified indicator foundation.
+                      const availabilityTone: IndicatorTone =
                         isAuthenticated === undefined
-                          ? 'bg-gray-500'
+                          ? 'neutral'
                           : !isAuthenticated
-                            ? 'bg-red-500'
+                            ? 'danger'
                             : needsRefresh
-                              ? 'bg-yellow-500'
-                              : 'bg-green-500';
+                              ? 'warning'
+                              : 'success';
                       return (
                         <div key={provider} data-testid="provider-section">
                           {groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
@@ -478,7 +482,7 @@ export default function SessionStatusBar({
                             >
                               {getProviderLabel(provider)}
                             </span>
-                            <span class={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
+                            <StatusDot tone={availabilityTone} />
                             {needsRefresh && (
                               <span class="text-yellow-400 text-[10px]" title="Token expiring soon">
                                 ⚠

--- a/packages/web/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/packages/web/src/components/__tests__/ConnectionStatus.test.tsx
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
  */
 
-import { render, cleanup } from '@testing-library/preact';
+import { cleanup, render } from '@testing-library/preact';
 import ConnectionStatus from '../ConnectionStatus';
 
 describe('ConnectionStatus', () => {
@@ -138,7 +138,7 @@ describe('ConnectionStatus', () => {
       expect(container.textContent).toContain('Reading files...');
     });
 
-    it('should show purple pulsing dot for default processing', () => {
+    it('should show blue pulsing dot for default processing', () => {
       const { container } = render(
         <ConnectionStatus
           connectionState="connected"
@@ -147,7 +147,8 @@ describe('ConnectionStatus', () => {
         />
       );
 
-      const dot = container.querySelector('.bg-purple-500');
+      // No streaming phase -> falls back to the generic 'processing' tone (info/blue).
+      const dot = container.querySelector('.bg-blue-500');
       expect(dot).toBeTruthy();
       expect(dot?.className).toContain('animate-pulse');
     });
@@ -262,7 +263,8 @@ describe('ConnectionStatus', () => {
         <ConnectionStatus connectionState="disconnected" isProcessing={false} />
       );
 
-      const text = container.querySelector('.text-gray-500');
+      // neutral tone text -> text-gray-400
+      const text = container.querySelector('.text-gray-400');
       expect(text).toBeTruthy();
     });
 
@@ -354,8 +356,8 @@ describe('ConnectionStatus', () => {
         />
       );
 
-      // Should use default purple color
-      const dot = container.querySelector('.bg-purple-500');
+      // Null phase -> falls back to the generic 'processing' tone (info/blue).
+      const dot = container.querySelector('.bg-blue-500');
       expect(dot).toBeTruthy();
     });
   });

--- a/packages/web/src/components/__tests__/ConnectionStatus.test.tsx
+++ b/packages/web/src/components/__tests__/ConnectionStatus.test.tsx
@@ -360,5 +360,23 @@ describe('ConnectionStatus', () => {
       const dot = container.querySelector('.bg-blue-500');
       expect(dot).toBeTruthy();
     });
+
+    it('should fall back to the processing tone for an unrecognized streaming phase', () => {
+      // Persisted phase values are only cast to the union at the type level, so
+      // a future/malformed phase can reach the indicator at runtime. It must
+      // not crash — it falls back to the generic 'processing' tone (info/blue).
+      const { container } = render(
+        <ConnectionStatus
+          connectionState="connected"
+          isProcessing={true}
+          currentAction="Working..."
+          streamingPhase={'compacting-legacy' as unknown as 'thinking'}
+        />
+      );
+
+      const dot = container.querySelector('.bg-blue-500');
+      expect(dot).toBeTruthy();
+      expect(container.textContent).toContain('Working...');
+    });
   });
 });

--- a/packages/web/src/components/__tests__/SessionListItem.test.tsx
+++ b/packages/web/src/components/__tests__/SessionListItem.test.tsx
@@ -451,6 +451,31 @@ describe('SessionListItem', () => {
       // interrupted is "at rest" -> falls through to the static lifecycle dot.
       expect(container.querySelector('.animate-pulse')).toBeNull();
     });
+
+    it('should fall through to the lifecycle dot for an unrecognized processing status', () => {
+      // Persisted processingState JSON is only cast to the union at the type
+      // level, so a legacy/unknown status can reach the indicator. It must not
+      // be treated as actively processing (which would pulse a misleading dot
+      // and suppress the badge/lifecycle dot) — it falls through to the at-rest
+      // path, matching the foundation's unknown-status → idle fallback.
+      mockStatuses.value = new Map([
+        [
+          'session-1',
+          {
+            processingState: { status: 'schema-v9-running' } as unknown as AgentProcessingState,
+            unreadCount: 0,
+          },
+        ],
+      ]);
+
+      const { container } = render(
+        <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
+      );
+
+      // No pulse; falls through to the static active lifecycle dot (green).
+      expect(container.querySelector('.animate-pulse')).toBeNull();
+      expect(container.querySelector('.bg-green-500')).toBeTruthy();
+    });
   });
 
   describe('Active Session Styling', () => {

--- a/packages/web/src/components/__tests__/SessionListItem.test.tsx
+++ b/packages/web/src/components/__tests__/SessionListItem.test.tsx
@@ -6,35 +6,20 @@
  * and archived status.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, act } from '@testing-library/preact';
-import { signal, computed } from '@preact/signals';
-import type { Session, AgentProcessingState } from '@hyperneo/shared';
+import type { AgentProcessingState, Session } from '@hyperneo/shared';
+import { computed, signal } from '@preact/signals';
+import { act, cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Define signals after imports - use getters in vi.mock to defer evaluation
 let mockStatuses: ReturnType<
-  typeof signal<Map<string, { processingState: AgentProcessingState; hasUnread: boolean }>>
+  typeof signal<Map<string, { processingState: AgentProcessingState; unreadCount: number }>>
 >;
 let mockCurrentSessionId: ReturnType<typeof signal<string | null>>;
 
 vi.mock('../../lib/session-status.ts', () => ({
   get allSessionStatuses() {
     return computed(() => mockStatuses.value);
-  },
-  getProcessingPhaseColor: (state: AgentProcessingState) => {
-    if (state.status === 'idle' || state.status === 'interrupted') return null;
-    if (state.status === 'queued') return { dot: 'bg-yellow-500', text: 'text-yellow-400' };
-    if (state.status === 'processing') {
-      switch (state.phase) {
-        case 'thinking':
-          return { dot: 'bg-blue-500', text: 'text-blue-400' };
-        case 'streaming':
-          return { dot: 'bg-green-500', text: 'text-green-400' };
-        default:
-          return { dot: 'bg-purple-500', text: 'text-purple-400' };
-      }
-    }
-    return null;
   },
 }));
 
@@ -61,7 +46,7 @@ vi.mock('../../lib/space-store', () => ({
 vi.mock('../../lib/toast', () => ({ toast: { error: renameMocks.toastError } }));
 
 // Initialize signals after mocks are set up
-mockStatuses = signal<Map<string, { processingState: AgentProcessingState; hasUnread: boolean }>>(
+mockStatuses = signal<Map<string, { processingState: AgentProcessingState; unreadCount: number }>>(
   new Map()
 );
 mockCurrentSessionId = signal<string | null>(null);
@@ -333,34 +318,35 @@ describe('SessionListItem', () => {
       mockStatuses.value = new Map();
     });
 
-    it('should not show indicator when no status exists', () => {
+    it('should not show an indicator when no status exists', () => {
       const { container } = render(
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      // No status indicator should be present
-      const indicator = container.querySelector('.animate-pulse');
-      expect(indicator).toBeNull();
+      // No status dot (labeled StatusDot exposes role="img") and no unread badge.
+      expect(container.querySelector('[role="img"]')).toBeNull();
+      expect(container.querySelector('.bg-blue-600')).toBeNull();
     });
 
-    it('should not show indicator when status is idle', () => {
+    it('should show a static lifecycle dot when idle and read', () => {
       mockStatuses.value = new Map([
-        ['session-1', { processingState: { status: 'idle' }, hasUnread: false }],
+        ['session-1', { processingState: { status: 'idle' }, unreadCount: 0 }],
       ]);
 
       const { container } = render(
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const indicator = container.querySelector('.animate-pulse');
-      expect(indicator).toBeNull();
+      // active lifecycle -> success (green) tone, static (no pulse)
+      expect(container.querySelector('.bg-green-500')).toBeTruthy();
+      expect(container.querySelector('.animate-pulse')).toBeNull();
     });
 
-    it('should show pulsing indicator when processing', () => {
+    it('should show a pulsing indicator when processing', () => {
       mockStatuses.value = new Map([
         [
           'session-1',
-          { processingState: { status: 'processing', phase: 'thinking' }, hasUnread: false },
+          { processingState: { status: 'processing', phase: 'thinking' }, unreadCount: 0 },
         ],
       ]);
 
@@ -368,15 +354,14 @@ describe('SessionListItem', () => {
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const pulsingIndicator = container.querySelector('.animate-pulse');
-      expect(pulsingIndicator).toBeTruthy();
+      expect(container.querySelector('.animate-pulse')).toBeTruthy();
     });
 
-    it('should show blue dot when thinking', () => {
+    it('should show a blue dot when thinking', () => {
       mockStatuses.value = new Map([
         [
           'session-1',
-          { processingState: { status: 'processing', phase: 'thinking' }, hasUnread: false },
+          { processingState: { status: 'processing', phase: 'thinking' }, unreadCount: 0 },
         ],
       ]);
 
@@ -384,15 +369,15 @@ describe('SessionListItem', () => {
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const blueDot = container.querySelector('.bg-blue-500');
-      expect(blueDot).toBeTruthy();
+      // thinking phase -> info (blue) tone
+      expect(container.querySelector('.bg-blue-500')).toBeTruthy();
     });
 
-    it('should show green dot when streaming', () => {
+    it('should show a green dot when streaming', () => {
       mockStatuses.value = new Map([
         [
           'session-1',
-          { processingState: { status: 'processing', phase: 'streaming' }, hasUnread: false },
+          { processingState: { status: 'processing', phase: 'streaming' }, unreadCount: 0 },
         ],
       ]);
 
@@ -400,46 +385,46 @@ describe('SessionListItem', () => {
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const greenDot = container.querySelector('.bg-green-500');
-      expect(greenDot).toBeTruthy();
+      // streaming phase -> success (green) tone
+      expect(container.querySelector('.bg-green-500')).toBeTruthy();
     });
 
-    it('should show yellow dot when queued', () => {
+    it('should show a yellow dot when queued', () => {
       mockStatuses.value = new Map([
-        ['session-1', { processingState: { status: 'queued' }, hasUnread: false }],
+        ['session-1', { processingState: { status: 'queued' }, unreadCount: 0 }],
       ]);
 
       const { container } = render(
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const yellowDot = container.querySelector('.bg-yellow-500');
-      expect(yellowDot).toBeTruthy();
+      // queued -> progress (yellow) tone
+      expect(container.querySelector('.bg-yellow-500')).toBeTruthy();
     });
 
-    it('should show static blue dot when has unread messages', () => {
+    it('should show a blue unread badge with the count when there are unseen messages', () => {
       mockStatuses.value = new Map([
-        ['session-1', { processingState: { status: 'idle' }, hasUnread: true }],
+        ['session-1', { processingState: { status: 'idle' }, unreadCount: 3 }],
       ]);
 
       const { container } = render(
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      // Should show blue unread dot
-      const unreadDot = container.querySelector('.bg-blue-500');
-      expect(unreadDot).toBeTruthy();
+      // UnreadBadge uses bg-blue-600 and renders the numeric count.
+      const badge = container.querySelector('.bg-blue-600');
+      expect(badge).toBeTruthy();
+      expect(badge?.textContent).toContain('3');
 
-      // Should NOT be pulsing (static dot)
-      const pulsingDot = container.querySelector('.animate-pulse');
-      expect(pulsingDot).toBeNull();
+      // Static — no pulse.
+      expect(container.querySelector('.animate-pulse')).toBeNull();
     });
 
     it('should prioritize processing state over unread', () => {
       mockStatuses.value = new Map([
         [
           'session-1',
-          { processingState: { status: 'processing', phase: 'streaming' }, hasUnread: true },
+          { processingState: { status: 'processing', phase: 'streaming' }, unreadCount: 5 },
         ],
       ]);
 
@@ -447,42 +432,24 @@ describe('SessionListItem', () => {
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      // Should show green streaming dot (processing takes priority)
-      const streamingDot = container.querySelector('.bg-green-500');
-      expect(streamingDot).toBeTruthy();
-
-      // Should be pulsing
-      const pulsingDot = container.querySelector('.animate-pulse');
-      expect(pulsingDot).toBeTruthy();
+      // Streaming dot (success/green) wins over the unread badge.
+      expect(container.querySelector('.bg-green-500')).toBeTruthy();
+      expect(container.querySelector('.animate-pulse')).toBeTruthy();
+      // No unread badge rendered while processing.
+      expect(container.querySelector('.bg-blue-600')).toBeNull();
     });
 
-    it('should show ping animation when processing', () => {
+    it('should not pulse for interrupted status', () => {
       mockStatuses.value = new Map([
-        [
-          'session-1',
-          { processingState: { status: 'processing', phase: 'thinking' }, hasUnread: false },
-        ],
+        ['session-1', { processingState: { status: 'interrupted' }, unreadCount: 0 }],
       ]);
 
       const { container } = render(
         <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
       );
 
-      const pingAnimation = container.querySelector('.animate-ping');
-      expect(pingAnimation).toBeTruthy();
-    });
-
-    it('should not show indicator for interrupted status', () => {
-      mockStatuses.value = new Map([
-        ['session-1', { processingState: { status: 'interrupted' }, hasUnread: false }],
-      ]);
-
-      const { container } = render(
-        <SessionListItem session={mockSession} onSessionClick={mockOnSessionClick} />
-      );
-
-      const indicator = container.querySelector('.animate-pulse');
-      expect(indicator).toBeNull();
+      // interrupted is "at rest" -> falls through to the static lifecycle dot.
+      expect(container.querySelector('.animate-pulse')).toBeNull();
     });
   });
 

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -8,9 +8,9 @@
  * Note: Tests without mock.module to avoid polluting other tests.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, act } from '@testing-library/preact';
 import type { ContextInfo, ModelInfo } from '@hyperneo/shared';
+import { act, cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SessionStatusBar from '../SessionStatusBar';
 
 // Configurable hub mock — defaults to null (no connection) so existing tests are unaffected.
@@ -884,10 +884,11 @@ describe('SessionStatusBar', () => {
       ) as HTMLButtonElement;
       fireEvent.click(modelButton);
 
-      // Provider availability dots have flex-shrink-0 to distinguish them from
-      // the connection status dot (which does not have that class)
+      // Availability dots are StatusDots inside the dropdown. Scope to the
+      // dropdown so the connection status dot (also a StatusDot) is excluded.
+      const dropdown = container.querySelector('[data-testid="model-dropdown"]')!;
       const providerDots = Array.from(
-        container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
+        dropdown.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
       );
       expect(providerDots.length).toBeGreaterThan(0);
     });
@@ -901,11 +902,9 @@ describe('SessionStatusBar', () => {
       ) as HTMLButtonElement;
       fireEvent.click(modelButton);
 
-      const providerDots = Array.from(
-        container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
-      );
-      expect(providerDots.length).toBeGreaterThan(0);
-      expect(providerDots[0].className).toContain('bg-gray-500');
+      // Unknown/unauthenticated provider -> neutral tone (bg-gray-500).
+      const dropdown = container.querySelector('[data-testid="model-dropdown"]')!;
+      expect(dropdown.querySelector('.bg-gray-500')).toBeTruthy();
     });
 
     it('should show green availability dot when provider is authenticated', async () => {
@@ -936,11 +935,9 @@ describe('SessionStatusBar', () => {
       ) as HTMLButtonElement;
       fireEvent.click(modelButton);
 
-      const providerDots = Array.from(
-        container.querySelectorAll('.w-2.h-2.rounded-full.flex-shrink-0')
-      );
-      expect(providerDots.length).toBeGreaterThan(0);
-      expect(providerDots[0].className).toContain('bg-green-500');
+      // Authenticated provider -> success tone (bg-green-500).
+      const dropdown = container.querySelector('[data-testid="model-dropdown"]')!;
+      expect(dropdown.querySelector('.bg-green-500')).toBeTruthy();
     });
   });
 });

--- a/packages/web/src/islands/__tests__/SessionList.test.tsx
+++ b/packages/web/src/islands/__tests__/SessionList.test.tsx
@@ -2,8 +2,9 @@
 /**
  * Tests for the Codex-style sessions sidebar.
  */
-import { computed, signal } from '@preact/signals';
+
 import type { Session, WorkspaceHistoryEntry } from '@hyperneo/shared';
+import { computed, signal } from '@preact/signals';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,7 +79,6 @@ vi.mock('../../lib/session-status.ts', () => ({
   get allSessionStatuses() {
     return mockSessionStatusesSignal;
   },
-  getProcessingPhaseColor: vi.fn(() => null),
 }));
 
 vi.mock('../../components/ArchiveConfirmDialog.tsx', () => ({

--- a/packages/web/src/lib/__tests__/session-status.test.ts
+++ b/packages/web/src/lib/__tests__/session-status.test.ts
@@ -5,12 +5,11 @@
  * Tests the actual exported functions from session-status.ts:
  * - initSessionStatusTracking()
  * - allSessionStatuses (computed signal)
- * - getProcessingPhaseColor()
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import type { Session, AgentProcessingState } from '@hyperneo/shared';
+import type { AgentProcessingState, Session } from '@hyperneo/shared';
 import type { Signal } from '@preact/signals';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock localStorage
 const createMockLocalStorage = () => {
@@ -76,115 +75,6 @@ describe('session-status (real module tests)', () => {
     ...overrides,
   });
 
-  describe('getProcessingPhaseColor', () => {
-    it('should return null for idle status', async () => {
-      // Mock dependencies
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'idle' })).toBeNull();
-    });
-
-    it('should return null for interrupted status', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'interrupted' })).toBeNull();
-    });
-
-    it('should return yellow for queued status', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'queued' })).toEqual({
-        dot: 'bg-yellow-500',
-        text: 'text-yellow-400',
-      });
-    });
-
-    it('should return blue for thinking phase', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'processing', phase: 'thinking' })).toEqual({
-        dot: 'bg-blue-500',
-        text: 'text-blue-400',
-      });
-    });
-
-    it('should return green for streaming phase', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'processing', phase: 'streaming' })).toEqual({
-        dot: 'bg-green-500',
-        text: 'text-green-400',
-      });
-    });
-
-    it('should return purple for finalizing phase', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'processing', phase: 'finalizing' })).toEqual({
-        dot: 'bg-purple-500',
-        text: 'text-purple-400',
-      });
-    });
-
-    it('should return yellow for initializing phase', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      expect(getProcessingPhaseColor({ status: 'processing', phase: 'initializing' })).toEqual({
-        dot: 'bg-yellow-500',
-        text: 'text-yellow-400',
-      });
-    });
-  });
-
   describe('allSessionStatuses computed signal', () => {
     it('should return empty map when no sessions', async () => {
       vi.doMock('../state.js', () => ({
@@ -219,7 +109,7 @@ describe('session-status (real module tests)', () => {
       expect(status?.processingState).toEqual({ status: 'processing', phase: 'thinking' });
     });
 
-    it('should compute hasUnread correctly', async () => {
+    it('should compute unreadCount correctly', async () => {
       mockSessions.value = [
         createMockSession('sess-1', {
           metadata: {
@@ -259,10 +149,10 @@ describe('session-status (real module tests)', () => {
       // Need to call initSessionStatusTracking to load the localStorage data
       module.initSessionStatusTracking();
 
-      // sess-1: 10 > 5, so unread
-      expect(allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(true);
-      // sess-2: 5 > 0, so unread
-      expect(allSessionStatuses.value.get('sess-2')?.hasUnread).toBe(true);
+      // sess-1: 10 - 5 = 5 unread
+      expect(allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(5);
+      // sess-2: 5 - 0 = 5 unread
+      expect(allSessionStatuses.value.get('sess-2')?.unreadCount).toBe(5);
     });
 
     it('should mark current session as read regardless of message count', async () => {
@@ -289,7 +179,7 @@ describe('session-status (real module tests)', () => {
 
       const { allSessionStatuses } = await import('../session-status.js');
 
-      expect(allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(false);
+      expect(allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(0);
     });
 
     it('should handle object processingState', async () => {
@@ -369,8 +259,8 @@ describe('session-status (real module tests)', () => {
       module.initSessionStatusTracking();
 
       // After initialization, check that statuses reflect loaded data
-      expect(module.allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(true); // 10 > 5
-      expect(module.allSessionStatuses.value.get('sess-2')?.hasUnread).toBe(true); // 15 > 10
+      expect(module.allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(5); // 10 - 5
+      expect(module.allSessionStatuses.value.get('sess-2')?.unreadCount).toBe(5); // 15 - 10
     });
 
     it('should subscribe to currentSessionIdSignal changes', async () => {
@@ -397,14 +287,14 @@ describe('session-status (real module tests)', () => {
       const module = await import('../session-status.js');
       module.initSessionStatusTracking();
 
-      // Initially unread
-      expect(module.allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(true);
+      // Initially unread (20 - 0)
+      expect(module.allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(20);
 
       // Simulate switching to this session (which marks it as read)
       mockCurrentSessionIdSignal.value = 'sess-1';
 
       // Now should be marked as read
-      expect(module.allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(false);
+      expect(module.allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(0);
     });
   });
 
@@ -549,7 +439,7 @@ describe('session-status (real module tests)', () => {
 
       // Should not throw, should handle gracefully
       expect(() => module.initSessionStatusTracking()).not.toThrow();
-      expect(module.allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(true); // 5 > 0 (default)
+      expect(module.allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(5); // 5 - 0 (default)
     });
 
     it('should handle empty localStorage', async () => {
@@ -578,8 +468,8 @@ describe('session-status (real module tests)', () => {
       const module = await import('../session-status.js');
 
       expect(() => module.initSessionStatusTracking()).not.toThrow();
-      // All sessions should be unread when no lastSeen data exists
-      expect(module.allSessionStatuses.value.get('sess-1')?.hasUnread).toBe(true);
+      // All sessions are fully unread when no lastSeen data exists
+      expect(module.allSessionStatuses.value.get('sess-1')?.unreadCount).toBe(5);
     });
   });
 
@@ -642,47 +532,7 @@ describe('session-status (real module tests)', () => {
       const status = allSessionStatuses.value.get('sess-1');
       expect(status).toBeDefined();
       expect(status?.processingState).toBeDefined();
-      expect(typeof status?.hasUnread).toBe('boolean');
-    });
-  });
-
-  describe('getProcessingPhaseColor edge cases', () => {
-    it('should return purple for unknown processing phase (default case)', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      // Test with an unknown phase value - should hit default case (line 196)
-      const result = getProcessingPhaseColor({
-        status: 'processing',
-        phase: 'unknown-phase' as unknown as AgentProcessingState['phase'],
-      });
-      expect(result).toEqual({
-        dot: 'bg-purple-500',
-        text: 'text-purple-400',
-      });
-    });
-
-    it('should return null for completely unknown status (final return null)', async () => {
-      vi.doMock('../state.js', () => ({
-        sessions: mockSessions,
-      }));
-      vi.doMock('../signals.js', () => ({
-        currentSessionIdSignal: mockCurrentSessionIdSignal,
-      }));
-
-      const { getProcessingPhaseColor } = await import('../session-status.js');
-
-      // Test with an unrecognized status - should hit final return null (line 200)
-      const result = getProcessingPhaseColor({
-        status: 'unknown-status' as unknown as AgentProcessingState['status'],
-      });
-      expect(result).toBeNull();
+      expect(typeof status?.unreadCount).toBe('number');
     });
   });
 

--- a/packages/web/src/lib/session-status.ts
+++ b/packages/web/src/lib/session-status.ts
@@ -1,13 +1,17 @@
 /**
  * Session Status Tracking
  *
- * Tracks session processing states and unread status for sidebar display.
+ * Tracks session processing states and unread counts for sidebar display.
  *
  * Features:
  * - Uses Session.processingState field from unified state.sessions channel
  * - NO per-session subscriptions (prevents rate limit issues)
  * - Tracks agent processing states (idle, queued, processing)
- * - Tracks unread status using localStorage persistence
+ * - Tracks unread counts using localStorage persistence
+ *
+ * Phase/lifecycle tones are derived from the unified indicator foundation
+ * (session-processing-phase.ts / session-lifecycle-status.ts) by consumers;
+ * this module only carries the raw state + unread count.
  *
  * Architecture Note:
  * Previously, this module subscribed to per-session state channels for every
@@ -16,10 +20,10 @@
  * processingState field from the Session object in the global sessions channel.
  */
 
-import { signal, computed } from '@preact/signals';
 import type { AgentProcessingState } from '@hyperneo/shared';
-import { sessions } from './state.ts';
+import { computed, signal } from '@preact/signals';
 import { currentSessionIdSignal } from './signals.ts';
+import { sessions } from './state.ts';
 
 /**
  * Storage key for unread tracking
@@ -32,8 +36,8 @@ const UNREAD_STORAGE_KEY = 'kai:session-last-seen';
 export interface SessionStatusInfo {
   /** Current processing state */
   processingState: AgentProcessingState;
-  /** Whether the session has unread messages */
-  hasUnread: boolean;
+  /** Number of unseen messages (0 when the session is read/current) */
+  unreadCount: number;
 }
 
 /**
@@ -153,49 +157,17 @@ export const allSessionStatuses = computed<Map<string, SessionStatusInfo>>(() =>
     // Parse processing state from Session.processingState field (JSON string)
     const processingState = parseProcessingState(session.processingState);
 
-    // Calculate unread status
+    // Calculate unread count: new messages since the session was last viewed.
+    // The current session is always considered read.
     const lastSeenCount = lastSeen.get(session.id) ?? 0;
     const currentCount = session.metadata.messageCount || 0;
-    const hasUnread = currentId !== session.id && currentCount > lastSeenCount;
+    const unreadCount = currentId !== session.id ? Math.max(0, currentCount - lastSeenCount) : 0;
 
     statuses.set(session.id, {
       processingState,
-      hasUnread,
+      unreadCount,
     });
   }
 
   return statuses;
 });
-
-/**
- * Get processing phase color (matches ContextIndicator colors)
- */
-export function getProcessingPhaseColor(
-  state: AgentProcessingState
-): { dot: string; text: string } | null {
-  if (state.status === 'idle' || state.status === 'interrupted') {
-    return null;
-  }
-
-  if (state.status === 'queued') {
-    return { dot: 'bg-yellow-500', text: 'text-yellow-400' };
-  }
-
-  // Processing state
-  if (state.status === 'processing') {
-    switch (state.phase) {
-      case 'initializing':
-        return { dot: 'bg-yellow-500', text: 'text-yellow-400' };
-      case 'thinking':
-        return { dot: 'bg-blue-500', text: 'text-blue-400' };
-      case 'streaming':
-        return { dot: 'bg-green-500', text: 'text-green-400' };
-      case 'finalizing':
-        return { dot: 'bg-purple-500', text: 'text-purple-400' };
-      default:
-        return { dot: 'bg-purple-500', text: 'text-purple-400' };
-    }
-  }
-
-  return null;
-}


### PR DESCRIPTION
Migrates the plain-chat indicator surfaces onto the unified indicator foundation (#2283) so semantic state renders consistently across the UI.

- **SessionListItem**: bespoke `StatusIndicator` → `StatusDot` + `UnreadBadge`. Actively processing pulses with the phase tone; unseen messages render a blue numeric badge; otherwise a static lifecycle dot.
- **session-status**: drops `getProcessingPhaseColor` (foundation mappings used instead) and exposes `unreadCount` instead of `hasUnread` so the badge shows the actual unseen count. localStorage logic unchanged.
- **ConnectionStatus**: connection/processing tones derived from the foundation (`StatusDot` + `indicator-tokens`); a null streaming phase now resolves to the info "processing" tone instead of purple.
- **SessionStatusBar**: model-picker provider availability dots use `StatusDot`.

Tests updated for the new classes/interface. `bun run check` and the full web vitest suite (6521 tests) pass.