### PR TITLE
fix(daemon): tell Fullstack QA Loop Coder to escalate no-code tasks via Runtime Execution Contract

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -130,6 +130,9 @@ import {
 
 const log = new Logger('task-agent-manager');
 const AGENT_MESSAGE_ENVELOPE_HEADER = /^─── Message from ([^\n]+) ───\n\n/;
+
+/** Central escalation target referenced by workflow slot prompts for misrouted tasks. */
+const WORKFLOW_ESCALATION_TARGET = 'space-agent';
 const AGENT_MESSAGE_ENVELOPE_REPLY_BLOCK = '\n\n─── Reply ───\nTo reply, use: ';
 
 function pendingSourceLevel(sourceAgentName: string): AgentMessageLevel {
@@ -2398,6 +2401,7 @@ export class TaskAgentManager {
       ...endNodeContractLines('  '),
       '  - list_artifacts({ nodeId?, type? }) — list artifacts for the current workflow run',
       '  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call returned "No such tool available", call this once and then retry the original tool',
+      `Escalation: send_message({ target: "${WORKFLOW_ESCALATION_TARGET}", message }) requests human/space-level judgment (use for misrouted no-code tasks or hard blockers).`,
       'Only contact the task-agent via send_message if you are blocked or need human input.',
     ].join('\n');
 
@@ -2483,6 +2487,9 @@ export class TaskAgentManager {
       }
     }
 
+    lines.push(
+      `Escalation: send_message({ target: "${WORKFLOW_ESCALATION_TARGET}", message }) requests human/space-level judgment (use for misrouted no-code tasks or hard blockers).`
+    );
     lines.push(
       'Only contact the task-agent via send_message if you are blocked or need human input.'
     );

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -397,6 +397,11 @@ const FULLSTACK_QA_PROMPT =
 
 const FULLSTACK_CODING_NOCHANGE_GUIDANCE =
   'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. This workflow only completes via a reviewed PR, so a no-change task is misrouted — escalate via `send_message` to the escalation target listed in your Runtime Execution Contract, explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
+// Immediate predecessor of the Fullstack no-code guidance (hard-coded `space-agent`).
+// Existing seeded spaces from that revision must be restamped to the
+// runtime-contract reference above.
+const RETIRED_PREVIOUS_FULLSTACK_CODING_NOCHANGE_GUIDANCE =
+  'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. This workflow only completes via a reviewed PR, so a no-change task is misrouted — send a message to `space-agent` explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
@@ -1706,6 +1711,9 @@ const BUILT_IN_PROMPT_PATCH_VARIANTS = [
   // No-code guidance was added to the Fullstack Coder steps. Existing seeded
   // spaces that lack it can be patched by dropping the guidance paragraph.
   [[FULLSTACK_CODING_NOCHANGE_GUIDANCE, '']],
+  // Immediate predecessor of the Fullstack no-code guidance hard-coded `space-agent`.
+  // Seeded spaces from that revision restamp to the runtime-contract reference.
+  [[FULLSTACK_CODING_NOCHANGE_GUIDANCE, RETIRED_PREVIOUS_FULLSTACK_CODING_NOCHANGE_GUIDANCE]],
   // Pre-PR-dev Research: PR step gained subscribe, handoff unchanged.
   [[CURRENT_RESEARCH_PR_STEP_PROMPT, RETIRED_RESEARCH_PR_STEP_PROMPT]],
   [[CURRENT_FULLSTACK_REVIEW_HANDOFF_PROMPT, RETIRED_FULLSTACK_REVIEW_HANDOFF_PROMPT]],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1551,6 +1551,15 @@ const CURRENT_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT =
   'reviewed PR, so a no-change task is misrouted — escalate via `send_message` to the ' +
   'escalation target listed in your Runtime Execution Contract, explaining that the task ' +
   'produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
+// Immediate predecessor of the current step-7 wording (hard-coded `space-agent`).
+// Existing seeded spaces that carry this literal must be restamped to the
+// runtime-contract reference above.
+const RETIRED_PREVIOUS_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT =
+  '7. If the task requires no code changes (validation-only, a diagnostic, or already ' +
+  'complete): do NOT create an empty commit or PR. This workflow only completes via a ' +
+  'reviewed PR, so a no-change task is misrouted — send a message to `space-agent` ' +
+  'explaining that the task produced no code changes and needs re-routing, then stop ' +
+  'and wait for guidance.\n\n';
 const RETIRED_CODING_WORKFLOW_VALIDATION_STEP_PROMPT =
   '7. If the task is validation-only and produced no code changes: do NOT create an empty commit or PR. ' +
   'Instead, call `save_artifact({ type: "result", append: true, summary: "<validation outcome>", data: { completion_mode: "validation_only", changed_files: 0, validation_outcome: "<passed|failed + evidence>" } })`, then ' +
@@ -1672,6 +1681,14 @@ const BUILT_IN_PROMPT_PATCH_VARIANTS = [
   // the now-removed "Validation Complete" node. Swapped independently — it
   // composes with the PR/handoff/rehandoff groups above via candidate chaining.
   [[CURRENT_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT, RETIRED_CODING_WORKFLOW_VALIDATION_STEP_PROMPT]],
+  // Immediate predecessor of the current step-7 wording: hard-coded `space-agent`.
+  // Seeded spaces from that revision restamp to the runtime-contract reference.
+  [
+    [
+      CURRENT_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT,
+      RETIRED_PREVIOUS_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT,
+    ],
+  ],
   // Pre-PR-dev Fullstack Coding: PR step gained subscribe, rest unchanged.
   [[CURRENT_FULLSTACK_CODING_PR_STEP_PROMPT, RETIRED_FULLSTACK_CODING_PR_STEP_PROMPT]],
   // Gate-era Fullstack Coding: PR step + ready prompt + step-4 handoff.

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -396,7 +396,7 @@ const FULLSTACK_QA_PROMPT =
   'approve_task (or submit_for_approval if autonomy blocks self-close). Do not merge or set auto-merge.';
 
 const FULLSTACK_CODING_NOCHANGE_GUIDANCE =
-  'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. This workflow only completes via a reviewed PR, so a no-change task is misrouted — send a message to `space-agent` explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
+  'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. This workflow only completes via a reviewed PR, so a no-change task is misrouted — escalate via `send_message` to the escalation target listed in your Runtime Execution Contract, explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
@@ -455,9 +455,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
               'you must re-supply it.\n' +
               '7. If the task requires no code changes (validation-only, a diagnostic, or already ' +
               'complete): do NOT create an empty commit or PR. This workflow only completes via a ' +
-              'reviewed PR, so a no-change task is misrouted — send a message to `space-agent` ' +
-              'explaining that the task produced no code changes and needs re-routing, then stop ' +
-              'and wait for guidance.\n\n' +
+              'reviewed PR, so a no-change task is misrouted — escalate via `send_message` to the ' +
+              'escalation target listed in your Runtime Execution Contract, explaining that the task ' +
+              'produced no code changes and needs re-routing, then stop and wait for guidance.\n\n' +
               'If re-activated after review:\n' +
               '1. Read the incoming message `data` — you should find `review_url` and ' +
               '`comment_urls` (an array of comment thread URLs). Open each one; do not rely on ' +
@@ -1543,13 +1543,14 @@ const RETIRED_HARDCODED_CODING_WORKFLOW_REHANDOFF_PROMPT =
 // Coding Workflow step 7: the Validation Complete escape hatch was removed.
 // Existing seeded spaces still carry the old step that handed validation-only
 // tasks off to the now-removed "Validation Complete" node; restamp swaps it for
-// the current guidance (escalate the misroute to space-agent, no empty PR).
+// the current guidance (escalate the misroute via the runtime-provided target,
+// no empty PR).
 const CURRENT_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT =
   '7. If the task requires no code changes (validation-only, a diagnostic, or already ' +
   'complete): do NOT create an empty commit or PR. This workflow only completes via a ' +
-  'reviewed PR, so a no-change task is misrouted — send a message to `space-agent` ' +
-  'explaining that the task produced no code changes and needs re-routing, then stop ' +
-  'and wait for guidance.\n\n';
+  'reviewed PR, so a no-change task is misrouted — escalate via `send_message` to the ' +
+  'escalation target listed in your Runtime Execution Contract, explaining that the task ' +
+  'produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
 const RETIRED_CODING_WORKFLOW_VALIDATION_STEP_PROMPT =
   '7. If the task is validation-only and produced no code changes: do NOT create an empty commit or PR. ' +
   'Instead, call `save_artifact({ type: "result", append: true, summary: "<validation outcome>", data: { completion_mode: "validation_only", changed_files: 0, validation_outcome: "<passed|failed + evidence>" } })`, then ' +

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -395,6 +395,9 @@ const FULLSTACK_QA_PROMPT =
   'and stop. If all green, save a passing result artifact with pr_url in data, then call ' +
   'approve_task (or submit_for_approval if autonomy blocks self-close). Do not merge or set auto-merge.';
 
+const FULLSTACK_CODING_NOCHANGE_GUIDANCE =
+  'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. This workflow only completes via a reviewed PR, so a no-change task is misrouted — send a message to `space-agent` explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
+
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
 
@@ -986,6 +989,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
  *   QA → Coding (test failures/regressions)
  *
  * QA is the end node. QA calls save_artifact() then approve_task() on success.
+ *
+ * For tasks that produce code changes (a PR). Validation-only tasks (no code
+ * changes) are misrouted here — the Coder should escalate to space-agent instead.
  */
 export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
   id: '',
@@ -1015,6 +1021,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
               '3. Open or update the PR and ensure it remains mergeable. After `gh pr create`, call `subscribe_pr_events({})` (no arguments needed — the PR URL is auto-resolved from the run). This subscribes you to review comments, CI failures, and reactions for your PR so you receive them directly and can act on them. Do this once per PR.\n' +
               '4. Hand off by calling `send_message` to the review target with ' +
               '`data: { pr_url: "<url>" }`; `save_artifact` alone will not deliver the handoff\n' +
+              FULLSTACK_CODING_NOCHANGE_GUIDANCE +
               '5. Share blockers clearly with Reviewer/QA when needed',
           },
           toolGuards: [CODER_NO_MERGE_GUARD],
@@ -1678,6 +1685,9 @@ const BUILT_IN_PROMPT_PATCH_VARIANTS = [
     [CURRENT_FULLSTACK_CODING_READY_PROMPT, RETIRED_HARDCODED_FULLSTACK_CODING_READY_PROMPT],
     [CURRENT_FULLSTACK_CODING_STEP_PROMPT, RETIRED_HARDCODED_FULLSTACK_CODING_STEP_PROMPT],
   ],
+  // No-code guidance was added to the Fullstack Coder steps. Existing seeded
+  // spaces that lack it can be patched by dropping the guidance paragraph.
+  [[FULLSTACK_CODING_NOCHANGE_GUIDANCE, '']],
   // Pre-PR-dev Research: PR step gained subscribe, handoff unchanged.
   [[CURRENT_RESEARCH_PR_STEP_PROMPT, RETIRED_RESEARCH_PR_STEP_PROMPT]],
   [[CURRENT_FULLSTACK_REVIEW_HANDOFF_PROMPT, RETIRED_FULLSTACK_REVIEW_HANDOFF_PROMPT]],

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-contract.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-contract.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit test for TaskAgentManager's Runtime Execution Contract.
+ *
+ * The contract is private, but the escalation target line is load-bearing:
+ * workflow slot prompts refer to it by name, so we verify it is rendered for
+ * both workflow and fallback (no-workflow) sessions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import type { SpaceWorkflow, NodeExecution, Space } from '@hyperneo/shared';
+
+describe('TaskAgentManager Runtime Execution Contract', () => {
+  function makeManager(): TaskAgentManager {
+    const db = new BunDatabase(':memory:');
+    // The contract builder only reads from the provided workflow/execution/space
+    // in this test; all other config fields can be stubbed.
+    return new TaskAgentManager({
+      db: { getDatabase: () => db },
+      internalEventBus: { subscribe: () => () => {} },
+    } as unknown as ConstructorParameters<typeof TaskAgentManager>[0]);
+  }
+
+  const space: Space = {
+    id: 'space-contract-test',
+    autonomyLevel: 1,
+  } as Space;
+
+  test('includes the centrally injected escalation target when no workflow is present', () => {
+    const manager = makeManager();
+    const execution: NodeExecution = {
+      id: 'exec-1',
+      agentName: 'coder',
+      workflowNodeId: 'node-1',
+    } as NodeExecution;
+
+    const contract = (
+      manager as unknown as Record<string, (w: null, e: NodeExecution, s: Space | null) => string>
+    ).buildNodeExecutionRuntimeContract(null, execution, space);
+
+    expect(contract).toContain('## Runtime Execution Contract');
+    expect(contract).toContain(
+      'Escalation: send_message({ target: "space-agent", message }) requests human/space-level judgment'
+    );
+  });
+
+  test('includes the centrally injected escalation target inside a workflow run', () => {
+    const manager = makeManager();
+    const workflow: SpaceWorkflow = {
+      id: 'wf-1',
+      spaceId: space.id,
+      name: 'Test Workflow',
+      nodes: [
+        {
+          id: 'node-1',
+          name: 'Coding',
+          agents: [{ agentId: 'Coder', name: 'coder' }],
+        },
+      ],
+      channels: [],
+      gates: [],
+      startNodeId: 'node-1',
+      endNodeId: 'node-1',
+      completionAutonomyLevel: 5,
+    } as unknown as SpaceWorkflow;
+
+    const execution: NodeExecution = {
+      id: 'exec-2',
+      agentName: 'coder',
+      workflowNodeId: 'node-1',
+    } as NodeExecution;
+
+    const contract = (
+      manager as unknown as Record<
+        string,
+        (w: SpaceWorkflow, e: NodeExecution, s: Space | null) => string
+      >
+    ).buildNodeExecutionRuntimeContract(workflow, execution, space);
+
+    expect(contract).toContain('Node: "Coding" (node-1)');
+    expect(contract).toContain(
+      'Escalation: send_message({ target: "space-agent", message }) requests human/space-level judgment'
+    );
+  });
+});

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -6201,6 +6201,39 @@ test('patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt mis
   expect(mergedPrompt).toContain('escalation target listed in your Runtime Execution Contract');
 });
 
+test('patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt with space-agent literal to runtime contract', () => {
+  const templateNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+  const templatePrompt = templateNode.agents[0].customPrompt!;
+  const previousGuidance =
+    'If the task requires no code changes (validation-only, a diagnostic, or already complete): do NOT create an empty commit or PR. ' +
+    'This workflow only completes via a reviewed PR, so a no-change task is misrouted — send a message to `space-agent` ' +
+    'explaining that the task produced no code changes and needs re-routing, then stop and wait for guidance.\n\n';
+  const stalePromptValue = templatePrompt.value.replace(
+    /If the task requires no code changes[\s\S]*?wait for guidance\.\n\n/,
+    previousGuidance
+  );
+  expect(stalePromptValue).not.toBe(templatePrompt.value);
+  expect(stalePromptValue).toContain('send a message to `space-agent`');
+
+  const existingNode: WorkflowNode = {
+    ...templateNode,
+    agents: templateNode.agents.map((a, i) =>
+      i === 0 ? { ...a, customPrompt: { value: stalePromptValue } } : a
+    ),
+  };
+
+  const merged = mergeNodeStructuralFieldsFromTemplate(
+    [existingNode],
+    FULLSTACK_QA_LOOP_WORKFLOW.nodes,
+    () => 'agent-coder'
+  );
+  const mergedCoder = merged.find((n) => n.name === 'Coding')!;
+  const mergedPrompt = mergedCoder.agents[0].customPrompt!.value;
+  expect(mergedPrompt).toBe(templatePrompt.value);
+  expect(mergedPrompt).toContain('escalation target listed in your Runtime Execution Contract');
+  expect(mergedPrompt).not.toContain('send a message to `space-agent`');
+});
+
 test('FULLSTACK_QA_LOOP_WORKFLOW Review node forbids gate-write while findings are open', () => {
   const reviewNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
   const prompt = reviewNode.agents[0].customPrompt!.value;

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -5823,6 +5823,43 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     expect(mergedPrompt).not.toContain('send_message(target="Validation Complete"');
   });
 
+  test('patchKnownBuiltInPromptDrift rewrites persisted Coding coder step 7 (space-agent literal -> runtime contract)', () => {
+    // Immediate predecessor of the current step-7 wording hard-coded `space-agent`.
+    // Seeded spaces from that revision must restamp to the runtime-contract reference.
+    const templateNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+    const templatePrompt = templateNode.agents[0].customPrompt!;
+    const previousStep7 =
+      '7. If the task requires no code changes (validation-only, a diagnostic, or already ' +
+      'complete): do NOT create an empty commit or PR. This workflow only completes via a ' +
+      'reviewed PR, so a no-change task is misrouted — send a message to `space-agent` ' +
+      'explaining that the task produced no code changes and needs re-routing, then stop ' +
+      'and wait for guidance.\n\n';
+    const stalePromptValue = templatePrompt.value.replace(
+      /7\. If the task requires no code changes[\s\S]*?wait for guidance\.\n\n/,
+      previousStep7
+    );
+    expect(stalePromptValue).not.toBe(templatePrompt.value);
+    expect(stalePromptValue).toContain('send a message to `space-agent`');
+
+    const existingNode: WorkflowNode = {
+      ...templateNode,
+      agents: templateNode.agents.map((a, i) =>
+        i === 0 ? { ...a, customPrompt: { value: stalePromptValue } } : a
+      ),
+    };
+
+    const merged = mergeNodeStructuralFieldsFromTemplate(
+      [existingNode],
+      CODING_WORKFLOW.nodes,
+      () => 'agent-coder'
+    );
+    const mergedCoder = merged.find((n) => n.name === 'Coding')!;
+    const mergedPrompt = mergedCoder.agents[0].customPrompt!.value;
+    expect(mergedPrompt).toBe(templatePrompt.value);
+    expect(mergedPrompt).toContain('escalation target listed in your Runtime Execution Contract');
+    expect(mergedPrompt).not.toContain('send a message to `space-agent`');
+  });
+
   test('migrated review-approval hook with per-node timeout preserves GitHub auth lookup', () => {
     // P2: when codexTimeoutSeconds differs from the default, migration builds
     // a fresh script string (not REVIEW_APPROVAL_SCRIPT identity). The hook

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -6126,6 +6126,44 @@ test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt uses behavioral hook handoff wordi
   expect(prompt).not.toContain('code-pr-gate');
 });
 
+test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt instructs space-agent escalation for no-code tasks', () => {
+  const codingNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+  const prompt = codingNode.agents[0].customPrompt!.value;
+
+  expect(prompt).toContain('If the task requires no code changes');
+  expect(prompt).toContain('send a message to `space-agent`');
+  expect(prompt).toContain('needs re-routing');
+  expect(prompt).toContain('do NOT create an empty commit or PR');
+});
+
+test('patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt missing no-code guidance', () => {
+  const templateNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+  const templatePrompt = templateNode.agents[0].customPrompt!;
+  const stalePromptValue = templatePrompt.value.replace(
+    /If the task requires no code changes[\s\S]*?wait for guidance\.\n\n/,
+    ''
+  );
+  expect(stalePromptValue).not.toBe(templatePrompt.value);
+
+  const existingNode: WorkflowNode = {
+    ...templateNode,
+    agents: templateNode.agents.map((a, i) =>
+      i === 0 ? { ...a, customPrompt: { value: stalePromptValue } } : a
+    ),
+  };
+
+  const merged = mergeNodeStructuralFieldsFromTemplate(
+    [existingNode],
+    FULLSTACK_QA_LOOP_WORKFLOW.nodes,
+    () => 'agent-coder'
+  );
+  const mergedCoder = merged.find((n) => n.name === 'Coding')!;
+  const mergedPrompt = mergedCoder.agents[0].customPrompt!.value;
+  expect(mergedPrompt).toBe(templatePrompt.value);
+  expect(mergedPrompt).toContain('If the task requires no code changes');
+  expect(mergedPrompt).toContain('send a message to `space-agent`');
+});
+
 test('FULLSTACK_QA_LOOP_WORKFLOW Review node forbids gate-write while findings are open', () => {
   const reviewNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
   const prompt = reviewNode.agents[0].customPrompt!.value;

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -5819,7 +5819,7 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
     const mergedCoder = merged.find((n) => n.name === 'Coding')!;
     const mergedPrompt = mergedCoder.agents[0].customPrompt!.value;
     expect(mergedPrompt).toBe(templatePrompt.value);
-    expect(mergedPrompt).toContain('send a message to `space-agent`');
+    expect(mergedPrompt).toContain('escalation target listed in your Runtime Execution Contract');
     expect(mergedPrompt).not.toContain('send_message(target="Validation Complete"');
   });
 
@@ -6126,12 +6126,12 @@ test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt uses behavioral hook handoff wordi
   expect(prompt).not.toContain('code-pr-gate');
 });
 
-test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt instructs space-agent escalation for no-code tasks', () => {
+test('FULLSTACK_QA_LOOP_WORKFLOW coder prompt instructs runtime escalation for no-code tasks', () => {
   const codingNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
   const prompt = codingNode.agents[0].customPrompt!.value;
 
   expect(prompt).toContain('If the task requires no code changes');
-  expect(prompt).toContain('send a message to `space-agent`');
+  expect(prompt).toContain('escalation target listed in your Runtime Execution Contract');
   expect(prompt).toContain('needs re-routing');
   expect(prompt).toContain('do NOT create an empty commit or PR');
 });
@@ -6161,7 +6161,7 @@ test('patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt mis
   const mergedPrompt = mergedCoder.agents[0].customPrompt!.value;
   expect(mergedPrompt).toBe(templatePrompt.value);
   expect(mergedPrompt).toContain('If the task requires no code changes');
-  expect(mergedPrompt).toContain('send a message to `space-agent`');
+  expect(mergedPrompt).toContain('escalation target listed in your Runtime Execution Contract');
 });
 
 test('FULLSTACK_QA_LOOP_WORKFLOW Review node forbids gate-write while findings are open', () => {


### PR DESCRIPTION
## Problem\n\nThe Fullstack QA Loop Review handoff is guarded by a `pr_ready` hook that requires an open, mergeable PR with no unresolved review threads. For validation-only tasks that produce no code changes (e.g. diagnostics, goal check-ins), the Coder had no PR to hand off, so `send_message` to Review was blocked.\n\n## Fix\n\nMirror the current Coding Workflow behavior on `dev`: add explicit guidance to the Fullstack Coder prompt that a no-code task is misrouted in this workflow. Instead of creating an empty commit/PR, the Coder should escalate via `send_message` to the escalation target listed in the Runtime Execution Contract and wait for re-routing.\n\n- Added `FULLSTACK_CODING_NOCHANGE_GUIDANCE` in `packages/daemon/src/lib/space/workflows/built-in-workflows.ts`.\n- Injected a central `WORKFLOW_ESCALATION_TARGET` into the Runtime Execution Contract assembled in `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` so the slot prompt reference is backed by the contract.\n- Removed the hard-coded `space-agent` literal from the Coding Workflow inline step 7 and `CURRENT_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT`.\n- Added `RETIRED_PREVIOUS_CODING_WORKFLOW_NOCHANGE_STEP_PROMPT` and a `BUILT_IN_PROMPT_PATCH_VARIANTS` entry so existing seeded spaces carrying the old literal are restamped to the runtime-contract reference.\n- Added `RETIRED_PREVIOUS_FULLSTACK_CODING_NOCHANGE_GUIDANCE` and a matching `BUILT_IN_PROMPT_PATCH_VARIANTS` entry for the same Fullstack predecessor.\n\n## Tests\n\n- Added `FULLSTACK_QA_LOOP_WORKFLOW coder prompt instructs runtime escalation for no-code tasks`.\n- Added `patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt missing no-code guidance`.\n- Added `patchKnownBuiltInPromptDrift rewrites persisted Fullstack Coder prompt with space-agent literal to runtime contract`.\n- Added `patchKnownBuiltInPromptDrift rewrites persisted Coding coder step 7 (space-agent literal -> runtime contract)`.\n- Added `packages/daemon/tests/unit/5-space/runtime/task-agent-manager-contract.test.ts` verifying the escalation target line appears in both fallback and workflow Runtime Execution Contracts.\n\n## Verification\n\n- `bun test --preload=./tests/unit/setup.ts ./tests/unit/5-space/workflow/built-in-workflows.test.ts` → 302 pass, 0 fail.\n- `bun test --preload=./tests/unit/setup.ts ./tests/unit/5-space/runtime/task-agent-manager-contract.test.ts` → 2 pass, 0 fail.\n- `./scripts/test-daemon.sh` → all daemon unit shards pass except two pre-existing, unrelated failures in `provider-service.test.ts` and `space-mcp-handlers.test.ts` (also fail on `dev` in this environment).\n- Typecheck and lint pass.