### PR TITLE
fix(space): curated 24-tool read-only surface for LH agents + coordinator fix

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -599,20 +599,31 @@ export class QueryOptionsBuilder {
     // File editing tools (Write/Edit/NotebookEdit) are excluded; the agent uses its
     // space-agent-tools MCP server for all coordination operations.
     if (this.ctx.session.type === 'space_chat') {
-      const spaceAllowedBuiltinTools = [
-        'Read',
-        'Glob',
-        'Grep',
-        'Bash',
-        'WebFetch',
-        'WebSearch',
-        'ToolSearch',
-        'AskUserQuestion',
-        'Agent',
-        'Task',
-        'TaskOutput',
-        'TaskStop',
-      ];
+      // The long-horizon coordinator runs in this session. When its config
+      // carries a curated `sdkToolsPreset` (set at provisioning via
+      // SpaceRuntimeService.setupSpaceAgentSession from
+      // LONG_HORIZON_AGENT_BUILTIN_TOOLS), honor it — the preset IS the
+      // coordinator's read-only tool surface and must not be clobbered. A
+      // genuine plain space:chat (no preset configured) falls back to the
+      // hardcoded restricted allowlist below.
+      const coordinatorToolset = config.sdkToolsPreset;
+      const isCoordinatorPreset = Array.isArray(coordinatorToolset);
+      const spaceAllowedBuiltinTools = isCoordinatorPreset
+        ? (coordinatorToolset as string[])
+        : [
+            'Read',
+            'Glob',
+            'Grep',
+            'Bash',
+            'WebFetch',
+            'WebSearch',
+            'ToolSearch',
+            'AskUserQuestion',
+            'Agent',
+            'Task',
+            'TaskOutput',
+            'TaskStop',
+          ];
       const spaceRestrictedBuiltinTools = ['Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
 
       // Space chat must not use Claude Code preset prompt.

--- a/packages/daemon/src/lib/space/agents/long-horizon-agent-tools.ts
+++ b/packages/daemon/src/lib/space/agents/long-horizon-agent-tools.ts
@@ -1,0 +1,77 @@
+/**
+ * Curated read-only tool surface for long-horizon (LH) Space agents.
+ *
+ * Replaces the blunt `claude_code` preset (PR #2294), which bundled
+ * interactive-CLI tooling LH agents don't need AND included `Write`/`Edit`/
+ * `MultiEdit` — reversing the deliberate read-only-coordinator design (PR #1567):
+ * LH/coordinator agents delegate file mutation to worker agents; their write
+ * surface is the `space-agent-tools` MCP, not direct file edits.
+ *
+ * This module is import-free so it can be shared by both the Space runtime
+ * (`space-runtime-service.ts`) and the query-time builder
+ * (`query-options-builder.ts`) without creating an import cycle.
+ *
+ * 24 built-ins — outputs go via the `space-agent-tools` MCP or worker
+ * delegation; durable scheduling goes via the MCP, transient self-pacing via
+ * the SDK cron/wakeup tools.
+ */
+
+/**
+ * The curated built-in tool list exposed to long-horizon Space agents.
+ *
+ * Read-only on workspace files: NO `Write`/`Edit`/`MultiEdit`/`NotebookEdit`.
+ * The always-attached `space-agent-tools` MCP provides durable write
+ * coordination (tasks, goals, gates, scheduling).
+ */
+export const LONG_HORIZON_AGENT_BUILTIN_TOOLS = [
+  // read / search / shell / web
+  'Read',
+  'Grep',
+  'Glob',
+  'Bash',
+  'WebFetch',
+  'WebSearch',
+  // subagents (parallel investigation)
+  'Agent',
+  'Task',
+  'TaskOutput',
+  'TaskStop',
+  // planning / UX
+  'AskUserQuestion',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  // local within-turn task tracking
+  'TaskCreate',
+  'TaskGet',
+  'TaskUpdate',
+  'TaskList',
+  // dispatch / meta
+  'Skill',
+  'ToolSearch',
+  // scheduling / self-pacing / background-watch
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'ScheduleWakeup',
+  'Monitor',
+] as const;
+
+/**
+ * Standing guardrail appended to every long-horizon agent's prompt.
+ *
+ * Resolves the layering confusion where an agent reached for the MCP scheduler
+ * (`create_scheduled_task`) when a transient SDK cron/wakeup was expected (and
+ * vice-versa). The two scheduling surfaces pick by horizon, not by guess; and
+ * the two task systems (local within-turn `Task*` vs durable MCP SpaceTasks)
+ * are kept distinct so the agent doesn't conflate them.
+ */
+export const LONG_HORIZON_SCHEDULING_GUARDRAIL = `## Scheduling & Task Systems
+
+You have two scheduling surfaces and two task systems. Pick by horizon and durability, not by guess:
+
+- **Durable / >7-day / goal- or forge-linked schedules** → \`create_scheduled_task\` (space-agent-tools MCP). These persist across sessions and daemon restarts.
+- **Transient self-pacing / short self-checks / live background-watch** → \`Cron*\` / \`ScheduleWakeup\` / \`Monitor\` (SDK built-ins). These live only within this turn's session.
+
+Distinguish the two task systems:
+- **Local \`Task*\`** (\`TaskCreate\`/\`TaskGet\`/\`TaskUpdate\`/\`TaskList\`) = within-turn planning scratchpad; not durable, not visible to other agents.
+- **MCP SpaceTasks** (\`create_standalone_task\`) = durable, dispatched work that other agents execute and that survives restarts.`;

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -38,6 +38,7 @@
 // ---------------------------------------------------------------------------
 
 import type { SpaceAutonomyLevel } from '@hyperneo/shared/types/space';
+import { LONG_HORIZON_SCHEDULING_GUARDRAIL } from './long-horizon-agent-tools';
 
 /** Minimal workflow summary for prompt embedding (avoids exposing full node graph). */
 export interface WorkflowSummary {
@@ -201,6 +202,11 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
       `space-coordination fallback only when direct coordination is still required. Task agents may ` +
       `message you; verify sender task/workflow context before acting.`
   );
+
+  // The coordinator has both the space-agent-tools MCP scheduler and the SDK
+  // cron/wakeup tools. Pin the layering so the two are picked by horizon, not
+  // guess (the long-horizon-agent standing guardrail).
+  sections.push(`\n${LONG_HORIZON_SCHEDULING_GUARDRAIL}`);
 
   if (context.background) {
     sections.push(`\n## Space Background\n\n${context.background}`);

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -77,6 +77,10 @@ import type { ExternalEventStore } from '../../external-events/external-event-st
 import type { ExternalEventService } from '../../external-events/external-event-service';
 import type { AgentMemoryRepository } from '../../../storage/repositories/agent-memory-repository';
 import type { SDKUserMessage } from '@hyperneo/shared/sdk';
+import {
+  LONG_HORIZON_AGENT_BUILTIN_TOOLS,
+  LONG_HORIZON_SCHEDULING_GUARDRAIL,
+} from '../agents/long-horizon-agent-tools';
 import { deriveWorkerDisallowedTools } from '../agents/tool-policy';
 import type { UUID } from 'crypto';
 
@@ -594,6 +598,14 @@ export class SpaceRuntimeService {
       (model
         ? await resolveAgentConfigProvider(model, currentProvider, currentModel)
         : undefined)) as Session['config']['provider'];
+    // Long-horizon agents append their instructions to the Claude Code preset
+    // prompt, followed by the standing scheduling/task-system guardrail so the
+    // two scheduling surfaces and two task systems are picked by horizon, not
+    // by guess (see LONG_HORIZON_SCHEDULING_GUARDRAIL).
+    const instructions = agent.instructions?.trim();
+    const systemPromptAppend = instructions
+      ? `${instructions}\n\n${LONG_HORIZON_SCHEDULING_GUARDRAIL}`
+      : LONG_HORIZON_SCHEDULING_GUARDRAIL;
     return {
       model,
       provider,
@@ -601,13 +613,15 @@ export class SpaceRuntimeService {
       systemPrompt: {
         type: 'preset',
         preset: 'claude_code',
-        append: agent.instructions,
+        append: systemPromptAppend,
       },
-      // Expose the full Claude Code tool surface (same preset an interactive
-      // session gets) rather than the SDK's minimal base default. The
+      // Curated explicit 24-tool surface, read-only on workspace files (no
+      // Write/Edit/MultiEdit/NotebookEdit) — outputs go via the space-agent-tools
+      // MCP or worker delegation. This replaces the blunt `claude_code` preset,
+      // which also bundled interactive-CLI tooling LH agents don't need. The
       // per-agent `toolPermissions.tools` profile + `disallowedTools` below
       // still opt down for agents with a configured profile.
-      sdkToolsPreset: { type: 'preset', preset: 'claude_code' },
+      sdkToolsPreset: [...LONG_HORIZON_AGENT_BUILTIN_TOOLS],
       features: LONG_TERM_AGENT_SESSION_FEATURES,
       disallowedTools: customDisallowedBuiltins.length > 0 ? customDisallowedBuiltins : undefined,
       agent: customDisallowedBuiltins.length > 0 ? agentKey : undefined,
@@ -1886,6 +1900,23 @@ export class SpaceRuntimeService {
       );
       await this.setupSpaceAgentSession(space);
     };
+
+    // The coordinator (a long-horizon agent) runs in this space:chat session and
+    // gets the curated read-only 24-tool surface. Persist it on the config so
+    // query-options-builder honors `sdkToolsPreset` instead of clobbering it
+    // with the hardcoded restricted list — runtime/query-time resolved, so
+    // existing sessions pick it up on the next query without recreate. Guarded
+    // so re-provisioning (space.created, daemon restart) is a no-op once set.
+    const currentToolset = session.getSessionData().config?.sdkToolsPreset;
+    const toolsetMatches =
+      Array.isArray(currentToolset) &&
+      currentToolset.length === LONG_HORIZON_AGENT_BUILTIN_TOOLS.length &&
+      LONG_HORIZON_AGENT_BUILTIN_TOOLS.every((tool, i) => currentToolset[i] === tool);
+    if (!toolsetMatches) {
+      await session.updateConfig({
+        sdkToolsPreset: [...LONG_HORIZON_AGENT_BUILTIN_TOOLS],
+      });
+    }
 
     session.setRuntimeSystemPrompt(
       buildSpaceChatSystemPrompt({

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -17,6 +17,7 @@ import {
   type QueryOptionsBuilderContext,
 } from '../../../../src/lib/agent/query-options-builder';
 import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
+import { LONG_HORIZON_AGENT_BUILTIN_TOOLS } from '../../../../src/lib/space/agents/long-horizon-agent-tools';
 import type { SettingsManager } from '../../../../src/lib/settings-manager';
 import { SkillsManager } from '../../../../src/lib/skills-manager';
 import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
@@ -987,6 +988,34 @@ describe('QueryOptionsBuilder', () => {
       expect(options.disallowedTools).not.toContain('Task');
       expect(options.disallowedTools).not.toContain('TaskOutput');
       expect(options.disallowedTools).not.toContain('TaskStop');
+    });
+
+    it('honors a coordinator sdkToolsPreset instead of clobbering it (Task #794)', async () => {
+      // The long-horizon coordinator runs in the space:chat session. Its config
+      // carries the curated 24-tool preset (set at provisioning); the builder
+      // must let it flow through rather than overwriting with the restricted list.
+      mockSession.type = 'space_chat';
+      mockSession.config.sdkToolsPreset = [...LONG_HORIZON_AGENT_BUILTIN_TOOLS];
+      const options = await builder.build();
+
+      expect(options.tools).toEqual([...LONG_HORIZON_AGENT_BUILTIN_TOOLS]);
+      // Read-only by design: no Write/Edit/MultiEdit in the tool surface.
+      expect(options.tools).not.toContain('Write');
+      expect(options.tools).not.toContain('Edit');
+      expect(options.tools).not.toContain('MultiEdit');
+      // Scheduling / self-pacing tools the coordinator needs are present.
+      expect(options.tools).toContain('CronCreate');
+      expect(options.tools).toContain('Monitor');
+      // The preset tools are auto-allowed (no permission prompts for the
+      // coordinator's own surface) alongside the space MCP wildcards.
+      expect(options.allowedTools).toEqual(
+        expect.arrayContaining([...LONG_HORIZON_AGENT_BUILTIN_TOOLS])
+      );
+      // Belt-and-suspenders: file mutation stays disallowed even though the
+      // preset already omits it.
+      expect(options.disallowedTools).toEqual(
+        expect.arrayContaining(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
+      );
     });
 
     it('should not include Write/Edit/NotebookEdit in space chat tool allowlist', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -16,6 +16,10 @@ import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntimeServiceConfig } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
+import {
+  LONG_HORIZON_AGENT_BUILTIN_TOOLS,
+  LONG_HORIZON_SCHEDULING_GUARDRAIL,
+} from '../../../../src/lib/space/agents/long-horizon-agent-tools.ts';
 import { longTermAgentSessionId } from '../../../../src/lib/space/long-term-agent-session.ts';
 import type { ActorRef, MessageRecord } from '../../../../../messaging/src/types.ts';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -577,6 +581,39 @@ describe('SpaceRuntimeService', () => {
       expect(promptArg.length).toBeGreaterThan(0);
     });
 
+    test('provisions the coordinator space:chat session with the 24-tool sdkToolsPreset (Task #794)', async () => {
+      // The coordinator runs in the space:chat session. setupSpaceAgentSession
+      // must persist the curated read-only preset on its config so the
+      // query-time builder honors it instead of the hardcoded restricted list.
+      const session = makeSession();
+      const sessionManager = makeSessionManager(session);
+      const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));
+
+      await svc.setupSpaceAgentSession(mockSpace);
+
+      expect(session.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sdkToolsPreset: [...LONG_HORIZON_AGENT_BUILTIN_TOOLS],
+        })
+      );
+    });
+
+    test('does not rewrite sdkToolsPreset when the coordinator preset is already set (idempotent)', async () => {
+      const session = makeSession();
+      // Pre-set the exact preset so the idempotency guard skips the write.
+      (session.getSessionData as Mock<typeof session.getSessionData>).mockReturnValue({
+        id: 'session-1',
+        metadata: {},
+        config: { sdkToolsPreset: [...LONG_HORIZON_AGENT_BUILTIN_TOOLS] },
+      } as Session);
+      const sessionManager = makeSessionManager(session);
+      const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));
+
+      await svc.setupSpaceAgentSession(mockSpace);
+
+      expect(session.updateConfig).not.toHaveBeenCalled();
+    });
+
     test('missing Space chat MCP callback re-runs setup and re-attaches tools', async () => {
       const session = makeSession();
       const sessionManager = makeSessionManager(session);
@@ -1021,10 +1058,10 @@ describe('SpaceRuntimeService', () => {
       ).mock.calls[0]![0] as { config: Partial<Session['config']> };
       expect(createSessionArg.config.provider).toBe('openrouter');
       expect(createSessionArg.config.model).toBeUndefined();
-      expect(createSessionArg.config.sdkToolsPreset).toEqual({
-        type: 'preset',
-        preset: 'claude_code',
-      });
+      expect(createSessionArg.config.sdkToolsPreset).toEqual([...LONG_HORIZON_AGENT_BUILTIN_TOOLS]);
+      expect(createSessionArg.config.sdkToolsPreset).not.toEqual(
+        expect.objectContaining({ type: 'preset' })
+      );
     });
 
     test('long-horizon event sessions refresh existing config before delivery', async () => {
@@ -1099,8 +1136,10 @@ describe('SpaceRuntimeService', () => {
           model: 'claude-new',
           provider: 'openrouter',
           settingSources: ['project'],
-          systemPrompt: expect.objectContaining({ append: 'Use updated tools.' }),
-          sdkToolsPreset: { type: 'preset', preset: 'claude_code' },
+          systemPrompt: expect.objectContaining({
+            append: expect.stringContaining('Use updated tools.'),
+          }),
+          sdkToolsPreset: [...LONG_HORIZON_AGENT_BUILTIN_TOOLS],
           disallowedTools: ['Bash', 'Write', 'MultiEdit', 'NotebookEdit'],
           agent: 'restricted-agent',
           agents: {
@@ -1112,6 +1151,13 @@ describe('SpaceRuntimeService', () => {
         })
       );
       expect(existingSession.resetQuery).toHaveBeenCalledWith({ restartQuery: true });
+      // The standing scheduling/task-system guardrail is appended to every
+      // long-horizon agent's preset system prompt (after its own instructions).
+      const updateCall = (existingSession.updateConfig as Mock).mock.calls[0]![0] as {
+        systemPrompt: { append: string };
+      };
+      expect(updateCall.systemPrompt.append).toContain('Use updated tools.');
+      expect(updateCall.systemPrompt.append).toContain(LONG_HORIZON_SCHEDULING_GUARDRAIL);
       expect(existingSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
         'delivery-1',
         'event payload'


### PR DESCRIPTION
Replaces the blunt `claude_code` tool preset (#2294) with a curated explicit 24-tool array that is read-only on workspace files (no Write/Edit/MultiEdit), and fixes the `space_chat` query-time override that was clobbering the coordinator's toolset — the coordinator's `space:chat` config is now provisioned with the preset and the builder honors it, so existing sessions pick it up without recreate. Also adds a scheduling/task-system guardrail (durable → MCP `create_scheduled_task`; transient → `Cron*`/`ScheduleWakeup`/`Monitor`) to LH agent and coordinator prompts.