### PR TITLE
feat(space): split drift into "Update available" vs "Customized"

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -429,7 +429,7 @@ export function setupSpaceAgentHandlers(
   // re-stamp its template_hash. Throws if the agent has no template_name
   // or the named preset no longer exists in code.
   messageHub.onRequest('spaceAgent.syncFromTemplate', async (data) => {
-    const params = data as { spaceId: string; agentId: string };
+    const params = data as { spaceId: string; agentId: string; expectedRowHash?: string };
     if (!params.spaceId) throw new Error('spaceId is required');
     if (!params.agentId) throw new Error('agentId is required');
 
@@ -446,7 +446,7 @@ export function setupSpaceAgentHandlers(
       throw new Error(`Agent not found: ${params.agentId}`);
     }
 
-    const result = await spaceAgentManager.syncFromTemplate(params.agentId);
+    const result = await spaceAgentManager.syncFromTemplate(params.agentId, params.expectedRowHash);
     if (!result.ok) throw new Error(result.error);
 
     internalEventBus

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -24,6 +24,7 @@ import type {
   UpdateSpaceWorkflowParams,
   DuplicateDriftReport,
   SpaceWorkflow,
+  SpaceWorkflowSyncDiff,
 } from '@hyperneo/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -146,13 +147,71 @@ function buildTemplateUpdateParams(
 }
 
 /**
+ * Build a structural before/after diff between a seeded workflow row and its
+ * live built-in template, covering the highest-signal fields: description,
+ * instructions, and the node set (by name). Returned by
+ * {@link spaceWorkflow.previewTemplateSync}. Kept concise so the preview modal
+ * can render a readable delta; the modal always states the full structure is
+ * overwritten on sync, so fields not enumerated here (channels/gates/hooks)
+ * are not silently hidden from the user.
+ */
+function buildWorkflowSyncDiff(
+  workflow: SpaceWorkflow,
+  template: SpaceWorkflow
+): SpaceWorkflowSyncDiff {
+  const diff: SpaceWorkflowSyncDiff = {};
+
+  if ((workflow.description ?? '') !== (template.description ?? '')) {
+    diff.description = { before: workflow.description ?? '', after: template.description ?? '' };
+  }
+  if ((workflow.instructions ?? '') !== (template.instructions ?? '')) {
+    diff.instructions = {
+      before: workflow.instructions ?? '',
+      after: template.instructions ?? '',
+    };
+  }
+
+  const beforeNodes = workflow.nodes.map((n) => n.name);
+  const afterNodes = template.nodes.map((n) => n.name);
+  if (!nameSetsEqual(beforeNodes, afterNodes)) {
+    const beforeSet = new Set(beforeNodes);
+    const afterSet = new Set(afterNodes);
+    diff.nodes = {
+      before: beforeNodes,
+      after: afterNodes,
+      added: afterNodes.filter((n) => !beforeSet.has(n)),
+      removed: beforeNodes.filter((n) => !afterSet.has(n)),
+    };
+  }
+
+  return diff;
+}
+
+/**
+ * Order-independent equality for two name lists. Node sets are an unordered
+ * identity, so a reordered node list must not register as a diff.
+ */
+function nameSetsEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  for (const name of b) {
+    if (!setA.has(name)) return false;
+  }
+  return true;
+}
+
+/**
  * Proactive drift check run once at daemon startup.
  *
- * Scans every space for workflows that were seeded from a built-in template but
- * have since drifted (i.e. the stored `templateHash` no longer matches the
- * current template's hash). Detected drifts are logged as warnings so operators
- * and developers see them in the daemon log even when no user has opened the
- * Workflow List UI.
+ * Scans every space for workflows seeded from a built-in template and reports
+ * the two-signal drift state per row:
+ *   - "update available" — the template improved in code (actionable: click
+ *     "Sync" to apply). Logged as a warning so operators notice it.
+ *   - "customized" — the row was locally edited but no template update is
+ *     pending (informational only). Logged at info level.
+ *
+ * A row can be both (locally edited AND a template update pending) — the
+ * dangerous case, surfaced as "update available (customized)".
  *
  * This function is intentionally non-blocking: failures (e.g. DB errors) are
  * caught and logged rather than propagated, so startup is never blocked by drift
@@ -169,11 +228,13 @@ export async function checkBuiltInWorkflowDriftOnStartup(
     const templates = getBuiltInWorkflows();
     const templateMap = new Map(templates.map((t) => [t.name, t]));
 
-    const driftedWorkflows: Array<{
+    const updatesAvailable: Array<{
       spaceName: string;
       workflowName: string;
       templateName: string;
+      customized: boolean;
     }> = [];
+    let customizedOnlyCount = 0;
 
     for (const space of spaces) {
       const workflows = workflowManager.listWorkflows(space.id);
@@ -184,26 +245,42 @@ export async function checkBuiltInWorkflowDriftOnStartup(
 
         const currentTemplateHash = computeWorkflowHash(template);
         const storedHash = workflow.templateHash ?? null;
+        const rowHash = computeWorkflowHash(workflow);
 
-        if (currentTemplateHash !== storedHash) {
-          driftedWorkflows.push({
+        const updateAvailable = currentTemplateHash !== storedHash;
+        const customized = rowHash !== storedHash;
+
+        if (updateAvailable) {
+          updatesAvailable.push({
             spaceName: space.name,
             workflowName: workflow.name,
             templateName: workflow.templateName,
+            customized,
           });
+        } else if (customized) {
+          customizedOnlyCount += 1;
         }
       }
     }
 
-    if (driftedWorkflows.length === 0) return;
+    if (updatesAvailable.length === 0 && customizedOnlyCount === 0) return;
 
-    log.warn(
-      `[startup] ${driftedWorkflows.length} workflow(s) have drifted from their built-in templates. ` +
-        `Open the Workflow List in the UI and click "Sync" to update them.`
-    );
-    for (const { spaceName, workflowName, templateName } of driftedWorkflows) {
+    if (updatesAvailable.length > 0) {
       log.warn(
-        `  • Space "${spaceName}" / Workflow "${workflowName}" (template: "${templateName}") is outdated`
+        `[startup] ${updatesAvailable.length} workflow(s) have a template update available. ` +
+          `Open the Workflow List in the UI and click "Sync" to apply them.`
+      );
+      for (const { spaceName, workflowName, templateName, customized } of updatesAvailable) {
+        log.warn(
+          `  • Space "${spaceName}" / Workflow "${workflowName}" (template: "${templateName}") — ` +
+            (customized ? 'update available (customized)' : 'update available')
+        );
+      }
+    }
+    if (customizedOnlyCount > 0) {
+      log.info(
+        `[startup] ${customizedOnlyCount} built-in workflow(s) have local customizations ` +
+          `(no template update pending).`
       );
     }
   } catch (err) {
@@ -527,7 +604,8 @@ export function setupSpaceWorkflowHandlers(
     // If no template tracking, no drift possible
     if (!workflow.templateName) {
       return {
-        drifted: false,
+        updateAvailable: false,
+        customized: false,
         templateName: null,
         currentTemplateHash: null,
         workflowContentHash: null,
@@ -541,7 +619,8 @@ export function setupSpaceWorkflowHandlers(
     if (!template) {
       // Template no longer exists — can't detect drift
       return {
-        drifted: false,
+        updateAvailable: false,
+        customized: false,
         templateName: workflow.templateName,
         currentTemplateHash: null,
         workflowContentHash: null,
@@ -549,22 +628,78 @@ export function setupSpaceWorkflowHandlers(
       };
     }
 
-    // Compute current template's hash
+    // Two independent signals, both measured against the stored hash:
+    //   - updateAvailable: the TEMPLATE moved in code (template improved).
+    //     Supersedes the "template was updated" half of the former `drifted` OR.
+    //   - customized: the ROW moved (user edited the workflow structure).
+    //     Supersedes the "user edited workflow" half of the former `drifted` OR.
+    // The old `drifted` was `(updateAvailable || customized)`; callers now get
+    // the split so the UI can say precisely what happened.
     const currentTemplateHash = computeWorkflowHash(template);
     const workflowContentHash = computeWorkflowHash(workflow);
-
-    // Drift if either:
-    // 1. The stored template_hash differs from the current template hash (template was updated)
-    // 2. The workflow content hash differs from the stored template_hash (user edited workflow)
     const storedHash = workflow.templateHash ?? null;
-    const drifted = currentTemplateHash !== storedHash || workflowContentHash !== storedHash;
 
     return {
-      drifted,
+      updateAvailable: currentTemplateHash !== storedHash,
+      customized: workflowContentHash !== storedHash,
       templateName: workflow.templateName,
       currentTemplateHash,
       workflowContentHash,
       storedHash,
+    };
+  });
+
+  // ─── spaceWorkflow.previewTemplateSync ──────────────────────────────────
+  // Compute the structural before/after diff that syncFromTemplate would
+  // apply for a single template-tracked workflow, WITHOUT writing. Powers the
+  // "Review diff" affordance before a reset — especially for the dangerous
+  // case (customized && updateAvailable), where local edits would be lost.
+  // Same validation + cross-space guard as syncFromTemplate. Apply reuses the
+  // existing syncFromTemplate RPC; this adds only a read path.
+  messageHub.onRequest('spaceWorkflow.previewTemplateSync', async (data) => {
+    const params = data as { id: string; spaceId: string };
+
+    if (!params.id) throw new Error('id is required');
+    if (!params.spaceId) throw new Error('spaceId is required');
+
+    const space = await spaceManager.getSpace(params.spaceId);
+    if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+    const workflow = workflowManager.getWorkflow(params.id);
+    if (!workflow) throw new Error(`Workflow not found: ${params.id}`);
+    if (workflow.spaceId !== params.spaceId) {
+      throw new Error(`Workflow not found: ${params.id}`);
+    }
+    if (!workflow.templateName) {
+      throw new Error(
+        `Workflow "${workflow.name}" is not linked to a built-in template and cannot be synced.`
+      );
+    }
+
+    const template = getBuiltInWorkflows().find((t) => t.name === workflow.templateName);
+    if (!template) {
+      throw new Error(
+        `Built-in template "${workflow.templateName}" not found. It may have been removed.`
+      );
+    }
+
+    const liveHash = computeWorkflowHash(template);
+    const rowHash = computeWorkflowHash(workflow);
+    const storedHash = workflow.templateHash ?? null;
+    const diff = buildWorkflowSyncDiff(workflow, template);
+
+    return {
+      preview: {
+        workflowId: workflow.id,
+        workflowName: workflow.name,
+        templateName: workflow.templateName,
+        storedHash,
+        liveHash,
+        rowHash,
+        updateAvailable: storedHash !== liveHash,
+        customized: rowHash !== storedHash,
+        diff,
+      },
     };
   });
 

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -705,7 +705,7 @@ export function setupSpaceWorkflowHandlers(
 
   // ─── spaceWorkflow.syncFromTemplate ─────────────────────────────────────
   messageHub.onRequest('spaceWorkflow.syncFromTemplate', async (data) => {
-    const params = data as { id: string; spaceId: string };
+    const params = data as { id: string; spaceId: string; expectedRowHash?: string };
 
     if (!params.id) {
       throw new Error('id is required');
@@ -731,6 +731,18 @@ export function setupSpaceWorkflowHandlers(
       throw new Error(
         `Workflow "${workflow.name}" is not linked to a built-in template and cannot be synced.`
       );
+    }
+
+    // Optimistic-concurrency guard: when a caller reviewed a diff, it passes
+    // the row hash observed at review time. Reject if the row has changed since
+    // (e.g. another client edited it) so unseen edits aren't silently overwritten.
+    if (params.expectedRowHash !== undefined) {
+      const currentRowHash = computeWorkflowHash(workflow);
+      if (currentRowHash !== params.expectedRowHash) {
+        throw new Error(
+          'This workflow changed since you opened the review. Close and reopen the diff to refresh.'
+        );
+      }
     }
 
     // Find the template

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -178,6 +178,13 @@ export class SpaceAgentManager {
    * doesn't match any current preset (e.g. a preset was deleted in code) are
    * silently skipped — there's nothing to sync against.
    *
+   * Two independent signals are derived, both measured against the stored
+   * hash as the common reference:
+   *   - `updateAvailable` — the template moved in code (currentHash !== storedHash).
+   *     This is byte-identical to the former `drifted` flag.
+   *   - `customized` — the row moved (rowHash !== storedHash), i.e. the user
+   *     edited the fingerprint fields. Informational only.
+   *
    * User-created agents (`templateName === null`) are NOT included in the
    * report at all; the UI relies on this to decide which cards get a badge.
    */
@@ -193,14 +200,21 @@ export class SpaceAgentManager {
 
       const currentHash = computeAgentTemplateHash(preset);
       const storedHash = agent.templateHash ?? null;
-      const drifted = storedHash !== currentHash;
+      const rowHash = computeAgentTemplateHash({
+        name: agent.name,
+        description: agent.description ?? '',
+        tools: agent.tools ?? [],
+        customPrompt: agent.customPrompt ?? '',
+      });
       entries.push({
         agentId: agent.id,
         agentName: agent.name,
         templateName: agent.templateName,
         storedHash,
         currentHash,
-        drifted,
+        rowHash,
+        updateAvailable: storedHash !== currentHash,
+        customized: rowHash !== storedHash,
       });
     }
 
@@ -266,10 +280,10 @@ export class SpaceAgentManager {
    * Returns the same errors as {@link syncFromTemplate}: agent not found, not
    * preset-tracked, or the named preset no longer exists in code.
    *
-   * `drifted` uses the same hash comparison as {@link getAgentDriftReport}. An
-   * empty `diff` with `drifted === true` is a valid state: it means the row's
-   * fields already match the preset but the stored hash is stale or missing
-   * (e.g. a backfill-unmatched legacy row).
+   * `updateAvailable` / `customized` use the same two-hash comparisons as
+   * {@link getAgentDriftReport}. An empty `diff` with `updateAvailable === true`
+   * is a valid state: it means the row's fields already match the preset but
+   * the stored hash is stale or missing (e.g. a backfill-unmatched legacy row).
    */
   async getTemplateSyncPreview(
     agentId: string
@@ -293,6 +307,13 @@ export class SpaceAgentManager {
     }
 
     const liveHash = computeAgentTemplateHash(preset);
+    const storedHash = existing.templateHash ?? null;
+    const rowHash = computeAgentTemplateHash({
+      name: existing.name,
+      description: existing.description ?? '',
+      tools: existing.tools ?? [],
+      customPrompt: existing.customPrompt ?? '',
+    });
     const diff: SpaceWorkerAgentSyncDiff = {};
 
     if ((existing.customPrompt ?? '') !== preset.customPrompt) {
@@ -320,9 +341,11 @@ export class SpaceAgentManager {
         agentId: existing.id,
         agentName: existing.name,
         templateName: existing.templateName,
-        storedHash: existing.templateHash ?? null,
+        storedHash,
         liveHash,
-        drifted: (existing.templateHash ?? null) !== liveHash,
+        rowHash,
+        updateAvailable: storedHash !== liveHash,
+        customized: rowHash !== storedHash,
         diff,
       },
     };

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -230,8 +230,16 @@ export class SpaceAgentManager {
    * The agent's `id`, `spaceId`, `name`, `model`, and `provider` are
    * preserved — only the fields that participate in the fingerprint are
    * overwritten.
+   *
+   * `expectedRowHash` is an optional optimistic-concurrency guard: when a
+   * caller reviewed a diff, it passes the row hash observed at review time, and
+   * the sync is rejected if the row has changed since (e.g. another client
+   * edited it), so unseen edits aren't silently overwritten.
    */
-  async syncFromTemplate(agentId: string): Promise<SpaceAgentResult<SpaceWorkerAgent>> {
+  async syncFromTemplate(
+    agentId: string,
+    expectedRowHash?: string
+  ): Promise<SpaceAgentResult<SpaceWorkerAgent>> {
     const existing = this.repo.getById(agentId);
     if (!existing) return { ok: false, error: `Agent not found: ${agentId}` };
     if (!existing.templateName) {
@@ -248,6 +256,24 @@ export class SpaceAgentManager {
         ok: false,
         error: `Preset template "${existing.templateName}" not found. It may have been removed from the code.`,
       };
+    }
+
+    // Optimistic-concurrency guard: reject if the row changed since the caller
+    // reviewed its diff, so a concurrent edit isn't overwritten unseen.
+    if (expectedRowHash !== undefined) {
+      const currentRowHash = computeAgentTemplateHash({
+        name: existing.name,
+        description: existing.description ?? '',
+        tools: existing.tools ?? [],
+        customPrompt: existing.customPrompt ?? '',
+      });
+      if (currentRowHash !== expectedRowHash) {
+        return {
+          ok: false,
+          error:
+            'This agent changed since you opened the review. Close and reopen the diff to refresh.',
+        };
+      }
     }
 
     const templateHash = computeAgentTemplateHash(preset);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -2297,6 +2297,38 @@ export function seedBuiltInWorkflows(
         const channelsChanged =
           removedLegacyPrReadyChannels ||
           JSON.stringify(mergedChannels) !== JSON.stringify(existingChannels);
+        const writeChannels = channelsChanged || stripped.channelsChanged;
+
+        // Stamp the hash of the ACTUALLY-merged row, then advance the stored
+        // hash ONLY when the merge fully converged the row to the current
+        // template (mergedHash === expectedHash). The merge above reconciles
+        // structural fields (nodes, channels, gates, hooks, post-approval,
+        // autonomy) and patches prompts that match known retired template text,
+        // but it deliberately preserves genuine user prompts, description, and
+        // instructions. If those still differ from the template, stamping
+        // `expectedHash` would falsely claim the row is fully up-to-date,
+        // collapse `updateAvailable` to false, and permanently hide the
+        // remaining template update (the matching hash skips the row on every
+        // later restart). Preserving the prior (stale) hash keeps the row
+        // honestly flagged "not up to date" so drift detection still surfaces a
+        // sync action — and because the merged content now differs from that
+        // prior hash, the row also reads as customized, routing the apply
+        // through review so a preserved edit isn't silently lost. This
+        // generalizes the per-channel maxCycles merge philosophy above
+        // (reconcile the field, then let the stamped hash reflect reality).
+        const mergedHash = computeWorkflowHash({
+          ...row,
+          nodes: stripped.nodes,
+          gates: stripped.gates,
+          // computeWorkflowHash treats null/undefined identically (?? [], truthy
+          // check), so normalizing to undefined just satisfies the SpaceWorkflow
+          // shape — the hashed value matches the persisted row either way.
+          hooks: stripped.hooks ?? undefined,
+          channels: writeChannels ? stripped.channels : row.channels,
+          completionAutonomyLevel: template.completionAutonomyLevel,
+          postApproval: undefined,
+        });
+        const stampedHash = mergedHash === expectedHash ? expectedHash : row.templateHash;
 
         workflowManager.updateWorkflow(row.id, {
           completionAutonomyLevel: template.completionAutonomyLevel,
@@ -2306,8 +2338,8 @@ export function seedBuiltInWorkflows(
           gates: stripped.gates,
           hooks: stripped.hooks ?? null,
           nodes: stripped.nodes,
-          ...(channelsChanged || stripped.channelsChanged ? { channels: stripped.channels } : {}),
-          templateHash: expectedHash,
+          ...(writeChannels ? { channels: stripped.channels } : {}),
+          templateHash: stampedHash,
         });
         restamped.push(template.name);
         builtInSeederLog.info(

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -512,7 +512,7 @@ describe('SpaceAgentManager', () => {
       expect(report.agents).toEqual([]);
     });
 
-    it('reports drifted=false when stored hash matches the current preset hash', async () => {
+    it('reports a pristine row as neither updateAvailable nor customized', async () => {
       // Use a known preset name ("Coder") so the manager can find a live
       // preset to compare against. We seed it with the real preset's hash.
       const { getPresetAgentTemplates } = await import(
@@ -539,12 +539,16 @@ describe('SpaceAgentManager', () => {
       expect(report.agents).toHaveLength(1);
       expect(report.agents[0].agentName).toBe('Coder');
       expect(report.agents[0].templateName).toBe('Coder');
-      expect(report.agents[0].drifted).toBe(false);
+      // Regression guard: updateAvailable is byte-identical to the former
+      // `drifted` flag on a pristine row (storedHash === currentHash → false).
+      expect(report.agents[0].updateAvailable).toBe(false);
+      expect(report.agents[0].customized).toBe(false);
+      expect(report.agents[0].rowHash).toBe(hash);
       expect(report.agents[0].storedHash).toBe(hash);
       expect(report.agents[0].currentHash).toBe(hash);
     });
 
-    it('reports drifted=true when stored hash differs from the current preset hash', async () => {
+    it('reports updateAvailable+customized when stored hash differs and the row was edited', async () => {
       await manager.create({
         spaceId: 'space-1',
         name: 'Coder',
@@ -557,12 +561,15 @@ describe('SpaceAgentManager', () => {
 
       const report = manager.getAgentDriftReport('space-1');
       expect(report.agents).toHaveLength(1);
-      expect(report.agents[0].drifted).toBe(true);
+      // Template moved (stale storedHash ≠ current preset hash) → updateAvailable.
+      expect(report.agents[0].updateAvailable).toBe(true);
+      // Row was edited (rowHash ≠ 'stale-hash-value') → customized.
+      expect(report.agents[0].customized).toBe(true);
       expect(report.agents[0].storedHash).toBe('stale-hash-value');
       expect(report.agents[0].currentHash).not.toBe('stale-hash-value');
     });
 
-    it('reports legacy coordinator Reviewer prompt rows as drifted without mutating them', async () => {
+    it('reports legacy coordinator Reviewer prompt rows as update-available without mutating them', async () => {
       const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
         '../../../../src/lib/space/agents/seed-agents'
       );
@@ -589,13 +596,16 @@ describe('SpaceAgentManager', () => {
 
       const report = manager.getAgentDriftReport('space-1');
       expect(report.agents).toHaveLength(1);
-      expect(report.agents[0].drifted).toBe(true);
+      // The row carries the legacy prompt verbatim, so its rowHash equals the
+      // stored legacy hash → not customized. The template moved on → updateAvailable.
+      expect(report.agents[0].updateAvailable).toBe(true);
+      expect(report.agents[0].customized).toBe(false);
       expect(report.agents[0].storedHash).toBe(legacyHash);
       expect(report.agents[0].currentHash).not.toBe(legacyHash);
       expect(manager.getById(created.value.id)?.customPrompt).toBe(LEGACY_REVIEWER_PROMPT);
     });
 
-    it('reports user-edited legacy Reviewer prompts as drifted', async () => {
+    it('reports user-edited legacy Reviewer prompts as update-available', async () => {
       const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
         '../../../../src/lib/space/agents/seed-agents'
       );
@@ -622,10 +632,11 @@ describe('SpaceAgentManager', () => {
 
       const report = manager.getAgentDriftReport('space-1');
       expect(report.agents).toHaveLength(1);
-      expect(report.agents[0].drifted).toBe(true);
+      expect(report.agents[0].updateAvailable).toBe(true);
+      expect(report.agents[0].customized).toBe(false);
     });
 
-    it('reports drifted=true when storedHash is null (post-backfill unmatchable rows)', async () => {
+    it('reports updateAvailable+customized when storedHash is null (post-backfill unmatchable rows)', async () => {
       await manager.create({
         spaceId: 'space-1',
         name: 'Coder',
@@ -636,7 +647,9 @@ describe('SpaceAgentManager', () => {
       const report = manager.getAgentDriftReport('space-1');
       expect(report.agents).toHaveLength(1);
       expect(report.agents[0].storedHash).toBeNull();
-      expect(report.agents[0].drifted).toBe(true);
+      // null !== currentHash → updateAvailable; rowHash !== null → customized.
+      expect(report.agents[0].updateAvailable).toBe(true);
+      expect(report.agents[0].customized).toBe(true);
     });
 
     it('skips rows whose templateName no longer matches any preset', async () => {
@@ -649,6 +662,57 @@ describe('SpaceAgentManager', () => {
 
       const report = manager.getAgentDriftReport('space-1');
       expect(report.agents).toEqual([]);
+    });
+
+    it('derives all four states from the three hashes (customized-only + update-available-only)', async () => {
+      // Explicit four-state matrix using an isolated space per state. The
+      // pristine case (both false) is covered above; here we pin the two
+      // mixed states that the legacy tests don't construct cleanly.
+      const { getPresetAgentTemplates } = await import(
+        '../../../../src/lib/space/agents/seed-agents'
+      );
+      const { computeAgentTemplateHash } = await import(
+        '../../../../src/lib/space/agents/agent-template-hash'
+      );
+      const coder = getPresetAgentTemplates().find((p) => p.name === 'Coder');
+      if (!coder) throw new Error('Coder preset missing');
+      const currentHash = computeAgentTemplateHash(coder);
+      const oldVersion = { ...coder, customPrompt: 'old prompt' };
+      const oldHash = computeAgentTemplateHash(oldVersion);
+
+      // update-available only: row matches its stored OLD version, but the
+      // live template has since moved → rowHash === storedHash, currentHash ≠.
+      insertSpace(db, 'space-update-only');
+      await manager.create({
+        spaceId: 'space-update-only',
+        name: 'Coder',
+        description: oldVersion.description,
+        tools: oldVersion.tools,
+        customPrompt: oldVersion.customPrompt,
+        templateName: 'Coder',
+        templateHash: oldHash,
+      });
+      const updateOnly = manager.getAgentDriftReport('space-update-only').agents[0];
+      expect(updateOnly.updateAvailable).toBe(true);
+      expect(updateOnly.customized).toBe(false);
+      expect(updateOnly.rowHash).toBe(oldHash);
+
+      // customized only: template did NOT move (storedHash === currentHash),
+      // but the user edited the row → rowHash ≠ storedHash.
+      insertSpace(db, 'space-custom-only');
+      await manager.create({
+        spaceId: 'space-custom-only',
+        name: 'Coder',
+        description: coder.description,
+        tools: coder.tools,
+        customPrompt: 'user edit',
+        templateName: 'Coder',
+        templateHash: currentHash,
+      });
+      const customOnly = manager.getAgentDriftReport('space-custom-only').agents[0];
+      expect(customOnly.updateAvailable).toBe(false);
+      expect(customOnly.customized).toBe(true);
+      expect(customOnly.rowHash).not.toBe(currentHash);
     });
   });
 
@@ -743,7 +807,7 @@ describe('SpaceAgentManager', () => {
       expect(result.value.provider).toBe('anthropic');
     });
 
-    it('re-stamps templateHash so a follow-up drift report shows drifted=false', async () => {
+    it('re-stamps templateHash so a follow-up drift report shows updateAvailable=false', async () => {
       const created = await manager.create({
         spaceId: 'space-1',
         name: 'Coder',
@@ -756,13 +820,15 @@ describe('SpaceAgentManager', () => {
       if (!created.ok) throw new Error('create failed');
 
       const before = manager.getAgentDriftReport('space-1');
-      expect(before.agents[0].drifted).toBe(true);
+      expect(before.agents[0].updateAvailable).toBe(true);
 
       const sync = await manager.syncFromTemplate(created.value.id);
       expect(sync.ok).toBe(true);
 
       const after = manager.getAgentDriftReport('space-1');
-      expect(after.agents[0].drifted).toBe(false);
+      // Sync overwrites fields + re-stamps the hash → both signals clear.
+      expect(after.agents[0].updateAvailable).toBe(false);
+      expect(after.agents[0].customized).toBe(false);
       expect(after.agents[0].storedHash).toBe(after.agents[0].currentHash);
     });
   });
@@ -823,7 +889,8 @@ describe('SpaceAgentManager', () => {
       expect(preview.agentId).toBe(created.value.id);
       expect(preview.agentName).toBe('Coder');
       expect(preview.templateName).toBe('Coder');
-      expect(preview.drifted).toBe(true);
+      expect(preview.updateAvailable).toBe(true);
+      expect(preview.customized).toBe(true);
       expect(preview.storedHash).toBe('stale-hash');
       expect(preview.liveHash).not.toBe('stale-hash');
 
@@ -870,12 +937,13 @@ describe('SpaceAgentManager', () => {
       expect(result.ok).toBe(true);
       if (!result.ok) throw new Error('expected ok');
 
-      expect(result.value.drifted).toBe(false);
+      expect(result.value.updateAvailable).toBe(false);
+      expect(result.value.customized).toBe(false);
       expect(result.value.diff).toEqual({});
       expect(result.value.storedHash).toBe(result.value.liveHash);
     });
 
-    it('reports drifted=true with an empty diff when only the stored hash is missing', async () => {
+    it('reports updateAvailable=true with an empty diff when only the stored hash is missing', async () => {
       // A backfill-unmatched legacy row: fields match the preset but
       // templateHash was never stamped. Preview should still flag drift
       // (hash mismatch) while reporting no field changes.
@@ -900,7 +968,7 @@ describe('SpaceAgentManager', () => {
       expect(result.ok).toBe(true);
       if (!result.ok) throw new Error('expected ok');
 
-      expect(result.value.drifted).toBe(true);
+      expect(result.value.updateAvailable).toBe(true);
       expect(result.value.storedHash).toBeNull();
       expect(result.value.diff).toEqual({});
     });

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -831,6 +831,66 @@ describe('SpaceAgentManager', () => {
       expect(after.agents[0].customized).toBe(false);
       expect(after.agents[0].storedHash).toBe(after.agents[0].currentHash);
     });
+
+    it('accepts sync when expectedRowHash matches the current row', async () => {
+      const { computeAgentTemplateHash } = await import(
+        '../../../../src/lib/space/agents/agent-template-hash'
+      );
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        description: 'old',
+        tools: ['Read'],
+        customPrompt: 'old',
+        templateName: 'Coder',
+        templateHash: 'stale-hash',
+      });
+      if (!created.ok) throw new Error('create failed');
+
+      const reviewedRowHash = computeAgentTemplateHash({
+        name: 'Coder',
+        description: 'old',
+        tools: ['Read'],
+        customPrompt: 'old',
+      });
+
+      const result = await manager.syncFromTemplate(created.value.id, reviewedRowHash);
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects sync when expectedRowHash no longer matches (concurrent edit)', async () => {
+      const { computeAgentTemplateHash } = await import(
+        '../../../../src/lib/space/agents/agent-template-hash'
+      );
+      const created = await manager.create({
+        spaceId: 'space-1',
+        name: 'Coder',
+        description: 'old',
+        tools: ['Read'],
+        customPrompt: 'old',
+        templateName: 'Coder',
+        templateHash: 'stale-hash',
+      });
+      if (!created.ok) throw new Error('create failed');
+
+      const reviewedRowHash = computeAgentTemplateHash({
+        name: 'Coder',
+        description: 'old',
+        tools: ['Read'],
+        customPrompt: 'old',
+      });
+
+      // Another client edits the row after the review → its row hash changes.
+      await manager.update(created.value.id, { customPrompt: 'concurrent edit by another client' });
+
+      const result = await manager.syncFromTemplate(created.value.id, reviewedRowHash);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toMatch(/changed since/i);
+      // The row is untouched — the sync was rejected, not applied.
+      expect(manager.getById(created.value.id)?.customPrompt).toBe(
+        'concurrent edit by another client'
+      );
+    });
   });
 
   describe('getTemplateSyncPreview', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -1080,14 +1080,17 @@ describe('Space Agent RPC Handlers', () => {
 
     it('returns an empty agents array for a space with no preset-tracked agents', async () => {
       const result = await call<{
-        report: { spaceId: string; agents: Array<{ drifted: boolean }> };
+        report: {
+          spaceId: string;
+          agents: Array<{ updateAvailable: boolean; customized: boolean }>;
+        };
       }>(hubData.handlers, 'spaceAgent.getDriftReport', { spaceId: 'space-1' });
 
       expect(result.report.spaceId).toBe('space-1');
       expect(result.report.agents).toEqual([]);
     });
 
-    it('reports a drifted=true entry when stored hash differs from current preset', async () => {
+    it('reports an updateAvailable+customized entry when stored hash differs and row was edited', async () => {
       // Insert a preset-tracked agent directly via the manager so we can
       // supply a stale hash without relying on the seeding pipeline.
       await manager.create({
@@ -1103,13 +1106,19 @@ describe('Space Agent RPC Handlers', () => {
       const result = await call<{
         report: {
           spaceId: string;
-          agents: Array<{ agentName: string; drifted: boolean; storedHash: string | null }>;
+          agents: Array<{
+            agentName: string;
+            updateAvailable: boolean;
+            customized: boolean;
+            storedHash: string | null;
+          }>;
         };
       }>(hubData.handlers, 'spaceAgent.getDriftReport', { spaceId: 'space-1' });
 
       expect(result.report.agents).toHaveLength(1);
       expect(result.report.agents[0].agentName).toBe('Coder');
-      expect(result.report.agents[0].drifted).toBe(true);
+      expect(result.report.agents[0].updateAvailable).toBe(true);
+      expect(result.report.agents[0].customized).toBe(true);
       expect(result.report.agents[0].storedHash).toBe('stale-hash');
     });
 
@@ -1341,7 +1350,8 @@ describe('Space Agent RPC Handlers', () => {
 
       const result = await call<{
         preview: {
-          drifted: boolean;
+          updateAvailable: boolean;
+          customized: boolean;
           storedHash: string | null;
           diff: { customPrompt?: { before: string; after: string } };
         };
@@ -1350,7 +1360,8 @@ describe('Space Agent RPC Handlers', () => {
         agentId: created.value.id,
       });
 
-      expect(result.preview.drifted).toBe(true);
+      expect(result.preview.updateAvailable).toBe(true);
+      expect(result.preview.customized).toBe(true);
       expect(result.preview.storedHash).toBe('stale-hash');
       expect(result.preview.diff.customPrompt?.before).toBe('old prompt');
       expect(result.preview.diff.customPrompt?.after.length).toBeGreaterThan(0);
@@ -1359,7 +1370,7 @@ describe('Space Agent RPC Handlers', () => {
       expect(manager.getById(created.value.id)?.customPrompt).toBe('old prompt');
     });
 
-    it('returns drifted=false with an empty diff for an in-sync agent', async () => {
+    it('returns updateAvailable=false with an empty diff for an in-sync agent', async () => {
       const { getPresetAgentTemplates } = await import(
         '../../../../src/lib/space/agents/seed-agents'
       );
@@ -1381,13 +1392,18 @@ describe('Space Agent RPC Handlers', () => {
       if (!created.ok) throw new Error('create failed');
 
       const result = await call<{
-        preview: { drifted: boolean; diff: Record<string, unknown> };
+        preview: {
+          updateAvailable: boolean;
+          customized: boolean;
+          diff: Record<string, unknown>;
+        };
       }>(hubData.handlers, 'spaceAgent.previewTemplateSync', {
         spaceId: 'space-1',
         agentId: created.value.id,
       });
 
-      expect(result.preview.drifted).toBe(false);
+      expect(result.preview.updateAvailable).toBe(false);
+      expect(result.preview.customized).toBe(false);
       expect(result.preview.diff).toEqual({});
     });
   });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -610,7 +610,7 @@ describe('space-workflow-handlers', () => {
   // ─── spaceWorkflow.detectDrift ────────────────────────────────────────────
 
   describe('spaceWorkflow.detectDrift', () => {
-    it('returns drifted=false with null hashes when workflow has no templateName', async () => {
+    it('returns neither signal with null hashes when workflow has no templateName', async () => {
       const wfNoTemplate: SpaceWorkflow = {
         ...mockWorkflow,
         templateName: undefined,
@@ -621,14 +621,15 @@ describe('space-workflow-handlers', () => {
         string,
         unknown
       >;
-      expect(result.drifted).toBe(false);
+      expect(result.updateAvailable).toBe(false);
+      expect(result.customized).toBe(false);
       expect(result.templateName).toBeNull();
       expect(result.currentTemplateHash).toBeNull();
       expect(result.workflowContentHash).toBeNull();
       expect(result.storedHash).toBeNull();
     });
 
-    it('returns drifted=false when template is not found in built-ins', async () => {
+    it('returns neither signal when template is not found in built-ins', async () => {
       const wfUnknownTemplate: SpaceWorkflow = {
         ...mockWorkflow,
         templateName: 'Unknown Template',
@@ -639,12 +640,13 @@ describe('space-workflow-handlers', () => {
         string,
         unknown
       >;
-      expect(result.drifted).toBe(false);
+      expect(result.updateAvailable).toBe(false);
+      expect(result.customized).toBe(false);
       expect(result.templateName).toBe('Unknown Template');
       expect(result.storedHash).toBe('abc123');
     });
 
-    it('returns drifted=false when workflow matches template and stored hash', async () => {
+    it('returns neither signal when workflow matches template and stored hash (pristine)', async () => {
       // Use the first built-in template and set hashes so there is no drift
       const [template] = getBuiltInWorkflows();
       const hash = computeWorkflowHash(template);
@@ -661,37 +663,46 @@ describe('space-workflow-handlers', () => {
         string,
         unknown
       >;
-      expect(result.drifted).toBe(false);
+      // Regression guard: updateAvailable is the former `drifted` half for the
+      // "template moved" condition — pristine row → false, unchanged behavior.
+      expect(result.updateAvailable).toBe(false);
+      expect(result.customized).toBe(false);
       expect(result.templateName).toBe(template.name);
       expect(result.storedHash).toBe(hash);
     });
 
-    it('returns drifted=true when stored hash differs from current template hash (template updated)', async () => {
+    it('returns updateAvailable only when the template moved but the row is at its stored version', async () => {
       const [template] = getBuiltInWorkflows();
       const currentHash = computeWorkflowHash(template);
-      // Stored hash is intentionally stale (template was updated after last sync)
-      const staleHash = 'stale-hash-from-old-version';
+      // Build an "old" version of the template (instructions changed) and seed
+      // the row with it + its hash. The row matches its stored version, so it
+      // is NOT customized — but the live template has since moved.
+      const oldVersion = { ...template, instructions: `${template.instructions ?? ''}\n[old]` };
+      const oldHash = computeWorkflowHash(oldVersion);
       const wfStale: SpaceWorkflow = {
-        ...template,
+        ...oldVersion,
         id: 'wf-1',
         spaceId: 'space-1',
         templateName: template.name,
-        templateHash: staleHash,
+        templateHash: oldHash,
       };
       setup(mockSpace, wfStale);
       const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
         string,
         unknown
       >;
-      expect(result.drifted).toBe(true);
+      expect(result.updateAvailable).toBe(true);
+      expect(result.customized).toBe(false);
       expect(result.currentTemplateHash).toBe(currentHash);
-      expect(result.storedHash).toBe(staleHash);
+      expect(result.workflowContentHash).toBe(oldHash);
+      expect(result.storedHash).toBe(oldHash);
     });
 
-    it('returns drifted=true when workflow content hash differs from stored hash (user edit)', async () => {
+    it('returns customized only when the workflow was edited but the template did not move', async () => {
       const [template] = getBuiltInWorkflows();
       const templateHash = computeWorkflowHash(template);
-      // Workflow has extra node compared to template — content diverges
+      // Workflow has extra node compared to template — content diverges, but
+      // storedHash still equals the (unchanged) current template hash.
       const wfEdited: SpaceWorkflow = {
         ...template,
         id: 'wf-1',
@@ -708,7 +719,31 @@ describe('space-workflow-handlers', () => {
         string,
         unknown
       >;
-      expect(result.drifted).toBe(true);
+      expect(result.updateAvailable).toBe(false);
+      expect(result.customized).toBe(true);
+    });
+
+    it('returns both signals when the template moved AND the row was edited', async () => {
+      const [template] = getBuiltInWorkflows();
+      const oldVersion = { ...template, instructions: `${template.instructions ?? ''}\n[old]` };
+      const wfBoth: SpaceWorkflow = {
+        ...oldVersion,
+        id: 'wf-1',
+        spaceId: 'space-1',
+        nodes: [
+          ...oldVersion.nodes,
+          { id: 'extra', name: 'Extra Node', agents: [{ agentId: 'a', name: 'A' }] },
+        ],
+        templateName: template.name,
+        templateHash: 'stale-hash',
+      };
+      setup(mockSpace, wfBoth);
+      const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+        string,
+        unknown
+      >;
+      expect(result.updateAvailable).toBe(true);
+      expect(result.customized).toBe(true);
     });
 
     it('throws when id is missing', async () => {
@@ -728,6 +763,84 @@ describe('space-workflow-handlers', () => {
       await expect(
         call('spaceWorkflow.detectDrift', { id: 'wf-1', spaceId: 'other-space' })
       ).rejects.toThrow('Workflow not found: wf-1');
+    });
+  });
+
+  // ─── spaceWorkflow.previewTemplateSync ──────────────────────────────────────
+
+  describe('spaceWorkflow.previewTemplateSync', () => {
+    it('registers the handler', () => {
+      setup();
+      expect(handlers.has('spaceWorkflow.previewTemplateSync')).toBe(true);
+    });
+
+    it('throws when id is missing', async () => {
+      setup();
+      await expect(
+        call('spaceWorkflow.previewTemplateSync', { spaceId: 'space-1' })
+      ).rejects.toThrow('id is required');
+    });
+
+    it('throws when spaceId is missing', async () => {
+      setup();
+      await expect(call('spaceWorkflow.previewTemplateSync', { id: 'wf-1' })).rejects.toThrow(
+        'spaceId is required'
+      );
+    });
+
+    it('throws when the workflow is not linked to a template', async () => {
+      const wfNoTemplate: SpaceWorkflow = { ...mockWorkflow, templateName: undefined };
+      setup(mockSpace, wfNoTemplate);
+      await expect(
+        call('spaceWorkflow.previewTemplateSync', { id: 'wf-1', spaceId: 'space-1' })
+      ).rejects.toThrow(/not linked to a built-in template/i);
+    });
+
+    it('returns a structural before/after diff without writing', async () => {
+      const [template] = getBuiltInWorkflows();
+      // Row = an old version (extra node + changed instructions); stored hash stale.
+      const wfEdited: SpaceWorkflow = {
+        ...template,
+        id: 'wf-1',
+        spaceId: 'space-1',
+        description: 'edited description',
+        instructions: 'edited instructions',
+        nodes: [
+          ...template.nodes,
+          { id: 'extra', name: 'Extra Node', agents: [{ agentId: 'a', name: 'A' }] },
+        ],
+        templateName: template.name,
+        templateHash: 'stale-hash',
+      };
+      setup(mockSpace, wfEdited);
+
+      const result = (await call('spaceWorkflow.previewTemplateSync', {
+        id: 'wf-1',
+        spaceId: 'space-1',
+      })) as {
+        preview: {
+          workflowId: string;
+          templateName: string;
+          updateAvailable: boolean;
+          customized: boolean;
+          diff: {
+            description?: { before: string; after: string };
+            instructions?: { before: string; after: string };
+            nodes?: { added: string[]; removed: string[] };
+          };
+        };
+      };
+
+      expect(result.preview.workflowId).toBe('wf-1');
+      expect(result.preview.templateName).toBe(template.name);
+      // Template moved (stale hash) AND row edited → both signals.
+      expect(result.preview.updateAvailable).toBe(true);
+      expect(result.preview.customized).toBe(true);
+      expect(result.preview.diff.description?.before).toBe('edited description');
+      expect(result.preview.diff.description?.after).toBe(template.description ?? '');
+      expect(result.preview.diff.instructions?.before).toBe('edited instructions');
+      // The extra node is present on the row but not on the template → removed on apply.
+      expect(result.preview.diff.nodes?.removed).toContain('Extra Node');
     });
   });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -1016,6 +1016,48 @@ describe('space-workflow-handlers', () => {
         call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' })
       ).rejects.toThrow('Cannot sync: no SpaceWorkerAgent found with name');
     });
+
+    it('rejects apply when expectedRowHash no longer matches (concurrent edit)', async () => {
+      const [template] = getBuiltInWorkflows();
+      const agents = agentsForTemplate(template);
+      const wfLinked: SpaceWorkflow = {
+        ...mockWorkflow,
+        templateName: template.name,
+        templateHash: 'old-hash',
+      };
+      setup(mockSpace, wfLinked, agents);
+      (workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(wfLinked);
+
+      // The reviewed hash does not match the current row → reject before writing.
+      await expect(
+        call('spaceWorkflow.syncFromTemplate', {
+          id: 'wf-1',
+          spaceId: 'space-1',
+          expectedRowHash: 'stale-reviewed-hash',
+        })
+      ).rejects.toThrow(/changed since/i);
+      expect(workflowManager.updateWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('applies when expectedRowHash matches the current row', async () => {
+      const [template] = getBuiltInWorkflows();
+      const agents = agentsForTemplate(template);
+      const wfLinked: SpaceWorkflow = {
+        ...mockWorkflow,
+        templateName: template.name,
+        templateHash: 'old-hash',
+      };
+      setup(mockSpace, wfLinked, agents);
+      (workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(wfLinked);
+
+      // The reviewed hash matches → sync proceeds.
+      await call('spaceWorkflow.syncFromTemplate', {
+        id: 'wf-1',
+        spaceId: 'space-1',
+        expectedRowHash: computeWorkflowHash(wfLinked),
+      });
+      expect(workflowManager.updateWorkflow).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ─── spaceWorkflow.detectDuplicateDrift ───────────────────────────────────

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1834,9 +1834,56 @@ describe('seedBuiltInWorkflows()', () => {
     expect(afterAgent.customPrompt?.value).toBe(sentinel);
     expect(afterAgent.agentId).toBe(reviewAgent.agentId);
     expect(afterReviewNode.id).toBe(reviewNode.id);
-    expect(after.templateHash).toBe(
+    // The sentinel prompt is a genuine customization the re-stamp preserves, so
+    // the row did NOT fully converge to the template. The stored hash must NOT
+    // advance to the template hash — otherwise updateAvailable would read false
+    // and the Workflow List would stop offering sync. The prior stale hash is
+    // preserved so the row stays honestly flagged for review.
+    expect(after.templateHash).toBe('stale-hash');
+    expect(after.templateHash).not.toBe(
       computeWorkflowHash(getBuiltInWorkflows().find((w) => w.name === CODING_WORKFLOW.name)!)
     );
+  });
+
+  test('re-stamp keeps updateAvailable alive when the template changed a non-merged field', () => {
+    // Regression guard (P1 #2): the re-stamp merges only structural fields
+    // (nodes/channels/gates/hooks/post-approval/autonomy). If the template
+    // improved in a field the merge does NOT reconcile — instructions,
+    // description, or a user prompt — then advancing the stored hash to the
+    // template's would collapse updateAvailable to false and the Workflow List
+    // would stop offering sync, permanently hiding the improvement. The re-stamp
+    // must NOT advance the hash past what it actually reconciled.
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+    const template = getBuiltInWorkflows().find((w) => w.name === CODING_WORKFLOW.name)!;
+    const expectedHash = computeWorkflowHash(template);
+
+    // Simulate a row that predates an instructions change: custom instructions
+    // (the merge won't reconcile these) + a stale stored hash.
+    manager.updateWorkflow(coding.id, { instructions: 'legacy custom instructions' });
+    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+      'pre-instructions-change-hash',
+      coding.id
+    );
+
+    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    expect(result.restamped).toContain(CODING_WORKFLOW.name);
+
+    const after = manager.getWorkflow(coding.id)!;
+    // Instructions are preserved (the merge doesn't reconcile them)...
+    expect(after.instructions).toBe('legacy custom instructions');
+    // ...so the row did NOT converge, and the stored hash must NOT have been
+    // advanced to the template's — updateAvailable stays true.
+    expect(after.templateHash).not.toBe(expectedHash);
+
+    // Derived drift signals (mirrors spaceWorkflow.detectDrift): the row stays
+    // actionable AND reads as customized, so the apply routes through review
+    // rather than a silent "safe" overwrite of the preserved instructions.
+    const rowHash = computeWorkflowHash(after);
+    const updateAvailable = expectedHash !== (after.templateHash ?? null);
+    const customized = rowHash !== (after.templateHash ?? null);
+    expect(updateAvailable).toBe(true);
+    expect(customized).toBe(true);
   });
 
   test('re-stamp patches exact retired built-in Coding prompt text', () => {
@@ -2109,7 +2156,10 @@ describe('seedBuiltInWorkflows()', () => {
     const after = manager.getWorkflow(coding.id)!;
     const afterCodingNode = after.nodes.find((n) => n.id === codingNode.id)!;
     expect(afterCodingNode.agents[0].customPrompt?.value).toBe(customizedPrompt);
-    expect(after.templateHash).toBe(
+    // Customized prompt preserved → partial convergence → stored hash is NOT
+    // advanced to the template hash (keeps the update signal alive for review).
+    expect(after.templateHash).toBe('customized-stale-prompt-hash');
+    expect(after.templateHash).not.toBe(
       computeWorkflowHash(getBuiltInWorkflows().find((w) => w.name === CODING_WORKFLOW.name)!)
     );
   });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1383,15 +1383,37 @@ export interface SpaceWorkerAgentDriftEntry {
   storedHash: string | null;
   /** Hash of the current preset definition in code. */
   currentHash: string;
-  /** True when {@link storedHash} differs from {@link currentHash}. */
-  drifted: boolean;
+  /**
+   * Hash of the row's CURRENT fingerprint fields
+   * (`name`, `description`, `tools`, `customPrompt`). Compared against
+   * {@link storedHash} to derive {@link customized}.
+   */
+  rowHash: string;
+  /**
+   * The TEMPLATE improved in code since this row was last seeded/synced
+   * ({@link currentHash} !== {@link storedHash}). Safe to apply — applying it
+   * loses no custom data unless {@link customized} is also true. Supersedes
+   * the old `drifted` flag with the identical comparison, so a pristine row
+   * has the same value it had under `drifted`.
+   */
+  updateAvailable: boolean;
+  /**
+   * The USER customized this row since it was last seeded/synced
+   * ({@link rowHash} !== {@link storedHash}). Purely informational — it never
+   * implies anything is wrong or needs action. Note: `name` is part of the
+   * fingerprint, so renaming a seeded agent registers as `customized`; this is
+   * harmless because {@link SpaceWorkerAgent} sync preserves the name.
+   */
+  customized: boolean;
 }
 
 /**
  * Returned by `spaceAgent.getDriftReport`. Lists all preset-seeded agents in
  * a space with the comparison between their stored fingerprint and the
- * current preset definition. Callers typically filter by `drifted === true`
- * to surface a UI badge / sync button.
+ * current preset definition. Callers surface a UI badge only when
+ * {@link SpaceWorkerAgentDriftEntry.updateAvailable} is true; a quiet
+ * "Customized" tag when only {@link SpaceWorkerAgentDriftEntry.customized}
+ * is true.
  */
 export interface SpaceWorkerAgentDriftReport {
   /** Space the report was generated for. */
@@ -1448,8 +1470,9 @@ export interface SpaceWorkerAgentSyncDiff {
 /**
  * Returned by `spaceAgent.previewTemplateSync`. Describes what
  * `spaceAgent.syncFromTemplate` would change for a single preset-tracked
- * agent, without writing. `drifted` uses the same hash comparison as the
- * drift report; `diff` adds the field-level before/after detail.
+ * agent, without writing. {@link updateAvailable} / {@link customized} use the
+ * same two-hash comparisons as the drift report; `diff` adds the field-level
+ * before/after detail.
  */
 export interface SpaceWorkerAgentSyncPreview {
   /** Agent UUID. */
@@ -1462,10 +1485,90 @@ export interface SpaceWorkerAgentSyncPreview {
   storedHash: string | null;
   /** Hash of the current preset definition in code. */
   liveHash: string;
-  /** True when {@link storedHash} differs from {@link liveHash}. */
-  drifted: boolean;
+  /** Hash of the row's current fingerprint fields. */
+  rowHash: string;
+  /** True when the template improved ({@link storedHash} !== {@link liveHash}). */
+  updateAvailable: boolean;
+  /** True when the user customized the row ({@link rowHash} !== {@link storedHash}). */
+  customized: boolean;
   /** Per-field before/after diff; empty when the fields already match. */
   diff: SpaceWorkerAgentSyncDiff;
+}
+
+// ============================================================================
+// Workflow template-sync preview (two-signal drift split)
+// ============================================================================
+
+/**
+ * Before/after for a single text field that differs between a seeded workflow
+ * row and its live built-in template. Mirrors {@link SpaceWorkerAgentSyncFieldDiff}.
+ */
+export interface SpaceWorkflowSyncFieldDiff {
+  /** Current value stored on the workflow row. */
+  before: string;
+  /** Value the live template would write on sync. */
+  after: string;
+}
+
+/**
+ * Name-keyed set delta for a structural collection (node names, gate ids,
+ * channel `from→to` keys). `added`/`removed` are derived from the two lists so
+ * the UI can render a concise delta without recomputing the set difference.
+ */
+export interface SpaceWorkflowSyncNameDelta {
+  /** Names currently on the workflow row. */
+  before: string[];
+  /** Names the live template would write on sync. */
+  after: string[];
+  /** Names in the template that are not on the current row. */
+  added: string[];
+  /** Names on the current row that the template no longer includes. */
+  removed: string[];
+}
+
+/**
+ * Per-field structural diff between a seeded {@link SpaceWorkflow} and its
+ * live built-in template. Only fields that actually differ are present. An
+ * empty object means the row's structure already matches the template (the row
+ * is in sync even if the stored hash is stale or missing).
+ *
+ * Covers the highest-signal structural fields — `description`, `instructions`,
+ * and the node set (by name). A full node-by-node deep diff is intentionally
+ * out of scope: workflow sync overwrites the entire structure, so the modal
+ * always states that explicitly regardless of which fields are enumerated here.
+ */
+export interface SpaceWorkflowSyncDiff {
+  description?: SpaceWorkflowSyncFieldDiff;
+  instructions?: SpaceWorkflowSyncFieldDiff;
+  nodes?: SpaceWorkflowSyncNameDelta;
+}
+
+/**
+ * Returned by `spaceWorkflow.previewTemplateSync`. Describes what
+ * `spaceWorkflow.syncFromTemplate` would change for a single
+ * template-tracked workflow, without writing. {@link updateAvailable} /
+ * {@link customized} use the same two-hash comparisons as
+ * `spaceWorkflow.detectDrift`; `diff` adds the structural before/after detail.
+ */
+export interface SpaceWorkflowSyncPreview {
+  /** Workflow UUID. */
+  workflowId: string;
+  /** Human-readable workflow name. */
+  workflowName: string;
+  /** Built-in template name this workflow was seeded from. */
+  templateName: string;
+  /** Hash captured the last time this row was seeded or synced. */
+  storedHash: string | null;
+  /** Hash of the current built-in template definition in code. */
+  liveHash: string;
+  /** Hash of the row's current structure. */
+  rowHash: string;
+  /** True when the template improved ({@link storedHash} !== {@link liveHash}). */
+  updateAvailable: boolean;
+  /** True when the user customized the row ({@link rowHash} !== {@link storedHash}). */
+  customized: boolean;
+  /** Structural before/after diff; empty when the structure already matches. */
+  diff: SpaceWorkflowSyncDiff;
 }
 
 // ============================================================================

--- a/packages/web/src/components/space/SpaceAgentPresetSyncDiffModal.tsx
+++ b/packages/web/src/components/space/SpaceAgentPresetSyncDiffModal.tsx
@@ -59,7 +59,9 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
   const handleApply = async () => {
     setApplying(true);
     try {
-      const updated = await spaceStore.syncAgentFromTemplate(agent.id);
+      // Pass the row hash observed at review time so the daemon rejects the
+      // apply if the agent changed since (optimistic-concurrency guard).
+      const updated = await spaceStore.syncAgentFromTemplate(agent.id, preview?.rowHash);
       toast.success(`"${agent.name}" updated from template`);
       onSynced(updated);
       onClose();

--- a/packages/web/src/components/space/SpaceWorkerAgentList.tsx
+++ b/packages/web/src/components/space/SpaceWorkerAgentList.tsx
@@ -18,9 +18,13 @@ import { SpaceAgentPresetSyncDiffModal } from './SpaceAgentPresetSyncDiffModal';
 import { connectionManager } from '../../lib/connection-manager';
 import { toast } from '../../lib/toast';
 
+/** Two-signal drift state for one agent, mirrored from the drift report. */
+type AgentDriftState = { updateAvailable: boolean; customized: boolean };
+
 interface AgentCardProps {
   agent: SpaceWorkerAgent;
-  drifted: boolean;
+  updateAvailable: boolean;
+  customized: boolean;
   syncing: boolean;
   onEdit: (agent: SpaceWorkerAgent) => void;
   onDelete: (agent: SpaceWorkerAgent) => void;
@@ -30,7 +34,8 @@ interface AgentCardProps {
 
 function AgentCard({
   agent,
-  drifted,
+  updateAvailable,
+  customized,
   syncing,
   onEdit,
   onDelete,
@@ -52,12 +57,24 @@ function AgentCard({
                 {status}
               </span>
             )}
-            {drifted && (
+            {updateAvailable && (
               <span
                 class="inline-flex flex-shrink-0 items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-xs text-amber-300"
-                title={`This worker agent was seeded from the "${agent.templateName}" preset and has drifted from the current definition.`}
+                title={`A newer version of the "${agent.templateName}" template is available. Apply it to bring this agent up to date.`}
               >
-                Outdated
+                Update available
+              </span>
+            )}
+            {customized && (
+              <span
+                class="inline-flex flex-shrink-0 items-center rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-400"
+                title={
+                  updateAvailable
+                    ? 'This agent has local edits on top of its template — review the diff before applying the update.'
+                    : "You've customized this agent from its template. No action needed."
+                }
+              >
+                Customized
               </span>
             )}
           </div>
@@ -78,25 +95,38 @@ function AgentCard({
           </div>
         </div>
         <div class="flex flex-shrink-0 items-center gap-1 opacity-70 transition-opacity group-hover:opacity-100">
-          {drifted && (
+          {updateAvailable && (
             <>
-              <button
-                type="button"
-                onClick={() => onShowDiff(agent)}
-                class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200"
-                title="Preview what resetting to the current preset would change"
-              >
-                Diff
-              </button>
-              <button
-                type="button"
-                onClick={() => onSync(agent)}
-                disabled={syncing}
-                class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200 disabled:opacity-50"
-                title="Sync from template (overwrites description, tools, and custom prompt)"
-              >
-                {syncing ? 'Syncing…' : 'Sync'}
-              </button>
+              {customized ? (
+                <button
+                  type="button"
+                  onClick={() => onShowDiff(agent)}
+                  class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200"
+                  title="This agent has local edits. Review the diff before applying the template update."
+                >
+                  Review diff
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => onShowDiff(agent)}
+                    class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200"
+                    title="Preview what the template update would change"
+                  >
+                    Diff
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onSync(agent)}
+                    disabled={syncing}
+                    class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200 disabled:opacity-50"
+                    title="Apply the template update (no local edits to lose)"
+                  >
+                    {syncing ? 'Applying…' : 'Apply'}
+                  </button>
+                </>
+              )}
             </>
           )}
           <button
@@ -173,11 +203,11 @@ export function SpaceWorkerAgentList() {
   const [syncingAgent, setSyncingAgent] = useState<SpaceWorkerAgent | null>(null);
   const [diffAgent, setDiffAgent] = useState<SpaceWorkerAgent | null>(null);
 
-  // Drift detection: set of agent IDs that have drifted from their preset.
-  // Empty until the first successful drift report fetch — agents not in the
-  // set render without the badge or sync button (the safe default when the
-  // daemon hasn't responded yet).
-  const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
+  // Drift detection: per-agent two-signal state (updateAvailable / customized).
+  // Empty until the first successful drift report fetch — agents absent from
+  // the map render without a badge or action (the safe default when the daemon
+  // hasn't responded yet).
+  const [agentDrift, setAgentDrift] = useState<Map<string, AgentDriftState>>(new Map());
   const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
 
   // Re-fetch drift report whenever the agent set changes. We watch a
@@ -207,11 +237,14 @@ export function SpaceWorkerAgentList() {
       .request<{ report: SpaceWorkerAgentDriftReport }>('spaceAgent.getDriftReport', { spaceId })
       .then((result) => {
         if (cancelled) return;
-        const ids = new Set<string>();
+        const next = new Map<string, AgentDriftState>();
         for (const entry of result.report.agents) {
-          if (entry.drifted) ids.add(entry.agentId);
+          next.set(entry.agentId, {
+            updateAvailable: entry.updateAvailable,
+            customized: entry.customized,
+          });
         }
-        setDriftedAgentIds(ids);
+        setAgentDrift(next);
       })
       .catch(() => {
         // Drift detection is best-effort — silently swallow errors so
@@ -224,13 +257,14 @@ export function SpaceWorkerAgentList() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- driftKey captures the list identity
   }, [spaceId, driftKey]);
 
-  // Clear drift state for an agent eagerly so the badge disappears before the
+  // Clear drift state for an agent eagerly so the badges disappear before the
   // next refresh cycle. The spaceAgent.updated event re-triggers the drift
-  // effect and reconciles authoritatively. Shared by the quick "Sync" confirm
-  // path and the diff modal's "Reset to preset".
+  // effect and reconciles authoritatively. Shared by the quick "Apply" confirm
+  // path and the diff modal's "Apply update".
   const clearDriftFor = (agentId: string) => {
-    setDriftedAgentIds((prev) => {
-      const next = new Set(prev);
+    setAgentDrift((prev) => {
+      if (!prev.has(agentId)) return prev;
+      const next = new Map(prev);
       next.delete(agentId);
       return next;
     });
@@ -244,9 +278,9 @@ export function SpaceWorkerAgentList() {
       await spaceStore.syncAgentFromTemplate(agent.id);
       clearDriftFor(agent.id);
       setSyncingAgent(null);
-      toast.success(`"${agent.name}" synced from template`);
+      toast.success(`"${agent.name}" updated from template`);
     } catch (err) {
-      toast.error(`Sync failed: ${err instanceof Error ? err.message : String(err)}`);
+      toast.error(`Update failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSyncingAgentId((current) => (current === agent.id ? null : current));
     }
@@ -350,18 +384,22 @@ export function SpaceWorkerAgentList() {
       ) : (
         <div class="scrollbar-dark min-h-0 flex-1 overflow-y-auto pr-3">
           <div class="min-h-[calc(100%+1px)]">
-            {sortedAgents.map((agent) => (
-              <AgentCard
-                key={agent.id}
-                agent={agent}
-                drifted={driftedAgentIds.has(agent.id)}
-                syncing={syncingAgentId === agent.id}
-                onEdit={handleEdit}
-                onDelete={handleDeleteClick}
-                onSync={setSyncingAgent}
-                onShowDiff={handleShowDiff}
-              />
-            ))}
+            {sortedAgents.map((agent) => {
+              const drift = agentDrift.get(agent.id);
+              return (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  updateAvailable={drift?.updateAvailable ?? false}
+                  customized={drift?.customized ?? false}
+                  syncing={syncingAgentId === agent.id}
+                  onEdit={handleEdit}
+                  onDelete={handleDeleteClick}
+                  onSync={setSyncingAgent}
+                  onShowDiff={handleShowDiff}
+                />
+              );
+            })}
           </div>
         </div>
       )}
@@ -381,9 +419,9 @@ export function SpaceWorkerAgentList() {
           isOpen
           onClose={() => setSyncingAgent(null)}
           onConfirm={handleSyncConfirm}
-          title="Sync Worker Agent from Template"
-          message={`Sync "${syncingAgent.name}" from the current "${syncingAgent.templateName ?? 'template'}" preset? This overwrites its description, tools, and custom prompt.`}
-          confirmText="Sync"
+          title="Apply template update"
+          message={`Apply the latest "${syncingAgent.templateName ?? 'template'}" template to "${syncingAgent.name}"? This updates its description, tools, and custom prompt to match the current template.`}
+          confirmText="Apply update"
           confirmButtonVariant="primary"
           isLoading={syncingAgentId === syncingAgent.id}
         />

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -24,6 +24,7 @@ import { toast } from '../../lib/toast.ts';
 import { ImportPreviewDialog } from './ImportPreviewDialog.tsx';
 import type { ImportPreviewResult, ImportConflictResolution } from './ImportPreviewDialog.tsx';
 import { downloadBundle, pickImportFile } from './export-import-utils.ts';
+import { WorkflowTemplateSyncDiffModal } from './WorkflowTemplateSyncDiffModal.tsx';
 
 // ============================================================================
 // Mini Step Visualization
@@ -123,11 +124,16 @@ function WorkflowCard({
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  // Drift detection state: null = unknown/checking, true = drifted, false = in sync
-  const [driftDrifted, setDriftDrifted] = useState<boolean | null>(null);
+  // Drift detection state: null = unknown/checking, otherwise the two-signal
+  // split (updateAvailable = template improved; customized = user edited).
+  const [driftState, setDriftState] = useState<{
+    updateAvailable: boolean;
+    customized: boolean;
+  } | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
   const [confirmSync, setConfirmSync] = useState(false);
+  const [diffOpen, setDiffOpen] = useState(false);
 
   // Duplicate-drift resync state
   const [confirmDupResync, setConfirmDupResync] = useState(false);
@@ -143,12 +149,16 @@ function WorkflowCard({
 
     let cancelled = false;
     hub
-      .request<{ drifted: boolean }>('spaceWorkflow.detectDrift', {
+      .request<{ updateAvailable: boolean; customized: boolean }>('spaceWorkflow.detectDrift', {
         id: workflow.id,
         spaceId,
       })
       .then((result) => {
-        if (!cancelled) setDriftDrifted(result.drifted);
+        if (!cancelled)
+          setDriftState({
+            updateAvailable: result.updateAvailable,
+            customized: result.customized,
+          });
       })
       .catch(() => {
         // Ignore drift detection errors silently
@@ -200,10 +210,11 @@ function WorkflowCard({
         spaceId,
       });
       setConfirmSync(false);
-      setDriftDrifted(false); // no longer drifted after sync
-      toast.success(`"${workflow.name}" synced from template`);
+      // Sync re-stamps the hash and overwrites structure → neither signal fires.
+      setDriftState({ updateAvailable: false, customized: false });
+      toast.success(`"${workflow.name}" updated from template`);
     } catch (err) {
-      setSyncError(err instanceof Error ? err.message : 'Sync failed');
+      setSyncError(err instanceof Error ? err.message : 'Update failed');
     } finally {
       setSyncing(false);
     }
@@ -253,9 +264,24 @@ function WorkflowCard({
               <span class="inline-flex items-center rounded border border-white/10 px-1.5 py-0.5 text-xs text-gray-400">
                 {workflow.templateName}
               </span>
-              {driftDrifted === true && (
-                <span class="inline-flex items-center rounded bg-yellow-500/10 px-1.5 py-0.5 text-xs text-yellow-300">
-                  Outdated
+              {driftState?.updateAvailable && (
+                <span
+                  class="inline-flex items-center rounded bg-amber-500/10 px-1.5 py-0.5 text-xs text-amber-300"
+                  title="A newer version of this template is available. Apply it to bring this workflow up to date."
+                >
+                  Update available
+                </span>
+              )}
+              {driftState?.customized && (
+                <span
+                  class="inline-flex items-center rounded bg-white/5 px-1.5 py-0.5 text-xs text-gray-400"
+                  title={
+                    driftState?.updateAvailable
+                      ? 'This workflow has local edits on top of its template — review the diff before applying the update.'
+                      : "You've customized this workflow from its template. No action needed."
+                  }
+                >
+                  Customized
                 </span>
               )}
               {duplicateDrift && (
@@ -294,15 +320,25 @@ function WorkflowCard({
             </>
           ) : (
             <>
-              {workflow.templateName && driftDrifted === true && (
-                <button
-                  onClick={() => setConfirmSync(true)}
-                  class="rounded-md px-2 py-1 text-xs text-yellow-300 transition-colors hover:bg-white/5 hover:text-yellow-200"
-                  title="Sync from template (overwrites local changes)"
-                >
-                  Sync
-                </button>
-              )}
+              {workflow.templateName &&
+                driftState?.updateAvailable &&
+                (driftState.customized ? (
+                  <button
+                    onClick={() => setDiffOpen(true)}
+                    class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200"
+                    title="This workflow has local edits. Review the diff before applying the template update."
+                  >
+                    Review diff
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => setConfirmSync(true)}
+                    class="rounded-md px-2 py-1 text-xs text-amber-300 transition-colors hover:bg-white/5 hover:text-amber-200"
+                    title="Apply the template update (no local edits to lose)"
+                  >
+                    Apply update
+                  </button>
+                ))}
               {duplicateDrift?.isNewest && (
                 <button
                   onClick={() => setConfirmDupResync(true)}
@@ -423,20 +459,18 @@ function WorkflowCard({
         </div>
       )}
 
-      {/* Sync from template confirmation modal */}
+      {/* Apply template update confirmation modal (safe case: no local edits) */}
       {confirmSync && (
         <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
           <div class="bg-dark-850 border border-dark-700 rounded-lg p-5 max-w-md w-full shadow-xl">
-            <h3 class="text-sm font-semibold text-gray-100 mb-2">Sync from template?</h3>
+            <h3 class="text-sm font-semibold text-gray-100 mb-2">Apply template update?</h3>
             <p class="text-xs text-gray-400 mb-1">
-              This will overwrite <span class="font-medium text-gray-200">"{workflow.name}"</span>{' '}
-              with the latest version of the{' '}
-              <span class="font-medium text-gray-200">"{workflow.templateName}"</span> template.
+              This updates <span class="font-medium text-gray-200">"{workflow.name}"</span> to the
+              latest version of the{' '}
+              <span class="font-medium text-gray-200">"{workflow.templateName}"</span> template
+              (structure, instructions, gates, and channels).
             </p>
-            <p class="text-xs text-red-400 mb-4">
-              All local edits to this workflow (nodes, channels, gates, instructions) will be
-              permanently lost.
-            </p>
+            <p class="text-xs text-gray-500 mb-4">No local customizations will be lost.</p>
             {syncError && (
               <div class="mb-3 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
                 {syncError}
@@ -458,11 +492,20 @@ function WorkflowCard({
                 disabled={syncing}
                 class="px-3 py-1.5 text-xs font-medium text-white bg-yellow-700 hover:bg-yellow-600 rounded transition-colors disabled:opacity-50"
               >
-                {syncing ? 'Syncing…' : 'Sync from template'}
+                {syncing ? 'Applying…' : 'Apply update'}
               </button>
             </div>
           </div>
         </div>
+      )}
+
+      {/* Review-diff modal (dangerous case: customized + update available) */}
+      {diffOpen && (
+        <WorkflowTemplateSyncDiffModal
+          workflow={workflow}
+          onClose={() => setDiffOpen(false)}
+          onApplied={() => setDriftState({ updateAvailable: false, customized: false })}
+        />
       )}
     </div>
   );

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -470,7 +470,10 @@ function WorkflowCard({
               <span class="font-medium text-gray-200">"{workflow.templateName}"</span> template
               (structure, instructions, gates, and channels).
             </p>
-            <p class="text-xs text-gray-500 mb-4">No local customizations will be lost.</p>
+            <p class="text-xs text-gray-500 mb-4">
+              No edits were detected to this workflow's steps, instructions, or prompts — though
+              applying still overwrites the full structure.
+            </p>
             {syncError && (
               <div class="mb-3 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
                 {syncError}

--- a/packages/web/src/components/space/WorkflowTemplateSyncDiffModal.tsx
+++ b/packages/web/src/components/space/WorkflowTemplateSyncDiffModal.tsx
@@ -1,39 +1,38 @@
 /**
- * SpaceAgentPresetSyncDiffModal
+ * WorkflowTemplateSyncDiffModal
  *
- * Preview-then-apply modal for applying a template update to a seeded worker
- * agent. Fetches a per-field before/after diff from
- * `spaceAgent.previewTemplateSync` on open, renders the deltas (customPrompt,
- * description, tools), and offers a one-click "Apply update" that runs the
- * existing `spaceAgent.syncFromTemplate`.
+ * Preview-then-apply modal for applying a template update to a seeded
+ * workflow. Fetches a structural before/after diff from
+ * `spaceWorkflow.previewTemplateSync` on open, renders the deltas
+ * (description, instructions, node set), and offers a one-click "Apply update"
+ * that runs the existing `spaceWorkflow.syncFromTemplate`.
  *
- * The diff covers exactly the fields sync overwrites, so what the user reviews
- * here is precisely what applying the update will change. Never automatic — the
- * apply only fires on an explicit click. This is the REQUIRED review path when
- * the agent is both customized and has an update available (local edits would
- * otherwise be lost).
+ * This is the REQUIRED review path when the workflow is both customized and
+ * has an update available — applying a structural update would otherwise
+ * silently discard the local edits. The apply is never automatic; it only
+ * fires on an explicit click.
  */
 
 import { useEffect, useState } from 'preact/hooks';
-import type { SpaceWorkerAgent, SpaceWorkerAgentSyncPreview } from '@hyperneo/shared';
+import type { SpaceWorkflowSummary, SpaceWorkflowSyncPreview } from '@hyperneo/shared';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
 
 interface Props {
-  agent: SpaceWorkerAgent;
+  workflow: SpaceWorkflowSummary;
   onClose: () => void;
-  /** Called with the freshly updated agent after a successful apply. */
-  onSynced: (agent: SpaceWorkerAgent) => void;
+  /** Called after a successful apply, before the modal closes. */
+  onApplied: () => void;
 }
 
-function hasDiff(preview: SpaceWorkerAgentSyncPreview): boolean {
-  return Boolean(preview.diff.customPrompt || preview.diff.description || preview.diff.tools);
+function hasDiff(preview: SpaceWorkflowSyncPreview): boolean {
+  return Boolean(preview.diff.description || preview.diff.instructions || preview.diff.nodes);
 }
 
-export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Props) {
-  const [preview, setPreview] = useState<SpaceWorkerAgentSyncPreview | null>(null);
+export function WorkflowTemplateSyncDiffModal({ workflow, onClose, onApplied }: Props) {
+  const [preview, setPreview] = useState<SpaceWorkflowSyncPreview | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
 
@@ -42,7 +41,7 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
     setPreview(null);
     setLoadError(null);
     spaceStore
-      .previewAgentTemplateSync(agent.id)
+      .previewWorkflowTemplateSync(workflow.id)
       .then((result) => {
         if (cancelled) return;
         setPreview(result);
@@ -54,14 +53,14 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
     return () => {
       cancelled = true;
     };
-  }, [agent.id]);
+  }, [workflow.id]);
 
   const handleApply = async () => {
     setApplying(true);
     try {
-      const updated = await spaceStore.syncAgentFromTemplate(agent.id);
-      toast.success(`"${agent.name}" updated from template`);
-      onSynced(updated);
+      await spaceStore.syncWorkflowFromTemplate(workflow.id);
+      toast.success(`"${workflow.name}" updated from template`);
+      onApplied();
       onClose();
     } catch (err) {
       toast.error(`Update failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -73,12 +72,16 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
   const loading = !preview && !loadError;
 
   return (
-    <Modal isOpen onClose={onClose} title={`Review update — ${agent.name}`} size="lg">
+    <Modal isOpen onClose={onClose} title={`Review update — ${workflow.name}`} size="lg">
       <div class="space-y-4">
         <p class="text-xs text-gray-500">
-          {agent.templateName
-            ? `A newer version of the "${agent.templateName}" template is available. Review what applying the update would change, then apply it.`
-            : 'This worker agent is not linked to a template.'}
+          A newer version of the "{workflow.templateName}" template is available. Review what
+          applying the update would change, then apply it.{' '}
+          {preview?.customized && (
+            <span class="text-amber-300/90">
+              This workflow has local edits — they will be overwritten.
+            </span>
+          )}
         </p>
 
         {loading && <p class="text-xs text-gray-600 animate-pulse">Loading diff...</p>}
@@ -87,18 +90,10 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
 
         {preview && !hasDiff(preview) && (
           <p class="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-gray-400">
-            Fields already match the template. Applying only re-stamps the version (
-            {preview.storedHash ? 'stale' : 'missing'} → current) so the badge clears.
+            The listed structure already matches the template. Applying re-syncs the full structure
+            and re-stamps the version ({preview.storedHash ? 'stale' : 'missing'} → current) so the
+            badge clears.
           </p>
-        )}
-
-        {preview && preview.diff.customPrompt && (
-          <DiffSection label="Custom prompt">
-            <BeforeAfter
-              before={preview.diff.customPrompt.before}
-              after={preview.diff.customPrompt.after}
-            />
-          </DiffSection>
         )}
 
         {preview && preview.diff.description && (
@@ -110,9 +105,18 @@ export function SpaceAgentPresetSyncDiffModal({ agent, onClose, onSynced }: Prop
           </DiffSection>
         )}
 
-        {preview && preview.diff.tools && (
-          <DiffSection label="Tools">
-            <ToolsDelta diff={preview.diff.tools} />
+        {preview && preview.diff.instructions && (
+          <DiffSection label="Instructions">
+            <BeforeAfter
+              before={preview.diff.instructions.before}
+              after={preview.diff.instructions.after}
+            />
+          </DiffSection>
+        )}
+
+        {preview && preview.diff.nodes && (
+          <DiffSection label="Steps">
+            <NameDelta diff={preview.diff.nodes} singular="step" />
           </DiffSection>
         )}
 
@@ -165,10 +169,12 @@ function BeforeAfter({ before, after }: { before: string; after: string }) {
   );
 }
 
-function ToolsDelta({
+function NameDelta({
   diff,
+  singular,
 }: {
-  diff: { before: string[]; after: string[]; added: string[]; removed: string[] };
+  diff: { added: string[]; removed: string[] };
+  singular: string;
 }) {
   return (
     <div class="space-y-2">
@@ -179,12 +185,12 @@ function ToolsDelta({
         {diff.added.length === 0 ? (
           <span class="text-xs text-gray-600">none</span>
         ) : (
-          diff.added.map((tool) => (
+          diff.added.map((name) => (
             <span
-              key={`add-${tool}`}
+              key={`add-${name}`}
               class="rounded border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-0.5 text-xs text-emerald-300"
             >
-              {tool}
+              {name}
             </span>
           ))
         )}
@@ -196,16 +202,19 @@ function ToolsDelta({
         {diff.removed.length === 0 ? (
           <span class="text-xs text-gray-600">none</span>
         ) : (
-          diff.removed.map((tool) => (
+          diff.removed.map((name) => (
             <span
-              key={`rm-${tool}`}
+              key={`rm-${name}`}
               class="rounded border border-red-500/30 bg-red-500/10 px-1.5 py-0.5 text-xs text-red-300"
             >
-              {tool}
+              {name}
             </span>
           ))
         )}
       </div>
+      <p class="text-[10px] text-gray-600">
+        Ordering and {singular} details are reconciled on apply.
+      </p>
     </div>
   );
 }

--- a/packages/web/src/components/space/WorkflowTemplateSyncDiffModal.tsx
+++ b/packages/web/src/components/space/WorkflowTemplateSyncDiffModal.tsx
@@ -58,7 +58,9 @@ export function WorkflowTemplateSyncDiffModal({ workflow, onClose, onApplied }: 
   const handleApply = async () => {
     setApplying(true);
     try {
-      await spaceStore.syncWorkflowFromTemplate(workflow.id);
+      // Pass the row hash observed at review time so the daemon rejects the
+      // apply if the workflow changed since (optimistic-concurrency guard).
+      await spaceStore.syncWorkflowFromTemplate(workflow.id, preview?.rowHash);
       toast.success(`"${workflow.name}" updated from template`);
       onApplied();
       onClose();
@@ -76,23 +78,31 @@ export function WorkflowTemplateSyncDiffModal({ workflow, onClose, onApplied }: 
       <div class="space-y-4">
         <p class="text-xs text-gray-500">
           A newer version of the "{workflow.templateName}" template is available. Review what
-          applying the update would change, then apply it.{' '}
-          {preview?.customized && (
-            <span class="text-amber-300/90">
-              This workflow has local edits — they will be overwritten.
-            </span>
-          )}
+          applying the update would change, then apply it.
         </p>
 
         {loading && <p class="text-xs text-gray-600 animate-pulse">Loading diff...</p>}
 
         {loadError && <p class="text-xs text-red-400">Failed to load diff: {loadError}</p>}
 
+        {/* Persistent warning: apply is a full structural overwrite. Shown in
+            every state so the review gate is substantive even when the
+            field-level diff is empty or omits the customized field — the diff
+            below only enumerates description/instructions/step-names, but sync
+            also overwrites gates, channels, hooks, and per-step settings. */}
+        {preview && (
+          <p class="rounded-md border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2 text-xs text-amber-200/90">
+            Applying overwrites the entire workflow structure — steps, instructions, gates,
+            channels, and per-step settings — with the current template.
+            {preview.customized ? ' Local edits will be lost.' : ''}
+          </p>
+        )}
+
         {preview && !hasDiff(preview) && (
-          <p class="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-gray-400">
-            The listed structure already matches the template. Applying re-syncs the full structure
-            and re-stamps the version ({preview.storedHash ? 'stale' : 'missing'} → current) so the
-            badge clears.
+          <p class="text-xs text-gray-400">
+            {preview.customized
+              ? 'No description, instructions, or step-name changes to show — the local edits are in gates, channels, hooks, or per-step prompts, all of which applying overwrites.'
+              : `No field-level changes to show — applying only re-stamps the version (${preview.storedHash ? 'stale' : 'missing'} → current) so the badge clears.`}
           </p>
         )}
 

--- a/packages/web/src/components/space/__tests__/SpaceWorkerAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceWorkerAgentList.test.tsx
@@ -297,7 +297,10 @@ describe('SpaceWorkerAgentList', () => {
     await waitFor(() => expect(getByText('Apply update')).toBeTruthy());
     fireEvent.click(getByText('Apply update'));
 
-    await waitFor(() => expect(mockSyncAgentFromTemplate).toHaveBeenCalledWith('coder-agent'));
+    // The apply passes the reviewed row hash (optimistic-concurrency guard).
+    await waitFor(() =>
+      expect(mockSyncAgentFromTemplate).toHaveBeenCalledWith('coder-agent', 'row')
+    );
     await waitFor(() => expect(queryByText(/Review update/)).toBeNull());
     // Both badges cleared eagerly after the apply.
     await waitFor(() => expect(queryByText('Update available')).toBeNull());

--- a/packages/web/src/components/space/__tests__/SpaceWorkerAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceWorkerAgentList.test.tsx
@@ -214,30 +214,30 @@ describe('SpaceWorkerAgentList', () => {
     expect(queryByText('Create a workflow to define worker agents.')).toBeNull();
   });
 
-  it('confirms before syncing a drifted worker agent from its template', async () => {
+  it('confirms before applying a template update to a worker agent (safe case)', async () => {
     mockAgents.value = [makeAgent('coder-agent', { templateName: 'coder' })];
     mockHubRequest.mockResolvedValueOnce({
-      report: { agents: [{ agentId: 'coder-agent', drifted: true }] },
+      report: { agents: [{ agentId: 'coder-agent', updateAvailable: true, customized: false }] },
     });
 
-    const { getAllByText, getByText, queryByText } = render(<SpaceWorkerAgentList />);
+    const { getByText, queryByText } = render(<SpaceWorkerAgentList />);
 
-    await waitFor(() => expect(getByText('Sync')).toBeTruthy());
-    fireEvent.click(getByText('Sync'));
+    await waitFor(() => expect(getByText('Apply')).toBeTruthy());
+    fireEvent.click(getByText('Apply'));
 
     expect(mockSyncAgentFromTemplate).not.toHaveBeenCalled();
-    expect(getByText('Sync Worker Agent from Template')).toBeTruthy();
+    expect(getByText('Apply template update')).toBeTruthy();
 
-    fireEvent.click(getAllByText('Sync')[1]);
+    fireEvent.click(getByText('Apply update'));
 
     await waitFor(() => expect(mockSyncAgentFromTemplate).toHaveBeenCalledWith('coder-agent'));
-    await waitFor(() => expect(queryByText('Sync Worker Agent from Template')).toBeNull());
+    await waitFor(() => expect(queryByText('Apply template update')).toBeNull());
   });
 
-  it('opens the preset diff modal when Diff is clicked on a drifted agent', async () => {
+  it('opens the review-update modal when Diff is clicked on an agent with an update', async () => {
     mockAgents.value = [makeAgent('coder-agent', { name: 'Coder', templateName: 'Coder' })];
     mockHubRequest.mockResolvedValueOnce({
-      report: { agents: [{ agentId: 'coder-agent', drifted: true }] },
+      report: { agents: [{ agentId: 'coder-agent', updateAvailable: true, customized: false }] },
     });
     mockPreviewAgentTemplateSync.mockResolvedValue({
       agentId: 'coder-agent',
@@ -245,7 +245,9 @@ describe('SpaceWorkerAgentList', () => {
       templateName: 'Coder',
       storedHash: 'stale',
       liveHash: 'live',
-      drifted: true,
+      rowHash: 'row',
+      updateAvailable: true,
+      customized: false,
       diff: { customPrompt: { before: 'old prompt', after: 'new prompt' } },
     });
 
@@ -254,17 +256,20 @@ describe('SpaceWorkerAgentList', () => {
     await waitFor(() => expect(getByText('Diff')).toBeTruthy());
     fireEvent.click(getByText('Diff'));
 
-    await waitFor(() => expect(getByText(/Preset diff/)).toBeTruthy());
+    await waitFor(() => expect(getByText(/Review update/)).toBeTruthy());
     await waitFor(() => expect(mockPreviewAgentTemplateSync).toHaveBeenCalledWith('coder-agent'));
     // Before/after content rendered.
     expect(getByText('old prompt')).toBeTruthy();
     expect(getByText('new prompt')).toBeTruthy();
   });
 
-  it('resets to preset from the diff modal and clears the drift badge', async () => {
+  it('requires reviewing the diff before applying an update to a customized agent', async () => {
+    // Dangerous case: customized AND update available. The only card action is
+    // "Review diff" — there is no quick "Apply" — so the user must view the
+    // diff before the sync applies.
     mockAgents.value = [makeAgent('coder-agent', { templateName: 'Coder' })];
     mockHubRequest.mockResolvedValueOnce({
-      report: { agents: [{ agentId: 'coder-agent', drifted: true }] },
+      report: { agents: [{ agentId: 'coder-agent', updateAvailable: true, customized: true }] },
     });
     mockPreviewAgentTemplateSync.mockResolvedValue({
       agentId: 'coder-agent',
@@ -272,7 +277,9 @@ describe('SpaceWorkerAgentList', () => {
       templateName: 'Coder',
       storedHash: 'stale',
       liveHash: 'live',
-      drifted: true,
+      rowHash: 'row',
+      updateAvailable: true,
+      customized: true,
       diff: { customPrompt: { before: 'old', after: 'new' } },
     });
     mockSyncAgentFromTemplate.mockResolvedValue(
@@ -281,17 +288,19 @@ describe('SpaceWorkerAgentList', () => {
 
     const { getByText, queryByText } = render(<SpaceWorkerAgentList />);
 
-    // Badge present before reset.
-    await waitFor(() => expect(getByText('Outdated')).toBeTruthy());
+    // Both badges present; no quick Apply button on a customized row.
+    await waitFor(() => expect(getByText('Update available')).toBeTruthy());
+    expect(getByText('Customized')).toBeTruthy();
+    expect(queryByText('Apply')).toBeNull();
 
-    fireEvent.click(getByText('Diff'));
-    await waitFor(() => expect(getByText('Reset to preset')).toBeTruthy());
-    fireEvent.click(getByText('Reset to preset'));
+    fireEvent.click(getByText('Review diff'));
+    await waitFor(() => expect(getByText('Apply update')).toBeTruthy());
+    fireEvent.click(getByText('Apply update'));
 
     await waitFor(() => expect(mockSyncAgentFromTemplate).toHaveBeenCalledWith('coder-agent'));
-    await waitFor(() => expect(queryByText(/Preset diff/)).toBeNull());
-    // Drift badge cleared eagerly after the reset.
-    await waitFor(() => expect(queryByText('Outdated')).toBeNull());
+    await waitFor(() => expect(queryByText(/Review update/)).toBeNull());
+    // Both badges cleared eagerly after the apply.
+    await waitFor(() => expect(queryByText('Update available')).toBeNull());
   });
 
   it('clears stale modals when the active space changes', async () => {

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -88,7 +88,8 @@ describe('WorkflowList', () => {
     mockHubRequest.mockReset();
     mockHubRequest.mockImplementation(async (method: string) => {
       if (method === 'spaceWorkflow.detectDuplicateDrift') return { reports: [] };
-      if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+      if (method === 'spaceWorkflow.detectDrift')
+        return { updateAvailable: false, customized: false };
       return undefined;
     });
   });
@@ -180,6 +181,70 @@ describe('WorkflowList', () => {
     const { getByText } = render(<WorkflowList {...props} />);
     fireEvent.click(getByText('Edit'));
     expect(defaultProps.onEditWorkflow).toHaveBeenCalledWith('wf-abc');
+  });
+
+  describe('template drift badge + apply', () => {
+    function workflowWithTemplate(): SpaceWorkflowSummary {
+      return makeWorkflow({ id: 'wf-1', templateName: 'Coding Workflow' });
+    }
+
+    function driftDetect(updateAvailable: boolean, customized: boolean): typeof mockHubRequest {
+      return vi.fn(async (method: string) => {
+        if (method === 'spaceWorkflow.detectDuplicateDrift') return { reports: [] };
+        if (method === 'spaceWorkflow.detectDrift') return { updateAvailable, customized };
+        return undefined;
+      });
+    }
+
+    it('renders an Update available badge and Apply update button when only an update is pending', async () => {
+      mockHubRequest.mockImplementation(driftDetect(true, false));
+      const props = { ...defaultProps, workflows: [workflowWithTemplate()] };
+      const { getByText, queryByText } = render(<WorkflowList {...props} />);
+
+      await waitFor(() => expect(getByText('Update available')).toBeTruthy());
+      expect(queryByText('Customized')).toBeNull();
+      expect(getByText('Apply update')).toBeTruthy();
+    });
+
+    it('renders both badges and a Review diff button for a customized row with an update', async () => {
+      mockHubRequest.mockImplementation(driftDetect(true, true));
+      const props = { ...defaultProps, workflows: [workflowWithTemplate()] };
+      const { getByText, queryByText } = render(<WorkflowList {...props} />);
+
+      await waitFor(() => expect(getByText('Update available')).toBeTruthy());
+      expect(getByText('Customized')).toBeTruthy();
+      // Dangerous case: no quick Apply — must review the diff first.
+      expect(queryByText('Apply update')).toBeNull();
+      expect(getByText('Review diff')).toBeTruthy();
+    });
+
+    it('renders a quiet Customized badge and no action when only customized', async () => {
+      mockHubRequest.mockImplementation(driftDetect(false, true));
+      const props = { ...defaultProps, workflows: [workflowWithTemplate()] };
+      const { getByText, queryByText } = render(<WorkflowList {...props} />);
+
+      await waitFor(() => expect(getByText('Customized')).toBeTruthy());
+      expect(queryByText('Update available')).toBeNull();
+      expect(queryByText('Apply update')).toBeNull();
+      expect(queryByText('Review diff')).toBeNull();
+    });
+
+    it('renders no drift badge or action for a pristine row', async () => {
+      mockHubRequest.mockImplementation(driftDetect(false, false));
+      const props = { ...defaultProps, workflows: [workflowWithTemplate()] };
+      const { queryByText } = render(<WorkflowList {...props} />);
+
+      // Give the async detectDrift a tick; nothing should render.
+      await waitFor(() =>
+        expect(mockHubRequest).toHaveBeenCalledWith('spaceWorkflow.detectDrift', {
+          id: 'wf-1',
+          spaceId: 'space-1',
+        })
+      );
+      expect(queryByText('Update available')).toBeNull();
+      expect(queryByText('Customized')).toBeNull();
+      expect(queryByText('Apply update')).toBeNull();
+    });
   });
 
   it('renders multiple workflows', () => {
@@ -278,7 +343,8 @@ describe('WorkflowList', () => {
             ],
           };
         }
-        if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+        if (method === 'spaceWorkflow.detectDrift')
+          return { updateAvailable: false, customized: false };
         return undefined;
       });
 
@@ -306,7 +372,8 @@ describe('WorkflowList', () => {
             ],
           };
         }
-        if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+        if (method === 'spaceWorkflow.detectDrift')
+          return { updateAvailable: false, customized: false };
         return undefined;
       });
 
@@ -334,7 +401,8 @@ describe('WorkflowList', () => {
             ],
           };
         }
-        if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+        if (method === 'spaceWorkflow.detectDrift')
+          return { updateAvailable: false, customized: false };
         return undefined;
       });
 
@@ -364,7 +432,8 @@ describe('WorkflowList', () => {
             ],
           };
         }
-        if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+        if (method === 'spaceWorkflow.detectDrift')
+          return { updateAvailable: false, customized: false };
         if (method === 'spaceWorkflow.resyncDuplicates') {
           expect(params).toMatchObject({
             spaceId: 'space-1',

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -302,7 +302,9 @@ function makeMockHub() {
             templateName: 'Coder',
             storedHash: 'stale',
             liveHash: 'live',
-            drifted: true,
+            rowHash: 'row',
+            updateAvailable: true,
+            customized: true,
             diff: { customPrompt: { before: 'old prompt', after: 'new prompt' } },
           },
         };
@@ -347,6 +349,20 @@ function makeMockHub() {
       // spaceWorkflow handlers return wrapped { workflow }
       if (method === 'spaceWorkflow.create') return { workflow: makeWorkflow('new-wf') };
       if (method === 'spaceWorkflow.update') return { workflow: makeWorkflow('wf1') };
+      if (method === 'spaceWorkflow.previewTemplateSync')
+        return {
+          preview: {
+            workflowId: params?.id as string,
+            workflowName: 'Workflow',
+            templateName: 'Coding Workflow',
+            storedHash: 'stale',
+            liveHash: 'live',
+            rowHash: 'row',
+            updateAvailable: true,
+            customized: true,
+            diff: { description: { before: 'old desc', after: 'new desc' } },
+          },
+        };
       if (method === 'nodeExecution.list') return { executions: [] };
       if (method === 'spaceGoal.list') return { goals: [] };
       if (method === 'spaceGoal.get') return { goal: makeGoal({ id: params?.goalId as string }) };
@@ -2002,8 +2018,24 @@ describe('SpaceStore — CRUD methods', () => {
       agentId: 'a1',
     });
     expect(preview.agentId).toBe('a1');
-    expect(preview.drifted).toBe(true);
+    expect(preview.updateAvailable).toBe(true);
+    expect(preview.customized).toBe(true);
     expect(preview.diff.customPrompt?.after).toBe('new prompt');
+  });
+
+  it('previewWorkflowTemplateSync calls spaceWorkflow.previewTemplateSync RPC and returns the preview', async () => {
+    await spaceStore.selectSpace('space-1');
+
+    const preview = await spaceStore.previewWorkflowTemplateSync('wf1');
+
+    expect(mockHub.request).toHaveBeenCalledWith('spaceWorkflow.previewTemplateSync', {
+      id: 'wf1',
+      spaceId: 'space-1',
+    });
+    expect(preview.workflowId).toBe('wf1');
+    expect(preview.updateAvailable).toBe(true);
+    expect(preview.customized).toBe(true);
+    expect(preview.diff.description?.after).toBe('new desc');
   });
 
   it('ignores returned agent when the active space changes before the request resolves', async () => {

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -66,6 +66,7 @@ import type {
   UpdateSpaceTaskParams,
   UpdateSpaceWorkflowParams,
   WorkflowRunArtifact,
+  SpaceWorkflowSyncPreview,
 } from '@hyperneo/shared';
 import { isUUID, Logger } from '@hyperneo/shared';
 import { computed, signal } from '@preact/signals';
@@ -2914,6 +2915,27 @@ class SpaceStore {
       { id: workflowId, spaceId }
     );
     return workflow;
+  }
+
+  /**
+   * Preview the structural before/after diff that `syncWorkflowFromTemplate`
+   * would apply, without writing. Powers the "Review diff" affordance before a
+   * workflow reset — required when the row is both customized and has an update
+   * available. Throws if the space is not selected, the hub is not connected,
+   * or the daemon rejects (non-template workflow, template removed).
+   */
+  async previewWorkflowTemplateSync(workflowId: string): Promise<SpaceWorkflowSyncPreview> {
+    const spaceId = this.spaceId.value;
+    if (!spaceId) throw new Error('No space selected');
+
+    const hub = connectionManager.getHubIfConnected();
+    if (!hub) throw new Error('Not connected');
+
+    const { preview } = await hub.request<{ preview: SpaceWorkflowSyncPreview }>(
+      'spaceWorkflow.previewTemplateSync',
+      { id: workflowId, spaceId }
+    );
+    return preview;
   }
 
   // ========================================

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2654,7 +2654,10 @@ class SpaceStore {
     return agent;
   }
 
-  async syncAgentFromTemplate(agentId: string): Promise<SpaceWorkerAgent> {
+  async syncAgentFromTemplate(
+    agentId: string,
+    expectedRowHash?: string
+  ): Promise<SpaceWorkerAgent> {
     const spaceId = this.spaceId.value;
     if (!spaceId) throw new Error('No space selected');
 
@@ -2666,6 +2669,7 @@ class SpaceStore {
       {
         spaceId,
         agentId,
+        ...(expectedRowHash !== undefined ? { expectedRowHash } : {}),
       }
     );
     this.upsertAgent(agent, spaceId);
@@ -2903,7 +2907,10 @@ class SpaceStore {
    * Sync a workflow from its built-in template, overwriting current content.
    * Requires the workflow to have been created from a built-in template (templateName set).
    */
-  async syncWorkflowFromTemplate(workflowId: string): Promise<SpaceWorkflow> {
+  async syncWorkflowFromTemplate(
+    workflowId: string,
+    expectedRowHash?: string
+  ): Promise<SpaceWorkflow> {
     const spaceId = this.spaceId.value;
     if (!spaceId) throw new Error('No space selected');
 
@@ -2912,7 +2919,11 @@ class SpaceStore {
 
     const { workflow } = await hub.request<{ workflow: SpaceWorkflow }>(
       'spaceWorkflow.syncFromTemplate',
-      { id: workflowId, spaceId }
+      {
+        id: workflowId,
+        spaceId,
+        ...(expectedRowHash !== undefined ? { expectedRowHash } : {}),
+      }
     );
     return workflow;
   }


### PR DESCRIPTION
Splits the agent/workflow `drifted` boolean into two independent signals — `updateAvailable` (the template improved in code) and `customized` (the user edited the row) — so the UI can say precisely what happened instead of a confusing "Outdated" badge. The dangerous case (customized + update available) now gates the apply behind a diff review modal; reuses PR #2305's read-only `previewTemplateSync` for agents and adds a parallel structural preview for workflows, with no new write RPC (`syncFromTemplate` stays the only sync surface).

`updateAvailable` is byte-identical to the former `drifted` on a pristine row, so the existing sync path is unchanged. Covered all four states for both agents and workflows in tests; the only failing check is the pre-existing, unrelated `space-mcp-handlers` / `provider-registry` failures already present on `dev`.