### PR TITLE
fix(space): index node_executions(agent_session_id) for MCP self-heal path

### DIFF
--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -786,6 +786,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   // as M163 on this branch; renumbered three times — 164, 166, 167 — as dev
   // shipped unrelated M163/M164/M165/M166 migrations.)
   run(migrationMarkerKey(167), () => runMigration167(db));
+
+  // Migration 168: Index node_executions(agent_session_id) so the runtime MCP
+  // self-heal rebind path (and the live-query task-scope filter) stop doing a
+  // full table scan on every agent-session lookup.
+  run(migrationMarkerKey(168), () => runMigration168(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -11444,5 +11449,25 @@ export function runMigration165(db: BunDatabase): void {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_space_external_event_deliveries_state_updated
     ON space_external_event_deliveries(state, updated_at)
+  `);
+}
+
+/**
+ * Migration 168: Index node_executions(agent_session_id).
+ *
+ * `getByAgentSessionId` / `listByAgentSessionId` (node-execution-repository) and
+ * the `buildTaskScopeFilter` nodeExecStmt (live-query-handlers) filter on
+ * `agent_session_id`, which the runtime MCP self-heal rebind path reads on every
+ * reconnect. With no supporting index these are full table scans; this index
+ * turns them into an index lookup.
+ */
+export function runMigration168(db: BunDatabase): void {
+  // Guard on the column (not just the table): historical-marker seeding tests
+  // boot a sentinel node_executions with a minimal column set, and older shapes
+  // never carried agent_session_id. Nothing to index in either case.
+  if (!tableHasColumn(db, 'node_executions', 'agent_session_id')) return;
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_node_executions_agent_session
+    ON node_executions(agent_session_id)
   `);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -788,8 +788,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   run(migrationMarkerKey(167), () => runMigration167(db));
 
   // Migration 168: Index node_executions(agent_session_id) so the runtime MCP
-  // self-heal rebind path (and the live-query task-scope filter) stop doing a
-  // full table scan on every agent-session lookup.
+  // self-heal rebind path (node-execution-repository getByAgentSessionId /
+  // listByAgentSessionId) stops doing a full table scan on every agent-session
+  // lookup. (The live-query task-scope nodeExecStmt already drives off
+  // idx_node_executions_run and is unaffected.)
   run(migrationMarkerKey(168), () => runMigration168(db));
 }
 
@@ -11455,11 +11457,15 @@ export function runMigration165(db: BunDatabase): void {
 /**
  * Migration 168: Index node_executions(agent_session_id).
  *
- * `getByAgentSessionId` / `listByAgentSessionId` (node-execution-repository) and
- * the `buildTaskScopeFilter` nodeExecStmt (live-query-handlers) filter on
- * `agent_session_id`, which the runtime MCP self-heal rebind path reads on every
- * reconnect. With no supporting index these are full table scans; this index
- * turns them into an index lookup.
+ * Serves the node-execution-repository hot path (`getByAgentSessionId` /
+ * `listByAgentSessionId`), which the runtime MCP self-heal rebind reads on every
+ * reconnect. `WHERE agent_session_id = ?` was a full table scan; this index turns
+ * it into `SEARCH ... USING INDEX idx_node_executions_agent_session`.
+ *
+ * Note: `buildTaskScopeFilter`'s nodeExecStmt (live-query-handlers) also filters
+ * on agent_session_id, but EXPLAIN shows it drives off the space_tasks primary
+ * key and the pre-existing idx_node_executions_run (workflow_run_id), so it is
+ * already covered and is not what this index serves.
  */
 export function runMigration168(db: BunDatabase): void {
   // Guard on the column (not just the table): historical-marker seeding tests

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-168_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-168_test.ts
@@ -5,9 +5,10 @@
  * ON node_executions(agent_session_id).
  *
  * The runtime MCP self-heal rebind path reads node_executions by agent_session_id
- * (node-execution-repository getByAgentSessionId / listByAgentSessionId) and the
- * live-query task-scope filter (buildTaskScopeFilter nodeExecStmt) filters on the
- * same column. Without an index these are full table scans.
+ * via node-execution-repository getByAgentSessionId / listByAgentSessionId; with
+ * no index that lookup was a full table scan. (The live-query task-scope
+ * nodeExecStmt also filters on agent_session_id but drives off the space_tasks PK
+ * and the pre-existing idx_node_executions_run, so it is already covered.)
  *
  * Covers:
  * - Index is created by runMigration168 on an existing node_executions table

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-168_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-168_test.ts
@@ -1,0 +1,182 @@
+/**
+ * Migration 168 Tests
+ *
+ * Migration 168: CREATE INDEX idx_node_executions_agent_session
+ * ON node_executions(agent_session_id).
+ *
+ * The runtime MCP self-heal rebind path reads node_executions by agent_session_id
+ * (node-execution-repository getByAgentSessionId / listByAgentSessionId) and the
+ * live-query task-scope filter (buildTaskScopeFilter nodeExecStmt) filters on the
+ * same column. Without an index these are full table scans.
+ *
+ * Covers:
+ * - Index is created by runMigration168 on an existing node_executions table
+ * - No-op (no error) when node_executions does not exist yet
+ * - Idempotency: running M168 twice does not error
+ * - Full migration chain creates the index
+ * - EXPLAIN QUERY PLAN for WHERE agent_session_id = ? uses the index (SEARCH, not SCAN)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration168 } from '../../../../../src/storage/schema/migrations.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function indexExists(db: BunDatabase, indexName: string): boolean {
+  const row = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+    .get(indexName);
+  return !!row;
+}
+
+/** Returns the joined EXPLAIN QUERY PLAN detail lines for a query. */
+function explainQueryPlan(db: BunDatabase, sql: string, ...params: unknown[]): string {
+  const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{
+    detail: string;
+  }>;
+  return rows.map((r) => r.detail).join('\n');
+}
+
+/** Create a minimal node_executions table (post-M109 shape) for targeted tests. */
+function createNodeExecutionsTable(db: BunDatabase): void {
+  db.exec(`
+		CREATE TABLE node_executions (
+			id TEXT PRIMARY KEY,
+			workflow_run_id TEXT NOT NULL,
+			workflow_node_id TEXT NOT NULL,
+			agent_name TEXT NOT NULL,
+			agent_id TEXT,
+			agent_session_id TEXT,
+			status TEXT NOT NULL DEFAULT 'pending',
+			result TEXT,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('Migration 168: node_executions(agent_session_id) index', () => {
+  let testDir: string;
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    testDir = join(process.cwd(), 'tmp', 'test-migration-168', `test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    const dbPath = join(testDir, 'test.db');
+    db = new BunDatabase(dbPath);
+    db.exec('PRAGMA foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      // ignore
+    }
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('index is created on an existing node_executions table', () => {
+    createNodeExecutionsTable(db);
+    expect(indexExists(db, 'idx_node_executions_agent_session')).toBe(false);
+
+    runMigration168(db);
+
+    expect(indexExists(db, 'idx_node_executions_agent_session')).toBe(true);
+  });
+
+  test('no-op when node_executions does not exist', () => {
+    expect(() => runMigration168(db)).not.toThrow();
+    expect(indexExists(db, 'idx_node_executions_agent_session')).toBe(false);
+  });
+
+  test('runMigration168 is idempotent — running twice does not error', () => {
+    createNodeExecutionsTable(db);
+    runMigration168(db);
+    expect(() => runMigration168(db)).not.toThrow();
+    expect(indexExists(db, 'idx_node_executions_agent_session')).toBe(true);
+  });
+
+  test('full migration chain creates the index', () => {
+    runMigrations(db, () => {});
+    expect(indexExists(db, 'idx_node_executions_agent_session')).toBe(true);
+  });
+
+  test('EXPLAIN QUERY PLAN uses the index for WHERE agent_session_id = ?', () => {
+    createNodeExecutionsTable(db);
+    runMigration168(db);
+
+    const now = Date.now();
+    // Seed several rows with distinct agent_session_ids so the planner has a
+    // realistic table to reason about (an empty table can bias toward a scan).
+    const stmt = db.prepare(
+      `INSERT INTO node_executions (id, workflow_run_id, workflow_node_id, agent_name, agent_session_id, status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    for (let i = 0; i < 10; i++) {
+      stmt.run(`ne-${i}`, 'run-1', 'node-1', 'agent', `sess-${i}`, 'in_progress', now, now);
+    }
+
+    // Simple point lookup (the shape the task asks us to verify).
+    const plan = explainQueryPlan(
+      db,
+      'SELECT * FROM node_executions WHERE agent_session_id = ?',
+      'sess-5'
+    );
+    // SEARCH (not SCAN) via our index; SELECT * reads table columns so it's a
+    // non-covering lookup.
+    expect(plan).toMatch(/SEARCH node_executions USING INDEX idx_node_executions_agent_session/);
+    expect(plan).not.toContain('SCAN node_executions');
+
+    // Same column predicate the repository / live-query hot path uses. SELECT 1
+    // needs no table columns, so the planner treats the index as covering.
+    const repoPlan = explainQueryPlan(
+      db,
+      `SELECT 1 FROM node_executions WHERE agent_session_id = ? LIMIT 1`,
+      'sess-5'
+    );
+    expect(repoPlan).toMatch(
+      /SEARCH node_executions USING (COVERING )?INDEX idx_node_executions_agent_session/
+    );
+    expect(repoPlan).not.toContain('SCAN node_executions');
+  });
+
+  test('EXPLAIN QUERY PLAN full-scans without the index (regression guard)', () => {
+    // Without the index the same query must full-scan — proves the index is what
+    // flips the plan, and guards against the index being silently dropped.
+    createNodeExecutionsTable(db);
+
+    const now = Date.now();
+    const stmt = db.prepare(
+      `INSERT INTO node_executions (id, workflow_run_id, workflow_node_id, agent_name, agent_session_id, status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    for (let i = 0; i < 10; i++) {
+      stmt.run(`ne-${i}`, 'run-1', 'node-1', 'agent', `sess-${i}`, 'in_progress', now, now);
+    }
+
+    const plan = explainQueryPlan(
+      db,
+      'SELECT * FROM node_executions WHERE agent_session_id = ?',
+      'sess-5'
+    );
+    expect(plan).toContain('SCAN node_executions');
+    expect(plan).not.toContain('idx_node_executions_agent_session');
+  });
+});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -253,6 +253,9 @@ export function createSpaceTables(db: BunDatabase): void {
     `CREATE INDEX IF NOT EXISTS idx_node_executions_node ON node_executions(workflow_run_id, workflow_node_id)`
   );
   db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_node_executions_agent_session ON node_executions(agent_session_id)`
+  );
+  db.exec(
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_node_executions_unique_slot ` +
       `ON node_executions(workflow_run_id, workflow_node_id, agent_name)`
   );


### PR DESCRIPTION
`node_executions` had no `agent_session_id` index, so the runtime MCP self-heal rebind path (`getByAgentSessionId` / `listByAgentSessionId` in node-execution-repository) did a full table scan on every rebind.

Migration 168 adds `idx_node_executions_agent_session`; `EXPLAIN QUERY PLAN` for `WHERE agent_session_id = ?` now shows `SEARCH ... USING INDEX` instead of `SCAN node_executions`. (The live-query `buildTaskScopeFilter` nodeExecStmt also filters on `agent_session_id`, but it drives off the `space_tasks` PK and the pre-existing `idx_node_executions_run`, so it was already covered — not served by this index.) The index is mirrored in the space test-db bootstrap so test DBs match production.

Closes #2333.