### PR TITLE
feat(github-events): ingest pull_request_review_thread webhook (#2322)

### DIFF
--- a/packages/daemon/src/lib/external-events/event-essence.ts
+++ b/packages/daemon/src/lib/external-events/event-essence.ts
@@ -68,7 +68,7 @@ export function formatExternalEventEssence(event: ExternalEventPublishedPayload)
       'pullRequestReviewId',
     ]);
   } else if (eventType === 'pull_request_review_thread') {
-    copyExternalEventFields(essence, payload, ['threadId', 'path', 'line']);
+    copyExternalEventFields(essence, payload, ['threadId', 'path', 'line', 'side']);
   } else if (eventType === 'pull_request_review') {
     copyExternalEventFields(essence, payload, ['state', 'submittedAt']);
   } else if (eventType === 'pull_request') {

--- a/packages/daemon/src/lib/external-events/event-essence.ts
+++ b/packages/daemon/src/lib/external-events/event-essence.ts
@@ -67,6 +67,8 @@ export function formatExternalEventEssence(event: ExternalEventPublishedPayload)
       'inReplyToId',
       'pullRequestReviewId',
     ]);
+  } else if (eventType === 'pull_request_review_thread') {
+    copyExternalEventFields(essence, payload, ['threadId', 'path', 'line']);
   } else if (eventType === 'pull_request_review') {
     copyExternalEventFields(essence, payload, ['state', 'submittedAt']);
   } else if (eventType === 'pull_request') {

--- a/packages/daemon/src/lib/external-events/github/github-event-extension.ts
+++ b/packages/daemon/src/lib/external-events/github/github-event-extension.ts
@@ -162,6 +162,7 @@ const WEBHOOK_EVENTS = [
   'issue_comment',
   'pull_request_review',
   'pull_request_review_comment',
+  'pull_request_review_thread',
   'check_run',
   'status',
 ];

--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -7,6 +7,7 @@ export type GitHubEventKind =
   | 'issue_comment'
   | 'pull_request_review'
   | 'pull_request_review_comment'
+  | 'pull_request_review_thread'
   | 'pull_request'
   | 'check_run'
   | 'status'
@@ -29,11 +30,15 @@ export type GitHubEventKind =
  *
  * The review-THREAD node id that `resolveReviewThread`
  * (`ResolveReviewThreadInput.threadId` = `PullRequestReviewThread.id`) and
- * `addPullRequestReviewThreadReply` (`pullRequestReviewThreadId`) require is
- * intentionally NOT captured: a comment's `node_id` is NOT its thread's node id,
- * and GitHub does not include the thread node id in webhook payloads or the REST
- * `/pulls/comments` response. It must be resolved at runtime by querying the PR's
- * `reviewThreads` connection, so it belongs to the consumer, not the normalizer.
+ * `addPullRequestReviewThreadReply` (`pullRequestReviewThreadId`) require:
+ * - For `pull_request_review_thread` webhooks (resolved/unresolved) it IS
+ *   captured directly from `thread.node_id` — GitHub includes it on this event,
+ *   so no runtime lookup is needed.
+ * - For comment events (`pull_request_review_comment`) it is NOT captured: a
+ *   comment's `node_id` is NOT its thread's node id, and GitHub does not include
+ *   the thread node id in those webhook payloads or the REST `/pulls/comments`
+ *   response. It must be resolved at runtime by querying the PR's `reviewThreads`
+ *   connection, so it belongs to the consumer, not the normalizer.
  */
 export interface NormalizedGitHubEvent {
   deliveryId: string;
@@ -188,6 +193,7 @@ export function normalizeGitHubWebhook(
     eventType !== 'issue_comment' &&
     eventType !== 'pull_request_review' &&
     eventType !== 'pull_request_review_comment' &&
+    eventType !== 'pull_request_review_thread' &&
     eventType !== 'pull_request'
   ) {
     return null;
@@ -282,6 +288,40 @@ export function normalizeGitHubWebhook(
       originalSide: getString(comment.original_side),
       inReplyToId: getNumber(comment.in_reply_to_id) || undefined,
       pullRequestReviewId: getNumber(comment.pull_request_review_id) || undefined,
+    };
+  } else if (eventType === 'pull_request_review_thread') {
+    const pr = asObject(root.pull_request);
+    const thread = asObject(root.thread);
+    // This is the one payload that carries the review-THREAD node id directly
+    // (thread.node_id = `PullRequestReviewThread.id`), so the resolve/reply
+    // mutations can act on it without a runtime GraphQL `reviewThreads` lookup.
+    nodeId = getString(thread.node_id);
+    const comments = Array.isArray(thread.comments) ? thread.comments : [];
+    const rootComment = asObject(comments[0]);
+    actor = userFrom(root.sender);
+    prNumber = getNumber(pr.number);
+    body = getString(rootComment.body);
+    // The thread's root (top-level) comment REST id powers the reply endpoint.
+    commentId = idString(rootComment.id);
+    // Resolution toggles recur (resolve → unresolved → resolve again), so the
+    // delivery id must be part of the identity or a later resolve would dedupe
+    // against an earlier one (mirrors the `pull_request` action dedupe key).
+    externalId = `pull_request_review_thread:${nodeId || deliveryId}:${action}:${deliveryId}`;
+    externalUrl = getString(
+      rootComment.html_url,
+      getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
+    );
+    occurredAt = parseGitHubTimestamp(rootComment.updated_at ?? rootComment.created_at);
+    title = `PR #${prNumber} review thread ${action}`;
+    extraPayload = {
+      title,
+      threadId: nodeId,
+      resolveHandle: nodeId ? { kind: 'pull_request_review_thread', threadId: nodeId } : undefined,
+      commentNodeId: getString(rootComment.node_id),
+      replyHandle: commentId ? { kind: 'pull_request_review_comment', commentId } : undefined,
+      path: getString(rootComment.path),
+      line: getNumber(rootComment.line) || undefined,
+      side: getString(rootComment.side),
     };
   } else {
     const pr = asObject(root.pull_request);
@@ -704,6 +744,8 @@ export function mapEventType(
       return { resource: 'pull_request', entityId, action: `review_${action}` };
     case 'pull_request_review_comment':
       return { resource: 'pull_request', entityId, action: `review_comment_${action}` };
+    case 'pull_request_review_thread':
+      return { resource: 'pull_request', entityId, action: `thread_${action}` };
     case 'reaction':
       return { resource: 'pull_request', entityId, action: `reaction_${action}` };
     case 'check_run':

--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -23,10 +23,11 @@ export type GitHubEventKind =
  *   to reply to a review comment. For review comments this is the ROOT comment
  *   id (resolved via `in_reply_to_id`, since the reply endpoint rejects a reply's
  *   own id and review threads are flat); for issue comments it is the comment's
- *   own id (issue comments are not threaded). Populated for issue-comment and
- *   review-comment events; empty for reviews, PRs, check runs, and reactions.
+ *   own id (issue comments are not threaded); for review-thread events it is the
+ *   thread's root comment id. Populated for issue-comment, review-comment, and
+ *   review-thread events; empty for reviews, PRs, check runs, and reactions.
  * - `nodeId`: the GraphQL `node_id` of the event's primary entity (the comment,
- *   review, or pull request).
+ *   review, pull request, or thread).
  *
  * The review-THREAD node id that `resolveReviewThread`
  * (`ResolveReviewThreadInput.threadId` = `PullRequestReviewThread.id`) and

--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -311,7 +311,13 @@ export function normalizeGitHubWebhook(
       rootComment.html_url,
       getString(pr.html_url, prUrl(repo.owner, repo.repo, prNumber))
     );
-    occurredAt = parseGitHubTimestamp(rootComment.updated_at ?? rootComment.created_at);
+    // `pr.updated_at` is bumped by the resolution action itself, so it is the
+    // closest available proxy for when the thread was resolved/unresolved. The
+    // root comment's timestamps only move when its body is edited (unrelated to
+    // resolution), so they are fallbacks for thin payloads only.
+    occurredAt = parseGitHubTimestamp(
+      pr.updated_at ?? rootComment.updated_at ?? rootComment.created_at
+    );
     title = `PR #${prNumber} review thread ${action}`;
     extraPayload = {
       title,

--- a/packages/daemon/tests/unit/2-handlers/github/external-event-essence-contract.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/external-event-essence-contract.test.ts
@@ -143,6 +143,50 @@ function issueCommentWebhook(overrides: Record<string, unknown> = {}): unknown {
   };
 }
 
+function reviewThreadWebhook(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    action: 'resolved',
+    repository: {
+      id: 1,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      owner: { login: 'acme' },
+      archive_url: `https://api.github.com/repos/acme/widgets/{${RAW_SENTINEL}}`,
+    },
+    sender: { login: 'reviewer', type: 'User' },
+    pull_request: {
+      number: 42,
+      node_id: 'PR_kwDOA_root',
+      html_url: 'https://github.com/acme/widgets/pull/42',
+      head: { sha: 'abc123deadbeef', ref: 'feature/fix' },
+      user: { login: 'alice', type: 'User' },
+      updated_at: '2026-07-22T00:00:00Z',
+    },
+    // The thread node id is the `PullRequestReviewThread.id` resolveReviewThread
+    // needs — present on this webhook (unlike review-comment webhooks).
+    thread: {
+      node_id: 'PRRT_kwDOA_thread',
+      comments: [
+        {
+          id: 4242,
+          node_id: 'PRRC_kwDOA_rootcomment',
+          pull_request_review_id: 99,
+          body: LONG_REVIEW_BODY,
+          path: 'packages/daemon/src/lib/external-events/delivery.ts',
+          line: 87,
+          side: 'RIGHT',
+          commit_id: 'abc123deadbeef',
+          html_url: 'https://github.com/acme/widgets/pull/42#discussion_r4242',
+          user: { login: 'reviewer', type: 'User' },
+          created_at: '2026-07-22T00:00:00Z',
+          updated_at: '2026-07-22T00:05:00Z',
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
 function reviewCommentPollingRow(): Record<string, unknown> {
   return {
     id: 4242,
@@ -333,6 +377,35 @@ describe('external_event essence contract — body + handles', () => {
       kind: 'pull_request_review_comment',
       commentId: '4242',
     });
+  });
+
+  it('pull_request_review_thread webhook projects the thread node id and resolveHandle into the essence', () => {
+    const event = webhookToEvent('pull_request_review_thread', reviewThreadWebhook());
+
+    // Re-expressed topic + the thread node id captured directly from the payload.
+    expect(event.topic).toBe('github/acme/widgets/pull_request/42.thread_resolved');
+    expect(event.payload.threadId).toBe('PRRT_kwDOA_thread');
+    expect(event.payload.resolveHandle).toEqual({
+      kind: 'pull_request_review_thread',
+      threadId: 'PRRT_kwDOA_thread',
+    });
+
+    const essence = essenceOf(event);
+    expect(essence.eventType).toBe('pull_request_review_thread');
+    expect(essence.action).toBe('resolved');
+    expect(essence.threadId).toBe('PRRT_kwDOA_thread');
+    expect(essence.resolveHandle).toEqual({
+      kind: 'pull_request_review_thread',
+      threadId: 'PRRT_kwDOA_thread',
+    });
+    // The thread's root comment body and location reach the essence as context.
+    expect(essence.body).toBe(LONG_REVIEW_BODY);
+    expect(essence).toMatchObject({
+      path: 'packages/daemon/src/lib/external-events/delivery.ts',
+      line: 87,
+    });
+    // Raw payload (incl. the deep sentinel) never leaks into the injected essence.
+    expect(JSON.stringify(essence)).not.toContain(RAW_SENTINEL);
   });
 });
 

--- a/packages/daemon/tests/unit/2-handlers/github/external-event-essence-contract.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/external-event-essence-contract.test.ts
@@ -160,7 +160,8 @@ function reviewThreadWebhook(overrides: Record<string, unknown> = {}): unknown {
       html_url: 'https://github.com/acme/widgets/pull/42',
       head: { sha: 'abc123deadbeef', ref: 'feature/fix' },
       user: { login: 'alice', type: 'User' },
-      updated_at: '2026-07-22T00:00:00Z',
+      // Resolution bumps the PR's updated_at; it is the latest timestamp here.
+      updated_at: '2026-07-22T00:10:00Z',
     },
     // The thread node id is the `PullRequestReviewThread.id` resolveReviewThread
     // needs — present on this webhook (unlike review-comment webhooks).
@@ -398,11 +399,13 @@ describe('external_event essence contract — body + handles', () => {
       kind: 'pull_request_review_thread',
       threadId: 'PRRT_kwDOA_thread',
     });
-    // The thread's root comment body and location reach the essence as context.
+    // The thread's root comment body and full location (path/line/side) reach
+    // the essence as context, matching the pull_request_review_comment projection.
     expect(essence.body).toBe(LONG_REVIEW_BODY);
     expect(essence).toMatchObject({
       path: 'packages/daemon/src/lib/external-events/delivery.ts',
       line: 87,
+      side: 'RIGHT',
     });
     // Raw payload (incl. the deep sentinel) never leaks into the injected essence.
     expect(JSON.stringify(essence)).not.toContain(RAW_SENTINEL);

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -118,6 +118,34 @@ function payloadFor(event: string): unknown {
       },
     };
   }
+  if (event === 'pull_request_review_thread') {
+    return {
+      action: 'resolved',
+      repository: baseRepo,
+      sender: { login: 'reviewer', type: 'User' },
+      pull_request: {
+        number: 7,
+        html_url: 'https://github.com/acme/widgets/pull/7',
+        user: { login: 'dev', type: 'User' },
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      thread: {
+        node_id: 'PRRT_kwAAA_thread',
+        comments: [
+          {
+            id: 4242,
+            node_id: 'PRRC_kwAAA_root',
+            body: 'nit: rename this',
+            path: 'src/file.ts',
+            line: 12,
+            html_url: 'https://github.com/acme/widgets/pull/7#discussion_r4242',
+            user: { login: 'reviewer', type: 'User' },
+            created_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+    };
+  }
   return {
     action: 'synchronize',
     repository: baseRepo,
@@ -417,6 +445,43 @@ describe('GitHubEventExtension', () => {
       webhookRequest(otherRepoPayload, 'issue_comment', await createSignature(otherRaw, 'secret'))
     );
     expect(repoNotWatched.status).toBe(404);
+
+    await extension.stop();
+  });
+
+  test('webhook delivers pull_request_review_thread as a .thread_resolved event', async () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO spaces (id, slug, name, workspace_path, status, created_at, updated_at) VALUES ('space-1', 'space-1', 'Space', '/tmp', 'active', 1, 1)`
+    ).run();
+    const { service, received } = setupExternalEventService(db);
+    const extension = new GitHubEventExtension(db);
+    const context = {
+      publisher: service,
+      config: new StaticExternalEventExtensionConfigStore({ globallyEnabled: true }),
+      onSourceConfigChanged() {},
+    };
+    await extension.start(context);
+    extension.repo.upsertWatchedRepo({
+      spaceId: 'space-1',
+      owner: 'acme',
+      repo: 'widgets',
+      webhookSecret: 'secret',
+    });
+
+    const payload = payloadFor('pull_request_review_thread');
+    const raw = JSON.stringify(payload);
+    const ok = await extension.routes[0].handle(
+      webhookRequest(payload, 'pull_request_review_thread', await createSignature(raw, 'secret'))
+    );
+    expect(ok.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received[0].topic).toBe('github/acme/widgets/pull_request/7.thread_resolved');
+    // The thread node id captured from the payload powers resolve actions downstream.
+    expect(received[0].payload.resolveHandle).toEqual({
+      kind: 'pull_request_review_thread',
+      threadId: 'PRRT_kwAAA_thread',
+    });
 
     await extension.stop();
   });
@@ -867,6 +932,7 @@ describe('GitHubEventExtension', () => {
         'issue_comment',
         'pull_request_review',
         'pull_request_review_comment',
+        'pull_request_review_thread',
         'check_run',
         'status',
       ]);
@@ -1391,6 +1457,7 @@ describe('GitHubEventExtension', () => {
               'issue_comment',
               'pull_request_review',
               'pull_request_review_comment',
+              'pull_request_review_thread',
               'check_run',
             ],
             config: { url: 'https://example.com/webhook/github/space', content_type: 'json' },
@@ -2205,6 +2272,7 @@ describe('GitHubEventExtension', () => {
               'issue_comment',
               'pull_request_review',
               'pull_request_review_comment',
+              'pull_request_review_thread',
               'check_run',
             ],
             config: { url: 'https://example.com/webhook/github/space', content_type: 'json' },
@@ -2333,6 +2401,7 @@ describe('GitHubEventExtension', () => {
               'issue_comment',
               'pull_request_review',
               'pull_request_review_comment',
+              'pull_request_review_thread',
               'check_run',
               'status',
             ],
@@ -2446,6 +2515,7 @@ describe('GitHubEventExtension', () => {
               'issue_comment',
               'pull_request_review',
               'pull_request_review_comment',
+              'pull_request_review_thread',
               'check_run',
             ],
             config: { url: 'https://example.com/webhook/github/space', content_type: 'form' },

--- a/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
@@ -137,7 +137,9 @@ function reviewThreadWebhook(overrides: Record<string, unknown> = {}): unknown {
       node_id: 'PR_kwAAA_pull',
       html_url: 'https://github.com/acme/widgets/pull/7',
       user: { login: 'dev', type: 'User' },
-      updated_at: '2026-01-01T00:00:00Z',
+      // Resolution bumps the PR's updated_at, so it is the latest timestamp and
+      // the closest proxy for when the thread was actually resolved.
+      updated_at: '2026-01-01T00:10:00Z',
     },
     thread: {
       node_id: 'PRRT_kwAAA_thread',
@@ -868,6 +870,9 @@ describe('normalizeGitHubWebhook — pull_request_review_thread', () => {
     expect(normalized.prNumber).toBe(7);
     expect(normalized.actor).toBe('reviewer');
     expect(normalized.body).toBe('nit: rename this');
+    // occurredAt tracks the PR's updated_at (resolution time), NOT the root
+    // comment's updated_at (last text edit) — which is older here (00:05 < 00:10).
+    expect(normalized.occurredAt).toBe(Date.parse('2026-01-01T00:10:00Z'));
     expect(normalized.payload).toMatchObject({
       title: 'PR #7 review thread resolved',
       threadId: 'PRRT_kwAAA_thread',
@@ -937,5 +942,18 @@ describe('normalizeGitHubWebhook — pull_request_review_thread', () => {
     // No thread id → no resolveHandle, but the event still publishes.
     expect(event.payload.resolveHandle).toBeUndefined();
     expect(event.topic).toBe('github/acme/widgets/pull_request/7.thread_resolved');
+  });
+
+  test('occurredAt falls back to the root comment timestamp when the PR object is thin', () => {
+    // A minimal webhook (no pr.updated_at) must still source a sensible time from
+    // the root comment rather than defaulting to the receive time.
+    const normalized = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-4',
+      reviewThreadWebhook({
+        pull_request: { number: 7, html_url: 'https://github.com/acme/widgets/pull/7' },
+      })
+    )!;
+    expect(normalized.occurredAt).toBe(Date.parse('2026-01-01T00:05:00Z'));
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-normalizer.test.ts
@@ -124,6 +124,43 @@ function pullRequestWebhook(overrides: Record<string, unknown> = {}): unknown {
   };
 }
 
+// `pull_request_review_thread` webhook (resolved/unresolved). Unlike review-
+// comment events, this payload carries the review-THREAD node id directly at
+// `thread.node_id` (the `PullRequestReviewThread.id` resolveReviewThread needs).
+function reviewThreadWebhook(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    action: 'resolved',
+    repository: { id: 1, name: 'widgets', full_name: 'Acme/Widgets', owner: { login: 'Acme' } },
+    sender: { login: 'reviewer', type: 'User' },
+    pull_request: {
+      number: 7,
+      node_id: 'PR_kwAAA_pull',
+      html_url: 'https://github.com/acme/widgets/pull/7',
+      user: { login: 'dev', type: 'User' },
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    thread: {
+      node_id: 'PRRT_kwAAA_thread',
+      comments: [
+        {
+          id: 4242,
+          node_id: 'PRRC_kwAAA_rootcomment',
+          pull_request_review_id: 99,
+          body: 'nit: rename this',
+          path: 'packages/daemon/src/file.ts',
+          line: 12,
+          side: 'RIGHT',
+          html_url: 'https://github.com/acme/widgets/pull/7#discussion_r4242',
+          user: { login: 'reviewer', type: 'User' },
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:05:00Z',
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
 describe('normalizeGitHubPollingRow — renamed repo uses payload URL, not stale watched config', () => {
   const staleWatched: GitHubPollingRepo = { owner: 'lsm', repo: 'neokai' };
 
@@ -813,5 +850,92 @@ describe('mapEventType — status', () => {
       action: 'status_failure',
     });
     expect(mapEventType('status', 'pending', '7').action).toBe('status_pending');
+  });
+});
+
+describe('normalizeGitHubWebhook — pull_request_review_thread', () => {
+  test('resolved action re-expresses as .thread_resolved and captures the thread node id', () => {
+    const normalized = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-1',
+      reviewThreadWebhook()
+    )!;
+    expect(normalized).not.toBeNull();
+    // The thread node id (the primary entity) is captured directly from the payload.
+    expect(normalized.nodeId).toBe('PRRT_kwAAA_thread');
+    // The root comment REST id powers the reply endpoint.
+    expect(normalized.commentId).toBe('4242');
+    expect(normalized.prNumber).toBe(7);
+    expect(normalized.actor).toBe('reviewer');
+    expect(normalized.body).toBe('nit: rename this');
+    expect(normalized.payload).toMatchObject({
+      title: 'PR #7 review thread resolved',
+      threadId: 'PRRT_kwAAA_thread',
+      resolveHandle: { kind: 'pull_request_review_thread', threadId: 'PRRT_kwAAA_thread' },
+      replyHandle: { kind: 'pull_request_review_comment', commentId: '4242' },
+      path: 'packages/daemon/src/file.ts',
+      line: 12,
+    });
+
+    const event = toExternalEvent('space-1', normalized);
+    expect(event.topic).toBe('github/acme/widgets/pull_request/7.thread_resolved');
+    expect(event.payload.resolveHandle).toEqual({
+      kind: 'pull_request_review_thread',
+      threadId: 'PRRT_kwAAA_thread',
+    });
+  });
+
+  test('unresolved action re-expresses as .thread_unresolved', () => {
+    const normalized = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-2',
+      reviewThreadWebhook({ action: 'unresolved' })
+    )!;
+    const event = toExternalEvent('space-1', normalized);
+    expect(event.topic).toBe('github/acme/widgets/pull_request/7.thread_unresolved');
+    // resolveHandle still identifies the thread regardless of transition direction.
+    expect(event.payload.resolveHandle).toEqual({
+      kind: 'pull_request_review_thread',
+      threadId: 'PRRT_kwAAA_thread',
+    });
+  });
+
+  test('distinct resolution transitions of the same thread do not dedupe', () => {
+    // A thread can be resolved, un-resolved, then resolved again. Each transition
+    // is a separate GitHub delivery, so the two `resolved` events must keep
+    // distinct dedupe keys (keyed by delivery id, like `pull_request` actions).
+    const first = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-resolve-1',
+      reviewThreadWebhook()
+    )!;
+    const second = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-resolve-2',
+      reviewThreadWebhook()
+    )!;
+    expect(second.dedupeKey).not.toBe(first.dedupeKey);
+    // Redelivering the same delivery id collapses to one event.
+    const redelivery = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-resolve-1',
+      reviewThreadWebhook()
+    )!;
+    expect(redelivery.dedupeKey).toBe(first.dedupeKey);
+  });
+
+  test('missing thread.node_id still normalizes and omits resolveHandle', () => {
+    const normalized = normalizeGitHubWebhook(
+      'pull_request_review_thread',
+      'delivery-3',
+      reviewThreadWebhook({ thread: { comments: [] } })
+    )!;
+    expect(normalized).not.toBeNull();
+    expect(normalized.nodeId).toBe('');
+    expect(normalized.commentId).toBe('');
+    const event = toExternalEvent('space-1', normalized);
+    // No thread id → no resolveHandle, but the event still publishes.
+    expect(event.payload.resolveHandle).toBeUndefined();
+    expect(event.topic).toBe('github/acme/widgets/pull_request/7.thread_resolved');
   });
 });

--- a/packages/web/src/components/space/SpaceExternalEventsSettings.tsx
+++ b/packages/web/src/components/space/SpaceExternalEventsSettings.tsx
@@ -769,8 +769,8 @@ export function SpaceExternalEventsSettings({
               </div>
               <p class="mt-1 text-xs text-gray-400">
                 Use a public HTTPS tunnel for local development. Configure GitHub webhooks for
-                pull_request, issue_comment, pull_request_review, pull_request_review_comment, and
-                check_run events.
+                pull_request, issue_comment, pull_request_review, pull_request_review_comment,
+                pull_request_review_thread, and check_run events.
               </p>
             </div>
 


### PR DESCRIPTION
Subscribes to the `pull_request_review_thread` (resolved/unresolved) webhook and re-expresses it as `.thread_resolved` / `.thread_unresolved` topics — `github/owner/repo/pull_request/N.thread_resolved` — so the require-conversation-resolution rule can react to thread state changes instead of re-querying the `reviewThreads` GraphQL connection each time.

Unlike review-comment events, this payload carries the review-thread node id directly (`thread.node_id` = `PullRequestReviewThread.id`), so the normalizer populates a `resolveHandle` keyed to it with no runtime lookup. Resolution toggles recur (resolve → unresolved → resolve), so the dedupe identity includes the delivery id, mirroring the `pull_request` pattern.

Touches the normalizer (`GitHubEventKind`, accept guard, normalization branch, `mapEventType`), the essence formatter (projects `threadId`/`path`/`line`), and `WEBHOOK_EVENTS` so auto-registered hooks receive the event and `validateRemoteHook` enforces it.