### PR TITLE
feat(github-events): re-express draft + queue transitions as distinct topics (#2328)

### DIFF
--- a/packages/daemon/src/lib/external-events/github/github-normalizer.ts
+++ b/packages/daemon/src/lib/external-events/github/github-normalizer.ts
@@ -625,9 +625,29 @@ export function mapEventType(
     case 'check_run':
       return { resource: 'pull_request', entityId, action: 'check_failed' };
     case 'pull_request':
-      return { resource: 'pull_request', entityId, action };
+      // Re-express draft-state and merge-queue transitions as distinct,
+      // matchable topics so consumers can subscribe/branch directly instead of
+      // pattern-matching raw GitHub actions. `converted_to_draft` is renamed
+      // `draft_opened` (the natural counterpart to ready_for_review — entering
+      // vs. leaving draft state); the queue actions already carry matchable
+      // names. Every other pull_request action (opened, closed, synchronize,
+      // labeled, ...) keeps raw passthrough — only these four transitions are
+      // re-expressed.
+      return {
+        resource: 'pull_request',
+        entityId,
+        action: PR_TRANSITION_TOPIC[action] ?? action,
+      };
   }
 }
+
+/** Distinct topics for the four draft/queue transition actions. See mapEventType. */
+const PR_TRANSITION_TOPIC: Record<string, string> = {
+  converted_to_draft: 'draft_opened',
+  ready_for_review: 'ready_for_review',
+  enqueued: 'enqueued',
+  dequeued: 'dequeued',
+};
 
 export function toExternalEvent(spaceId: string, event: NormalizedGitHubEvent): ExternalEvent {
   const repoOwner = event.repoOwner.toLowerCase();

--- a/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/github-event-extension.test.ts
@@ -357,6 +357,42 @@ describe('GitHubEventExtension', () => {
     expect(normalizeGitHubWebhook('check_run', 'delivery-1', payload)).toBeNull();
   });
 
+  test('re-expresses draft and merge-queue transitions as distinct pull_request topics', () => {
+    // converted_to_draft is renamed draft_opened (the counterpart to
+    // ready_for_review); the queue actions keep their GitHub names. The raw
+    // action is preserved in the payload and dedupeKey — only the topic is
+    // re-expressed.
+    const transitions: Array<[string, string]> = [
+      ['converted_to_draft', 'draft_opened'],
+      ['ready_for_review', 'ready_for_review'],
+      ['enqueued', 'enqueued'],
+      ['dequeued', 'dequeued'],
+    ];
+    for (const [action, topicAction] of transitions) {
+      const payload = { ...(payloadFor('pull_request') as Record<string, unknown>), action };
+      const normalized = normalizeGitHubWebhook('pull_request', 'delivery-1', payload)!;
+      expect(mapEventType(normalized.eventType, normalized.action, normalized.entityId)).toEqual({
+        resource: 'pull_request',
+        entityId: '7',
+        action: topicAction,
+      });
+      const event = toExternalEvent('space-1', normalized);
+      expect(event.topic).toBe(`github/acme/widgets/pull_request/7.${topicAction}`);
+      expect(event.payload.action).toBe(action);
+      // dedupeKey is keyed on the raw GitHub action, not the re-expressed topic.
+      expect(event.dedupeKey).toBe(`acme/widgets:pull_request:77:${action}:delivery-1`);
+    }
+  });
+
+  test('keeps raw passthrough for non-transition pull_request actions', () => {
+    for (const action of ['opened', 'closed', 'synchronize', 'reopened', 'labeled', 'edited']) {
+      const payload = { ...(payloadFor('pull_request') as Record<string, unknown>), action };
+      const normalized = normalizeGitHubWebhook('pull_request', 'delivery-1', payload)!;
+      const event = toExternalEvent('space-1', normalized);
+      expect(event.topic).toBe(`github/acme/widgets/pull_request/7.${action}`);
+    }
+  });
+
   test('webhook verifies signatures, checks enablement, and publishes ExternalEventService event', async () => {
     const db = setupDb();
     db.prepare(


### PR DESCRIPTION
Row 8 of the #2320 spec. `pull_request` actions `converted_to_draft`, `ready_for_review`, `enqueued`, `dequeued` previously flowed as the raw `pull_request/<id>.<action>` topic, requiring consumers to pattern-match raw GitHub actions.

This extends the `mapEventType` `pull_request` case to emit distinct, matchable topics: `converted_to_draft` → `draft_opened` (the counterpart to `ready_for_review`), while the three queue actions keep their GitHub names. All other `pull_request` actions keep raw passthrough. The raw action is preserved in the payload and dedupeKey — only the topic is re-expressed.

Closes #2328.
