### PR TITLE
perf(daemon): drop redundant sdk_messages indexes; use sdk_uuid column [#2335]

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2891,7 +2891,7 @@ WITH top_level AS (
   -- Cap window orders by (timestamp, rowid) so a LiveQuery limit that cuts
   -- through same-millisecond hook_started/progress/response rows keeps the
   -- later phases (insertion order) instead of dropping the terminal response
-  -- by random UUID. The planner falls back to idx_sdk_messages_session + a
+  -- by random UUID. The planner falls back to idx_sdk_messages_session_timestamp_id + a
   -- bounded temp sort (rowid isn't in the composite index) — acceptable for a
   -- capped window, and correctness beats the micro-optimisation here.
   ORDER BY timestamp DESC, rowid DESC

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1155,8 +1155,7 @@ export class SDKMessageRepository {
       `SELECT id, sdk_message, timestamp FROM sdk_messages
 	       WHERE session_id = ?
 	         AND send_status = ?
-	         AND json_extract(sdk_message, '$.uuid') = ?
-	       ORDER BY timestamp ASC
+	         AND sdk_uuid = ?
 	       LIMIT 1`
     );
     const row = stmt.get(sessionId, status, uuid) as {
@@ -1379,41 +1378,24 @@ export class SDKMessageRepository {
   }
 
   /**
-   * Get a single user message by UUID
+   * Get a single user message by UUID.
    *
    * Used by rewind to look up a specific checkpoint/message.
    *
-   * The previous implementation loaded every user row for the session and
-   * scanned in JS — O(N) per lookup. The current form uses
-   * `idx_sdk_messages_uuid_status (session_id, send_status,
-   * json_extract uuid)` for a full 3-column index seek.
+   * Seeks `idx_sdk_messages_session_uuid (session_id, sdk_uuid)` directly.
+   * `sdk_uuid` is populated for every row — set at INSERT time via
+   * `extractSdkUuid` and backfilled for legacy rows by migration 163 — so
+   * filtering on the column is equivalent to `json_extract(sdk_message,'$.uuid')`
+   * without the per-row JSON parse. The old implementation probed each
+   * `send_status` in turn because the superseded `idx_sdk_messages_uuid_status`
+   * (session_id, send_status, json_extract uuid) only picked its 3-column seek
+   * when `send_status` was constrained to a single value; that workaround is
+   * gone now that the index has been dropped.
    *
-   * Coverage must match `getUserMessages` (which returns user rows of
-   * every `send_status`), otherwise rewind would surface a checkpoint
-   * it then can't resolve. We probe each known status in turn — the
-   * planner only picks the full 3-column seek when `send_status` is
-   * constrained to a single value, so `IN (…)` is not enough — and a
-   * final fallback covers legacy rows with NULL `send_status` (none
-   * observed in the current production DB but historically possible).
-   *
-   * Determinism: if duplicate uuids exist within the same session
-   * (no DB-level uniqueness constraint on the json_extract'd uuid),
-   * the previous implementation returned the chronologically earliest
-   * row across the whole session. We preserve that by collecting every
-   * matching row from each per-status seek (via `.all()` rather than
-   * `LIMIT 1`) and picking the overall earliest in JS. The NULL
-   * fallback is only consulted when no indexed-status seek matched,
-   * so legacy and modern data don't compete on every call — a
-   * duplicate uuid co-existing across NULL and a known status in the
-   * same session is not a real-world case.
-   *
-   * Benchmark on the largest production session (3 335 user rows in a
-   * 42 061-row table): ~294 ms (before, full-function wall-clock) →
-   * ~0.95 ms (after, full-function wall-clock) — ~310x speedup. The
-   * raw 4-seek SQLite cost is only ~0.04 ms; the remainder is
-   * JSON.parse + content extraction on the matched row. NULL fallback
-   * alone is ~220 ms but only runs when no indexed status matched,
-   * which the production DB has never been observed to need.
+   * There is no DB-level uniqueness constraint on `sdk_uuid`, so a uuid can in
+   * principle be shared by several user rows in the same session. We collect
+   * every match and return the chronologically earliest — rewind's
+   * deletion-bound math depends on the timestamp being the earliest occurrence.
    *
    * @param sessionId - The session ID
    * @param uuid - The message UUID
@@ -1423,62 +1405,23 @@ export class SDKMessageRepository {
     sessionId: string,
     uuid: string
   ): { uuid: string; timestamp: number; content: string } | undefined {
-    // Fast path: indexed seek against idx_sdk_messages_uuid_status. We
-    // probe each known send_status separately because the planner only
-    // picks the 3-column index when send_status is constrained to a
-    // single value; `IN (…)` falls back to a session-partition scan.
-    // We deliberately omit `ORDER BY` here — adding one causes the
-    // planner to switch to `idx_sdk_messages_session (session_id,
-    // timestamp)` and lose the indexed seek (~0.01 ms → ~200 ms).
-    // In-bucket determinism is recovered by collecting all matches per
-    // bucket and picking the earliest in JS below.
-    const indexedStmt = this.db.prepare(
-      `SELECT sdk_message, timestamp FROM sdk_messages
-       WHERE session_id = ?
-         AND send_status = ?
-         AND message_type = 'user'
-         AND json_extract(sdk_message, '$.uuid') = ?`
-    );
-
-    const STATUSES_TO_PROBE: SendStatus[] = ['consumed', 'failed', 'enqueued', 'deferred'];
-    const candidates: Array<{ sdk_message: string; timestamp: string }> = [];
-    for (const status of STATUSES_TO_PROBE) {
-      const rows = indexedStmt.all(sessionId, status, uuid) as Array<{
-        sdk_message: string;
-        timestamp: string;
-      }>;
-      for (const r of rows) candidates.push(r);
-    }
-
-    // Fallback: legacy rows with NULL send_status. Not observed in the
-    // current production DB but historically possible. This path scans
-    // the session partition rather than seeking the index, so only run
-    // it when no indexed status seek matched — otherwise it would
-    // dominate the cost on every call.
-    if (candidates.length === 0) {
-      const fallbackStmt = this.db.prepare(
+    const rows = this.db
+      .prepare(
         `SELECT sdk_message, timestamp FROM sdk_messages
-       WHERE session_id = ?
-         AND send_status IS NULL
-         AND message_type = 'user'
-         AND json_extract(sdk_message, '$.uuid') = ?
-       ORDER BY timestamp ASC
-       LIMIT 1`
-      );
-      const nullRow = fallbackStmt.get(sessionId, uuid) as
-        | { sdk_message: string; timestamp: string }
-        | undefined;
-      if (nullRow) candidates.push(nullRow);
-    }
+         WHERE session_id = ?
+           AND message_type = 'user'
+           AND sdk_uuid = ?`
+      )
+      .all(sessionId, uuid) as Array<{ sdk_message: string; timestamp: string }>;
+    if (rows.length === 0) return undefined;
 
-    if (candidates.length === 0) return undefined;
-
-    // Pick the chronologically earliest match — matches the previous
-    // full-session ORDER BY timestamp ASC scan + first-match behavior
-    // that rewind timestamp math depends on.
-    let earliest = candidates[0];
-    for (let i = 1; i < candidates.length; i++) {
-      if (candidates[i].timestamp < earliest.timestamp) earliest = candidates[i];
+    // Pick the chronologically earliest match — preserves the previous
+    // full-session ORDER BY timestamp ASC + first-match behavior that rewind
+    // timestamp math depends on (only relevant if a uuid is shared by several
+    // user rows in the same session).
+    let earliest = rows[0];
+    for (let i = 1; i < rows.length; i++) {
+      if (rows[i].timestamp < earliest.timestamp) earliest = rows[i];
     }
     return this.parseUserMessageRow(earliest, uuid);
   }
@@ -1684,14 +1627,14 @@ export class SDKMessageRepository {
         `SELECT id FROM sdk_messages
        WHERE session_id = ?
          AND message_type = 'hyperneo_action'
-         AND json_extract(sdk_message, '$.uuid') = ?`
+         AND sdk_uuid = ?`
       )
       .get(sessionId, messageUuid) as { id: string } | undefined;
     const stmt = this.db.prepare(
       `UPDATE sdk_messages SET sdk_message = ?
        WHERE session_id = ?
          AND message_type = 'hyperneo_action'
-         AND json_extract(sdk_message, '$.uuid') = ?`
+         AND sdk_uuid = ?`
     );
     stmt.run(JSON.stringify(updated), sessionId, messageUuid);
     if (row) this.upsertMessageSearchRow(row.id);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -924,8 +924,8 @@ function createAgentMemoryTables(db: BunDatabase): void {
  * Create database indexes for performance
  */
 function createIndexes(db: BunDatabase): void {
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session
-      ON sdk_messages(session_id, timestamp)`);
+  // idx_sdk_messages_session (session_id, timestamp) was dropped in migration
+  // 173 — a strict prefix of idx_sdk_messages_session_timestamp_id below.
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
       ON sdk_messages(session_id, timestamp DESC, id DESC)`);
   // Plain B-tree index over the materialised parent_tool_use_id column.
@@ -935,8 +935,9 @@ function createIndexes(db: BunDatabase): void {
       ON sdk_messages(session_id, parent_tool_use_id)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_renderable_terminal
       ON sdk_messages(session_id, is_renderable, is_terminal, timestamp, id)`);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_uuid_status
-      ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`);
+  // idx_sdk_messages_uuid_status (session_id, send_status, json_extract uuid)
+  // was dropped in migration 173 — superseded by idx_sdk_messages_session_uuid
+  // (session_id, sdk_uuid); the uuid lookups now filter on the sdk_uuid column.
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_type
       ON sdk_messages(message_type, message_subtype)`);
   // Makes the chat-view subtype filters sargable: the messages.bySession

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -832,6 +832,16 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   //   orphans so drift forces a diff review before any overwrite. Idempotent /
   //   no-op on already-tracked rows. See m172-backfill-orphaned-preset-agents.ts.
   run(migrationMarkerKey(172), () => runMigration172(db));
+
+  // Migration 173: Drop the redundant idx_sdk_messages_session (a strict
+  // prefix of idx_sdk_messages_session_timestamp_id) and the superseded
+  // idx_sdk_messages_uuid_status expression index (replaced by the column
+  // index idx_sdk_messages_session_uuid from M163; the uuid lookups now
+  // filter on the sdk_uuid column directly). New databases never receive
+  // either index — this brings existing ones to parity. Idempotent via
+  // DROP INDEX IF EXISTS. (Originally M170 on this branch; renumbered to
+  // M173 because dev shipped M170/M171/M172 for preset/template backfills.)
+  run(migrationMarkerKey(173), () => runMigration173(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -11582,4 +11592,27 @@ export function runMigration169(db: BunDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_subtype_parent
     ON sdk_messages(session_id, message_subtype_norm, parent_tool_use_id)
   `);
+}
+
+/**
+ * Migration 173: Drop two redundant `sdk_messages` indexes.
+ *
+ * - `idx_sdk_messages_session (session_id, timestamp)` is a strict prefix of
+ *   `idx_sdk_messages_session_timestamp_id (session_id, timestamp DESC, id DESC)`,
+ *   so every query the 2-column index served is served at least as well by the
+ *   3-column index. Maintaining the extra B-tree forced an update on every
+ *   insert into the multi-million-row table for no query benefit.
+ * - `idx_sdk_messages_uuid_status (session_id, send_status, json_extract uuid)`
+ *   — the expression index added in M113 — is superseded by the column index
+ *   `idx_sdk_messages_session_uuid (session_id, sdk_uuid)` from M163. The three
+ *   uuid lookups now filter on the `sdk_uuid` column directly, so the
+ *   expression index is dead weight (and slower, parsing JSON per row).
+ *
+ * New databases never receive either index (createIndexes no longer creates
+ * them); this brings existing databases to parity. Idempotent.
+ */
+export function runMigration173(db: BunDatabase): void {
+  if (!tableExists(db, 'sdk_messages')) return;
+  db.exec(`DROP INDEX IF EXISTS idx_sdk_messages_session`);
+  db.exec(`DROP INDEX IF EXISTS idx_sdk_messages_uuid_status`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -783,10 +783,9 @@ describe('messages.bySession — SQL behavior', () => {
   test('uses the session timestamp index for the top-level window', () => {
     const plan = queryPlan(db, 's1', 200);
     // The top-level window is session-scoped, so it must use a session index
-    // (either the composite idx_sdk_messages_session_timestamp_id or the
-    // shorter idx_sdk_messages_session) and never a full table scan. The cap
-    // orders by (timestamp, rowid) for correct same-ms hook-phase ordering, so
-    // the planner may pick the shorter index + a bounded temp sort.
+    // (idx_sdk_messages_session_timestamp_id) and never a full table scan. The
+    // cap orders by (timestamp, rowid) for correct same-ms hook-phase ordering;
+    // rowid isn't in the composite index, so the planner does a bounded temp sort.
     expect(plan).toMatch(/idx_sdk_messages_session(_timestamp_id)?\b/);
     expect(plan).not.toContain('SCAN sdk_messages USING');
   });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-173-drop-redundant-indexes.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-173-drop-redundant-indexes.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration173 } from '../../../../../src/storage/schema/migrations';
+
+/**
+ * The pre-173 `sdk_messages` index set: the two redundant indexes that M173
+ * drops are present, alongside the M163 column index (`session_uuid`) that
+ * supersedes `idx_sdk_messages_uuid_status`. Mirrors an existing database —
+ * one that already ran M163 — being upgraded in place.
+ */
+function createPre173SdkMessages(db: BunDatabase): void {
+  db.exec(`
+    CREATE TABLE sdk_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      message_type TEXT NOT NULL,
+      message_subtype TEXT,
+      sdk_message TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      send_status TEXT,
+      sdk_uuid TEXT
+    )
+  `);
+  db.exec(`CREATE INDEX idx_sdk_messages_session ON sdk_messages(session_id, timestamp)`);
+  db.exec(
+    `CREATE INDEX idx_sdk_messages_session_timestamp_id ON sdk_messages(session_id, timestamp DESC, id DESC)`
+  );
+  db.exec(
+    `CREATE INDEX idx_sdk_messages_uuid_status ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`
+  );
+  db.exec(`CREATE INDEX idx_sdk_messages_session_uuid ON sdk_messages(session_id, sdk_uuid)`);
+}
+
+function indexExists(db: BunDatabase, name: string): boolean {
+  return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`).get(name);
+}
+
+describe('Migration 173: drop redundant sdk_messages indexes', () => {
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    db = new BunDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  test('drops idx_sdk_messages_session (strict prefix of session_timestamp_id)', () => {
+    createPre173SdkMessages(db);
+    expect(indexExists(db, 'idx_sdk_messages_session')).toBe(true);
+    runMigration173(db);
+    expect(indexExists(db, 'idx_sdk_messages_session')).toBe(false);
+  });
+
+  test('drops idx_sdk_messages_uuid_status (superseded by session_uuid)', () => {
+    createPre173SdkMessages(db);
+    expect(indexExists(db, 'idx_sdk_messages_uuid_status')).toBe(true);
+    runMigration173(db);
+    expect(indexExists(db, 'idx_sdk_messages_uuid_status')).toBe(false);
+  });
+
+  test('leaves idx_sdk_messages_session_uuid and session_timestamp_id intact', () => {
+    createPre173SdkMessages(db);
+    runMigration173(db);
+    expect(indexExists(db, 'idx_sdk_messages_session_uuid')).toBe(true);
+    expect(indexExists(db, 'idx_sdk_messages_session_timestamp_id')).toBe(true);
+  });
+
+  test('uuid lookups seek idx_sdk_messages_session_uuid after the drop (sargable)', () => {
+    createPre173SdkMessages(db);
+    runMigration173(db);
+    // Seed a realistic mix so the planner has stats and prefers the selective
+    // (session_id, sdk_uuid) seek over a session partition walk.
+    const insert = db.prepare(
+      `INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status, sdk_uuid)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    );
+    for (let i = 0; i < 50; i++) {
+      insert.run(
+        `r${i}`,
+        's1',
+        i % 5 === 0 ? 'user' : 'assistant',
+        '{"uuid":"u' + i + '"}',
+        '2024-01-01',
+        'consumed',
+        `u${i}`
+      );
+    }
+
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+          SELECT id FROM sdk_messages
+          WHERE session_id = 's1' AND send_status = 'consumed' AND sdk_uuid = 'u5'`
+      )
+      .all() as Array<{ detail: string }>;
+    const text = plan.map((row) => row.detail).join('\n');
+    expect(text).toContain('idx_sdk_messages_session_uuid');
+    expect(text).not.toContain('SCAN sdk_messages');
+  });
+
+  test('is idempotent', () => {
+    createPre173SdkMessages(db);
+    runMigration173(db);
+    expect(() => runMigration173(db)).not.toThrow();
+  });
+
+  test('is a no-op without sdk_messages', () => {
+    expect(() => runMigration173(db)).not.toThrow();
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -88,6 +88,7 @@ describe('SDKMessageRepository', () => {
 			CREATE INDEX idx_sdk_messages_session ON sdk_messages(session_id);
 			CREATE INDEX idx_sdk_messages_timestamp ON sdk_messages(timestamp);
 			CREATE INDEX idx_sdk_messages_task_id ON sdk_messages(task_id);
+			CREATE INDEX idx_sdk_messages_session_uuid ON sdk_messages(session_id, sdk_uuid);
 		`);
     repository = new SDKMessageRepository(db as any);
   });
@@ -1609,12 +1610,10 @@ describe('SDKMessageRepository', () => {
     });
 
     // Regression: the original implementation loaded every user row for the
-    // session and scanned in JS — O(N) per lookup. The current impl uses
-    // indexed seeks against (session_id, send_status, json_extract uuid)
-    // for messages saved via saveUserMessage (the production path), with a
-    // fallback scan for legacy NULL-send_status rows. The test schema
-    // mirrors the core migrations but omits idx_sdk_messages_uuid_status;
-    // correctness is still validated here.
+    // session and scanned in JS — O(N) per lookup. The current impl seeks
+    // idx_sdk_messages_session_uuid (session_id, sdk_uuid) directly; sdk_uuid
+    // is populated at INSERT time, so the column seek matches the old
+    // json_extract form without the per-row JSON parse.
     it('should find the right message among many user rows in the same session', () => {
       const sessionId = 'session-busy';
       for (let i = 0; i < 50; i++) {
@@ -1723,6 +1722,95 @@ describe('SDKMessageRepository', () => {
 
       expect(message).toBeDefined();
       expect(message?.content).toBe('Earliest failed copy');
+    });
+  });
+
+  // The three uuid lookups must seek the (session_id, sdk_uuid) column index
+  // rather than scanning the session partition or parsing JSON per row. These
+  // EXPLAIN assertions guard against regressing to a json_extract / non-sargable
+  // form. The inline schema above includes idx_sdk_messages_session_uuid to
+  // mirror the post-M163 production schema.
+  describe('uuid lookups use the sdk_uuid column index', () => {
+    function queryPlan(sql: string, params: unknown[]): string {
+      const rows = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{
+        detail: string;
+      }>;
+      return rows.map((r) => r.detail).join('\n');
+    }
+
+    beforeEach(() => {
+      // Seed a realistic mix in one session so the planner has stats and
+      // prefers the selective (session_id, sdk_uuid) seek over a partition walk.
+      const insert = db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, is_renderable, is_terminal, parent_tool_use_id, task_id, sdk_uuid, replacement_metadata_normalized)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`
+      );
+      for (let i = 0; i < 50; i++) {
+        insert.run(
+          `u${i}`,
+          's1',
+          i % 5 === 0 ? 'user' : 'assistant',
+          null,
+          JSON.stringify({ type: 'user', uuid: `uuid-${i}` }),
+          new Date(Date.now() + i).toISOString(),
+          'consumed',
+          null,
+          1,
+          0,
+          null,
+          null,
+          `uuid-${i}`
+        );
+      }
+      insert.run(
+        'act1',
+        's1',
+        'hyperneo_action',
+        'prompt',
+        JSON.stringify({ uuid: 'action-1' }),
+        new Date().toISOString(),
+        null,
+        null,
+        1,
+        0,
+        null,
+        null,
+        'action-1'
+      );
+    });
+
+    it('getMessageByStatusAndUuid seeks idx_sdk_messages_session_uuid', () => {
+      const plan = queryPlan(
+        `SELECT id, sdk_message, timestamp FROM sdk_messages
+         WHERE session_id = ? AND send_status = ? AND sdk_uuid = ? LIMIT 1`,
+        ['s1', 'consumed', 'uuid-5']
+      );
+      expect(plan).toContain('idx_sdk_messages_session_uuid');
+      expect(plan).not.toContain('SCAN sdk_messages');
+    });
+
+    it('getUserMessageByUuid seeks idx_sdk_messages_session_uuid', () => {
+      const plan = queryPlan(
+        `SELECT sdk_message, timestamp FROM sdk_messages
+         WHERE session_id = ?
+           AND message_type = 'user'
+           AND sdk_uuid = ?`,
+        ['s1', 'uuid-5']
+      );
+      expect(plan).toContain('idx_sdk_messages_session_uuid');
+      expect(plan).not.toContain('SCAN sdk_messages');
+    });
+
+    it('updateHyperNeoActionMessageByUuid seeks idx_sdk_messages_session_uuid', () => {
+      const plan = queryPlan(
+        `SELECT id FROM sdk_messages
+         WHERE session_id = ?
+           AND message_type = 'hyperneo_action'
+           AND sdk_uuid = ?`,
+        ['s1', 'action-1']
+      );
+      expect(plan).toContain('idx_sdk_messages_session_uuid');
+      expect(plan).not.toContain('SCAN sdk_messages');
     });
   });
 

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -544,16 +544,12 @@ export function createSpaceTables(db: BunDatabase): void {
 			FOREIGN KEY (source_message_id) REFERENCES sdk_messages(id) ON DELETE CASCADE
 		)
 	`);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session
-		ON sdk_messages(session_id, timestamp)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
 		ON sdk_messages(session_id, timestamp DESC, id DESC)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool_use_id
 		ON sdk_messages(session_id, parent_tool_use_id)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_renderable_terminal
 		ON sdk_messages(session_id, is_renderable, is_terminal, timestamp, id)`);
-  db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_uuid_status
-		ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_type
 		ON sdk_messages(message_type, message_subtype)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_subtype_parent


### PR DESCRIPTION
Switches the three `sdk_messages` uuid lookups (`getMessageByStatusAndUuid`, `getUserMessageByUuid`, `updateHyperNeoActionMessageByUuid`) from `json_extract(sdk_message,'$.uuid')` to the `sdk_uuid` column so they seek the M163 index `idx_sdk_messages_session_uuid` (verified via EXPLAIN), then drops the two redundant indexes that makes safe to remove: `idx_sdk_messages_uuid_status` (the superseded M113 expression index) and `idx_sdk_messages_session` (a strict prefix of `idx_sdk_messages_session_timestamp_id`, maintained on every insert for no query benefit). Migration 170 drops them for existing DBs; new DBs never receive them.

`getUserMessageByUuid`'s per-`send_status` probe loop + NULL fallback existed only to work around the old index's leading-column rule, so it collapses to a single seek (earliest-match determinism preserved); for `getMessageByStatusAndUuid` the vestigial `ORDER BY timestamp ASC` is dropped since `sdk_uuid` is unique per session.

Closes #2335.