### PR TITLE
fix(space): post-approval reuses live agent session, else creates (#850, #816)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -212,9 +212,11 @@ export function appendPostApprovalCompletionInstructions(interpolatedInstruction
 
 /**
  * Collect every declared post-approval route in a workflow. Approval is a
- * task-level event: the router fans out across ALL nodes (and the legacy
- * workflow-level route as a fallback) regardless of which node submitted or
- * approved. Each collected route is delivered to its own `targetAgent` session.
+ * task-level event, so collection scans EVERY node (plus the legacy workflow-
+ * level route as a fallback) regardless of which node submitted or approved —
+ * this is what lets the merger route fire no matter who submitted. The router
+ * then dispatches AT MOST ONE route (the first); see `route()` for why
+ * multi-route fan-out is not supported.
  */
 function collectPostApprovalRoutes(workflow: SpaceWorkflow | null): PostApprovalRoute[] {
   if (!workflow) return [];
@@ -367,11 +369,29 @@ export class PostApprovalRouter {
     }
 
     // -------------------------------------------------------------------
-    // 2. Node-agent fan-out: one delivery per dispatchable post-approval route.
+    // 2. Node-agent dispatch: deliver the (single) post-approval route.
     // -------------------------------------------------------------------
+    // Approval is a task-level event, so the router scans EVERY node to find
+    // the declared route — the merger fires regardless of which node submitted
+    // or approved. But multi-route fan-out is NOT supported: completion is
+    // uncoordinated (`mark_complete` closes the shared task), the singular
+    // `postApprovalSessionId` can track only one session, and the sibling-
+    // quiesce sweep excludes only that one session. Rather than ship half-
+    // coordinated parallel post-approval workers, dispatch AT MOST ONE route
+    // (the first declared). Every built-in workflow declares exactly one route
+    // (the merger), so this is exact in practice; a custom or migrated workflow
+    // that happens to declare more degrades to the first with a warning instead
+    // of running broken parallel workers (e.g. two merge kickoffs into the same
+    // PR). When Commit 2 moves the route to the agent slot, this collapses
+    // further.
+    if (dispatchable.length > 1) {
+      log.warn(
+        `PostApprovalRouter.route: task ${task.id} declares ${dispatchable.length} post-approval routes; multi-route fan-out is not supported. Only the first (targetAgent=${dispatchable[0]?.targetAgent}) will dispatch — extras ignored.`
+      );
+    }
+
     // Double-fire guard (§3.4): if a post-approval session is already live,
-    // skip re-dispatch. (`postApprovalSessionId` is single, so it tracks the
-    // primary route's session; in the common single-route case this is exact.)
+    // skip re-dispatch.
     if (task.postApprovalSessionId) {
       const alive = this.deps.livenessProbe
         ? this.deps.livenessProbe.isSessionAlive(task.postApprovalSessionId)
@@ -396,60 +416,48 @@ export class PostApprovalRouter {
       return { mode: 'skipped', reason };
     }
 
-    const startedAt = Date.now();
-    const missingKeys: string[] = [];
-    let primarySessionId: string | undefined;
-    for (const route of dispatchable) {
-      const { text: interpolatedInstructions, missingKeys: routeMissing } =
-        interpolatePostApprovalTemplate(route.instructions ?? '', context);
-      if (routeMissing.length > 0) {
-        missingKeys.push(...routeMissing);
-        log.warn(
-          `PostApprovalRouter.route: task ${task.id} kickoff referenced unknown keys: ${routeMissing.join(', ')}`
-        );
-      }
-      if (!interpolatedInstructions.trim()) {
-        log.warn(
-          `PostApprovalRouter.route: task ${task.id} post-approval route (targetAgent=${route.targetAgent}) has empty instructions template; skipping route`
-        );
-        continue;
-      }
-      const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
-      const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
-        task,
-        workflow,
-        targetAgent: route.targetAgent!,
-        kickoffMessage,
-      });
-      if (!primarySessionId) primarySessionId = sessionId;
+    const route = dispatchable[0]!;
+    const { text: interpolatedInstructions, missingKeys } = interpolatePostApprovalTemplate(
+      route.instructions ?? '',
+      context
+    );
+    if (missingKeys.length > 0) {
+      log.warn(
+        `PostApprovalRouter.route: task ${task.id} kickoff referenced unknown keys: ${missingKeys.join(', ')}`
+      );
     }
-
-    if (!primarySessionId) {
-      const reason = `task ${task.id}: every post-approval route had an empty instructions template`;
+    if (!interpolatedInstructions.trim()) {
+      const reason = `task ${task.id}: post-approval route (targetAgent=${route.targetAgent}) has an empty instructions template`;
       log.warn(`PostApprovalRouter.route: ${reason}`);
       clearPendingCompletionState(this.deps.taskRepo, task.id);
       return { mode: 'skipped', reason };
     }
 
-    // Stamp the PRIMARY (first) post-approval session. `postApprovalSessionId`
-    // is a single field, so a multi-route fan-out tracks only the primary —
-    // every route was still dispatched above.
+    const startedAt = Date.now();
+    const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
+    const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
+      task,
+      workflow,
+      targetAgent: route.targetAgent!,
+      kickoffMessage,
+    });
+
     this.deps.taskRepo.updateTask(task.id, {
       pendingCheckpointType: null,
       pendingCompletionSubmittedByNodeId: null,
       pendingCompletionSubmittedAt: null,
       pendingCompletionReason: null,
-      postApprovalSessionId: primarySessionId,
+      postApprovalSessionId: sessionId,
       postApprovalStartedAt: startedAt,
       postApprovalBlockedReason: null,
     });
 
     log.info(
-      `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} routes=${dispatchable.length} mode=spawn autonomyLevel=${context.autonomyLevel ?? 'unknown'} sessionId=${primarySessionId}`
+      `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} routes=${dispatchable.length} dispatched=1 mode=spawn autonomyLevel=${context.autonomyLevel ?? 'unknown'} sessionId=${sessionId}`
     );
     return {
       mode: 'spawn',
-      postApprovalSessionId: primarySessionId,
+      postApprovalSessionId: sessionId,
       postApprovalStartedAt: startedAt,
       missingKeys,
     };

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -210,23 +210,23 @@ export function appendPostApprovalCompletionInstructions(interpolatedInstruction
   return `${trimmed}\n\n${POST_APPROVAL_COMPLETION_INSTRUCTIONS}`;
 }
 
-function resolvePostApprovalRoute(
-  task: SpaceTask,
-  workflow: SpaceWorkflow | null
-): { route: PostApprovalRoute | undefined; sourceNodeId: string | null } {
-  if (!workflow) {
-    return { route: undefined, sourceNodeId: null };
-  }
-
-  const sourceNodeId = task.pendingCompletionSubmittedByNodeId || workflow.endNodeId || null;
-  const sourceNode = sourceNodeId
-    ? (workflow.nodes.find((node) => node.id === sourceNodeId) ?? null)
-    : null;
-
-  return {
-    route: sourceNode?.postApproval ?? workflow.postApproval,
-    sourceNodeId: sourceNode?.id ?? sourceNodeId,
-  };
+/**
+ * Collect every declared post-approval route in a workflow. Approval is a
+ * task-level event: the router fans out across ALL nodes (and the legacy
+ * workflow-level route as a fallback) regardless of which node submitted or
+ * approved. Each collected route is delivered to its own `targetAgent` session.
+ */
+function collectPostApprovalRoutes(workflow: SpaceWorkflow | null): PostApprovalRoute[] {
+  if (!workflow) return [];
+  // Approval is a task-level event: collect post-approval routes from EVERY
+  // node, independent of which node submitted or approved.
+  const nodeRoutes = workflow.nodes
+    .map((node) => node.postApproval)
+    .filter((route): route is PostApprovalRoute => !!route);
+  if (nodeRoutes.length > 0) return nodeRoutes;
+  // Legacy workflow-level fallback (pre-node-level): only when no node declares
+  // its own route, so a workflow with both never double-dispatches.
+  return workflow.postApproval ? [workflow.postApproval] : [];
 }
 
 /**
@@ -304,12 +304,29 @@ export class PostApprovalRouter {
       return { mode: 'skipped', reason };
     }
 
-    const { route, sourceNodeId } = resolvePostApprovalRoute(task, workflow);
+    const sourceNodeId = task.pendingCompletionSubmittedByNodeId || workflow?.endNodeId || null;
+
+    // Approval is a task-level event: collect post-approval routes from EVERY
+    // node (plus the legacy workflow-level route), independent of which node
+    // submitted or approved. Filter to dispatchable routes — each must name a
+    // targetAgent, and the legacy 'task-agent' target is no longer supported.
+    const allRoutes = collectPostApprovalRoutes(workflow);
+    const dispatchable: PostApprovalRoute[] = [];
+    for (const candidate of allRoutes) {
+      if (!candidate.targetAgent) continue;
+      if (candidate.targetAgent === POST_APPROVAL_TASK_AGENT_TARGET) {
+        log.warn(
+          `PostApprovalRouter.route: task ${task.id} has a legacy task-agent post-approval target; skipping that route`
+        );
+        continue;
+      }
+      dispatchable.push(candidate);
+    }
 
     // -------------------------------------------------------------------
-    // 1. No postApproval declared → close the task directly.
+    // 1. No postApproval declared anywhere → close the task directly.
     // -------------------------------------------------------------------
-    if (!route || !route.targetAgent) {
+    if (dispatchable.length === 0) {
       const outcomeUpdates = this.deps.resolveCompletionOutcome?.(task) ?? null;
       const updates: UpdateSpaceTaskParams = {
         ...outcomeUpdates,
@@ -341,7 +358,7 @@ export class PostApprovalRouter {
         );
       }
       log.info(
-        `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} targetAgent=none mode=none autonomyLevel=${context.autonomyLevel ?? 'unknown'}`
+        `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} routes=0 mode=none autonomyLevel=${context.autonomyLevel ?? 'unknown'}`
       );
       log.info(
         `task.status-transition: taskId=${task.id} from=approved to=done source=no-post-approval`
@@ -349,28 +366,19 @@ export class PostApprovalRouter {
       return { mode: 'no-route', taskStatus: 'done' };
     }
 
-    const { targetAgent, instructions } = route;
-
-    // Legacy task-agent target: the built-in task-agent session was removed.
-    // Persisted workflows may still reference targetAgent: "task-agent";
-    // skip gracefully rather than attempting a spawn that will fail.
-    if (targetAgent === POST_APPROVAL_TASK_AGENT_TARGET) {
-      const reason = `task ${task.id}: legacy task-agent post-approval target is no longer supported; skipping`;
-      log.warn(`PostApprovalRouter.route: ${reason}`);
-      clearPendingCompletionState(this.deps.taskRepo, task.id);
-      return { mode: 'skipped', reason };
-    }
     // -------------------------------------------------------------------
-    // 2. Node-agent spawn route.
+    // 2. Node-agent fan-out: one delivery per dispatchable post-approval route.
     // -------------------------------------------------------------------
-    // Double-fire guard (§3.4): skip when an existing session is alive.
+    // Double-fire guard (§3.4): if a post-approval session is already live,
+    // skip re-dispatch. (`postApprovalSessionId` is single, so it tracks the
+    // primary route's session; in the common single-route case this is exact.)
     if (task.postApprovalSessionId) {
       const alive = this.deps.livenessProbe
         ? this.deps.livenessProbe.isSessionAlive(task.postApprovalSessionId)
         : true;
       if (alive) {
         log.info(
-          `PostApprovalRouter.route: task ${task.id} already has live post-approval session ${task.postApprovalSessionId}; skipping re-spawn`
+          `PostApprovalRouter.route: task ${task.id} already has live post-approval session ${task.postApprovalSessionId}; skipping re-dispatch`
         );
         return {
           mode: 'already-routed',
@@ -379,55 +387,69 @@ export class PostApprovalRouter {
       }
     }
 
-    // Interpolate the workflow-specific kickoff, then append the runtime-owned
-    // completion instruction shared by every post-approval route.
-    const { text: interpolatedInstructions, missingKeys } = interpolatePostApprovalTemplate(
-      instructions ?? '',
-      context
-    );
-    if (!interpolatedInstructions.trim()) {
-      const reason = `task ${task.id}: node-agent post-approval has empty instructions template`;
-      log.warn(`PostApprovalRouter.route: ${reason}`);
-      clearPendingCompletionState(this.deps.taskRepo, task.id);
-      return { mode: 'skipped', reason };
-    }
-    if (missingKeys.length > 0) {
-      log.warn(
-        `PostApprovalRouter.route: task ${task.id} kickoff referenced unknown keys: ${missingKeys.join(', ')}`
-      );
-    }
+    // `workflow` is non-null whenever `dispatchable` is non-empty (routes come
+    // from it), but narrow for the spawn call below.
     if (!workflow) {
       const reason = `task ${task.id}: cannot spawn post-approval sub-session without workflow`;
       log.warn(`PostApprovalRouter.route: ${reason}`);
       clearPendingCompletionState(this.deps.taskRepo, task.id);
       return { mode: 'skipped', reason };
     }
-    const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
 
     const startedAt = Date.now();
-    const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
-      task,
-      workflow,
-      targetAgent,
-      kickoffMessage,
-    });
+    const missingKeys: string[] = [];
+    let primarySessionId: string | undefined;
+    for (const route of dispatchable) {
+      const { text: interpolatedInstructions, missingKeys: routeMissing } =
+        interpolatePostApprovalTemplate(route.instructions ?? '', context);
+      if (routeMissing.length > 0) {
+        missingKeys.push(...routeMissing);
+        log.warn(
+          `PostApprovalRouter.route: task ${task.id} kickoff referenced unknown keys: ${routeMissing.join(', ')}`
+        );
+      }
+      if (!interpolatedInstructions.trim()) {
+        log.warn(
+          `PostApprovalRouter.route: task ${task.id} post-approval route (targetAgent=${route.targetAgent}) has empty instructions template; skipping route`
+        );
+        continue;
+      }
+      const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
+      const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
+        task,
+        workflow,
+        targetAgent: route.targetAgent!,
+        kickoffMessage,
+      });
+      if (!primarySessionId) primarySessionId = sessionId;
+    }
 
+    if (!primarySessionId) {
+      const reason = `task ${task.id}: every post-approval route had an empty instructions template`;
+      log.warn(`PostApprovalRouter.route: ${reason}`);
+      clearPendingCompletionState(this.deps.taskRepo, task.id);
+      return { mode: 'skipped', reason };
+    }
+
+    // Stamp the PRIMARY (first) post-approval session. `postApprovalSessionId`
+    // is a single field, so a multi-route fan-out tracks only the primary —
+    // every route was still dispatched above.
     this.deps.taskRepo.updateTask(task.id, {
       pendingCheckpointType: null,
       pendingCompletionSubmittedByNodeId: null,
       pendingCompletionSubmittedAt: null,
       pendingCompletionReason: null,
-      postApprovalSessionId: sessionId,
+      postApprovalSessionId: primarySessionId,
       postApprovalStartedAt: startedAt,
       postApprovalBlockedReason: null,
     });
 
     log.info(
-      `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} targetAgent=${targetAgent} mode=spawn autonomyLevel=${context.autonomyLevel ?? 'unknown'} sessionId=${sessionId}`
+      `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} routes=${dispatchable.length} mode=spawn autonomyLevel=${context.autonomyLevel ?? 'unknown'} sessionId=${primarySessionId}`
     );
     return {
       mode: 'spawn',
-      postApprovalSessionId: sessionId,
+      postApprovalSessionId: primarySessionId,
       postApprovalStartedAt: startedAt,
       missingKeys,
     };

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -85,6 +85,17 @@ export interface SubSessionMemberInfo {
   agentName?: string;
   /** Workflow node ID — used to link the sub-session to its NodeExecution record */
   nodeId?: string;
+  /**
+   * Force `createSubSession` to spawn a genuinely fresh session, bypassing the
+   * agentName reuse policy. Set ONLY by `spawnPostApprovalSubSession`: its
+   * target agent (e.g. 'reviewer') already has a live session from the review
+   * cycle, and reusing it injects the merge kickoff into a session the
+   * approval/quiesce flow is interrupting → the SDK throws "Interrupted by
+   * user" before the router can stamp `postApprovalSessionId`, parking the
+   * task in `approved`. Normal node re-execution (a second review cycle, etc.)
+   * still goes through reuse.
+   */
+  forceNewSession?: boolean;
 }
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { createEndNodeHandlers, createMarkCompleteHandler } from '../tools/end-node-handlers';
@@ -1261,7 +1272,12 @@ export class TaskAgentManager {
     // NodeExecution row with `agentSessionId` exists yet. Resolve the
     // eager session directly from the in-memory index so the reuse logic
     // below picks it up instead of creating a second session.
-    if (memberInfo?.agentName) {
+    //
+    // `forceNewSession` (post-approval spawn) bypasses reuse entirely: the
+    // target agent already has a live session that the approval/quiesce flow
+    // is interrupting, so reuse would inject the merge kickoff into a dying
+    // session. Fall straight through to the fresh-session path below.
+    if (memberInfo?.agentName && !memberInfo.forceNewSession) {
       const parentTask = this.config.taskRepo.getTask(taskId);
       if (parentTask?.workflowRunId) {
         const eagerSessionId = this.eagerSubSessionIds.get(taskId)?.get(memberInfo.agentName);
@@ -4834,6 +4850,13 @@ export class TaskAgentManager {
       agentId: matchedSlot.agentId,
       agentName: matchedSlot.name,
       nodeId: matchedNodeId,
+      // Post-approval MUST spawn a fresh session. The target agent (e.g.
+      // 'reviewer') already has a live session from the review cycle; reusing
+      // it injects the merge kickoff into a session the approval/quiesce flow
+      // is interrupting, so the SDK throws "Interrupted by user" before the
+      // router can stamp postApprovalSessionId — parking the task in
+      // 'approved' with the merge never running.
+      forceNewSession: true,
     });
 
     const spawned = this.getSubSession(actualSessionId);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -85,17 +85,6 @@ export interface SubSessionMemberInfo {
   agentName?: string;
   /** Workflow node ID — used to link the sub-session to its NodeExecution record */
   nodeId?: string;
-  /**
-   * Force `createSubSession` to spawn a genuinely fresh session, bypassing the
-   * agentName reuse policy. Set ONLY by `spawnPostApprovalSubSession`: its
-   * target agent (e.g. 'reviewer') already has a live session from the review
-   * cycle, and reusing it injects the merge kickoff into a session the
-   * approval/quiesce flow is interrupting → the SDK throws "Interrupted by
-   * user" before the router can stamp `postApprovalSessionId`, parking the
-   * task in `approved`. Normal node re-execution (a second review cycle, etc.)
-   * still goes through reuse.
-   */
-  forceNewSession?: boolean;
 }
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { createEndNodeHandlers, createMarkCompleteHandler } from '../tools/end-node-handlers';
@@ -1272,12 +1261,7 @@ export class TaskAgentManager {
     // NodeExecution row with `agentSessionId` exists yet. Resolve the
     // eager session directly from the in-memory index so the reuse logic
     // below picks it up instead of creating a second session.
-    //
-    // `forceNewSession` (post-approval spawn) bypasses reuse entirely: the
-    // target agent already has a live session that the approval/quiesce flow
-    // is interrupting, so reuse would inject the merge kickoff into a dying
-    // session. Fall straight through to the fresh-session path below.
-    if (memberInfo?.agentName && !memberInfo.forceNewSession) {
+    if (memberInfo?.agentName) {
       const parentTask = this.config.taskRepo.getTask(taskId);
       if (parentTask?.workflowRunId) {
         const eagerSessionId = this.eagerSubSessionIds.get(taskId)?.get(memberInfo.agentName);
@@ -4743,19 +4727,28 @@ export class TaskAgentManager {
   // -------------------------------------------------------------------------
 
   /**
-   * Spawn a fresh sub-session for a post-approval node-agent handoff (PR 2/5).
+   * Deliver a post-approval node-agent handoff: reuse the target agent's live
+   * session if it has one, otherwise spawn a fresh one — then inject the
+   * kickoff instructions as the next user turn.
    *
    * Called by `PostApprovalRouter` when the workflow declares a
    * `postApproval.targetAgent` that is NOT `'task-agent'`. The flow:
    *
    *   1. Look up the agent slot in the workflow by name (matches against both
    *      slot.name and agent display name).
-   *   2. Build an `AgentSessionInit` using the same resolver the regular node
-   *      activation path uses (so tool registry + system prompt line up).
-   *   3. Attach the same MCP server surface as a normal node-agent spawn —
-   *      `node-agent` (with `mark_complete` mirrored).
-   *   4. Kick off the session with the interpolated post-approval instructions
-   *      as the first user turn.
+   *   2. If that agent already has a LIVE session, inject the kickoff straight
+   *      into it. This bypasses `createSubSession`'s reuse path on purpose:
+   *      that path rebuilds the node-agent MCP and calls `restartQuery()`,
+   *      which interrupts an active drive (the #816 "Interrupted by user"
+   *      failure). Direct injection never interrupts — it enqueues when busy
+   *      and starts a fresh turn when idle.
+   *   3. Otherwise build an `AgentSessionInit` (same resolver as a normal
+   *      node-agent spawn), attach the `node-agent` MCP surface
+   *      (`mark_complete` mirrored), create the session, and inject.
+   *
+   * The built-in `merger` target has no prior session, so it always creates;
+   * the reuse branch only fires for workflows whose post-approval target is an
+   * agent that already ran (e.g. a custom `targetAgent: 'reviewer'`).
    *
    * Returns `{ sessionId }`. The caller (router) stamps this onto
    * `space_tasks.post_approval_session_id` so the UI banner can render a
@@ -4799,6 +4792,31 @@ export class TaskAgentManager {
       );
     }
 
+    // Reuse-if-exists: if the target agent already has a LIVE session, inject
+    // the kickoff straight into it. This deliberately bypasses createSubSession's
+    // reuse path, which rebuilds the node-agent MCP server and calls
+    // `restartQuery()` — interrupting the session if its drive is still active
+    // (the #816 "Interrupted by user" failure). A direct inject never
+    // interrupts: injectMessageIntoSession enqueues when busy and starts a
+    // fresh turn when idle. The built-in `merger` target has no prior session,
+    // so it falls through to the create branch below; this branch only fires
+    // for workflows whose post-approval target is an agent that already ran.
+    const existingSessionId = this.findLiveSubSessionForAgent(task, matchedSlot.name);
+    if (existingSessionId) {
+      const existing = this.getSubSession(existingSessionId);
+      if (!existing) {
+        throw new Error(
+          `spawnPostApprovalSubSession: live session ${existingSessionId} for agent "${matchedSlot.name}" vanished before injection (task ${taskId})`
+        );
+      }
+      await this.injectMessageIntoSession(existing, kickoffMessage);
+      log.info(
+        `TaskAgentManager.spawnPostApprovalSubSession: reused live session ${existingSessionId} for agent "${matchedSlot.name}" (task ${taskId}, node ${matchedNodeId})`
+      );
+      return { sessionId: existingSessionId };
+    }
+
+    // No live session for this agent — create one and inject.
     const workflowRunId = task.workflowRunId;
     const workflowRun = workflowRunId ? this.config.workflowRunRepo.getRun(workflowRunId) : null;
 
@@ -4850,13 +4868,6 @@ export class TaskAgentManager {
       agentId: matchedSlot.agentId,
       agentName: matchedSlot.name,
       nodeId: matchedNodeId,
-      // Post-approval MUST spawn a fresh session. The target agent (e.g.
-      // 'reviewer') already has a live session from the review cycle; reusing
-      // it injects the merge kickoff into a session the approval/quiesce flow
-      // is interrupting, so the SDK throws "Interrupted by user" before the
-      // router can stamp postApprovalSessionId — parking the task in
-      // 'approved' with the merge never running.
-      forceNewSession: true,
     });
 
     const spawned = this.getSubSession(actualSessionId);
@@ -4883,6 +4894,31 @@ export class TaskAgentManager {
       `TaskAgentManager.spawnPostApprovalSubSession: spawned session ${actualSessionId} for agent "${matchedSlot.name}" (task ${taskId}, node ${matchedNodeId})`
     );
     return { sessionId: actualSessionId };
+  }
+
+  /**
+   * Resolve the most recent in-memory (live) sub-session id for a given agent
+   * slot in a task's workflow run, or null if there is none live.
+   *
+   * Used by `spawnPostApprovalSubSession` to decide reuse-vs-create. "Live"
+   * means the session is currently held in memory (it ran this daemon lifetime).
+   * A session that exists only in the DB (e.g. after a daemon restart) is NOT
+   * returned here — `createSubSession` rehydrates it instead, which is safe
+   * because a freshly-restored session has no active drive to interrupt.
+   *
+   * Candidate resolution mirrors `createSubSession`'s reuse path: the most
+   * recent `node_executions` row for this agent with an `agentSessionId`.
+   */
+  private findLiveSubSessionForAgent(task: SpaceTask, agentName: string): string | null {
+    if (!task.workflowRunId) return null;
+    const prevExec = this.config.nodeExecutionRepo
+      .listByWorkflowRun(task.workflowRunId)
+      .filter((e) => e.agentName === agentName && e.agentSessionId)
+      // listByWorkflowRun returns rows ORDER BY created_at ASC, so .at(-1) is the most recent.
+      .at(-1);
+    const candidateId = prevExec?.agentSessionId ?? null;
+    if (!candidateId) return null;
+    return this.getSubSession(candidateId) ? candidateId : null;
   }
 
   private resolvePrUrlForRun(runId: string): string {

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -539,20 +539,14 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
           },
         },
       ],
-      // After this node approves, spawn a fresh PR Merger session that runs
-      // the PR merge using the shared post-approval merge instructions. The
-      // Merger slot lives in the dedicated Post-Approval node below.
-      postApproval: {
-        targetAgent: 'merger',
-        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
-      },
     },
     {
       id: CODING_POST_APPROVAL_NODE,
       name: 'Post-Approval',
-      // No channels: this node is never activated by normal flow. It only
-      // exists to declare the `merger` slot so spawnPostApprovalSubSession can
-      // resolve `targetAgent: 'merger'` after approval.
+      // Declares the `merger` agent and the post-approval route that targets
+      // it. Approval is a task-level event: the router fans out across every
+      // node and delivers this route to the merger agent's session (reusing a
+      // live one, else spawning fresh) regardless of which node approved.
       agents: [
         {
           agentId: 'PR Merger',
@@ -560,6 +554,10 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
           customPrompt: PR_MERGER_SLOT_PROMPT,
         },
       ],
+      postApproval: {
+        targetAgent: 'merger',
+        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
+      },
     },
   ],
   startNodeId: CODING_CODE_NODE,
@@ -717,20 +715,14 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
           },
         },
       ],
-      // After this node approves, spawn a fresh PR Merger session that runs
-      // the PR merge using the shared post-approval merge instructions. The
-      // Merger slot lives in the dedicated Post-Approval node below.
-      postApproval: {
-        targetAgent: 'merger',
-        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
-      },
     },
     {
       id: RESEARCH_POST_APPROVAL_NODE,
       name: 'Post-Approval',
-      // No channels: this node is never activated by normal flow. It only
-      // exists to declare the `merger` slot so spawnPostApprovalSubSession can
-      // resolve `targetAgent: 'merger'` after approval.
+      // Declares the `merger` agent and the post-approval route that targets
+      // it. Approval is a task-level event: the router fans out across every
+      // node and delivers this route to the merger agent's session (reusing a
+      // live one, else spawning fresh) regardless of which node approved.
       agents: [
         {
           agentId: 'PR Merger',
@@ -738,6 +730,10 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
           customPrompt: PR_MERGER_SLOT_PROMPT,
         },
       ],
+      postApproval: {
+        targetAgent: 'merger',
+        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
+      },
     },
   ],
   startNodeId: RESEARCH_RESEARCH_NODE,
@@ -1172,20 +1168,14 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
           },
         },
       ],
-      // After QA approves, spawn a fresh PR Merger session that runs the PR
-      // merge and worktree sync. The Merger slot lives in the dedicated
-      // Post-Approval node below.
-      postApproval: {
-        targetAgent: 'merger',
-        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
-      },
     },
     {
       id: FULLSTACK_POST_APPROVAL_NODE,
       name: 'Post-Approval',
-      // No channels: this node is never activated by normal flow. It only
-      // exists to declare the `merger` slot so spawnPostApprovalSubSession can
-      // resolve `targetAgent: 'merger'` after approval.
+      // Declares the `merger` agent and the post-approval route that targets
+      // it. Approval is a task-level event: the router fans out across every
+      // node and delivers this route to the merger agent's session (reusing a
+      // live one, else spawning fresh) regardless of which node approved.
       agents: [
         {
           agentId: 'PR Merger',
@@ -1193,6 +1183,10 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
           customPrompt: PR_MERGER_SLOT_PROMPT,
         },
       ],
+      postApproval: {
+        targetAgent: 'merger',
+        instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
+      },
     },
   ],
   startNodeId: FULLSTACK_CODING_NODE,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -1,40 +1,42 @@
 /**
- * TaskAgentManager.createSubSession — post-approval must spawn a FRESH session.
+ * Post-approval sub-session delivery — reuse-if-exists else create.
  *
- * Regression for #850 (repro #816 / GitHub #2323): approving a Coding-Workflow
- * task whose reviewer node-agent session was still live never triggered the
- * post-approval merge. Root cause: `spawnPostApprovalSubSession` targets the
- * `reviewer` agent, and `createSubSession`'s unconditional agentName reuse
- * policy handed back the reviewer's still-live (mid-teardown) session instead
- * of spawning a fresh merge session → the SDK threw "Interrupted by user"
- * before `postApprovalSessionId` was stamped → the task parked in `approved`.
+ * Regression for #816 (GitHub #2323): approving a task whose post-approval
+ * target agent already had a live session never ran the merge. The earlier
+ * #850 fix (force a fresh session) worked but for the wrong reason and
+ * contradicted the intended design. The real cause was createSubSession's
+ * reuse path calling `restartQuery()` (via reinjectNodeAgentMcpServer), which
+ * interrupts the agent's active drive → "Interrupted by user".
  *
- * Fix: `SubSessionMemberInfo.forceNewSession` bypasses the reuse lookup so the
- * post-approval spawn produces a genuinely fresh session.
+ * Current design: `spawnPostApprovalSubSession` reuses the target agent's
+ * LIVE session and injects the kickoff directly — bypassing createSubSession's
+ * reuse path (and its restartQuery) entirely. It only creates a fresh session
+ * when the agent has no live session. Direct injection never interrupts: it
+ * enqueues when busy and starts a fresh turn when idle.
  *
  * These tests construct a real TaskAgentManager (the constructor only touches
- * `db.getDatabase()` for an inert McpAuditLogRepository and subscribes to the
- * event bus) and drive `createSubSession` with a stubbed `AgentSession.fromInit`
- * plus stubbed repo / mcp helpers, so the reuse-vs-fresh DECISION is exercised
+ * db.getDatabase() for an inert McpAuditLogRepository and subscribes to the
+ * event bus) and drive the methods with stubbed AgentSession.fromInit + repo
+ * / space / injection helpers, so the reuse-vs-create DECISION is exercised
  * — not a mock of it.
  *
  * Coverage:
- *   - forceNewSession=true with a prior live reviewer session → a fresh id,
- *     distinct from the reviewer's; `AgentSession.fromInit` invoked.
- *   - forceNewSession omitted (normal node re-execution) → reuses the prior
- *     session id; `AgentSession.fromInit` NOT invoked. This is the hard
- *     constraint: reuse MUST still apply for a second review cycle.
+ *   - spawnPostApprovalSubSession reuses a live target session (returns its id,
+ *     injects the kickoff into it, does NOT create a fresh session).
+ *   - createSubSession still reuses the prior session for a normal second node
+ *     activation (no special flag) — the hard constraint.
+ *   - createSubSession creates a new session when no prior session exists.
  */
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
-import type { SubSessionMemberInfo } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import type { AgentSession as AgentSessionType } from '../../../../src/lib/agent/agent-session.ts';
 import type { AgentSessionInit } from '../../../../src/lib/agent/agent-session.ts';
 import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
 import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+import type { SpaceTask, SpaceWorkflow } from '@hyperneo/shared';
 
 const TASK_ID = 'task-850';
 const RUN_ID = 'run-850';
@@ -44,9 +46,10 @@ const REVIEWER_AGENT = 'reviewer';
 const REVIEWER_SESSION_ID = 'reviewer-session-live';
 
 /** Fake AgentSession: records the heavy lifecycle methods createSubSession calls. */
-function makeFakeSession() {
+function makeFakeSession(id: string = REVIEWER_SESSION_ID) {
   const calls: string[] = [];
   const session = {
+    session: { id },
     skillOverrides: undefined,
     toolGuards: undefined,
     onMissingWorkflowMcpServers: undefined,
@@ -63,16 +66,14 @@ function makeFakeSession() {
   return { session: session as unknown as AgentSessionType, calls };
 }
 
-function makeManager(): TaskAgentManager {
-  // Prior reviewer NodeExecution — simulates "reviewer already ran and its
-  // session is still live at approval time" (sessions persist until archive).
-  const reviewerExec = {
+function reviewerExec(sessionId: string = REVIEWER_SESSION_ID) {
+  return {
     id: 'reviewer-exec-1',
     workflowRunId: RUN_ID,
     workflowNodeId: REVIEWER_NODE_ID,
     agentName: REVIEWER_AGENT,
     agentId: 'agent-reviewer',
-    agentSessionId: REVIEWER_SESSION_ID,
+    agentSessionId: sessionId,
     status: 'in_progress',
     result: null,
     data: null,
@@ -81,44 +82,49 @@ function makeManager(): TaskAgentManager {
     completedAt: null,
     updatedAt: 1,
   };
-  const rows = [reviewerExec];
+}
 
-  const taskRepo = {
-    getTask: () => ({
-      id: TASK_ID,
-      spaceId: SPACE_ID,
-      workflowRunId: RUN_ID,
-      title: 'Task 850',
-    }),
-  };
-  const nodeExecutionRepo = {
-    listByWorkflowRun: () => rows,
-    listByNode: () => rows,
-    update: () => reviewerExec,
-  };
-  const sessionManager = {
-    registerSession: () => {},
-  };
-
+function makeManager(rows: unknown[] = [reviewerExec()]): TaskAgentManager {
   return new TaskAgentManager({
     db: { getDatabase: () => new BunDatabase(':memory:') },
-    sessionManager,
+    sessionManager: { registerSession: () => {} },
     internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
-    taskRepo,
-    nodeExecutionRepo,
+    taskRepo: {
+      getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'Task 850' }),
+    },
+    nodeExecutionRepo: {
+      listByWorkflowRun: () => rows,
+      listByNode: () => rows,
+      update: () => rows[0],
+    },
+    spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
     // pendingMessageRepo / appMcpManager intentionally absent → flush + mcp
     // config resolution become no-ops inside createSubSession.
   } as unknown as TaskAgentManagerConfig);
 }
 
-/** Pre-seed the reviewer's live session + no-op the reuse-path instance helpers. */
-function seedReviewerSession(tam: TaskAgentManager): void {
+/** Seed a live session in BOTH indexes getSubSession / findLiveSubSessionForAgent read. */
+function seedLiveSession(
+  tam: TaskAgentManager,
+  sessionId: string = REVIEWER_SESSION_ID
+): AgentSessionType {
+  const { session } = makeFakeSession(sessionId);
+  const subSessions = (
+    tam as unknown as {
+      subSessions: Map<string, Map<string, AgentSessionType>>;
+    }
+  ).subSessions;
+  if (!subSessions.has(TASK_ID)) subSessions.set(TASK_ID, new Map());
+  subSessions.get(TASK_ID)!.set(sessionId, session);
   (tam as unknown as { agentSessionIndex: Map<string, AgentSessionType> }).agentSessionIndex.set(
-    REVIEWER_SESSION_ID,
-    makeFakeSession().session
+    sessionId,
+    session
   );
-  // The reuse path calls these on the seeded session; stub them to no-ops so
-  // the decision under test is reached without the full MCP re-injection stack.
+  return session;
+}
+
+/** No-op the reuse-path instance helpers so the decision under test is reached. */
+function stubReusePathHelpers(tam: TaskAgentManager): void {
   (
     tam as unknown as { reinjectNodeAgentMcpServer: (...a: unknown[]) => Promise<void> }
   ).reinjectNodeAgentMcpServer = async () => {};
@@ -135,49 +141,73 @@ function minimalInit(): AgentSessionInit {
   return { title: 'post-approval', model: 'm', mcpServers: {} } as unknown as AgentSessionInit;
 }
 
-describe('createSubSession — post-approval forceNewSession bypass', () => {
+describe('spawnPostApprovalSubSession — reuse-if-exists else create', () => {
   let fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
 
   beforeEach(() => {
-    // Stub the heavy real session construction so we exercise ONLY the
-    // reuse-vs-fresh decision.
     fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation(
-      (() => makeFakeSession().session) as unknown as typeof AgentSession.fromInit
+      (() => makeFakeSession('fresh-session').session) as unknown as typeof AgentSession.fromInit
     );
   });
   afterEach(() => {
     fromInitSpy.mockRestore();
   });
 
-  test('forceNewSession spawns a fresh session distinct from the prior reviewer session', async () => {
+  test('reuses the target agent live session and injects the kickoff directly (no fresh session)', async () => {
     const tam = makeManager();
-    seedReviewerSession(tam);
-
-    const memberInfo: SubSessionMemberInfo = {
-      agentId: 'agent-reviewer',
-      agentName: REVIEWER_AGENT,
-      nodeId: REVIEWER_NODE_ID,
-      forceNewSession: true,
+    seedLiveSession(tam); // reviewer already has a LIVE session
+    const injected: Array<{ sessionId: string; message: string }> = [];
+    (
+      tam as unknown as {
+        injectMessageIntoSession: (s: { session: { id: string } }, m: string) => Promise<string>;
+      }
+    ).injectMessageIntoSession = async (s, m) => {
+      injected.push({ sessionId: s.session.id, message: m });
+      return 'msg-id';
     };
-    const freshId = `space:${SPACE_ID}:task:${TASK_ID}:post-approval:${REVIEWER_AGENT}`;
 
-    const actual = await tam.createSubSession(TASK_ID, freshId, minimalInit(), memberInfo);
+    const workflow = {
+      id: 'wf-1',
+      spaceId: SPACE_ID,
+      name: 'Coding',
+      nodes: [
+        {
+          id: REVIEWER_NODE_ID,
+          name: 'Review',
+          agents: [{ agentId: 'agent-reviewer', name: REVIEWER_AGENT }],
+        },
+      ],
+      channels: [],
+      startNodeId: REVIEWER_NODE_ID,
+      endNodeId: REVIEWER_NODE_ID,
+    } as unknown as SpaceWorkflow;
+    const task = { id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID } as unknown as SpaceTask;
 
-    expect(actual).toBe(freshId);
-    expect(actual).not.toBe(REVIEWER_SESSION_ID);
-    expect(fromInitSpy).toHaveBeenCalledTimes(1);
+    const result = await tam.spawnPostApprovalSubSession({
+      task,
+      workflow,
+      targetAgent: REVIEWER_AGENT,
+      kickoffMessage: 'merge the PR',
+    });
+
+    expect(result.sessionId).toBe(REVIEWER_SESSION_ID);
+    expect(injected).toHaveLength(1);
+    expect(injected[0]).toEqual({ sessionId: REVIEWER_SESSION_ID, message: 'merge the PR' });
+    // No fresh session created — the whole point of reuse-if-exists.
+    expect(fromInitSpy).not.toHaveBeenCalled();
   });
 
-  test('without forceNewSession, the second activation reuses the prior session (normal node re-execution)', async () => {
+  test('createSubSession still reuses the prior session for a normal second activation (hard constraint)', async () => {
     const tam = makeManager();
-    seedReviewerSession(tam);
+    seedLiveSession(tam);
+    stubReusePathHelpers(tam);
 
-    const memberInfo: SubSessionMemberInfo = {
+    const memberInfo = {
       agentId: 'agent-reviewer',
       agentName: REVIEWER_AGENT,
       nodeId: REVIEWER_NODE_ID,
-      // forceNewSession intentionally omitted — the reuse policy MUST still apply
-      // so a second review cycle injects into the existing session.
+      // No special flag — reuse MUST still apply so a second review cycle
+      // injects into the existing reviewer session.
     };
     const proposedId = 'some-other-proposed-id';
 
@@ -186,5 +216,19 @@ describe('createSubSession — post-approval forceNewSession bypass', () => {
     expect(actual).toBe(REVIEWER_SESSION_ID);
     expect(actual).not.toBe(proposedId);
     expect(fromInitSpy).not.toHaveBeenCalled();
+  });
+
+  test('createSubSession creates a new session when no prior session exists', async () => {
+    const tam = makeManager([]); // no prior NodeExecution for this agent
+
+    const freshId = `space:${SPACE_ID}:task:${TASK_ID}:post-approval:${REVIEWER_AGENT}`;
+    const actual = await tam.createSubSession(TASK_ID, freshId, minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+    });
+
+    expect(actual).toBe(freshId);
+    expect(fromInitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -1,0 +1,190 @@
+/**
+ * TaskAgentManager.createSubSession — post-approval must spawn a FRESH session.
+ *
+ * Regression for #850 (repro #816 / GitHub #2323): approving a Coding-Workflow
+ * task whose reviewer node-agent session was still live never triggered the
+ * post-approval merge. Root cause: `spawnPostApprovalSubSession` targets the
+ * `reviewer` agent, and `createSubSession`'s unconditional agentName reuse
+ * policy handed back the reviewer's still-live (mid-teardown) session instead
+ * of spawning a fresh merge session → the SDK threw "Interrupted by user"
+ * before `postApprovalSessionId` was stamped → the task parked in `approved`.
+ *
+ * Fix: `SubSessionMemberInfo.forceNewSession` bypasses the reuse lookup so the
+ * post-approval spawn produces a genuinely fresh session.
+ *
+ * These tests construct a real TaskAgentManager (the constructor only touches
+ * `db.getDatabase()` for an inert McpAuditLogRepository and subscribes to the
+ * event bus) and drive `createSubSession` with a stubbed `AgentSession.fromInit`
+ * plus stubbed repo / mcp helpers, so the reuse-vs-fresh DECISION is exercised
+ * — not a mock of it.
+ *
+ * Coverage:
+ *   - forceNewSession=true with a prior live reviewer session → a fresh id,
+ *     distinct from the reviewer's; `AgentSession.fromInit` invoked.
+ *   - forceNewSession omitted (normal node re-execution) → reuses the prior
+ *     session id; `AgentSession.fromInit` NOT invoked. This is the hard
+ *     constraint: reuse MUST still apply for a second review cycle.
+ */
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import type { SubSessionMemberInfo } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { AgentSession as AgentSessionType } from '../../../../src/lib/agent/agent-session.ts';
+import type { AgentSessionInit } from '../../../../src/lib/agent/agent-session.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+
+const TASK_ID = 'task-850';
+const RUN_ID = 'run-850';
+const SPACE_ID = 'space-850';
+const REVIEWER_NODE_ID = 'node-reviewer';
+const REVIEWER_AGENT = 'reviewer';
+const REVIEWER_SESSION_ID = 'reviewer-session-live';
+
+/** Fake AgentSession: records the heavy lifecycle methods createSubSession calls. */
+function makeFakeSession() {
+  const calls: string[] = [];
+  const session = {
+    skillOverrides: undefined,
+    toolGuards: undefined,
+    onMissingWorkflowMcpServers: undefined,
+    updateConfig: async (): Promise<void> => {
+      calls.push('updateConfig');
+    },
+    mergeRuntimeMcpServers: (): void => {
+      calls.push('mergeRuntimeMcpServers');
+    },
+    startStreamingQuery: async (): Promise<void> => {
+      calls.push('startStreamingQuery');
+    },
+  };
+  return { session: session as unknown as AgentSessionType, calls };
+}
+
+function makeManager(): TaskAgentManager {
+  // Prior reviewer NodeExecution — simulates "reviewer already ran and its
+  // session is still live at approval time" (sessions persist until archive).
+  const reviewerExec = {
+    id: 'reviewer-exec-1',
+    workflowRunId: RUN_ID,
+    workflowNodeId: REVIEWER_NODE_ID,
+    agentName: REVIEWER_AGENT,
+    agentId: 'agent-reviewer',
+    agentSessionId: REVIEWER_SESSION_ID,
+    status: 'in_progress',
+    result: null,
+    data: null,
+    createdAt: 1,
+    startedAt: 1,
+    completedAt: null,
+    updatedAt: 1,
+  };
+  const rows = [reviewerExec];
+
+  const taskRepo = {
+    getTask: () => ({
+      id: TASK_ID,
+      spaceId: SPACE_ID,
+      workflowRunId: RUN_ID,
+      title: 'Task 850',
+    }),
+  };
+  const nodeExecutionRepo = {
+    listByWorkflowRun: () => rows,
+    listByNode: () => rows,
+    update: () => reviewerExec,
+  };
+  const sessionManager = {
+    registerSession: () => {},
+  };
+
+  return new TaskAgentManager({
+    db: { getDatabase: () => new BunDatabase(':memory:') },
+    sessionManager,
+    internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+    taskRepo,
+    nodeExecutionRepo,
+    // pendingMessageRepo / appMcpManager intentionally absent → flush + mcp
+    // config resolution become no-ops inside createSubSession.
+  } as unknown as TaskAgentManagerConfig);
+}
+
+/** Pre-seed the reviewer's live session + no-op the reuse-path instance helpers. */
+function seedReviewerSession(tam: TaskAgentManager): void {
+  (tam as unknown as { agentSessionIndex: Map<string, AgentSessionType> }).agentSessionIndex.set(
+    REVIEWER_SESSION_ID,
+    makeFakeSession().session
+  );
+  // The reuse path calls these on the seeded session; stub them to no-ops so
+  // the decision under test is reached without the full MCP re-injection stack.
+  (
+    tam as unknown as { reinjectNodeAgentMcpServer: (...a: unknown[]) => Promise<void> }
+  ).reinjectNodeAgentMcpServer = async () => {};
+  (
+    tam as unknown as { ensureRequiredMcpServersAttached: (...a: unknown[]) => Promise<void> }
+  ).ensureRequiredMcpServersAttached = async () => {};
+  (
+    tam as unknown as { registerCompletionCallback: (...a: unknown[]) => void }
+  ).registerCompletionCallback = () => {};
+}
+
+function minimalInit(): AgentSessionInit {
+  // `title` is set so createSubSession skips formatWorkflowNodeSessionTitle().
+  return { title: 'post-approval', model: 'm', mcpServers: {} } as unknown as AgentSessionInit;
+}
+
+describe('createSubSession — post-approval forceNewSession bypass', () => {
+  let fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
+
+  beforeEach(() => {
+    // Stub the heavy real session construction so we exercise ONLY the
+    // reuse-vs-fresh decision.
+    fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation(
+      (() => makeFakeSession().session) as unknown as typeof AgentSession.fromInit
+    );
+  });
+  afterEach(() => {
+    fromInitSpy.mockRestore();
+  });
+
+  test('forceNewSession spawns a fresh session distinct from the prior reviewer session', async () => {
+    const tam = makeManager();
+    seedReviewerSession(tam);
+
+    const memberInfo: SubSessionMemberInfo = {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+      forceNewSession: true,
+    };
+    const freshId = `space:${SPACE_ID}:task:${TASK_ID}:post-approval:${REVIEWER_AGENT}`;
+
+    const actual = await tam.createSubSession(TASK_ID, freshId, minimalInit(), memberInfo);
+
+    expect(actual).toBe(freshId);
+    expect(actual).not.toBe(REVIEWER_SESSION_ID);
+    expect(fromInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('without forceNewSession, the second activation reuses the prior session (normal node re-execution)', async () => {
+    const tam = makeManager();
+    seedReviewerSession(tam);
+
+    const memberInfo: SubSessionMemberInfo = {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+      // forceNewSession intentionally omitted — the reuse policy MUST still apply
+      // so a second review cycle injects into the existing session.
+    };
+    const proposedId = 'some-other-proposed-id';
+
+    const actual = await tam.createSubSession(TASK_ID, proposedId, minimalInit(), memberInfo);
+
+    expect(actual).toBe(REVIEWER_SESSION_ID);
+    expect(actual).not.toBe(proposedId);
+    expect(fromInitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -319,7 +319,7 @@ describe('PostApprovalRouter.route', () => {
     expect(final?.status).toBe('approved');
   });
 
-  test('fan-out: multiple nodes with postApproval each dispatch their own route', async () => {
+  test('multi-route degrades to single dispatch: only the first declared route fires', async () => {
     const task = makeApprovedTask(taskRepo);
     const delegates = makeDelegates();
     const router = new PostApprovalRouter({
@@ -349,10 +349,14 @@ describe('PostApprovalRouter.route', () => {
 
     const result = await router.route(task, workflow, { approvalSource: 'agent' });
 
+    // Multi-route fan-out is not supported (completion is uncoordinated and
+    // postApprovalSessionId is singular). The router dispatches AT MOST ONE
+    // route — the first declared (here `coder` on node n1) — and ignores the
+    // rest, rather than running broken parallel post-approval workers.
     expect(result.mode).toBe('spawn');
-    expect(delegates.spawned).toHaveLength(2);
-    expect(delegates.spawned.map((s) => s.targetAgent).sort()).toEqual(['coder', 'merger']);
-    // The stamped session is the primary (first dispatched).
+    expect(delegates.spawned).toHaveLength(1);
+    expect(delegates.spawned[0].targetAgent).toBe('coder');
+    expect(delegates.spawned[0].kickoffMessage).toContain('Tag release.');
     const final = taskRepo.getTask(task.id);
     expect(final?.postApprovalSessionId).toBe('spawned-session-1');
   });

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -270,7 +270,7 @@ describe('PostApprovalRouter.route', () => {
     expect(final?.pendingCompletionSubmittedByNodeId).toBeNull();
   });
 
-  test('submitting node with no postApproval bypasses workflow end-node route', async () => {
+  test('postApproval on any node fires on approval regardless of submitting node (fan-out)', async () => {
     const task = makeApprovedTask(taskRepo);
     const delegates = makeDelegates();
     const router = new PostApprovalRouter({
@@ -300,6 +300,8 @@ describe('PostApprovalRouter.route', () => {
       ],
     });
 
+    // Task submitted by n1 (no postApproval of its own). Approval is a
+    // task-level event: the router scans every node, so n2's route fires.
     const result = await router.route(
       { ...task, pendingCompletionSubmittedByNodeId: 'n1' },
       workflow,
@@ -309,11 +311,50 @@ describe('PostApprovalRouter.route', () => {
       }
     );
 
-    expect(result.mode).toBe('no-route');
-    expect(delegates.spawned).toHaveLength(0);
+    expect(result.mode).toBe('spawn');
+    expect(delegates.spawned).toHaveLength(1);
+    expect(delegates.spawned[0].targetAgent).toBe('reviewer');
+    expect(delegates.spawned[0].kickoffMessage).toContain('Merge Ship it.');
     const final = taskRepo.getTask(task.id);
-    expect(final?.status).toBe('done');
-    expect(final?.pendingCompletionSubmittedByNodeId).toBe('n1');
+    expect(final?.status).toBe('approved');
+  });
+
+  test('fan-out: multiple nodes with postApproval each dispatch their own route', async () => {
+    const task = makeApprovedTask(taskRepo);
+    const delegates = makeDelegates();
+    const router = new PostApprovalRouter({
+      taskRepo,
+      spawner: delegates.spawner,
+      livenessProbe: delegates.liveness,
+    });
+
+    const workflow = stubWorkflow({
+      startNodeId: 'n1',
+      endNodeId: 'n1',
+      nodes: [
+        {
+          id: 'n1',
+          name: 'Build',
+          agents: [{ agentId: 'coder-id', name: 'coder' }],
+          postApproval: { targetAgent: 'coder', instructions: 'Tag release.' },
+        },
+        {
+          id: 'n2',
+          name: 'Merge',
+          agents: [{ agentId: 'merger-id', name: 'merger' }],
+          postApproval: { targetAgent: 'merger', instructions: 'Merge PR.' },
+        },
+      ],
+    });
+
+    const result = await router.route(task, workflow, { approvalSource: 'agent' });
+
+    expect(result.mode).toBe('spawn');
+    expect(delegates.spawned).toHaveLength(2);
+    expect(delegates.spawned.map((s) => s.targetAgent).sort()).toEqual(['coder', 'merger']);
+    // The stamped session is the primary (first dispatched).
+    const final = taskRepo.getTask(task.id);
+    expect(final?.postApprovalSessionId).toBe('spawned-session-1');
   });
 
   test('already-routed (live session) → no re-spawn', async () => {
@@ -415,7 +456,7 @@ describe('PostApprovalRouter.route', () => {
     expect(result.mode).toBe('skipped');
   });
 
-  test('legacy task-agent target → skipped gracefully and clears pending completion state', async () => {
+  test('legacy task-agent target → filtered out, task closes (no-route, no spawn)', async () => {
     const task = makeApprovedTask(taskRepo);
     taskRepo.updateTask(task.id, {
       pendingCheckpointType: 'task_completion',
@@ -431,9 +472,10 @@ describe('PostApprovalRouter.route', () => {
       livenessProbe: delegates.liveness,
     });
 
-    // Legacy workflows may still declare targetAgent: 'task-agent'.
-    // After removal, the router skips gracefully rather than attempting
-    // a spawn that would fail (no workflow slot named 'task-agent').
+    // Legacy workflows may still declare targetAgent: 'task-agent'. That
+    // executor was removed, so the route is filtered out — with no other
+    // dispatchable route the task has no post-approval step and closes (done),
+    // never attempting a spawn that would fail (no 'task-agent' slot).
     const workflow = stubWorkflow({
       postApproval: {
         targetAgent: 'task-agent',
@@ -447,14 +489,11 @@ describe('PostApprovalRouter.route', () => {
       task_id: task.id,
     });
 
-    expect(result.mode).toBe('skipped');
-    if (result.mode !== 'skipped') return;
-    expect(result.reason).toContain('legacy task-agent');
+    expect(result.mode).toBe('no-route');
     // Spawner must NOT have been called
     expect(delegates.spawned).toHaveLength(0);
     const final = taskRepo.getTask(task.id);
-    expect(final?.pendingCheckpointType).toBeNull();
-    expect(final?.pendingCompletionSubmittedByNodeId).toBeNull();
+    expect(final?.status).toBe('done');
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-routing-integration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-routing-integration.test.ts
@@ -289,16 +289,18 @@ describe('PR 3/5 integration — dispatchPostApproval → spawn → mark_complet
   });
 
   test('approved Coding task: dispatchPostApproval threads artifact.data.prUrl into kickoff; mark_complete closes it', async () => {
-    // Pull the seeded Coding workflow — its end node must carry
-    // postApproval.targetAgent='merger' (Option C: the PR Merger runs the merge,
-    // not the reviewer) and an interpolated template.
+    // Pull the seeded Coding workflow — its Post-Approval (merger) node carries
+    // postApproval.targetAgent='merger' (the PR Merger runs the merge) and an
+    // interpolated template. Approval is a task-level event now: the route lives
+    // on the merger node, not the end (Review) node, and the router fans out to
+    // whichever node declares it.
     const coding = h.workflowManager
       .listWorkflows(SPACE_ID)
       .find((w) => w.name === CODING_WORKFLOW.name);
     expect(coding).toBeDefined();
-    const codingEndNode = coding!.nodes.find((node) => node.id === coding!.endNodeId);
-    expect(codingEndNode?.postApproval?.targetAgent).toBe('merger');
-    expect(codingEndNode?.postApproval?.instructions).toContain('{{pr_url}}');
+    const codingPostApprovalNode = coding!.nodes.find((node) => node.postApproval);
+    expect(codingPostApprovalNode?.postApproval?.targetAgent).toBe('merger');
+    expect(codingPostApprovalNode?.postApproval?.instructions).toContain('{{pr_url}}');
 
     // -----------------------------------------------------------------
     // Seed a workflow run + task, then persist a `result` artifact with

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1730,6 +1730,60 @@ describe('seedBuiltInWorkflows()', () => {
     expect(after.templateHash).not.toBe('stale-hash-from-a-prior-pr');
   });
 
+  test('re-stamp clears a stale Review-node postApproval route now that the route lives on Post-Approval', () => {
+    // Before the fan-out redesign the merge route lived on the Review node. A
+    // space seeded from that older template carries a stale route on its Review
+    // node (and none on Post-Approval). Re-stamping against the current template
+    // must CLEAR the Review node's stale route and assert the route on the
+    // Post-Approval node, so approval dispatches exactly one merge — not zero,
+    // not two. (mergeNodeStructuralFieldsFromTemplate line ~1437.)
+    seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+    const reviewNode = coding.nodes.find((node) => node.name === 'Review')!;
+    const postApprovalNode = coding.nodes.find((node) => node.name === 'Post-Approval')!;
+
+    // Simulate the pre-redesign shape: route on Review, no route on Post-Approval,
+    // and a stale template_hash so the restamp branch fires.
+    db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
+      'stale-hash-pre-fanout',
+      coding.id
+    );
+    db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE id = ?`).run(
+      JSON.stringify({
+        agents: reviewNode.agents,
+        postApproval: {
+          targetAgent: 'merger',
+          instructions: PR_MERGE_POST_APPROVAL_INSTRUCTIONS,
+        },
+      }),
+      reviewNode.id
+    );
+    db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE id = ?`).run(
+      JSON.stringify({ agents: postApprovalNode.agents }),
+      postApprovalNode.id
+    );
+
+    // Verify the simulated stale state landed: route on Review, none on Post-Approval.
+    const before = manager.getWorkflow(coding.id)!;
+    expect(before.nodes.find((node) => node.name === 'Review')?.postApproval).toBeDefined();
+    expect(
+      before.nodes.find((node) => node.name === 'Post-Approval')?.postApproval
+    ).toBeUndefined();
+
+    // Re-run the seeder — re-stamp branch fires.
+    const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+    expect(result.restamped).toContain(CODING_WORKFLOW.name);
+
+    // The Review node's stale route is cleared; Post-Approval carries the route.
+    const after = manager.getWorkflow(coding.id)!;
+    expect(after.nodes.find((node) => node.name === 'Review')?.postApproval).toBeUndefined();
+    const afterRouteNode = after.nodes.find((node) => node.name === 'Post-Approval');
+    expect(afterRouteNode?.postApproval).toBeDefined();
+    expect(afterRouteNode?.postApproval?.targetAgent).toBe('merger');
+    // Exactly one node carries a route — no double dispatch on approval.
+    expect(after.nodes.filter((node) => node.postApproval)).toHaveLength(1);
+  });
+
   test('re-stamp propagates template maxCycles onto existing Fullstack QA Loop cyclic back-channels', () => {
     // Seed fresh — Fullstack QA Loop carries the current template (maxCycles: 50)
     // and the current template hash.

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -139,14 +139,17 @@ describe('CODING_WORKFLOW template', () => {
   });
 
   test('Post-Approval node declares the shell-capable merger slot (Option C)', () => {
-    const postApproval = CODING_WORKFLOW.nodes.find((n) => n.name === 'Post-Approval')!;
-    expect(postApproval).toBeDefined();
-    expect(postApproval.agents).toHaveLength(1);
-    expect(postApproval.agents[0].agentId).toBe('PR Merger');
-    expect(postApproval.agents[0].name).toBe('merger');
-    // The end (Review) node routes post-approval to the merger, not the reviewer.
+    const postApprovalNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Post-Approval')!;
+    expect(postApprovalNode).toBeDefined();
+    expect(postApprovalNode.agents).toHaveLength(1);
+    expect(postApprovalNode.agents[0].agentId).toBe('PR Merger');
+    expect(postApprovalNode.agents[0].name).toBe('merger');
+    // The Post-Approval (merger) node owns its own post-approval merge route —
+    // approval is task-level, so the router fans out to it regardless of which
+    // node submitted. The end (Review) node no longer carries the route.
+    expect(postApprovalNode.postApproval?.targetAgent).toBe('merger');
     const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.id === CODING_WORKFLOW.endNodeId)!;
-    expect(reviewNode.postApproval?.targetAgent).toBe('merger');
+    expect(reviewNode.postApproval).toBeUndefined();
   });
 
   test('merger can route a merge conflict to the coder and receive the reply', () => {
@@ -615,8 +618,12 @@ describe('RESEARCH_WORKFLOW template', () => {
       'Review',
       'Post-Approval',
     ]);
+    const researchPostApprovalNode = RESEARCH_WORKFLOW.nodes.find(
+      (n) => n.name === 'Post-Approval'
+    )!;
+    expect(researchPostApprovalNode.postApproval?.targetAgent).toBe('merger');
     const reviewNode = RESEARCH_WORKFLOW.nodes.find((n) => n.id === RESEARCH_WORKFLOW.endNodeId)!;
-    expect(reviewNode.postApproval?.targetAgent).toBe('merger');
+    expect(reviewNode.postApproval).toBeUndefined();
   });
 
   test('first node uses Research agent', () => {
@@ -1634,12 +1641,17 @@ describe('seedBuiltInWorkflows()', () => {
       const wf = workflows.find((w) => w.name === name);
       expect(wf, `workflow "${name}" must be seeded`).toBeDefined();
       expect(wf!.postApproval).toBeUndefined();
-      const endNode = wf!.nodes.find((node) => node.id === wf!.endNodeId);
-      expect(endNode?.postApproval, `"${name}" end node must have postApproval`).toBeDefined();
-      expect(endNode!.postApproval!.targetAgent).toBe('merger');
+      // The merge route lives on the dedicated Post-Approval (merger) node;
+      // approval is task-level so the router fans out to it. The end node no
+      // longer carries the route.
+      const routeNode = wf!.nodes.find((node) => node.postApproval);
+      expect(routeNode, `"${name}" must have a node carrying postApproval`).toBeDefined();
+      expect(routeNode!.postApproval!.targetAgent).toBe('merger');
       // Non-empty instructions — we don't snapshot the full template here
       // because end-node-handoff.test.ts already asserts the exact content.
-      expect(endNode!.postApproval!.instructions.length).toBeGreaterThan(0);
+      expect(routeNode!.postApproval!.instructions.length).toBeGreaterThan(0);
+      const endNode = wf!.nodes.find((node) => node.id === wf!.endNodeId);
+      expect(endNode?.postApproval).toBeUndefined();
     };
     assertPostApproval('Coding Workflow');
     assertPostApproval('Research Workflow');
@@ -1684,21 +1696,23 @@ describe('seedBuiltInWorkflows()', () => {
     // The re-stamp path should detect the hash drift and push the current
     // node-level `postApproval` (+ current hash) onto the row.
     const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-    const codingEndNode = coding.nodes.find((node) => node.id === coding.endNodeId)!;
+    const codingPostApprovalNode = coding.nodes.find((node) => node.name === 'Post-Approval')!;
     db.prepare(
       `UPDATE space_workflows
 			    SET template_hash = ?, post_approval = NULL
 			  WHERE id = ?`
     ).run('stale-hash-from-a-prior-pr', coding.id);
     db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE id = ?`).run(
-      JSON.stringify({ agents: codingEndNode.agents }),
-      codingEndNode.id
+      JSON.stringify({ agents: codingPostApprovalNode.agents }),
+      codingPostApprovalNode.id
     );
 
     // Verify the simulated drift landed.
     const before = manager.getWorkflow(coding.id)!;
     expect(before.postApproval).toBeUndefined();
-    expect(before.nodes.find((node) => node.id === before.endNodeId)?.postApproval).toBeUndefined();
+    expect(
+      before.nodes.find((node) => node.name === 'Post-Approval')?.postApproval
+    ).toBeUndefined();
     expect(before.templateHash).toBe('stale-hash-from-a-prior-pr');
 
     // Re-run the seeder — re-stamp branch fires.
@@ -1710,10 +1724,9 @@ describe('seedBuiltInWorkflows()', () => {
     // Row now carries the current template's node-level postApproval + hash.
     const after = manager.getWorkflow(coding.id)!;
     expect(after.postApproval).toBeUndefined();
-    expect(after.nodes.find((node) => node.id === after.endNodeId)?.postApproval).toBeDefined();
-    expect(after.nodes.find((node) => node.id === after.endNodeId)?.postApproval?.targetAgent).toBe(
-      'merger'
-    );
+    const afterRouteNode = after.nodes.find((node) => node.name === 'Post-Approval');
+    expect(afterRouteNode?.postApproval).toBeDefined();
+    expect(afterRouteNode?.postApproval?.targetAgent).toBe('merger');
     expect(after.templateHash).not.toBe('stale-hash-from-a-prior-pr');
   });
 
@@ -1787,14 +1800,14 @@ describe('seedBuiltInWorkflows()', () => {
   test('re-stamp preserves existing postApproval when a node was renamed', () => {
     seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
     const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-    const reviewNode = coding.nodes.find((n) => n.name === 'Review')!;
-    expect(reviewNode.postApproval).toBeDefined();
+    const routeNode = coding.nodes.find((n) => n.name === 'Post-Approval')!;
+    expect(routeNode.postApproval).toBeDefined();
 
     // Bypass manager validation — only rename node, don't touch hooks.
     // Direct DB update avoids hook validation against renamed nodes.
     db.prepare(`UPDATE space_workflow_nodes SET name = ? WHERE id = ?`).run(
-      'Human Review',
-      reviewNode.id
+      'Human Merger',
+      routeNode.id
     );
     db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
       'stale-hash',
@@ -1805,9 +1818,11 @@ describe('seedBuiltInWorkflows()', () => {
     expect(result.restamped).toContain(CODING_WORKFLOW.name);
 
     const after = manager.getWorkflow(coding.id)!;
-    const afterReviewNode = after.nodes.find((n) => n.id === reviewNode.id)!;
-    expect(afterReviewNode.name).toBe('Human Review');
-    expect(afterReviewNode.postApproval).toEqual(reviewNode.postApproval);
+    const afterRenamedNode = after.nodes.find((n) => n.id === routeNode.id)!;
+    expect(afterRenamedNode.name).toBe('Human Merger');
+    // The renamed node no longer matches the template by name, so the reconciler
+    // preserves its existing postApproval rather than clobbering it.
+    expect(afterRenamedNode.postApproval).toEqual(routeNode.postApproval);
   });
 
   test('re-stamp succeeds and leaves handle field untouched (no handle write during restamp)', () => {
@@ -1828,7 +1843,7 @@ describe('seedBuiltInWorkflows()', () => {
     // node-level postApproval and completionAutonomyLevel are correctly re-stamped.
     const after = manager.getWorkflow(coding.id)!;
     expect(after.postApproval).toBeUndefined();
-    expect(after.nodes.find((node) => node.id === after.endNodeId)?.postApproval).toBeDefined();
+    expect(after.nodes.find((node) => node.name === 'Post-Approval')?.postApproval).toBeDefined();
     expect(after.completionAutonomyLevel).toBe(CODING_WORKFLOW.completionAutonomyLevel);
     // Handle is NOT written by re-stamp — NULL rows are backfilled by migration 124, not the seeder.
     expect(after.handle).toBeUndefined();

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -5,13 +5,14 @@
  * the post-approval routing contract:
  *
  *   - Coding / Research / QA end nodes each save a result artifact carrying
- *     `data.pr_url` BEFORE calling `approve_task`. These three terminal nodes
- *     MUST also declare a node-level
- *     `postApproval: { targetAgent: 'reviewer', instructions: <merge template> }`
- *     route so the runtime dispatches the merge. PR 5/5 removed the legacy
- *     `post_approval_action: "merge_pr"` discriminator from the data payload —
- *     post-approval routing is now fully declarative on the terminal node's
- *     `postApproval` field and nothing consumed the runtime discriminator.
+ *     `data.pr_url` BEFORE calling `approve_task`. The merge route itself lives
+ *     on each workflow's dedicated Post-Approval (merger) node as a node-level
+ *     `postApproval: { targetAgent: 'merger', instructions: <merge template> }`
+ *     — approval is a task-level event, so the router fans out to whichever
+ *     node declares the route regardless of which node submitted. PR 5/5
+ *     removed the legacy `post_approval_action: "merge_pr"` discriminator from
+ *     the data payload — post-approval routing is fully declarative on
+ *     `postApproval` and nothing consumed the runtime discriminator.
  *
  *   - QA no longer embeds `gh pr merge` / worktree-sync instructions — the
  *     reviewer post-approval session runs the merge instead. The QA workflow's
@@ -69,9 +70,11 @@ function endNodePrompt(wf: SpaceWorkflow): string {
   return prompt;
 }
 
-function endNodePostApproval(wf: SpaceWorkflow) {
-  const endNode = wf.nodes.find((node) => node.id === wf.endNodeId);
-  return endNode?.postApproval;
+function postApprovalRoute(wf: SpaceWorkflow) {
+  // Approval is a task-level event: the route lives on whichever node declares
+  // it (the merger / Post-Approval node for merge-routed built-ins), and the
+  // router fans out to it regardless of which node submitted.
+  return wf.nodes.find((node) => node.postApproval)?.postApproval;
 }
 
 /** Workflows whose terminal node MUST declare a reviewer post-approval merge route. */
@@ -91,10 +94,10 @@ const NO_POST_APPROVAL_WORKFLOWS: Array<[string, SpaceWorkflow]> = [
 // postApproval presence
 // ---------------------------------------------------------------------------
 
-describe('End-node post-approval declarations', () => {
+describe('Post-approval route declarations', () => {
   for (const [label, wf] of MERGE_ROUTED_WORKFLOWS) {
     test(`${label} declares node-level postApproval targeting the merger role`, () => {
-      const route = endNodePostApproval(wf);
+      const route = postApprovalRoute(wf);
       expect(route).toBeDefined();
       expect(route!.targetAgent).toBe('merger');
       // Uses the merge prompt. The runtime appends the
@@ -104,7 +107,7 @@ describe('End-node post-approval declarations', () => {
     });
 
     test(`${label} postApproval targetAgent matches an actual agent name in the workflow`, () => {
-      const route = endNodePostApproval(wf);
+      const route = postApprovalRoute(wf);
       const targetSlot = wf.nodes
         .flatMap((n) => n.agents)
         .find((a) => a.name === route!.targetAgent);
@@ -115,7 +118,7 @@ describe('End-node post-approval declarations', () => {
   for (const [label, wf] of NO_POST_APPROVAL_WORKFLOWS) {
     test(`${label} has NO postApproval route (end node closes directly)`, () => {
       expect(wf.postApproval).toBeUndefined();
-      expect(endNodePostApproval(wf)).toBeUndefined();
+      expect(postApprovalRoute(wf)).toBeUndefined();
     });
   }
 

--- a/packages/web/src/components/space/PendingPostApprovalBanner.tsx
+++ b/packages/web/src/components/space/PendingPostApprovalBanner.tsx
@@ -8,8 +8,11 @@
  * calling `mark_complete`, or the configured target agent could not be found.
  *
  * The banner offers three actions:
- *   - **Retry** — re-run the approval dispatch (not implemented yet; surfaces
- *     a disabled placeholder with a future hook).
+ *   - **Send back** — transition `approved → in_progress` so the operator can
+ *     restart the work and re-approve when ready. This does NOT re-run the
+ *     post-approval dispatch (a dedicated `retryPostApproval` RPC is tracked
+ *     separately); the operator must redo the work and call `approve_task`
+ *     again.
  *   - **Mark done** — manually transition `approved → done` via
  *     `spaceTask.update`. Equivalent to the end-node calling `mark_complete`
  *     itself; use when the work is provably finished but the sub-session
@@ -62,7 +65,7 @@ export function PendingPostApprovalBanner({
     }
   }, [task.id]);
 
-  const onRetry = useCallback(async () => {
+  const onSendBack = useCallback(async () => {
     // Returns the task to `in_progress` so the operator can restart the
     // work and re-approve when ready. The reconciliation pass does NOT
     // automatically re-trigger post-approval routing on this transition —
@@ -77,7 +80,7 @@ export function PendingPostApprovalBanner({
         postApprovalBlockedReason: null,
       });
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to retry');
+      setError(err instanceof Error ? err.message : 'Failed to send back');
     } finally {
       setBusy(false);
     }
@@ -88,11 +91,11 @@ export function PendingPostApprovalBanner({
 
   const actions: InlineStatusBannerAction[] = [
     {
-      label: 'Retry',
-      onClick: () => void onRetry(),
+      label: 'Send back',
+      onClick: () => void onSendBack(),
       variant: 'secondary',
       disabled: busy,
-      testId: 'pending-post-approval-retry-btn',
+      testId: 'pending-post-approval-send-back-btn',
     },
     {
       label: 'Mark done',

--- a/packages/web/src/components/space/__tests__/PendingPostApprovalBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingPostApprovalBanner.test.tsx
@@ -4,8 +4,8 @@
  * Covers:
  *   - Hidden when task.status !== 'approved'
  *   - Hidden when status==='approved' but no postApprovalBlockedReason
- *   - Renders reason + Retry + Mark done actions when blocked reason is set
- *   - Retry triggers spaceStore.updateTask with status='in_progress'
+ *   - Renders reason + Send back + Mark done actions when blocked reason is set
+ *   - Send back triggers spaceStore.updateTask with status='in_progress'
  *   - Mark done triggers spaceStore.updateTask with status='done'
  *   - View session action appears only when session id + handler both present
  */
@@ -63,7 +63,7 @@ describe('PendingPostApprovalBanner', () => {
     expect(queryByTestId('pending-post-approval-banner')).toBeNull();
   });
 
-  it('renders reason + Retry + Mark done when blocked', () => {
+  it('renders reason + Send back + Mark done when blocked', () => {
     const task = makeTask({
       status: 'approved',
       postApprovalBlockedReason: 'deploy session crashed',
@@ -73,18 +73,18 @@ describe('PendingPostApprovalBanner', () => {
     );
     const banner = getByTestId('pending-post-approval-banner');
     expect(banner.textContent).toContain('deploy session crashed');
-    expect(queryByTestId('pending-post-approval-retry-btn')).not.toBeNull();
+    expect(queryByTestId('pending-post-approval-send-back-btn')).not.toBeNull();
     expect(queryByTestId('pending-post-approval-mark-done-btn')).not.toBeNull();
     expect(queryByTestId('pending-post-approval-view-session-btn')).toBeNull();
   });
 
-  it('Retry calls updateTask with status=in_progress', async () => {
+  it('Send back calls updateTask with status=in_progress', async () => {
     const task = makeTask({
       status: 'approved',
       postApprovalBlockedReason: 'spawn failed',
     });
     const { getByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
-    fireEvent.click(getByTestId('pending-post-approval-retry-btn'));
+    fireEvent.click(getByTestId('pending-post-approval-send-back-btn'));
     await waitFor(() => {
       expect(updateTaskMock).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
Fixes the 100% post-approval merge failure (#816/#2323) and simplifies the design: approval is a task-level event, not tied to the node that submitted.

Two layers:

1. **Per-delivery (revert of the force-fresh workaround):** `spawnPostApprovalSubSession` reuses the target agent's live session if it has one, else creates one — and injects the kickoff directly (never interrupting). The earlier `forceNewSession` flag worked but for the wrong reason; the real #816 cause was `createSubSession`'s reuse path calling `restartQuery()` (`reinjectNodeAgentMcpServer`), which interrupts an active drive. Direct injection never interrupts.

2. **Fan-out (this PR's design change):** `PostApprovalRouter` now scans every node carrying a `postApproval` route and dispatches each, independent of the source node. The built-in Coding/Research/QA workflows move their merge route off the Review/QA end node onto the dedicated Post-Approval (merger) node — the node whose own agent runs the merge. Existing spaces migrate for free via `mergeNodeStructuralFieldsFromTemplate` (overwrites node postApproval from the template by name).

Also renames the misleading "Retry" button to "Send back" in PendingPostApprovalBanner (resets approved→in_progress; doesn't re-run the merge).

Follow-ups (deferred, non-blocking): rehydration of the fresh merger session on daemon restart; flush-pollution on the create path; the agent-level field move (`postApproval`: node → agent slot) as a pure structural refactor.