### PR TITLE
fix(space): attach space-agent-tools to post-approval merger session [#852]

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1662,6 +1662,72 @@ export class SpaceRuntimeService {
   }
 
   /**
+   * Build the generic-member `space-agent-tools` MCP server for a Space session.
+   *
+   * This is the single source of truth for the ad-hoc-member (and post-approval)
+   * `space-agent-tools` server config — extracted from `attachSpaceToolsToMemberSession`
+   * so non-SpaceRuntime-owned spawns that the Space MCP policy still classifies as
+   * members (notably `TaskAgentManager.spawnPostApprovalSubSession`) can attach the
+   * SAME server without hand-rolling a parallel builder. See task #852: a post-approval
+   * session resolves to `ad_hoc_member` in `resolveSpaceMcpSessionPolicy`, so the
+   * `ensureMemberSpaceMcpInvariant` guard requires `space-agent-tools` on it.
+   *
+   * `sessionId` becomes the server's `mySessionId` (writer-identity / reply routing).
+   */
+  buildMemberSpaceToolsMcpServer(space: Space, sessionId: string): McpServerConfig {
+    const spaceManagerForApproval = this.config.spaceManager;
+    return createSpaceAgentMcpServer({
+      spaceId: space.id,
+      db: this.config.db,
+      longHorizonAgentRepo: this.config.longHorizonAgentRepo,
+      runtime: this.runtime,
+      workflowManager: this.config.spaceWorkflowManager,
+      spaceManager: this.config.spaceManager,
+      taskRepo: this.config.taskRepo,
+      nodeExecutionRepo: this.nodeExecutionRepo,
+      workflowRunRepo: this.config.workflowRunRepo,
+      taskManager: new SpaceTaskManager(
+        this.config.db,
+        space.id,
+        this.config.reactiveDb,
+        this.config.evolutionScopeService
+      ),
+      spaceAgentManager: this.config.spaceAgentManager,
+      sessionManager: this.config.sessionManager,
+      clearLongTermAgentSessionProvider: (sid, aid) =>
+        this.clearLongTermAgentSessionProvider(sid, aid),
+      getRuntimeSession: (sid) =>
+        this.taskAgentManager?.getCachedAgentSessionById(sid) ?? undefined,
+      taskAgentManager: this.taskAgentManager ?? undefined,
+      gateDataRepo: this.config.gateDataRepo,
+      internalEventBus: this.config.internalEventBus,
+      onGateChanged: (runId, gateId) => {
+        void this.notifyGateDataChanged(runId, gateId).catch(() => {});
+      },
+      pendingMessageQueue: this.config.pendingMessageRepo,
+      getSpaceAutonomyLevel: async (sid) => {
+        const s = await spaceManagerForApproval.getSpace(sid);
+        return s?.autonomyLevel ?? 1;
+      },
+      // Member sessions don't declare themselves as "space-agent"; they are
+      // ordinary participants in the Space. Leaving myAgentName undefined
+      // means gate writer-authorization paths that rely on matching the
+      // writer name fall through to the autonomy path, which is the
+      // correct gating behavior for non-space-agent callers.
+      mySessionId: sessionId,
+      auditLogRepo: this.auditLogRepo,
+      scheduleService: this.config.scheduleService,
+      goalService: this.config.goalService,
+      evolutionScopeService: this.config.evolutionScopeService,
+      evolutionEpisodeService: this.config.evolutionEpisodeService,
+      replyRoutingRegistry: this.config.replyRoutingRegistry,
+      messageResolver: this.createMessageResolver(space.id),
+      longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
+      externalEventStore: this.config.externalEventStore,
+    }) as unknown as McpServerConfig;
+  }
+
+  /**
    * Attach generic Space MCP servers to an ad-hoc Space member session.
    *
    * Role selection is centralised in `resolveSpaceMcpSessionPolicy`; this method
@@ -1706,59 +1772,10 @@ export class SpaceRuntimeService {
     // last-writer-wins, so the uncapped server would win and defeat the ceiling.
     if (this.sessionBelongsToLongHorizonAgent(spaceId, session.id)) return;
 
-    const spaceManagerForApproval = this.config.spaceManager;
-    const mcpServer = createSpaceAgentMcpServer({
-      spaceId: space.id,
-      db: this.config.db,
-      longHorizonAgentRepo: this.config.longHorizonAgentRepo,
-      runtime: this.runtime,
-      workflowManager: this.config.spaceWorkflowManager,
-      spaceManager: this.config.spaceManager,
-      taskRepo: this.config.taskRepo,
-      nodeExecutionRepo: this.nodeExecutionRepo,
-      workflowRunRepo: this.config.workflowRunRepo,
-      taskManager: new SpaceTaskManager(
-        this.config.db,
-        space.id,
-        this.config.reactiveDb,
-        this.config.evolutionScopeService
-      ),
-      spaceAgentManager: this.config.spaceAgentManager,
-      sessionManager: this.config.sessionManager,
-      clearLongTermAgentSessionProvider: (sid, aid) =>
-        this.clearLongTermAgentSessionProvider(sid, aid),
-      getRuntimeSession: (sid) =>
-        this.taskAgentManager?.getCachedAgentSessionById(sid) ?? undefined,
-      taskAgentManager: this.taskAgentManager ?? undefined,
-      gateDataRepo: this.config.gateDataRepo,
-      internalEventBus: this.config.internalEventBus,
-      onGateChanged: (runId, gateId) => {
-        void this.notifyGateDataChanged(runId, gateId).catch(() => {});
-      },
-      pendingMessageQueue: this.config.pendingMessageRepo,
-      getSpaceAutonomyLevel: async (sid) => {
-        const s = await spaceManagerForApproval.getSpace(sid);
-        return s?.autonomyLevel ?? 1;
-      },
-      // Member sessions don't declare themselves as "space-agent"; they are
-      // ordinary participants in the Space. Leaving myAgentName undefined
-      // means gate writer-authorization paths that rely on matching the
-      // writer name fall through to the autonomy path, which is the
-      // correct gating behavior for non-space-agent callers.
-      mySessionId: session.id,
-      auditLogRepo: this.auditLogRepo,
-      scheduleService: this.config.scheduleService,
-      goalService: this.config.goalService,
-      evolutionScopeService: this.config.evolutionScopeService,
-      evolutionEpisodeService: this.config.evolutionEpisodeService,
-      replyRoutingRegistry: this.config.replyRoutingRegistry,
-      messageResolver: this.createMessageResolver(space.id),
-      longTermAgentDelivery: this.longTermAgentDeliveryCallbacks(),
-      externalEventStore: this.config.externalEventStore,
-    });
+    const mcpServer = this.buildMemberSpaceToolsMcpServer(space, session.id);
 
     const additional: Record<string, McpServerConfig> = {
-      'space-agent-tools': mcpServer as unknown as McpServerConfig,
+      'space-agent-tools': mcpServer,
     };
     if (this.config.memoryRepo) {
       additional['agent-memory'] = createAgentMemoryMcpServer({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4860,6 +4860,22 @@ export class TaskAgentManager {
       mcpServers: {
         ...init.mcpServers,
         'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+        // #852: a post-approval session carries no NodeExecution row and its id
+        // has no `:exec:` segment, so resolveSpaceMcpSessionPolicy classifies it as
+        // an ad-hoc Space member — and ensureMemberSpaceMcpInvariant therefore
+        // REQUIRES `space-agent-tools` on it (same as any ad-hoc member). The spawn
+        // previously attached only node-agent + agent-memory, so the merger's first
+        // turn tripped the invariant and was misrecorded as "Interrupted by user".
+        //
+        // Attach via the SAME builder attachSpaceToolsToMemberSession uses (no
+        // hand-rolled parallel server). init.mcpServers is merged into the session's
+        // runtime MCP map inside createSubSession BEFORE startStreamingQuery, so the
+        // server is present when runQuery runs the invariant at first turn — this is
+        // race-free, unlike a post-create merge which can lose to runQuery's check.
+        'space-agent-tools': this.config.spaceRuntimeService.buildMemberSpaceToolsMcpServer(
+          space,
+          sessionId
+        ),
         ...this.buildAgentMemoryMcpServers(spaceId, sessionId),
       },
     };
@@ -4876,6 +4892,17 @@ export class TaskAgentManager {
         `spawnPostApprovalSubSession: spawned session ${actualSessionId} not registered in memory`
       );
     }
+
+    // #852: wire the Space-member MCP self-heal so a future regression (cache
+    // eviction / DB reload dropping the in-process `space-agent-tools` server)
+    // recovers via reattachMemberSpaceTools instead of tripping
+    // ensureMemberSpaceMcpInvariant. Sub-sessions are created via
+    // AgentSession.fromInit, which — unlike SessionManager.createAgentSessionFromSession
+    // — does NOT wire this callback, so attach it explicitly here, mirroring what
+    // attachSpaceToolsToMemberSession wires for normal ad-hoc members.
+    spawned.onMissingMemberSpaceMcpServers = async (sid: string) => {
+      await this.config.spaceRuntimeService.reattachMemberSpaceTools(sid);
+    };
 
     await this.ensureNodeAgentAttached(spawned, {
       taskId,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -66,6 +66,34 @@ function makeFakeSession(id: string = REVIEWER_SESSION_ID) {
   return { session: session as unknown as AgentSessionType, calls };
 }
 
+/**
+ * Fake AgentSession that CAPTURES every `mergeRuntimeMcpServers` argument, so a
+ * test can assert exactly which MCP servers reached the session's runtime map
+ * (the map `QueryRunner.ensureMemberSpaceMcpInvariant` reads at first turn).
+ * Also exposes a settable `onMissingMemberSpaceMcpServers` for self-heal wiring.
+ */
+function makeCapturingFakeSession(id: string): {
+  session: AgentSessionType;
+  mergedArgs: Record<string, unknown>[];
+} {
+  const mergedArgs: Record<string, unknown>[] = [];
+  const session = {
+    session: { id },
+    skillOverrides: undefined,
+    toolGuards: undefined,
+    onMissingWorkflowMcpServers: undefined,
+    onMissingMemberSpaceMcpServers: undefined as
+      | ((sessionId: string, missing: string[]) => Promise<void>)
+      | undefined,
+    updateConfig: async (): Promise<void> => {},
+    mergeRuntimeMcpServers: (arg: Record<string, unknown>): void => {
+      mergedArgs.push(arg);
+    },
+    startStreamingQuery: async (): Promise<void> => {},
+  };
+  return { session: session as unknown as AgentSessionType, mergedArgs };
+}
+
 function reviewerExec(sessionId: string = REVIEWER_SESSION_ID) {
   return {
     id: 'reviewer-exec-1',
@@ -230,5 +258,96 @@ describe('spawnPostApprovalSubSession — reuse-if-exists else create', () => {
 
     expect(actual).toBe(freshId);
     expect(fromInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression for #852: the built-in `merger` (and any post-approval target with no
+  // live session) takes the CREATE branch. That session is classified as an ad-hoc
+  // Space member by resolveSpaceMcpSessionPolicy, so ensureMemberSpaceMcpInvariant
+  // REQUIRES `space-agent-tools` on it. Previously the spawn attached only node-agent
+  // + agent-memory, so the first turn threw the MCP-invariant error (misrecorded as
+  // "Interrupted by user"). This test pins the fix: space-agent-tools is attached via
+  // the shared member builder and reaches the session's runtime MCP map (the map the
+  // invariant reads) before the first turn, and the self-heal callback is wired.
+  test('CREATE branch attaches space-agent-tools before first turn + wires self-heal (#852)', async () => {
+    const tam = makeManager([]); // no NodeExecution row → no live session → CREATE branch
+    // resolveSessionId probes db.getSession(); makeManager omits it, so add a stub.
+    (tam.config as unknown as { db: Record<string, unknown> }).db.getSession = () => null;
+    (tam.config as unknown as Record<string, unknown>).workflowRunRepo = { getRun: () => null };
+    (tam.config as unknown as Record<string, unknown>).spaceAgentManager = {
+      getById: () => ({
+        id: 'agent-reviewer',
+        name: REVIEWER_AGENT,
+        customPrompt: 'merge the approved PR',
+        model: 'm',
+        tools: [],
+      }),
+    };
+
+    const satMarker = { __role: 'space-agent-tools' };
+    const buildCalls: Array<{ spaceId: string; sessionId: string }> = [];
+    const reattachCalls: string[] = [];
+    (tam.config as unknown as Record<string, unknown>).spaceRuntimeService = {
+      buildMemberSpaceToolsMcpServer: (space: { id: string }, sid: string) => {
+        buildCalls.push({ spaceId: space.id, sessionId: sid });
+        return satMarker;
+      },
+      reattachMemberSpaceTools: async (sid: string) => {
+        reattachCalls.push(sid);
+      },
+    };
+    // The real node-agent builder needs many config fields; stub it — node-agent
+    // attachment is orthogonal to the space-agent-tools fix under test.
+    (
+      tam as unknown as { buildNodeAgentMcpServerForSession: () => unknown }
+    ).buildNodeAgentMcpServerForSession = () => ({ __role: 'node-agent' });
+    (
+      tam as unknown as { ensureNodeAgentAttached: (...a: unknown[]) => Promise<void> }
+    ).ensureNodeAgentAttached = async () => {};
+    (
+      tam as unknown as { injectMessageIntoSession: (...a: unknown[]) => Promise<string> }
+    ).injectMessageIntoSession = async () => 'msg-id';
+
+    const fake = makeCapturingFakeSession('fresh-merger');
+    fromInitSpy.mockImplementation((() => fake.session) as unknown as typeof AgentSession.fromInit);
+
+    const workflow = {
+      id: 'wf-1',
+      spaceId: SPACE_ID,
+      name: 'Coding',
+      nodes: [
+        {
+          id: REVIEWER_NODE_ID,
+          name: 'Review',
+          agents: [{ agentId: 'agent-reviewer', name: REVIEWER_AGENT }],
+        },
+      ],
+      channels: [],
+      gates: [],
+      startNodeId: REVIEWER_NODE_ID,
+      endNodeId: REVIEWER_NODE_ID,
+    } as unknown as SpaceWorkflow;
+    const task = { id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID } as unknown as SpaceTask;
+
+    const result = await tam.spawnPostApprovalSubSession({
+      task,
+      workflow,
+      targetAgent: REVIEWER_AGENT,
+      kickoffMessage: 'merge the approved PR',
+    });
+
+    // `space-agent-tools` reached the session's runtime MCP map — the exact map
+    // QueryRunner.ensureMemberSpaceMcpInvariant inspects at first turn.
+    const merged = fake.mergedArgs.at(-1)!;
+    expect(merged['space-agent-tools']).toBe(satMarker);
+    expect(merged['node-agent']).toEqual({ __role: 'node-agent' });
+    // Built via the shared member builder (no hand-rolled server), scoped to this
+    // space + the spawned session id.
+    expect(buildCalls).toEqual([{ spaceId: SPACE_ID, sessionId: result.sessionId }]);
+
+    // Self-heal callback is wired and delegates to the standard reattach path, so a
+    // future regression (cache eviction / DB reload) recovers instead of throwing.
+    expect(typeof fake.session.onMissingMemberSpaceMcpServers).toBe('function');
+    await fake.session.onMissingMemberSpaceMcpServers!(result.sessionId, ['space-agent-tools']);
+    expect(reattachCalls).toEqual([result.sessionId]);
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-mcp-session-policy.test.ts
@@ -129,6 +129,38 @@ describe('resolveSpaceMcpSessionPolicy', () => {
     expect(policy.requiredServers).toBe(SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS);
   });
 
+  test('routes post-approval sub-sessions as ad-hoc members requiring space-agent-tools (#852)', () => {
+    // A post-approval spawn (e.g. the built-in `merger`) carries NO NodeExecution
+    // row and its id has no `:exec:` segment, so it must NOT be mistaken for a
+    // workflow worker (which only requires `node-agent`). It is an ad-hoc Space
+    // member and therefore requires `space-agent-tools` — the invariant
+    // `spawnPostApprovalSubSession` must satisfy by attaching that server, else
+    // `ensureMemberSpaceMcpInvariant` throws at first turn.
+    const session = makeSession({
+      id: 'space:space-1:task:task-1:post-approval:merger',
+      type: 'worker',
+      context: { spaceId: 'space-1', taskId: 'task-1' },
+    });
+    const policy = resolveSpaceMcpSessionPolicy(session, {
+      nodeExecutionRepo: {
+        getByAgentSessionId: () => null,
+        getById: () => null,
+      },
+      taskRepo: { getTask: () => makeTask({ id: 'task-1', spaceId: 'space-1' }) },
+    });
+
+    expect(policy).toMatchObject({
+      role: 'ad_hoc_member',
+      spaceId: 'space-1',
+      owner: 'space-runtime',
+      attachGenericSpaceTools: true,
+      isWorkflowWorker: false,
+    });
+    expect(policy.requiredServers).toBe(SPACE_AD_HOC_MEMBER_REQUIRED_MCP_SERVERS);
+    // Belt-and-braces: this is exactly the set ensureMemberSpaceMcpInvariant enforces.
+    expect(missingMcpServers(undefined, policy.requiredServers)).toEqual(['space-agent-tools']);
+  });
+
   test('routes workflow workers by node execution ownership, not session ID shape', () => {
     const session = makeSession({
       id: 'opaque-worker-session',


### PR DESCRIPTION
Post-approval spawns (e.g. the built-in `merger`) built `init.mcpServers` with only `node-agent` + `agent-memory`. A post-approval session carries no NodeExecution row and its id has no `:exec:` segment, so `resolveSpaceMcpSessionPolicy` classifies it as `ad_hoc_member` — and `QueryRunner.ensureMemberSpaceMcpInvariant` therefore **requires `space-agent-tools`** on it. The missing server made the merger's first turn throw the MCP-invariant error, which `approvePendingCompletion` misrecorded as "Interrupted by user". #850/#2374 fixed a separate reuse-path issue and never touched this omission, which is why the same failure recurred after merging it.

This attaches `space-agent-tools` in `spawnPostApprovalSubSession` via the same builder `attachSpaceToolsToMemberSession` uses (extracted to `SpaceRuntimeService.buildMemberSpaceToolsMcpServer` — no hand-rolled server). Because `init.mcpServers` is merged into the session's runtime MCP map inside `createSubSession` **before** `startStreamingQuery`, the server is present when `runQuery` runs the invariant at first turn — race-free. It also wires `onMissingMemberSpaceMcpServers → reattachMemberSpaceTools` so a future regression self-heals instead of throwing. Normal workflow-worker node-agent sessions are untouched (they remain `workflow_worker`, require only `node-agent`, and never hit this spawn path).

Recovery for already-parked tasks (#785, #816, #848, …): their dispatch already failed, so they still need a manual Mark done or a send-back → re-approve to exercise the now-working path.
