### PR TITLE
docs(workflow-engine): RFC + ADR for data-defined workflow engine

### DIFF
--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 11. All human + codex-connector review rounds to date; every
+Proposed — Revision 12. All human + codex-connector review rounds to date; every
 code-level claim re-verified directly against current source. States complete invariants +
 phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
@@ -128,7 +128,8 @@ legacy removal before parity.**
 ## Design-review decisions (resolved/revised across 3 rounds)
 
 1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
-   history table + **read cutover** (run reads resolve through the pinned version, not the
+   history table **(every version, including the current pinned one, appended before a run
+   references it)** + **read cutover** (run reads resolve through the pinned version, not the
    mutable head). **Deletion-safety** (no `workflow_id` FK — orphan, not erase; guard all
    delete paths + version-FK). **Phase 1e** delays run-`done` until post-approval resolves
    (today `space-runtime.ts:7814` sets `done` before `dispatchPostApproval`).

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -1,0 +1,120 @@
+# ADR 0003: Data-Defined Workflow Engine
+
+## Status
+
+Proposed — awaiting design review. Phase 0 (architecture only); no runtime changes.
+Companion RFC: `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
+
+## Context
+
+HyperNeo's Space workflow system has organically become a capable agent-collaboration
+engine: a `SpaceWorkflow` (nodes / channels / gates / hooks / post-approval routes) is
+interpreted by a generic runtime that drives runs by activating work items, evaluating
+gates, and routing durable messages. A code survey for this RFC found that the engine is
+already **~85% data-defined**:
+
+- There is no `switch(workflowType)` / `switch(nodeType)` dispatch in the core runtime.
+  Topology, gate evaluation, cycle caps, completion detection, and post-approval routing
+  are all data-driven.
+- A clean connector abstraction already exists
+  (`packages/daemon/src/lib/space/runtime/connectors/`) — `Connector` / `ConnectorOp` /
+  `ConnectorOutcome` / `ConnectorAuth` behind a generic registry — and the connector layer
+  is being rolled out behind a feature flag (`isConnectorsLayerEnabled()`).
+- Goal V2 (`space_goals`) is already layered cleanly above the engine as a "what/when"
+  trigger/spec layer, while `SpaceWorkflow` is the "how" execution-definition layer.
+
+However, the remaining ~15% is **domain-specific (GitHub/PR/Codex) logic leaking into the
+generic type and core paths**, and single-process execution let us defer two durability
+seams. Concretely:
+
+- `WorkflowNode.requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` are
+  first-class fields on the **generic** shared type (`packages/shared/src/types/space.ts:2287`,
+  duplicated at `:2321`), with a ~300-line Codex feature compiler in
+  `gate-features.ts` and Codex-specific validation in `space-workflow-manager.ts:559–646`.
+- `pr_url` is an implicit handoff contract threaded through the channel router
+  (`getPrUrlForRun`, `channel-router.ts:363`), gate-script env (`PR_URL`),
+  `gate-evaluator.ts:563`, the post-approval template context, and the
+  `space_tasks.pr_url` / `pr_number` / `pr_created_at` columns. (Migration 84's stated
+  intent was already to replace these columns with `workflow_run_artifacts` —
+  `migrations.ts:380` — confirming the canonical direction, but the extraction is
+  incomplete.)
+- Daemon-restart recovery has a GitHub-specific path
+  (`rehydrateActiveRunPrEventSubscriptions`, `space-runtime-service.ts:2523`).
+- There are **no leases or fencing tokens**: single-process SQLite transactions suffice
+  today, but the seams needed for multi-worker durability (and for cleanly resolving the
+  recurring "stranded message delivery" class, tasks #859–#862) are absent.
+- Definitions are mutable; an edit can silently change the behavior of an in-flight run.
+
+The goal (#874) is to make this a **domain-agnostic, durable execution framework** —
+usable for business processes, manufacturing, ecommerce, personal-assistant workflows, and
+agent collaboration — with a strictly incremental, compatibility-first migration.
+
+## Decision
+
+Adopt the foundational rule:
+
+> **Data-defined behavior, code-defined semantics, plugin-defined capabilities.**
+
+- **Data-defined behavior.** All workflow-specific behavior lives in immutable, versioned
+  **definitions** (topology, transitions, prompts, policies, approval thresholds, delivery
+  targets, timers). The kernel interprets definitions and **never branches on which
+  workflow is running.**
+- **Code-defined semantics.** The generic kernel owns the *meaning* of transitions,
+  durable work items and append-only attempts, roles/actor assignment, authorization,
+  leases, idempotency, approvals, timers, inbox/outbox delivery, retries, recovery, audit,
+  and terminal semantics. These are universal.
+- **Plugin-defined capabilities.** Domain actions (GitHub, ecommerce, MES, travel) are
+  **connectors** in a generic capability registry, invoked by id. Agents, humans, and
+  services are **workers**; sessions are execution *resources*, not workflow identity.
+  Messages communicate; explicit outcomes/signals/commands advance process state.
+
+Concretely, **accept the RFC's phased extraction plan** (`docs/design/workflow-engine-rfc.md` §9):
+
+1. Immutable, versioned definitions pinned on runs.
+2. Generic `runtime_context` map replacing the `pr_url` implicit contract.
+3. Generic `gateFeatureOverrides` replacing `requireCodexApproval` / the codex feature.
+4. Append-only attempts + leases/fencing (flag-gated).
+5. Connector-declared `recoverRun` hook replacing GitHub-specific recovery.
+6. Reference definitions (ecommerce return, manufacturing defect, travel) proving
+   genericity.
+7. Retire the legacy `room/` Mission System after parity.
+
+Each phase is one compatibility-preserving PR behind adapters/feature flags, with dual-read
+where needed, migration tests, and explicit rollback criteria. **No big-bang rewrite; no
+silent reinterpretation of active runs; no legacy removal before parity evidence.**
+
+## Consequences
+
+**Positive**
+
+- The engine becomes usable for arbitrary domains without core changes — adding ecommerce,
+  manufacturing, or travel workflows means authoring a definition + connector, not editing
+  the kernel.
+- Existing workflows keep running unchanged throughout; the migration is bounded extraction,
+  not a rewrite, because the model is already largely correct.
+- Leases + fencing + append-only attempts close the durability gap that produces stranded
+  message delivery (#859–#862) and make recovery observable and auditable.
+- Definition versioning makes in-flight runs immune to silent behavior changes from edits.
+- Goal V2 is validated as the correct trigger layer above a generic execution engine.
+
+**Negative**
+
+- Several phases of dual-read/dual-write code and adapters to maintain until parity is
+  proven and the legacy path is removed — near-term complexity for long-term cleanliness.
+- Leases/fencing add a new subsystem; even flag-gated, it must be tested under crash,
+  duplicate-wake, and concurrent-claim scenarios.
+- Reference workflows (Phase 6) add fixture/test surface that must be maintained.
+
+**Neutral**
+
+- The `room/` legacy Mission System is frozen, not deleted; retirement is gated on parity
+  evidence and a quiet period (Phase 7).
+- Terminology is intentionally unchanged where the current vocabulary is already correct
+  (Run, Work item, Gate, Channel) to keep the migration incremental and the diff
+  reviewable.
+
+## Open questions (deferred to review of the RFC)
+
+See RFC §12: definition-version storage shape; whether leases are required in the
+single-process path now or strictly flag-gated; whether legacy goals are migrated or
+frozen; whether reference workflows ship in-tree or as a separate examples package.

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 4. Four review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 5. Five review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
 `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 5. Five review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 6. Six review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
 `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
@@ -76,7 +76,9 @@ Concretely, **accept the RFC's phased plan** (§9): extraction **plus** new prim
 4. Append-only attempts + leases/**fencing-on-every-write** (preserve idle/reactivation).
 5. Full GitHub external-event path behind connector capabilities.
 6. Reference definitions as in-tree `reference/` fixtures.
-7. Goal-system unification audit (legacy tables are dormant; de-facto frozen).
+7. Goal-system unification audit — legacy tables are a **documented compatibility surface,
+   dormant at runtime** (CLAUDE.md L172-181; no live writers); treat as a compatibility
+   surface until equivalence is proven (not "de-facto frozen").
 
 Durability cluster: **1b** transactional outbox + receiver-side dedup; **1c** durable retry
 deadlines; **1d** append-only `workflow_transition_log`; **4b** mutating-connector command

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,8 +2,11 @@
 
 ## Status
 
-Proposed — awaiting design review. Phase 0 (architecture only); no runtime changes.
-Companion RFC: `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
+Proposed — Revision 2. Architecture approved in design review (PR #2396); the human
+review's doc-accuracy fixes and the codex-connector inline review (which surfaced several
+P1 durability gaps) are incorporated, all claims re-verified against code. Re-requesting
+review. Phase 0 (architecture only); no runtime changes. Companion RFC:
+`docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
 
 ## Context
 
@@ -20,30 +23,55 @@ already **~85% data-defined**:
   (`packages/daemon/src/lib/space/runtime/connectors/`) — `Connector` / `ConnectorOp` /
   `ConnectorOutcome` / `ConnectorAuth` behind a generic registry — and the connector layer
   is being rolled out behind a feature flag (`isConnectorsLayerEnabled()`).
-- Goal V2 (`space_goals`) is already layered cleanly above the engine as a "what/when"
-  trigger/spec layer, while `SpaceWorkflow` is the "how" execution-definition layer.
+- Goal V2 (`space_goals`) is layered above the engine as a "what/when" trigger/spec layer,
+  while `SpaceWorkflow` is the "how" execution-definition layer. **Note:** there is a second,
+  also-active goal model — the room-era `goals`/`mission_executions` "Mission System"
+  (`goal-repository.ts`, driven by `goal-automation-execute.handler.ts`) — whose relationship
+  to `space_goals` is unresolved; it is **not** legacy (see Decision 7).
 
-However, the remaining ~15% is **domain-specific (GitHub/PR/Codex) logic leaking into the
-generic type and core paths**, and single-process execution let us defer two durability
-seams. Concretely:
+However, the remaining work is larger than "extract GitHub." There is domain-specific
+(GitHub/PR/Codex) logic leaking into the generic type and core paths, **and** several
+durability guarantees a "durable execution framework" requires are not yet met by the
+current single-process code. The codex-connector inline review surfaced the latter; all
+points below were re-verified against the code:
 
 - `WorkflowNode.requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` are
-  first-class fields on the **generic** shared type (`packages/shared/src/types/space.ts:2287`,
-  duplicated at `:2321`), with a ~300-line Codex feature compiler in
-  `gate-features.ts` and Codex-specific validation in `space-workflow-manager.ts:559–646`.
-- `pr_url` is an implicit handoff contract threaded through the channel router
+  first-class fields on the **generic** node types (`packages/shared/src/types/space.ts`:
+  `WorkflowNode` `:2287`, `WorkflowNodeInput` `:2321`, **and `ExportedWorkflowNode` `:2802`**
+  the portable export format), plus an `effectiveNodes` projection in
+  `updateWorkflow` (`space-workflow-manager.ts:314-316, 325-327`) that copies them through.
+  The codex feature compiler dominates `gate-features.ts` (codex paths span `:36`–`:619` of
+  631 lines), with Codex-specific validation in `space-workflow-manager.ts:559–646`.
+- `pr_url` is an implicit **runtime handoff** threaded through the channel router
   (`getPrUrlForRun`, `channel-router.ts:363`), gate-script env (`PR_URL`),
-  `gate-evaluator.ts:563`, the post-approval template context, and the
-  `space_tasks.pr_url` / `pr_number` / `pr_created_at` columns. (Migration 84's stated
-  intent was already to replace these columns with `workflow_run_artifacts` —
-  `migrations.ts:380` — confirming the canonical direction, but the extraction is
-  incomplete.)
-- Daemon-restart recovery has a GitHub-specific path
-  (`rehydrateActiveRunPrEventSubscriptions`, `space-runtime-service.ts:2523`).
-- There are **no leases or fencing tokens**: single-process SQLite transactions suffice
-  today, but the seams needed for multi-worker durability (and for cleanly resolving the
-  recurring "stranded message delivery" class, tasks #859–#862) are absent.
-- Definitions are mutable; an edit can silently change the behavior of an in-flight run.
+  `gate-evaluator.ts:563`, and the post-approval template context. The `space_tasks.pr_url`
+  columns were **already dropped** in migration 84 (`runMigration84`, `migrations.ts:6514`,
+  replaced by `workflow_run_artifacts`); only the runtime handoff remains to extract.
+- The full GitHub external-event path (restart recovery `rehydrateActiveRunPrEventSubscriptions`,
+  topic normalization, check-failure reopening, PR-URL matching, auto-subscriptions,
+  retained-event replay) lives in `space-runtime.ts`, not just restart recovery.
+- **No transactional outbox:** `send_message` commits the gate write before delivery, and
+  **live targets are delivered directly with no durable row** (only inactive targets hit
+  `pending_agent_messages`). A crash between the transition and live delivery opens the gate
+  but loses the handoff.
+- **No leases or fencing tokens**, and connector/gate **retry deadlines are in-memory only**
+  (`GateRetryScheduler`, `gate-retry-scheduler.ts:10-11,34`) — a restart loses a rate-limit
+  deadline and can strand a non-polled gate indefinitely.
+- **No append-only transition audit:** `workflow_run_artifacts` are upserts
+  (`UNIQUE(...)`), not append-only; nothing records every status/approval/cancel/gate-reset/
+  routing transition.
+- **Definition deletion is unsafe:** `space_workflow_runs.workflow_id` is `ON DELETE CASCADE`
+  and `deleteWorkflow` (`space-workflow-manager.ts:445`) has no active-run guard — deleting a
+  definition erases in-flight runs. (Definitions are also mutable, so an edit can silently
+  change an in-flight run.)
+- **Mutating connectors have no idempotency:** `ConnectorContext`/`ConnectorOp` carry no
+  command key or reconcile-unknown semantics; a crash after a remote `issueRefund`/`book`
+  succeeds but before the SQLite commit would duplicate the side effect.
+- **Terminal-vs-completion conflation:** `CompletionDetector.isComplete` returns true on
+  `reportedStatus != null`; the RFC must not treat that as terminal for leases/timers/
+  delivery, since approval and post-approval work may still be in flight.
+- **Work-item lifecycle:** `NodeExecutionStatus` has no `done`; terminal = `idle | cancelled`,
+  and successful turns become reactivatable `idle` rows.
 
 The goal (#874) is to make this a **domain-agnostic, durable execution framework** —
 usable for business processes, manufacturing, ecommerce, personal-assistant workflows, and
@@ -66,18 +94,32 @@ Adopt the foundational rule:
 - **Plugin-defined capabilities.** Domain actions (GitHub, ecommerce, MES, travel) are
   **connectors** in a generic capability registry, invoked by id. Agents, humans, and
   services are **workers**; sessions are execution *resources*, not workflow identity.
-  Messages communicate; explicit outcomes/signals/commands advance process state.
+  Channel-directed sends and explicit outcomes/commands advance process state; untargeted
+  free text only communicates.
 
-Concretely, **accept the RFC's phased extraction plan** (`docs/design/workflow-engine-rfc.md` §9):
+Concretely, **accept the RFC's phased plan** (`docs/design/workflow-engine-rfc.md` §9),
+which is extraction **plus** a durability cluster that closes the verified gaps first:
 
-1. Immutable, versioned definitions pinned on runs.
-2. Generic `runtime_context` map replacing the `pr_url` implicit contract.
-3. Generic `gateFeatureOverrides` replacing `requireCodexApproval` / the codex feature.
-4. Append-only attempts + leases/fencing (flag-gated).
-5. Connector-declared `recoverRun` hook replacing GitHub-specific recovery.
-6. Reference definitions (ecommerce return, manufacturing defect, travel) proving
-   genericity.
-7. Retire the legacy `room/` Mission System after parity.
+1. Immutable, versioned, **deletion-safe** definitions pinned on runs (tombstone/version-FK
+   + active-run guard; remove the `workflow_id` cascade).
+2. Generic `runtime_context` map replacing the `pr_url` runtime handoff (PR data already in
+   `workflow_run_artifacts` post-M84).
+3. Generic `gateFeatureOverrides` replacing `requireCodexApproval` / the codex feature
+   (all three node-type copies + the `effectiveNodes` projection).
+4. Append-only attempts + leases/fencing (flag-gated), **preserving the idle/reactivation
+   work-item lifecycle**.
+5. Full GitHub external-event path behind connector capabilities (`recoverRun` +
+   subscription/matching/reopen), not just restart recovery.
+6. Reference definitions (ecommerce return, manufacturing defect, travel) as in-tree
+   `reference/` fixtures proving genericity.
+7. **Goal-system unification audit** — determine the relationship between
+   `goals`/`mission_executions` and `space_goals` from evidence; **do not freeze or retire**
+   either (the Mission System is active).
+
+Durability cluster (new, closes verified gaps): **1b** transactional outbox (persist every
+delivery — live + inactive — in the transition transaction); **1c** durable connector/gate
+retry deadlines (rehydrate on restart); **1d** append-only `workflow_transition_log`;
+**4b** mutating-connector command idempotency + reconcile-unknown.
 
 Each phase is one compatibility-preserving PR behind adapters/feature flags, with dual-read
 where needed, migration tests, and explicit rollback criteria. **No big-bang rewrite; no
@@ -92,10 +134,13 @@ silent reinterpretation of active runs; no legacy removal before parity evidence
   the kernel.
 - Existing workflows keep running unchanged throughout; the migration is bounded extraction,
   not a rewrite, because the model is already largely correct.
-- Leases + fencing + append-only attempts close the durability gap that produces stranded
-  message delivery (#859–#862) and make recovery observable and auditable.
-- Definition versioning makes in-flight runs immune to silent behavior changes from edits.
-- Goal V2 is validated as the correct trigger layer above a generic execution engine.
+- Leases + fencing + append-only attempts + transactional outbox + durable retry deadlines
+  close the durability gaps that produce stranded message delivery (#859–#862) and lost
+  handoffs, and make recovery observable and auditable.
+- Definition versioning + deletion-safety make in-flight runs immune to silent behavior
+  changes from edits **and** to erasure from definition deletion.
+- Mutating-connector idempotency makes ecommerce/travel-style side effects safe under crash.
+- The goal trigger layer sits cleanly above a generic execution engine.
 
 **Negative**
 
@@ -107,14 +152,27 @@ silent reinterpretation of active runs; no legacy removal before parity evidence
 
 **Neutral**
 
-- The `room/` legacy Mission System is frozen, not deleted; retirement is gated on parity
-  evidence and a quiet period (Phase 7).
+- Two goal models (`goals`/`mission_executions` and `space_goals`) coexist for now; their
+  unification is deferred to an evidence-driven audit (Phase 7), not assumed.
 - Terminology is intentionally unchanged where the current vocabulary is already correct
   (Run, Work item, Gate, Channel) to keep the migration incremental and the diff
   reviewable.
 
-## Open questions (deferred to review of the RFC)
+## Design-review decisions (resolved / revised)
 
-See RFC §12: definition-version storage shape; whether leases are required in the
-single-process path now or strictly flag-gated; whether legacy goals are migrated or
-frozen; whether reference workflows ship in-tree or as a separate examples package.
+From the review of PR #2396 (see RFC §12); all re-verified against code.
+
+1. **Definition versioning** → in-row content hash (`definition_version`) pinned on the run
+   + append-only `space_workflow_definition_versions` history table (avoids indirection on
+   hot-path `getWorkflow` reads). **Plus deletion-safety** (added after verification showed
+   the `ON DELETE CASCADE` + guardless `deleteWorkflow` gap): tombstone/version-FK retaining
+   referenced versions + an active-run guard.
+2. **Lease scope** → flag-gated no-op for the single-process path; enforced only when a
+   second worker exists.
+3. **Goal V2 unification** → ~~freeze legacy read-only~~ **REVERSED.** Verification shows
+   `goals`/`mission_executions` is an **active** Mission System (`goal-repository.ts`,
+   `atomicStartExecution`, monotonic `execution_number`, driven by
+   `goal-automation-execute.handler.ts`), not legacy. The "freeze" decision rested on an
+   unverified premise; it is replaced by an evidence-driven unification **audit** (Phase 7)
+   with no freeze or retirement in the meantime.
+4. **Reference workflows** → in-tree under a marked `reference/`/fixtures path, not seeded.

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Proposed — Revision 6. Six review rounds (human reviewer + codex-connector bot); every
-code-level claim re-verified directly against current source. Re-requesting review.
+Proposed — Revision 7. Six review rounds (human reviewer + codex-connector bot); every
+code-level claim re-verified directly against current source. States complete invariants +
+phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
 `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
 

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 8. Six review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 9. Seven review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. States complete invariants +
 phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 10. Seven review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 11. All human + codex-connector review rounds to date; every
 code-level claim re-verified directly against current source. States complete invariants +
 phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
@@ -24,9 +24,12 @@ a durable, domain-agnostic framework requires:
   `ExportedWorkflowNode` `:2802`) + the `effectiveNodes` projection
   (`space-workflow-manager.ts:314-316,325-327`); codex compiler across `gate-features.ts`
   (`:36`–`:619`); the `pr_url` runtime handoff (`getPrUrlForRun` `channel-router.ts:363`,
-  `PR_URL` env, `gate-evaluator.ts:563`); and the full GitHub external-event path in
+  `PR_URL` env, `gate-evaluator.ts:563`); the full GitHub external-event path in
   `space-runtime.ts` (recovery, topic normalization, check-failure reopen, PR-URL match,
-  auto-subscriptions, retained-event replay).
+  auto-subscriptions, retained-event replay); and the GitHub `post_review` tool
+  (`postGitHubReview` via `gh api`) registered for every workflow end/approval-authority
+  node via `isApprovalAuthorityNode` (`task-agent-manager.ts:4779`, block `:4762-4818`)
+  with its schema (`node-agent-tool-schemas.ts:527`, registry `:623`).
 - **Missing primitives (verified):** imperative connector-action steps — connectors are
   read-only validators/hooks only (`external-state-validator.ts:84`, `hook-executor.ts:203`)
   and `WorkflowNode.agents` must be non-empty, so `issueRefund`/`fileDefect`/`book` cannot
@@ -74,8 +77,11 @@ Concretely, **accept the RFC's phased plan** (§9): extraction **plus** new prim
 2. Generic `runtime_context` (extract the `pr_url` handoff; `space_tasks` pr columns already
    dropped in M84).
 3. Generic `gateFeatureOverrides` (codex → plugin; all three node-type copies + projection).
-4. Append-only attempts + leases/**fencing-on-every-write** (preserve idle/reactivation).
-5. Full GitHub external-event path behind connector capabilities.
+4. Append-only attempts + leases/**fencing on leased-worker writes only** (unleased
+   commands use status/generation guards, §6.3; preserve idle/reactivation).
+5. Full GitHub external-event path **+ the GitHub `post_review` outbound tool** behind
+   connector capabilities (node-declared tool grants, not the hardcoded
+   `isApprovalAuthorityNode` predicate).
 6. Reference definitions as in-tree `reference/` fixtures.
 7. Goal-system unification audit — legacy tables are a **documented compatibility surface,
    dormant at runtime** (CLAUDE.md L172-181; no live writers); treat as a compatibility
@@ -126,9 +132,10 @@ legacy removal before parity.**
    mutable head). **Deletion-safety** (no `workflow_id` FK — orphan, not erase; guard all
    delete paths + version-FK). **Phase 1e** delays run-`done` until post-approval resolves
    (today `space-runtime.ts:7814` sets `done` before `dispatchPostApproval`).
-2. **Lease scope** → flag-gated no-op for single-process; fencing token guards **every**
-   worker write; mutating-connector keys derive from logical command identity + activation
-   ordinal (stable across attempts); connector capability versions pinned per action.
+2. **Lease scope** → flag-gated no-op for single-process; fencing token guards
+   **leased-worker writes only** (unleased human/kernel commands use status/generation
+   guards, §6.3); mutating-connector keys derive from logical command identity + activation
+   ordinal (stable across attempts); connector capability versions pinned at run creation (§5).
 3. **Goal V2** → `goals`/`mission_executions` is a **documented compatibility surface,
    dormant at runtime** (CLAUDE.md L172-181 defines it as the Mission System; no live
    writers). Phase 7 treats it as a compatibility surface: prove equivalence before freeze/remove.

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 7. Six review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 8. Six review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. States complete invariants +
 phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 9. Seven review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 10. Seven review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. States complete invariants +
 phase boundaries; all mechanism deferred to phase PRs. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,80 +2,51 @@
 
 ## Status
 
-Proposed — Revision 2. Architecture approved in design review (PR #2396); the human
-review's doc-accuracy fixes and the codex-connector inline review (which surfaced several
-P1 durability gaps) are incorporated, all claims re-verified against code. Re-requesting
-review. Phase 0 (architecture only); no runtime changes. Companion RFC:
+Proposed — Revision 3. Three review rounds (human reviewer + codex-connector bot); every
+code-level claim re-verified directly against current source. Re-requesting review.
+Phase 0 (architecture only); no runtime changes. Companion RFC:
 `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
 
 ## Context
 
-HyperNeo's Space workflow system has organically become a capable agent-collaboration
-engine: a `SpaceWorkflow` (nodes / channels / gates / hooks / post-approval routes) is
-interpreted by a generic runtime that drives runs by activating work items, evaluating
-gates, and routing durable messages. A code survey for this RFC found that the engine is
-already **~85% data-defined**:
+HyperNeo's Space workflow system is a capable agent-collaboration engine: a `SpaceWorkflow`
+(nodes/channels/gates/hooks/post-approval) is interpreted by a generic runtime. The
+**definition model and connector registry are already generic and data-defined** (no
+`switch(workflowType/nodeType)` dispatch in core; connectors behind a flag).
 
-- There is no `switch(workflowType)` / `switch(nodeType)` dispatch in the core runtime.
-  Topology, gate evaluation, cycle caps, completion detection, and post-approval routing
-  are all data-driven.
-- A clean connector abstraction already exists
-  (`packages/daemon/src/lib/space/runtime/connectors/`) — `Connector` / `ConnectorOp` /
-  `ConnectorOutcome` / `ConnectorAuth` behind a generic registry — and the connector layer
-  is being rolled out behind a feature flag (`isConnectorsLayerEnabled()`).
-- Goal V2 (`space_goals`) is layered above the engine as a "what/when" trigger/spec layer,
-  while `SpaceWorkflow` is the "how" execution-definition layer. **Note:** there is a second,
-  also-active goal model — the room-era `goals`/`mission_executions` "Mission System"
-  (`goal-repository.ts`, driven by `goal-automation-execute.handler.ts`) — whose relationship
-  to `space_goals` is unresolved; it is **not** legacy (see Decision 7).
+However, the engine is **not** "fully expressive with zero kernel changes." A code survey
+(verified directly, three rounds) found domain leakage **and** missing primitives/durability
+a durable, domain-agnostic framework requires:
 
-However, the remaining work is larger than "extract GitHub." There is domain-specific
-(GitHub/PR/Codex) logic leaking into the generic type and core paths, **and** several
-durability guarantees a "durable execution framework" requires are not yet met by the
-current single-process code. The codex-connector inline review surfaced the latter; all
-points below were re-verified against the code:
-
-- `WorkflowNode.requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` are
-  first-class fields on the **generic** node types (`packages/shared/src/types/space.ts`:
-  `WorkflowNode` `:2287`, `WorkflowNodeInput` `:2321`, **and `ExportedWorkflowNode` `:2802`**
-  the portable export format), plus an `effectiveNodes` projection in
-  `updateWorkflow` (`space-workflow-manager.ts:314-316, 325-327`) that copies them through.
-  The codex feature compiler dominates `gate-features.ts` (codex paths span `:36`–`:619` of
-  631 lines), with Codex-specific validation in `space-workflow-manager.ts:559–646`.
-- `pr_url` is an implicit **runtime handoff** threaded through the channel router
-  (`getPrUrlForRun`, `channel-router.ts:363`), gate-script env (`PR_URL`),
-  `gate-evaluator.ts:563`, and the post-approval template context. The `space_tasks.pr_url`
-  columns were **already dropped** in migration 84 (`runMigration84`, `migrations.ts:6514`,
-  replaced by `workflow_run_artifacts`); only the runtime handoff remains to extract.
-- The full GitHub external-event path (restart recovery `rehydrateActiveRunPrEventSubscriptions`,
-  topic normalization, check-failure reopening, PR-URL matching, auto-subscriptions,
-  retained-event replay) lives in `space-runtime.ts`, not just restart recovery.
-- **No transactional outbox:** `send_message` commits the gate write before delivery, and
-  **live targets are delivered directly with no durable row** (only inactive targets hit
-  `pending_agent_messages`). A crash between the transition and live delivery opens the gate
-  but loses the handoff.
-- **No leases or fencing tokens**, and connector/gate **retry deadlines are in-memory only**
-  (`GateRetryScheduler`, `gate-retry-scheduler.ts:10-11,34`) — a restart loses a rate-limit
-  deadline and can strand a non-polled gate indefinitely.
-- **No append-only transition audit:** `workflow_run_artifacts` are upserts
-  (`UNIQUE(...)`), not append-only; nothing records every status/approval/cancel/gate-reset/
-  routing transition.
-- **Definition deletion is unsafe:** `space_workflow_runs.workflow_id` is `ON DELETE CASCADE`
-  and `deleteWorkflow` (`space-workflow-manager.ts:445`) has no active-run guard — deleting a
-  definition erases in-flight runs. (Definitions are also mutable, so an edit can silently
-  change an in-flight run.)
-- **Mutating connectors have no idempotency:** `ConnectorContext`/`ConnectorOp` carry no
-  command key or reconcile-unknown semantics; a crash after a remote `issueRefund`/`book`
-  succeeds but before the SQLite commit would duplicate the side effect.
-- **Terminal-vs-completion conflation:** `CompletionDetector.isComplete` returns true on
-  `reportedStatus != null`; the RFC must not treat that as terminal for leases/timers/
-  delivery, since approval and post-approval work may still be in flight.
-- **Work-item lifecycle:** `NodeExecutionStatus` has no `done`; terminal = `idle | cancelled`,
-  and successful turns become reactivatable `idle` rows.
-
-The goal (#874) is to make this a **domain-agnostic, durable execution framework** —
-usable for business processes, manufacturing, ecommerce, personal-assistant workflows, and
-agent collaboration — with a strictly incremental, compatibility-first migration.
+- **Domain leakage:** `requireCodexApproval`/`codexPollIntervalMs`/`codexTimeoutSeconds` on
+  three generic node types (`WorkflowNode` `space.ts:2287`, `WorkflowNodeInput` `:2321`,
+  `ExportedWorkflowNode` `:2802`) + the `effectiveNodes` projection
+  (`space-workflow-manager.ts:314-316,325-327`); codex compiler across `gate-features.ts`
+  (`:36`–`:619`); the `pr_url` runtime handoff (`getPrUrlForRun` `channel-router.ts:363`,
+  `PR_URL` env, `gate-evaluator.ts:563`); and the full GitHub external-event path in
+  `space-runtime.ts` (recovery, topic normalization, check-failure reopen, PR-URL match,
+  auto-subscriptions, retained-event replay).
+- **Missing primitives (verified):** imperative connector-action steps — connectors are
+  read-only validators/hooks only (`external-state-validator.ts:84`, `hook-executor.ts:203`)
+  and `WorkflowNode.agents` must be non-empty, so `issueRefund`/`fileDefect`/`book` cannot
+  run as durable steps; and an in-run pause/resume timer (`task_schedules` make new runs,
+  `GatePoll` re-evaluates, hook-retries retry — none pauses/resumes one run).
+- **Durability gaps (verified):** no transactional outbox (live targets bypass the durable
+  inbox; gate write commits before delivery); in-memory retry deadlines
+  (`GateRetryScheduler`, `gate-retry-scheduler.ts:10-11,34`); upsert "audit"
+  (`workflow_run_artifacts` `UNIQUE(...)`, not append-only); mutable/unpinned definitions
+  (runs re-read the live row each tick; `definition_version` not stamped at creation);
+  **no `workflow_id` FK** on `space_workflow_runs` (M60 rebuilt it FK-free; M71 preserved
+  that) so deletion **orphans** runs, and `deleteWorkflow` (`:445`) + import-replacement +
+  `deleteByWorkflowId` all lack an active-run guard; no mutating-connector idempotency;
+  `postApprovalSessionId` stamped only after spawn (`post-approval-router.ts:113`) so a
+  spawn-time crash can double-dispatch the merger.
+- **Terminal semantics (verified):** `done`/`cancelled` **reopen** to `in_progress`
+  (`workflow-run-status-machine.ts`); the only tombstone is `SpaceTask.archivedAt`.
+- **Goal model:** `space_goals` is the active model; `goals`/`mission_executions` is
+  **dormant/legacy** (schema `index.ts:405` labels it legacy; `atomicStartExecution`/
+  `insertExecution` have zero non-test callers; the live automation handler uses
+  `SpaceGoalRepository`→`space_goals`).
 
 ## Decision
 
@@ -84,95 +55,75 @@ Adopt the foundational rule:
 > **Data-defined behavior, code-defined semantics, plugin-defined capabilities.**
 
 - **Data-defined behavior.** All workflow-specific behavior lives in immutable, versioned
-  **definitions** (topology, transitions, prompts, policies, approval thresholds, delivery
-  targets, timers). The kernel interprets definitions and **never branches on which
-  workflow is running.**
-- **Code-defined semantics.** The generic kernel owns the *meaning* of transitions,
-  durable work items and append-only attempts, roles/actor assignment, authorization,
-  leases, idempotency, approvals, timers, inbox/outbox delivery, retries, recovery, audit,
-  and terminal semantics. These are universal.
-- **Plugin-defined capabilities.** Domain actions (GitHub, ecommerce, MES, travel) are
-  **connectors** in a generic capability registry, invoked by id. Agents, humans, and
-  services are **workers**; sessions are execution *resources*, not workflow identity.
-  Channel-directed sends and explicit outcomes/commands advance process state; untargeted
-  free text only communicates.
+  definitions; the kernel never branches on which workflow is running.
+- **Code-defined semantics.** The generic kernel owns transitions, durable work items and
+  append-only attempts, leases/fencing, idempotency, approvals, timers, inbox/outbox
+  delivery, retries, recovery, audit, and terminal semantics.
+- **Plugin-defined capabilities.** Domain actions are connectors invoked by id. Workers
+  (agents/humans/services) execute work items; sessions are resources, not identity.
 
-Concretely, **accept the RFC's phased plan** (`docs/design/workflow-engine-rfc.md` §9),
-which is extraction **plus** a durability cluster that closes the verified gaps first:
+Concretely, **accept the RFC's phased plan** (§9): extraction **plus** new primitives
+**plus** a durability cluster.
 
-1. Immutable, versioned, **deletion-safe** definitions pinned on runs (tombstone/version-FK
-   + active-run guard; remove the `workflow_id` cascade).
-2. Generic `runtime_context` map replacing the `pr_url` runtime handoff (PR data already in
-   `workflow_run_artifacts` post-M84).
-3. Generic `gateFeatureOverrides` replacing `requireCodexApproval` / the codex feature
-   (all three node-type copies + the `effectiveNodes` projection).
-4. Append-only attempts + leases/fencing (flag-gated), **preserving the idle/reactivation
-   work-item lifecycle**.
-5. Full GitHub external-event path behind connector capabilities (`recoverRun` +
-   subscription/matching/reopen), not just restart recovery.
-6. Reference definitions (ecommerce return, manufacturing defect, travel) as in-tree
-   `reference/` fixtures proving genericity.
-7. **Goal-system unification audit** — determine the relationship between
-   `goals`/`mission_executions` and `space_goals` from evidence; **do not freeze or retire**
-   either (the Mission System is active).
+1. Immutable, versioned, **deletion-safe** definitions pinned **at run creation** (guard all
+   delete/replacement paths; orphan/tombstone policy; version-level FK — there is no
+   `workflow_id` FK to "remove").
+2. Generic `runtime_context` (extract the `pr_url` handoff; `space_tasks` pr columns already
+   dropped in M84).
+3. Generic `gateFeatureOverrides` (codex → plugin; all three node-type copies + projection).
+4. Append-only attempts + leases/**fencing-on-every-write** (preserve idle/reactivation).
+5. Full GitHub external-event path behind connector capabilities.
+6. Reference definitions as in-tree `reference/` fixtures.
+7. Goal-system unification audit (legacy tables are dormant; de-facto frozen).
 
-Durability cluster (new, closes verified gaps): **1b** transactional outbox (persist every
-delivery — live + inactive — in the transition transaction); **1c** durable connector/gate
-retry deadlines (rehydrate on restart); **1d** append-only `workflow_transition_log`;
-**4b** mutating-connector command idempotency + reconcile-unknown.
+Durability cluster: **1b** transactional outbox + receiver-side dedup; **1c** durable retry
+deadlines; **1d** append-only `workflow_transition_log`; **4b** mutating-connector command
+idempotency (key = logical command identity, stable across attempts) + reconcile-unknown.
 
-Each phase is one compatibility-preserving PR behind adapters/feature flags, with dual-read
-where needed, migration tests, and explicit rollback criteria. **No big-bang rewrite; no
-silent reinterpretation of active runs; no legacy removal before parity evidence.**
+New primitives: **5b** connector-action step (durable connector-op steps); **5c** in-run
+pause/resume timer. These are forced by the ecommerce/travel reference workflows (§8), not
+speculative.
+
+Each phase is one compatibility-preserving PR behind adapters/flags, with migration tests and
+explicit rollback. **No big-bang rewrite; no silent reinterpretation of active runs; no
+legacy removal before parity.**
 
 ## Consequences
 
 **Positive**
 
-- The engine becomes usable for arbitrary domains without core changes — adding ecommerce,
-  manufacturing, or travel workflows means authoring a definition + connector, not editing
-  the kernel.
-- Existing workflows keep running unchanged throughout; the migration is bounded extraction,
-  not a rewrite, because the model is already largely correct.
-- Leases + fencing + append-only attempts + transactional outbox + durable retry deadlines
-  close the durability gaps that produce stranded message delivery (#859–#862) and lost
-  handoffs, and make recovery observable and auditable.
-- Definition versioning + deletion-safety make in-flight runs immune to silent behavior
-  changes from edits **and** to erasure from definition deletion.
-- Mutating-connector idempotency makes ecommerce/travel-style side effects safe under crash.
-- The goal trigger layer sits cleanly above a generic execution engine.
+- Domain-agnostic execution: adding a domain = authoring a definition + connectors (agent-
+  driven/validator-gated/scheduled workflows need no kernel change; ecommerce/travel need
+  the phased primitives).
+- The durability cluster closes the stranded-delivery (#859–#862) and lost-handoff classes
+  and makes recovery observable and auditable.
+- Definition versioning + deletion-safety make in-flight runs immune to edits and to
+  orphaning.
+- Mutating-connector idempotency makes ecommerce/travel side effects crash-safe.
 
 **Negative**
 
-- Several phases of dual-read/dual-write code and adapters to maintain until parity is
-  proven and the legacy path is removed — near-term complexity for long-term cleanliness.
-- Leases/fencing add a new subsystem; even flag-gated, it must be tested under crash,
-  duplicate-wake, and concurrent-claim scenarios.
-- Reference workflows (Phase 6) add fixture/test surface that must be maintained.
+- Two new kernel primitives (connector-action steps, in-run timers) plus a durability
+  cluster — more new code than pure extraction.
+- Phases of dual-read/dual-write adapters to maintain until parity.
+- Leases/fencing must be tested under crash, duplicate-wake, concurrent-claim, restart.
 
 **Neutral**
 
-- Two goal models (`goals`/`mission_executions` and `space_goals`) coexist for now; their
-  unification is deferred to an evidence-driven audit (Phase 7), not assumed.
-- Terminology is intentionally unchanged where the current vocabulary is already correct
-  (Run, Work item, Gate, Channel) to keep the migration incremental and the diff
-  reviewable.
+- The dormant `goals`/`mission_executions` tables coexist with `space_goals` until the
+  Phase 7 audit decides their fate.
+- Terminology is unchanged where already correct (Run, Work item, Gate, Channel).
 
-## Design-review decisions (resolved / revised)
+## Design-review decisions (resolved/revised across 3 rounds)
 
-From the review of PR #2396 (see RFC §12); all re-verified against code.
-
-1. **Definition versioning** → in-row content hash (`definition_version`) pinned on the run
-   + append-only `space_workflow_definition_versions` history table (avoids indirection on
-   hot-path `getWorkflow` reads). **Plus deletion-safety** (added after verification showed
-   the `ON DELETE CASCADE` + guardless `deleteWorkflow` gap): tombstone/version-FK retaining
-   referenced versions + an active-run guard.
-2. **Lease scope** → flag-gated no-op for the single-process path; enforced only when a
-   second worker exists.
-3. **Goal V2 unification** → ~~freeze legacy read-only~~ **REVERSED.** Verification shows
-   `goals`/`mission_executions` is an **active** Mission System (`goal-repository.ts`,
-   `atomicStartExecution`, monotonic `execution_number`, driven by
-   `goal-automation-execute.handler.ts`), not legacy. The "freeze" decision rested on an
-   unverified premise; it is replaced by an evidence-driven unification **audit** (Phase 7)
-   with no freeze or retirement in the meantime.
-4. **Reference workflows** → in-tree under a marked `reference/`/fixtures path, not seeded.
+1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
+   history table. **Deletion-safety** corrected (no `workflow_id` FK exists — orphan, not
+   erase; guard all delete paths + orphan policy + version-FK).
+2. **Lease scope** → flag-gated no-op for single-process; fencing token guards **every**
+   worker write.
+3. **Goal V2** → `goals`/`mission_executions` is **dormant/legacy** (v2 wrongly called it
+   "active" — corrected; the original "freeze" was right in substance). Phase 7 =
+   evidence-driven unification audit.
+4. **Reference workflows** → in-tree `reference/` fixtures, not seeded.
+5. **Expressiveness** → "zero kernel changes" re-scoped: connector-action steps (5b) and
+   in-run timers (5c) are required new primitives for ecommerce/travel.

--- a/docs/adr/0003-data-defined-workflow-engine.md
+++ b/docs/adr/0003-data-defined-workflow-engine.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed — Revision 3. Three review rounds (human reviewer + codex-connector bot); every
+Proposed — Revision 4. Four review rounds (human reviewer + codex-connector bot); every
 code-level claim re-verified directly against current source. Re-requesting review.
 Phase 0 (architecture only); no runtime changes. Companion RFC:
 `docs/design/workflow-engine-rfc.md`. Tracks goal task #874.
@@ -42,7 +42,9 @@ a durable, domain-agnostic framework requires:
   `postApprovalSessionId` stamped only after spawn (`post-approval-router.ts:113`) so a
   spawn-time crash can double-dispatch the merger.
 - **Terminal semantics (verified):** `done`/`cancelled` **reopen** to `in_progress`
-  (`workflow-run-status-machine.ts`); the only tombstone is `SpaceTask.archivedAt`.
+  (`workflow-run-status-machine.ts`); the only tombstone is `SpaceTask.archivedAt`. Run-`done`
+  is **premature today** — set at `space-runtime.ts:7814` before `dispatchPostApproval`
+  (`:7858`), so the run is `done` while the merger still runs (Phase 1e delays it).
 - **Goal model:** `space_goals` is the active model; `goals`/`mission_executions` is
   **dormant/legacy** (schema `index.ts:405` labels it legacy; `atomicStartExecution`/
   `insertExecution` have zero non-test callers; the live automation handler uses
@@ -117,13 +119,16 @@ legacy removal before parity.**
 ## Design-review decisions (resolved/revised across 3 rounds)
 
 1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
-   history table. **Deletion-safety** corrected (no `workflow_id` FK exists — orphan, not
-   erase; guard all delete paths + orphan policy + version-FK).
+   history table + **read cutover** (run reads resolve through the pinned version, not the
+   mutable head). **Deletion-safety** (no `workflow_id` FK — orphan, not erase; guard all
+   delete paths + version-FK). **Phase 1e** delays run-`done` until post-approval resolves
+   (today `space-runtime.ts:7814` sets `done` before `dispatchPostApproval`).
 2. **Lease scope** → flag-gated no-op for single-process; fencing token guards **every**
-   worker write.
-3. **Goal V2** → `goals`/`mission_executions` is **dormant/legacy** (v2 wrongly called it
-   "active" — corrected; the original "freeze" was right in substance). Phase 7 =
-   evidence-driven unification audit.
+   worker write; mutating-connector keys derive from logical command identity + activation
+   ordinal (stable across attempts); connector capability versions pinned per action.
+3. **Goal V2** → `goals`/`mission_executions` is a **documented compatibility surface,
+   dormant at runtime** (CLAUDE.md L172-181 defines it as the Mission System; no live
+   writers). Phase 7 treats it as a compatibility surface: prove equivalence before freeze/remove.
 4. **Reference workflows** → in-tree `reference/` fixtures, not seeded.
 5. **Expressiveness** → "zero kernel changes" re-scoped: connector-action steps (5b) and
    in-run timers (5c) are required new primitives for ecommerce/travel.

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,7 +1,7 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 3 (Phase 0, architecture only; no runtime changes).
-Incorporates three review rounds (human reviewer + codex-connector bot). Every
+Status: Proposed — Revision 5 (Phase 0, architecture only; no runtime changes).
+Incorporates five review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
 revision. Date: 2026-08-07. Tracks goal task #874.
 Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
@@ -117,10 +117,16 @@ Executable tables the kernel enforces, encoded as data (the
 | `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
 | `cancelled` | resume | `in_progress` | task not archived | **reopen** |
 
-**Terminal vs tombstone (critical, fixes v2 contradiction):** `done`/`cancelled` are
-*finished attempt states* that reopen (`workflow-run-status-machine.ts`); **the only
-tombstone is `SpaceTask.archivedAt`.** Durability consumers (delivery, leases, timers)
-**must key off task-archive (or explicit hard-cancel), never off run `done`/`cancelled`**.
+**Finalization vs delivery-fail vs tombstone (reconciles §6.6 — fixes v4 over-correction):**
+`done`/`cancelled` are *finished attempt states* that reopen (`workflow-run-status-machine.ts`);
+**the only tombstone (non-reopenable) is `SpaceTask.archivedAt`.** Three distinct durability
+signals, not one: (a) **finalization** — release leases / stop timers / stop active dispatch
+when the canonical task is terminal (`done`/`cancelled`) **and** post-approval has resolved
+(the `task.status==='done'` guard in §6.6); (b) **delivery hard-fail** — only on archive or
+explicit hard-cancel, **not** on run-`done`/`cancelled` (those reopen — a `done` run may yet
+receive a follow-up message); (c) **reopen prevention** — archive only. (v4 conflated (a)
+and (b) by saying *all* durability consumers key off archive — that would strand a run whose
+task is `done` but not yet archived; corrected.)
 
 **Run-`done` is premature today (verified, fixes v3 error):** the tick sets the run to
 `done` at `space-runtime.ts:7814` *before* `dispatchPostApproval` (`:7858`); the task then
@@ -136,16 +142,23 @@ only via `mark_complete` — corrected.)
 `pending | in_progress | idle | waiting_rebind | blocked | cancelled`. Terminal = `idle |
 cancelled` (no `done`); success → reactivatable `idle`.
 
-| from | event | to | guard | side effect |
+| from | event | to | guard / status | side effect |
 |---|---|---|---|---|
-| `pending` | worker claims | `in_progress` | lease + fencing token acquired (§6.3) | **append attempt #N** (single append point) |
-| `in_progress` | terminal outcome | `idle` | — | release lease (reactivatable) |
-| `in_progress` | needs peer input | `waiting_rebind` | — | — |
-| `waiting_rebind`/`idle` | input arrives / crash / lease expiry / timeout | `pending` | budget remaining, not archived | (no append — the next claim appends) |
-| any | task archived / hard-cancel | `cancelled` | — | release lease |
+| `pending` | worker claims | `in_progress` | lease + fencing token (§6.3) | **append attempt #N** (single append point) |
+| `in_progress` | terminal outcome | `idle` | current | release lease (reactivatable) |
+| `in_progress` | needs peer input | `waiting_rebind` | current | — |
+| `in_progress` | gate blocks / agent fail | `blocked` | current | — |
+| `in_progress` | task archived / hard-cancel | `cancelled` | current | release lease |
+| `in_progress` | **worker crash / lease expiry** | `pending` | **Phase 4** — fenced reclaim; not in `VALID_NODE_EXECUTION_TRANSITIONS` today | (no append; next claim appends) |
+| `waiting_rebind` | input / wake / timeout | `pending` | current | (no append) |
+| `idle` | cyclic re-entry / reactivation | `in_progress` | current | append attempt |
+| `cancelled` | run resumed (non-archived) | `in_progress` | current — `cancelled:['in_progress']`, `activateNode` reuses cancelled rows | append attempt |
+| `blocked` | human resolved | `in_progress` | current | — |
 
-**Phase 4 caveat:** because the lifecycle is idle/reactivation-based, Phase 4 must preserve
-those semantics when adding append-only attempts — not "append without behavior change."
+Transitions match `VALID_NODE_EXECUTION_TRANSITIONS` (`node-execution-manager.ts:39-46`);
+the **only** Phase-4 addition is `in_progress→pending` (fenced lease-expiry reclaim for
+crashed workers — the gap that defeats crash-recovery today). Phase 4 must preserve the
+idle/reactivation semantics when adding append-only attempts.
 
 ### 3.3 Gate lifecycle — unchanged (closed→pending_approval→open; cyclic reset).
 
@@ -206,6 +219,11 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
      (`SpaceWorkflowManager.deleteWorkflow`, import-replacement, `deleteByWorkflowId`);
    - adopt an **orphan/tombstone policy** (soft-delete the definition; runs keep their
      pinned version);
+4. **Read cutover + backfill (migration invariant):** a pin is inert unless run reads
+   resolve through it — add a version-aware accessor used by every run read
+   (`channel-router`, `space-runtime`), and at cutover **backfill every existing in-flight
+   run** (snapshot its workflow head into history) so pre-migration runs have a resolvable
+   version and are not stranded. (Accessor shape / backfill SQL = Phase-1-PR scope.)
    - add a **version-level FK** (runs reference a definition *version*, not the mutable
      head) once versioning lands.
 4. `SpaceWorkflow` shape is otherwise unchanged.
@@ -299,9 +317,13 @@ a non-polled gate.
 ### 6.5 Recovery
 
 `SpaceRuntimeService.start()` recovers (long-term inbox → `recoverStalledRuns`): skip if
-in-flight; finalize only when the task is truly terminal (archived) and post-approval
-finished — **not** on `reportedStatus`/run-`done` alone (those reopen). GitHub-specific
-recovery + the full GitHub event path move behind connector capabilities (Phase 5).
+in-flight; **finalize when the canonical task is terminal (`done`/`cancelled`) AND
+post-approval has resolved** — consistent with §6.6's `task.status==='done'` guard. Archive
+is a *separate* concern — the non-reopenable tombstone (§3.1), not the finalize trigger: a
+crash after `mark_complete` (task `done`) but before the run-transition commits must not
+strand the run. `reportedStatus`/`CompletionDetector` alone is not a finalize signal
+(post-approval may still be in flight). GitHub-specific recovery + the full GitHub event
+path move behind connector capabilities (Phase 5).
 
 ### 6.6 Idempotency summary (target mechanisms)
 
@@ -369,7 +391,7 @@ that depend on them.
 | Phase | Deliverable | Mode | Rollback |
 |---|---|---|---|
 | **0** (this RFC) | RFC + ADR, approval | docs | n/a |
-| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK); **read cutover** — add a version-aware accessor and route every run read (`channel-router`, `space-runtime`) through the pinned history row, not `getWorkflow(head)` (otherwise the pin is inert) | shadow history; pin at creation; route run reads through pinned version | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
+| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK); **read cutover** — add a version-aware accessor and route every run read (`channel-router`, `space-runtime`) through the pinned history row, not `getWorkflow(head)` (otherwise the pin is inert) | shadow history; pin at creation; route run reads through pinned version; **backfill: snapshot a resolvable version for every pre-existing run before enabling the cutover / version-level FK** (existing runs pre-date the column; mechanism deferred to Phase 1 PR) | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
 | 1b | Transactional outbox (persist every delivery, live + inactive, in the transition tx) + receiver-side dedup | write both; cutover when proven | fall back to direct live delivery |
 | 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | in-memory scheduler still works while populated |
 | 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
@@ -393,15 +415,20 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
 ## 11. Migration safety invariants
 
 1. A run executes its pinned definition version (pinned at **creation**); edits/deletions
-   never mutate or orphan in-flight runs (Phase 1).
+   never mutate or orphan in-flight runs (Phase 1). **Upgrade invariant:** Phase 1 backfills
+   a resolvable version for every pre-existing run (they pre-date the column) before the
+   cutover/FK is enabled, so no active run is stranded.
 2. No legacy removal before parity.
 3. One invariant/capability per PR; each independently revertible.
 4. Migration + restart/concurrency tests for every runtime change.
 5. **Domain concepts never re-enter generic type/core paths** — acceptance `grep` (incl.
    `ExportedWorkflowNode`, `effectiveNodes`, the GitHub event-path symbols in
    `space-runtime.ts`) returns nothing outside adapters/plugins.
-6. **Terminal = task-archive, not run `done`/`cancelled`** (which reopen); durability
-   consumers key off true terminal state.
+6. **Three distinct durability signals — don't conflate** (reconciles §3.1/§6.5/§6.6):
+   **finalization** (release leases / stop timers) keys off task terminal (`done`/`cancelled`)
+   + post-approval resolved; **delivery hard-fail** keys off archive or explicit hard-cancel
+   (NOT run-`done`/`cancelled`, which reopen); **reopen-prevention / tombstone** =
+   `SpaceTask.archivedAt` only.
 7. **Idempotency keys are stable across attempts**; fencing tokens guard every worker write.
 
 ## 12. Design-review decisions (resolved / revised across 3 rounds)

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 11 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 12 (Phase 0, architecture only; no runtime changes).
 Incorporates all human + codex-connector review rounds to date. Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
@@ -127,7 +127,8 @@ activation); mechanism deferred to the phase PR.
 **the only tombstone (non-reopenable) is `SpaceTask.archivedAt`.** Three distinct durability
 signals, not one: (a) **finalization** — release leases / stop timers / stop active dispatch
 when the canonical task is terminal (`done`/`cancelled`) **and** post-approval has resolved
-(the `task.status==='done'` guard in §6.6); (b) **delivery hard-fail** — only on **archive**
+(§6.6 finalize transition: task-terminal triggers; re-entry short-circuits on
+`run.status==='done'`); (b) **delivery hard-fail** — only on **archive**
 (the sole hard-failure condition — `cancelled` reopens, so there is no separate "hard-cancel"
 signal; a user cancel that should discard handoffs archives the task), **not** on
 run-`done`/`cancelled`; (c) **reopen prevention** — archive only. (v4 conflated (a)
@@ -210,9 +211,11 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
 
 **Decision:**
 1. `definition_version` = in-row content hash, **pinned on the run row at creation**
-   (atomically with the initial run insert), with prior versions in an append-only
-   `space_workflow_definition_versions` history table. (In-row avoids indirection on the
-   hot-path `getWorkflow` reads.)
+   (atomically with the initial run insert). **Every version — including the one a new run
+   pins — is appended to the immutable `space_workflow_definition_versions` history table
+   *before* the run row references it**, so the version-level FK (§4 #5) always targets an
+   immutable row, never the mutable head. (In-row hash avoids indirection on the hot-path
+   `getWorkflow` reads; the history row is the immutable FK target.)
 2. Built-in re-stamping becomes version-bumping, not in-place mutation. **Caveat (verified gap): built-in gate scripts are NOT pinned today** — `ChannelRouter.doEvaluateGate` (`channel-router.ts:1516`) overrides the stored gate script with `getBuiltInGateScript(workflow.templateName, …)` from the **current** template on every eval, so a template update changes an older run's gate behavior even with pinned reads. Phase 1 must resolve gate scripts from the **pinned template version** (or remove the live override); the pinning invariant does not hold for built-in gates until then.
 3. **Deletion-safety (no cascade to "remove" — there is none):**
    - add a **not-archived guard** to **every** deletion/replacement path
@@ -332,7 +335,8 @@ a non-polled gate.
 
 `SpaceRuntimeService.start()` recovers (long-term inbox → `recoverStalledRuns`): skip if
 in-flight; **finalize when the canonical task is terminal (`done`/`cancelled`) AND
-post-approval has resolved** — consistent with §6.6's `task.status==='done'` guard. Archive
+post-approval has resolved** — the §6.6 finalize transition
+(re-entry short-circuits on `run.status==='done'`). Archive
 is a *separate* concern — the non-reopenable tombstone (§3.1), not the finalize trigger: a
 crash after `mark_complete` (task `done`) but before the run-transition commits must not
 strand the run. `reportedStatus`/`CompletionDetector` alone is not a finalize signal
@@ -348,7 +352,7 @@ path move behind connector capabilities (Phase 5).
 | Claim a work item | lease CAS + fencing token checked on every **leased-worker** write (unleased human/kernel commands use status/generation guards) |
 | Mutating connector op | command key (logical identity, stable across attempts) + reconcile-unknown |
 | Post-approval dispatch | **persist dispatch work-item before spawn**; reconcile on recovery |
-| Finalize run | task-status guard (re-entry short-circuits on `task.status==='done'`) |
+| Finalize run | task-terminal (`done`/`cancelled`) + post-approval-resolved **triggers** the transition; re-entry short-circuits on `run.status==='done'` |
 | Gate open cache | `gate_open_state` + staleness guard |
 | Connector/gate retry | persisted deadline, rehydrated on restart |
 
@@ -419,7 +423,7 @@ that depend on them.
 | 5 | Full GitHub external-event path **+ the GitHub `post_review` outbound tool** (registered today for every end/approval-authority node via `isApprovalAuthorityNode` `task-agent-manager.ts:4779`, block `:4762-4818`; schema `node-agent-tool-schemas.ts:527`, registry `:623`) behind connector capabilities — node-declared tool grants, not hardcoded predicates | legacy retained until proven | fall back |
 | 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal; each action references the run-creation pin, §5) | new node/work-item kind behind flag | drain per §11.8 |
 | 5c | **In-run pause/resume timer** primitive + recovery | new timer type | drain per §11.8 |
-| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests — using **sandbox/fake mutating connectors** with observable idempotent effects for ecommerce/travel (they're the workflows that forced connector-action + idempotency; read-only fixtures couldn't prove those primitives) | read-only; no production seeding | remove fixture |
+| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests — using **sandbox/fake mutating connectors** with observable idempotent effects for ecommerce/travel (they're the workflows that forced connector-action + idempotency; read-only fixtures couldn't prove those primitives) | fixture-only/unseeded (mutating fakes); no production seeding | remove fixture |
 | 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
 
 ## 10. Deferred features
@@ -432,8 +436,10 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
 
 1. A run executes its pinned definition version (pinned at **creation**); edits/deletions
    never mutate or orphan in-flight runs (Phase 1). **Upgrade invariant:** Phase 1 backfills
-   a resolvable version for every pre-existing run (they pre-date the column) before the
-   cutover/FK is enabled, so no active run is stranded.
+   a resolvable version for every pre-existing **non-archived** run (they pre-date the column)
+   before the cutover/FK is enabled, so no active run is stranded — consistent with §4.4's
+   non-archived backfill scope. Archived orphans (whose definition was deleted before the
+   guard) may have no payload to reconstruct and are permitted to remain unpinned.
 2. No legacy removal before parity.
 3. One invariant/capability per PR; each independently revertible.
 4. Migration + restart/concurrency tests for every runtime change.
@@ -442,8 +448,8 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
    `space-runtime.ts`) returns nothing outside adapters/plugins.
 6. **Three distinct durability signals — don't conflate** (reconciles §3.1/§6.5/§6.6):
    **finalization** (release leases / stop timers) keys off task terminal (`done`/`cancelled`)
-   + post-approval resolved; **delivery hard-fail** keys off archive or explicit hard-cancel
-   (NOT run-`done`/`cancelled`, which reopen); **reopen-prevention / tombstone** =
+   + post-approval resolved; **delivery hard-fail** keys off **archive only** (no separate hard-cancel signal — §3.1;
+   `done`/`cancelled` reopen, so they are NOT hard-fail); **reopen-prevention / tombstone** =
    `SpaceTask.archivedAt` only.
 7. **Idempotency keys are stable across attempts**; fencing tokens guard every
    **leased-worker** write (unleased human/kernel commands use status/generation guards).
@@ -457,7 +463,8 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
 ## 12. Design-review decisions (resolved / revised across 3 rounds)
 
 1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
-   history table + **read cutover** (route run reads through the pinned version). **Deletion-
+   history table **(every version, including the current pinned one, appended before a run
+   references it)** + **read cutover** (route run reads through the pinned version). **Deletion-
    safety** (no `workflow_id` FK — orphan, not erase; guard all delete paths + version-FK).
    **Phase 1e** delays run-`done` until post-approval resolves (v3 wrongly claimed `done` is
    post-`mark_complete`; verified `space-runtime.ts:7814` sets it before `dispatchPostApproval`).

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 8 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 9 (Phase 0, architecture only; no runtime changes).
 Incorporates six review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
@@ -152,6 +152,10 @@ cancelled` (no `done`; success parks as reactivatable `idle`). Invariants:
 - **One attempt per freshly-leased invocation:** every activation that acquires a fresh lease
   (claim, idle/cancelled/blocked reactivation) appends exactly one attempt row;
   reset-to-pending does not.
+- **Activation produces the complete declared slot set:** multi-slot node activation
+  creates/reconciles every declared agent slot (atomic transaction or idempotent reconcile),
+  not a short-circuit on the first active execution — so a crash mid-fan-out doesn't leave
+  agents unactivated.
 
 Exact transition wiring and attempt schema are Phase-4-PR mechanism.
 
@@ -163,7 +167,7 @@ Exact transition wiring and attempt schema are Phase-4-PR mechanism.
 |---|---|---|---|
 | `pending` | target activates | `delivered` | **receiver-side dedup** required (§6.2) — crash between inject and mark-delivered must not double-deliver |
 | `pending` | TTL elapsed, attempts < max | `pending` (retry) | backoff |
-| `pending` | max attempts | `failed` | actionable terminal failure |
+| `pending` | max attempts | `failed` | **must propagate** to an actionable run/task state (dead-letter) — a `failed` row alone strands the workflow |
 | `pending` | **task archived** (true tombstone) | `failed` | NOT on run `done`/`cancelled` (those reopen) |
 
 **Gap (§6.1–6.2):** only inactive targets get a durable row today; live targets are
@@ -208,7 +212,7 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
    (atomically with the initial run insert), with prior versions in an append-only
    `space_workflow_definition_versions` history table. (In-row avoids indirection on the
    hot-path `getWorkflow` reads.)
-2. Built-in re-stamping becomes version-bumping, not in-place mutation.
+2. Built-in re-stamping becomes version-bumping, not in-place mutation. **Caveat (verified gap): built-in gate scripts are NOT pinned today** — `ChannelRouter.doEvaluateGate` (`channel-router.ts:1516`) overrides the stored gate script with `getBuiltInGateScript(workflow.templateName, …)` from the **current** template on every eval, so a template update changes an older run's gate behavior even with pinned reads. Phase 1 must resolve gate scripts from the **pinned template version** (or remove the live override); the pinning invariant does not hold for built-in gates until then.
 3. **Deletion-safety (no cascade to "remove" — there is none):**
    - add a **not-archived guard** to **every** deletion/replacement path
      (`SpaceWorkflowManager.deleteWorkflow`, import-replacement, `deleteByWorkflowId`) —
@@ -259,8 +263,10 @@ must be non-empty).
 - **Connector capability/schema versioning:** the registry today allows an existing
   connector id to be overwritten; a durable action persisted under one implementation could
   be recovered/reconciled under a different one after an upgrade. Pin a connector
-  capability/schema version with each durable action and retain a compatible implementation
-  for every in-flight version (do not silently overwrite an in-use connector id).
+  capability/schema version **resolved and pinned at definition/run creation (not at
+  action-creation) and retained until the task is archived** — so a run that reaches a
+  connector node later, or reopens/cycles after a registry upgrade, still uses its
+  creation-time versions (do not silently overwrite an in-use connector id).
 - **Connector-action step primitive:** a new work-item/node kind that executes a connector
   op as a durable step with persisted inputs, outcome, retry, and reconciliation — so
   `shop.issueRefund` / `mes.fileDefect` / `travel.book` can run as definition steps, not as
@@ -399,6 +405,7 @@ that depend on them.
 | 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | drain per §11.8 |
 | 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
 | 1e | Run-`done` ties to the canonical task reaching durable `done` (today premature, `space-runtime.ts:7814`) | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
+| 1f | Durable post-approval dispatch: persist the dispatch work-item BEFORE spawning the merger sub-session; reconcile on recovery — closes the spawn→stamp crash window that today lets recovery spawn a second merger (§3.6/§6.6) | new durability row | drain per §11.8 |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
 | 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,9 +1,11 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 6 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 7 (Phase 0, architecture only; no runtime changes).
 Incorporates six review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
-revision. Date: 2026-08-07. Tracks goal task #874.
+revision. Per the agreed scope rule, this revision states **complete invariants +
+phase boundaries** and defers all mechanism (sequences, tables, schemas, wiring) to
+the phase PRs. Date: 2026-08-07. Tracks goal task #874.
 Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
 
 > **Honest thesis (revised).** The engine's *definition model* (topology / gates /
@@ -111,7 +113,7 @@ Executable tables the kernel enforces, encoded as data (the
 |---|---|---|---|---|
 | `pending` | run created | (pinned) | definition resolvable | **stamp `definition_version` at creation**, before activation (§4) |
 | `pending` | start node activated | `in_progress` | — | (startWorkflowRun) |
-| `in_progress` | `reportedStatus` set / `CompletionDetector` | `done` (premature today) | `runIsComplete` | **today:** `transitionRunStatusAndEmit(run,'done')` runs at `space-runtime.ts:7814`, BEFORE `dispatchPostApproval` (`:7858`); the task is then parked at `approved` awaiting `mark_complete`. So run-`done` is reached **before** the merger — see Phase 1e |
+| `in_progress` | `reportedStatus` set / `CompletionDetector` | `done` (premature today) | `runIsComplete` | today premature (`space-runtime.ts:7814`); Phase 1e ties run-`done` to durable task-`done` |
 | `in_progress` | agent failed / gate needs human | `blocked` | — | `failure_reason` set |
 | `in_progress`/`blocked` | cancel | `cancelled` | — | |
 | `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
@@ -135,39 +137,26 @@ receive a follow-up message); (c) **reopen prevention** — archive only. (v4 co
 and (b) by saying *all* durability consumers key off archive — that would strand a run whose
 task is `done` but not yet archived; corrected.)
 
-**Run-`done` is premature today (verified, fixes v3 error):** the tick sets the run to
-`done` at `space-runtime.ts:7814` *before* `dispatchPostApproval` (`:7858`); the task then
-sits at `approved` while the post-approval/merger worker runs, and reaches task-`done` only
-on `mark_complete`. So a run can be `done` while real work (the merger) is still in flight —
-exactly why durability consumers must not key off run-`done`. **Phase 1e** delays the run-`done`
-transition to when the canonical task reaches `done` — immediate for `no-route`, or via
-`mark_complete` (`approved→done`) for routed workflows (the spawned merger runs async after
-`dispatchPostApproval` returns, so the dispatcher return is not the right trigger). This is a
-required migration, not deferred. (v3 wrongly claimed `done` is reached only via
-`mark_complete`; v4-v5 Phase 1e wording "after the route resolves" was also imprecise — corrected.)
+**Run-`done` ties to durable task-`done` (Phase 1e invariant):** today the run is set `done`
+prematurely (`space-runtime.ts:7814`, before the post-approval/merger completes). Phase 1e
+makes run-`done` coincide with the canonical task reaching durable `done` — not the
+post-approval dispatcher return. (Mechanism deferred to the Phase 1e PR.)
 
-### 3.2 Work item lifecycle (matches `NodeExecutionStatus`, `node-execution-manager.ts:67`)
+### 3.2 Work item lifecycle — invariants
 
-`pending | in_progress | idle | waiting_rebind | blocked | cancelled`. Terminal = `idle |
-cancelled` (no `done`); success → reactivatable `idle`.
+Statuses (match `NodeExecutionStatus`, `node-execution-manager.ts:39-67`): `pending |
+in_progress | idle | waiting_rebind | blocked | cancelled`. Per-execution terminal = `idle |
+cancelled` (no `done`; success parks as reactivatable `idle`). Invariants:
 
-| from | event | to | guard / status | side effect |
-|---|---|---|---|---|
-| `pending` | worker claims | `in_progress` | lease + fencing token (§6.3) | **append attempt #N** (single append point) |
-| `in_progress` | terminal outcome | `idle` | current | release lease (reactivatable) |
-| `in_progress` | needs peer input | `waiting_rebind` | current | — |
-| `in_progress` | gate blocks / agent fail | `blocked` | current | — |
-| `in_progress` | task archived / hard-cancel | `cancelled` | current | release lease |
-| `in_progress` | **worker crash / lease expiry** | `pending` | **Phase 4** — fenced reclaim; not in `VALID_NODE_EXECUTION_TRANSITIONS` today | (no append; next claim appends) |
-| `waiting_rebind` | input / wake / timeout | `pending` | current | (no append) |
-| `idle` | cyclic re-entry / reactivation | `in_progress` | current | append attempt |
-| `cancelled` | run resumed (non-archived) | `in_progress` | current — `cancelled:['in_progress']`, `activateNode` reuses cancelled rows | append attempt |
-| `blocked` | human resolved | `in_progress` | current | — |
+- **Lease on every activation:** every transition INTO `in_progress` — claim, idle/cancelled
+  reactivation, blocked-resume — acquires a fresh lease + fencing token (§6.3).
+- **Every non-archived item is reclaimable:** a crashed `in_progress` item returns to
+  claimable via fenced lease-expiry (the one Phase-4 addition to
+  `VALID_NODE_EXECUTION_TRANSITIONS`); `cancelled→in_progress` reactivates on run resume.
+- **One attempt per claim:** append-only attempts are created at the `pending→in_progress`
+  claim only (not at reset-to-pending).
 
-Transitions match `VALID_NODE_EXECUTION_TRANSITIONS` (`node-execution-manager.ts:39-46`);
-the **only** Phase-4 addition is `in_progress→pending` (fenced lease-expiry reclaim for
-crashed workers — the gap that defeats crash-recovery today). Phase 4 must preserve the
-idle/reactivation semantics when adding append-only attempts.
+Exact transition wiring and attempt schema are Phase-4-PR mechanism.
 
 ### 3.3 Gate lifecycle — unchanged (closed→pending_approval→open; cyclic reset).
 
@@ -233,13 +222,10 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
    (`channel-router`, `space-runtime`), and at cutover **backfill every existing in-flight
    run** (snapshot its workflow head into history) so pre-migration runs have a resolvable
    version and are not stranded. (Accessor shape / backfill SQL = Phase-1-PR scope.)
-5. **Pinning scope includes referenced agent configs:** the workflow payload carries
-   `agentId` + slot overrides, but `resolveAgentInit` loads the **current mutable**
-   `SpaceWorkerAgent` (`agentManager.getById`, `custom-agent.ts:752`) at each spawn — so
-   editing an agent's model/prompt/tools/provider after run creation changes an in-flight
-   run. The pin must therefore snapshot/version referenced agent configs with the run (or the
-   pinning contract must explicitly account for these mutable dependencies); mechanism
-   deferred to the Phase 1 PR.
+5. **Pinning boundary:** Phase 1 pins the **definition**. Referenced agent configs are a
+   **separate mutable dependency** — `resolveAgentInit` loads the current agent at spawn
+   (`custom-agent.ts:752`) — so the pinning contract must account for them (snapshot/version
+   with the run); mechanism deferred to the Phase 1 PR.
    - add a **version-level FK** (runs reference a definition *version*, not the mutable
      head) once versioning lands.
 4. `SpaceWorkflow` shape is otherwise unchanged.
@@ -409,18 +395,18 @@ that depend on them.
 | Phase | Deliverable | Mode | Rollback |
 |---|---|---|---|
 | **0** (this RFC) | RFC + ADR, approval | docs | n/a |
-| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK); **read cutover** — add a version-aware accessor and route every run read (`channel-router`, `space-runtime`) through the pinned history row, not `getWorkflow(head)` (otherwise the pin is inert) | shadow history; pin at creation; route run reads through pinned version; **backfill: snapshot a resolvable version for every pre-existing run before enabling the cutover / version-level FK** (existing runs pre-date the column; mechanism deferred to Phase 1 PR) | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
-| 1b | Transactional outbox (persist every delivery, live + inactive, in the transition tx) + receiver-side dedup | write both; cutover when proven | fall back to direct live delivery |
-| 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | in-memory scheduler still works while populated |
+| 1 | Immutable versioned definitions: `definition_version` pinned at run creation + `space_workflow_definition_versions` history; deletion-safe (guard all delete/replacement paths; orphan/tombstone; version-level FK); run reads resolve through the pinned version (not the mutable head) | shadow history; pin at creation | additive pins/history; readers revert only where live definition is provably equivalent (no `workflow_id` FK — no cascade to restore) |
+| 1b | Transactional outbox: persist every delivery (live + inactive) in the transition; receiver-side dedup | write both; cutover when proven | drain per §11.8 |
+| 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | drain per §11.8 |
 | 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
-| 1e | **Delay run-`done` until the task reaches `done`** — today the run is set `done` at `space-runtime.ts:7814` before `dispatchPostApproval` (`:7858`). Tie run-`done` to the **canonical task** reaching `done` — immediate for `no-route`, or via `mark_complete` (`approved→done`) for routed workflows. **Not** merely "after `dispatchPostApproval` returns": that awaits only `spawnPostApprovalSubSession`, after which the spawned merger still runs and finishes later on `mark_complete` — so keying off the dispatcher return would preserve the bug. (Alt: an intermediate nonterminal run state until `mark_complete`.) | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
+| 1e | Run-`done` ties to the canonical task reaching durable `done` (today premature, `space-runtime.ts:7814`) | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
 | 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | toggle flag |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
-| 5b | **Connector-action step primitive** (durable connector-op steps w/ persisted inputs/outcome/retry/reconcile; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | **keep handlers/schema readable during rollback**; disable new creation; drain/migrate in-flight instances before removing support (not bare flag-off, which would strand pinned runs) |
-| 5c | **In-run pause/resume timer** primitive + recovery | new timer type | same as 5b — drain/migrate in-flight timers before removing support |
+| 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | drain per §11.8 |
+| 5c | **In-run pause/resume timer** primitive + recovery | new timer type | drain per §11.8 |
 | 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests — using **sandbox/fake mutating connectors** with observable idempotent effects for ecommerce/travel (they're the workflows that forced connector-action + idempotency; read-only fixtures couldn't prove those primitives) | read-only; no production seeding | remove fixture |
 | 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
 

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 12 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 13 (Phase 0, architecture only; no runtime changes).
 Incorporates all human + codex-connector review rounds to date. Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
@@ -127,8 +127,8 @@ activation); mechanism deferred to the phase PR.
 **the only tombstone (non-reopenable) is `SpaceTask.archivedAt`.** Three distinct durability
 signals, not one: (a) **finalization** — release leases / stop timers / stop active dispatch
 when the canonical task is terminal (`done`/`cancelled`) **and** post-approval has resolved
-(§6.6 finalize transition: task-terminal triggers; re-entry short-circuits on
-`run.status==='done'`); (b) **delivery hard-fail** — only on **archive**
+(§6.6 finalize transition: task-terminal triggers; re-entry short-circuits once the run is
+terminal — `done`/`cancelled`); (b) **delivery hard-fail** — only on **archive**
 (the sole hard-failure condition — `cancelled` reopens, so there is no separate "hard-cancel"
 signal; a user cancel that should discard handoffs archives the task), **not** on
 run-`done`/`cancelled`; (c) **reopen prevention** — archive only. (v4 conflated (a)
@@ -282,7 +282,8 @@ must be non-empty).
 ### 6.1 Transactional outbox (target + verified gap)
 
 **Target:** every transition is one SQLite transaction that atomically (1) validates the
-guard (CAS `WHERE status=?` AND fencing token, §6.3), (2) writes status + append-only
+guard (CAS on `current_status`; a fencing token for leased-worker writes only — unleased
+commands use status/generation guards, §6.3), (2) writes status + append-only
 attempt/transition rows, (3) **enqueues every resulting delivery (live + inactive)**, (4)
 persists any retry deadline, (5) releases/acquires leases. This is the existing pattern for
 cycle-increment + gate-reset (`channel-router.ts:1752`) but **not** for delivery: today the
@@ -336,7 +337,7 @@ a non-polled gate.
 `SpaceRuntimeService.start()` recovers (long-term inbox → `recoverStalledRuns`): skip if
 in-flight; **finalize when the canonical task is terminal (`done`/`cancelled`) AND
 post-approval has resolved** — the §6.6 finalize transition
-(re-entry short-circuits on `run.status==='done'`). Archive
+(re-entry short-circuits once the run is terminal — `done`/`cancelled`). Archive
 is a *separate* concern — the non-reopenable tombstone (§3.1), not the finalize trigger: a
 crash after `mark_complete` (task `done`) but before the run-transition commits must not
 strand the run. `reportedStatus`/`CompletionDetector` alone is not a finalize signal
@@ -352,7 +353,7 @@ path move behind connector capabilities (Phase 5).
 | Claim a work item | lease CAS + fencing token checked on every **leased-worker** write (unleased human/kernel commands use status/generation guards) |
 | Mutating connector op | command key (logical identity, stable across attempts) + reconcile-unknown |
 | Post-approval dispatch | **persist dispatch work-item before spawn**; reconcile on recovery |
-| Finalize run | task-terminal (`done`/`cancelled`) + post-approval-resolved **triggers** the transition; re-entry short-circuits on `run.status==='done'` |
+| Finalize run | canonical task terminal (`done`/`cancelled`) + post-approval-resolved **triggers** the run-`done` transition; re-entry short-circuits once the **run** is terminal (`done`/`cancelled`) |
 | Gate open cache | `gate_open_state` + staleness guard |
 | Connector/gate retry | persisted deadline, rehydrated on restart |
 
@@ -418,6 +419,7 @@ that depend on them.
 | 1f | Durable post-approval dispatch: persist the dispatch work-item BEFORE spawning the merger sub-session; reconcile on recovery — closes the spawn→stamp crash window that today lets recovery spawn a second merger (§3.6/§6.6) | new durability row | drain per §11.8 |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
+| 3b | Remove the deprecated `codex_review_bot` legacy fields from the 3 generic node types + projection + export schema, once the Phase 3 cutover is proven (confines compatibility parsing to an adapter; satisfies the §11.5 acceptance grep that domain concepts vanish from generic types) | removal after parity | fields already unused post-cutover |
 | 4 | Append-only attempts + leases/**fencing on leased-worker writes** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path **+ the GitHub `post_review` outbound tool** (registered today for every end/approval-authority node via `isApprovalAuthorityNode` `task-agent-manager.ts:4779`, block `:4762-4818`; schema `node-agent-tool-schemas.ts:527`, registry `:623`) behind connector capabilities — node-declared tool grants, not hardcoded predicates | legacy retained until proven | fall back |
@@ -431,6 +433,28 @@ that depend on them.
 Subprocesses/nested calls; complex event correlation; distributed execution (leases are the
 seam); compensation/saga (use corrective nodes); org/role modeling; visual designer/BPMN
 import; process mining. (The premature run-`done` is NOT deferred — Phase 1e owns it.)
+
+### 10.1 Scope-pending runtime invariants (escalated to human — round 12)
+
+Four invariants surfaced in round-12 review and are verified real, but their **scope is
+unresolved**: each may be Phase-0-defining (state here) or an implementation-phase detail
+(defer to the phase PR / §10). Drafted as one-line invariant statements only — no mechanism —
+so any can be moved to §10 wholesale on the human's call.
+
+- **Drain durable deliveries through finalization** (§3.1/§6.1): finalization stops workers
+  and timers but **continues draining** outbox deliveries — a delivery committed just before
+  the task terminals may be the event that reopens the run, and §3.4 permits delivery failure
+  only on archive.
+- **Lease renewal on an ownership heartbeat, not SDK progress** (§6.3): a working agent paused
+  on a long model call yields no SDK progress and would be reclaimed, causing duplicate side
+  effects; renew from an alive heartbeat with a separate execution timeout for stuck workers.
+- **Deletion safety for pre-run references** (§4 #3): the not-archived deletion guard protects
+  **runs**, not schedules or queued standalone tasks naming the workflow via
+  `preferredWorkflowId` (which silently fall back to auto-select); deletion must reject,
+  pause, or rebind these durable pre-run references.
+- **Armed in-run timer counts as in-flight work for recovery** (§6.5/Phase 5c): a run paused
+  on the in-run timer has idle/cancelled node-executions but an in-progress task; recovery
+  must rehydrate timers first and exclude timer-waiting runs from stalled-run detection.
 
 ## 11. Migration safety invariants
 

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,11 +1,11 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 10 (Phase 0, architecture only; no runtime changes).
-Incorporates six review rounds (human reviewer + codex-connector bot). Every
+Status: Proposed — Revision 11 (Phase 0, architecture only; no runtime changes).
+Incorporates all human + codex-connector review rounds to date. Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
 phase boundaries** and defers all mechanism (sequences, tables, schemas, wiring) to
-the phase PRs. Date: 2026-08-07. Tracks goal task #874.
+the phase PRs. Date: 2026-08-08. Tracks goal task #874.
 Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
 
 > **Honest thesis (revised).** The engine's *definition model* (topology / gates /
@@ -360,6 +360,7 @@ path move behind connector capabilities (Phase 5).
 | `gate-features.ts` codex paths (`:36`–`:619`) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via `registerGateFeature` plugin | move to `gate-features/codex.ts` plugin |
 | `pr_url` runtime handoff (`getPrUrlForRun` `channel-router.ts:363`, `PR_URL` env, `gate-evaluator.ts:563`, post-approval template) | per-run `runtime_context` map | dual-read; source = `gate_data`/hook-state/`workflow_run_artifacts` (`space_tasks` pr columns dropped in M84) |
 | Full GitHub external-event path in `space-runtime.ts` (restart recovery, topic normalization, check-failure reopen, PR-URL match, auto-subscriptions, retained-event replay) | connector `recoverRun` + subscription/matching/reopen capabilities | Phase 5 |
+| GitHub `post_review` tool (`postGitHubReview` via `gh api`) registered for **every** workflow end/approval-authority node via `isApprovalAuthorityNode` (`task-agent-manager.ts:4779`, block `:4762-4818`) + its schema (`node-agent-tool-schemas.ts:527`, registry `:623`) | node-declared connector tool capability (register generically from the definition, not by a hardcoded end-node predicate) | Phase 5 |
 | Mutable definitions + unpinned created runs + **orphaning deletion** (no FK; guardless `deleteWorkflow` + bypass paths) | immutable + versioned + **pinned at creation** + deletion-safe | Phase 1: history table; pin at creation; guard **all** delete paths; orphan/tombstone policy; version-level FK |
 | Inline crash-retry | append-only attempts + leases/fencing | Phase 4 (preserve idle/reactivation) |
 | Live-target delivery non-durable; in-memory retry deadlines; upsert "audit" | transactional outbox + durable retries + transition log | Phases 1b/1c/1d |
@@ -415,8 +416,8 @@ that depend on them.
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
 | 4 | Append-only attempts + leases/**fencing on leased-worker writes** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
-| 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
-| 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | drain per §11.8 |
+| 5 | Full GitHub external-event path **+ the GitHub `post_review` outbound tool** (registered today for every end/approval-authority node via `isApprovalAuthorityNode` `task-agent-manager.ts:4779`, block `:4762-4818`; schema `node-agent-tool-schemas.ts:527`, registry `:623`) behind connector capabilities — node-declared tool grants, not hardcoded predicates | legacy retained until proven | fall back |
+| 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal; each action references the run-creation pin, §5) | new node/work-item kind behind flag | drain per §11.8 |
 | 5c | **In-run pause/resume timer** primitive + recovery | new timer type | drain per §11.8 |
 | 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests — using **sandbox/fake mutating connectors** with observable idempotent effects for ecommerce/travel (they're the workflows that forced connector-action + idempotency; read-only fixtures couldn't prove those primitives) | read-only; no production seeding | remove fixture |
 | 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
@@ -460,9 +461,10 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
    safety** (no `workflow_id` FK — orphan, not erase; guard all delete paths + version-FK).
    **Phase 1e** delays run-`done` until post-approval resolves (v3 wrongly claimed `done` is
    post-`mark_complete`; verified `space-runtime.ts:7814` sets it before `dispatchPostApproval`).
-2. **Lease scope** → flag-gated no-op for single-process; fencing token guards every worker
-   write; mutating-connector keys derive from logical command identity + activation ordinal
-   (stable across attempts), with connector capability versions pinned per action.
+2. **Lease scope** → flag-gated no-op for single-process; fencing token guards leased-worker
+   writes only (unleased human/kernel commands use status/generation guards, §6.3);
+   mutating-connector keys derive from logical command identity + activation ordinal
+   (stable across attempts), with connector capability versions pinned at run creation (§5).
 3. **Goal V2** → `goals`/`mission_executions` is a **documented compatibility surface,
    dormant at runtime** (CLAUDE.md L172-181 defines it as the Mission System; no live
    writers — `atomicStartExecution`/`insertExecution` have zero non-test callers; automation

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,7 +1,7 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 5 (Phase 0, architecture only; no runtime changes).
-Incorporates five review rounds (human reviewer + codex-connector bot). Every
+Status: Proposed — Revision 6 (Phase 0, architecture only; no runtime changes).
+Incorporates six review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
 revision. Date: 2026-08-07. Tracks goal task #874.
 Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
@@ -117,6 +117,13 @@ Executable tables the kernel enforces, encoded as data (the
 | `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
 | `cancelled` | resume | `in_progress` | task not archived | **reopen** |
 
+**Reopen invariant:** reopen must move **both** the run **and** its non-archived canonical
+task back to `in_progress` atomically. Today `ChannelRouter.reopenRun`
+(`channel-router.ts:1810`) changes only the run status, leaving the task terminal — so
+`CompletionDetector.isComplete` immediately re-finalizes the reopened run. Phase 4/1e must
+make reopen also reopen the task (or completion detection must distinguish a reopened
+activation); mechanism deferred to the phase PR.
+
 **Finalization vs delivery-fail vs tombstone (reconciles §6.6 — fixes v4 over-correction):**
 `done`/`cancelled` are *finished attempt states* that reopen (`workflow-run-status-machine.ts`);
 **the only tombstone (non-reopenable) is `SpaceTask.archivedAt`.** Three distinct durability
@@ -133,9 +140,11 @@ task is `done` but not yet archived; corrected.)
 sits at `approved` while the post-approval/merger worker runs, and reaches task-`done` only
 on `mark_complete`. So a run can be `done` while real work (the merger) is still in flight —
 exactly why durability consumers must not key off run-`done`. **Phase 1e** delays the run-`done`
-transition until the post-approval route resolves (or introduces an intermediate nonterminal
-run state); this is a required migration, not deferred. (v3 wrongly claimed `done` is reached
-only via `mark_complete` — corrected.)
+transition to when the canonical task reaches `done` — immediate for `no-route`, or via
+`mark_complete` (`approved→done`) for routed workflows (the spawned merger runs async after
+`dispatchPostApproval` returns, so the dispatcher return is not the right trigger). This is a
+required migration, not deferred. (v3 wrongly claimed `done` is reached only via
+`mark_complete`; v4-v5 Phase 1e wording "after the route resolves" was also imprecise — corrected.)
 
 ### 3.2 Work item lifecycle (matches `NodeExecutionStatus`, `node-execution-manager.ts:67`)
 
@@ -224,6 +233,13 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
    (`channel-router`, `space-runtime`), and at cutover **backfill every existing in-flight
    run** (snapshot its workflow head into history) so pre-migration runs have a resolvable
    version and are not stranded. (Accessor shape / backfill SQL = Phase-1-PR scope.)
+5. **Pinning scope includes referenced agent configs:** the workflow payload carries
+   `agentId` + slot overrides, but `resolveAgentInit` loads the **current mutable**
+   `SpaceWorkerAgent` (`agentManager.getById`, `custom-agent.ts:752`) at each spawn — so
+   editing an agent's model/prompt/tools/provider after run creation changes an in-flight
+   run. The pin must therefore snapshot/version referenced agent configs with the run (or the
+   pinning contract must explicitly account for these mutable dependencies); mechanism
+   deferred to the Phase 1 PR.
    - add a **version-level FK** (runs reference a definition *version*, not the mutable
      head) once versioning lands.
 4. `SpaceWorkflow` shape is otherwise unchanged.
@@ -295,7 +311,9 @@ a non-polled gate.
 
 - Claim = acquire `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the
   same transaction as `in_progress`; refresh on real SDK progress (addresses stranded-
-  delivery class, #859–#862).
+  delivery class, #859–#862). **Every entry INTO `in_progress` acquires a fresh lease+token**
+  — including `idle`/`cancelled` reactivation (which today bypass the `pending→in_progress`
+  claim path and would otherwise run with no/stale token); mechanism deferred to Phase 4 PR.
 - **Fencing on EVERY worker-owned write:** a monotonic token invalidates a stale owner only
   if every transition, outbox enqueue, completion write, and connector-action outcome
   compares the presented token against the current lease token (guarding only on
@@ -395,15 +413,15 @@ that depend on them.
 | 1b | Transactional outbox (persist every delivery, live + inactive, in the transition tx) + receiver-side dedup | write both; cutover when proven | fall back to direct live delivery |
 | 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | in-memory scheduler still works while populated |
 | 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
-| 1e | **Delay run-`done` until post-approval resolves** — today the run is set `done` at `space-runtime.ts:7814` before `dispatchPostApproval` (`:7858`); move the `done` transition to after the post-approval route resolves, or introduce an intermediate nonterminal run state | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
+| 1e | **Delay run-`done` until the task reaches `done`** — today the run is set `done` at `space-runtime.ts:7814` before `dispatchPostApproval` (`:7858`). Tie run-`done` to the **canonical task** reaching `done` — immediate for `no-route`, or via `mark_complete` (`approved→done`) for routed workflows. **Not** merely "after `dispatchPostApproval` returns": that awaits only `spawnPostApprovalSubSession`, after which the spawned merger still runs and finishes later on `mark_complete` — so keying off the dispatcher return would preserve the bug. (Alt: an intermediate nonterminal run state until `mark_complete`.) | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
-| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection) | deprecated alias | alias honored |
+| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
 | 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | toggle flag |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
 | 5b | **Connector-action step primitive** (durable connector-op steps w/ persisted inputs/outcome/retry/reconcile; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | **keep handlers/schema readable during rollback**; disable new creation; drain/migrate in-flight instances before removing support (not bare flag-off, which would strand pinned runs) |
 | 5c | **In-run pause/resume timer** primitive + recovery | new timer type | same as 5b — drain/migrate in-flight timers before removing support |
-| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests | read-only; no seeding | remove fixture |
+| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests — using **sandbox/fake mutating connectors** with observable idempotent effects for ecommerce/travel (they're the workflows that forced connector-action + idempotency; read-only fixtures couldn't prove those primitives) | read-only; no production seeding | remove fixture |
 | 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
 
 ## 10. Deferred features
@@ -430,6 +448,12 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
    (NOT run-`done`/`cancelled`, which reopen); **reopen-prevention / tombstone** =
    `SpaceTask.archivedAt` only.
 7. **Idempotency keys are stable across attempts**; fencing tokens guard every worker write.
+8. **Rollback drains in-flight state, never a bare flag-flip:** any phase that creates
+   durable state (outbox rows, retry deadlines, connector-action/timer instances, version
+   pins) must, on rollback, keep the schema + dispatcher/worker readable and drain or
+   migrate existing instances **before** removing execution support — a bare flag-flip
+   strands persisted rows (outbox handoffs lost; persisted retry deadlines never fire after
+   the in-memory scheduler restarts). Mechanism per phase PR.
 
 ## 12. Design-review decisions (resolved / revised across 3 rounds)
 

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 7 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 8 (Phase 0, architecture only; no runtime changes).
 Incorporates six review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
@@ -43,8 +43,9 @@ The foundational rule:
 - Runtime changes. Phase 0 is design + approval only.
 - BPMN/BPEL parity; a visual designer; distributed multi-process execution now (we design
   the seams — leases, fencing — but stay single-process until a measured bottleneck).
-- Deciding the fate of the dormant legacy `goals`/`mission_executions` tables — they are
-  de-facto frozen already (§7); a unification audit is deferred (Phase 7).
+- Deciding the fate of the dormant legacy `goals`/`mission_executions` tables — they are a
+  documented compatibility surface, dormant at runtime (§7); a unification audit is deferred
+  (Phase 7).
 
 ### What is already generic (verified)
 
@@ -107,17 +108,12 @@ between "channel sends reopen" and "done/cancelled are terminal."
 Executable tables the kernel enforces, encoded as data (the
 `VALID_NODE_EXECUTION_TRANSITIONS` / `VALID_TRANSITIONS` patterns are the model).
 
-### 3.1 Run lifecycle (matches `workflow-run-status-machine.ts`)
+### 3.1 Run lifecycle — invariants
 
-| from | event | to | guard | notes |
-|---|---|---|---|---|
-| `pending` | run created | (pinned) | definition resolvable | **stamp `definition_version` at creation**, before activation (§4) |
-| `pending` | start node activated | `in_progress` | — | (startWorkflowRun) |
-| `in_progress` | `reportedStatus` set / `CompletionDetector` | `done` (premature today) | `runIsComplete` | today premature (`space-runtime.ts:7814`); Phase 1e ties run-`done` to durable task-`done` |
-| `in_progress` | agent failed / gate needs human | `blocked` | — | `failure_reason` set |
-| `in_progress`/`blocked` | cancel | `cancelled` | — | |
-| `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
-| `cancelled` | resume | `in_progress` | task not archived | **reopen** |
+Run statuses/transitions follow `workflow-run-status-machine.ts` verbatim — including
+`pending→cancelled` (init-failure cleanup), `blocked→in_progress` (resolution), and
+`done`/`cancelled→in_progress` (reopen). (`definition_version` is stamped at run creation —
+§4.) Load-bearing invariants for this design:
 
 **Reopen invariant:** reopen must move **both** the run **and** its non-archived canonical
 task back to `in_progress` atomically. Today `ChannelRouter.reopenRun`
@@ -153,8 +149,9 @@ cancelled` (no `done`; success parks as reactivatable `idle`). Invariants:
 - **Every non-archived item is reclaimable:** a crashed `in_progress` item returns to
   claimable via fenced lease-expiry (the one Phase-4 addition to
   `VALID_NODE_EXECUTION_TRANSITIONS`); `cancelled→in_progress` reactivates on run resume.
-- **One attempt per claim:** append-only attempts are created at the `pending→in_progress`
-  claim only (not at reset-to-pending).
+- **One attempt per freshly-leased invocation:** every activation that acquires a fresh lease
+  (claim, idle/cancelled/blocked reactivation) appends exactly one attempt row;
+  reset-to-pending does not.
 
 Exact transition wiring and attempt schema are Phase-4-PR mechanism.
 
@@ -213,8 +210,10 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
    hot-path `getWorkflow` reads.)
 2. Built-in re-stamping becomes version-bumping, not in-place mutation.
 3. **Deletion-safety (no cascade to "remove" — there is none):**
-   - add an **active-run guard** to **every** deletion/replacement path
-     (`SpaceWorkflowManager.deleteWorkflow`, import-replacement, `deleteByWorkflowId`);
+   - add a **not-archived guard** to **every** deletion/replacement path
+     (`SpaceWorkflowManager.deleteWorkflow`, import-replacement, `deleteByWorkflowId`) —
+     protect every run whose canonical task is **not archived** (including reopenable
+     `done`/`cancelled`), not just currently-active statuses;
    - adopt an **orphan/tombstone policy** (soft-delete the definition; runs keep their
      pinned version);
 4. **Read cutover + backfill (migration invariant):** a pin is inert unless run reads
@@ -402,7 +401,7 @@ that depend on them.
 | 1e | Run-`done` ties to the canonical task reaching durable `done` (today premature, `space-runtime.ts:7814`) | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
-| 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | toggle flag |
+| 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
 | 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | drain per §11.8 |

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,554 +1,408 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 2 (Phase 0, architecture only; no runtime changes).
-Incorporates design-review feedback (PR #2396): human-reviewer doc-accuracy fixes
-and the codex-connector inline review, all claims re-verified against the code.
-Date: 2026-08-07. Tracks goal task #874. Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
+Status: Proposed — Revision 3 (Phase 0, architecture only; no runtime changes).
+Incorporates three review rounds (human reviewer + codex-connector bot). Every
+code-level claim below was re-verified directly against the current source this
+revision. Date: 2026-08-07. Tracks goal task #874.
+Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
+
+> **Honest thesis (revised).** The engine's *definition model* (topology / gates /
+> channels / hooks / post-approval) and its *connector registry* are already generic
+> and data-defined, and there is no `switch(workflowType/nodeType)` dispatch in core.
+> **But** the engine is **not** "fully expressive with zero kernel changes": it lacks
+> primitives a durable, domain-agnostic framework needs — **imperative connector-action
+> steps** (connectors are read-only validators/hooks today), **in-run pause/resume
+> timers**, a **transactional outbox**, **durable retry deadlines**, an **append-only
+> transition log**, **deletion-safe versioning**, and **mutating-connector idempotency**.
+> These missing primitives are the bulk of the remaining work — they are NEW, not
+> extraction — and are forced by the reference workflows (§8), not speculative.
 
 ## 1. Goal and non-goals
 
 ### Goal
 
 Evolve HyperNeo's Space workflow system into a **domain-agnostic, durable execution
-framework** suitable for business processes, manufacturing, ecommerce, personal-assistant
+framework** for business processes, manufacturing, ecommerce, personal-assistant
 workflows, and agent collaboration — without a big-bang rewrite.
 
-The foundational rule, in one line:
+The foundational rule:
 
 > **Data-defined behavior, code-defined semantics, plugin-defined capabilities.**
 
-- **Data-defined behavior** — every workflow-specific behavior (topology, transitions,
-  prompts, policies, approval thresholds, delivery targets, timers) lives in an immutable,
-  versioned **definition** that the kernel interprets. The kernel never branches on
-  *which* workflow is running.
-- **Code-defined semantics** — the generic kernel owns the *meaning* of transitions,
-  durability, leases, idempotency, approvals, timers, delivery, recovery, audit, and
-  terminal states. These semantics are universal and not parameterized by domain.
-- **Plugin-defined capabilities** — domain actions (call GitHub, call an ERP, book a
-  flight, run a validator) are **connectors** registered into a generic capability
-  registry. The kernel invokes them by id; it does not know what they do.
+- **Data-defined behavior** — workflow-specific behavior lives in an immutable, versioned
+  **definition** the kernel interprets; the kernel never branches on *which* workflow runs.
+- **Code-defined semantics** — the generic kernel owns transitions, durability, leases,
+  idempotency, approvals, timers, delivery, recovery, audit, and terminal semantics.
+- **Plugin-defined capabilities** — domain actions are **connectors** in a generic registry,
+  invoked by id.
 
 ### Non-goals (this RFC)
 
-- Implementing runtime changes. Phase 0 is design + approval only.
-- BPMN/BPEL parity. We adopt patterns incrementally as reference workflows demand them.
-- A visual designer or external format import.
-- Distributed multi-process execution now. We design the seams (leases, fencing) but keep
-  a single-process daemon until a measured bottleneck forces scaling.
-- Deciding the fate of the two overlapping goal models. `goals`/`mission_executions` is an
-  **active** Mission System (§7), not legacy; unifying it with `space_goals` is a separate
-  investigation deferred past this RFC (Phase 7 re-scoped).
+- Runtime changes. Phase 0 is design + approval only.
+- BPMN/BPEL parity; a visual designer; distributed multi-process execution now (we design
+  the seams — leases, fencing — but stay single-process until a measured bottleneck).
+- Deciding the fate of the dormant legacy `goals`/`mission_executions` tables — they are
+  de-facto frozen already (§7); a unification audit is deferred (Phase 7).
 
-### Why this is tractable now
+### What is already generic (verified)
 
-The current engine is already largely data-defined. A code survey confirms:
+- No `switch(workflowType)` / `switch(nodeType)` dispatch in core. Topology, gate
+  evaluation, cycle caps, completion detection, post-approval routing are data-driven.
+- A connector abstraction + registry exist (`connectors/`), rolled out behind a flag
+  (`isConnectorsLayerEnabled()`).
 
-- There is **no `switch(workflowType)` or `switch(nodeType)` dispatch** in the core runtime.
-  Topology (nodes/channels/gates/hooks/post-approval), gate evaluation, cycle caps,
-  completion detection, and post-approval routing are all data-driven.
-- A clean **connector abstraction already exists** (`packages/daemon/src/lib/space/runtime/connectors/`)
-  with a generic registry (`Connector` / `ConnectorOp` / `ConnectorOutcome` /
-  `ConnectorAuth`), a predicate DSL (`predicate.ts`), and validator presets.
-- The connector layer is being rolled out **behind a feature flag**
-  (`isConnectorsLayerEnabled()`, gated in `hook-executor.ts`).
+### What is missing (verified) — the actual work
 
-So this is **not a rewrite**. It is a bounded extraction **plus** closing durability seams
-that single-process execution let us defer. The remaining work is larger than "extract
-GitHub" alone: several durability guarantees the goal demands (transactional outbox,
-durable retry deadlines, append-only transition audit, deletion-safe versioning, mutating-
-connector idempotency) are **not yet met** by the current code. Those gaps are enumerated
-in §6 and drive new phases in §9.
+- **Imperative connector-action steps** do not exist: `WorkflowNode.agents` must be
+  non-empty (`space.ts:2274,2276`), connectors are invoked only as read-only validators
+  (`external-state-validator.ts:84,91`) and hook auth lookups (`hook-executor.ts:203,207`).
+- **In-run pause/resume timer** does not exist: `task_schedules` create *new* runs,
+  `GatePoll` re-evaluates a gate, hook-retries retry a hook — none pauses and later
+  resumes one run.
+- **Transactional outbox** absent: live targets bypass the durable inbox.
+- **Durable retry deadlines** absent: `GateRetryScheduler` is in-memory.
+- **Append-only transition log** absent: `workflow_run_artifacts` are upserts.
+- **Deletion-safe versioning** absent: deleting a definition **orphans** runs (no FK) and
+  no deletion path has an active-run guard.
+- **Mutating-connector idempotency** absent: the contract carries no command key.
 
 ## 2. Canonical concepts
 
-We adopt the existing vocabulary wherever it is already correct — a parallel rename would
-violate the incremental, compatibility-first constraint. New terms are introduced only
-where the current model conflates or omits something.
+We keep the existing vocabulary where correct (a rename would violate incrementalism).
 
 | Canonical term | Current implementation | Notes |
 |---|---|---|
-| **Definition** | `SpaceWorkflow` (`packages/shared/src/types/space.ts:2419`) | Becomes **immutable + versioned + deletion-safe** (§4). |
-| **Run** | `space_workflow_runs` row (`migrations.ts:2713`) | One execution of a definition. *(target: pins `definition_version`; today re-reads the live workflow row each tick — §4)* |
-| **Work item** | `node_executions` row (`migrations.ts:5912`) | Statuses: `pending\|in_progress\|idle\|waiting_rebind\|blocked\|cancelled`. **Terminal = `idle` \| `cancelled`** (there is no `done`; a successful turn becomes a reactivatable `idle` row). |
-| **Attempt** | (implicit: crash-retry-with-counting in tick loop) | **New, append-only**: an execution attempt of a work item. |
-| **Token / activation** | `ChannelRouter.activateNode` creating `node_executions` | A channel-directed `send_message` or a gate-open *activates* a downstream node (see "advances state" below). |
-| **Gate** | `Gate` + `gate_data` + `gate_open_state` | Declaration in definition; runtime state in `gate_data`; open-cache in `gate_open_state`. |
-| **Channel** | `WorkflowChannel` (`space.ts:2215`) | Directed message pipe `from → to`, optional `gateId`, `maxCycles`. |
-| **Approval** | Gate with `requiredLevel` / external `writers: []` field + `completionAutonomyLevel` | Human or autonomy-gated sign-off. |
-| **Delivery** | `pending_agent_messages` (inbox) + `AgentMessageRouter` (outbox) | Durable **only for inactive targets** today; live targets bypass the inbox (§6.1–6.2 gap). |
-| **Timer** | `task_schedules` (cron/at) + `GatePoll` (interval) + hook retry timers | Connector/gate **retry deadlines are in-memory only** today (§6.3 gap). |
-| **Connector / capability** | `connectors/` registry + validator presets | Domain actions behind an id. Read-only ops are safe today; **mutating ops need command idempotency** (§5 gap). |
-| **Task** | `space_tasks` | User-facing unit; 1:1 with a run via `workflow_run_id`. Sole completion source of truth. |
-| **Goal** | `space_goals` **and** `goals`/`mission_executions` (both active) | Two overlapping models; unification deferred (§7, Phase 7). |
-| **Worker** | A Space agent session | Agents/humans/services are workers; sessions are execution *resources*, not identity. |
+| **Definition** | `SpaceWorkflow` (`space.ts:2419`) | Becomes immutable + versioned + deletion-safe (§4). |
+| **Run** | `space_workflow_runs` row (`migrations.ts:2713`) | *(target: pins `definition_version` at **creation**; today re-reads the live row each tick — §4)*. `done`/`cancelled` **reopen** to `in_progress` (`workflow-run-status-machine.ts`); the only tombstone is `SpaceTask.archivedAt`. |
+| **Work item** | `node_executions` row | `pending\|in_progress\|idle\|waiting_rebind\|blocked\|cancelled`. Terminal = `idle\|cancelled` (no `done`); success parks as reactivatable `idle`. |
+| **Attempt** | (implicit crash-retry-with-counting) | New, append-only (§6.4). |
+| **Activation** | `ChannelRouter.activateNode` | A channel-directed `send_message` or gate-open activates a downstream node — and can reopen a finished run (below). |
+| **Gate / Channel / Approval** | `Gate`+`gate_data`+`gate_open_state`; `WorkflowChannel`; `requiredLevel`/`completionAutonomyLevel` | Unchanged. |
+| **Delivery** | `pending_agent_messages`/`space_agent_inbox_messages` (inbox) + `AgentMessageRouter` | Durable only for **inactive** targets today; live targets bypass the inbox (§6.1). |
+| **Timer** | `task_schedules` (new-run cron/at) + `GatePoll` (repeat eval) + hook retry | **No in-run pause/resume** primitive today (§3.5). |
+| **Connector** | `connectors/` registry | Read-only validators/hooks only today; **imperative connector-action steps are a new primitive** (§5). |
+| **Task** | `space_tasks` | User-facing unit; 1:1 with a run. Sole completion source of truth. **archivedAt is the only tombstone.** |
+| **Goal** | `space_goals` (active); `goals`/`mission_executions` (**dormant/legacy**) | One active model; the legacy tables are de-facto frozen (§7). |
+| **Worker** | Space agent session | Agents/humans/services are workers; sessions are resources, not identity. |
 
-**Mental model.** A *Goal* says *what* to achieve and *when* (trigger layer). It creates a
-*Task* and a *Run* of a *Definition*. The kernel drives the run by *activating work items*
-along *channels*, respecting *gates*. Workers pick up work items, emit *outcomes*, and the
-kernel transitions the run deterministically. *Connectors* provide domain actions. Delivery
-is durable and idempotent so workers can crash, retry, and recover without losing or
-duplicating work.
+**Mental model.** A *Goal* (what/when) creates a *Task* and a *Run* of a *Definition*. The
+kernel activates work items along channels respecting gates. Workers emit outcomes; the
+kernel transitions the run. Connectors provide domain actions. Delivery is durable and
+idempotent so workers can crash, retry, and recover without loss or duplication.
 
-### What advances process state
+### What advances process state (reconciled with reopen)
 
-> **Channel-directed sends and explicit outcomes/commands advance process state;
-> untargeted free text only communicates.**
+> **Channel-directed sends and explicit outcomes/commands advance state; untargeted free
+> text only communicates.** Finished runs (`done`/`cancelled`) are **not** tombstones — a
+> channel send can reopen them (`done→in_progress`, `cancelled→in_progress`); only
+> `SpaceTask.archivedAt` is final.
 
-A `send_message` **on a declared channel** is itself a structured activation command — it
-carries `from → to` topology and is gated, and the kernel's `ChannelRouter.deliverMessage`
-lazily activates the target node, advances cyclic-channel state, and can reopen a run.
-Existing workflows rely on this for handoffs. Therefore the invariant is **not** "a message
-never moves the graph"; it is: only *channel-directed* sends and *structured outcomes*
-(gate writes that open a gate; terminal work-item outcomes; commands like
-`submit_for_approval`/`approve_task`/`mark_complete`; timer fires) advance state. Untargeted
-broadcasts (`*`) and free text do not. This matches current behavior — we preserve it
-rather than migrate to a separate activation command.
+This matches `workflow-run-status-machine.ts` exactly and removes the v2 contradiction
+between "channel sends reopen" and "done/cancelled are terminal."
 
 ## 3. Lifecycle / state-transition tables
 
-These are the executable transition tables the kernel enforces, encoded as data (the
-`VALID_NODE_EXECUTION_TRANSITIONS` pattern at `node-execution-manager.ts:39` is the model).
-Where the existing set already matches, the table is a formalization; differences are
-called out.
+Executable tables the kernel enforces, encoded as data (the
+`VALID_NODE_EXECUTION_TRANSITIONS` / `VALID_TRANSITIONS` patterns are the model).
 
-### 3.1 Run lifecycle
+### 3.1 Run lifecycle (matches `workflow-run-status-machine.ts`)
 
-A run is **terminal** (`done`/`cancelled`) only when the canonical task is terminal **and**
-any post-approval route has finished. `reportedStatus` being set is a **completion request**,
-not a terminal state — the run must not be treated as terminal (for leases, timers,
-activation, or delivery) while approval or post-approval work is still in flight.
+| from | event | to | guard | notes |
+|---|---|---|---|---|
+| `pending` | run created | (pinned) | definition resolvable | **stamp `definition_version` at creation**, before activation (§4) |
+| `pending` | start node activated | `in_progress` | — | (startWorkflowRun) |
+| `in_progress` | completion resolved post-approval | `done` | task terminal + post-approval finished | reached via `mark_complete`; not on `reportedStatus` alone |
+| `in_progress` | agent failed / gate needs human | `blocked` | — | `failure_reason` set |
+| `in_progress`/`blocked` | cancel | `cancelled` | — | |
+| `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
+| `cancelled` | resume | `in_progress` | task not archived | **reopen** |
+
+**Terminal vs tombstone (critical, fixes v2 contradiction):** `done`/`cancelled` are
+*finished attempt states* that reopen; **the only tombstone is `SpaceTask.archivedAt`.**
+Durability consumers (delivery, leases, timers) **must key off task-archive (or explicit
+hard-cancel), never off run `done`/`cancelled`** — otherwise they short-circuit a run that
+is about to be reopened. Today the engine reaches `done` only after `mark_complete`
+(post-merger), so the merger window is already covered by the `approved` task status; no
+new `completing` run-status is required (it would need a `WorkflowRunStatus` migration with
+its own phase — deferred unless a gap is observed).
+
+### 3.2 Work item lifecycle (matches `NodeExecutionStatus`, `node-execution-manager.ts:67`)
+
+`pending | in_progress | idle | waiting_rebind | blocked | cancelled`. Terminal = `idle |
+cancelled` (no `done`); success → reactivatable `idle`.
 
 | from | event | to | guard | side effect |
 |---|---|---|---|---|
-| `pending` | start node activated | `in_progress` | definition resolvable at pinned version | stamp `definition_version` |
-| `in_progress` | `reportedStatus` set / `CompletionDetector.isComplete` | **`completing`** (nonterminal) | task not yet terminal | resolve through approval gate (§3.6); do **not** release leases / stop timers yet |
-| `completing` | task → `done`/`cancelled` AND post-approval resolved | `done`/`cancelled` | terminal | release leases, stop timers, cancel pending delivery |
-| `in_progress` | all work items terminal, no completion signal, restart | `blocked` | recovery pass | `failure_reason = 'agentCrash'` |
-| `in_progress` | human reject | `blocked` | `failure_reason = 'humanRejected'` | — |
-| `in_progress` | max iterations / node timeout | `blocked` | `failure_reason ∈ {maxIterationsReached, nodeTimeout}` | — |
-| `in_progress`/`blocked` | human cancel | `cancelled` | — | cascade-cancel work items, release leases |
-| `blocked` | manual restart / recovery claim | `in_progress` | work item re-activated | — |
+| `pending` | worker claims | `in_progress` | lease + fencing token acquired (§6.3) | append attempt #1 |
+| `in_progress` | terminal outcome | `idle` | — | release lease (reactivatable) |
+| `in_progress` | needs peer input | `waiting_rebind` | — | — |
+| `waiting_rebind`/`idle` | input arrives / crash / lease expiry / timeout | `pending` | budget remaining, not archived | append attempt #N, backoff |
+| any | task archived / hard-cancel | `cancelled` | — | release lease |
 
-`done`, `cancelled` are terminal. `blocked` is recoverable. `completing` is a nonterminal
-held state (the run is still live for approval/merger). Today the engine reaches `done`
-through the tick's `resolveTaskApproval` after `CompletionDetector` fires; we make the
-nonterminal window explicit so durability consumers do not short-circuit early. Re-entrant
-finalization short-circuits on `task.status === 'done'` (no separate stamp —
-`completion_actions_fired_at` was dropped in M104).
+**Phase 4 caveat:** because the lifecycle is idle/reactivation-based, Phase 4 must preserve
+those semantics when adding append-only attempts — not "append without behavior change."
 
-### 3.2 Work item lifecycle
+### 3.3 Gate lifecycle — unchanged (closed→pending_approval→open; cyclic reset).
 
-Matches `NodeExecutionStatus` (`space.ts:1111`): `pending | in_progress | idle |
-waiting_rebind | blocked | cancelled`. **Terminal = `idle | cancelled`**
-(`TERMINAL_NODE_EXECUTION_STATUSES`, `node-execution-manager.ts:67`). There is **no `done`**;
-a successful turn parks as a reactivatable `idle` row.
-
-| from | event | to | guard | side effect |
-|---|---|---|---|---|
-| `pending` | worker claims | `in_progress` | lease acquired (§6.3), idempotent activation short-circuit | append attempt #1 |
-| `in_progress` | worker emits terminal outcome | `idle` | — | release lease (reactivatable) |
-| `in_progress` | worker needs peer input | `waiting_rebind` | — | lease continues or parks |
-| `in_progress` | gate blocks downstream | (self unchanged) | — | downstream not activated |
-| `waiting_rebind` | input arrives / wake | `pending` | budget remaining, not terminal | append attempt #N, backoff |
-| `in_progress`/`idle` | worker crash / lease expiry | `pending` (retry) | budget remaining | append attempt #N |
-| `in_progress`/`idle` | timeout | `pending` (retry) | budget remaining | append attempt #N |
-| `idle` | run cancelled | `cancelled` | — | release lease |
-| retry exhausted | max attempts reached | `blocked` | — | run → `blocked` (`agentCrash`) |
-
-**Phase 4 caveat (verified):** because the real lifecycle is idle/reactivation-based (not
-`done`-then-retry-from-`in_progress`), Phase 4 cannot "merely append attempt records without
-changing observable behavior." It must preserve the idle/reactivation semantics and either
-model attempts against the existing statuses or include a tested status reconciliation.
-This is acknowledged in the Phase 4 scope.
-
-### 3.3 Gate lifecycle
+### 3.4 Delivery lifecycle (target)
 
 | from | event | to | notes |
 |---|---|---|---|
-| `closed` | writer writes field / script runs / validator runs | re-evaluated | all fields pass → `open` |
-| `closed` | autonomy threshold not met and validation passes | `pending_approval` | task → `review`; surfaces in UI |
-| `closed` | autonomy threshold met and validation passes | `open` | auto-approval |
-| `pending_approval` | human approves | `open` | — |
-| `pending_approval` | human rejects | `closed` (or run `blocked`) | `resetOnCycle` may clear data |
-| `open` | gate opens | activates downstream work items via `onGateDataChanged` | — |
-| `open` | new cycle (cyclic channel) | `closed` | `channel_cycles++`, `gate_data` reset if `resetOnCycle` |
-
-Gate open-cache (`gate_open_state`) is persisted across restart with a staleness guard
-(`opened_workflow_updated_at`) — preserved as-is.
-
-### 3.4 Delivery (inbox/outbox) lifecycle — target
-
-| from | event | to | notes |
-|---|---|---|---|
-| `pending` | target worker activates | `delivered` | `flushPendingMessagesForTarget`, idempotent by `idempotency_key` |
+| `pending` | target activates | `delivered` | **receiver-side dedup** required (§6.2) — crash between inject and mark-delivered must not double-deliver |
 | `pending` | TTL elapsed, attempts < max | `pending` (retry) | backoff |
-| `pending` | max attempts reached | `failed` | actionable terminal failure surfaced |
-| `pending` | run/work item terminal | `failed` | do not deliver to dead workers |
+| `pending` | max attempts | `failed` | actionable terminal failure |
+| `pending` | **task archived** (true tombstone) | `failed` | NOT on run `done`/`cancelled` (those reopen) |
 
-**Gap (§6.1–6.2):** today only *inactive* targets get a durable inbox row; **live targets
-are delivered directly with no durable row**, so a crash between the state transition and
-live delivery loses the handoff. The target state above is the goal; reaching it is the
-transactional-outbox phase.
+**Gap (§6.1–6.2):** only inactive targets get a durable row today; live targets are
+delivered directly with no durable row, so a crash between transition and live delivery
+loses the handoff. The target table is the goal; the transactional-outbox phase reaches it.
 
-### 3.5 Timer lifecycle — target
+### 3.5 Timer lifecycle — current + missing primitive
 
-| type | trigger | effect |
-|---|---|---|
-| schedule (`task_schedules`) | cron / `run_at` reaches `next_run_at` | enqueue fire job → new run/task instance |
-| gate poll (`GatePoll`) | `intervalMs` tick while run `in_progress` | run gate script; if stdout changed, inject message |
-| hook retry (`WorkflowHookRetrySettings`) | `next_retry_at` | re-run hook with backoff |
-| **connector/gate retry** (`GateRetryScheduler`) | `retryAfterMs` | re-evaluate gate after backoff |
-
-**Gap (§6.3):** `GateRetryScheduler` stores `retryAfterMs` in an in-memory `Map` +
-`setTimeout` (`gate-retry-scheduler.ts:10-11,34`). A daemon restart loses the deadline, so a
-rate-limited non-polled gate can stay closed indefinitely. Persisting these deadlines is a
-durability phase.
-
-All timers stop on run terminal state (but not before — see §3.1 `completing`).
+| type | trigger | effect | status |
+|---|---|---|---|
+| schedule (`task_schedules`) | cron/`run_at` | new run/task instance | exists |
+| gate poll (`GatePoll`) | `intervalMs` | re-evaluate gate script | exists |
+| hook retry | `next_retry_at` | re-run hook | exists |
+| connector/gate retry (`GateRetryScheduler`) | `retryAfterMs` | re-evaluate gate | exists but **in-memory** (§6.3) |
+| **in-run pause/resume** | wait-until / event | **resume the same run later** | **missing primitive** (§8.4) |
 
 ### 3.6 Approval lifecycle
 
-| from | event | to | guard |
-|---|---|---|---|
-| work item emits `submit_for_approval` | command accepted | task `review` | `space.autonomyLevel < completionAutonomyLevel` → human gate; else auto |
-| task `review` | human `approve` | `approved` → post-approval route | double-fire guard (`postApprovalSessionId` set + alive → no-op) |
-| task `review` | human `reject` | `in_progress` (feedback to worker) | — |
-| `approved` | post-approval route done | `done` | `mark_complete` |
+`submit_for_approval` → task `review` → human `approve` → `approved` → post-approval route
+→ `done` (`mark_complete`); reject → `in_progress`. **Post-approval dispatch must persist a
+dispatch work-item BEFORE spawning** the sub-session (§6.6) — `postApprovalSessionId` is
+the *output* of spawn (`post-approval-router.ts:113`) and is stamped only after spawn, so a
+crash during spawn leaves no guard and recovery can spawn a second merger.
 
 ## 4. Workflow-definition schema (immutable, versioned, deletion-safe)
 
-**Problem today.** Definitions are mutable (`SpaceWorkflowManager.updateWorkflow`) and only
-soft-version-tracked via `templateHash` + `updatedAt`. Node IDs are stable
-(`validateStableNodeIds`) but a definition edit can silently change the behavior of an
-*in-flight* run, because runs re-read the live workflow row each tick. Separately,
-`space_workflow_runs.workflow_id` is `ON DELETE CASCADE` and `deleteWorkflow`
-(`space-workflow-manager.ts:445`) has **no active-run guard**, so deleting a definition
-erases the supposedly-pinned in-flight run and its execution history.
+**Problems today (verified):**
+1. Definitions are mutable (`updateWorkflow`); a run re-reads the live row each tick, so an
+   edit silently changes an in-flight run.
+2. `definition_version` is stamped on `pending→in_progress`, leaving a created-but-unstarted
+   run unpinned (an edit/re-seed/tombstone before activation breaks the invariant).
+3. Deleting a definition **orphans** runs: there is **no `workflow_id` FK** on
+   `space_workflow_runs` (M60 rebuilt the table FK-free at `migrations.ts:4976`; M71
+   preserved that shape at `:5810`; confirmed by the "Orphaned-run handling" comment at
+   `:990`). `deleteWorkflow` (`space-workflow-manager.ts:445`) has no active-run guard, and
+   other deletion paths bypass even that (import-replacement calls
+   `workflowRepo.deleteWorkflow` directly; duplicate-resync calls
+   `workflowRunRepo.deleteByWorkflowId`).
 
-**Decision (design review + verification).**
+**Decision:**
+1. `definition_version` = in-row content hash, **pinned on the run row at creation**
+   (atomically with the initial run insert), with prior versions in an append-only
+   `space_workflow_definition_versions` history table. (In-row avoids indirection on the
+   hot-path `getWorkflow` reads.)
+2. Built-in re-stamping becomes version-bumping, not in-place mutation.
+3. **Deletion-safety (no cascade to "remove" — there is none):**
+   - add an **active-run guard** to **every** deletion/replacement path
+     (`SpaceWorkflowManager.deleteWorkflow`, import-replacement, `deleteByWorkflowId`);
+   - adopt an **orphan/tombstone policy** (soft-delete the definition; runs keep their
+     pinned version);
+   - add a **version-level FK** (runs reference a definition *version*, not the mutable
+     head) once versioning lands.
+4. `SpaceWorkflow` shape is otherwise unchanged.
 
-1. Version = an **in-row content hash** (`definition_version`) stamped on the definition
-   row **and pinned on the run** at start, with prior versions retained in an append-only
-   **`space_workflow_definition_versions`** history table. In-row (not a separate
-   current-version table) avoids indirection on the ~15 hot-path `getWorkflow` reads per
-   tick. Existing runs read their pinned version; new runs get the latest.
-2. Built-in template re-stamping (`seedBuiltInWorkflows` hash-drift merge) becomes
-   version-bumping rather than in-place mutation of live behavior.
-3. **Deletion safety (verified gap):** Phase 1 must also make definition deletion safe for
-   pinned runs — either **tombstoned (soft-deleted) definitions** or **version-level foreign
-   keys** that retain every version referenced by a run, **plus an active-run guard** in
-   `deleteWorkflow` (refuse or cascade-cancel cleanly). The current `ON DELETE CASCADE` on
-   `workflow_id` must be removed or redirected to the version. Includes an explicit deletion
-   migration + test.
-4. The shape of `SpaceWorkflow` is otherwise unchanged — versioning + deletion-safety are
-   wrappers, not a schema redesign. Existing readers keep working; they resolve through the
-   pinned version.
+## 5. Capability / connector contract (read-only today; mutating + imperative steps are new)
 
-**Reference definition schema** (TypeScript-ish, abbreviated — matches current
-`SpaceWorkflow`):
-
-```ts
-interface WorkflowDefinition {
-  id: string;                       // definition id (stable across versions)
-  definitionVersion: string;        // content hash; immutable once published
-  name: string;
-  startNodeId: string;
-  endNodeId?: string;
-
-  nodes: Node[];                    // groups of agent slots; parallel execution
-  channels: Channel[];              // directed from→to, optional gateId, maxCycles
-  gates: Gate[];                    // fields | script | validator | features | poll
-  hooks?: Hook[];                   // validators on MCP calls / runtime events
-
-  completionAutonomyLevel: AutonomyLevel;   // self-close vs human review
-  postApproval?: PostApprovalRoute;          // node-level routes
-  runtimeContextContract?: RuntimeContextKey[]; // §7 — replaces implicit pr_url
-
-  tags?: string[];                  // workflow-selector hints (default, v2, …)
-}
-
-interface Node {
-  id: string; name: string;
-  agents: NodeAgent[];              // slots: agentId, model, prompt, toolGuards, timeoutMs, …
-  gateFeatureOverrides?: Record<string, unknown>; // §7 — replaces requireCodexApproval
-  postApproval?: PostApprovalRoute;
-}
-```
-
-Definitions are **declarations**; the kernel interprets them. Adding a domain (ecommerce,
-manufacturing, travel) means authoring a definition + registering connectors — **zero
-kernel changes**.
-
-## 5. Capability / connector contract
-
-The contract is sufficient for today's **read-only** external-state lookups. It is
-**not yet sufficient for mutating operations** the reference workflows need
-(`issueRefund`, `restockItem`, `book`).
+The contract serves today's **read-only** external-state lookups. It does **not** support
+mutating ops or imperative steps:
 
 ```ts
-type ConnectorOutcome =
-  | { ok: true; data: unknown }
+type ConnectorOutcome = { ok: true; data: unknown }
   | { ok: false; error: string; retryable?: boolean; retryAfterMs?: number };
-
 type ConnectorOp = (params: unknown, ctx: ConnectorContext) => Promise<ConnectorOutcome>;
-
-interface Connector {
-  readonly id: string;                       // 'github', 'shop', 'mes', 'travel', …
-  readonly ops: Record<string, ConnectorOp>; // 'getPr', 'createReturn', 'fileDefect', …
-  readonly auth?: ConnectorAuth;             // env-injected secrets
-}
+interface Connector { id: string; ops: Record<string, ConnectorOp>; auth?: ConnectorAuth; }
 ```
 
-**Gap (verified):** neither `ConnectorContext` nor `ConnectorOp` carries a stable command
-idempotency key or a way to reconcile an unknown outcome. A crash after the remote service
-succeeds but before the SQLite transition commits would let recovery issue a **duplicate**
-refund or booking.
+**Gaps (verified):** no command idempotency key; no reconcile-unknown; and no
+connector-action step type (connectors are validators/hooks only, `WorkflowNode.agents`
+must be non-empty).
 
-**Decision:** before any mutating connector ships, extend the contract with:
-- a **command idempotency key** on `ConnectorContext` (derived from the run/work-item +
-  step + attempt) so connectors can de-duplicate against the remote system, and
-- **reconciliation semantics** for unknown outcomes (a connector must be able to answer
-  "did this command already take effect?" so recovery can confirm rather than blindly retry).
-
-Read-only connectors are unchanged. This is gated behind a "mutating-connector readiness"
-phase; the reference workflows that mutate (ecommerce refund, travel booking) depend on it.
-
-- **Registry**: `registerConnector` / `getConnector` / `isRegisteredConnector` /
-  `getRegisteredConnectorIds`.
-- **Validator layer**: a gate `validator: { kind: 'built_in', id }` composes a connector op
-  + a predicate (`eq`/`empty`/`all`/`any`).
-- **Domain packs**: `github` (existing: `getPr`, `getPrReadiness`, `getReactions`,
-  `getReviewEvidence`; presets `pr_ready`, `pr_merged`, `review_posted`, `codex_review_bot`);
-  `shop`, `mes`, `travel` (new reference).
-
-The kernel calls connectors by id+op. Outcomes are typed `ConnectorOutcome` so retryability
-and rate-limit backoff (`retryAfterMs`) are first-class — but the consumer of `retryAfterMs`
-(`GateRetryScheduler`) must persist the deadline (§3.5/§6.3).
+**Decision (before mutating/imperative connectors ship):**
+- **Command idempotency key** on `ConnectorContext` derived from the **logical command
+  identity** (run + work-item + step + op + params-hash), **stable across every attempt,
+  retry, and reconciliation** — NOT derived from the attempt (a retry gets a new attempt but
+  MUST reuse the same key so the remote deduplicates).
+- **Reconcile-unknown** semantics: a connector must answer "did this command already take
+  effect?" so recovery confirms rather than blindly retries.
+- **Connector-action step primitive:** a new work-item/node kind that executes a connector
+  op as a durable step with persisted inputs, outcome, retry, and reconciliation — so
+  `shop.issueRefund` / `mes.fileDefect` / `travel.book` can run as definition steps, not as
+  repeatedly-evaluated validators. (Phases in §9.)
 
 ## 6. Durability, transaction, and recovery model
 
-### 6.1 SQLite command transaction boundary (target + verified gap)
+### 6.1 Transactional outbox (target + verified gap)
 
-**Target:** every state transition is a single SQLite transaction that atomically (1)
-validates the guard (CAS-style `WHERE current_status = ?`), (2) writes the new status +
-append-only attempt/transition row, (3) **enqueues every resulting delivery in the same
-transaction** (transactional outbox), (4) releases/acquires leases, and (5) persists any
-retry deadline.
+**Target:** every transition is one SQLite transaction that atomically (1) validates the
+guard (CAS `WHERE status=?` AND fencing token, §6.3), (2) writes status + append-only
+attempt/transition rows, (3) **enqueues every resulting delivery (live + inactive)**, (4)
+persists any retry deadline, (5) releases/acquires leases. This is the existing pattern for
+cycle-increment + gate-reset (`channel-router.ts:1752`) but **not** for delivery: today the
+gate write commits before `AgentMessageRouter.deliverMessage`, and live targets are
+delivered with no durable row. The outbox phase makes delivery transactional.
 
-This is the existing pattern for *one* transition (`db.transaction()` for atomic
-cycle-increment + gate-data-reset, `channel-router.ts:1752`). **Gap:** it is not the pattern
-for delivery. Today `send_message` commits the gate write (`gateDataRepo.merge`) and only
-then awaits `AgentMessageRouter.deliverMessage`; **live targets are delivered directly
-without a durable row** (only inactive targets hit `pending_agent_messages`). A daemon crash
-in that gap opens the gate but loses the handoff. The rule "never split a transition's write
-from its outbox enqueue" is therefore a **new** requirement with its own phase — the current
-delivery system is explicitly *not* "correct and untouched."
+### 6.2 Inbox/outbox + receiver-side dedup
 
-### 6.2 Inbox / outbox
+- Outbox persisted in the transition transaction; `AgentMessageRouter` drains rows for live
+  **and** inactive targets.
+- Inbox idempotency today is a unique partial index on pending rows — but that prevents
+  duplicate *rows*, not duplicate *dispatch*: if the dispatcher injects into a live session
+  and crashes before marking the row delivered, restart re-injects. **Receiver-side dedup**
+  (a delivery key the receiving session recognizes) or a durable ack is required before
+  claiming live delivery is idempotent.
 
-- **Outbox** (within the transition transaction): every resulting delivery persisted before
-  commit. `AgentMessageRouter` becomes the outbox dispatcher that drains rows for both live
-  and inactive targets.
-- **Inbox** (`pending_agent_messages` for node-agents; `space_agent_inbox_messages` for
-  long-horizon agents): durable queues drained on worker activation. Today only the
-  inactive-target path writes here; the outbox phase unifies live + inactive.
-- **Idempotency**: `idempotency_key` unique partial indexes on both inboxes. Activation is
-  idempotent (`activateNode` short-circuits on existing active executions).
+### 6.3 Leases/fencing + durable retry deadlines (verified gaps)
 
-### 6.3 Leases / fencing + durable retry deadlines
+No lease/fencing today; `GateRetryScheduler` is in-memory (`Map`+`setTimeout`,
+`gate-retry-scheduler.ts:10-11,34`) so a restart loses a rate-limit deadline and can strand
+a non-polled gate.
 
-Today there is **no lease or fencing token**, and connector/gate **retry deadlines are
-in-memory** (`GateRetryScheduler`, `gate-retry-scheduler.ts:10-11,34`). Both are durability
-gaps.
+- Claim = acquire `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the
+  same transaction as `in_progress`; refresh on real SDK progress (addresses stranded-
+  delivery class, #859–#862).
+- **Fencing on EVERY worker-owned write:** a monotonic token invalidates a stale owner only
+  if every transition, outbox enqueue, completion write, and connector-action outcome
+  compares the presented token against the current lease token (guarding only on
+  `current_status` is insufficient — after reclaim, stale and new owners both see
+  `in_progress`).
+- **Durable retry deadlines:** persist `retryAfterMs` to the timer/job model keyed by
+  `(run, gate)`, rehydrated/cancelled on restart (not flag-gated — a lost deadline strands
+  a gate).
 
-**Decision (designed now; flag-gated / required when distributed):**
+### 6.4 Append-only attempts + transition audit (verified gap)
 
-- A worker **claims** a work item by acquiring a lease row
-  `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the same transaction
-  that sets `in_progress`. A monotonic **fencing token** invalidates stale claims.
-- Leases are **refreshed on real progress** (SDK message stream tick) so slow-but-alive work
-  is not falsely retried — directly addressing the recurring stranded-delivery class
-  (tasks #859–#862).
-- **Durable retry deadlines**: connector/gate `retryAfterMs` is persisted to the timer/job
-  model (a `gate_retries` row or `job_queue` entry keyed by `(run_id, gate_id)`) and
-  rehydrated or cancelled on restart. This is required for the recovery guarantees in §6.5
-  and is **not** flag-gated (a lost deadline silently strands a gate).
-
-### 6.4 Append-only attempts and transition audit (verified gap)
-
-- **Attempts** (`node_execution_attempts`, new): one row per execution attempt of a work
-  item — `work_item_id`, `attempt_number`, `owner`, `started_at`, `ended_at`, `outcome`,
-  `failure_reason`. Retries append; nothing mutates history.
-- **Transition audit (gap):** `workflow_run_artifacts` are **upserts**
-  (`UNIQUE(run_id, node_id, artifact_type, artifact_key)`, `migrations.ts:6514`), not
-  append-only; hook-result artifacts cover only hook evaluations; attempts cover only
-  work-item attempts. None records every run/task status change, approval, cancellation,
-  gate reset, or routing transition. So the prior claim "every transition is reconstructable
-  from append-only tables" was wrong. **Decision:** add an append-only
-  **`workflow_transition_log`** (run/task status changes, approvals, cancellations, gate
-  resets, routing transitions, with actor + command metadata), or explicitly narrow the
-  audit guarantee to "work-item attempts + typed outputs" and adjust recovery accordingly.
-  The full audit table is recommended for a durable execution framework.
+- Attempts (`node_execution_attempts`): one row per attempt, append-only.
+- **Transition audit:** `workflow_run_artifacts` are upserts (`UNIQUE(...)`,
+  `migrations.ts:6514`), not append-only; hook-result artifacts cover only hooks; attempts
+  cover only work items. None records every run/task status change, approval, cancel,
+  gate-reset, or routing transition. Add an append-only `workflow_transition_log`
+  (+ actor + command metadata), or narrow the audit claim explicitly.
 
 ### 6.5 Recovery
 
-`SpaceRuntimeService.start()` chains recovery today (long-term inbox →
-`recoverStalledRuns`): skip if work is in flight, finalize if a completion signal is
-recorded, force `blocked` (`agentCrash`) if everything is terminal with no signal.
-**Caveat:** "finalize if a completion signal is recorded" must respect §3.1 — do not mark
-`done` (and thus stop timers/release leases/drop delivery) while approval or post-approval
-work is unresolved. Recovery is preserved and **generalized**: GitHub-specific recovery and
-the broader GitHub event path move behind a **connector-declared recovery hook** so the
-recovery pass invokes `connector.recoverRun(run)` (§7, Phase 5).
+`SpaceRuntimeService.start()` recovers (long-term inbox → `recoverStalledRuns`): skip if
+in-flight; finalize only when the task is truly terminal (archived) and post-approval
+finished — **not** on `reportedStatus`/run-`done` alone (those reopen). GitHub-specific
+recovery + the full GitHub event path move behind connector capabilities (Phase 5).
 
-### 6.6 Idempotency summary
+### 6.6 Idempotency summary (target mechanisms)
 
-| Operation | Idempotency mechanism |
+| Operation | Mechanism |
 |---|---|
 | Activate a node | short-circuit on existing active executions |
-| Deliver a message (target) | `idempotency_key` unique index on inbox |
-| Claim a work item | lease row CAS + fencing token |
-| Finalize run to terminal | canonical task-status guard (re-entry short-circuits on `task.status === 'done'`) |
-| Gate open cache | `gate_open_state` with staleness guard |
-| Post-approval dispatch | `postApprovalSessionId` + liveness probe (double-fire guard) |
-| **Mutating connector op** (target) | command idempotency key + reconcile-unknown (§5) |
-| **Connector/gate retry** (target) | persisted deadline rehydrated on restart (§6.3) |
+| Deliver a message | inbox unique key **+ receiver-side dedup / durable ack** |
+| Claim a work item | lease CAS + fencing token checked on **every** worker write |
+| Mutating connector op | command key (logical identity, stable across attempts) + reconcile-unknown |
+| Post-approval dispatch | **persist dispatch work-item before spawn**; reconcile on recovery |
+| Finalize run | task-status guard (re-entry short-circuits on `task.status==='done'`) |
+| Gate open cache | `gate_open_state` + staleness guard |
+| Connector/gate retry | persisted deadline, rehydrated on restart |
 
 ## 7. Compatibility map — current → target
 
-Extraction behind adapters; each row is a bounded change (phases in §9).
-
-| Current (domain-specific / gap) | Target (generic / closed) | Adapter strategy |
+| Current (domain-specific / gap) | Target | Strategy |
 |---|---|---|
-| `requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` on the generic node types — `WorkflowNode` (`space.ts:2287`), `WorkflowNodeInput` (`:2321`), **and `ExportedWorkflowNode` (`:2802`)** — plus the `effectiveNodes` projection in `updateWorkflow` (`space-workflow-manager.ts:314-316, 325-327`) | `node.gateFeatureOverrides['codex_review_bot']` on all three shapes | dual-read; all three type copies + the projection updated together or the export round-trip leaks codex; deprecated alias until migrated |
-| `gate-features.ts` codex paths (first ref `:36` through `maybeInjectCodexFeature` at `:619`; file is 631 lines) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via existing `registerGateFeature` plugin | move compiler into a `gate-features/codex.ts` plugin; validation → generic override-schema validation |
-| `pr_url` implicit **runtime handoff**: `ChannelRouterConfig.getPrUrlForRun` (`channel-router.ts:363`, `:1547`), `gate-script-executor` `PR_URL` env, `gate-evaluator` `gateData.pr_url` (`:563`), post-approval template context | generic per-run **`runtime_context`** map; `pr_url` is one populated key | dual-read `runtime_context['pr_url'] ?? legacy`; **PR data already lives in `workflow_run_artifacts`** — `space_tasks.pr_url/pr_number/pr_created_at` were dropped in M84 (`runMigration84`, `migrations.ts:6514`, table rebuild `space_tasks_m84_new`) and the `:2255`/`:2771` occurrences are the legacy room `tasks` table / the historical pre-M84 `space_tasks` CREATE respectively. Compat source = `gate_data` + hook-local state + `workflow_run_artifacts` |
-| Full GitHub external-event path in `space-runtime.ts`: PR-subscription restart recovery (`rehydrateActiveRunPrEventSubscriptions`), topic normalization, check-failure reopening, PR-URL extraction/matching, automatic subscriptions, retained-event replay | connector-declared `recoverRun` + connector-owned subscription/matching/reopen policy | move the whole path behind github-connector capabilities (Phase 5); legacy retained until proven |
-| Mutable definitions + `ON DELETE CASCADE` `workflow_id` + no `deleteWorkflow` guard | immutable + versioned + pinned + deletion-safe (§4) | shadow-write version history; tombstone/version-FK + active-run guard; remove the cascade |
-| Inline crash-retry-with-counting | append-only attempts + leases (§6.3–6.4) | preserve idle/reactivation lifecycle (§3.2); attempt table + lease behind flag |
-| Live-target delivery bypasses durable inbox; in-memory retry deadlines; upsert "audit" | transactional outbox + durable retry deadlines + append-only transition log (§6.1–6.4) | new durability phases |
-| Mutating connectors with no command idempotency | command key + reconcile-unknown (§5) | extend contract before mutating connectors ship |
-| Two **active** goal models: `goals`/`mission_executions` (Mission System: `goal-repository.ts`, `atomicStartExecution`, monotonic `execution_number`, driven by `goal-automation-execute.handler.ts`) **and** `space_goals`/`space_goal_events` | undecided — unification requires a dedicated audit | **deferred** (Phase 7 re-scoped); neither is assumed legacy |
+| `requireCodexApproval`/`codexPollIntervalMs`/`codexTimeoutSeconds` on 3 generic node types (`WorkflowNode` `space.ts:2287`, `WorkflowNodeInput` `:2321`, `ExportedWorkflowNode` `:2802`) + `effectiveNodes` projection (`space-workflow-manager.ts:314-316,325-327`) | `gateFeatureOverrides['codex_review_bot']` on all three + projection | dual-read; update all together; deprecated alias |
+| `gate-features.ts` codex paths (`:36`–`:619`) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via `registerGateFeature` plugin | move to `gate-features/codex.ts` plugin |
+| `pr_url` runtime handoff (`getPrUrlForRun` `channel-router.ts:363`, `PR_URL` env, `gate-evaluator.ts:563`, post-approval template) | per-run `runtime_context` map | dual-read; source = `gate_data`/hook-state/`workflow_run_artifacts` (`space_tasks` pr columns dropped in M84) |
+| Full GitHub external-event path in `space-runtime.ts` (restart recovery, topic normalization, check-failure reopen, PR-URL match, auto-subscriptions, retained-event replay) | connector `recoverRun` + subscription/matching/reopen capabilities | Phase 5 |
+| Mutable definitions + unpinned created runs + **orphaning deletion** (no FK; guardless `deleteWorkflow` + bypass paths) | immutable + versioned + **pinned at creation** + deletion-safe | Phase 1: history table; pin at creation; guard **all** delete paths; orphan/tombstone policy; version-level FK |
+| Inline crash-retry | append-only attempts + leases/fencing | Phase 4 (preserve idle/reactivation) |
+| Live-target delivery non-durable; in-memory retry deadlines; upsert "audit" | transactional outbox + durable retries + transition log | Phases 1b/1c/1d |
+| Mutating/imperative connectors unsupported | command-id + reconcile + connector-action step primitive | Phase 4b + 5b |
+| In-run pause/resume timer missing | durable in-run wait/resume primitive | Phase 5c |
+| `goals`/`mission_executions` **dormant/legacy** (schema `:405` labels legacy; `atomicStartExecution`/`insertExecution` have zero non-test callers; automation uses `SpaceGoalRepository`→`space_goals`) | one active goal model above the engine | Phase 7: unification audit; de-facto frozen already |
 
-**What is already correct and untouched:** topology model, agent slots + `toolGuards` +
-`eventInterests`, gate field/script/validator/poll model, channels + cycle caps,
-`pending_agent_messages`/`space_agent_inbox_messages` durable delivery **for inactive
-targets**, `gate_open_state`, `workflow_run_artifacts`, `task_schedules`/`job_queue`
-schedules, connector registry, the LLM workflow selector, and the channel-directed-
-send-as-activation semantics (§2).
+**Already correct/untouched:** topology, agent slots + `toolGuards` + `eventInterests`,
+gate field/script/validator/poll, channels + cycle caps, inactive-target durable delivery,
+`gate_open_state`, `workflow_run_artifacts`, `task_schedules`/`job_queue`, connector
+registry, LLM workflow selector, channel-send-as-activation + reopen semantics.
 
-## 8. Reference workflows (expressiveness proof)
+## 8. Reference workflows (expressiveness — honestly re-scoped)
 
-Four definitions prove the kernel + connectors express each domain without core changes.
-The first exists; the others are sketched to validate the model. Note: the ecommerce and
-travel sketches use **mutating** connectors and therefore depend on the §5 idempotency work.
+Today's kernel fully expresses **agent-driven, validator-gated, schedule-triggered**
+workflows. It does **not** yet express imperative connector-action steps or in-run
+pause/resume timers. So:
 
-### 8.1 PR review (exists today)
+- **PR review** — expressible today (`CODING_WORKFLOW`). Gates: `pr_ready`, `codex_review_bot`,
+  human approval. Post-approval: PR Merger slot. Validated by existence.
+- **Manufacturing defect / CAPA** — expressible today (agent triage/containment/CAPA nodes,
+  `writers: []` QA gates, recurring `task_schedule` trend monitor, `mes.*` as
+  validators/lookups). Connectors used read-only.
+- **Ecommerce return** — needs the **connector-action primitive** (`shop.issueRefund`,
+  `shop.restockItem` as durable mutating steps) + **mutating-connector idempotency**.
+  Expressible *after* Phases 4b + 5b.
+- **Personal travel** — needs the connector-action primitive **and** the **in-run
+  pause/resume timer** (pre-trip reminder that resumes the same run). Expressible *after*
+  Phases 4b + 5b + 5c.
 
-`CODING_WORKFLOW` / `FULLSTACK_QA_LOOP_WORKFLOW`. Nodes: Coder → Review → QA →
-Post-Approval. Gates: `pr_ready` (connector `github.getPrReadiness` + predicate),
-`codex_review_bot` (feature), human approval gate. Post-approval: PR Merger slot. Target =
-same definition with `pr_url` from `runtime_context` and codex from
-`gateFeatureOverrides`.
-
-### 8.2 Ecommerce return (new sketch; uses mutating connectors)
-
-```
-[intake] → [eligibility gate] → [inspect] → [decision gate]
-   ├─ refund  → [shop.issueRefund] → [notify] → end
-   └─ exchange→ [shop.restockItem] → [ship replacement] → end
-```
-High-value returns: human approval gate. Mutating ops (`issueRefund`, `restockItem`) require
-the §5 command-id + reconcile contract.
-
-### 8.3 Manufacturing defect / CAPA (new sketch)
-
-```
-[report] → [triage] → [containment] → [corrective-action gate] → [implement CAPA] → [verification gate] → [close]
-```
-Severity-driven routing; QA sign-off gates (`writers: []`); recurring trend monitor
-(`task_schedule`). Connectors: `mes.fileDefect`, `mes.getRouting`, `mes.recordNonconformance`.
-
-### 8.4 Personal travel assistant (new sketch; uses mutating connectors)
-
-```
-[capture intent] → [search flights + hotels] → [assemble itinerary] → [confirmation gate] → [travel.book] → [reminders (timer)] → [monitor]
-```
-`travel.book` requires §5 idempotency.
-
-**Conclusion:** all four are expressible as definitions + connectors. No topology/gate/timer
-concept must be added. The only contract addition is mutating-connector idempotency (§5).
+**Conclusion (revised):** the definition+connector model is the right abstraction and needs
+no redesign, but "fully expressive with zero kernel changes" was overstated. Two primitives
+(connector-action steps, in-run timers) plus the durability cluster are required to cover
+all four reference domains. Those primitives are phased (§9), not speculative — they are
+forced by the reference workflows.
 
 ## 9. Phased roadmap
 
-One compatibility-preserving PR per phase. Each: shadow/flag first, dual-read only when
-necessary, migration + restart/concurrency tests, explicit rollback. **No phase removes
-legacy behavior before parity evidence exists.** New durability phases (1b–1e) close the
-verified gaps before the extraction phases that depend on them.
+One compatibility-preserving PR per phase; shadow/flag first; migration + restart/concurrency
+tests; explicit rollback. Durability + primitive phases precede the extractions/validations
+that depend on them.
 
 | Phase | Deliverable | Mode | Rollback |
 |---|---|---|---|
-| **0** (this RFC) | RFC + ADR, approval | docs only | n/a |
-| 1 | Immutable versioned definitions: in-row `definition_version` hash pinned on runs + `space_workflow_definition_versions` history **+ deletion-safety** (tombstone/version-FK, active-run guard in `deleteWorkflow`, remove `workflow_id` cascade) | shadow-write history; runs read pinned version; legacy live-read unaffected | drop pin column; restore cascade |
-| **1b** | Transactional outbox: persist every resulting delivery (live + inactive) in the transition transaction; `AgentMessageRouter` drains rows | write both paths; cutover when proven | fall back to direct live delivery |
-| **1c** | Durable retry deadlines: persist connector/gate `retryAfterMs` to timer/job model; rehydrate/cancel by `(run, gate)` | new table/job type | in-memory scheduler still works while populated |
-| **1d** | Append-only `workflow_transition_log` (status/approval/cancel/gate-reset/routing, + actor + command) | append-only; readers opt-in | stop writing; no behavior change |
-| 2 | Generic `runtime_context` map; extract `pr_url` runtime handoff behind it | dual-read `runtime_context['pr_url'] ?? legacy`; source = `gate_data`/hook-state/`workflow_run_artifacts` (columns already gone post-M84) | flip dual-read back |
-| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` to a plugin (all three node type copies + `effectiveNodes`) | keep `requireCodexApproval` as deprecated alias | alias still honored |
-| 4 | Append-only attempts + leases/fencing (flag-gated); **preserve idle/reactivation lifecycle** (§3.2) | flag off = single-process no-op | toggle flag |
-| **4b** | Mutating-connector readiness: command idempotency key + reconcile-unknown on `ConnectorContext`/`ConnectorOp` | read-only connectors unaffected | gate behind connector capability flag |
-| 5 | Full GitHub external-event path behind connector capabilities (`recoverRun` + subscription/matching/reopen) | github-connector owns the path; legacy retained until proven | fall back to legacy paths |
-| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests | read-only reference; no production seeding | remove fixture |
-| 7 | **Goal-system unification audit** (not "retire legacy"): determine the relationship between `goals`/`mission_executions` and `space_goals`; decide migration/freeze **from evidence** | investigation + design only first | n/a |
+| **0** (this RFC) | RFC + ADR, approval | docs | n/a |
+| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK) | shadow history; pin at creation; live reads unaffected | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
+| 1b | Transactional outbox (persist every delivery, live + inactive, in the transition tx) + receiver-side dedup | write both; cutover when proven | fall back to direct live delivery |
+| 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | in-memory scheduler still works while populated |
+| 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
+| 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
+| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection) | deprecated alias | alias honored |
+| 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | toggle flag |
+| 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
+| 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
+| 5b | **Connector-action step primitive** (durable connector-op steps w/ persisted inputs/outcome/retry/reconcile) | new node/work-item kind behind flag | flag off |
+| 5c | **In-run pause/resume timer** primitive + recovery | new timer type | flag off |
+| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests | read-only; no seeding | remove fixture |
+| 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
 
-## 10. Deferred features (do not build speculatively)
+## 10. Deferred features
 
-- Subprocesses / nested workflow calls; complex event correlation (CEPII); distributed /
-  horizontally-scaled execution (leases are the seam); compensation/saga rollback (use
-  explicit corrective nodes); org/role modeling beyond slots + `writers`; visual designer /
-  BPMN import; process mining; BPEL orchestration-vs-choreography refactor.
-- **Goal-system unification** (Phase 7) — requires a dedicated audit; do not assume either
-  model is legacy.
+Subprocesses/nested calls; complex event correlation; distributed execution (leases are the
+seam); compensation/saga (use corrective nodes); org/role modeling; visual designer/BPMN
+import; process mining; formal `completing` run-status (today's `approved` covers the merger
+window — add only if a gap is observed).
 
-## 11. Migration safety invariants (must hold throughout)
+## 11. Migration safety invariants
 
-1. **No silent reinterpretation of active runs** — a run executes its pinned definition
-   version; edits/deletions never mutate or erase in-flight runs (Phase 1 + deletion-safety).
-2. **No legacy removal before parity** — every extraction keeps the old path until a
-   migration test + production evidence show equivalence.
-3. **One invariant/capability per PR** — each phase independently reviewable and revertible.
-4. **Migration + restart/concurrency tests** accompany every runtime change — recovery,
-   idempotency, lease correctness, outbox atomicity, and durable-retry rehydration tested
-   under crash + duplicate-wake + concurrent-claim + restart.
-5. **Domain concepts never re-enter the generic type or core paths.** Acceptance criterion:
-   `grep` for `pr_url`, `codex`, `requireCodexApproval` in `packages/shared/src/types/space.ts`
-   (incl. `ExportedWorkflowNode`) and `packages/daemon/src/lib/space/runtime/*`, plus the
-   `effectiveNodes` projection in `managers/space-workflow-manager.ts` and the GitHub
-   external-event symbols in `space-runtime.ts`, returns nothing outside adapters/plugins
-   (measured over phases).
-6. **A run is not terminal until its task and post-approval route are** (§3.1) — durability
-   consumers (leases, timers, delivery) must key off true terminal state, not
-   `reportedStatus`/`CompletionDetector` alone.
+1. A run executes its pinned definition version (pinned at **creation**); edits/deletions
+   never mutate or orphan in-flight runs (Phase 1).
+2. No legacy removal before parity.
+3. One invariant/capability per PR; each independently revertible.
+4. Migration + restart/concurrency tests for every runtime change.
+5. **Domain concepts never re-enter generic type/core paths** — acceptance `grep` (incl.
+   `ExportedWorkflowNode`, `effectiveNodes`, the GitHub event-path symbols in
+   `space-runtime.ts`) returns nothing outside adapters/plugins.
+6. **Terminal = task-archive, not run `done`/`cancelled`** (which reopen); durability
+   consumers key off true terminal state.
+7. **Idempotency keys are stable across attempts**; fencing tokens guard every worker write.
 
-## 12. Design-review decisions (resolved / revised)
+## 12. Design-review decisions (resolved / revised across 3 rounds)
 
-From the review of PR #2396. All re-verified against code.
+1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
+   history table. **Deletion-safety** added (no `workflow_id` FK exists — orphan, not erase;
+   guard all delete paths + orphan policy + version-FK).
+2. **Lease scope** → flag-gated no-op for single-process.
+3. **Goal V2** → `goals`/`mission_executions` is **dormant/legacy** (verified: schema labels
+   it legacy; `atomicStartExecution`/`insertExecution` have zero non-test callers; the live
+   automation handler uses `SpaceGoalRepository`→`space_goals`). De-facto frozen already;
+   Phase 7 is an evidence-driven unification audit. *(v2 wrongly called it "active" —
+   corrected; the original "freeze" was right in substance.)*
+4. **Reference workflows** → in-tree `reference/` fixtures, not seeded.
+5. **Expressiveness (new)** → "zero kernel changes" re-scoped: connector-action steps
+   (Phase 5b) and in-run timers (Phase 5c) are required new primitives for ecommerce/travel.
 
-1. **Definition versioning** → in-row content hash pinned on run + append-only
-   `space_workflow_definition_versions` history table. (Phases 1.) **Plus deletion-safety**
-   (tombstone/version-FK + active-run guard) — added after verification showed the
-   `ON DELETE CASCADE` + guardless `deleteWorkflow` gap.
-2. **Lease scope** → flag-gated no-op for single-process; enforced only when a second worker
-   exists. (Phase 4.)
-3. **Goal V2 unification** → ~~freeze legacy read-only~~ **REVERSED.** Verification shows
-   `goals`/`mission_executions` is an **active** Mission System (`goal-repository.ts`,
-   `atomicStartExecution` with monotonic `execution_number`, driven by
-   `goal-automation-execute.handler.ts`), not legacy. Freezing it would halt active
-   behavior. Re-scoped to a unification **audit** in Phase 7; no freeze or retirement
-   without evidence. (The original "freeze" decision rested on an unverified premise —
-   flagged to the reviewer.)
-4. **Reference workflows** → in-tree under a marked `reference/`/fixtures path, not seeded.
-   (Phase 6.)
-
-Phase 0 produces no code; upon approval, Phase 1 (+ durability cluster 1b–1d) begins behind
-adapters.
+Phase 0 produces no code; upon approval, Phase 1 (+ durability cluster 1b–1d) begins.

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,9 +1,9 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed (Phase 0 — architecture only; no runtime changes)
-Date: 2026-08-07
-Tracks: Goal task #874 — "Evolve HyperNeo into a generic data-defined workflow engine"
-Companion: `docs/adr/0003-data-defined-workflow-engine.md`
+Status: Proposed — Revision 2 (Phase 0, architecture only; no runtime changes).
+Incorporates design-review feedback (PR #2396): human-reviewer doc-accuracy fixes
+and the codex-connector inline review, all claims re-verified against the code.
+Date: 2026-08-07. Tracks goal task #874. Companion: `docs/adr/0003-data-defined-workflow-engine.md`.
 
 ## 1. Goal and non-goals
 
@@ -35,27 +35,29 @@ The foundational rule, in one line:
 - A visual designer or external format import.
 - Distributed multi-process execution now. We design the seams (leases, fencing) but keep
   a single-process daemon until a measured bottleneck forces scaling.
-- Retiring the legacy `room/` Mission System. It is mapped to a compatibility adapter and
-  scheduled for retirement only after parity and migration evidence exist.
+- Deciding the fate of the two overlapping goal models. `goals`/`mission_executions` is an
+  **active** Mission System (§7), not legacy; unifying it with `space_goals` is a separate
+  investigation deferred past this RFC (Phase 7 re-scoped).
 
 ### Why this is tractable now
 
-The current engine is already **~85% data-defined**. A code survey confirms:
+The current engine is already largely data-defined. A code survey confirms:
 
-- There is **no `switch(workflowType)` or `switch(nodeType)` dispatch** anywhere in the
-  core runtime. Topology (nodes/channels/gates/hooks/post-approval), gate evaluation, cycle
-  caps, completion detection, and post-approval routing are all driven by data.
+- There is **no `switch(workflowType)` or `switch(nodeType)` dispatch** in the core runtime.
+  Topology (nodes/channels/gates/hooks/post-approval), gate evaluation, cycle caps,
+  completion detection, and post-approval routing are all data-driven.
 - A clean **connector abstraction already exists** (`packages/daemon/src/lib/space/runtime/connectors/`)
   with a generic registry (`Connector` / `ConnectorOp` / `ConnectorOutcome` /
-  `ConnectorAuth`), a predicate DSL (`predicate.ts`), and validator presets. The engine
-  already admits any registered connector id — `'github'` is no longer special in the type.
+  `ConnectorAuth`), a predicate DSL (`predicate.ts`), and validator presets.
 - The connector layer is being rolled out **behind a feature flag**
   (`isConnectorsLayerEnabled()`, gated in `hook-executor.ts`).
 
-So this is **not a rewrite**. It is a bounded extraction: purge the remaining
-domain-specific concepts (GitHub/PR/Codex) from the generic type and core paths, harden
-the durability seams that single-process execution let us defer, and formalize the
-versioning and recovery model. The concrete leakage sites are enumerated in §6.
+So this is **not a rewrite**. It is a bounded extraction **plus** closing durability seams
+that single-process execution let us defer. The remaining work is larger than "extract
+GitHub" alone: several durability guarantees the goal demands (transactional outbox,
+durable retry deadlines, append-only transition audit, deletion-safe versioning, mutating-
+connector idempotency) are **not yet met** by the current code. Those gaps are enumerated
+in §6 and drive new phases in §9.
 
 ## 2. Canonical concepts
 
@@ -65,77 +67,99 @@ where the current model conflates or omits something.
 
 | Canonical term | Current implementation | Notes |
 |---|---|---|
-| **Definition** | `SpaceWorkflow` (`packages/shared/src/types/space.ts:2419`) | Becomes **immutable + versioned** (§4). |
-| **Run** | `space_workflow_runs` row (`migrations.ts:2713`) | One execution of a definition. Pins `definition_version`. |
-| **Work item** | `node_executions` row (`migrations.ts:5912`) | A unit of work assigned to a worker. Statuses: `pending\|in_progress\|idle\|waiting_rebind\|blocked\|cancelled\|done`. |
-| **Attempt** | (implicit: crash-retry-with-counting in tick loop) | **New, append-only**: an execution attempt of a work item. Makes retries auditable (§5). |
-| **Token / activation** | `ChannelRouter.activateNode` creating `node_executions` | Lazy, event-driven. A message or gate-open *activates* a downstream node. |
+| **Definition** | `SpaceWorkflow` (`packages/shared/src/types/space.ts:2419`) | Becomes **immutable + versioned + deletion-safe** (§4). |
+| **Run** | `space_workflow_runs` row (`migrations.ts:2713`) | One execution of a definition. *(target: pins `definition_version`; today re-reads the live workflow row each tick — §4)* |
+| **Work item** | `node_executions` row (`migrations.ts:5912`) | Statuses: `pending\|in_progress\|idle\|waiting_rebind\|blocked\|cancelled`. **Terminal = `idle` \| `cancelled`** (there is no `done`; a successful turn becomes a reactivatable `idle` row). |
+| **Attempt** | (implicit: crash-retry-with-counting in tick loop) | **New, append-only**: an execution attempt of a work item. |
+| **Token / activation** | `ChannelRouter.activateNode` creating `node_executions` | A channel-directed `send_message` or a gate-open *activates* a downstream node (see "advances state" below). |
 | **Gate** | `Gate` + `gate_data` + `gate_open_state` | Declaration in definition; runtime state in `gate_data`; open-cache in `gate_open_state`. |
 | **Channel** | `WorkflowChannel` (`space.ts:2215`) | Directed message pipe `from → to`, optional `gateId`, `maxCycles`. |
 | **Approval** | Gate with `requiredLevel` / external `writers: []` field + `completionAutonomyLevel` | Human or autonomy-gated sign-off. |
-| **Delivery** | `pending_agent_messages` (inbox) + `AgentMessageRouter` (outbox) | Durable, idempotent (§5). |
-| **Timer** | `task_schedules` (cron/at) + `GatePoll` (interval) + hook retry timers | Three existing timer mechanisms, unified conceptually. |
-| **Connector / capability** | `connectors/` registry + validator presets | Domain actions behind an id. |
+| **Delivery** | `pending_agent_messages` (inbox) + `AgentMessageRouter` (outbox) | Durable **only for inactive targets** today; live targets bypass the inbox (§6.1–6.2 gap). |
+| **Timer** | `task_schedules` (cron/at) + `GatePoll` (interval) + hook retry timers | Connector/gate **retry deadlines are in-memory only** today (§6.3 gap). |
+| **Connector / capability** | `connectors/` registry + validator presets | Domain actions behind an id. Read-only ops are safe today; **mutating ops need command idempotency** (§5 gap). |
 | **Task** | `space_tasks` | User-facing unit; 1:1 with a run via `workflow_run_id`. Sole completion source of truth. |
-| **Goal** | `space_goals` (Goal V2) + legacy `goals` | The **what/when layer**: objectives, recurring triggers, progress. Layered above the engine. |
-| **Worker** | A Space agent session (`space_chat` / `space_task_agent` / LH agent) | Agents/humans/services are all workers. Sessions are execution *resources*, not workflow identity. |
+| **Goal** | `space_goals` **and** `goals`/`mission_executions` (both active) | Two overlapping models; unification deferred (§7, Phase 7). |
+| **Worker** | A Space agent session | Agents/humans/services are workers; sessions are execution *resources*, not identity. |
 
 **Mental model.** A *Goal* says *what* to achieve and *when* (trigger layer). It creates a
 *Task* and a *Run* of a *Definition*. The kernel drives the run by *activating work items*
-along *channels*, respecting *gates*. Workers (agents/humans/services) pick up work items,
-emit *outcomes* (messages, gate writes, artifact writes, commands), and the kernel
-transitions the run deterministically. *Connectors* provide domain actions workers or
-gates call. Delivery is durable and idempotent so workers can crash, retry, and recover
-without losing or duplicating work.
+along *channels*, respecting *gates*. Workers pick up work items, emit *outcomes*, and the
+kernel transitions the run deterministically. *Connectors* provide domain actions. Delivery
+is durable and idempotent so workers can crash, retry, and recover without losing or
+duplicating work.
 
 ### What advances process state
 
-> **Messages communicate; explicit outcomes/signals/commands advance process state.**
+> **Channel-directed sends and explicit outcomes/commands advance process state;
+> untargeted free text only communicates.**
 
-A message alone never transitions a run. State advances only through *structured* acts that
-the kernel interprets: a gate write that opens a gate (→ activates downstream work items),
-a terminal work-item outcome (`done`/`cancelled`), an explicit command
-(`submit_for_approval`, `approve_task`, `mark_complete`), or a timer firing. Free-text
-messaging between workers does not move the process graph. This is already the case today
-and is preserved as an invariant.
+A `send_message` **on a declared channel** is itself a structured activation command — it
+carries `from → to` topology and is gated, and the kernel's `ChannelRouter.deliverMessage`
+lazily activates the target node, advances cyclic-channel state, and can reopen a run.
+Existing workflows rely on this for handoffs. Therefore the invariant is **not** "a message
+never moves the graph"; it is: only *channel-directed* sends and *structured outcomes*
+(gate writes that open a gate; terminal work-item outcomes; commands like
+`submit_for_approval`/`approve_task`/`mark_complete`; timer fires) advance state. Untargeted
+broadcasts (`*`) and free text do not. This matches current behavior — we preserve it
+rather than migrate to a separate activation command.
 
 ## 3. Lifecycle / state-transition tables
 
-These are the **executable** transition tables the kernel enforces. They are encoded as
-data (the current `VALID_NODE_EXECUTION_TRANSITIONS` pattern is the model). Where the
-existing transition set already matches, the table is a formalization, not a change.
+These are the executable transition tables the kernel enforces, encoded as data (the
+`VALID_NODE_EXECUTION_TRANSITIONS` pattern at `node-execution-manager.ts:39` is the model).
+Where the existing set already matches, the table is a formalization; differences are
+called out.
 
 ### 3.1 Run lifecycle
+
+A run is **terminal** (`done`/`cancelled`) only when the canonical task is terminal **and**
+any post-approval route has finished. `reportedStatus` being set is a **completion request**,
+not a terminal state — the run must not be treated as terminal (for leases, timers,
+activation, or delivery) while approval or post-approval work is still in flight.
 
 | from | event | to | guard | side effect |
 |---|---|---|---|---|
 | `pending` | start node activated | `in_progress` | definition resolvable at pinned version | stamp `definition_version` |
-| `in_progress` | completion signal recorded | `done` | `CompletionDetector.isComplete` (task `done`/`cancelled` or `reportedStatus != null`) | fire idempotent completion actions (`completion_actions_fired_at`) |
+| `in_progress` | `reportedStatus` set / `CompletionDetector.isComplete` | **`completing`** (nonterminal) | task not yet terminal | resolve through approval gate (§3.6); do **not** release leases / stop timers yet |
+| `completing` | task → `done`/`cancelled` AND post-approval resolved | `done`/`cancelled` | terminal | release leases, stop timers, cancel pending delivery |
 | `in_progress` | all work items terminal, no completion signal, restart | `blocked` | recovery pass | `failure_reason = 'agentCrash'` |
 | `in_progress` | human reject | `blocked` | `failure_reason = 'humanRejected'` | — |
 | `in_progress` | max iterations / node timeout | `blocked` | `failure_reason ∈ {maxIterationsReached, nodeTimeout}` | — |
 | `in_progress`/`blocked` | human cancel | `cancelled` | — | cascade-cancel work items, release leases |
 | `blocked` | manual restart / recovery claim | `in_progress` | work item re-activated | — |
 
-`done`, `cancelled` are **terminal**. `blocked` is recoverable. Legacy `completed`/
-`needs_attention` strings are compatibility aliases for `done`/`blocked`.
+`done`, `cancelled` are terminal. `blocked` is recoverable. `completing` is a nonterminal
+held state (the run is still live for approval/merger). Today the engine reaches `done`
+through the tick's `resolveTaskApproval` after `CompletionDetector` fires; we make the
+nonterminal window explicit so durability consumers do not short-circuit early. Re-entrant
+finalization short-circuits on `task.status === 'done'` (no separate stamp —
+`completion_actions_fired_at` was dropped in M104).
 
 ### 3.2 Work item lifecycle
 
+Matches `NodeExecutionStatus` (`space.ts:1111`): `pending | in_progress | idle |
+waiting_rebind | blocked | cancelled`. **Terminal = `idle | cancelled`**
+(`TERMINAL_NODE_EXECUTION_STATUSES`, `node-execution-manager.ts:67`). There is **no `done`**;
+a successful turn parks as a reactivatable `idle` row.
+
 | from | event | to | guard | side effect |
 |---|---|---|---|---|
-| `pending` | worker claims | `in_progress` | lease acquired (§5), idempotent activation short-circuit | append attempt #1 |
-| `in_progress` | worker emits terminal outcome | `done` | completion checks pass | release lease |
-| `in_progress` | worker needs peer input | `idle` / `waiting_rebind` | — | lease continues or parks |
+| `pending` | worker claims | `in_progress` | lease acquired (§6.3), idempotent activation short-circuit | append attempt #1 |
+| `in_progress` | worker emits terminal outcome | `idle` | — | release lease (reactivatable) |
+| `in_progress` | worker needs peer input | `waiting_rebind` | — | lease continues or parks |
 | `in_progress` | gate blocks downstream | (self unchanged) | — | downstream not activated |
-| `in_progress` | worker crash / lease expiry | `pending` (retry) | attempt budget remaining, not terminal | append attempt #N, backoff |
+| `waiting_rebind` | input arrives / wake | `pending` | budget remaining, not terminal | append attempt #N, backoff |
+| `in_progress`/`idle` | worker crash / lease expiry | `pending` (retry) | budget remaining | append attempt #N |
 | `in_progress`/`idle` | timeout | `pending` (retry) | budget remaining | append attempt #N |
-| `pending`/`in_progress` | run cancelled | `cancelled` | — | release lease |
-| `pending` (retry exhausted) | max attempts reached | `blocked` | — | run → `blocked` (`agentCrash`) |
+| `idle` | run cancelled | `cancelled` | — | release lease |
+| retry exhausted | max attempts reached | `blocked` | — | run → `blocked` (`agentCrash`) |
 
-`done`, `cancelled` are terminal. Today, retries are inline (crash-retry-with-counting);
-this RFC formalizes them as an **append-only attempt log** (§5) without changing the
-observable behavior.
+**Phase 4 caveat (verified):** because the real lifecycle is idle/reactivation-based (not
+`done`-then-retry-from-`in_progress`), Phase 4 cannot "merely append attempt records without
+changing observable behavior." It must preserve the idle/reactivation semantics and either
+model attempts against the existing statuses or include a tested status reconciliation.
+This is acknowledged in the Phase 4 scope.
 
 ### 3.3 Gate lifecycle
 
@@ -152,24 +176,35 @@ observable behavior.
 Gate open-cache (`gate_open_state`) is persisted across restart with a staleness guard
 (`opened_workflow_updated_at`) — preserved as-is.
 
-### 3.4 Delivery (inbox/outbox) lifecycle
+### 3.4 Delivery (inbox/outbox) lifecycle — target
 
 | from | event | to | notes |
 |---|---|---|---|
 | `pending` | target worker activates | `delivered` | `flushPendingMessagesForTarget`, idempotent by `idempotency_key` |
-| `pending` | TTL (60s) elapsed, attempts < max (3) | `pending` (retry) | backoff |
+| `pending` | TTL elapsed, attempts < max | `pending` (retry) | backoff |
 | `pending` | max attempts reached | `failed` | actionable terminal failure surfaced |
 | `pending` | run/work item terminal | `failed` | do not deliver to dead workers |
 
-### 3.5 Timer lifecycle
+**Gap (§6.1–6.2):** today only *inactive* targets get a durable inbox row; **live targets
+are delivered directly with no durable row**, so a crash between the state transition and
+live delivery loses the handoff. The target state above is the goal; reaching it is the
+transactional-outbox phase.
+
+### 3.5 Timer lifecycle — target
 
 | type | trigger | effect |
 |---|---|---|
-| schedule (`task_schedules`) | cron / `run_at` reaches `next_run_at` | enqueue fire job → creates a new run/task instance |
-| gate poll (`GatePoll`) | `intervalMs` tick while run `in_progress` | run gate script; if stdout changed, inject message into target node |
+| schedule (`task_schedules`) | cron / `run_at` reaches `next_run_at` | enqueue fire job → new run/task instance |
+| gate poll (`GatePoll`) | `intervalMs` tick while run `in_progress` | run gate script; if stdout changed, inject message |
 | hook retry (`WorkflowHookRetrySettings`) | `next_retry_at` | re-run hook with backoff |
+| **connector/gate retry** (`GateRetryScheduler`) | `retryAfterMs` | re-evaluate gate after backoff |
 
-All timers stop on run terminal state.
+**Gap (§6.3):** `GateRetryScheduler` stores `retryAfterMs` in an in-memory `Map` +
+`setTimeout` (`gate-retry-scheduler.ts:10-11,34`). A daemon restart loses the deadline, so a
+rate-limited non-polled gate can stay closed indefinitely. Persisting these deadlines is a
+durability phase.
+
+All timers stop on run terminal state (but not before — see §3.1 `completing`).
 
 ### 3.6 Approval lifecycle
 
@@ -180,27 +215,33 @@ All timers stop on run terminal state.
 | task `review` | human `reject` | `in_progress` (feedback to worker) | — |
 | `approved` | post-approval route done | `done` | `mark_complete` |
 
-## 4. Workflow-definition schema (immutable, versioned)
+## 4. Workflow-definition schema (immutable, versioned, deletion-safe)
 
-**Problem today.** Definitions are mutable (`SpaceWorkflowManager.updateWorkflow`) and
-only soft-version-tracked via `templateHash` + `updatedAt`. Node IDs are stable
-(`validateStableNodeIds`) so a definition edit can silently change the behavior of an
-*in-flight* run. This violates the "data-defined behavior" rule for durability: a run
-must execute against the exact definition it started under.
+**Problem today.** Definitions are mutable (`SpaceWorkflowManager.updateWorkflow`) and only
+soft-version-tracked via `templateHash` + `updatedAt`. Node IDs are stable
+(`validateStableNodeIds`) but a definition edit can silently change the behavior of an
+*in-flight* run, because runs re-read the live workflow row each tick. Separately,
+`space_workflow_runs.workflow_id` is `ON DELETE CASCADE` and `deleteWorkflow`
+(`space-workflow-manager.ts:445`) has **no active-run guard**, so deleting a definition
+erases the supposedly-pinned in-flight run and its execution history.
 
-**Decision.**
+**Decision (design review + verification).**
 
-1. Introduce a **definition version** as a content hash of the canonicalized definition
-   (extend `workflows/template-hash.ts`). Store `definition_version` on the **definition
-   row** and **pin it on the run** at start (`space_workflow_runs.definition_version`).
-2. Editing a definition produces a **new version row** (or, pragmatically, a new
-   `definition_version` stamped on the same row with the prior version retained in an
-   append-only `space_workflow_definition_versions` audit table). Existing runs keep
-   reading their pinned version; new runs get the latest.
-3. Built-in template re-stamping (`seedBuiltInWorkflows` hash-drift merge) becomes
+1. Version = an **in-row content hash** (`definition_version`) stamped on the definition
+   row **and pinned on the run** at start, with prior versions retained in an append-only
+   **`space_workflow_definition_versions`** history table. In-row (not a separate
+   current-version table) avoids indirection on the ~15 hot-path `getWorkflow` reads per
+   tick. Existing runs read their pinned version; new runs get the latest.
+2. Built-in template re-stamping (`seedBuiltInWorkflows` hash-drift merge) becomes
    version-bumping rather than in-place mutation of live behavior.
-4. The shape of `SpaceWorkflow` is otherwise unchanged — this is a versioning wrapper, not
-   a schema redesign. Existing readers keep working; they simply resolve through the
+3. **Deletion safety (verified gap):** Phase 1 must also make definition deletion safe for
+   pinned runs — either **tombstoned (soft-deleted) definitions** or **version-level foreign
+   keys** that retain every version referenced by a run, **plus an active-run guard** in
+   `deleteWorkflow` (refuse or cascade-cancel cleanly). The current `ON DELETE CASCADE` on
+   `workflow_id` must be removed or redirected to the version. Includes an explicit deletion
+   migration + test.
+4. The shape of `SpaceWorkflow` is otherwise unchanged — versioning + deletion-safety are
+   wrappers, not a schema redesign. Existing readers keep working; they resolve through the
    pinned version.
 
 **Reference definition schema** (TypeScript-ish, abbreviated — matches current
@@ -221,7 +262,7 @@ interface WorkflowDefinition {
 
   completionAutonomyLevel: AutonomyLevel;   // self-close vs human review
   postApproval?: PostApprovalRoute;          // node-level routes
-  runtimeContextContract?: RuntimeContextKey[]; // §6.2 — replaces implicit pr_url
+  runtimeContextContract?: RuntimeContextKey[]; // §7 — replaces implicit pr_url
 
   tags?: string[];                  // workflow-selector hints (default, v2, …)
 }
@@ -229,7 +270,7 @@ interface WorkflowDefinition {
 interface Node {
   id: string; name: string;
   agents: NodeAgent[];              // slots: agentId, model, prompt, toolGuards, timeoutMs, …
-  gateFeatureOverrides?: Record<string, unknown>; // §6.1 — replaces requireCodexApproval
+  gateFeatureOverrides?: Record<string, unknown>; // §7 — replaces requireCodexApproval
   postApproval?: PostApprovalRoute;
 }
 ```
@@ -240,7 +281,9 @@ kernel changes**.
 
 ## 5. Capability / connector contract
 
-The contract already exists and is correct. We formalize it; no redesign.
+The contract is sufficient for today's **read-only** external-state lookups. It is
+**not yet sufficient for mutating operations** the reference workflows need
+(`issueRefund`, `restockItem`, `book`).
 
 ```ts
 type ConnectorOutcome =
@@ -256,243 +299,256 @@ interface Connector {
 }
 ```
 
-- **Registry**: `registerConnector` / `getConnector` / `isRegisteredConnector` /
-  `getRegisteredConnectorIds`. Side-effect modules (`connectors/production.ts`) register
-  at startup.
-- **Validator layer**: a gate `validator: { kind: 'built_in', id }` composes a connector op
-  + a predicate (`eq`/`empty`/`all`/`any`). The validator does not know what a PR is —
-  domain knowledge lives in `connectors/presets.ts`.
-- **Domain packs** ship as connector + preset modules:
-  - `github` (existing): `getPr`, `getPrReadiness`, `getReactions`, `getReviewEvidence`;
-    presets `pr_ready`, `pr_merged`, `review_posted`, `codex_review_bot`.
-  - `shop` (new, reference): `createReturn`, `getOrder`, `issueRefund`, `restockItem`.
-  - `mes` (new, reference): `fileDefect`, `getRouting`, `recordNonconformance`.
-  - `travel` (new, reference): `searchFlights`, `searchHotels`, `book`, `getItinerary`.
+**Gap (verified):** neither `ConnectorContext` nor `ConnectorOp` carries a stable command
+idempotency key or a way to reconcile an unknown outcome. A crash after the remote service
+succeeds but before the SQLite transition commits would let recovery issue a **duplicate**
+refund or booking.
 
-The kernel calls connectors by id+op. Outcomes are typed `ConnectorOutcome` so
-retryability and rate-limit backoff (`retryAfterMs`) are first-class — the existing
-`GateRetryScheduler` path already consumes these.
+**Decision:** before any mutating connector ships, extend the contract with:
+- a **command idempotency key** on `ConnectorContext` (derived from the run/work-item +
+  step + attempt) so connectors can de-duplicate against the remote system, and
+- **reconciliation semantics** for unknown outcomes (a connector must be able to answer
+  "did this command already take effect?" so recovery can confirm rather than blindly retry).
+
+Read-only connectors are unchanged. This is gated behind a "mutating-connector readiness"
+phase; the reference workflows that mutate (ecommerce refund, travel booking) depend on it.
+
+- **Registry**: `registerConnector` / `getConnector` / `isRegisteredConnector` /
+  `getRegisteredConnectorIds`.
+- **Validator layer**: a gate `validator: { kind: 'built_in', id }` composes a connector op
+  + a predicate (`eq`/`empty`/`all`/`any`).
+- **Domain packs**: `github` (existing: `getPr`, `getPrReadiness`, `getReactions`,
+  `getReviewEvidence`; presets `pr_ready`, `pr_merged`, `review_posted`, `codex_review_bot`);
+  `shop`, `mes`, `travel` (new reference).
+
+The kernel calls connectors by id+op. Outcomes are typed `ConnectorOutcome` so retryability
+and rate-limit backoff (`retryAfterMs`) are first-class — but the consumer of `retryAfterMs`
+(`GateRetryScheduler`) must persist the deadline (§3.5/§6.3).
 
 ## 6. Durability, transaction, and recovery model
 
-### 6.1 SQLite command transaction boundary
+### 6.1 SQLite command transaction boundary (target + verified gap)
 
-Every state transition is a **single SQLite transaction** that atomically:
-1. validates the guard (CAS-style `WHERE current_status = ?`),
-2. writes the new status + append-only attempt/audit row,
-3. enqueues any resulting delivery/outbox messages and timers, and
-4. releases/acquires leases.
+**Target:** every state transition is a single SQLite transaction that atomically (1)
+validates the guard (CAS-style `WHERE current_status = ?`), (2) writes the new status +
+append-only attempt/transition row, (3) **enqueues every resulting delivery in the same
+transaction** (transactional outbox), (4) releases/acquires leases, and (5) persists any
+retry deadline.
 
-This is the existing pattern (`db.transaction()` for atomic cycle-increment +
-gate-data-reset in `channel-router.ts:244`). The rule is to **never split a transition's
-write across transactions** — outbox/delivery must be enqueued in the same transaction as
-the state write (transactional outbox), so a crash between "state written" and "message
-sent" is impossible.
+This is the existing pattern for *one* transition (`db.transaction()` for atomic
+cycle-increment + gate-data-reset, `channel-router.ts:1752`). **Gap:** it is not the pattern
+for delivery. Today `send_message` commits the gate write (`gateDataRepo.merge`) and only
+then awaits `AgentMessageRouter.deliverMessage`; **live targets are delivered directly
+without a durable row** (only inactive targets hit `pending_agent_messages`). A daemon crash
+in that gap opens the gate but loses the handoff. The rule "never split a transition's write
+from its outbox enqueue" is therefore a **new** requirement with its own phase — the current
+delivery system is explicitly *not* "correct and untouched."
 
 ### 6.2 Inbox / outbox
 
-- **Outbox** (within the transition transaction): messages to be delivered. `AgentMessageRouter`
-  is the outbox dispatcher.
+- **Outbox** (within the transition transaction): every resulting delivery persisted before
+  commit. `AgentMessageRouter` becomes the outbox dispatcher that drains rows for both live
+  and inactive targets.
 - **Inbox** (`pending_agent_messages` for node-agents; `space_agent_inbox_messages` for
-  long-horizon agents): durable queues drained on worker activation.
-- **Idempotency**: `idempotency_key` unique partial indexes on both inboxes. Duplicate
-  wake/deliver requests are no-ops. Activation is idempotent (`activateNode` short-circuits
-  on existing active executions).
+  long-horizon agents): durable queues drained on worker activation. Today only the
+  inactive-target path writes here; the outbox phase unifies live + inactive.
+- **Idempotency**: `idempotency_key` unique partial indexes on both inboxes. Activation is
+  idempotent (`activateNode` short-circuits on existing active executions).
 
-### 6.3 Leases / fencing (the main durability gap)
+### 6.3 Leases / fencing + durable retry deadlines
 
-Today there is **no lease or fencing token** — the daemon is single-process and relies on
-SQLite transactions + per-gate evaluation coalescing. This is acceptable while single-process
-but blocks future multi-worker durability and makes "is this work item actually still being
-worked?" non-observable.
+Today there is **no lease or fencing token**, and connector/gate **retry deadlines are
+in-memory** (`GateRetryScheduler`, `gate-retry-scheduler.ts:10-11,34`). Both are durability
+gaps.
 
-**Decision (designed now, required only when distributed):**
+**Decision (designed now; flag-gated / required when distributed):**
 
 - A worker **claims** a work item by acquiring a lease row
-  `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the same
-  transaction that sets `in_progress`.
-- A **fencing token** (monotonic per work item) invalidates stale claims: any write from a
-  token older than the current lease is rejected. This is the classic fencing-token
-  pattern and is necessary the moment a worker can be resurrected after a crash and
-  operate on stale state.
-- Leases are **refreshed on real progress** (SDK message stream tick) so slow-but-alive
-  work is not falsely retried — directly addressing the recurring bug class in tasks
-  #859–#862 (stranded message delivery).
-- Recovery reclaims work items whose lease expired without progress.
+  `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the same transaction
+  that sets `in_progress`. A monotonic **fencing token** invalidates stale claims.
+- Leases are **refreshed on real progress** (SDK message stream tick) so slow-but-alive work
+  is not falsely retried — directly addressing the recurring stranded-delivery class
+  (tasks #859–#862).
+- **Durable retry deadlines**: connector/gate `retryAfterMs` is persisted to the timer/job
+  model (a `gate_retries` row or `job_queue` entry keyed by `(run_id, gate_id)`) and
+  rehydrated or cancelled on restart. This is required for the recovery guarantees in §6.5
+  and is **not** flag-gated (a lost deadline silently strands a gate).
 
-This is introduced **behind a flag** and is a no-op for the single-process path until a
-second worker exists. It is the dependency-ready seam for #859–#862's recovery phase.
-
-### 6.4 Append-only attempts and audit
+### 6.4 Append-only attempts and transition audit (verified gap)
 
 - **Attempts** (`node_execution_attempts`, new): one row per execution attempt of a work
   item — `work_item_id`, `attempt_number`, `owner`, `started_at`, `ended_at`, `outcome`,
   `failure_reason`. Retries append; nothing mutates history.
-- **Audit**: `workflow_run_artifacts` (typed node outputs) + `workflow_hook_result_artifacts`
-  (hook results) already form an audit trail; attempts complete it. Every transition is
-  reconstructable from append-only tables.
+- **Transition audit (gap):** `workflow_run_artifacts` are **upserts**
+  (`UNIQUE(run_id, node_id, artifact_type, artifact_key)`, `migrations.ts:6514`), not
+  append-only; hook-result artifacts cover only hook evaluations; attempts cover only
+  work-item attempts. None records every run/task status change, approval, cancellation,
+  gate reset, or routing transition. So the prior claim "every transition is reconstructable
+  from append-only tables" was wrong. **Decision:** add an append-only
+  **`workflow_transition_log`** (run/task status changes, approvals, cancellations, gate
+  resets, routing transitions, with actor + command metadata), or explicitly narrow the
+  audit guarantee to "work-item attempts + typed outputs" and adjust recovery accordingly.
+  The full audit table is recommended for a durable execution framework.
 
 ### 6.5 Recovery
 
 `SpaceRuntimeService.start()` chains recovery today (long-term inbox →
 `recoverStalledRuns`): skip if work is in flight, finalize if a completion signal is
-recorded, force `blocked` (`agentCrash`) if everything is terminal with no signal. This is
-preserved and **generalized**: GitHub-specific recovery
-(`rehydrateActiveRunPrEventSubscriptions`) moves behind a **connector-declared recovery
-hook** so the recovery pass invokes `connector.recoverRun(run)` for each connector the run
-used (§7).
+recorded, force `blocked` (`agentCrash`) if everything is terminal with no signal.
+**Caveat:** "finalize if a completion signal is recorded" must respect §3.1 — do not mark
+`done` (and thus stop timers/release leases/drop delivery) while approval or post-approval
+work is unresolved. Recovery is preserved and **generalized**: GitHub-specific recovery and
+the broader GitHub event path move behind a **connector-declared recovery hook** so the
+recovery pass invokes `connector.recoverRun(run)` (§7, Phase 5).
 
 ### 6.6 Idempotency summary
 
 | Operation | Idempotency mechanism |
 |---|---|
 | Activate a node | short-circuit on existing active executions |
-| Deliver a message | `idempotency_key` unique index on inbox |
-| Claim a work item | lease row CAS |
-| Fire completion actions | `completion_actions_fired_at` stamp |
+| Deliver a message (target) | `idempotency_key` unique index on inbox |
+| Claim a work item | lease row CAS + fencing token |
+| Finalize run to terminal | canonical task-status guard (re-entry short-circuits on `task.status === 'done'`) |
 | Gate open cache | `gate_open_state` with staleness guard |
 | Post-approval dispatch | `postApprovalSessionId` + liveness probe (double-fire guard) |
+| **Mutating connector op** (target) | command idempotency key + reconcile-unknown (§5) |
+| **Connector/gate retry** (target) | persisted deadline rehydrated on restart (§6.3) |
 
 ## 7. Compatibility map — current → target
 
-The migration is extraction behind adapters. Each row is a bounded change; phases in §9.
+Extraction behind adapters; each row is a bounded change (phases in §9).
 
-| Current (domain-specific) | Target (generic) | Adapter strategy |
+| Current (domain-specific / gap) | Target (generic / closed) | Adapter strategy |
 |---|---|---|
-| `WorkflowNode.requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` (`space.ts:2287`, dup `:2321`) | `node.gateFeatureOverrides['codex_review_bot']` | dual-read; built-in templates rewritten to the override form; field kept as deprecated alias until templates migrate |
-| `gate-features.ts` Codex compiler (`:209–510`) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via existing `registerGateFeature` plugin | move compiler into a `gate-features/codex.ts` plugin module; validation becomes generic override-schema validation |
-| `pr_url` implicit handoff: `ChannelRouterConfig.getPrUrlForRun` (`channel-router.ts:363`, `:1547`), `gate-script-executor` `PR_URL` env, `gate-evaluator` `gateData.pr_url` (`:563`), post-approval template context, `space_tasks.pr_url/pr_number/pr_created_at` columns (`migrations.ts:2255`) | generic per-run **`runtime_context`** map; `pr_url` is one populated key | dual-read `runtime_context['pr_url'] ?? legacy`; migration 84's stated intent ("replace pr columns with artifacts", `migrations.ts:380`) is the canonical path — PR data moves to `workflow_run_artifacts` |
-| `rehydrateActiveRunPrEventSubscriptions` (`space-runtime-service.ts:2523`) | `connector.recoverRun(run)` invoked for each run-used connector | GitHub connector declares the recovery hook; runtime calls generically |
-| Mutable definitions (`updateWorkflow`) | immutable + versioned, pinned on run (§4) | shadow-write version table first; runs read pinned version; edit produces new version |
-| Inline crash-retry-with-counting | append-only attempts + leases (§6.3–6.4) | introduce attempt table + lease behind flag; behavior identical until multi-worker |
-| Two goal systems: legacy `goals`/`mission_executions` vs `space_goals` | single Goal V2 trigger layer above the engine | legacy tables retained read-only; no new writes; retire after parity |
+| `requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` on the generic node types — `WorkflowNode` (`space.ts:2287`), `WorkflowNodeInput` (`:2321`), **and `ExportedWorkflowNode` (`:2802`)** — plus the `effectiveNodes` projection in `updateWorkflow` (`space-workflow-manager.ts:314-316, 325-327`) | `node.gateFeatureOverrides['codex_review_bot']` on all three shapes | dual-read; all three type copies + the projection updated together or the export round-trip leaks codex; deprecated alias until migrated |
+| `gate-features.ts` codex paths (first ref `:36` through `maybeInjectCodexFeature` at `:619`; file is 631 lines) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via existing `registerGateFeature` plugin | move compiler into a `gate-features/codex.ts` plugin; validation → generic override-schema validation |
+| `pr_url` implicit **runtime handoff**: `ChannelRouterConfig.getPrUrlForRun` (`channel-router.ts:363`, `:1547`), `gate-script-executor` `PR_URL` env, `gate-evaluator` `gateData.pr_url` (`:563`), post-approval template context | generic per-run **`runtime_context`** map; `pr_url` is one populated key | dual-read `runtime_context['pr_url'] ?? legacy`; **PR data already lives in `workflow_run_artifacts`** — `space_tasks.pr_url/pr_number/pr_created_at` were dropped in M84 (`runMigration84`, `migrations.ts:6514`, table rebuild `space_tasks_m84_new`) and the `:2255`/`:2771` occurrences are the legacy room `tasks` table / the historical pre-M84 `space_tasks` CREATE respectively. Compat source = `gate_data` + hook-local state + `workflow_run_artifacts` |
+| Full GitHub external-event path in `space-runtime.ts`: PR-subscription restart recovery (`rehydrateActiveRunPrEventSubscriptions`), topic normalization, check-failure reopening, PR-URL extraction/matching, automatic subscriptions, retained-event replay | connector-declared `recoverRun` + connector-owned subscription/matching/reopen policy | move the whole path behind github-connector capabilities (Phase 5); legacy retained until proven |
+| Mutable definitions + `ON DELETE CASCADE` `workflow_id` + no `deleteWorkflow` guard | immutable + versioned + pinned + deletion-safe (§4) | shadow-write version history; tombstone/version-FK + active-run guard; remove the cascade |
+| Inline crash-retry-with-counting | append-only attempts + leases (§6.3–6.4) | preserve idle/reactivation lifecycle (§3.2); attempt table + lease behind flag |
+| Live-target delivery bypasses durable inbox; in-memory retry deadlines; upsert "audit" | transactional outbox + durable retry deadlines + append-only transition log (§6.1–6.4) | new durability phases |
+| Mutating connectors with no command idempotency | command key + reconcile-unknown (§5) | extend contract before mutating connectors ship |
+| Two **active** goal models: `goals`/`mission_executions` (Mission System: `goal-repository.ts`, `atomicStartExecution`, monotonic `execution_number`, driven by `goal-automation-execute.handler.ts`) **and** `space_goals`/`space_goal_events` | undecided — unification requires a dedicated audit | **deferred** (Phase 7 re-scoped); neither is assumed legacy |
 
 **What is already correct and untouched:** topology model, agent slots + `toolGuards` +
 `eventInterests`, gate field/script/validator/poll model, channels + cycle caps,
-`pending_agent_messages`/`space_agent_inbox_messages` durable delivery, `gate_open_state`,
-`workflow_run_artifacts`, `task_schedules`/`job_queue` timers, connector registry, the
-"messages communicate, outcomes advance state" invariant, and the LLM workflow selector
-(returning an id with deterministic tag fallback).
+`pending_agent_messages`/`space_agent_inbox_messages` durable delivery **for inactive
+targets**, `gate_open_state`, `workflow_run_artifacts`, `task_schedules`/`job_queue`
+schedules, connector registry, the LLM workflow selector, and the channel-directed-
+send-as-activation semantics (§2).
 
 ## 8. Reference workflows (expressiveness proof)
 
-Four definitions prove the kernel + connectors express each domain **without core changes**.
-The first already exists; the other three are sketched to validate the model, not to ship.
+Four definitions prove the kernel + connectors express each domain without core changes.
+The first exists; the others are sketched to validate the model. Note: the ecommerce and
+travel sketches use **mutating** connectors and therefore depend on the §5 idempotency work.
 
 ### 8.1 PR review (exists today)
 
-`CODING_WORKFLOW` / `FULLSTACK_QA_LOOP_WORKFLOW` in `built-in-workflows.ts`. Nodes:
-Coder → Review → QA → Post-Approval. Gates: `pr_ready` (connector `github.getPrReadiness`
-+ predicate), `codex_review_bot` (feature), human approval gate
-(`completionAutonomyLevel`). Post-approval: PR Merger slot. **Already data-defined**;
-target = same definition with `pr_url` read from `runtime_context` and codex from
+`CODING_WORKFLOW` / `FULLSTACK_QA_LOOP_WORKFLOW`. Nodes: Coder → Review → QA →
+Post-Approval. Gates: `pr_ready` (connector `github.getPrReadiness` + predicate),
+`codex_review_bot` (feature), human approval gate. Post-approval: PR Merger slot. Target =
+same definition with `pr_url` from `runtime_context` and codex from
 `gateFeatureOverrides`.
 
-### 8.2 Ecommerce return (new sketch)
+### 8.2 Ecommerce return (new sketch; uses mutating connectors)
 
 ```
-[intake: receive return] → [eligibility gate] → [inspect] → [decision gate]
-   ├─ refund  → [connector shop.issueRefund] → [notify] → end
-   └─ exchange→ [connector shop.restockItem] → [ship replacement] → end
+[intake] → [eligibility gate] → [inspect] → [decision gate]
+   ├─ refund  → [shop.issueRefund] → [notify] → end
+   └─ exchange→ [shop.restockItem] → [ship replacement] → end
 ```
-- High-value returns: human approval gate (`requiredLevel`).
-- Connectors: `shop.getOrder`, `shop.createReturn`, `shop.issueRefund`, `shop.restockItem`.
-- No GitHub knowledge anywhere in the kernel.
+High-value returns: human approval gate. Mutating ops (`issueRefund`, `restockItem`) require
+the §5 command-id + reconcile contract.
 
 ### 8.3 Manufacturing defect / CAPA (new sketch)
 
 ```
-[report defect] → [triage: root-cause + severity] → [containment] → [corrective-action gate]
-   → [implement CAPA] → [verification gate] → [close] → end
+[report] → [triage] → [containment] → [corrective-action gate] → [implement CAPA] → [verification gate] → [close]
 ```
-- Severity-driven routing via gate fields.
-- QA sign-off gates with `writers: []` (external/human).
-- Recurring goal monitors defect trends (`task_schedule` cron) — leverages Goal V2.
-- Connectors: `mes.fileDefect`, `mes.getRouting`, `mes.recordNonconformance`.
+Severity-driven routing; QA sign-off gates (`writers: []`); recurring trend monitor
+(`task_schedule`). Connectors: `mes.fileDefect`, `mes.getRouting`, `mes.recordNonconformance`.
 
-### 8.4 Personal travel assistant (new sketch)
+### 8.4 Personal travel assistant (new sketch; uses mutating connectors)
 
 ```
-[capture intent] → [search: shop flights + hotels] → [assemble itinerary]
-   → [confirmation gate] → [book] → [pre-trip reminders (timer)] → [during-trip monitor]
+[capture intent] → [search flights + hotels] → [assemble itinerary] → [confirmation gate] → [travel.book] → [reminders (timer)] → [monitor]
 ```
-- Confirmation gate = human approval.
-- Timers: `GatePoll` or `task_schedule` for reminders.
-- Connectors: `travel.searchFlights`, `travel.searchHotels`, `travel.book`.
-- Demonstrates human-in-the-loop + timers + multiple connectors.
+`travel.book` requires §5 idempotency.
 
-**Conclusion of §8:** all four domains are expressible as definitions + connectors. No
-field, gate primitive, timer, or delivery concept needs to be added to satisfy them. This
-is the evidence that the generic kernel is sufficient and that BPMN-scale features can be
-deferred.
+**Conclusion:** all four are expressible as definitions + connectors. No topology/gate/timer
+concept must be added. The only contract addition is mutating-connector idempotency (§5).
 
 ## 9. Phased roadmap
 
-One compatibility-preserving PR per phase. Each phase: shadow projection or feature flag
-first, dual-read/write only when necessary, migration tests, explicit rollback criteria.
-**No phase removes legacy behavior before parity evidence exists.**
+One compatibility-preserving PR per phase. Each: shadow/flag first, dual-read only when
+necessary, migration + restart/concurrency tests, explicit rollback. **No phase removes
+legacy behavior before parity evidence exists.** New durability phases (1b–1e) close the
+verified gaps before the extraction phases that depend on them.
 
 | Phase | Deliverable | Mode | Rollback |
 |---|---|---|---|
 | **0** (this RFC) | RFC + ADR, approval | docs only | n/a |
-| 1 | Immutable versioned definitions; pin `definition_version` on runs | shadow-write version table; runs read pinned version; legacy reads unaffected | drop the pin column; behavior reverts to live-read |
-| 2 | Generic `runtime_context` map; extract `pr_url` behind it | dual-read `runtime_context['pr_url'] ?? legacy`; move `space_tasks.pr_url*` → artifacts (migration 84 intent) | flip dual-read back to legacy |
-| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` to plugin | keep `requireCodexApproval` as deprecated alias; templates rewritten | alias still honored |
-| 4 | Append-only attempts + leases/fencing (flag-gated) | flag off = single-process no-op; flag on = lease enforced | toggle flag |
-| 5 | Connector-declared `recoverRun` hook; extract PR subscription recovery | GitHub connector declares hook; runtime calls generically; legacy path retained until proven | fall back to legacy rehydrate |
-| 6 | Author ecommerce-return, manufacturing-defect, travel definitions + connectors as **reference fixtures + tests** | read-only reference; no production wiring | remove fixture |
-| 7 | Retire legacy `room/` Mission System (goals/mission_executions) | after parity + no writes for N releases | tables retained read-only |
-
-Phases 1–5 are the dependency-ready core; 6 validates genericity; 7 is cleanup. Each is
-small, reviewable, and independently revertible.
+| 1 | Immutable versioned definitions: in-row `definition_version` hash pinned on runs + `space_workflow_definition_versions` history **+ deletion-safety** (tombstone/version-FK, active-run guard in `deleteWorkflow`, remove `workflow_id` cascade) | shadow-write history; runs read pinned version; legacy live-read unaffected | drop pin column; restore cascade |
+| **1b** | Transactional outbox: persist every resulting delivery (live + inactive) in the transition transaction; `AgentMessageRouter` drains rows | write both paths; cutover when proven | fall back to direct live delivery |
+| **1c** | Durable retry deadlines: persist connector/gate `retryAfterMs` to timer/job model; rehydrate/cancel by `(run, gate)` | new table/job type | in-memory scheduler still works while populated |
+| **1d** | Append-only `workflow_transition_log` (status/approval/cancel/gate-reset/routing, + actor + command) | append-only; readers opt-in | stop writing; no behavior change |
+| 2 | Generic `runtime_context` map; extract `pr_url` runtime handoff behind it | dual-read `runtime_context['pr_url'] ?? legacy`; source = `gate_data`/hook-state/`workflow_run_artifacts` (columns already gone post-M84) | flip dual-read back |
+| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` to a plugin (all three node type copies + `effectiveNodes`) | keep `requireCodexApproval` as deprecated alias | alias still honored |
+| 4 | Append-only attempts + leases/fencing (flag-gated); **preserve idle/reactivation lifecycle** (§3.2) | flag off = single-process no-op | toggle flag |
+| **4b** | Mutating-connector readiness: command idempotency key + reconcile-unknown on `ConnectorContext`/`ConnectorOp` | read-only connectors unaffected | gate behind connector capability flag |
+| 5 | Full GitHub external-event path behind connector capabilities (`recoverRun` + subscription/matching/reopen) | github-connector owns the path; legacy retained until proven | fall back to legacy paths |
+| 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests | read-only reference; no production seeding | remove fixture |
+| 7 | **Goal-system unification audit** (not "retire legacy"): determine the relationship between `goals`/`mission_executions` and `space_goals`; decide migration/freeze **from evidence** | investigation + design only first | n/a |
 
 ## 10. Deferred features (do not build speculatively)
 
-Each is deferred until a reference workflow or an observed failure requires it.
-
-- **Subprocesses / nested workflow calls.** Current flat + cyclic-channel model suffices;
-  add when a reference workflow genuinely needs composition.
-- **Complex event correlation (CEPII).** Current `eventInterests` topic globs +
-  `subscribe_external_event` suffice.
-- **Distributed / horizontally-scaled execution.** Single-process until a measured
-  bottleneck. Leases (§6.3) are the seam.
-- **Compensation / saga rollback transactions.** Use explicit corrective nodes in the
-  definition instead; add saga semantics only if rollback correctness proves too hard to
-  model declaratively.
-- **Organization / role modeling beyond agent slots + `writers`.** Defer until a domain
-  needs an org chart.
-- **Visual designer / BPMN import / process mining.** Out of scope.
-- **BPEL-style orchestration-vs-choreography refactor.** Current agent-centric choreography
-  is the model; keep it.
+- Subprocesses / nested workflow calls; complex event correlation (CEPII); distributed /
+  horizontally-scaled execution (leases are the seam); compensation/saga rollback (use
+  explicit corrective nodes); org/role modeling beyond slots + `writers`; visual designer /
+  BPMN import; process mining; BPEL orchestration-vs-choreography refactor.
+- **Goal-system unification** (Phase 7) — requires a dedicated audit; do not assume either
+  model is legacy.
 
 ## 11. Migration safety invariants (must hold throughout)
 
-1. **No silent reinterpretation of active runs.** A run executes its pinned definition
-   version; definition edits never mutate in-flight runs (Phase 1).
-2. **No legacy removal before parity.** Every extraction keeps the old path until a migration
-   test + production evidence show equivalence.
-3. **One invariant or capability per PR.** Each phase is independently reviewable and
-   revertible (explicit rollback column above).
-4. **Migration tests + restart/concurrency tests accompany every runtime change.** Recovery
-   (`recoverStalledRuns`), idempotency (`idempotency_key`), and lease correctness are
-   tested under crash + duplicate-wake + concurrent-claim.
-5. **Domain-specific concepts never re-enter the generic type or core paths.** The RFC's
-   acceptance criterion: `grep` for `pr_url`, `codex`, `requireCodexApproval` in
-   `packages/shared/src/types/space.ts` and `packages/daemon/src/lib/space/runtime/*`
-   returns nothing outside adapters/plugins (measured over phases, not required at Phase 0).
+1. **No silent reinterpretation of active runs** — a run executes its pinned definition
+   version; edits/deletions never mutate or erase in-flight runs (Phase 1 + deletion-safety).
+2. **No legacy removal before parity** — every extraction keeps the old path until a
+   migration test + production evidence show equivalence.
+3. **One invariant/capability per PR** — each phase independently reviewable and revertible.
+4. **Migration + restart/concurrency tests** accompany every runtime change — recovery,
+   idempotency, lease correctness, outbox atomicity, and durable-retry rehydration tested
+   under crash + duplicate-wake + concurrent-claim + restart.
+5. **Domain concepts never re-enter the generic type or core paths.** Acceptance criterion:
+   `grep` for `pr_url`, `codex`, `requireCodexApproval` in `packages/shared/src/types/space.ts`
+   (incl. `ExportedWorkflowNode`) and `packages/daemon/src/lib/space/runtime/*`, plus the
+   `effectiveNodes` projection in `managers/space-workflow-manager.ts` and the GitHub
+   external-event symbols in `space-runtime.ts`, returns nothing outside adapters/plugins
+   (measured over phases).
+6. **A run is not terminal until its task and post-approval route are** (§3.1) — durability
+   consumers (leases, timers, delivery) must key off true terminal state, not
+   `reportedStatus`/`CompletionDetector` alone.
 
-## 12. Open questions for review
+## 12. Design-review decisions (resolved / revised)
 
-1. **Definition versioning storage**: separate `space_workflow_definition_versions` table vs.
-   in-row versioning with an audit table — which is preferred given the mutation-heavy
-   built-in re-stamping flow?
-2. **Lease scope**: do we want leases required for the single-process path now (stronger
-   invariants, more code) or strictly flag-gated until a second worker exists (smaller
-   blast radius)? This RFC proposes flag-gated; confirm.
-3. **Goal V2 unification**: should legacy `goals`/`mission_executions` be migrated to
-   `space_goals` explicitly, or frozen read-only until organic attrition? (Affects Phase 7
-   only.)
-4. **Reference workflow ownership (Phase 6)**: ship ecommerce/manufacturing/travel as
-   in-tree reference fixtures (recommended) vs. a separate examples package.
+From the review of PR #2396. All re-verified against code.
 
-Phase 0 produces no code; upon approval, Phase 1 begins behind adapters.
+1. **Definition versioning** → in-row content hash pinned on run + append-only
+   `space_workflow_definition_versions` history table. (Phases 1.) **Plus deletion-safety**
+   (tombstone/version-FK + active-run guard) — added after verification showed the
+   `ON DELETE CASCADE` + guardless `deleteWorkflow` gap.
+2. **Lease scope** → flag-gated no-op for single-process; enforced only when a second worker
+   exists. (Phase 4.)
+3. **Goal V2 unification** → ~~freeze legacy read-only~~ **REVERSED.** Verification shows
+   `goals`/`mission_executions` is an **active** Mission System (`goal-repository.ts`,
+   `atomicStartExecution` with monotonic `execution_number`, driven by
+   `goal-automation-execute.handler.ts`), not legacy. Freezing it would halt active
+   behavior. Re-scoped to a unification **audit** in Phase 7; no freeze or retirement
+   without evidence. (The original "freeze" decision rested on an unverified premise —
+   flagged to the reviewer.)
+4. **Reference workflows** → in-tree under a marked `reference/`/fixtures path, not seeded.
+   (Phase 6.)
+
+Phase 0 produces no code; upon approval, Phase 1 (+ durability cluster 1b–1d) begins behind
+adapters.

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,0 +1,498 @@
+# RFC: Data-Defined Workflow Engine
+
+Status: Proposed (Phase 0 — architecture only; no runtime changes)
+Date: 2026-08-07
+Tracks: Goal task #874 — "Evolve HyperNeo into a generic data-defined workflow engine"
+Companion: `docs/adr/0003-data-defined-workflow-engine.md`
+
+## 1. Goal and non-goals
+
+### Goal
+
+Evolve HyperNeo's Space workflow system into a **domain-agnostic, durable execution
+framework** suitable for business processes, manufacturing, ecommerce, personal-assistant
+workflows, and agent collaboration — without a big-bang rewrite.
+
+The foundational rule, in one line:
+
+> **Data-defined behavior, code-defined semantics, plugin-defined capabilities.**
+
+- **Data-defined behavior** — every workflow-specific behavior (topology, transitions,
+  prompts, policies, approval thresholds, delivery targets, timers) lives in an immutable,
+  versioned **definition** that the kernel interprets. The kernel never branches on
+  *which* workflow is running.
+- **Code-defined semantics** — the generic kernel owns the *meaning* of transitions,
+  durability, leases, idempotency, approvals, timers, delivery, recovery, audit, and
+  terminal states. These semantics are universal and not parameterized by domain.
+- **Plugin-defined capabilities** — domain actions (call GitHub, call an ERP, book a
+  flight, run a validator) are **connectors** registered into a generic capability
+  registry. The kernel invokes them by id; it does not know what they do.
+
+### Non-goals (this RFC)
+
+- Implementing runtime changes. Phase 0 is design + approval only.
+- BPMN/BPEL parity. We adopt patterns incrementally as reference workflows demand them.
+- A visual designer or external format import.
+- Distributed multi-process execution now. We design the seams (leases, fencing) but keep
+  a single-process daemon until a measured bottleneck forces scaling.
+- Retiring the legacy `room/` Mission System. It is mapped to a compatibility adapter and
+  scheduled for retirement only after parity and migration evidence exist.
+
+### Why this is tractable now
+
+The current engine is already **~85% data-defined**. A code survey confirms:
+
+- There is **no `switch(workflowType)` or `switch(nodeType)` dispatch** anywhere in the
+  core runtime. Topology (nodes/channels/gates/hooks/post-approval), gate evaluation, cycle
+  caps, completion detection, and post-approval routing are all driven by data.
+- A clean **connector abstraction already exists** (`packages/daemon/src/lib/space/runtime/connectors/`)
+  with a generic registry (`Connector` / `ConnectorOp` / `ConnectorOutcome` /
+  `ConnectorAuth`), a predicate DSL (`predicate.ts`), and validator presets. The engine
+  already admits any registered connector id — `'github'` is no longer special in the type.
+- The connector layer is being rolled out **behind a feature flag**
+  (`isConnectorsLayerEnabled()`, gated in `hook-executor.ts`).
+
+So this is **not a rewrite**. It is a bounded extraction: purge the remaining
+domain-specific concepts (GitHub/PR/Codex) from the generic type and core paths, harden
+the durability seams that single-process execution let us defer, and formalize the
+versioning and recovery model. The concrete leakage sites are enumerated in §6.
+
+## 2. Canonical concepts
+
+We adopt the existing vocabulary wherever it is already correct — a parallel rename would
+violate the incremental, compatibility-first constraint. New terms are introduced only
+where the current model conflates or omits something.
+
+| Canonical term | Current implementation | Notes |
+|---|---|---|
+| **Definition** | `SpaceWorkflow` (`packages/shared/src/types/space.ts:2419`) | Becomes **immutable + versioned** (§4). |
+| **Run** | `space_workflow_runs` row (`migrations.ts:2713`) | One execution of a definition. Pins `definition_version`. |
+| **Work item** | `node_executions` row (`migrations.ts:5912`) | A unit of work assigned to a worker. Statuses: `pending\|in_progress\|idle\|waiting_rebind\|blocked\|cancelled\|done`. |
+| **Attempt** | (implicit: crash-retry-with-counting in tick loop) | **New, append-only**: an execution attempt of a work item. Makes retries auditable (§5). |
+| **Token / activation** | `ChannelRouter.activateNode` creating `node_executions` | Lazy, event-driven. A message or gate-open *activates* a downstream node. |
+| **Gate** | `Gate` + `gate_data` + `gate_open_state` | Declaration in definition; runtime state in `gate_data`; open-cache in `gate_open_state`. |
+| **Channel** | `WorkflowChannel` (`space.ts:2215`) | Directed message pipe `from → to`, optional `gateId`, `maxCycles`. |
+| **Approval** | Gate with `requiredLevel` / external `writers: []` field + `completionAutonomyLevel` | Human or autonomy-gated sign-off. |
+| **Delivery** | `pending_agent_messages` (inbox) + `AgentMessageRouter` (outbox) | Durable, idempotent (§5). |
+| **Timer** | `task_schedules` (cron/at) + `GatePoll` (interval) + hook retry timers | Three existing timer mechanisms, unified conceptually. |
+| **Connector / capability** | `connectors/` registry + validator presets | Domain actions behind an id. |
+| **Task** | `space_tasks` | User-facing unit; 1:1 with a run via `workflow_run_id`. Sole completion source of truth. |
+| **Goal** | `space_goals` (Goal V2) + legacy `goals` | The **what/when layer**: objectives, recurring triggers, progress. Layered above the engine. |
+| **Worker** | A Space agent session (`space_chat` / `space_task_agent` / LH agent) | Agents/humans/services are all workers. Sessions are execution *resources*, not workflow identity. |
+
+**Mental model.** A *Goal* says *what* to achieve and *when* (trigger layer). It creates a
+*Task* and a *Run* of a *Definition*. The kernel drives the run by *activating work items*
+along *channels*, respecting *gates*. Workers (agents/humans/services) pick up work items,
+emit *outcomes* (messages, gate writes, artifact writes, commands), and the kernel
+transitions the run deterministically. *Connectors* provide domain actions workers or
+gates call. Delivery is durable and idempotent so workers can crash, retry, and recover
+without losing or duplicating work.
+
+### What advances process state
+
+> **Messages communicate; explicit outcomes/signals/commands advance process state.**
+
+A message alone never transitions a run. State advances only through *structured* acts that
+the kernel interprets: a gate write that opens a gate (→ activates downstream work items),
+a terminal work-item outcome (`done`/`cancelled`), an explicit command
+(`submit_for_approval`, `approve_task`, `mark_complete`), or a timer firing. Free-text
+messaging between workers does not move the process graph. This is already the case today
+and is preserved as an invariant.
+
+## 3. Lifecycle / state-transition tables
+
+These are the **executable** transition tables the kernel enforces. They are encoded as
+data (the current `VALID_NODE_EXECUTION_TRANSITIONS` pattern is the model). Where the
+existing transition set already matches, the table is a formalization, not a change.
+
+### 3.1 Run lifecycle
+
+| from | event | to | guard | side effect |
+|---|---|---|---|---|
+| `pending` | start node activated | `in_progress` | definition resolvable at pinned version | stamp `definition_version` |
+| `in_progress` | completion signal recorded | `done` | `CompletionDetector.isComplete` (task `done`/`cancelled` or `reportedStatus != null`) | fire idempotent completion actions (`completion_actions_fired_at`) |
+| `in_progress` | all work items terminal, no completion signal, restart | `blocked` | recovery pass | `failure_reason = 'agentCrash'` |
+| `in_progress` | human reject | `blocked` | `failure_reason = 'humanRejected'` | — |
+| `in_progress` | max iterations / node timeout | `blocked` | `failure_reason ∈ {maxIterationsReached, nodeTimeout}` | — |
+| `in_progress`/`blocked` | human cancel | `cancelled` | — | cascade-cancel work items, release leases |
+| `blocked` | manual restart / recovery claim | `in_progress` | work item re-activated | — |
+
+`done`, `cancelled` are **terminal**. `blocked` is recoverable. Legacy `completed`/
+`needs_attention` strings are compatibility aliases for `done`/`blocked`.
+
+### 3.2 Work item lifecycle
+
+| from | event | to | guard | side effect |
+|---|---|---|---|---|
+| `pending` | worker claims | `in_progress` | lease acquired (§5), idempotent activation short-circuit | append attempt #1 |
+| `in_progress` | worker emits terminal outcome | `done` | completion checks pass | release lease |
+| `in_progress` | worker needs peer input | `idle` / `waiting_rebind` | — | lease continues or parks |
+| `in_progress` | gate blocks downstream | (self unchanged) | — | downstream not activated |
+| `in_progress` | worker crash / lease expiry | `pending` (retry) | attempt budget remaining, not terminal | append attempt #N, backoff |
+| `in_progress`/`idle` | timeout | `pending` (retry) | budget remaining | append attempt #N |
+| `pending`/`in_progress` | run cancelled | `cancelled` | — | release lease |
+| `pending` (retry exhausted) | max attempts reached | `blocked` | — | run → `blocked` (`agentCrash`) |
+
+`done`, `cancelled` are terminal. Today, retries are inline (crash-retry-with-counting);
+this RFC formalizes them as an **append-only attempt log** (§5) without changing the
+observable behavior.
+
+### 3.3 Gate lifecycle
+
+| from | event | to | notes |
+|---|---|---|---|
+| `closed` | writer writes field / script runs / validator runs | re-evaluated | all fields pass → `open` |
+| `closed` | autonomy threshold not met and validation passes | `pending_approval` | task → `review`; surfaces in UI |
+| `closed` | autonomy threshold met and validation passes | `open` | auto-approval |
+| `pending_approval` | human approves | `open` | — |
+| `pending_approval` | human rejects | `closed` (or run `blocked`) | `resetOnCycle` may clear data |
+| `open` | gate opens | activates downstream work items via `onGateDataChanged` | — |
+| `open` | new cycle (cyclic channel) | `closed` | `channel_cycles++`, `gate_data` reset if `resetOnCycle` |
+
+Gate open-cache (`gate_open_state`) is persisted across restart with a staleness guard
+(`opened_workflow_updated_at`) — preserved as-is.
+
+### 3.4 Delivery (inbox/outbox) lifecycle
+
+| from | event | to | notes |
+|---|---|---|---|
+| `pending` | target worker activates | `delivered` | `flushPendingMessagesForTarget`, idempotent by `idempotency_key` |
+| `pending` | TTL (60s) elapsed, attempts < max (3) | `pending` (retry) | backoff |
+| `pending` | max attempts reached | `failed` | actionable terminal failure surfaced |
+| `pending` | run/work item terminal | `failed` | do not deliver to dead workers |
+
+### 3.5 Timer lifecycle
+
+| type | trigger | effect |
+|---|---|---|
+| schedule (`task_schedules`) | cron / `run_at` reaches `next_run_at` | enqueue fire job → creates a new run/task instance |
+| gate poll (`GatePoll`) | `intervalMs` tick while run `in_progress` | run gate script; if stdout changed, inject message into target node |
+| hook retry (`WorkflowHookRetrySettings`) | `next_retry_at` | re-run hook with backoff |
+
+All timers stop on run terminal state.
+
+### 3.6 Approval lifecycle
+
+| from | event | to | guard |
+|---|---|---|---|
+| work item emits `submit_for_approval` | command accepted | task `review` | `space.autonomyLevel < completionAutonomyLevel` → human gate; else auto |
+| task `review` | human `approve` | `approved` → post-approval route | double-fire guard (`postApprovalSessionId` set + alive → no-op) |
+| task `review` | human `reject` | `in_progress` (feedback to worker) | — |
+| `approved` | post-approval route done | `done` | `mark_complete` |
+
+## 4. Workflow-definition schema (immutable, versioned)
+
+**Problem today.** Definitions are mutable (`SpaceWorkflowManager.updateWorkflow`) and
+only soft-version-tracked via `templateHash` + `updatedAt`. Node IDs are stable
+(`validateStableNodeIds`) so a definition edit can silently change the behavior of an
+*in-flight* run. This violates the "data-defined behavior" rule for durability: a run
+must execute against the exact definition it started under.
+
+**Decision.**
+
+1. Introduce a **definition version** as a content hash of the canonicalized definition
+   (extend `workflows/template-hash.ts`). Store `definition_version` on the **definition
+   row** and **pin it on the run** at start (`space_workflow_runs.definition_version`).
+2. Editing a definition produces a **new version row** (or, pragmatically, a new
+   `definition_version` stamped on the same row with the prior version retained in an
+   append-only `space_workflow_definition_versions` audit table). Existing runs keep
+   reading their pinned version; new runs get the latest.
+3. Built-in template re-stamping (`seedBuiltInWorkflows` hash-drift merge) becomes
+   version-bumping rather than in-place mutation of live behavior.
+4. The shape of `SpaceWorkflow` is otherwise unchanged — this is a versioning wrapper, not
+   a schema redesign. Existing readers keep working; they simply resolve through the
+   pinned version.
+
+**Reference definition schema** (TypeScript-ish, abbreviated — matches current
+`SpaceWorkflow`):
+
+```ts
+interface WorkflowDefinition {
+  id: string;                       // definition id (stable across versions)
+  definitionVersion: string;        // content hash; immutable once published
+  name: string;
+  startNodeId: string;
+  endNodeId?: string;
+
+  nodes: Node[];                    // groups of agent slots; parallel execution
+  channels: Channel[];              // directed from→to, optional gateId, maxCycles
+  gates: Gate[];                    // fields | script | validator | features | poll
+  hooks?: Hook[];                   // validators on MCP calls / runtime events
+
+  completionAutonomyLevel: AutonomyLevel;   // self-close vs human review
+  postApproval?: PostApprovalRoute;          // node-level routes
+  runtimeContextContract?: RuntimeContextKey[]; // §6.2 — replaces implicit pr_url
+
+  tags?: string[];                  // workflow-selector hints (default, v2, …)
+}
+
+interface Node {
+  id: string; name: string;
+  agents: NodeAgent[];              // slots: agentId, model, prompt, toolGuards, timeoutMs, …
+  gateFeatureOverrides?: Record<string, unknown>; // §6.1 — replaces requireCodexApproval
+  postApproval?: PostApprovalRoute;
+}
+```
+
+Definitions are **declarations**; the kernel interprets them. Adding a domain (ecommerce,
+manufacturing, travel) means authoring a definition + registering connectors — **zero
+kernel changes**.
+
+## 5. Capability / connector contract
+
+The contract already exists and is correct. We formalize it; no redesign.
+
+```ts
+type ConnectorOutcome =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string; retryable?: boolean; retryAfterMs?: number };
+
+type ConnectorOp = (params: unknown, ctx: ConnectorContext) => Promise<ConnectorOutcome>;
+
+interface Connector {
+  readonly id: string;                       // 'github', 'shop', 'mes', 'travel', …
+  readonly ops: Record<string, ConnectorOp>; // 'getPr', 'createReturn', 'fileDefect', …
+  readonly auth?: ConnectorAuth;             // env-injected secrets
+}
+```
+
+- **Registry**: `registerConnector` / `getConnector` / `isRegisteredConnector` /
+  `getRegisteredConnectorIds`. Side-effect modules (`connectors/production.ts`) register
+  at startup.
+- **Validator layer**: a gate `validator: { kind: 'built_in', id }` composes a connector op
+  + a predicate (`eq`/`empty`/`all`/`any`). The validator does not know what a PR is —
+  domain knowledge lives in `connectors/presets.ts`.
+- **Domain packs** ship as connector + preset modules:
+  - `github` (existing): `getPr`, `getPrReadiness`, `getReactions`, `getReviewEvidence`;
+    presets `pr_ready`, `pr_merged`, `review_posted`, `codex_review_bot`.
+  - `shop` (new, reference): `createReturn`, `getOrder`, `issueRefund`, `restockItem`.
+  - `mes` (new, reference): `fileDefect`, `getRouting`, `recordNonconformance`.
+  - `travel` (new, reference): `searchFlights`, `searchHotels`, `book`, `getItinerary`.
+
+The kernel calls connectors by id+op. Outcomes are typed `ConnectorOutcome` so
+retryability and rate-limit backoff (`retryAfterMs`) are first-class — the existing
+`GateRetryScheduler` path already consumes these.
+
+## 6. Durability, transaction, and recovery model
+
+### 6.1 SQLite command transaction boundary
+
+Every state transition is a **single SQLite transaction** that atomically:
+1. validates the guard (CAS-style `WHERE current_status = ?`),
+2. writes the new status + append-only attempt/audit row,
+3. enqueues any resulting delivery/outbox messages and timers, and
+4. releases/acquires leases.
+
+This is the existing pattern (`db.transaction()` for atomic cycle-increment +
+gate-data-reset in `channel-router.ts:244`). The rule is to **never split a transition's
+write across transactions** — outbox/delivery must be enqueued in the same transaction as
+the state write (transactional outbox), so a crash between "state written" and "message
+sent" is impossible.
+
+### 6.2 Inbox / outbox
+
+- **Outbox** (within the transition transaction): messages to be delivered. `AgentMessageRouter`
+  is the outbox dispatcher.
+- **Inbox** (`pending_agent_messages` for node-agents; `space_agent_inbox_messages` for
+  long-horizon agents): durable queues drained on worker activation.
+- **Idempotency**: `idempotency_key` unique partial indexes on both inboxes. Duplicate
+  wake/deliver requests are no-ops. Activation is idempotent (`activateNode` short-circuits
+  on existing active executions).
+
+### 6.3 Leases / fencing (the main durability gap)
+
+Today there is **no lease or fencing token** — the daemon is single-process and relies on
+SQLite transactions + per-gate evaluation coalescing. This is acceptable while single-process
+but blocks future multi-worker durability and makes "is this work item actually still being
+worked?" non-observable.
+
+**Decision (designed now, required only when distributed):**
+
+- A worker **claims** a work item by acquiring a lease row
+  `work_item_leases(work_item_id, owner, fencing_token, expires_at)` in the same
+  transaction that sets `in_progress`.
+- A **fencing token** (monotonic per work item) invalidates stale claims: any write from a
+  token older than the current lease is rejected. This is the classic fencing-token
+  pattern and is necessary the moment a worker can be resurrected after a crash and
+  operate on stale state.
+- Leases are **refreshed on real progress** (SDK message stream tick) so slow-but-alive
+  work is not falsely retried — directly addressing the recurring bug class in tasks
+  #859–#862 (stranded message delivery).
+- Recovery reclaims work items whose lease expired without progress.
+
+This is introduced **behind a flag** and is a no-op for the single-process path until a
+second worker exists. It is the dependency-ready seam for #859–#862's recovery phase.
+
+### 6.4 Append-only attempts and audit
+
+- **Attempts** (`node_execution_attempts`, new): one row per execution attempt of a work
+  item — `work_item_id`, `attempt_number`, `owner`, `started_at`, `ended_at`, `outcome`,
+  `failure_reason`. Retries append; nothing mutates history.
+- **Audit**: `workflow_run_artifacts` (typed node outputs) + `workflow_hook_result_artifacts`
+  (hook results) already form an audit trail; attempts complete it. Every transition is
+  reconstructable from append-only tables.
+
+### 6.5 Recovery
+
+`SpaceRuntimeService.start()` chains recovery today (long-term inbox →
+`recoverStalledRuns`): skip if work is in flight, finalize if a completion signal is
+recorded, force `blocked` (`agentCrash`) if everything is terminal with no signal. This is
+preserved and **generalized**: GitHub-specific recovery
+(`rehydrateActiveRunPrEventSubscriptions`) moves behind a **connector-declared recovery
+hook** so the recovery pass invokes `connector.recoverRun(run)` for each connector the run
+used (§7).
+
+### 6.6 Idempotency summary
+
+| Operation | Idempotency mechanism |
+|---|---|
+| Activate a node | short-circuit on existing active executions |
+| Deliver a message | `idempotency_key` unique index on inbox |
+| Claim a work item | lease row CAS |
+| Fire completion actions | `completion_actions_fired_at` stamp |
+| Gate open cache | `gate_open_state` with staleness guard |
+| Post-approval dispatch | `postApprovalSessionId` + liveness probe (double-fire guard) |
+
+## 7. Compatibility map — current → target
+
+The migration is extraction behind adapters. Each row is a bounded change; phases in §9.
+
+| Current (domain-specific) | Target (generic) | Adapter strategy |
+|---|---|---|
+| `WorkflowNode.requireCodexApproval` / `codexPollIntervalMs` / `codexTimeoutSeconds` (`space.ts:2287`, dup `:2321`) | `node.gateFeatureOverrides['codex_review_bot']` | dual-read; built-in templates rewritten to the override form; field kept as deprecated alias until templates migrate |
+| `gate-features.ts` Codex compiler (`:209–510`) + Codex validation (`space-workflow-manager.ts:559–646`) | `codex_review_bot` registered via existing `registerGateFeature` plugin | move compiler into a `gate-features/codex.ts` plugin module; validation becomes generic override-schema validation |
+| `pr_url` implicit handoff: `ChannelRouterConfig.getPrUrlForRun` (`channel-router.ts:363`, `:1547`), `gate-script-executor` `PR_URL` env, `gate-evaluator` `gateData.pr_url` (`:563`), post-approval template context, `space_tasks.pr_url/pr_number/pr_created_at` columns (`migrations.ts:2255`) | generic per-run **`runtime_context`** map; `pr_url` is one populated key | dual-read `runtime_context['pr_url'] ?? legacy`; migration 84's stated intent ("replace pr columns with artifacts", `migrations.ts:380`) is the canonical path — PR data moves to `workflow_run_artifacts` |
+| `rehydrateActiveRunPrEventSubscriptions` (`space-runtime-service.ts:2523`) | `connector.recoverRun(run)` invoked for each run-used connector | GitHub connector declares the recovery hook; runtime calls generically |
+| Mutable definitions (`updateWorkflow`) | immutable + versioned, pinned on run (§4) | shadow-write version table first; runs read pinned version; edit produces new version |
+| Inline crash-retry-with-counting | append-only attempts + leases (§6.3–6.4) | introduce attempt table + lease behind flag; behavior identical until multi-worker |
+| Two goal systems: legacy `goals`/`mission_executions` vs `space_goals` | single Goal V2 trigger layer above the engine | legacy tables retained read-only; no new writes; retire after parity |
+
+**What is already correct and untouched:** topology model, agent slots + `toolGuards` +
+`eventInterests`, gate field/script/validator/poll model, channels + cycle caps,
+`pending_agent_messages`/`space_agent_inbox_messages` durable delivery, `gate_open_state`,
+`workflow_run_artifacts`, `task_schedules`/`job_queue` timers, connector registry, the
+"messages communicate, outcomes advance state" invariant, and the LLM workflow selector
+(returning an id with deterministic tag fallback).
+
+## 8. Reference workflows (expressiveness proof)
+
+Four definitions prove the kernel + connectors express each domain **without core changes**.
+The first already exists; the other three are sketched to validate the model, not to ship.
+
+### 8.1 PR review (exists today)
+
+`CODING_WORKFLOW` / `FULLSTACK_QA_LOOP_WORKFLOW` in `built-in-workflows.ts`. Nodes:
+Coder → Review → QA → Post-Approval. Gates: `pr_ready` (connector `github.getPrReadiness`
++ predicate), `codex_review_bot` (feature), human approval gate
+(`completionAutonomyLevel`). Post-approval: PR Merger slot. **Already data-defined**;
+target = same definition with `pr_url` read from `runtime_context` and codex from
+`gateFeatureOverrides`.
+
+### 8.2 Ecommerce return (new sketch)
+
+```
+[intake: receive return] → [eligibility gate] → [inspect] → [decision gate]
+   ├─ refund  → [connector shop.issueRefund] → [notify] → end
+   └─ exchange→ [connector shop.restockItem] → [ship replacement] → end
+```
+- High-value returns: human approval gate (`requiredLevel`).
+- Connectors: `shop.getOrder`, `shop.createReturn`, `shop.issueRefund`, `shop.restockItem`.
+- No GitHub knowledge anywhere in the kernel.
+
+### 8.3 Manufacturing defect / CAPA (new sketch)
+
+```
+[report defect] → [triage: root-cause + severity] → [containment] → [corrective-action gate]
+   → [implement CAPA] → [verification gate] → [close] → end
+```
+- Severity-driven routing via gate fields.
+- QA sign-off gates with `writers: []` (external/human).
+- Recurring goal monitors defect trends (`task_schedule` cron) — leverages Goal V2.
+- Connectors: `mes.fileDefect`, `mes.getRouting`, `mes.recordNonconformance`.
+
+### 8.4 Personal travel assistant (new sketch)
+
+```
+[capture intent] → [search: shop flights + hotels] → [assemble itinerary]
+   → [confirmation gate] → [book] → [pre-trip reminders (timer)] → [during-trip monitor]
+```
+- Confirmation gate = human approval.
+- Timers: `GatePoll` or `task_schedule` for reminders.
+- Connectors: `travel.searchFlights`, `travel.searchHotels`, `travel.book`.
+- Demonstrates human-in-the-loop + timers + multiple connectors.
+
+**Conclusion of §8:** all four domains are expressible as definitions + connectors. No
+field, gate primitive, timer, or delivery concept needs to be added to satisfy them. This
+is the evidence that the generic kernel is sufficient and that BPMN-scale features can be
+deferred.
+
+## 9. Phased roadmap
+
+One compatibility-preserving PR per phase. Each phase: shadow projection or feature flag
+first, dual-read/write only when necessary, migration tests, explicit rollback criteria.
+**No phase removes legacy behavior before parity evidence exists.**
+
+| Phase | Deliverable | Mode | Rollback |
+|---|---|---|---|
+| **0** (this RFC) | RFC + ADR, approval | docs only | n/a |
+| 1 | Immutable versioned definitions; pin `definition_version` on runs | shadow-write version table; runs read pinned version; legacy reads unaffected | drop the pin column; behavior reverts to live-read |
+| 2 | Generic `runtime_context` map; extract `pr_url` behind it | dual-read `runtime_context['pr_url'] ?? legacy`; move `space_tasks.pr_url*` → artifacts (migration 84 intent) | flip dual-read back to legacy |
+| 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` to plugin | keep `requireCodexApproval` as deprecated alias; templates rewritten | alias still honored |
+| 4 | Append-only attempts + leases/fencing (flag-gated) | flag off = single-process no-op; flag on = lease enforced | toggle flag |
+| 5 | Connector-declared `recoverRun` hook; extract PR subscription recovery | GitHub connector declares hook; runtime calls generically; legacy path retained until proven | fall back to legacy rehydrate |
+| 6 | Author ecommerce-return, manufacturing-defect, travel definitions + connectors as **reference fixtures + tests** | read-only reference; no production wiring | remove fixture |
+| 7 | Retire legacy `room/` Mission System (goals/mission_executions) | after parity + no writes for N releases | tables retained read-only |
+
+Phases 1–5 are the dependency-ready core; 6 validates genericity; 7 is cleanup. Each is
+small, reviewable, and independently revertible.
+
+## 10. Deferred features (do not build speculatively)
+
+Each is deferred until a reference workflow or an observed failure requires it.
+
+- **Subprocesses / nested workflow calls.** Current flat + cyclic-channel model suffices;
+  add when a reference workflow genuinely needs composition.
+- **Complex event correlation (CEPII).** Current `eventInterests` topic globs +
+  `subscribe_external_event` suffice.
+- **Distributed / horizontally-scaled execution.** Single-process until a measured
+  bottleneck. Leases (§6.3) are the seam.
+- **Compensation / saga rollback transactions.** Use explicit corrective nodes in the
+  definition instead; add saga semantics only if rollback correctness proves too hard to
+  model declaratively.
+- **Organization / role modeling beyond agent slots + `writers`.** Defer until a domain
+  needs an org chart.
+- **Visual designer / BPMN import / process mining.** Out of scope.
+- **BPEL-style orchestration-vs-choreography refactor.** Current agent-centric choreography
+  is the model; keep it.
+
+## 11. Migration safety invariants (must hold throughout)
+
+1. **No silent reinterpretation of active runs.** A run executes its pinned definition
+   version; definition edits never mutate in-flight runs (Phase 1).
+2. **No legacy removal before parity.** Every extraction keeps the old path until a migration
+   test + production evidence show equivalence.
+3. **One invariant or capability per PR.** Each phase is independently reviewable and
+   revertible (explicit rollback column above).
+4. **Migration tests + restart/concurrency tests accompany every runtime change.** Recovery
+   (`recoverStalledRuns`), idempotency (`idempotency_key`), and lease correctness are
+   tested under crash + duplicate-wake + concurrent-claim.
+5. **Domain-specific concepts never re-enter the generic type or core paths.** The RFC's
+   acceptance criterion: `grep` for `pr_url`, `codex`, `requireCodexApproval` in
+   `packages/shared/src/types/space.ts` and `packages/daemon/src/lib/space/runtime/*`
+   returns nothing outside adapters/plugins (measured over phases, not required at Phase 0).
+
+## 12. Open questions for review
+
+1. **Definition versioning storage**: separate `space_workflow_definition_versions` table vs.
+   in-row versioning with an audit table — which is preferred given the mutation-heavy
+   built-in re-stamping flow?
+2. **Lease scope**: do we want leases required for the single-process path now (stronger
+   invariants, more code) or strictly flag-gated until a second worker exists (smaller
+   blast radius)? This RFC proposes flag-gated; confirm.
+3. **Goal V2 unification**: should legacy `goals`/`mission_executions` be migrated to
+   `space_goals` explicitly, or frozen read-only until organic attrition? (Affects Phase 7
+   only.)
+4. **Reference workflow ownership (Phase 6)**: ship ecommerce/manufacturing/travel as
+   in-tree reference fixtures (recommended) vs. a separate examples package.
+
+Phase 0 produces no code; upon approval, Phase 1 begins behind adapters.

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Data-Defined Workflow Engine
 
-Status: Proposed — Revision 9 (Phase 0, architecture only; no runtime changes).
+Status: Proposed — Revision 10 (Phase 0, architecture only; no runtime changes).
 Incorporates six review rounds (human reviewer + codex-connector bot). Every
 code-level claim below was re-verified directly against the current source this
 revision. Per the agreed scope rule, this revision states **complete invariants +
@@ -85,7 +85,7 @@ We keep the existing vocabulary where correct (a rename would violate incrementa
 | **Timer** | `task_schedules` (new-run cron/at) + `GatePoll` (repeat eval) + hook retry | **No in-run pause/resume** primitive today (§3.5). |
 | **Connector** | `connectors/` registry | Read-only validators/hooks only today; **imperative connector-action steps are a new primitive** (§5). |
 | **Task** | `space_tasks` | User-facing unit; 1:1 with a run. Sole completion source of truth. **archivedAt is the only tombstone.** |
-| **Goal** | `space_goals` (active); `goals`/`mission_executions` (**dormant/legacy**) | One active model; the legacy tables are de-facto frozen (§7). |
+| **Goal** | `space_goals` (active); `goals`/`mission_executions` (**dormant/legacy**) | One active model; the legacy tables are a documented compatibility surface, dormant at runtime (§7). |
 | **Worker** | Space agent session | Agents/humans/services are workers; sessions are resources, not identity. |
 
 **Mental model.** A *Goal* (what/when) creates a *Task* and a *Run* of a *Definition*. The
@@ -127,9 +127,10 @@ activation); mechanism deferred to the phase PR.
 **the only tombstone (non-reopenable) is `SpaceTask.archivedAt`.** Three distinct durability
 signals, not one: (a) **finalization** — release leases / stop timers / stop active dispatch
 when the canonical task is terminal (`done`/`cancelled`) **and** post-approval has resolved
-(the `task.status==='done'` guard in §6.6); (b) **delivery hard-fail** — only on archive or
-explicit hard-cancel, **not** on run-`done`/`cancelled` (those reopen — a `done` run may yet
-receive a follow-up message); (c) **reopen prevention** — archive only. (v4 conflated (a)
+(the `task.status==='done'` guard in §6.6); (b) **delivery hard-fail** — only on **archive**
+(the sole hard-failure condition — `cancelled` reopens, so there is no separate "hard-cancel"
+signal; a user cancel that should discard handoffs archives the task), **not** on
+run-`done`/`cancelled`; (c) **reopen prevention** — archive only. (v4 conflated (a)
 and (b) by saying *all* durability consumers key off archive — that would strand a run whose
 task is `done` but not yet archived; corrected.)
 
@@ -222,9 +223,10 @@ crash during spawn leaves no guard and recovery can spawn a second merger.
      pinned version);
 4. **Read cutover + backfill (migration invariant):** a pin is inert unless run reads
    resolve through it — add a version-aware accessor used by every run read
-   (`channel-router`, `space-runtime`), and at cutover **backfill every existing in-flight
-   run** (snapshot its workflow head into history) so pre-migration runs have a resolvable
-   version and are not stranded. (Accessor shape / backfill SQL = Phase-1-PR scope.)
+   (`channel-router`, `space-runtime`), and at cutover **backfill every existing run whose
+   canonical task is not archived** (including reopenable `done`/`cancelled`) — consistent
+   with the §4.3 deletion guard — so pre-migration reopenable runs have a resolvable version
+   and are not stranded. (Accessor shape / backfill SQL = Phase-1-PR scope.)
 5. **Pinning boundary:** Phase 1 pins the **definition**. Referenced agent configs are a
    **separate mutable dependency** — `resolveAgentInit` loads the current agent at spawn
    (`custom-agent.ts:752`) — so the pinning contract must account for them (snapshot/version
@@ -305,11 +307,14 @@ a non-polled gate.
   delivery class, #859–#862). **Every entry INTO `in_progress` acquires a fresh lease+token**
   — including `idle`/`cancelled` reactivation (which today bypass the `pending→in_progress`
   claim path and would otherwise run with no/stale token); mechanism deferred to Phase 4 PR.
-- **Fencing on EVERY worker-owned write:** a monotonic token invalidates a stale owner only
-  if every transition, outbox enqueue, completion write, and connector-action outcome
-  compares the presented token against the current lease token (guarding only on
-  `current_status` is insufficient — after reclaim, stale and new owners both see
-  `in_progress`).
+- **Fencing scopes to leased-worker writes only:** a monotonic token invalidates a stale
+  owner when every write made *on behalf of a leased worker* (transition, outbox enqueue,
+  completion, connector-action outcome) compares the presented token against the current
+  lease token (guarding only on `current_status` is insufficient — after reclaim, stale and
+  new owners both see `in_progress`). **Unleased commands** — human/kernel actions
+  (approval, cancellation, delivery failure, timer firing) — carry no lease and use
+  status/generation guards, not fencing (so Phase 1b's outbox does not depend on Phase 4's
+  leases).
 - **Durable retry deadlines:** persist `retryAfterMs` to the timer/job model keyed by
   `(run, gate)`, rehydrated/cancelled on restart (not flag-gated — a lost deadline strands
   a gate).
@@ -338,9 +343,9 @@ path move behind connector capabilities (Phase 5).
 
 | Operation | Mechanism |
 |---|---|
-| Activate a node | short-circuit on existing active executions |
+| Activate a node | reconcile the **complete declared slot set** (§3.2), idempotent — a crash mid-fan-out leaves no agent unactivated |
 | Deliver a message | inbox unique key **+ receiver-side dedup / durable ack** |
-| Claim a work item | lease CAS + fencing token checked on **every** worker write |
+| Claim a work item | lease CAS + fencing token checked on every **leased-worker** write (unleased human/kernel commands use status/generation guards) |
 | Mutating connector op | command key (logical identity, stable across attempts) + reconcile-unknown |
 | Post-approval dispatch | **persist dispatch work-item before spawn**; reconcile on recovery |
 | Finalize run | task-status guard (re-entry short-circuits on `task.status==='done'`) |
@@ -408,7 +413,7 @@ that depend on them.
 | 1f | Durable post-approval dispatch: persist the dispatch work-item BEFORE spawning the merger sub-session; reconcile on recovery — closes the spawn→stamp crash window that today lets recovery spawn a second merger (§3.6/§6.6) | new durability row | drain per §11.8 |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection **+ the export format**: `export-format.ts` validates/serializes only the legacy codex fields today, so the override must be added to `exportedWorkflowNodeSchema` + `exportWorkflow` or it's stripped on round-trip) | deprecated alias | alias honored |
-| 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |
+| 4 | Append-only attempts + leases/**fencing on leased-worker writes** (flag-gated); preserve idle/reactivation | flag off = no-op | drain per §11.8 (active leases) |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
 | 5b | **Connector-action step primitive** (durable connector-op steps; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | drain per §11.8 |
@@ -439,7 +444,8 @@ import; process mining. (The premature run-`done` is NOT deferred — Phase 1e o
    + post-approval resolved; **delivery hard-fail** keys off archive or explicit hard-cancel
    (NOT run-`done`/`cancelled`, which reopen); **reopen-prevention / tombstone** =
    `SpaceTask.archivedAt` only.
-7. **Idempotency keys are stable across attempts**; fencing tokens guard every worker write.
+7. **Idempotency keys are stable across attempts**; fencing tokens guard every
+   **leased-worker** write (unleased human/kernel commands use status/generation guards).
 8. **Rollback drains in-flight state, never a bare flag-flip:** any phase that creates
    durable state (outbox rows, retry deadlines, connector-action/timer instances, version
    pins) must, on rollback, keep the schema + dispatcher/worker readable and drain or

--- a/docs/design/workflow-engine-rfc.md
+++ b/docs/design/workflow-engine-rfc.md
@@ -111,20 +111,25 @@ Executable tables the kernel enforces, encoded as data (the
 |---|---|---|---|---|
 | `pending` | run created | (pinned) | definition resolvable | **stamp `definition_version` at creation**, before activation (§4) |
 | `pending` | start node activated | `in_progress` | — | (startWorkflowRun) |
-| `in_progress` | completion resolved post-approval | `done` | task terminal + post-approval finished | reached via `mark_complete`; not on `reportedStatus` alone |
+| `in_progress` | `reportedStatus` set / `CompletionDetector` | `done` (premature today) | `runIsComplete` | **today:** `transitionRunStatusAndEmit(run,'done')` runs at `space-runtime.ts:7814`, BEFORE `dispatchPostApproval` (`:7858`); the task is then parked at `approved` awaiting `mark_complete`. So run-`done` is reached **before** the merger — see Phase 1e |
 | `in_progress` | agent failed / gate needs human | `blocked` | — | `failure_reason` set |
 | `in_progress`/`blocked` | cancel | `cancelled` | — | |
 | `done` | channel send / follow-up | `in_progress` | task not archived | **reopen** (not a tombstone) |
 | `cancelled` | resume | `in_progress` | task not archived | **reopen** |
 
 **Terminal vs tombstone (critical, fixes v2 contradiction):** `done`/`cancelled` are
-*finished attempt states* that reopen; **the only tombstone is `SpaceTask.archivedAt`.**
-Durability consumers (delivery, leases, timers) **must key off task-archive (or explicit
-hard-cancel), never off run `done`/`cancelled`** — otherwise they short-circuit a run that
-is about to be reopened. Today the engine reaches `done` only after `mark_complete`
-(post-merger), so the merger window is already covered by the `approved` task status; no
-new `completing` run-status is required (it would need a `WorkflowRunStatus` migration with
-its own phase — deferred unless a gap is observed).
+*finished attempt states* that reopen (`workflow-run-status-machine.ts`); **the only
+tombstone is `SpaceTask.archivedAt`.** Durability consumers (delivery, leases, timers)
+**must key off task-archive (or explicit hard-cancel), never off run `done`/`cancelled`**.
+
+**Run-`done` is premature today (verified, fixes v3 error):** the tick sets the run to
+`done` at `space-runtime.ts:7814` *before* `dispatchPostApproval` (`:7858`); the task then
+sits at `approved` while the post-approval/merger worker runs, and reaches task-`done` only
+on `mark_complete`. So a run can be `done` while real work (the merger) is still in flight —
+exactly why durability consumers must not key off run-`done`. **Phase 1e** delays the run-`done`
+transition until the post-approval route resolves (or introduces an intermediate nonterminal
+run state); this is a required migration, not deferred. (v3 wrongly claimed `done` is reached
+only via `mark_complete` — corrected.)
 
 ### 3.2 Work item lifecycle (matches `NodeExecutionStatus`, `node-execution-manager.ts:67`)
 
@@ -133,10 +138,10 @@ cancelled` (no `done`); success → reactivatable `idle`.
 
 | from | event | to | guard | side effect |
 |---|---|---|---|---|
-| `pending` | worker claims | `in_progress` | lease + fencing token acquired (§6.3) | append attempt #1 |
+| `pending` | worker claims | `in_progress` | lease + fencing token acquired (§6.3) | **append attempt #N** (single append point) |
 | `in_progress` | terminal outcome | `idle` | — | release lease (reactivatable) |
 | `in_progress` | needs peer input | `waiting_rebind` | — | — |
-| `waiting_rebind`/`idle` | input arrives / crash / lease expiry / timeout | `pending` | budget remaining, not archived | append attempt #N, backoff |
+| `waiting_rebind`/`idle` | input arrives / crash / lease expiry / timeout | `pending` | budget remaining, not archived | (no append — the next claim appends) |
 | any | task archived / hard-cancel | `cancelled` | — | release lease |
 
 **Phase 4 caveat:** because the lifecycle is idle/reactivation-based, Phase 4 must preserve
@@ -223,11 +228,20 @@ must be non-empty).
 
 **Decision (before mutating/imperative connectors ship):**
 - **Command idempotency key** on `ConnectorContext` derived from the **logical command
-  identity** (run + work-item + step + op + params-hash), **stable across every attempt,
-  retry, and reconciliation** — NOT derived from the attempt (a retry gets a new attempt but
-  MUST reuse the same key so the remote deduplicates).
+  identity** (run + work-item + step + op + params-hash) **plus an activation ordinal**,
+  stable across every attempt, retry, and reconciliation — NOT derived from the attempt. The
+  ordinal is essential: a `node_executions` row is **reused on `idle` reactivation**
+  (including cyclic re-entry), so without it, a later *intentional* activation with the same
+  params would hash identically and the remote would suppress the new refund/booking as a
+  "retry." The ordinal is unique per logical activation, reused by all attempts of that
+  activation.
 - **Reconcile-unknown** semantics: a connector must answer "did this command already take
   effect?" so recovery confirms rather than blindly retries.
+- **Connector capability/schema versioning:** the registry today allows an existing
+  connector id to be overwritten; a durable action persisted under one implementation could
+  be recovered/reconciled under a different one after an upgrade. Pin a connector
+  capability/schema version with each durable action and retain a compatible implementation
+  for every in-flight version (do not silently overwrite an in-use connector id).
 - **Connector-action step primitive:** a new work-item/node kind that executes a connector
   op as a durable step with persisted inputs, outcome, retry, and reconciliation — so
   `shop.issueRefund` / `mes.fileDefect` / `travel.book` can run as definition steps, not as
@@ -315,7 +329,7 @@ recovery + the full GitHub event path move behind connector capabilities (Phase 
 | Live-target delivery non-durable; in-memory retry deadlines; upsert "audit" | transactional outbox + durable retries + transition log | Phases 1b/1c/1d |
 | Mutating/imperative connectors unsupported | command-id + reconcile + connector-action step primitive | Phase 4b + 5b |
 | In-run pause/resume timer missing | durable in-run wait/resume primitive | Phase 5c |
-| `goals`/`mission_executions` **dormant/legacy** (schema `:405` labels legacy; `atomicStartExecution`/`insertExecution` have zero non-test callers; automation uses `SpaceGoalRepository`→`space_goals`) | one active goal model above the engine | Phase 7: unification audit; de-facto frozen already |
+| `goals`/`mission_executions` — **documented compatibility surface, dormant at runtime** (CLAUDE.md L172-181 defines them as the Mission System; schema seeds them; `GoalRepository` exists) but **no live production writers** (`atomicStartExecution`/`insertExecution` have zero non-test callers; live automation uses `SpaceGoalRepository`→`space_goals`) | one active goal model above the engine | Phase 7: **treat as a compatibility surface** — audit must prove equivalence before any freeze/remove; assume neither fully-active nor safely-frozen |
 
 **Already correct/untouched:** topology, agent slots + `toolGuards` + `eventInterests`,
 gate field/script/validator/poll, channels + cycle caps, inactive-target durable delivery,
@@ -355,17 +369,18 @@ that depend on them.
 | Phase | Deliverable | Mode | Rollback |
 |---|---|---|---|
 | **0** (this RFC) | RFC + ADR, approval | docs | n/a |
-| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK) | shadow history; pin at creation; live reads unaffected | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
+| 1 | Immutable versioned definitions: in-row `definition_version` **pinned at run creation** + `space_workflow_definition_versions` history; **deletion-safety** (guard all delete/replacement paths; orphan/tombstone; version-level FK); **read cutover** — add a version-aware accessor and route every run read (`channel-router`, `space-runtime`) through the pinned history row, not `getWorkflow(head)` (otherwise the pin is inert) | shadow history; pin at creation; route run reads through pinned version | **keep pins/history additive**; flip readers back only where live definition is provably equivalent (do NOT "drop pin / restore cascade" — there is no cascade) |
 | 1b | Transactional outbox (persist every delivery, live + inactive, in the transition tx) + receiver-side dedup | write both; cutover when proven | fall back to direct live delivery |
 | 1c | Durable connector/gate retry deadlines (rehydrate on restart) | new table/job type | in-memory scheduler still works while populated |
 | 1d | Append-only `workflow_transition_log` | append-only; opt-in readers | stop writing |
+| 1e | **Delay run-`done` until post-approval resolves** — today the run is set `done` at `space-runtime.ts:7814` before `dispatchPostApproval` (`:7858`); move the `done` transition to after the post-approval route resolves, or introduce an intermediate nonterminal run state | behavior change guarded by flag; migration + tests | flag back to premature-`done` |
 | 2 | Generic `runtime_context`; extract `pr_url` handoff | dual-read | flip back |
 | 3 | Generic `gateFeatureOverrides`; extract `codex_review_bot` (3 type copies + projection) | deprecated alias | alias honored |
 | 4 | Append-only attempts + leases/**fencing-on-every-write** (flag-gated); preserve idle/reactivation | flag off = no-op | toggle flag |
 | 4b | Mutating-connector readiness: command key (logical identity, stable across attempts) + reconcile-unknown | read-only connectors unaffected | capability flag |
 | 5 | Full GitHub external-event path behind connector capabilities | legacy retained until proven | fall back |
-| 5b | **Connector-action step primitive** (durable connector-op steps w/ persisted inputs/outcome/retry/reconcile) | new node/work-item kind behind flag | flag off |
-| 5c | **In-run pause/resume timer** primitive + recovery | new timer type | flag off |
+| 5b | **Connector-action step primitive** (durable connector-op steps w/ persisted inputs/outcome/retry/reconcile; command key + activation ordinal + connector version pinned per action) | new node/work-item kind behind flag | **keep handlers/schema readable during rollback**; disable new creation; drain/migrate in-flight instances before removing support (not bare flag-off, which would strand pinned runs) |
+| 5c | **In-run pause/resume timer** primitive + recovery | new timer type | same as 5b — drain/migrate in-flight timers before removing support |
 | 6 | ecommerce-return, manufacturing-defect, travel definitions + connectors as **in-tree `reference/` fixtures** (not seeded) + tests | read-only; no seeding | remove fixture |
 | 7 | Goal-system unification audit (`goals`/`mission_executions` are dormant; decide migrate vs formal-freeze from evidence) | investigation + design first | n/a |
 
@@ -373,8 +388,7 @@ that depend on them.
 
 Subprocesses/nested calls; complex event correlation; distributed execution (leases are the
 seam); compensation/saga (use corrective nodes); org/role modeling; visual designer/BPMN
-import; process mining; formal `completing` run-status (today's `approved` covers the merger
-window — add only if a gap is observed).
+import; process mining. (The premature run-`done` is NOT deferred — Phase 1e owns it.)
 
 ## 11. Migration safety invariants
 
@@ -393,14 +407,19 @@ window — add only if a gap is observed).
 ## 12. Design-review decisions (resolved / revised across 3 rounds)
 
 1. **Definition versioning** → in-row content hash **pinned at run creation** + append-only
-   history table. **Deletion-safety** added (no `workflow_id` FK exists — orphan, not erase;
-   guard all delete paths + orphan policy + version-FK).
-2. **Lease scope** → flag-gated no-op for single-process.
-3. **Goal V2** → `goals`/`mission_executions` is **dormant/legacy** (verified: schema labels
-   it legacy; `atomicStartExecution`/`insertExecution` have zero non-test callers; the live
-   automation handler uses `SpaceGoalRepository`→`space_goals`). De-facto frozen already;
-   Phase 7 is an evidence-driven unification audit. *(v2 wrongly called it "active" —
-   corrected; the original "freeze" was right in substance.)*
+   history table + **read cutover** (route run reads through the pinned version). **Deletion-
+   safety** (no `workflow_id` FK — orphan, not erase; guard all delete paths + version-FK).
+   **Phase 1e** delays run-`done` until post-approval resolves (v3 wrongly claimed `done` is
+   post-`mark_complete`; verified `space-runtime.ts:7814` sets it before `dispatchPostApproval`).
+2. **Lease scope** → flag-gated no-op for single-process; fencing token guards every worker
+   write; mutating-connector keys derive from logical command identity + activation ordinal
+   (stable across attempts), with connector capability versions pinned per action.
+3. **Goal V2** → `goals`/`mission_executions` is a **documented compatibility surface,
+   dormant at runtime** (CLAUDE.md L172-181 defines it as the Mission System; no live
+   writers — `atomicStartExecution`/`insertExecution` have zero non-test callers; automation
+   uses `SpaceGoalRepository`→`space_goals`). Phase 7 treats it as a compatibility surface:
+   prove equivalence before any freeze/remove. *(v2 wrongly called it "active"; v3's
+   "de-facto frozen" overstated it — corrected to compatibility surface.)*
 4. **Reference workflows** → in-tree `reference/` fixtures, not seeded.
 5. **Expressiveness (new)** → "zero kernel changes" re-scoped: connector-action steps
    (Phase 5b) and in-run timers (Phase 5c) are required new primitives for ecommerce/travel.


### PR DESCRIPTION
Phase 0 (architecture only, no runtime changes) for goal task #874 — evolving the Space workflow system into a domain-agnostic, durable execution framework.

Two docs proposing the foundational rule (**data-defined behavior, code-defined semantics, plugin-defined capabilities**) and an incremental, compatibility-first extraction plan grounded in a code survey showing the engine is already ~85% data-defined (no `switch(workflowType)` dispatch; a connector registry already exists behind a flag). The RFC covers canonical concepts, executable state-transition tables, an immutable versioned definition schema, the capability/connector contract, the durability/recovery model (transactions, leases/fencing, inbox/outbox, timers, idempotency, audit), a current→target compatibility map naming the concrete leakage sites (`requireCodexApproval`, the `pr_url` implicit contract, GitHub-specific recovery), four reference workflows (PR review, ecommerce return, manufacturing defect, travel), a phased one-PR-per-phase roadmap with rollback criteria, and a deferred-feature list. ADR 0003 records the decision and consequences.

Looking for design approval on the rule, the roadmap, and the four open questions in RFC §12 before any Phase 1 implementation.