### PR TITLE
feat(daemon): make message-delivery v2 the default, migrate Space injectors

### DIFF
--- a/docs/features/message-delivery-v2.md
+++ b/docs/features/message-delivery-v2.md
@@ -1,8 +1,42 @@
 # Message Delivery v2 — Durable Delivery on `job_queue`
 
-- **Status:** Proposed — supersedes the incremental approach in [`message-delivery-lifecycle.md`](./message-delivery-lifecycle.md) (task #859 phase 2)
+- **Status:** **Default-on** (opt out with `HYPERNEO_MESSAGE_DELIVERY_V2=0`). Supersedes the incremental approach in [`message-delivery-lifecycle.md`](./message-delivery-lifecycle.md) (task #859 phase 2).
 - **Date:** 2026-08-08
 - **Owners:** Marc Liu; design input from Reviewer pass (rounds 1–28)
+
+---
+
+## Default-on & rollback
+
+Message-delivery v2 is the **default** dispatch path. Every primary kickoff —
+ordinary chat (`message.persisted` → `AgentSession.deliverChatMessage`) and the
+Space / long-term-agent / task-agent injectors — routes through the
+`deliverMessage` chokepoint so each user message becomes one durable
+`message_delivery` job_queue row with atomic single-owner claim, lease
+heartbeat, `reclaimStale` crash recovery, and `(session, UUID)`-scoped
+consumption acknowledgment.
+
+**Roll back without a redeploy** by setting, before daemon start:
+
+```
+HYPERNEO_MESSAGE_DELIVERY_V2=0     # or =false
+```
+
+With the flag off, `isMessageDeliveryV2Enabled()` (read at runtime in
+`packages/daemon/src/lib/agent/message-delivery.ts`) returns false and every
+entry point falls back to the legacy inline path it owned before v2:
+
+- Ordinary chat: `message.persisted` → `startQueryAndEnqueue` (inline
+  `ensureQueryStarted` + `enqueueWithId`) instead of `deliverChatMessage`.
+- Space / long-term-agent / task-agent injectors: `ensureQueryStarted` +
+  `enqueueWithId` instead of `deliverAndMarkQueued`.
+
+The legacy deferred-message replay, UI promote-deferred, and rate-limit
+auto-retry kickoffs stay on the inline path under both modes (they are the
+explicit follow-up migration; `recoverOrphanedConsumedMessages` is retained as
+their crash backstop and carries a `durableOwned` guard so it never fights v2-
+owned messages). The flag is read at runtime (no persisted-config skew), so an
+operator can flip it and restart to recover without a code change.
 
 ---
 

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -85,7 +85,7 @@ import {
   TASK_SCHEDULE_FIRE,
 } from './lib/job-queue-constants';
 import { createMessageDeliveryHandler } from './lib/job-handlers/message-delivery.handler';
-import { asMessageDeliveryPayload, isMessageDeliveryV2Enabled } from './lib/agent/message-delivery';
+import { asMessageDeliveryPayload } from './lib/agent/message-delivery';
 import { handleTaskScheduleFire } from './lib/job-handlers/task-schedule-fire.handler';
 import {
   backfillLongHorizonAgentReminderNextRunAt,
@@ -970,21 +970,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       MEMORY_CONSOLIDATION,
       createMemoryConsolidationHandler(db.agentMemory, jobQueue)
     );
-
-    // Message-delivery v2 rollback: if v2 is OFF at boot (the
-    // HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out), drain durable delivery jobs left
-    // over from a prior v2-on run so they don't linger under the legacy regime
-    // — new messages take the legacy inline path, and the drained jobs'
-    // sdk_messages rows (still enqueued/consumed) fall to the legacy replay +
-    // orphan-recovery backstops.
-    if (!isMessageDeliveryV2Enabled()) {
-      const drained = jobQueue.cancelAllMessageDelivery();
-      if (drained > 0) {
-        logInfo(
-          `message_delivery: v2 disabled at boot; cancelled ${drained} lingering durable job(s)`
-        );
-      }
-    }
 
     // Message-delivery v2 — durable user-message delivery on job_queue (flag-
     // gated for ordinary chat; see docs/features/message-delivery-v2.md). The

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -1033,14 +1033,33 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
                 /* dead-letter publish is best-effort */
               });
           }
-          // Release a pre-claim queued marker still owned by this terminal turn.
-          // Conditional settlement preserves any newer turn's ownership.
-          sessionManager
-            ?.getSession(payload.sessionId)
-            ?.settleSkippedDelivery(payload.messageUuid)
-            .catch(() => {
-              /* dead-letter state settlement is best-effort */
-            });
+          // For a task-agent kickoff that dead-lettered before reaching the SDK,
+          // emit session.error and AWAIT it before settling the queued marker:
+          // the marker settlement publishes an idle that registerCompletionCallback
+          // would otherwise treat as successful work (the failed kickoff row
+          // itself satisfies the SDK-message count). session.error fires the
+          // callback's error path → handleSubSessionError marks the execution
+          // blocked instead. Wrapped because onDead is sync; the body runs
+          // ordered fire-and-forget. (Codex P1.)
+          void (async () => {
+            if (payload.origin === 'space_inject') {
+              try {
+                await internalEventBus.publish('session.error', {
+                  sessionId: payload.sessionId,
+                  error: 'Task-agent kickoff delivery exhausted its retries (dead-lettered).',
+                });
+              } catch {
+                /* best-effort */
+              }
+            }
+            // Release a pre-claim queued marker still owned by this terminal turn.
+            // Conditional settlement preserves any newer turn's ownership.
+            await sessionManager
+              ?.getSession(payload.sessionId)
+              ?.settleSkippedDelivery(payload.messageUuid);
+          })().catch(() => {
+            /* dead-letter state settlement is best-effort */
+          });
         },
       }
     );

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -85,6 +85,7 @@ import {
   TASK_SCHEDULE_FIRE,
 } from './lib/job-queue-constants';
 import { createMessageDeliveryHandler } from './lib/job-handlers/message-delivery.handler';
+import { settleMessageDeliveryDeadLetter } from './lib/job-handlers/message-delivery-dead-letter';
 import { asMessageDeliveryPayload } from './lib/agent/message-delivery';
 import { handleTaskScheduleFire } from './lib/job-handlers/task-schedule-fire.handler';
 import {
@@ -1021,43 +1022,24 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
           if (!payload) return;
           const sdkRepo = reactiveDb?.db.getSDKMessageRepo();
           if (!sdkRepo) return;
-          const flipped = sdkRepo.markDeliveryFailedByUuid(payload.sessionId, payload.messageUuid);
-          if (flipped) {
-            internalEventBus
-              .publish('messages.statusChanged', {
-                sessionId: payload.sessionId,
-                messageIds: [flipped],
+          const session = sessionManager?.getSession(payload.sessionId);
+          // Settlement (mark failed → broadcast → session.error for space_inject
+          // → release queued marker) is extracted + unit-tested; the ordering
+          // (session.error before the settlement idle) is load-bearing. See
+          // message-delivery-dead-letter.ts. (Codex P1.)
+          void settleMessageDeliveryDeadLetter(payload, {
+            markDeliveryFailedByUuid: (sid, uuid) => sdkRepo.markDeliveryFailedByUuid(sid, uuid),
+            publishStatusChanged: (sid, messageIds) =>
+              internalEventBus.publish('messages.statusChanged', {
+                sessionId: sid,
+                messageIds,
                 status: 'failed',
-              })
-              .catch(() => {
-                /* dead-letter publish is best-effort */
-              });
-          }
-          // For a task-agent kickoff that dead-lettered before reaching the SDK,
-          // emit session.error and AWAIT it before settling the queued marker:
-          // the marker settlement publishes an idle that registerCompletionCallback
-          // would otherwise treat as successful work (the failed kickoff row
-          // itself satisfies the SDK-message count). session.error fires the
-          // callback's error path → handleSubSessionError marks the execution
-          // blocked instead. Wrapped because onDead is sync; the body runs
-          // ordered fire-and-forget. (Codex P1.)
-          void (async () => {
-            if (payload.origin === 'space_inject') {
-              try {
-                await internalEventBus.publish('session.error', {
-                  sessionId: payload.sessionId,
-                  error: 'Task-agent kickoff delivery exhausted its retries (dead-lettered).',
-                });
-              } catch {
-                /* best-effort */
-              }
-            }
-            // Release a pre-claim queued marker still owned by this terminal turn.
-            // Conditional settlement preserves any newer turn's ownership.
-            await sessionManager
-              ?.getSession(payload.sessionId)
-              ?.settleSkippedDelivery(payload.messageUuid);
-          })().catch(() => {
+              }),
+            publishSessionError: (sid, error) =>
+              internalEventBus.publish('session.error', { sessionId: sid, error }),
+            settleSkippedDelivery: (uuid) =>
+              session?.settleSkippedDelivery(uuid) ?? Promise.resolve(),
+          }).catch(() => {
             /* dead-letter state settlement is best-effort */
           });
         },

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -85,7 +85,7 @@ import {
   TASK_SCHEDULE_FIRE,
 } from './lib/job-queue-constants';
 import { createMessageDeliveryHandler } from './lib/job-handlers/message-delivery.handler';
-import { asMessageDeliveryPayload } from './lib/agent/message-delivery';
+import { asMessageDeliveryPayload, isMessageDeliveryV2Enabled } from './lib/agent/message-delivery';
 import { handleTaskScheduleFire } from './lib/job-handlers/task-schedule-fire.handler';
 import {
   backfillLongHorizonAgentReminderNextRunAt,
@@ -970,6 +970,21 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       MEMORY_CONSOLIDATION,
       createMemoryConsolidationHandler(db.agentMemory, jobQueue)
     );
+
+    // Message-delivery v2 rollback: if v2 is OFF at boot (the
+    // HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out), drain durable delivery jobs left
+    // over from a prior v2-on run so they don't linger under the legacy regime
+    // — new messages take the legacy inline path, and the drained jobs'
+    // sdk_messages rows (still enqueued/consumed) fall to the legacy replay +
+    // orphan-recovery backstops.
+    if (!isMessageDeliveryV2Enabled()) {
+      const drained = jobQueue.cancelAllMessageDelivery();
+      if (drained > 0) {
+        logInfo(
+          `message_delivery: v2 disabled at boot; cancelled ${drained} lingering durable job(s)`
+        );
+      }
+    }
 
     // Message-delivery v2 — durable user-message delivery on job_queue (flag-
     // gated for ordinary chat; see docs/features/message-delivery-v2.md). The

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -982,7 +982,16 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
       MESSAGE_DELIVERY,
       createMessageDeliveryHandler({
         jobQueue,
-        getSession: (sessionId: string) => sessionManager?.getSession(sessionId) ?? null,
+        // Resolve task-agent sub-sessions through TaskAgentManager FIRST: the
+        // provisioned session carries the node-agent MCP server + callbacks that
+        // a generic SessionManager-cached AgentSession lacks, so QueryRunner
+        // would reject startup on its MCP invariant. If the sub-session isn't
+        // rehydrated yet (restart race), fall back to SessionManager — the job
+        // fails on the generic session and retries once rehydration provisions it.
+        getSession: (sessionId: string) =>
+          taskAgentManager?.getSubSession(sessionId) ??
+          sessionManager?.getSession(sessionId) ??
+          null,
         // Status-aware loader: content + send_status. The handler branches on
         // status (consumed = already delivered, don't re-feed; deferred = user
         // deferred; failed = terminal) — see message-delivery.handler + #2592/#2597.

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -735,7 +735,12 @@ export class AcpQueryRunner {
 
               if (!this.ctx.isCleaningUp()) {
                 const processingState = stateManager.getState();
-                await stateManager.setIdle({ suppressDeliveryWaiters: true });
+                // Mirrors the non-ACP runner: this idle is potentially terminal
+                // (the throwing message may have been the final result; no
+                // replacement query starts here), so drain the delivery waiters
+                // rather than suppress — otherwise a durable turn whose result
+                // handling threw hangs `processing` and blocks the turn slot.
+                await stateManager.setIdle();
 
                 await errorManager.handleError(
                   session.id,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -875,7 +875,7 @@ export class AcpQueryRunner {
           ? 'Auto-retrying ACP query after startup timeout (1 retry).'
           : 'Auto-retrying ACP query after transient connection error (1 retry).'
       );
-      await stateManager.setIdle();
+      await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       if (isStartupTimeout && createdAcpSessionDuringRun && !receivedAcpMessageDuringRun) {
         this.persistAcpSessionId(undefined);

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -735,12 +735,15 @@ export class AcpQueryRunner {
 
               if (!this.ctx.isCleaningUp()) {
                 const processingState = stateManager.getState();
-                // Mirrors the non-ACP runner: this idle is potentially terminal
-                // (the throwing message may have been the final result; no
-                // replacement query starts here), so drain the delivery waiters
-                // rather than suppress — otherwise a durable turn whose result
-                // handling threw hangs `processing` and blocks the turn slot.
-                await stateManager.setIdle();
+                // Mirrors the non-ACP runner: only publish the terminal idle
+                // (draining delivery waiters) when the throwing message ends the
+                // turn (the final `result`). A non-terminal message leaves the
+                // ACP run consuming; draining mid-run would release the
+                // active-turn slot while output is still being produced. For a
+                // `result` throw this is the terminal idle. (Codex P1.)
+                if ((acpMessage as SDKMessage).type === 'result') {
+                  await stateManager.setIdle();
+                }
 
                 await errorManager.handleError(
                   session.id,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -735,7 +735,7 @@ export class AcpQueryRunner {
 
               if (!this.ctx.isCleaningUp()) {
                 const processingState = stateManager.getState();
-                await stateManager.setIdle();
+                await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
                 await errorManager.handleError(
                   session.id,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -21,6 +21,7 @@ import { getProviderRegistry } from '../providers/factory';
 import { getProviderService, getUserConfiguredAnthropicEnv } from '../provider-service';
 import { AcpProvider } from '../providers/acp-provider';
 import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from '../agent/transient-error-patterns';
+import { drainDeliveryWaitersOnTerminalSDKMessage } from '../agent/message-delivery';
 import {
   refreshQueryEnvFromProcess,
   type QueryRunnerContext,
@@ -737,13 +738,11 @@ export class AcpQueryRunner {
                 const processingState = stateManager.getState();
                 // Mirrors the non-ACP runner: only publish the terminal idle
                 // (draining delivery waiters) when the throwing message ends the
-                // turn (the final `result`). A non-terminal message leaves the
-                // ACP run consuming; draining mid-run would release the
-                // active-turn slot while output is still being produced. For a
-                // `result` throw this is the terminal idle. (Codex P1.)
-                if ((acpMessage as SDKMessage).type === 'result') {
-                  await stateManager.setIdle();
-                }
+                // turn (the final `result`).
+                await drainDeliveryWaitersOnTerminalSDKMessage(
+                  stateManager,
+                  acpMessage as SDKMessage
+                );
 
                 await errorManager.handleError(
                   session.id,

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -893,7 +893,7 @@ export class AgentSession
   // Interrupt and Reset
   // ============================================================================
 
-  async handleInterrupt(): Promise<void> {
+  async handleInterrupt(opts?: { preserveDeliveryJobs?: boolean }): Promise<void> {
     // Cancel any rate-limit recovery so an in-flight fallback switch / armed
     // cooldown timer can't switch the model or replay the stale message after
     // the user explicitly stopped the turn.
@@ -902,8 +902,9 @@ export class AgentSession
     // The durable-delivery cancel lives in InterruptHandler.handleInterrupt —
     // the single chokepoint every interrupt path reaches (client.interrupt RPC
     // → agent.interruptRequest subscriber → the raw handler, and the space
-    // paths via this wrapper). See Codex (#3744105273).
-    await this.interruptHandler.handleInterrupt();
+    // paths via this wrapper). See Codex (#3744105273). `preserveDeliveryJobs`
+    // is forwarded for restart-bound shutdown stops.
+    await this.interruptHandler.handleInterrupt(opts);
   }
 
   async resetQuery(options?: {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1155,8 +1155,10 @@ export class AgentSession
       ) {
         this.logger.info('Rate limit auto-retry aborted before re-enqueue (episode superseded).');
         // The durable turn this retry would have re-driven is abandoned — release
-        // its turn-end waiter so the job doesn't hang `processing`.
-        this.stateManager.releaseIdleWaiters();
+        // its turn-end waiter so the job doesn't hang `processing`. Scope the
+        // release to this episode's generation so a NEWER turn's waiter (armed
+        // after the cancel/reset bumped the generation) is left untouched.
+        this.stateManager.releaseIdleWaiters(episodeGeneration);
         return false;
       }
 
@@ -1874,7 +1876,16 @@ export class AgentSession
       // restored as idle and the streaming query doesn't leave idle until input
       // is observed, so treating that pre-input idle as terminal would complete
       // the durable job while history replay is still running.
-      const turnEnd = this.stateManager.waitForIdleTransition();
+      // Tag the waiter with the current rate-limit episode generation so a
+      // narrowly-scoped release (a superseded rate-limit retry calling
+      // releaseIdleWaiters(episodeGeneration)) resolves only this turn's waiter
+      // — not a newer turn's waiter armed after a cancel()/reset() bumped the
+      // generation. The generation here equals the one scheduleRetry later
+      // captures as episodeGeneration (its own supersession guard keeps the
+      // generation stable at this value through the 429'd turn's life).
+      const turnEnd = this.stateManager.waitForIdleTransition(
+        this.rateLimitWatchdog.getGeneration()
+      );
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
       // prior attempt already did (alreadyConsumed = reclaim after a crash): the
       // SDK resume-from-history already holds a consumed kickoff, so re-feeding
@@ -1911,16 +1922,16 @@ export class AgentSession
     }
     // Long awaits OUTSIDE the lock — ownership mutations and mid-turn steers can
     // proceed while the provider acknowledges the kickoff and runs the turn.
-    await started.acknowledgment;
     // Complete at TURN-END (the idle transition). queryPromise is raced only as
     // a safety net for a query that closes without an idle (e.g. a hard crash);
     // in streaming-input mode queryPromise never resolves at turn-end, so
     // turnEnd wins and the job completes promptly when the SDK finishes the turn.
     try {
+      await started.acknowledgment;
       await Promise.race([started.turnEnd.promise, started.queryPromise.catch(() => {})]);
     } finally {
       // Cancel the waiter if it didn't win the race (e.g. queryPromise resolved
-      // on query-close) so it isn't left in the map.
+      // on query-close, or acknowledgment rejected) so it isn't left in the map.
       started.turnEnd.cancel();
     }
     return { outcome: 'completed' };

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -2039,8 +2039,16 @@ export class AgentSession
       // steer can never steal it by publishing message.persisted first.
       let role: 'turn' | 'steer';
       try {
+        // Legacy-owned turn guard (see deliverAndMarkQueued): a session can be
+        // `processing` a legacy-replayed turn with no active v2 turn row; force a
+        // steer so this chat parks behind it instead of racing it. The deferred
+        // legacy-replay migration removes the need for this guard. (Codex P1.)
+        const legacyOwnedTurn =
+          this.stateManager.getState().status === 'processing' &&
+          !this.db.getJobQueueRepo().hasActiveTurnDelivery(this.session.id);
         role = deliverMessage(this.db.getJobQueueRepo(), this.session.id, messageUuid, {
           origin: 'chat',
+          ...(legacyOwnedTurn ? { role: 'steer' as const } : {}),
         });
       } catch (err) {
         // The user row was already saved `enqueued` by MessagePersistence. If job

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1942,7 +1942,7 @@ export class AgentSession
       // confirm the source record only after genuine consumption, not bare
       // enqueue (which can still dead-letter). No-op when no waiter is armed.
       // (Codex P1.)
-      signalDeliveryConsumed(messageUuid);
+      signalDeliveryConsumed(this.session.id, messageUuid);
       await Promise.race([started.turnEnd.promise, started.queryPromise.catch(() => {})]);
     } finally {
       // Cancel the waiter if it didn't win the race (e.g. queryPromise resolved
@@ -2003,7 +2003,7 @@ export class AgentSession
     await action.acknowledgment;
     // The steer was consumed by the live turn (onSent) — signal long-horizon
     // delivery waiters awaiting consumption. No-op when none are armed. (Codex P1.)
-    signalDeliveryConsumed(messageUuid);
+    signalDeliveryConsumed(this.session.id, messageUuid);
     return { outcome: 'consumed' };
   }
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1855,6 +1855,14 @@ export class AgentSession
       if (claimGuard && !claimGuard()) {
         return { kind: 'aborted' as const };
       }
+      // Arm the turn-end wait BEFORE ensureQueryStarted: a reclaimed consumed
+      // turn resumes from history during the async query start, and a fast
+      // terminal idle would be missed by a waiter armed afterward (the job would
+      // then hang `processing` because the streaming queryPromise never resolves
+      // at turn-end). On the 'blocked' path the waiter resolves harmlessly on a
+      // later idle — the job parks and re-drives, re-arming. See
+      // ProcessingStateManager.waitForIdleTransition.
+      const turnEnd = this.stateManager.waitForIdleTransition();
       const queryStartResult = await this.lifecycleManager.ensureQueryStarted();
       if (queryStartResult === 'blocked') {
         return { kind: 'blocked' as const };
@@ -1863,14 +1871,6 @@ export class AgentSession
       if (!queryPromise) {
         throw new Error('message_delivery: query did not start; cannot drive turn');
       }
-      // Arm the turn-end wait BEFORE the kickoff can be consumed: the delivery
-      // job must stay `processing` for the SDK turn's duration and complete at
-      // turn-end (the idle transition), not at query-close. queryPromise only
-      // resolves on query-CLOSE — in streaming-input mode that is never at
-      // turn-end, so awaiting it alone hangs the job `processing` forever and
-      // every later message misclassifies as a steer. See
-      // ProcessingStateManager.waitForIdleTransition.
-      const turnEnd = this.stateManager.waitForIdleTransition();
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
       // prior attempt already did (alreadyConsumed = reclaim after a crash): the
       // SDK resume-from-history already holds a consumed kickoff, so re-feeding

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -2032,12 +2032,21 @@ export class AgentSession
         this.db.getSDKMessageRepo().markDeliveryFailedByUuid(this.session.id, messageUuid);
         throw err;
       }
-      if (role === 'turn') {
-        // A new chat turn supersedes any armed rate-limit cooldown: cancel the
-        // watchdog so its timer doesn't replay the previous prompt instead of
-        // letting this turn run. The legacy inline path did this at the top of
-        // startQueryAndEnqueue; the v2 chat path bypasses it, so do it here.
+      // A new chat message supersedes an armed rate-limit recovery episode. For a
+      // `turn` this always holds (fresh user input). For a `steer` it must ALSO
+      // hold while the session is in rate_limit_cooldown: the prior durable turn
+      // still occupies the active-turn slot there, so the replacement is
+      // classified as a steer and would park while the watchdog's timer replays
+      // the stale prompt instead of letting the user's replacement take over.
+      // (Mirrors the legacy inline path's unconditional cancel at the top of
+      // startQueryAndEnqueue.) Gate the steer case on the cooldown state so a
+      // normal steer into a LIVE turn does NOT bump the generation — that would
+      // desync the rate-limit episode from the active turn's turn-end waiter tag
+      // (see driveDeliveryTurn) and strand it on a later 429. (Codex P1.)
+      if (role === 'turn' || this.stateManager.getState().status === 'rate_limit_cooldown') {
         this.rateLimitWatchdog.cancel();
+      }
+      if (role === 'turn') {
         try {
           // Preserve a legacy-owned live turn: role arbitration can return turn
           // when no durable turn row exists even though the session is processing.

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1154,6 +1154,9 @@ export class AgentSession
         this.rateLimitWatchdog.isSuperseded(episodeGeneration)
       ) {
         this.logger.info('Rate limit auto-retry aborted before re-enqueue (episode superseded).');
+        // The durable turn this retry would have re-driven is abandoned — release
+        // its turn-end waiter so the job doesn't hang `processing`.
+        this.stateManager.releaseIdleWaiters();
         return false;
       }
 
@@ -1855,26 +1858,24 @@ export class AgentSession
       if (claimGuard && !claimGuard()) {
         return { kind: 'aborted' as const };
       }
-      // Arm the turn-end wait BEFORE ensureQueryStarted: a reclaimed consumed
-      // turn resumes from history during the async query start, and a fast
-      // terminal idle would be missed by a waiter armed afterward (the job would
-      // then hang `processing` because the streaming queryPromise never resolves
-      // at turn-end). On the 'blocked' path the waiter resolves harmlessly on a
-      // later idle — the job parks and re-drives, re-arming. See
-      // ProcessingStateManager.waitForIdleTransition.
-      const turnEnd = this.stateManager.waitForIdleTransition();
       const queryStartResult = await this.lifecycleManager.ensureQueryStarted();
       if (queryStartResult === 'blocked') {
-        // Park: cancel the turn-end waiter so it doesn't accumulate across the
-        // 5s reclaims. The next drive attempt arms a fresh one.
-        turnEnd.cancel();
         return { kind: 'blocked' as const };
       }
       const queryPromise = this.queryPromise;
       if (!queryPromise) {
-        turnEnd.cancel();
         throw new Error('message_delivery: query did not start; cannot drive turn');
       }
+      // Arm the turn-end wait AFTER ensureQueryStarted: ensureQueryStarted awaits
+      // a preceding interrupt's completion, and that interrupt's terminal
+      // setIdle() fires BEFORE the await resolves — arming earlier would let it
+      // resolve this turn's waiter for a turn that hasn't started yet. If the
+      // session is somehow already idle here (an instant reclaimed turn ended
+      // during startup), complete immediately rather than hanging on an idle
+      // that already passed.
+      const turnEnd = this.stateManager.isIdle()
+        ? { promise: Promise.resolve(), cancel: () => {} }
+        : this.stateManager.waitForIdleTransition();
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
       // prior attempt already did (alreadyConsumed = reclaim after a crash): the
       // SDK resume-from-history already holds a consumed kickoff, so re-feeding
@@ -2022,6 +2023,11 @@ export class AgentSession
         throw err;
       }
       if (role === 'turn') {
+        // A new chat turn supersedes any armed rate-limit cooldown: cancel the
+        // watchdog so its timer doesn't replay the previous prompt instead of
+        // letting this turn run. The legacy inline path did this at the top of
+        // startQueryAndEnqueue; the v2 chat path bypasses it, so do it here.
+        this.rateLimitWatchdog.cancel();
         try {
           // Preserve a legacy-owned live turn: role arbitration can return turn
           // when no durable turn row exists even though the session is processing.

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1176,7 +1176,14 @@ export class AgentSession
       return true;
     } catch (error) {
       this.logger.error('Rate limit auto-retry failed:', error);
-      await this.stateManager.setIdle();
+      // Suppress the drain: returning false makes the watchdog schedule another
+      // startup attempt for this same episode, so the old prompt is still slated
+      // for replay — draining here would complete the durable job and free the
+      // active-turn slot while the retry continues, letting a new message admit
+      // as a competing turn. The waiter is released when the episode is actually
+      // abandoned (supersession → releaseIdleWaiters(gen) above) or superseded by
+      // a successful retry (terminal idle). (Codex P1.)
+      await this.stateManager.setIdle({ suppressDeliveryWaiters: true });
       return false;
     }
   }

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1955,8 +1955,8 @@ export class AgentSession
    * Ordinary-chat entry for message-delivery v2: enqueue a durable delivery job
    * (role decided atomically by the job_queue index) instead of driving the
    * query inline. The message_delivery handler then drives/feeds the turn.
-   * Flag-gated; the `message.persisted` subscriber calls this only when
-   * HYPERNEO_MESSAGE_DELIVERY_V2 is set.
+   * Default-on (HYPERNEO_MESSAGE_DELIVERY_V2); the `message.persisted`
+   * subscriber calls this unless the flag is explicitly disabled (=0).
    */
   async settleSkippedDelivery(messageUuid: string): Promise<void> {
     await withSessionLock(this.session.id, () =>

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1865,10 +1865,14 @@ export class AgentSession
       const turnEnd = this.stateManager.waitForIdleTransition();
       const queryStartResult = await this.lifecycleManager.ensureQueryStarted();
       if (queryStartResult === 'blocked') {
+        // Park: cancel the turn-end waiter so it doesn't accumulate across the
+        // 5s reclaims. The next drive attempt arms a fresh one.
+        turnEnd.cancel();
         return { kind: 'blocked' as const };
       }
       const queryPromise = this.queryPromise;
       if (!queryPromise) {
+        turnEnd.cancel();
         throw new Error('message_delivery: query did not start; cannot drive turn');
       }
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
@@ -1885,6 +1889,7 @@ export class AgentSession
         // Without this recheck both attempts would admit the same kickoff. See
         // Codex (#3744971818).
         if (claimGuard && !claimGuard()) {
+          turnEnd.cancel();
           return { kind: 'aborted' as const };
         }
         acknowledgment = this.messageQueue.admitWithId(messageUuid, content, false, {
@@ -1911,7 +1916,13 @@ export class AgentSession
     // a safety net for a query that closes without an idle (e.g. a hard crash);
     // in streaming-input mode queryPromise never resolves at turn-end, so
     // turnEnd wins and the job completes promptly when the SDK finishes the turn.
-    await Promise.race([started.turnEnd, started.queryPromise.catch(() => {})]);
+    try {
+      await Promise.race([started.turnEnd.promise, started.queryPromise.catch(() => {})]);
+    } finally {
+      // Cancel the waiter if it didn't win the race (e.g. queryPromise resolved
+      // on query-close) so it isn't left in the map.
+      started.turnEnd.cancel();
+    }
     return { outcome: 'completed' };
   }
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1137,8 +1137,12 @@ export class AgentSession
     );
 
     try {
-      // Ensure the session is idle before starting a new query
-      await this.stateManager.setIdle();
+      // Ensure the session is idle before starting a new query. Suppress the
+      // delivery-waiter drain: this idle is a retry mid-point (the query is
+      // re-started below via startQueryAndEnqueue), not a terminal turn-end —
+      // draining here would complete the durable job while the prompt is still
+      // being retried, freeing the active-turn slot for a competing turn.
+      await this.stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       // A cancel/reset/interrupt during the setIdle await (or the preceding
       // switch teardown) bumps the episode generation. Don't re-enqueue the stale

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -218,6 +218,7 @@ import { MessageQueue } from './message-queue';
 import {
   MESSAGE_DELIVERY_PARK_MS,
   deliverMessage,
+  signalDeliveryConsumed,
   withSessionLock,
   type DriveTurnOutcome,
   type FeedSteerOutcome,
@@ -1929,6 +1930,12 @@ export class AgentSession
     // turnEnd wins and the job completes promptly when the SDK finishes the turn.
     try {
       await started.acknowledgment;
+      // The kickoff was admitted by the SDK (onSent) — the message is consumed.
+      // Signal long-horizon delivery waiters (injectLongTermAgentMessage) so they
+      // confirm the source record only after genuine consumption, not bare
+      // enqueue (which can still dead-letter). No-op when no waiter is armed.
+      // (Codex P1.)
+      signalDeliveryConsumed(messageUuid);
       await Promise.race([started.turnEnd.promise, started.queryPromise.catch(() => {})]);
     } finally {
       // Cancel the waiter if it didn't win the race (e.g. queryPromise resolved
@@ -1987,6 +1994,9 @@ export class AgentSession
     // Admission happened atomically under the lock; only the provider
     // acknowledgment is awaited here.
     await action.acknowledgment;
+    // The steer was consumed by the live turn (onSent) — signal long-horizon
+    // delivery waiters awaiting consumption. No-op when none are armed. (Codex P1.)
+    signalDeliveryConsumed(messageUuid);
     return { outcome: 'consumed' };
   }
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1869,13 +1869,12 @@ export class AgentSession
       // Arm the turn-end wait AFTER ensureQueryStarted: ensureQueryStarted awaits
       // a preceding interrupt's completion, and that interrupt's terminal
       // setIdle() fires BEFORE the await resolves — arming earlier would let it
-      // resolve this turn's waiter for a turn that hasn't started yet. If the
-      // session is somehow already idle here (an instant reclaimed turn ended
-      // during startup), complete immediately rather than hanging on an idle
-      // that already passed.
-      const turnEnd = this.stateManager.isIdle()
-        ? { promise: Promise.resolve(), cancel: () => {} }
-        : this.stateManager.waitForIdleTransition();
+      // resolve this turn's waiter for a turn that hasn't started yet. Don't
+      // short-circuit on a current isIdle(): a reclaimed consumed turn is
+      // restored as idle and the streaming query doesn't leave idle until input
+      // is observed, so treating that pre-input idle as terminal would complete
+      // the durable job while history replay is still running.
+      const turnEnd = this.stateManager.waitForIdleTransition();
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
       // prior attempt already did (alreadyConsumed = reclaim after a crash): the
       // SDK resume-from-history already holds a consumed kickoff, so re-feeding

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1859,6 +1859,14 @@ export class AgentSession
       if (!queryPromise) {
         throw new Error('message_delivery: query did not start; cannot drive turn');
       }
+      // Arm the turn-end wait BEFORE the kickoff can be consumed: the delivery
+      // job must stay `processing` for the SDK turn's duration and complete at
+      // turn-end (the idle transition), not at query-close. queryPromise only
+      // resolves on query-CLOSE — in streaming-input mode that is never at
+      // turn-end, so awaiting it alone hangs the job `processing` forever and
+      // every later message misclassifies as a steer. See
+      // ProcessingStateManager.waitForIdleTransition.
+      const turnEnd = this.stateManager.waitForIdleTransition();
       // Feed the kickoff (resolves on onSent = the SDK consumed it) UNLESS a
       // prior attempt already did (alreadyConsumed = reclaim after a crash): the
       // SDK resume-from-history already holds a consumed kickoff, so re-feeding
@@ -1879,7 +1887,7 @@ export class AgentSession
           durable: true,
         });
       }
-      return { kind: 'driving' as const, queryPromise, acknowledgment };
+      return { kind: 'driving' as const, queryPromise, turnEnd, acknowledgment };
     });
     if (started.kind === 'blocked') {
       // Mirror the legacy startQueryAndEnqueue path: report the session as
@@ -1895,7 +1903,11 @@ export class AgentSession
     // Long awaits OUTSIDE the lock — ownership mutations and mid-turn steers can
     // proceed while the provider acknowledges the kickoff and runs the turn.
     await started.acknowledgment;
-    await started.queryPromise.catch(() => {});
+    // Complete at TURN-END (the idle transition). queryPromise is raced only as
+    // a safety net for a query that closes without an idle (e.g. a hard crash);
+    // in streaming-input mode queryPromise never resolves at turn-end, so
+    // turnEnd wins and the job completes promptly when the SDK finishes the turn.
+    await Promise.race([started.turnEnd, started.queryPromise.catch(() => {})]);
     return { outcome: 'completed' };
   }
 

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -455,8 +455,17 @@ export class AskUserQuestionHandler {
     // perspective. Going to idle (rather than processing) lets the SDK
     // query restart cleanly via ensureQueryStarted(). Suppress the delivery-
     // waiter drain: this idle is a retry mid-point (the query restarts below to
-    // inject the tool result), not a terminal turn-end.
-    await stateManager.setIdle({ suppressDeliveryWaiters: true });
+    // inject the tool result), not a terminal turn-end. If the suppressed idle
+    // rejects (e.g. a session.updated subscriber fails during publish), release
+    // the waiter before propagating — this sits outside the reinjection try
+    // below, so without the release the durable turn would hang `processing`.
+    // (Codex P1.)
+    try {
+      await stateManager.setIdle({ suppressDeliveryWaiters: true });
+    } catch (idleError) {
+      stateManager.releaseIdleWaiters();
+      throw idleError;
+    }
 
     // Build the tool_result content text. For `allow`, serialize the answers
     // as JSON so the agent can parse them. For `deny`, use the cancellation

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -517,6 +517,16 @@ export class AskUserQuestionHandler {
         `AskUserQuestion ${toolUseId}: failed to inject tool_result after restart`,
         error
       );
+      // The answer reinjection failed, so this turn can't continue: end it
+      // (terminal setIdle) to release the durable-delivery turn waiter —
+      // otherwise driveDeliveryTurn's job hangs `processing` waiting for an
+      // idle that will never come. Best-effort; don't let a publish failure
+      // mask the original error.
+      try {
+        await stateManager.setIdle();
+      } catch {
+        /* non-fatal — the turn is abandoned either way */
+      }
       // Leave the queued answer in place — a future canUseTool fire can
       // still consume it. Do not rethrow; the user's RPC already
       // succeeded from their perspective (the question is marked

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -453,8 +453,10 @@ export class AskUserQuestionHandler {
 
     // Drop waiting_for_input state — the question is resolved from the user's
     // perspective. Going to idle (rather than processing) lets the SDK
-    // query restart cleanly via ensureQueryStarted().
-    await stateManager.setIdle();
+    // query restart cleanly via ensureQueryStarted(). Suppress the delivery-
+    // waiter drain: this idle is a retry mid-point (the query restarts below to
+    // inject the tool result), not a terminal turn-end.
+    await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
     // Build the tool_result content text. For `allow`, serialize the answers
     // as JSON so the agent can parse them. For `deny`, use the cancellation

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -482,12 +482,22 @@ export class AskUserQuestionHandler {
 
     const mode: 'submitted' | 'cancelled' = result.behavior === 'allow' ? 'submitted' : 'cancelled';
 
-    await internalEventBus.publish('question.injected_as_tool_result', {
-      sessionId: session.id,
-      toolUseId,
-      mode,
-      viaCanUseTool: false,
-    });
+    // This publish sits between the suppressed idle above and the reinjection
+    // try below; a rejecting subscriber would stop execution before the
+    // reinjection catch's terminal idle, leaving the durable turn waiter
+    // pending (the question is already resolved, so nothing retries it). Wrap it
+    // in the same release-on-failure cleanup. (Codex P1.)
+    try {
+      await internalEventBus.publish('question.injected_as_tool_result', {
+        sessionId: session.id,
+        toolUseId,
+        mode,
+        viaCanUseTool: false,
+      });
+    } catch (publishError) {
+      stateManager.releaseIdleWaiters();
+      throw publishError;
+    }
 
     // Best-effort: start the SDK query and enqueue the tool_result. If the
     // agent session has no ensureQueryStarted (e.g. a unit-test context),

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -126,11 +126,11 @@ export class EventSubscriptionSetup {
       'message.persisted',
       async (data) => {
         if (data.skipQueryStart) return;
-        // Message-delivery v2: route ordinary chat through the durable job_queue
-        // chokepoint (role decided atomically by the index) instead of driving
-        // the query inline. Flag-gated; Space injectors still call
-        // startQueryAndEnqueue directly (migrated in step 2). See
-        // docs/features/message-delivery-v2.md §12.
+        // Message-delivery v2 (default-on): route ordinary chat through the
+        // durable job_queue chokepoint (role decided atomically by the index)
+        // instead of driving the query inline. Space / long-term-agent injectors
+        // route through the same durable path via deliverAndMarkQueued. See
+        // docs/features/message-delivery-v2.md.
         if (isMessageDeliveryV2Enabled() && this.ctx.deliverChatMessage) {
           await this.ctx.deliverChatMessage(data.messageId);
           return;

--- a/packages/daemon/src/lib/agent/interrupt-handler.ts
+++ b/packages/daemon/src/lib/agent/interrupt-handler.ts
@@ -58,8 +58,16 @@ export class InterruptHandler {
   /**
    * Handle interrupt request
    * Uses official SDK interrupt() method
+   *
+   * Pass `{ preserveDeliveryJobs: true }` on a stop path that is about to
+   * RESTART (daemon graceful shutdown): the caller has already requeued in-flight
+   * message_delivery rows for the next boot, so the default cancel-everything
+   * behavior here would delete the very handoff that requeue preserved. The
+   * query abort + SDK interrupt still run (the in-flight turn must unwind so
+   * cleanup doesn't block); only the durable-job cancellation is skipped.
+   * (Codex P1.)
    */
-  async handleInterrupt(): Promise<void> {
+  async handleInterrupt(opts?: { preserveDeliveryJobs?: boolean }): Promise<void> {
     const { session, messageHub, messageQueue, stateManager, logger } = this.ctx;
 
     // Durable-delivery cancel FIRST (message-delivery v2): revoke EVERY active
@@ -69,16 +77,19 @@ export class InterruptHandler {
     // handler, space paths via the AgentSession wrapper). Without it a pending
     // turn/steer job survives the user's interrupt and is claimed afterwards.
     // Legacy path: no message_delivery jobs exist → no-op. Consumed rows are
-    // untouched (they WERE delivered). See Codex (#3743968030, #3744105273).
-    await withSessionLock(session.id, async () => {
-      const messageUuids =
-        this.ctx.db.getJobQueueRepo?.()?.cancelForSessionWithMessages(session.id) ?? [];
-      if (messageUuids.length === 0) return;
-      const sdkRepo = this.ctx.db.getSDKMessageRepo?.();
-      for (const messageUuid of messageUuids) {
-        sdkRepo?.markDeliveryFailedByUuid(session.id, messageUuid);
-      }
-    });
+    // untouched (they WERE delivered). SKIPPED on a restart-bound shutdown stop
+    // (see opts.preserveDeliveryJobs). See Codex (#3743968030, #3744105273).
+    if (!opts?.preserveDeliveryJobs) {
+      await withSessionLock(session.id, async () => {
+        const messageUuids =
+          this.ctx.db.getJobQueueRepo?.()?.cancelForSessionWithMessages(session.id) ?? [];
+        if (messageUuids.length === 0) return;
+        const sdkRepo = this.ctx.db.getSDKMessageRepo?.();
+        for (const messageUuid of messageUuids) {
+          sdkRepo?.markDeliveryFailedByUuid(session.id, messageUuid);
+        }
+      });
+    }
 
     const currentState = stateManager.getState();
 

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -360,15 +360,17 @@ export async function withSessionLock<T>(sessionId: string, fn: () => Promise<T>
  * session queued — as ONE per-session critical section (under
  * {@link withSessionLock}). Role arbitration and queued ownership must be atomic
  * so a concurrently-injected steer can never win the queued marker that belongs
- * to the turn. This is the shared primitive behind `AgentSession.deliverChatMessage`
- * and the migrated Space / long-term-agent injectors; the caller persists the
- * user message BEFORE calling this (the handler reloads content by UUID).
+ * to the turn. Used by the migrated Space (`spaceAgentInjector`,
+ * `injectMessageIntoSession`) and long-term-agent injectors; the caller persists
+ * the user message BEFORE calling this (the handler reloads content by UUID).
+ * (`AgentSession.deliverChatMessage` inlines the same deliver + mark-queued
+ * sequence rather than calling this — it needs the role for its cooldown
+ * supersession, so it doesn't fit the shared shape.)
  *
- * `stateManager` is optional so callers whose session view doesn't expose it
- * (e.g. the long-term-agent structural type) skip the queued marker rather than
- * crash; on a real AgentSession it is present and the marker is set.
- * `onEnqueueFailure` (if provided) terminalizes the persisted row when
- * `deliverMessage` throws, mirroring `deliverChatMessage`'s failure handling.
+ * `stateManager` is optional: when absent (e.g. a long-term-agent session view
+ * that doesn't expose it) the queued marker is skipped instead of crashing; on a
+ * real AgentSession it is present and the marker is set. `onEnqueueFailure`
+ * (if provided) terminalizes the persisted row when `deliverMessage` throws.
  */
 export async function deliverAndMarkQueued(args: {
   jobQueue: JobQueueRepository;

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -10,9 +10,10 @@
  *
  * See docs/features/message-delivery-v2.md for the full design.
  *
- * Flag-gated (HYPERNEO_MESSAGE_DELIVERY_V2); ordinary chat is routed first
- * (§12 step 1). Space injectors + diagnostics re-pointing + decommissioning of
- * the phase-1 reconciliation machinery follow in steps 2–4.
+ * Default-on (opt out with `HYPERNEO_MESSAGE_DELIVERY_V2=0`). Ordinary chat and
+ * the Space / long-term-agent injectors all route through `deliverMessage`; the
+ * legacy deferred-replay and rate-limit-retry kickoffs remain on the inline path
+ * (backstopped by `recoverOrphanedConsumedMessages`) pending a follow-up.
  */
 
 import type { MessageContent } from '@hyperneo/shared';
@@ -44,15 +45,14 @@ export type MessageDeliveryPayload = {
 };
 
 /**
- * The env-var gate for the v2 path. While off, ordinary chat keeps using the
- * `message.persisted → startQueryAndEnqueue` flow untouched. Steps 2–4 migrate
- * the remaining origins and then decommission the old path.
+ * The env-var gate for the v2 path. Default ON — durable delivery owns dispatch
+ * for ordinary chat and the Space/long-term-agent injectors. Set
+ * `HYPERNEO_MESSAGE_DELIVERY_V2=0` (or `=false`) to roll back to the legacy
+ * `message.persisted → startQueryAndEnqueue` inline flow.
  */
 export function isMessageDeliveryV2Enabled(): boolean {
-  return (
-    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 === '1' ||
-    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 === 'true'
-  );
+  const v = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+  return v !== '0' && v !== 'false';
 }
 
 /**

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -254,6 +254,61 @@ export interface MessageDeliverySession {
 }
 
 /**
+ * Per-messageUuid consumption waiters. The long-horizon injector awaits its
+ * durable job's SDK consumption (onSent) before confirming the source record —
+ * restoring the legacy "delivered = consumed" semantic that the v2 fire-and-
+ * forget enqueue regressed. The bridge signals here from
+ * {@link MessageDeliverySession.driveDeliveryTurn}/{@link feedDeliverySteer}
+ * when the SDK admits the message. (Codex P1.)
+ */
+const deliveryConsumptionWaiters = new Map<string, Set<() => void>>();
+
+/**
+ * Register a wait for the durable job's SDK consumption. The `promise` resolves
+ * when {@link signalDeliveryConsumed} fires for this UUID (or never, if the job
+ * never reaches the SDK — bound the wait with a timeout and call `cancel()` to
+ * avoid leaking the entry).
+ */
+export function waitForDeliveryConsumption(messageUuid: string): {
+  promise: Promise<void>;
+  cancel: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  let waiters = deliveryConsumptionWaiters.get(messageUuid);
+  if (!waiters) {
+    waiters = new Set();
+    deliveryConsumptionWaiters.set(messageUuid, waiters);
+  }
+  waiters.add(resolve);
+  return {
+    promise,
+    cancel: () => {
+      const set = deliveryConsumptionWaiters.get(messageUuid);
+      if (set) {
+        set.delete(resolve);
+        if (set.size === 0) deliveryConsumptionWaiters.delete(messageUuid);
+      }
+    },
+  };
+}
+
+/**
+ * Signal that the durable job for `messageUuid` was consumed by the SDK (onSent).
+ * Resolves all waiters and clears the entry. No-op if none are waiting
+ * (e.g. consumption before any caller registered, or a delivery with no
+ * long-horizon source awaiting).
+ */
+export function signalDeliveryConsumed(messageUuid: string): void {
+  const waiters = deliveryConsumptionWaiters.get(messageUuid);
+  if (!waiters) return;
+  deliveryConsumptionWaiters.delete(messageUuid);
+  for (const resolve of waiters) resolve();
+}
+
+/**
  * In-process per-session mutex. Guards ONLY the brief turn start/stop + steer
  * state-check windows — NOT the long turn await. The feed itself is
  * concurrent-safe (§8). Holding this lock across a full SDK turn would block

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -275,57 +275,66 @@ export interface MessageDeliverySession {
 }
 
 /**
- * Per-messageUuid consumption waiters. The long-horizon injector awaits its
- * durable job's SDK consumption (onSent) before confirming the source record —
- * restoring the legacy "delivered = consumed" semantic that the v2 fire-and-
- * forget enqueue regressed. The bridge signals here from
+ * Per-(session, messageUuid) consumption waiters. The long-horizon injector
+ * awaits its durable job's SDK consumption (onSent) before confirming the
+ * source record — restoring the legacy "delivered = consumed" semantic that the
+ * v2 fire-and-forget enqueue regressed. The bridge signals here from
  * {@link MessageDeliverySession.driveDeliveryTurn}/{@link feedDeliverySteer}
- * when the SDK admits the message. (Codex P1.)
+ * when the SDK admits the message. Keyed by BOTH session + UUID so a multi-
+ * target delivery (the same MessageRecord/id to several agents) can't let one
+ * session's consumption signal resolve another session's waiter. (Codex P1.)
  */
 const deliveryConsumptionWaiters = new Map<string, Set<() => void>>();
 
+const consumptionKey = (sessionId: string, messageUuid: string) => `${sessionId}\0${messageUuid}`;
+
 /**
  * Register a wait for the durable job's SDK consumption. The `promise` resolves
- * when {@link signalDeliveryConsumed} fires for this UUID (or never, if the job
- * never reaches the SDK — bound the wait with a timeout and call `cancel()` to
- * avoid leaking the entry).
+ * when {@link signalDeliveryConsumed} fires for this session + UUID (or never,
+ * if the job never reaches the SDK — bound the wait with a timeout and call
+ * `cancel()` to avoid leaking the entry).
  */
-export function waitForDeliveryConsumption(messageUuid: string): {
+export function waitForDeliveryConsumption(
+  sessionId: string,
+  messageUuid: string
+): {
   promise: Promise<void>;
   cancel: () => void;
 } {
+  const key = consumptionKey(sessionId, messageUuid);
   let resolve!: () => void;
   const promise = new Promise<void>((r) => {
     resolve = r;
   });
-  let waiters = deliveryConsumptionWaiters.get(messageUuid);
+  let waiters = deliveryConsumptionWaiters.get(key);
   if (!waiters) {
     waiters = new Set();
-    deliveryConsumptionWaiters.set(messageUuid, waiters);
+    deliveryConsumptionWaiters.set(key, waiters);
   }
   waiters.add(resolve);
   return {
     promise,
     cancel: () => {
-      const set = deliveryConsumptionWaiters.get(messageUuid);
+      const set = deliveryConsumptionWaiters.get(key);
       if (set) {
         set.delete(resolve);
-        if (set.size === 0) deliveryConsumptionWaiters.delete(messageUuid);
+        if (set.size === 0) deliveryConsumptionWaiters.delete(key);
       }
     },
   };
 }
 
 /**
- * Signal that the durable job for `messageUuid` was consumed by the SDK (onSent).
- * Resolves all waiters and clears the entry. No-op if none are waiting
- * (e.g. consumption before any caller registered, or a delivery with no
- * long-horizon source awaiting).
+ * Signal that the durable job for `messageUuid` was consumed by the SDK (onSent)
+ * in `sessionId`. Resolves all waiters for that (session, UUID) and clears the
+ * entry. No-op if none are waiting (e.g. consumption before any caller
+ * registered, or a delivery with no long-horizon source awaiting). Session-
+ * scoped so a multi-target delivery can't cross-resolve. (Codex P1.)
  */
-export function signalDeliveryConsumed(messageUuid: string): void {
-  const waiters = deliveryConsumptionWaiters.get(messageUuid);
+export function signalDeliveryConsumed(sessionId: string, messageUuid: string): void {
+  const waiters = deliveryConsumptionWaiters.get(consumptionKey(sessionId, messageUuid));
   if (!waiters) return;
-  deliveryConsumptionWaiters.delete(messageUuid);
+  deliveryConsumptionWaiters.delete(consumptionKey(sessionId, messageUuid));
   for (const resolve of waiters) resolve();
 }
 
@@ -345,11 +354,12 @@ export function signalDeliveryConsumed(messageUuid: string): void {
  * so the job can self-heal via a retry that re-registers the wait. (Codex P1.)
  */
 export async function awaitDeliveryConsumption(args: {
+  sessionId: string;
   messageUuid: string;
   deliver: () => Promise<void>;
   terminalizeOnTimeout?: () => void;
 }): Promise<void> {
-  const consumed = waitForDeliveryConsumption(args.messageUuid);
+  const consumed = waitForDeliveryConsumption(args.sessionId, args.messageUuid);
   let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
   try {
     await args.deliver();

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -330,6 +330,50 @@ export function signalDeliveryConsumed(messageUuid: string): void {
 }
 
 /**
+ * Await a durable delivery job's SDK consumption (onSent) after enqueueing it,
+ * restoring the legacy "delivered = consumed" semantic. `deliver` performs the
+ * enqueue (e.g. {@link deliverAndMarkQueued}); the await races the consumption
+ * signal against a timeout (HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS, default
+ * 30s, matching the legacy MessageQueue timeout) and rejects on timeout so a
+ * caller doesn't acknowledge a delivery that may yet dead-letter.
+ *
+ * `terminalizeOnTimeout` is invoked on timeout (or if `deliver` throws) ONLY for
+ * paths that created a FRESH job this call (no prior row). It terminalizes the
+ * persisted row so the durable job isn't later consumed alongside a retry that
+ * mints a fresh UUID (direct send_message paths carry no stable id) — preventing
+ * a duplicate. OMIT it for existing-row paths (stable id, e.g. the inbox flush)
+ * so the job can self-heal via a retry that re-registers the wait. (Codex P1.)
+ */
+export async function awaitDeliveryConsumption(args: {
+  messageUuid: string;
+  deliver: () => Promise<void>;
+  terminalizeOnTimeout?: () => void;
+}): Promise<void> {
+  const consumed = waitForDeliveryConsumption(args.messageUuid);
+  let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await args.deliver();
+    const consumptionTimeoutMs =
+      Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
+    await Promise.race([
+      consumed.promise,
+      new Promise<void>((_, reject) => {
+        consumptionTimeout = setTimeout(
+          () => reject(new Error('delivery not consumed within timeout')),
+          consumptionTimeoutMs
+        );
+      }),
+    ]);
+  } catch (err) {
+    args.terminalizeOnTimeout?.();
+    throw err;
+  } finally {
+    if (consumptionTimeout) clearTimeout(consumptionTimeout);
+    consumed.cancel();
+  }
+}
+
+/**
  * In-process per-session mutex. Guards ONLY the brief turn start/stop + steer
  * state-check windows — NOT the long turn await. The feed itself is
  * concurrent-safe (§8). Holding this lock across a full SDK turn would block

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -374,7 +374,10 @@ export async function withSessionLock<T>(sessionId: string, fn: () => Promise<T>
  */
 export async function deliverAndMarkQueued(args: {
   jobQueue: JobQueueRepository;
-  stateManager?: { setQueuedIfIdle(messageId: string): Promise<boolean> };
+  stateManager?: {
+    setQueuedIfIdle(messageId: string): Promise<boolean>;
+    getState(): { status: string };
+  };
   sessionId: string;
   messageUuid: string;
   origin: MessageDeliveryOrigin;
@@ -383,9 +386,22 @@ export async function deliverAndMarkQueued(args: {
   await withSessionLock(args.sessionId, async () => {
     let role: MessageDeliveryRole;
     try {
+      // Legacy-owned turn guard: while v2 is default-on, QueryModeHandler still
+      // replays deferred/enqueued rows directly through MessageQueue, so a
+      // session can be `processing` a live SDK turn with NO active v2 turn row.
+      // The index would classify this injection as a fresh turn (it sees no v2
+      // turn), racing the legacy turn + letting its idle prematurely resolve the
+      // new waiter. Force a `steer` so the new message parks behind the legacy
+      // turn and promotes only once that turn ends. The deferred legacy-replay
+      // migration removes the need for this guard. (Codex P1.)
+      const legacyOwnedTurn =
+        !!args.stateManager &&
+        args.stateManager.getState().status === 'processing' &&
+        !args.jobQueue.hasActiveTurnDelivery(args.sessionId);
       role = deliverMessage(args.jobQueue, args.sessionId, args.messageUuid, {
         origin: args.origin,
         parentToolUseId: null,
+        ...(legacyOwnedTurn ? { role: 'steer' as const } : {}),
       });
     } catch (err) {
       args.onEnqueueFailure?.();

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -278,3 +278,48 @@ export async function withSessionLock<T>(sessionId: string, fn: () => Promise<T>
     if (sessionLocks.get(sessionId) === next) sessionLocks.delete(sessionId);
   }
 }
+
+/**
+ * Enqueue a durable delivery job and, when it inserts as a turn, mark the
+ * session queued — as ONE per-session critical section (under
+ * {@link withSessionLock}). Role arbitration and queued ownership must be atomic
+ * so a concurrently-injected steer can never win the queued marker that belongs
+ * to the turn. This is the shared primitive behind `AgentSession.deliverChatMessage`
+ * and the migrated Space / long-term-agent injectors; the caller persists the
+ * user message BEFORE calling this (the handler reloads content by UUID).
+ *
+ * `stateManager` is optional so callers whose session view doesn't expose it
+ * (e.g. the long-term-agent structural type) skip the queued marker rather than
+ * crash; on a real AgentSession it is present and the marker is set.
+ * `onEnqueueFailure` (if provided) terminalizes the persisted row when
+ * `deliverMessage` throws, mirroring `deliverChatMessage`'s failure handling.
+ */
+export async function deliverAndMarkQueued(args: {
+  jobQueue: JobQueueRepository;
+  stateManager?: { setQueuedIfIdle(messageId: string): Promise<boolean> };
+  sessionId: string;
+  messageUuid: string;
+  origin: MessageDeliveryOrigin;
+  onEnqueueFailure?: () => void;
+}): Promise<void> {
+  await withSessionLock(args.sessionId, async () => {
+    let role: MessageDeliveryRole;
+    try {
+      role = deliverMessage(args.jobQueue, args.sessionId, args.messageUuid, {
+        origin: args.origin,
+        parentToolUseId: null,
+      });
+    } catch (err) {
+      args.onEnqueueFailure?.();
+      throw err;
+    }
+    if (role === 'turn' && args.stateManager) {
+      try {
+        await args.stateManager.setQueuedIfIdle(args.messageUuid);
+      } catch {
+        // Non-fatal — the durable job is already enqueued; the handler will
+        // drive the turn. Mirrors deliverChatMessage's warn-and-continue.
+      }
+    }
+  });
+}

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -17,8 +17,29 @@
  */
 
 import type { MessageContent } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import { MESSAGE_DELIVERY } from '../job-queue-constants';
+
+/**
+ * On an SDK-message handling error, publish the terminal idle (draining the
+ * delivery waiters) ONLY when the throwing message ends the turn — the final
+ * `result`. A non-terminal message (e.g. an assistant message whose
+ * `sdk.message` subscriber rejected) leaves the live query still consuming;
+ * draining mid-turn would complete the durable job and release the active-turn
+ * slot while output is still being produced, letting a later prompt admit as
+ * another turn against the same query. The query's own `finally` publishes the
+ * terminal idle when the generator closes. Shared by the Claude and ACP runners'
+ * handleSDKMessage catch blocks. (Codex P1.)
+ */
+export async function drainDeliveryWaitersOnTerminalSDKMessage(
+  stateManager: { setIdle(): Promise<void> },
+  message: SDKMessage
+): Promise<void> {
+  if (message.type === 'result') {
+    await stateManager.setIdle();
+  }
+}
 
 /** Which slot a delivery occupies relative to its session's active turn. */
 export type MessageDeliveryRole = 'turn' | 'steer';

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -24,6 +24,11 @@ export class ProcessingStateManager {
   private isCompacting = false;
   private logger: Logger;
   private onIdleCallback?: () => Promise<void>;
+  /**
+   * Resolvers awaiting the next idle transition (the message-delivery bridge
+   * awaiting a turn's end). Drained in {@link setIdle}.
+   */
+  private idleWaiters: Array<() => void> = [];
 
   constructor(
     private sessionId: string,
@@ -39,6 +44,21 @@ export class ProcessingStateManager {
    */
   setOnIdleCallback(callback: () => Promise<void>): void {
     this.onIdleCallback = callback;
+  }
+
+  /**
+   * Resolve when the session next transitions to idle. The message-delivery
+   * bridge arms this to await a turn's completion: the v2 delivery job must stay
+   * `processing` for the SDK turn's duration and complete at turn-end. Awaiting
+   * `queryPromise` is wrong in streaming-input mode — it resolves only on
+   * query-CLOSE (never at turn-end), so the turn job would hang `processing`
+   * forever and every subsequent message would misclassify as a steer. Arm
+   * BEFORE the turn starts so a fast turn's idle cannot be missed.
+   */
+  waitForIdleTransition(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
   }
 
   /**
@@ -117,6 +137,13 @@ export class ProcessingStateManager {
    */
   async setIdle(): Promise<void> {
     await this.setState({ status: 'idle' });
+
+    // Resolve turn-end waiters (e.g. the message-delivery bridge awaiting this
+    // turn's completion) before the onIdle callback so the delivery job
+    // completes promptly at turn-end.
+    const waiters = this.idleWaiters;
+    this.idleWaiters = [];
+    for (const resolve of waiters) resolve();
 
     // Execute idle callback if set (e.g., for deferred restarts)
     if (this.onIdleCallback) {

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -133,9 +133,6 @@ export class ProcessingStateManager {
   }
 
   /**
-   * Set state to idle
-   */
-  /**
    * Set state to idle. Pass `{ suppressDeliveryWaiters: true }` on a
    * NON-terminal idle — one that is immediately followed by a query re-start
    * (e.g. QueryRunner's startup-timeout / message-not-found / transient-

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -25,10 +25,13 @@ export class ProcessingStateManager {
   private logger: Logger;
   private onIdleCallback?: () => Promise<void>;
   /**
-   * Resolvers awaiting the next idle transition (the message-delivery bridge
-   * awaiting a turn's end). Drained in {@link setIdle}.
+   * Resolvers awaiting the next terminal idle transition (the message-delivery
+   * bridge awaiting a turn's end), keyed by arm id so a caller can cancel its
+   * own waiter (failure/park paths) without leaking or accumulating across
+   * reclaims. Drained in {@link setIdle}.
    */
-  private idleWaiters: Array<() => void> = [];
+  private idleWaiters: Map<number, () => void> = new Map();
+  private nextIdleWaiterId = 0;
 
   constructor(
     private sessionId: string,
@@ -47,18 +50,29 @@ export class ProcessingStateManager {
   }
 
   /**
-   * Resolve when the session next transitions to idle. The message-delivery
-   * bridge arms this to await a turn's completion: the v2 delivery job must stay
-   * `processing` for the SDK turn's duration and complete at turn-end. Awaiting
-   * `queryPromise` is wrong in streaming-input mode — it resolves only on
-   * query-CLOSE (never at turn-end), so the turn job would hang `processing`
-   * forever and every subsequent message would misclassify as a steer. Arm
-   * BEFORE the turn starts so a fast turn's idle cannot be missed.
+   * Arm a wait for the next TERMINAL idle transition. The message-delivery
+   * bridge (`driveDeliveryTurn`) awaits `promise` to complete a durable job at
+   * turn-end — awaiting `queryPromise` instead is wrong in streaming-input mode
+   * (it resolves only on query-CLOSE, never at turn-end, so the job would hang).
+   * Returns a handle: call `cancel()` from failure/park paths so the waiter is
+   * removed (not left to accumulate across reclaims); the `promise` resolves on
+   * the next non-suppressed {@link setIdle} or never (if cancelled, it is
+   * abandoned — nobody awaits it). Arm BEFORE the turn starts so a fast turn's
+   * idle cannot be missed.
    */
-  waitForIdleTransition(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      this.idleWaiters.push(resolve);
+  waitForIdleTransition(): { promise: Promise<void>; cancel: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
     });
+    const id = this.nextIdleWaiterId++;
+    this.idleWaiters.set(id, resolve);
+    return {
+      promise,
+      cancel: () => {
+        this.idleWaiters.delete(id);
+      },
+    };
   }
 
   /**
@@ -142,15 +156,18 @@ export class ProcessingStateManager {
    * being retried, freeing the active-turn slot for a competing turn.
    */
   async setIdle(opts?: { suppressDeliveryWaiters?: boolean }): Promise<void> {
-    await this.setState({ status: 'idle' });
-
-    // Resolve turn-end waiters (e.g. the message-delivery bridge awaiting this
-    // turn's completion) before the onIdle callback so the delivery job
-    // completes promptly at turn-end — but only on a TERMINAL idle.
-    if (!opts?.suppressDeliveryWaiters) {
-      const waiters = this.idleWaiters;
-      this.idleWaiters = [];
-      for (const resolve of waiters) resolve();
+    // setState persists the idle state BEFORE publishing it, so drain the
+    // turn-end waiters in a finally — the state IS idle even if the event
+    // publication throws, and a waiting delivery job must not hang on a
+    // publish failure. Only on a TERMINAL idle (suppress on retry mid-points).
+    try {
+      await this.setState({ status: 'idle' });
+    } finally {
+      if (!opts?.suppressDeliveryWaiters) {
+        const waiters = [...this.idleWaiters.values()];
+        this.idleWaiters.clear();
+        for (const resolve of waiters) resolve();
+      }
     }
 
     // Execute idle callback if set (e.g., for deferred restarts)

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -76,6 +76,18 @@ export class ProcessingStateManager {
   }
 
   /**
+   * Resolve + clear ALL idle waiters. Used when a rate-limit retry is superseded
+   * (the durable turn it would have re-driven is abandoned): resolves the waiter
+   * — rather than cancelling it — so an awaiting driveDeliveryTurn completes its
+   * job instead of hanging `processing`.
+   */
+  releaseIdleWaiters(): void {
+    const waiters = [...this.idleWaiters.values()];
+    this.idleWaiters.clear();
+    for (const resolve of waiters) resolve();
+  }
+
+  /**
    * Restore processing state from database
    * Called on session initialization to recover state after restart
    */

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -35,6 +35,14 @@ export class ProcessingStateManager {
    */
   private idleWaiters: Map<number, { resolve: () => void; gen?: number }> = new Map();
   private nextIdleWaiterId = 0;
+  /**
+   * True while the deferred-restart `onIdleCallback` is running. A reentrant
+   * `setIdle` from the callback's own stop/start must NOT re-fire the callback
+   * (double restart) NOR drain the waiters (the outer call owns the drain,
+   * deferred until the restart completes so durable turn ownership survives the
+   * restart). (Codex P1.)
+   */
+  private idleCallbackInFlight = false;
 
   constructor(
     private sessionId: string,
@@ -175,27 +183,38 @@ export class ProcessingStateManager {
    * being retried, freeing the active-turn slot for a competing turn.
    */
   async setIdle(opts?: { suppressDeliveryWaiters?: boolean }): Promise<void> {
+    // If a deferred-restart callback is in flight (a reentrant idle from its
+    // stop/start), suppress the drain too — the outer call owns it, deferred
+    // until the restart completes so durable turn ownership survives the restart.
+    const suppressDrain = opts?.suppressDeliveryWaiters || this.idleCallbackInFlight;
     // setState persists the idle state BEFORE publishing it, so drain the
     // turn-end waiters in a finally — the state IS idle even if the event
     // publication throws, and a waiting delivery job must not hang on a
     // publish failure. Only on a TERMINAL idle (suppress on retry mid-points).
     try {
       await this.setState({ status: 'idle' });
+      // Run the deferred-restart callback BEFORE releasing durable turn
+      // ownership (draining the waiters). Resolving the waiters first would let
+      // driveDeliveryTurn complete + free the active-turn slot while the callback
+      // is still stopping/starting the query, so a message arriving in that
+      // window could start a new turn concurrent with the restart. The reentrant
+      // guard prevents a double restart from the callback's own idle transition.
+      if (this.onIdleCallback && !this.idleCallbackInFlight) {
+        this.idleCallbackInFlight = true;
+        try {
+          await this.onIdleCallback();
+        } catch (error) {
+          this.logger.error('Error in onIdle callback:', error);
+          // Don't re-throw - callback errors shouldn't break state transitions
+        } finally {
+          this.idleCallbackInFlight = false;
+        }
+      }
     } finally {
-      if (!opts?.suppressDeliveryWaiters) {
+      if (!suppressDrain) {
         const waiters = [...this.idleWaiters.values()];
         this.idleWaiters.clear();
         for (const w of waiters) w.resolve();
-      }
-    }
-
-    // Execute idle callback if set (e.g., for deferred restarts)
-    if (this.onIdleCallback) {
-      try {
-        await this.onIdleCallback();
-      } catch (error) {
-        this.logger.error('Error in onIdle callback:', error);
-        // Don't re-throw - callback errors shouldn't break state transitions
       }
     }
   }

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -28,9 +28,12 @@ export class ProcessingStateManager {
    * Resolvers awaiting the next terminal idle transition (the message-delivery
    * bridge awaiting a turn's end), keyed by arm id so a caller can cancel its
    * own waiter (failure/park paths) without leaking or accumulating across
-   * reclaims. Drained in {@link setIdle}.
+   * reclaims. Each carries an optional episode-generation tag so a narrowly-
+   * scoped release (a superseded rate-limit retry) only resolves waiters from
+   * that episode — not a newer turn's waiter armed after the generation bumped.
+   * Drained in {@link setIdle} (terminal) / {@link releaseIdleWaiters}.
    */
-  private idleWaiters: Map<number, () => void> = new Map();
+  private idleWaiters: Map<number, { resolve: () => void; gen?: number }> = new Map();
   private nextIdleWaiterId = 0;
 
   constructor(
@@ -60,13 +63,13 @@ export class ProcessingStateManager {
    * abandoned — nobody awaits it). Arm BEFORE the turn starts so a fast turn's
    * idle cannot be missed.
    */
-  waitForIdleTransition(): { promise: Promise<void>; cancel: () => void } {
+  waitForIdleTransition(episodeGen?: number): { promise: Promise<void>; cancel: () => void } {
     let resolve!: () => void;
     const promise = new Promise<void>((r) => {
       resolve = r;
     });
     const id = this.nextIdleWaiterId++;
-    this.idleWaiters.set(id, resolve);
+    this.idleWaiters.set(id, { resolve, gen: episodeGen });
     return {
       promise,
       cancel: () => {
@@ -76,15 +79,19 @@ export class ProcessingStateManager {
   }
 
   /**
-   * Resolve + clear ALL idle waiters. Used when a rate-limit retry is superseded
+   * Resolve + clear idle waiters. Used when a rate-limit retry is superseded
    * (the durable turn it would have re-driven is abandoned): resolves the waiter
    * — rather than cancelling it — so an awaiting driveDeliveryTurn completes its
-   * job instead of hanging `processing`.
+   * job instead of hanging `processing`. Pass an `episodeGen` to resolve ONLY
+   * waiters armed under that episode (a retry must not release a newer turn's
+   * waiter armed after the generation bumped); omit it to resolve all.
    */
-  releaseIdleWaiters(): void {
-    const waiters = [...this.idleWaiters.values()];
-    this.idleWaiters.clear();
-    for (const resolve of waiters) resolve();
+  releaseIdleWaiters(episodeGen?: number): void {
+    const matching = [...this.idleWaiters.entries()].filter(
+      ([, w]) => episodeGen === undefined || w.gen === episodeGen
+    );
+    for (const [id] of matching) this.idleWaiters.delete(id);
+    for (const [, w] of matching) w.resolve();
   }
 
   /**
@@ -178,7 +185,7 @@ export class ProcessingStateManager {
       if (!opts?.suppressDeliveryWaiters) {
         const waiters = [...this.idleWaiters.values()];
         this.idleWaiters.clear();
-        for (const resolve of waiters) resolve();
+        for (const w of waiters) w.resolve();
       }
     }
 

--- a/packages/daemon/src/lib/agent/processing-state-manager.ts
+++ b/packages/daemon/src/lib/agent/processing-state-manager.ts
@@ -135,15 +135,26 @@ export class ProcessingStateManager {
   /**
    * Set state to idle
    */
-  async setIdle(): Promise<void> {
+  /**
+   * Set state to idle. Pass `{ suppressDeliveryWaiters: true }` on a
+   * NON-terminal idle — one that is immediately followed by a query re-start
+   * (e.g. QueryRunner's startup-timeout / message-not-found / transient-
+   * connection auto-retries call setIdle before recursing into runQuery).
+   * Resolving the delivery waiters on such a retry idle would let
+   * driveDeliveryTurn complete the durable job while the same prompt is still
+   * being retried, freeing the active-turn slot for a competing turn.
+   */
+  async setIdle(opts?: { suppressDeliveryWaiters?: boolean }): Promise<void> {
     await this.setState({ status: 'idle' });
 
     // Resolve turn-end waiters (e.g. the message-delivery bridge awaiting this
     // turn's completion) before the onIdle callback so the delivery job
-    // completes promptly at turn-end.
-    const waiters = this.idleWaiters;
-    this.idleWaiters = [];
-    for (const resolve of waiters) resolve();
+    // completes promptly at turn-end — but only on a TERMINAL idle.
+    if (!opts?.suppressDeliveryWaiters) {
+      const waiters = this.idleWaiters;
+      this.idleWaiters = [];
+      for (const resolve of waiters) resolve();
+    }
 
     // Execute idle callback if set (e.g., for deferred restarts)
     if (this.onIdleCallback) {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -375,6 +375,12 @@ export class QueryLifecycleManager {
    */
   async restart(): Promise<void> {
     const { session, internalEventBus, messageHandler } = this.ctx;
+    // True once the old query is stopped AND the suppressed idle is reached. A
+    // failure before this point leaves the original SDK query still running, so
+    // releasing the waiter would free the active-turn slot mid-turn; only
+    // release if we suppressed the drain (old query stopped) but then failed to
+    // establish a replacement. (Codex P1.)
+    let reachedSuppressedIdle = false;
 
     try {
       // Clear error state and circuit breaker before stopping.
@@ -392,6 +398,7 @@ export class QueryLifecycleManager {
       // new query increments the generation — triggering the stale-query guard
       // and skipping setIdle(). This explicit call guarantees clean state.
       await this.ctx.stateManager.setIdle({ suppressDeliveryWaiters: true });
+      reachedSuppressedIdle = true;
 
       // Validate and repair SDK session file before restarting.
       // Includes cross-path migration when effective CWD changed since session init.
@@ -426,12 +433,15 @@ export class QueryLifecycleManager {
       await this.ctx.startStreamingQuery();
     } catch (error) {
       // restart failed BEFORE a replacement query was established (validation,
-      // cache clear, or startStreamingQuery threw). The suppressed setIdle above
-      // left the active delivery waiter pending — release it so the durable turn
-      // doesn't hang `processing` and block the active-turn slot. The waiter
-      // resolves (driveDeliveryTurn completes the job); the failed restart
-      // surfaces its own error to the caller. (Codex P1.)
-      this.ctx.stateManager.releaseIdleWaiters();
+      // cache clear, or startStreamingQuery threw). Only release the suppressed
+      // waiter if the old query was already stopped (reachedSuppressedIdle) — a
+      // failure before stop() (e.g. a session.errorClear subscriber rejecting at
+      // the publish above) leaves the original SDK query running, and releasing
+      // would complete the delivery job + free the active-turn slot mid-turn.
+      // (Codex P1.)
+      if (reachedSuppressedIdle) {
+        this.ctx.stateManager.releaseIdleWaiters();
+      }
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       throw new Error(`Query restart failed: ${errorMessage}`);
     }
@@ -472,6 +482,12 @@ export class QueryLifecycleManager {
       return { success: true };
     }
 
+    // True once the old query is stopped AND the suppressed idle is reached (a
+    // restartAfter reset). A failure after this leaves the durable turn waiter
+    // pending (the suppress deferred its drain to the restart) — release it in
+    // the catch so it doesn't hang `processing`. (Codex P1.)
+    let reachedSuppressedIdle = false;
+
     try {
       // Pre-stop: Preserve cost tracking
       const lastSdkCost = session.metadata?.lastSdkCost || 0;
@@ -507,6 +523,7 @@ export class QueryLifecycleManager {
       // active-turn slot). (Codex P1.)
       this.ctx.firstMessageReceived = false;
       await stateManager.setIdle({ suppressDeliveryWaiters: restartAfter });
+      reachedSuppressedIdle = true;
 
       // Clear models cache to ensure fresh model info is fetched from DB
       // This is critical for model switch to pick up the new model
@@ -550,6 +567,13 @@ export class QueryLifecycleManager {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error('Query reset failed:', error);
+      // A restartAfter reset suppressed the waiter drain (the restart owns it);
+      // if the replacement startup then failed, release the waiter so the
+      // durable turn doesn't hang `processing` and block the active-turn slot.
+      // (Mirrors restart()'s failure path. Codex P1.)
+      if (restartAfter && reachedSuppressedIdle) {
+        this.ctx.stateManager.releaseIdleWaiters();
+      }
       return { success: false, error: errorMessage };
     }
   }

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -391,7 +391,7 @@ export class QueryLifecycleManager {
       // the old queryPromise, the old query's finally block may run AFTER the
       // new query increments the generation — triggering the stale-query guard
       // and skipping setIdle(). This explicit call guarantees clean state.
-      await this.ctx.stateManager.setIdle();
+      await this.ctx.stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       // Validate and repair SDK session file before restarting.
       // Includes cross-path migration when effective CWD changed since session init.
@@ -493,7 +493,7 @@ export class QueryLifecycleManager {
 
       // Post-stop: Reset state
       this.ctx.firstMessageReceived = false;
-      await stateManager.setIdle();
+      await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       // Clear models cache to ensure fresh model info is fetched from DB
       // This is critical for model switch to pick up the new model

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -425,6 +425,13 @@ export class QueryLifecycleManager {
 
       await this.ctx.startStreamingQuery();
     } catch (error) {
+      // restart failed BEFORE a replacement query was established (validation,
+      // cache clear, or startStreamingQuery threw). The suppressed setIdle above
+      // left the active delivery waiter pending — release it so the durable turn
+      // doesn't hang `processing` and block the active-turn slot. The waiter
+      // resolves (driveDeliveryTurn completes the job); the failed restart
+      // surfaces its own error to the caller. (Codex P1.)
+      this.ctx.stateManager.releaseIdleWaiters();
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       throw new Error(`Query restart failed: ${errorMessage}`);
     }

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -491,9 +491,15 @@ export class QueryLifecycleManager {
         catchQueryErrors: true,
       });
 
-      // Post-stop: Reset state
+      // Post-stop: Reset state. Suppress the delivery-waiter drain ONLY when a
+      // restart follows (this is a retry mid-point — the query is re-started
+      // below). When restartAfter is false the reset is TERMINAL (no
+      // startStreamingQuery): the turn that was driving a durable job is
+      // abandoned, so its turn-end waiter MUST drain here or driveDeliveryTurn
+      // hangs forever (the job keeps heartbeating `processing`, blocking the
+      // active-turn slot). (Codex P1.)
       this.ctx.firstMessageReceived = false;
-      await stateManager.setIdle({ suppressDeliveryWaiters: true });
+      await stateManager.setIdle({ suppressDeliveryWaiters: restartAfter });
 
       // Clear models cache to ensure fresh model info is fetched from DB
       // This is critical for model switch to pick up the new model

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -870,14 +870,18 @@ export class QueryRunner {
           // state persistence to avoid cascading "closed database" errors.
           if (!this.ctx.isCleaningUp()) {
             const processingState = stateManager.getState();
-            // This idle is potentially TERMINAL: if the throwing message was the
-            // final SDK `result`, no normal setIdle follows (the for-await just
-            // ends) and this path does NOT start a replacement query. Suppressing
-            // the delivery-waiter drain would leave driveDeliveryTurn waiting
-            // forever while its job heartbeats `processing`, blocking the
-            // active-turn slot. Drain (no suppress) so a durable turn whose
-            // result-handling threw still completes. (Codex P1.)
-            await stateManager.setIdle();
+            // Only publish the terminal idle (draining the delivery waiters) when
+            // the throwing message actually ends the turn — the final `result`.
+            // A non-terminal message (e.g. an `sdk.message` subscriber rejecting
+            // on an assistant message) leaves the live query still consuming:
+            // draining here would complete the durable job and release the
+            // active-turn slot while the turn is still producing output, letting
+            // a subsequent prompt admit as another turn against the same query.
+            // For a `result` throw the for-await ends and no normal idle follows,
+            // so this drain is the terminal one. (Codex P1.)
+            if ((message as SDKMessage).type === 'result') {
+              await stateManager.setIdle();
+            }
 
             await errorManager.handleError(
               session.id,

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -870,7 +870,14 @@ export class QueryRunner {
           // state persistence to avoid cascading "closed database" errors.
           if (!this.ctx.isCleaningUp()) {
             const processingState = stateManager.getState();
-            await stateManager.setIdle({ suppressDeliveryWaiters: true });
+            // This idle is potentially TERMINAL: if the throwing message was the
+            // final SDK `result`, no normal setIdle follows (the for-await just
+            // ends) and this path does NOT start a replacement query. Suppressing
+            // the delivery-waiter drain would leave driveDeliveryTurn waiting
+            // forever while its job heartbeats `processing`, blocking the
+            // active-turn slot. Drain (no suppress) so a durable turn whose
+            // result-handling threw still completes. (Codex P1.)
+            await stateManager.setIdle();
 
             await errorManager.handleError(
               session.id,

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -990,7 +990,7 @@ export class QueryRunner {
       // Skip messageQueue.clear() so the user's pending message is preserved for the retry.
       if (isStartupTimeout && retryAttempt === 0 && !this.ctx.isCleaningUp()) {
         logger.warn('Auto-retrying query after startup timeout (1 retry).');
-        await stateManager.setIdle();
+        await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
         // Close the current queryObject BEFORE retrying to prevent the
         // "Already connected to a transport" crash. The finally{} block has not
@@ -1029,7 +1029,7 @@ export class QueryRunner {
         // with the same 'No message found' error.
         this.ctx.consumePendingResumeSessionAt?.();
         logger.warn('Auto-retrying query without one-shot resumeSessionAt.');
-        await stateManager.setIdle();
+        await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
         if (this.ctx.queryObject) {
           try {
@@ -1062,7 +1062,7 @@ export class QueryRunner {
         !this.ctx.isCleaningUp()
       ) {
         logger.warn('Auto-retrying query after transient connection error (1 retry).');
-        await stateManager.setIdle();
+        await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
         // Re-enqueue the last consumed user message so the retry has input to
         // process.  Without this, the message was already shifted out of

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -870,7 +870,7 @@ export class QueryRunner {
           // state persistence to avoid cascading "closed database" errors.
           if (!this.ctx.isCleaningUp()) {
             const processingState = stateManager.getState();
-            await stateManager.setIdle();
+            await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
             await errorManager.handleError(
               session.id,

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -16,6 +16,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { MessageContent, MessageHub, Session } from '@hyperneo/shared';
 import { generateUUID } from '@hyperneo/shared';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
+import { drainDeliveryWaitersOnTerminalSDKMessage } from './message-delivery';
 import type { UUID } from 'crypto';
 import { Database } from '../../storage/database';
 import { ErrorCategory, ErrorManager } from '../error-manager';
@@ -872,16 +873,7 @@ export class QueryRunner {
             const processingState = stateManager.getState();
             // Only publish the terminal idle (draining the delivery waiters) when
             // the throwing message actually ends the turn — the final `result`.
-            // A non-terminal message (e.g. an `sdk.message` subscriber rejecting
-            // on an assistant message) leaves the live query still consuming:
-            // draining here would complete the durable job and release the
-            // active-turn slot while the turn is still producing output, letting
-            // a subsequent prompt admit as another turn against the same query.
-            // For a `result` throw the for-await ends and no normal idle follows,
-            // so this drain is the terminal one. (Codex P1.)
-            if ((message as SDKMessage).type === 'result') {
-              await stateManager.setIdle();
-            }
+            await drainDeliveryWaitersOnTerminalSDKMessage(stateManager, message as SDKMessage);
 
             await errorManager.handleError(
               session.id,

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -727,6 +727,17 @@ export class RateLimitWatchdog {
     return generation !== this.generation;
   }
 
+  /**
+   * The current episode generation. Callers arm a wait tagged with this value
+   * so a later, narrowly-scoped release (e.g. {@link
+   * ProcessingStateManager.releaseIdleWaiters}) only resolves waiters from the
+   * same episode — not a newer turn's waiter armed after a cancel()/reset()
+   * bumped the generation.
+   */
+  getGeneration(): number {
+    return this.generation;
+  }
+
   private cancelCooldownTimer(): void {
     if (this.cooldownTimer !== null) {
       clearTimeout(this.cooldownTimer);

--- a/packages/daemon/src/lib/job-handlers/message-delivery-dead-letter.ts
+++ b/packages/daemon/src/lib/job-handlers/message-delivery-dead-letter.ts
@@ -39,9 +39,16 @@ export async function settleMessageDeliveryDeadLetter(
 ): Promise<void> {
   const flipped = settlement.markDeliveryFailedByUuid(payload.sessionId, payload.messageUuid);
   if (flipped) {
-    void settlement.publishStatusChanged(payload.sessionId, [flipped]);
+    // Fire-and-forget BUT guarded: a rejecting messages.statusChanged subscriber
+    // must not surface as an unhandled rejection in the dead-letter path. (Codex P1.)
+    void settlement.publishStatusChanged(payload.sessionId, [flipped]).catch(() => {});
   }
-  if (payload.origin === 'space_inject') {
+  // Only a dead-lettered KICKOFF (the node's initial turn) should mark the
+  // execution blocked. `space_inject` is also the origin for ordinary peer/human
+  // handoffs delivered to an already-running node session, which are steers
+  // (role !== 'turn') — a failed mid-turn handoff must NOT block a node whose
+  // kickoff + current turn succeeded. (Codex P1.)
+  if (payload.origin === 'space_inject' && payload.role === 'turn') {
     try {
       await settlement.publishSessionError(payload.sessionId, DEAD_LETTER_SESSION_ERROR);
     } catch {

--- a/packages/daemon/src/lib/job-handlers/message-delivery-dead-letter.ts
+++ b/packages/daemon/src/lib/job-handlers/message-delivery-dead-letter.ts
@@ -1,0 +1,52 @@
+/**
+ * message_delivery dead-letter settlement — extracted from app.ts's `onDead`
+ * hook so the load-bearing ordering (session.error BEFORE queued-marker
+ * settlement for a task-agent kickoff) is unit-testable without full app wiring.
+ */
+
+import type { MessageDeliveryPayload } from '../agent/message-delivery';
+
+/** The narrow settlement operations a dead-letter performs. app.ts adapts its
+ *  reactiveDb / internal event bus / session manager to this interface. */
+export interface MessageDeliveryDeadLetterSettlement {
+  /** Terminalize the persisted kickoff row as `failed`; returns its db id. */
+  markDeliveryFailedByUuid(sessionId: string, uuid: string): string | null;
+  /** Broadcast the row's status flip so pagination/UI reflects the failure. */
+  publishStatusChanged(sessionId: string, messageIds: string[]): Promise<unknown>;
+  /** Publish a terminal `session.error` for the session. */
+  publishSessionError(sessionId: string, error: string): Promise<unknown>;
+  /** Release the pre-claim queued marker still owned by this terminal turn. */
+  settleSkippedDelivery(messageUuid: string): Promise<unknown>;
+}
+
+export const DEAD_LETTER_SESSION_ERROR =
+  'Task-agent kickoff delivery exhausted its retries (dead-lettered).';
+
+/**
+ * Settle a dead-lettered message_delivery job: terminalize the persisted row,
+ * broadcast the status, and (for a task-agent `space_inject` kickoff) emit
+ * `session.error` BEFORE settling the queued marker.
+ *
+ * The ordering matters: the settlement publishes an idle transition, and
+ * `registerCompletionCallback` would otherwise treat that idle as successful
+ * work (the failed kickoff row itself satisfies the SDK-message count). The
+ * `session.error` fires the callback's error path → `handleSubSessionError`
+ * marks the node execution `blocked` instead. (Codex P1.)
+ */
+export async function settleMessageDeliveryDeadLetter(
+  payload: MessageDeliveryPayload,
+  settlement: MessageDeliveryDeadLetterSettlement
+): Promise<void> {
+  const flipped = settlement.markDeliveryFailedByUuid(payload.sessionId, payload.messageUuid);
+  if (flipped) {
+    void settlement.publishStatusChanged(payload.sessionId, [flipped]);
+  }
+  if (payload.origin === 'space_inject') {
+    try {
+      await settlement.publishSessionError(payload.sessionId, DEAD_LETTER_SESSION_ERROR);
+    } catch {
+      /* best-effort — settlement must still run */
+    }
+  }
+  await settlement.settleSkippedDelivery(payload.messageUuid);
+}

--- a/packages/daemon/src/lib/job-queue-constants.ts
+++ b/packages/daemon/src/lib/job-queue-constants.ts
@@ -6,7 +6,7 @@
 // ─── Message delivery (v2) ────────────────────────────────────────────────────
 // Durable delivery ownership: one job_queue row per user message (turn or steer).
 // The message-delivery.handler drives the SDK turn / feeds the live transport;
-// see docs/features/message-delivery-v2.md. Flag-gated (HYPERNEO_MESSAGE_DELIVERY_V2).
+// see docs/features/message-delivery-v2.md. Default-on (HYPERNEO_MESSAGE_DELIVERY_V2=0 to opt out).
 export const MESSAGE_DELIVERY = 'message_delivery';
 
 export const SESSION_TITLE_GENERATION = 'session.title_generation';

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -87,9 +87,9 @@ import { SpaceWorkflowRepository } from '../../storage/repositories/space-workfl
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
 import {
+  awaitDeliveryConsumption,
   deliverAndMarkQueued,
   isMessageDeliveryV2Enabled,
-  waitForDeliveryConsumption,
 } from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
@@ -897,6 +897,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       // don't insert a duplicate sdk_messages row or re-drive a terminal one.
       const sdkMessageRepo = deps.reactiveDb.db.getSDKMessageRepo();
       const existing = sdkMessageRepo.getDeliveryContent(sessionId, messageId);
+      const fresh = !existing;
       if (!existing) {
         deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
       } else if (existing.sendStatus === 'consumed') {
@@ -904,38 +905,31 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       } else if (existing.sendStatus === 'failed') {
         sdkMessageRepo.reopenDeliveryByUuid(sessionId, messageId);
       }
-      // Await SDK consumption (onSent) before returning, mirroring the LTA +
-      // task-agent injectors + the legacy enqueueWithId path. Without this a
-      // direct send_message handoff (no retained source row to retry) is recorded
-      // as delivered after a bare enqueue that may yet dead-letter. Rejects on
-      // timeout so the router doesn't acknowledge a delivery that may fail; the
-      // durable job keeps running and a later retry re-registers the wait. (Codex P1.)
-      const consumed = waitForDeliveryConsumption(messageId);
-      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await deliverAndMarkQueued({
-          jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
-          stateManager: session.stateManager,
-          sessionId,
-          messageUuid: messageId,
-          origin: 'space_agent',
-          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
-        });
-        const consumptionTimeoutMs =
-          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
-        await Promise.race([
-          consumed.promise,
-          new Promise<void>((_, reject) => {
-            consumptionTimeout = setTimeout(
-              () => reject(new Error('space-agent handoff not consumed within timeout')),
-              consumptionTimeoutMs
-            );
+      // Await SDK consumption (onSent) before returning — a direct send_message
+      // handoff has no retained source row to retry, so it must not record
+      // delivered after a bare enqueue that may yet dead-letter. On timeout,
+      // terminalize ONLY a fresh row: direct send_message carries no stable id,
+      // so a retry mints a fresh UUID — terminalizing the timed-out fresh job
+      // stops it being consumed alongside the retry (duplicate). The flush path
+      // carries a stable id (existing row), so it omits the terminalize. (Codex P1.)
+      await awaitDeliveryConsumption({
+        messageUuid: messageId,
+        deliver: () =>
+          deliverAndMarkQueued({
+            jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
+            stateManager: session.stateManager,
+            sessionId,
+            messageUuid: messageId,
+            origin: 'space_agent',
+            onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
           }),
-        ]);
-      } finally {
-        if (consumptionTimeout) clearTimeout(consumptionTimeout);
-        consumed.cancel();
-      }
+        ...(fresh
+          ? {
+              terminalizeOnTimeout: () =>
+                sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
+            }
+          : {}),
+      });
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -86,7 +86,7 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
-import { deliverMessage } from '../agent/message-delivery';
+import { deliverMessage, isMessageDeliveryV2Enabled } from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
@@ -884,14 +884,28 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         content: [{ type: 'text' as const, text: message }],
       },
     };
-    // Persist first (content lives in sdk_messages), then enqueue a durable
-    // message_delivery job — the handler claims it and drives the turn. Replaces
-    // the inline ensureQueryStarted + enqueueWithId (no durable owner).
-    deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-    deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
-      origin: 'space_agent',
-      parentToolUseId: null,
-    });
+    if (isMessageDeliveryV2Enabled()) {
+      // Persist first (content lives in sdk_messages), then enqueue a durable
+      // message_delivery job — the handler claims it and drives the turn.
+      deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      try {
+        deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
+          origin: 'space_agent',
+          parentToolUseId: null,
+        });
+      } catch (err) {
+        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
+        // has no owner — terminalize it so a restart/replay can't run the orphaned
+        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
+        deps.reactiveDb.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
+        throw err;
+      }
+    } else {
+      // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
+      await session.ensureQueryStarted();
+      deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      await session.messageQueue.enqueueWithId(messageId, message);
+    }
   };
 
   // Task Agent Manager — manages Task Agent session lifecycle and message injection.

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -888,18 +888,25 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       },
     };
     if (isMessageDeliveryV2Enabled()) {
-      // Persist first (content lives in sdk_messages), then enqueue a durable
-      // message_delivery job + mark queued as one per-session critical section —
-      // the handler claims the job and drives the turn.
-      deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      // Idempotent persist (mirrors the LTA injector): when retried with a
+      // stable id (the pending-row id from flushPendingMessagesForSpaceAgent),
+      // don't insert a duplicate sdk_messages row or re-drive a terminal one.
+      const sdkMessageRepo = deps.reactiveDb.db.getSDKMessageRepo();
+      const existing = sdkMessageRepo.getDeliveryContent(sessionId, messageId);
+      if (!existing) {
+        deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      } else if (existing.sendStatus === 'consumed') {
+        return; // genuinely delivered on a prior attempt — don't re-drive
+      } else if (existing.sendStatus === 'failed') {
+        sdkMessageRepo.reopenDeliveryByUuid(sessionId, messageId);
+      }
       await deliverAndMarkQueued({
         jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
         stateManager: session.stateManager,
         sessionId,
         messageUuid: messageId,
         origin: 'space_agent',
-        onEnqueueFailure: () =>
-          deps.reactiveDb.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId),
+        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
       });
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -888,8 +888,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       // Persist first (content lives in sdk_messages), then enqueue a durable
       // message_delivery job — the handler claims it and drives the turn.
       deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      let role: 'turn' | 'steer';
       try {
-        deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
+        role = deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
           origin: 'space_agent',
           parentToolUseId: null,
         });
@@ -899,6 +900,17 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         // original. Mirrors AgentSession.deliverChatMessage's failure handling.
         deps.reactiveDb.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
         throw err;
+      }
+      if (role === 'turn') {
+        // Mark the session queued so a 'defer' message arriving before the
+        // processor claims the job is preserved for the next turn (its busy
+        // check only sees processing/queued) rather than classified as a steer
+        // on this pending turn. Mirrors deliverChatMessage / injectMessage.
+        try {
+          await session.stateManager.setQueuedIfIdle(messageId);
+        } catch {
+          // non-fatal — the durable job is already enqueued
+        }
       }
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -86,6 +86,7 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
+import { deliverMessage } from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
@@ -883,9 +884,14 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         content: [{ type: 'text' as const, text: message }],
       },
     };
-    await session.ensureQueryStarted();
+    // Persist first (content lives in sdk_messages), then enqueue a durable
+    // message_delivery job — the handler claims it and drives the turn. Replaces
+    // the inline ensureQueryStarted + enqueueWithId (no durable owner).
     deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-    await session.messageQueue.enqueueWithId(messageId, message);
+    deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
+      origin: 'space_agent',
+      parentToolUseId: null,
+    });
   };
 
   // Task Agent Manager — manages Task Agent session lifecycle and message injection.

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -913,6 +913,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       // stops it being consumed alongside the retry (duplicate). The flush path
       // carries a stable id (existing row), so it omits the terminalize. (Codex P1.)
       await awaitDeliveryConsumption({
+        sessionId,
         messageUuid: messageId,
         deliver: () =>
           deliverAndMarkQueued({

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -858,7 +858,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   const spaceAgentInjector = async (
     spaceId: string,
     message: string,
-    replyToSessionId?: string | null
+    replyToSessionId?: string | null,
+    explicitMessageId?: string
   ): Promise<void> => {
     let sessionId = replyToSessionId || `space:chat:${spaceId}`;
     let session = await sessionManagerRef.getSessionAsync(sessionId);
@@ -872,7 +873,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     if (!session) {
       throw new Error(`Session not found for Space Agent reply routing: ${sessionId}`);
     }
-    const messageId = generateUUID();
+    // An explicit id (the pending-row id from flushPendingMessagesForSpaceAgent)
+    // dedups a crash-retry: deliverAndMarkQueued/getActiveDeliveryRole keys on it.
+    const messageId = explicitMessageId ?? generateUUID();
     const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
       type: 'user' as const,
       uuid: messageId as UUID,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -86,7 +86,11 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
-import { deliverAndMarkQueued, isMessageDeliveryV2Enabled } from '../agent/message-delivery';
+import {
+  deliverAndMarkQueued,
+  isMessageDeliveryV2Enabled,
+  waitForDeliveryConsumption,
+} from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
@@ -900,14 +904,38 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       } else if (existing.sendStatus === 'failed') {
         sdkMessageRepo.reopenDeliveryByUuid(sessionId, messageId);
       }
-      await deliverAndMarkQueued({
-        jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
-        stateManager: session.stateManager,
-        sessionId,
-        messageUuid: messageId,
-        origin: 'space_agent',
-        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
-      });
+      // Await SDK consumption (onSent) before returning, mirroring the LTA +
+      // task-agent injectors + the legacy enqueueWithId path. Without this a
+      // direct send_message handoff (no retained source row to retry) is recorded
+      // as delivered after a bare enqueue that may yet dead-letter. Rejects on
+      // timeout so the router doesn't acknowledge a delivery that may fail; the
+      // durable job keeps running and a later retry re-registers the wait. (Codex P1.)
+      const consumed = waitForDeliveryConsumption(messageId);
+      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await deliverAndMarkQueued({
+          jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
+          stateManager: session.stateManager,
+          sessionId,
+          messageUuid: messageId,
+          origin: 'space_agent',
+          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
+        });
+        const consumptionTimeoutMs =
+          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
+        await Promise.race([
+          consumed.promise,
+          new Promise<void>((_, reject) => {
+            consumptionTimeout = setTimeout(
+              () => reject(new Error('space-agent handoff not consumed within timeout')),
+              consumptionTimeoutMs
+            );
+          }),
+        ]);
+      } finally {
+        if (consumptionTimeout) clearTimeout(consumptionTimeout);
+        consumed.cancel();
+      }
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -86,7 +86,7 @@ import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import { SpaceLongHorizonAgentRepository } from '../../storage/repositories/space-long-horizon-agent-repository';
-import { deliverMessage, isMessageDeliveryV2Enabled } from '../agent/message-delivery';
+import { deliverAndMarkQueued, isMessageDeliveryV2Enabled } from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
 import type { EvolutionRepository } from '../../storage/repositories/evolution-repository';
@@ -886,32 +886,18 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     };
     if (isMessageDeliveryV2Enabled()) {
       // Persist first (content lives in sdk_messages), then enqueue a durable
-      // message_delivery job — the handler claims it and drives the turn.
+      // message_delivery job + mark queued as one per-session critical section —
+      // the handler claims the job and drives the turn.
       deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-      let role: 'turn' | 'steer';
-      try {
-        role = deliverMessage(deps.reactiveDb.db.getJobQueueRepo(), sessionId, messageId, {
-          origin: 'space_agent',
-          parentToolUseId: null,
-        });
-      } catch (err) {
-        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
-        // has no owner — terminalize it so a restart/replay can't run the orphaned
-        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
-        deps.reactiveDb.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
-        throw err;
-      }
-      if (role === 'turn') {
-        // Mark the session queued so a 'defer' message arriving before the
-        // processor claims the job is preserved for the next turn (its busy
-        // check only sees processing/queued) rather than classified as a steer
-        // on this pending turn. Mirrors deliverChatMessage / injectMessage.
-        try {
-          await session.stateManager.setQueuedIfIdle(messageId);
-        } catch {
-          // non-fatal — the durable job is already enqueued
-        }
-      }
+      await deliverAndMarkQueued({
+        jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
+        stateManager: session.stateManager,
+        sessionId,
+        messageUuid: messageId,
+        origin: 'space_agent',
+        onEnqueueFailure: () =>
+          deps.reactiveDb.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId),
+      });
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -594,18 +594,28 @@ export class SpaceRuntimeService {
       );
     }
     if (isMessageDeliveryV2Enabled()) {
-      // Persist first (content lives in sdk_messages), then enqueue a durable
-      // message_delivery job — the handler claims it and drives the turn.
-      reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      // Idempotent persist: external-event delivery / inbox flush can be retried
+      // with the same idempotency key after a crash between job insertion and
+      // source bookkeeping. sdk_uuid is indexed but not unique, so an
+      // unconditional save would insert a duplicate row that lingers forever.
+      // Skip the save when a row already exists, and never re-drive a terminal
+      // (consumed/failed/deferred/submitted) message.
+      const existing = reactiveDb.getSDKMessageRepo().getDeliveryContent(sessionId, id);
+      if (!existing) {
+        reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      } else if (existing.sendStatus !== 'enqueued') {
+        return id; // already terminal — a crash-retry must not re-drive it
+      }
+      // else: persisted 'enqueued' but crashed before the job — enqueue it;
+      // deliverMessage dedups the active job via getActiveDeliveryRole.
       try {
         deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
           origin: 'long_term_agent',
           parentToolUseId: null,
         });
       } catch (err) {
-        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
-        // has no owner — terminalize it so a restart/replay can't run the orphaned
-        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
+        // The row was saved 'enqueued'; if durable enqueue throws the prompt has
+        // no owner — terminalize it. Mirrors deliverChatMessage's handling.
         reactiveDb.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, id);
         throw err;
       }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -49,7 +49,7 @@ import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-l
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { AgentSession } from '../../agent/agent-session';
-import { deliverMessage } from '../../agent/message-delivery';
+import { deliverMessage, isMessageDeliveryV2Enabled } from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
@@ -583,17 +583,37 @@ export class SpaceRuntimeService {
         content: [{ type: 'text' as const, text: message }],
       },
     };
-    // Persist first, then enqueue a durable message_delivery job — the handler
-    // claims it and drives the turn. Replaces the inline ensureQueryStarted +
-    // enqueueWithId (no durable owner). reactiveDb is optional on the config but
-    // always present in production wiring; skip (matching prior behavior) if absent.
     const reactiveDb = this.config.reactiveDb?.db;
-    if (reactiveDb) {
+    if (!reactiveDb) {
+      // reactiveDb is optional on the config but always present in production
+      // wiring. Under v2 the handler reloads content by UUID, so without it the
+      // message can be neither persisted nor delivered — fail loudly rather than
+      // silently dropping it.
+      throw new Error(
+        `injectLongTermAgentMessage: reactiveDb unavailable; cannot deliver to ${sessionId}`
+      );
+    }
+    if (isMessageDeliveryV2Enabled()) {
+      // Persist first (content lives in sdk_messages), then enqueue a durable
+      // message_delivery job — the handler claims it and drives the turn.
       reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-      deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
-        origin: 'long_term_agent',
-        parentToolUseId: null,
-      });
+      try {
+        deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
+          origin: 'long_term_agent',
+          parentToolUseId: null,
+        });
+      } catch (err) {
+        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
+        // has no owner — terminalize it so a restart/replay can't run the orphaned
+        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
+        reactiveDb.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, id);
+        throw err;
+      }
+    } else {
+      // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
+      await session.ensureQueryStarted();
+      reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      await session.messageQueue.enqueueWithId(id, message);
     }
     return id;
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -49,6 +49,7 @@ import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-l
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { AgentSession } from '../../agent/agent-session';
+import { deliverMessage } from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
@@ -582,9 +583,18 @@ export class SpaceRuntimeService {
         content: [{ type: 'text' as const, text: message }],
       },
     };
-    await session.ensureQueryStarted();
-    this.config.reactiveDb?.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-    await session.messageQueue.enqueueWithId(id, message);
+    // Persist first, then enqueue a durable message_delivery job — the handler
+    // claims it and drives the turn. Replaces the inline ensureQueryStarted +
+    // enqueueWithId (no durable owner). reactiveDb is optional on the config but
+    // always present in production wiring; skip (matching prior behavior) if absent.
+    const reactiveDb = this.config.reactiveDb?.db;
+    if (reactiveDb) {
+      reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+      deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
+        origin: 'long_term_agent',
+        parentToolUseId: null,
+      });
+    }
     return id;
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -598,15 +598,22 @@ export class SpaceRuntimeService {
       // with the same idempotency key after a crash between job insertion and
       // source bookkeeping. sdk_uuid is indexed but not unique, so an
       // unconditional save would insert a duplicate row that lingers forever.
-      // Skip the save when a row already exists, and never re-drive a terminal
-      // (consumed/failed/deferred/submitted) message.
-      const existing = reactiveDb.getSDKMessageRepo().getDeliveryContent(sessionId, id);
+      // Distinguish prior outcomes: a `consumed` row genuinely ran (don't
+      // re-drive); a `failed` row means a prior attempt's enqueue threw and
+      // terminalized it — reopen it so this retry can deliver; an `enqueued`
+      // row just needs its job (re-)enqueued.
+      const sdkMessageRepo = reactiveDb.getSDKMessageRepo();
+      const existing = sdkMessageRepo.getDeliveryContent(sessionId, id);
       if (!existing) {
         reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-      } else if (existing.sendStatus !== 'enqueued') {
-        return id; // already terminal — a crash-retry must not re-drive it
+      } else if (existing.sendStatus === 'consumed') {
+        return id; // genuinely delivered on a prior attempt — don't re-drive
+      } else if (existing.sendStatus === 'failed') {
+        // Prior enqueue threw and terminalized the row; the handler skips
+        // `failed`, so reopen it before re-enqueueing.
+        sdkMessageRepo.reopenDeliveryByUuid(sessionId, id);
       }
-      // else: persisted 'enqueued' but crashed before the job — enqueue it;
+      // else (enqueued/deferred/submitted): row exists; just (re-)enqueue —
       // deliverMessage dedups the active job via getActiveDeliveryRole.
       try {
         deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -642,6 +642,7 @@ export class SpaceRuntimeService {
       // id, so its retry reopens + self-heals; terminalizing would kill a legit
       // in-flight job). (Codex P1.)
       await awaitDeliveryConsumption({
+        sessionId,
         messageUuid: id,
         deliver: () =>
           deliverAndMarkQueued({

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -475,7 +475,15 @@ export class SpaceRuntimeService {
   ): Promise<string | null> {
     const session = await this.ensureLongTermAgentSession(actor);
     if (!session) return null;
-    await this.injectLongTermAgentMessage(session, message.body);
+    // Pass the message's stable identifier so a consumption-timeout retry
+    // (injectLongTermAgentMessage rejects but the durable job keeps running)
+    // reuses the same UUID — the idempotent persist + getActiveDeliveryRole guard
+    // then prevent a second durable job + duplicated agent actions. (Codex P1.)
+    await this.injectLongTermAgentMessage(
+      session,
+      message.body,
+      message.idempotencyKey ?? message.messageId
+    );
     return session.getSessionData().id;
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -49,7 +49,11 @@ import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-l
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { AgentSession } from '../../agent/agent-session';
-import { deliverAndMarkQueued, isMessageDeliveryV2Enabled } from '../../agent/message-delivery';
+import {
+  deliverAndMarkQueued,
+  isMessageDeliveryV2Enabled,
+  waitForDeliveryConsumption,
+} from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
@@ -618,14 +622,39 @@ export class SpaceRuntimeService {
       // else (enqueued/deferred/submitted): row exists; just (re-)enqueue —
       // deliverMessage dedups the active job via getActiveDeliveryRole. Enqueue
       // + mark queued as one per-session critical section (deliverAndMarkQueued).
-      await deliverAndMarkQueued({
-        jobQueue: reactiveDb.getJobQueueRepo(),
-        stateManager: session.stateManager,
-        sessionId,
-        messageUuid: id,
-        origin: 'long_term_agent',
-        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
-      });
+      //
+      // Restore the legacy "delivered = consumed by the SDK" semantic: register
+      // the consumption wait BEFORE enqueuing (the handler can claim + consume
+      // quickly), then await the SDK's onSent before returning. Callers
+      // (flushLongTermAgentInbox / deliverLongHorizonExternalEvent) thus confirm
+      // the source record only after genuine consumption — not bare enqueue,
+      // which can still dead-letter. Bounded by a timeout (matching the legacy
+      // 30s MessageQueue timeout; overridable for tests) so a parked/busy session
+      // can't hang the flush; on timeout we proceed (the bare-enqueue floor).
+      // (Codex P1.)
+      const consumed = waitForDeliveryConsumption(id);
+      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await deliverAndMarkQueued({
+          jobQueue: reactiveDb.getJobQueueRepo(),
+          stateManager: session.stateManager,
+          sessionId,
+          messageUuid: id,
+          origin: 'long_term_agent',
+          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
+        });
+        const consumptionTimeoutMs =
+          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
+        await Promise.race([
+          consumed.promise,
+          new Promise<void>((resolve) => {
+            consumptionTimeout = setTimeout(resolve, consumptionTimeoutMs);
+          }),
+        ]);
+      } finally {
+        if (consumptionTimeout) clearTimeout(consumptionTimeout);
+        consumed.cancel();
+      }
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -566,6 +566,8 @@ export class SpaceRuntimeService {
       getSessionData(): Session;
       ensureQueryStarted(): Promise<void>;
       messageQueue: { enqueueWithId: (id: string, message: string) => Promise<void> };
+      /** Present on real AgentSessions; marked optional so test mocks need not stub it. */
+      stateManager?: { setQueuedIfIdle(messageId: string): Promise<boolean> };
     },
     message: string,
     messageId?: string
@@ -615,8 +617,9 @@ export class SpaceRuntimeService {
       }
       // else (enqueued/deferred/submitted): row exists; just (re-)enqueue —
       // deliverMessage dedups the active job via getActiveDeliveryRole.
+      let role: 'turn' | 'steer';
       try {
-        deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
+        role = deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
           origin: 'long_term_agent',
           parentToolUseId: null,
         });
@@ -625,6 +628,15 @@ export class SpaceRuntimeService {
         // no owner — terminalize it. Mirrors deliverChatMessage's handling.
         reactiveDb.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, id);
         throw err;
+      }
+      if (role === 'turn' && session.stateManager) {
+        // Mark the session queued so it reports non-idle while the turn job is
+        // pending, mirroring deliverChatMessage / the other injectors.
+        try {
+          await session.stateManager.setQueuedIfIdle(id);
+        } catch {
+          // non-fatal — the durable job is already enqueued
+        }
       }
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -630,7 +630,10 @@ export class SpaceRuntimeService {
       // the source record only after genuine consumption — not bare enqueue,
       // which can still dead-letter. Bounded by a timeout (matching the legacy
       // 30s MessageQueue timeout; overridable for tests) so a parked/busy session
-      // can't hang the flush; on timeout we proceed (the bare-enqueue floor).
+      // can't hang the flush. On timeout the job is still pending/retrying and
+      // may yet dead-letter, so REJECT (do not acknowledge) — callers catch and
+      // retry the source record; the durable job keeps running and a later retry
+      // re-registers the wait, so a slow-but-successful delivery self-heals.
       // (Codex P1.)
       const consumed = waitForDeliveryConsumption(id);
       let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -647,8 +650,11 @@ export class SpaceRuntimeService {
           Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
         await Promise.race([
           consumed.promise,
-          new Promise<void>((resolve) => {
-            consumptionTimeout = setTimeout(resolve, consumptionTimeoutMs);
+          new Promise<void>((_, reject) => {
+            consumptionTimeout = setTimeout(
+              () => reject(new Error('long-term-agent delivery not consumed within timeout')),
+              consumptionTimeoutMs
+            );
           }),
         ]);
       } finally {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -579,7 +579,10 @@ export class SpaceRuntimeService {
       ensureQueryStarted(): Promise<void>;
       messageQueue: { enqueueWithId: (id: string, message: string) => Promise<void> };
       /** Present on real AgentSessions; marked optional so test mocks need not stub it. */
-      stateManager?: { setQueuedIfIdle(messageId: string): Promise<boolean> };
+      stateManager?: {
+        setQueuedIfIdle(messageId: string): Promise<boolean>;
+        getState(): { status: string };
+      };
     },
     message: string,
     messageId?: string

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -646,6 +646,8 @@ export class SpaceRuntimeService {
           origin: 'long_term_agent',
           onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
         });
+        // Ceiling on the wait for the SDK to consume the message (onSent).
+        // Matches the legacy 30s MessageQueue timeout; override for tests.
         const consumptionTimeoutMs =
           Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
         await Promise.race([

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -50,9 +50,9 @@ import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { AgentSession } from '../../agent/agent-session';
 import {
+  awaitDeliveryConsumption,
   deliverAndMarkQueued,
   isMessageDeliveryV2Enabled,
-  waitForDeliveryConsumption,
 } from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
@@ -621,6 +621,7 @@ export class SpaceRuntimeService {
       // row just needs its job (re-)enqueued.
       const sdkMessageRepo = reactiveDb.getSDKMessageRepo();
       const existing = sdkMessageRepo.getDeliveryContent(sessionId, id);
+      const fresh = !existing;
       if (!existing) {
         reactiveDb.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
       } else if (existing.sendStatus === 'consumed') {
@@ -634,46 +635,27 @@ export class SpaceRuntimeService {
       // deliverMessage dedups the active job via getActiveDeliveryRole. Enqueue
       // + mark queued as one per-session critical section (deliverAndMarkQueued).
       //
-      // Restore the legacy "delivered = consumed by the SDK" semantic: register
-      // the consumption wait BEFORE enqueuing (the handler can claim + consume
-      // quickly), then await the SDK's onSent before returning. Callers
+      // Await SDK consumption (onSent) before returning — callers
       // (flushLongTermAgentInbox / deliverLongHorizonExternalEvent) thus confirm
-      // the source record only after genuine consumption — not bare enqueue,
-      // which can still dead-letter. Bounded by a timeout (matching the legacy
-      // 30s MessageQueue timeout; overridable for tests) so a parked/busy session
-      // can't hang the flush. On timeout the job is still pending/retrying and
-      // may yet dead-letter, so REJECT (do not acknowledge) — callers catch and
-      // retry the source record; the durable job keeps running and a later retry
-      // re-registers the wait, so a slow-but-successful delivery self-heals.
-      // (Codex P1.)
-      const consumed = waitForDeliveryConsumption(id);
-      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await deliverAndMarkQueued({
-          jobQueue: reactiveDb.getJobQueueRepo(),
-          stateManager: session.stateManager,
-          sessionId,
-          messageUuid: id,
-          origin: 'long_term_agent',
-          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
-        });
-        // Ceiling on the wait for the SDK to consume the message (onSent).
-        // Matches the legacy 30s MessageQueue timeout; override for tests.
-        const consumptionTimeoutMs =
-          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
-        await Promise.race([
-          consumed.promise,
-          new Promise<void>((_, reject) => {
-            consumptionTimeout = setTimeout(
-              () => reject(new Error('long-term-agent delivery not consumed within timeout')),
-              consumptionTimeoutMs
-            );
+      // the source record only after genuine consumption, not bare enqueue. On
+      // timeout, terminalize ONLY a fresh row (the inbox flush carries a stable
+      // id, so its retry reopens + self-heals; terminalizing would kill a legit
+      // in-flight job). (Codex P1.)
+      await awaitDeliveryConsumption({
+        messageUuid: id,
+        deliver: () =>
+          deliverAndMarkQueued({
+            jobQueue: reactiveDb.getJobQueueRepo(),
+            stateManager: session.stateManager,
+            sessionId,
+            messageUuid: id,
+            origin: 'long_term_agent',
+            onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
           }),
-        ]);
-      } finally {
-        if (consumptionTimeout) clearTimeout(consumptionTimeout);
-        consumed.cancel();
-      }
+        ...(fresh
+          ? { terminalizeOnTimeout: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id) }
+          : {}),
+      });
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -49,7 +49,7 @@ import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-l
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { AgentSession } from '../../agent/agent-session';
-import { deliverMessage, isMessageDeliveryV2Enabled } from '../../agent/message-delivery';
+import { deliverAndMarkQueued, isMessageDeliveryV2Enabled } from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
 import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
@@ -616,28 +616,16 @@ export class SpaceRuntimeService {
         sdkMessageRepo.reopenDeliveryByUuid(sessionId, id);
       }
       // else (enqueued/deferred/submitted): row exists; just (re-)enqueue —
-      // deliverMessage dedups the active job via getActiveDeliveryRole.
-      let role: 'turn' | 'steer';
-      try {
-        role = deliverMessage(reactiveDb.getJobQueueRepo(), sessionId, id, {
-          origin: 'long_term_agent',
-          parentToolUseId: null,
-        });
-      } catch (err) {
-        // The row was saved 'enqueued'; if durable enqueue throws the prompt has
-        // no owner — terminalize it. Mirrors deliverChatMessage's handling.
-        reactiveDb.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, id);
-        throw err;
-      }
-      if (role === 'turn' && session.stateManager) {
-        // Mark the session queued so it reports non-idle while the turn job is
-        // pending, mirroring deliverChatMessage / the other injectors.
-        try {
-          await session.stateManager.setQueuedIfIdle(id);
-        } catch {
-          // non-fatal — the durable job is already enqueued
-        }
-      }
+      // deliverMessage dedups the active job via getActiveDeliveryRole. Enqueue
+      // + mark queued as one per-session critical section (deliverAndMarkQueued).
+      await deliverAndMarkQueued({
+        jobQueue: reactiveDb.getJobQueueRepo(),
+        stateManager: session.stateManager,
+        sessionId,
+        messageUuid: id,
+        origin: 'long_term_agent',
+        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id),
+      });
     } else {
       // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
       await session.ensureQueryStarted();

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -56,6 +56,7 @@ import type { UUID } from 'crypto';
 import type { SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
 import { AgentSession } from '../../../lib/agent/agent-session';
+import { deliverMessage } from '../../../lib/agent/message-delivery';
 import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
@@ -4530,6 +4531,16 @@ export class TaskAgentManager {
    * `validateImageSizes` so users get the same early "resize image" error
    * instead of a downstream API failure.
    */
+  /**
+   * True if any message_delivery job (turn or steer) is pending or processing
+   * for the session. Used to gate resetContextPerTurn so a `/clear` does not race
+   * a v2 turn whose job is enqueued but not yet claimed — the session's live
+   * processing state lags the durable job state under v2. Read-only indexed SELECT.
+   */
+  private hasActiveDeliveryJob(sessionId: string): boolean {
+    return this.config.db.getJobQueueRepo().activeDeliveryMessageUuids(sessionId).size > 0;
+  }
+
   private async injectMessageIntoSession(
     session: AgentSession,
     message: string,
@@ -4615,16 +4626,19 @@ export class TaskAgentManager {
     // is processed. Only task inputs clear — human input and system recovery are
     // classified at the inject entry points and never reach here as 'task'. Skip
     // when there is no prior context (the slot's first turn — a fresh session has
-    // no sdkSessionId yet) or when the session is mid-turn (busy), so the clear
-    // cannot race with queued input and never wastes a no-op clear. `/clear` is
-    // an SDK command, so the gate is sdkSessionId: an ACP (codex) slot with the
-    // flag set clears nothing until ACP grows an equivalent.
+    // no sdkSessionId yet), when the session is mid-turn (busy), OR when a
+    // durable delivery job is already pending/processing for the session (the v2
+    // turn will drive shortly; a clear now would race it), so the clear cannot
+    // race with queued input and never wastes a no-op clear. `/clear` is an SDK
+    // command, so the gate is sdkSessionId: an ACP (codex) slot with the flag set
+    // clears nothing until ACP grows an equivalent.
     const hasPriorContext = !!session.session.sdkSessionId;
     const shouldClearContext =
       inputKind === 'task' &&
       !isBusy &&
       hasPriorContext &&
-      this.slotResetsContextForSession(sessionId);
+      this.slotResetsContextForSession(sessionId) &&
+      !this.hasActiveDeliveryJob(sessionId);
     if (shouldClearContext) {
       try {
         await session.clearConversationContext();
@@ -4636,12 +4650,20 @@ export class TaskAgentManager {
       }
     }
 
-    await session.ensureQueryStarted();
+    // Persist the kickoff BEFORE enqueuing the durable delivery job — the handler
+    // reloads content by UUID, so the sdk_messages row must exist when the job is
+    // claimed (else the handler sees no content and drops the message). Image /
+    // multi-modal content is persisted verbatim in sdkUserMessage and reloaded by
+    // the handler, so no special enqueue handling is needed.
     const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
-    // When images are present, enqueue the multi-modal content array so the SDK
-    // sees image blocks alongside the text. Otherwise pass the plain string to
-    // preserve the existing behaviour for callers that don't supply images.
-    await session.messageQueue.enqueueWithId(messageId, hasImages ? sdkContent : message);
+    // deliverMessage enqueues a message_delivery job (role turn/steer decided
+    // atomically by the job_queue index); the handler then owns ensureQueryStarted
+    // and feeding the live transport. Replaces the inline ensureQueryStarted +
+    // enqueueWithId, which had no durable owner.
+    deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
+      origin: 'space_inject',
+      parentToolUseId: null,
+    });
     return dbId;
   }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4654,6 +4654,14 @@ export class TaskAgentManager {
     const parentTask = parentTaskId ? this.config.taskRepo.getTask(parentTaskId) : null;
     const parentLimited = parentTask ? isRateOrUsageLimited(parentTask.status) : false;
     if ((deliveryMode === 'defer' && isBusy) || inRateLimitCooldown || parentLimited) {
+      // An existing row that isn't already `deferred` (e.g. a `failed` row just
+      // reopened to `enqueued`) must be flipped to `deferred` here, or
+      // QueryModeHandler's replay — which selects only `send_status='deferred'` —
+      // never picks it up and the handoff is lost on an idle parent-limited
+      // session. (Codex P1.)
+      if (v2Enabled && existing && existing.sendStatus !== 'deferred') {
+        this.config.db.getSDKMessageRepo().markDeliveryDeferredByUuid(sessionId, messageId);
+      }
       // Reuse the existing row if present (idempotent); only insert on the first
       // attempt — a duplicate deferred row would replay the handoff multiple times.
       const dbId = existing

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1986,7 +1986,8 @@ export class TaskAgentManager {
             origin,
             isSyntheticMessage,
             images,
-            inputKind
+            inputKind,
+            messageId
           );
         }
       }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -56,7 +56,10 @@ import type { UUID } from 'crypto';
 import type { SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
 import { AgentSession } from '../../../lib/agent/agent-session';
-import { deliverMessage, isMessageDeliveryV2Enabled } from '../../../lib/agent/message-delivery';
+import {
+  deliverAndMarkQueued,
+  isMessageDeliveryV2Enabled,
+} from '../../../lib/agent/message-delivery';
 import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
@@ -4519,19 +4522,6 @@ export class TaskAgentManager {
   // -------------------------------------------------------------------------
 
   /**
-   * Inject a message (optionally with image attachments) into an AgentSession.
-   *
-   * Mirrors the multi-modal content shape produced by `buildMessageContent`
-   * in `MessagePersistence.persist` (the regular non-space chat path): when
-   * `images` is non-empty the SDK message content becomes a multi-modal
-   * block array (images first, then text) and is passed through to
-   * `MessageQueue.enqueueWithId`, which already accepts
-   * `string | MessageContent[]`. Image base64 sizes are validated against
-   * the same Anthropic API limit as the non-space path via
-   * `validateImageSizes` so users get the same early "resize image" error
-   * instead of a downstream API failure.
-   */
-  /**
    * True if any message_delivery job (turn or steer) is pending or processing
    * for the session. Used to gate resetContextPerTurn so a `/clear` does not race
    * a v2 turn whose job is enqueued but not yet claimed — the session's live
@@ -4656,36 +4646,19 @@ export class TaskAgentManager {
       // the job is claimed. Image/multimodal content is persisted verbatim and
       // reloaded by the handler, so no special enqueue handling is needed.
       const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
-      let role: 'turn' | 'steer';
-      try {
-        // deliverMessage enqueues a message_delivery job (role turn/steer decided
-        // atomically by the job_queue index); the handler then owns
-        // ensureQueryStarted and feeding the live transport.
-        role = deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
-          origin: 'space_inject',
-          parentToolUseId: null,
-        });
-      } catch (err) {
-        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
-        // has no owner — terminalize it so a restart/replay can't run the orphaned
-        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
-        this.config.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
-        throw err;
-      }
-      if (role === 'turn') {
-        // Mark the session queued so task-pause / live-session checks treat a
-        // pending turn job as non-idle. Without this, a pause that lands before
-        // the delivery processor claims the job skips the (idle-reporting)
-        // session, and the handler later runs the agent while the task is paused.
-        try {
-          await session.stateManager.setQueuedIfIdle(messageId);
-        } catch (error) {
-          log.warn(
-            `TaskAgentManager: queued-state publication failed for ${sessionId}: ` +
-              `${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-      }
+      // Enqueue the durable delivery job + mark queued as one per-session critical
+      // section (deliverAndMarkQueued holds withSessionLock so a concurrent steer
+      // can't steal the turn's queued marker). The handler then owns
+      // ensureQueryStarted and feeding the live transport.
+      await deliverAndMarkQueued({
+        jobQueue: this.config.db.getJobQueueRepo(),
+        stateManager: session.stateManager,
+        sessionId,
+        messageUuid: messageId,
+        origin: 'space_inject',
+        onEnqueueFailure: () =>
+          this.config.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId),
+      });
       return dbId;
     }
     // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -59,6 +59,7 @@ import { AgentSession } from '../../../lib/agent/agent-session';
 import {
   deliverAndMarkQueued,
   isMessageDeliveryV2Enabled,
+  waitForDeliveryConsumption,
 } from '../../../lib/agent/message-delivery';
 import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
@@ -4720,14 +4721,40 @@ export class TaskAgentManager {
         ? messageId
         : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
       const sdkMessageRepo = this.config.db.getSDKMessageRepo();
-      await deliverAndMarkQueued({
-        jobQueue: this.config.db.getJobQueueRepo(),
-        stateManager: session.stateManager,
-        sessionId,
-        messageUuid: messageId,
-        origin: 'space_inject',
-        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
-      });
+      // Restore the legacy "delivered = consumed by the SDK" semantic (the legacy
+      // path awaited messageQueue.enqueueWithId until onSent). Without this, a
+      // direct handoff (e.g. the live send_message path) returns delivered after a
+      // bare enqueue, but the job can later dead-letter without the recipient ever
+      // seeing it — and unlike the flush path there's no retained source row to
+      // retry. Await SDK consumption (onSent), rejecting on timeout so callers
+      // don't acknowledge a delivery that may yet dead-letter; the durable job
+      // keeps running and a later retry re-registers the wait. (Codex P1.)
+      const consumed = waitForDeliveryConsumption(messageId);
+      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await deliverAndMarkQueued({
+          jobQueue: this.config.db.getJobQueueRepo(),
+          stateManager: session.stateManager,
+          sessionId,
+          messageUuid: messageId,
+          origin: 'space_inject',
+          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
+        });
+        const consumptionTimeoutMs =
+          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
+        await Promise.race([
+          consumed.promise,
+          new Promise<void>((_, reject) => {
+            consumptionTimeout = setTimeout(
+              () => reject(new Error('task-agent handoff not consumed within timeout')),
+              consumptionTimeoutMs
+            );
+          }),
+        ]);
+      } finally {
+        if (consumptionTimeout) clearTimeout(consumptionTimeout);
+        consumed.cancel();
+      }
       return dbId;
     }
     // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4553,6 +4553,17 @@ export class TaskAgentManager {
     return this.config.db.getJobQueueRepo().activeDeliveryMessageUuids(sessionId).size > 0;
   }
 
+  /**
+   * Inject a handoff/user message into a sub-session under v2 durable delivery.
+   * Idempotent on the message UUID (hoisted before the deferred save AND the
+   * resetContextPerTurn clear): a flush retry reusing the pending-row id reuses
+   * the existing `sdk_messages` row instead of inserting a duplicate, and an
+   * already-consumed row short-circuits (no `/clear`, no re-drive). Defers when
+   * the target is busy / rate-limited / parent-limited (marking the row
+   * `deferred` for QueryModeHandler replay); otherwise enqueues a durable
+   * `message_delivery` job via {@link deliverAndMarkQueued}. Returns the row id
+   * (the stable message UUID when a row already exists).
+   */
   private async injectMessageIntoSession(
     session: AgentSession,
     message: string,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4660,11 +4660,27 @@ export class TaskAgentManager {
     }
 
     if (isMessageDeliveryV2Enabled()) {
-      // Persist the kickoff BEFORE enqueuing the durable delivery job — the
-      // handler reloads content by UUID, so the sdk_messages row must exist when
-      // the job is claimed. Image/multimodal content is persisted verbatim and
-      // reloaded by the handler, so no special enqueue handling is needed.
-      const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
+      // Idempotent persist (mirrors the LTA + Space-agent injectors): a flush
+      // retry after a crash between injection and markDelivered reuses the same
+      // pending-row id, but saveUserMessage mints a fresh row id each call — so
+      // without this guard the retry inserts a SECOND sdk_messages row (same
+      // sdk_uuid). sdk_uuid isn't unique and getDeliveryContent picks the oldest,
+      // so the retry's row strands as `enqueued`; if the first job already
+      // completed, the retry additionally re-drives the oldest consumed turn.
+      // Distinguish prior outcomes: `consumed` ⇒ genuinely delivered, don't
+      // re-drive; `failed` ⇒ a prior enqueue threw and terminalized it, reopen;
+      // otherwise the row exists, just (re-)enqueue its job. (Codex P1.)
+      const sdkMessageRepo = this.config.db.getSDKMessageRepo();
+      const existing = sdkMessageRepo.getDeliveryContent(sessionId, messageId);
+      if (existing?.sendStatus === 'consumed') {
+        return messageId; // genuinely delivered on a prior attempt — don't re-drive
+      }
+      if (existing?.sendStatus === 'failed') {
+        sdkMessageRepo.reopenDeliveryByUuid(sessionId, messageId);
+      }
+      const dbId = existing
+        ? messageId // row already persisted (enqueued/deferred/reopened) — reuse it
+        : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
       // Enqueue the durable delivery job + mark queued as one per-session critical
       // section (deliverAndMarkQueued holds withSessionLock so a concurrent steer
       // can't steal the turn's queued marker). The handler then owns
@@ -4675,8 +4691,7 @@ export class TaskAgentManager {
         sessionId,
         messageUuid: messageId,
         origin: 'space_inject',
-        onEnqueueFailure: () =>
-          this.config.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId),
+        onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
       });
       return dbId;
     }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3433,10 +3433,16 @@ export class TaskAgentManager {
     // 1. Stop sub-sessions (interrupt + cleanup, no DB delete).
     // stopSessionPreserveDb unsubscribes listeners and drops completion
     // callbacks for each session ID as part of its teardown.
+    // preserveDeliveryJobs: shutdown requeues in-flight message_delivery rows
+    // for the next boot (app.ts) BEFORE this runs — cancelling them here would
+    // delete the durable handoff we just preserved. The query still aborts so
+    // cleanup doesn't block; only the durable-job cancel is skipped.
     const nodeMap = this.subSessions.get(taskId);
     if (nodeMap) {
       for (const [subSessionId, session] of nodeMap) {
-        await this.stopSessionPreserveDb(subSessionId, session);
+        await this.stopSessionPreserveDb(subSessionId, session, {
+          preserveDeliveryJobs: true,
+        });
         this.agentSessionIndex.delete(subSessionId);
       }
       this.subSessions.delete(taskId);
@@ -4724,7 +4730,7 @@ export class TaskAgentManager {
   private async stopSessionPreserveDb(
     sessionId: string,
     session: AgentSession,
-    options: { strict?: boolean } = {}
+    options: { strict?: boolean; preserveDeliveryJobs?: boolean } = {}
   ): Promise<void> {
     const unsub = this.sessionListeners.get(sessionId);
     if (!options.strict && unsub) {
@@ -4737,7 +4743,13 @@ export class TaskAgentManager {
 
     let stopError: unknown;
     try {
-      await session.handleInterrupt();
+      // preserveDeliveryJobs: on a restart-bound shutdown stop, do NOT cancel
+      // the session's message_delivery jobs — app.ts already requeued them for
+      // the next boot, and handleInterrupt's default cancel would delete the
+      // durable handoff we just preserved. (Codex P1.)
+      await session.handleInterrupt(
+        options.preserveDeliveryJobs ? { preserveDeliveryJobs: true } : undefined
+      );
     } catch (err) {
       stopError = err;
       log.warn(`TaskAgentManager: failed to interrupt session ${sessionId}:`, err);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4617,6 +4617,28 @@ export class TaskAgentManager {
       },
     };
 
+    // Idempotent persist guard (v2), hoisted BEFORE the deferred save AND the
+    // resetContextPerTurn clear. A flush retry / concurrent flush reuses the
+    // pending-row id, but saveUserMessage mints a fresh row id each call.
+    // Without this guard up front, (a) the deferred branch inserts a SECOND
+    // deferred row with the same non-unique sdk_uuid — QueryModeHandler replays
+    // every deferred row, so the handoff delivers multiple times; and (b) a
+    // crash after the delivery job completed but before markDelivered retries
+    // the same id, reaches resetContextPerTurn's /clear, and rotates away the
+    // context holding the just-delivered handoff. `consumed` ⇒ already
+    // delivered — return without clearing/re-saving/re-driving; `failed` ⇒ a
+    // prior enqueue threw and terminalized it — reopen. (Codex P1.)
+    const v2Enabled = isMessageDeliveryV2Enabled();
+    const existing = v2Enabled
+      ? this.config.db.getSDKMessageRepo().getDeliveryContent(sessionId, messageId)
+      : null;
+    if (existing?.sendStatus === 'consumed') {
+      return messageId; // genuinely delivered on a prior attempt — no clear, no re-drive
+    }
+    if (existing?.sendStatus === 'failed') {
+      this.config.db.getSDKMessageRepo().reopenDeliveryByUuid(sessionId, messageId);
+    }
+
     // defer + busy → persist as deferred for replay after current turn completes.
     // A session in rate_limit_cooldown is paused on a rate/usage cap — ALWAYS
     // defer incoming messages (even `immediate` delivery from an external event
@@ -4632,7 +4654,11 @@ export class TaskAgentManager {
     const parentTask = parentTaskId ? this.config.taskRepo.getTask(parentTaskId) : null;
     const parentLimited = parentTask ? isRateOrUsageLimited(parentTask.status) : false;
     if ((deliveryMode === 'defer' && isBusy) || inRateLimitCooldown || parentLimited) {
-      const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
+      // Reuse the existing row if present (idempotent); only insert on the first
+      // attempt — a duplicate deferred row would replay the handoff multiple times.
+      const dbId = existing
+        ? messageId
+        : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
       return dbId;
     }
 
@@ -4665,32 +4691,16 @@ export class TaskAgentManager {
       }
     }
 
-    if (isMessageDeliveryV2Enabled()) {
-      // Idempotent persist (mirrors the LTA + Space-agent injectors): a flush
-      // retry after a crash between injection and markDelivered reuses the same
-      // pending-row id, but saveUserMessage mints a fresh row id each call — so
-      // without this guard the retry inserts a SECOND sdk_messages row (same
-      // sdk_uuid). sdk_uuid isn't unique and getDeliveryContent picks the oldest,
-      // so the retry's row strands as `enqueued`; if the first job already
-      // completed, the retry additionally re-drives the oldest consumed turn.
-      // Distinguish prior outcomes: `consumed` ⇒ genuinely delivered, don't
-      // re-drive; `failed` ⇒ a prior enqueue threw and terminalized it, reopen;
-      // otherwise the row exists, just (re-)enqueue its job. (Codex P1.)
-      const sdkMessageRepo = this.config.db.getSDKMessageRepo();
-      const existing = sdkMessageRepo.getDeliveryContent(sessionId, messageId);
-      if (existing?.sendStatus === 'consumed') {
-        return messageId; // genuinely delivered on a prior attempt — don't re-drive
-      }
-      if (existing?.sendStatus === 'failed') {
-        sdkMessageRepo.reopenDeliveryByUuid(sessionId, messageId);
-      }
+    if (v2Enabled) {
+      // The idempotent lookup + consumed/failed handling ran hoisted above; here
+      // only the (re-)enqueue + queued marker remain. Reuse the existing row if
+      // present, else insert `enqueued`. deliverAndMarkQueued holds withSessionLock
+      // so a concurrent steer can't steal the turn's queued marker; the handler
+      // then owns ensureQueryStarted and feeding the live transport.
       const dbId = existing
-        ? messageId // row already persisted (enqueued/deferred/reopened) — reuse it
+        ? messageId
         : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
-      // Enqueue the durable delivery job + mark queued as one per-session critical
-      // section (deliverAndMarkQueued holds withSessionLock so a concurrent steer
-      // can't steal the turn's queued marker). The handler then owns
-      // ensureQueryStarted and feeding the live transport.
+      const sdkMessageRepo = this.config.db.getSDKMessageRepo();
       await deliverAndMarkQueued({
         jobQueue: this.config.db.getJobQueueRepo(),
         stateManager: session.stateManager,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -57,9 +57,9 @@ import type { SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
 import { AgentSession } from '../../../lib/agent/agent-session';
 import {
+  awaitDeliveryConsumption,
   deliverAndMarkQueued,
   isMessageDeliveryV2Enabled,
-  waitForDeliveryConsumption,
 } from '../../../lib/agent/message-delivery';
 import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
@@ -4721,40 +4721,32 @@ export class TaskAgentManager {
         ? messageId
         : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
       const sdkMessageRepo = this.config.db.getSDKMessageRepo();
-      // Restore the legacy "delivered = consumed by the SDK" semantic (the legacy
-      // path awaited messageQueue.enqueueWithId until onSent). Without this, a
-      // direct handoff (e.g. the live send_message path) returns delivered after a
-      // bare enqueue, but the job can later dead-letter without the recipient ever
-      // seeing it — and unlike the flush path there's no retained source row to
-      // retry. Await SDK consumption (onSent), rejecting on timeout so callers
-      // don't acknowledge a delivery that may yet dead-letter; the durable job
-      // keeps running and a later retry re-registers the wait. (Codex P1.)
-      const consumed = waitForDeliveryConsumption(messageId);
-      let consumptionTimeout: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await deliverAndMarkQueued({
-          jobQueue: this.config.db.getJobQueueRepo(),
-          stateManager: session.stateManager,
-          sessionId,
-          messageUuid: messageId,
-          origin: 'space_inject',
-          onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
-        });
-        const consumptionTimeoutMs =
-          Number(process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS) || 30_000;
-        await Promise.race([
-          consumed.promise,
-          new Promise<void>((_, reject) => {
-            consumptionTimeout = setTimeout(
-              () => reject(new Error('task-agent handoff not consumed within timeout')),
-              consumptionTimeoutMs
-            );
+      // Await SDK consumption (onSent) before returning — a direct handoff (the
+      // live send_message path) has no retained source row to retry, so it must
+      // not report delivered after a bare enqueue that may yet dead-letter. On
+      // timeout, terminalize ONLY a fresh row: direct send_message carries no
+      // stable id, so a retry mints a fresh UUID — terminalizing the timed-out
+      // fresh job stops it being consumed alongside the retry (duplicate). The
+      // flush path carries a stable id (existing row), so it omits the
+      // terminalize and self-heals via retry. (Codex P1.)
+      await awaitDeliveryConsumption({
+        messageUuid: messageId,
+        deliver: () =>
+          deliverAndMarkQueued({
+            jobQueue: this.config.db.getJobQueueRepo(),
+            stateManager: session.stateManager,
+            sessionId,
+            messageUuid: messageId,
+            origin: 'space_inject',
+            onEnqueueFailure: () => sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
           }),
-        ]);
-      } finally {
-        if (consumptionTimeout) clearTimeout(consumptionTimeout);
-        consumed.cancel();
-      }
+        ...(!existing
+          ? {
+              terminalizeOnTimeout: () =>
+                sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId),
+            }
+          : {}),
+      });
       return dbId;
     }
     // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -56,7 +56,7 @@ import type { UUID } from 'crypto';
 import type { SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
 import { AgentSession } from '../../../lib/agent/agent-session';
-import { deliverMessage } from '../../../lib/agent/message-delivery';
+import { deliverMessage, isMessageDeliveryV2Enabled } from '../../../lib/agent/message-delivery';
 import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
@@ -4650,20 +4650,36 @@ export class TaskAgentManager {
       }
     }
 
-    // Persist the kickoff BEFORE enqueuing the durable delivery job — the handler
-    // reloads content by UUID, so the sdk_messages row must exist when the job is
-    // claimed (else the handler sees no content and drops the message). Image /
-    // multi-modal content is persisted verbatim in sdkUserMessage and reloaded by
-    // the handler, so no special enqueue handling is needed.
+    if (isMessageDeliveryV2Enabled()) {
+      // Persist the kickoff BEFORE enqueuing the durable delivery job — the
+      // handler reloads content by UUID, so the sdk_messages row must exist when
+      // the job is claimed. Image/multimodal content is persisted verbatim and
+      // reloaded by the handler, so no special enqueue handling is needed.
+      const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
+      try {
+        // deliverMessage enqueues a message_delivery job (role turn/steer decided
+        // atomically by the job_queue index); the handler then owns
+        // ensureQueryStarted and feeding the live transport.
+        deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
+          origin: 'space_inject',
+          parentToolUseId: null,
+        });
+      } catch (err) {
+        // The row was just saved 'enqueued'; if durable enqueue throws the prompt
+        // has no owner — terminalize it so a restart/replay can't run the orphaned
+        // original. Mirrors AgentSession.deliverChatMessage's failure handling.
+        this.config.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
+        throw err;
+      }
+      return dbId;
+    }
+    // Legacy inline path (HYPERNEO_MESSAGE_DELIVERY_V2=0 opt-out).
+    await session.ensureQueryStarted();
     const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
-    // deliverMessage enqueues a message_delivery job (role turn/steer decided
-    // atomically by the job_queue index); the handler then owns ensureQueryStarted
-    // and feeding the live transport. Replaces the inline ensureQueryStarted +
-    // enqueueWithId, which had no durable owner.
-    deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
-      origin: 'space_inject',
-      parentToolUseId: null,
-    });
+    // When images are present, enqueue the multi-modal content array so the SDK
+    // sees image blocks alongside the text. Otherwise pass the plain string to
+    // preserve the existing behaviour for callers that don't supply images.
+    await session.messageQueue.enqueueWithId(messageId, hasImages ? sdkContent : message);
     return dbId;
   }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -327,7 +327,9 @@ export interface TaskAgentManagerConfig {
   spaceAgentInjector?: (
     spaceId: string,
     message: string,
-    replyToSessionId?: string | null
+    replyToSessionId?: string | null,
+    /** Pending-row id (crash-retry dedup key); forwarded as the delivery UUID. */
+    explicitMessageId?: string
   ) => Promise<void>;
   /**
    * Schedule service — shared business logic for managing task schedules.
@@ -1837,7 +1839,7 @@ export class TaskAgentManager {
         const replyTo =
           extractReplyToSessionId(message) ??
           (registry && row.taskId ? registry.get(row.taskId) : null);
-        await inject(spaceId, message, replyTo);
+        await inject(spaceId, message, replyTo, row.id);
         repo.markDelivered(row.id, spaceChatSessionId);
         this.emitPendingDelivered(row.id, spaceChatSessionId, row);
       } catch (err) {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4656,11 +4656,12 @@ export class TaskAgentManager {
       // the job is claimed. Image/multimodal content is persisted verbatim and
       // reloaded by the handler, so no special enqueue handling is needed.
       const dbId = this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
+      let role: 'turn' | 'steer';
       try {
         // deliverMessage enqueues a message_delivery job (role turn/steer decided
         // atomically by the job_queue index); the handler then owns
         // ensureQueryStarted and feeding the live transport.
-        deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
+        role = deliverMessage(this.config.db.getJobQueueRepo(), sessionId, messageId, {
           origin: 'space_inject',
           parentToolUseId: null,
         });
@@ -4670,6 +4671,20 @@ export class TaskAgentManager {
         // original. Mirrors AgentSession.deliverChatMessage's failure handling.
         this.config.db.getSDKMessageRepo().markDeliveryFailedByUuid(sessionId, messageId);
         throw err;
+      }
+      if (role === 'turn') {
+        // Mark the session queued so task-pause / live-session checks treat a
+        // pending turn job as non-idle. Without this, a pause that lands before
+        // the delivery processor claims the job skips the (idle-reporting)
+        // session, and the handler later runs the agent while the task is paused.
+        try {
+          await session.stateManager.setQueuedIfIdle(messageId);
+        } catch (error) {
+          log.warn(
+            `TaskAgentManager: queued-state publication failed for ${sessionId}: ` +
+              `${error instanceof Error ? error.message : String(error)}`
+          );
+        }
       }
       return dbId;
     }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4730,6 +4730,7 @@ export class TaskAgentManager {
       // flush path carries a stable id (existing row), so it omits the
       // terminalize and self-heals via retry. (Codex P1.)
       await awaitDeliveryConsumption({
+        sessionId,
         messageUuid: messageId,
         deliver: () =>
           deliverAndMarkQueued({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1716,7 +1716,15 @@ export class TaskAgentManager {
             })
         : `[Message from human]: ${row.message}`;
       try {
-        await this.injectSubSessionMessage(sessionId, message, isSyntheticMessage);
+        await this.injectSubSessionMessage(
+          sessionId,
+          message,
+          isSyntheticMessage,
+          undefined,
+          undefined,
+          undefined,
+          row.id
+        );
         repo.markDelivered(row.id, sessionId);
         this.emitPendingDelivered(row.id, sessionId, row);
       } catch (err) {
@@ -1886,7 +1894,8 @@ export class TaskAgentManager {
      * — must pass 'system' so they do NOT trigger a `resetContextPerTurn`
      * clear (the contract: only task inputs clear).
      */
-    inputKindOverride?: MessageInputKind
+    inputKindOverride?: MessageInputKind,
+    messageId?: string
   ): Promise<string> {
     const inputKind: MessageInputKind =
       inputKindOverride ?? (isSyntheticMessage ? 'task' : 'human');
@@ -1897,7 +1906,8 @@ export class TaskAgentManager {
       isSyntheticMessage,
       images,
       deliveryMode,
-      inputKind
+      inputKind,
+      messageId
     );
   }
 
@@ -1920,7 +1930,8 @@ export class TaskAgentManager {
     isSyntheticMessage = true,
     images?: MessageImage[],
     deliveryMode: 'immediate' | 'defer' = 'immediate',
-    inputKind: MessageInputKind = 'task'
+    inputKind: MessageInputKind = 'task',
+    messageId?: string
   ): Promise<string> {
     // Reject inject for a cancelled/archived task or cancelled run — the session
     // may still be in memory (idle, not evicted on cancel) but must not be
@@ -1957,7 +1968,8 @@ export class TaskAgentManager {
           origin,
           isSyntheticMessage,
           images,
-          inputKind
+          inputKind,
+          messageId
         );
       }
 
@@ -1987,7 +1999,8 @@ export class TaskAgentManager {
           origin,
           isSyntheticMessage,
           images,
-          inputKind
+          inputKind,
+          messageId
         );
       }
       throw new Error(`Sub-session not found: ${subSessionId}`);
@@ -4538,7 +4551,8 @@ export class TaskAgentManager {
     origin?: MessageOrigin,
     isSyntheticMessage = true,
     images?: MessageImage[],
-    inputKind: MessageInputKind = 'task'
+    inputKind: MessageInputKind = 'task',
+    explicitMessageId?: string
   ): Promise<string> {
     const sessionId = session.session.id;
     const state = session.getProcessingState();
@@ -4558,7 +4572,9 @@ export class TaskAgentManager {
       state.status === 'interrupted' ||
       state.status === 'rate_limit_cooldown';
 
-    const messageId = generateUUID();
+    // An explicit id (the pending-message row id from flushPendingMessagesForTarget)
+    // makes a crash-retry dedup: deliverMessage/getActiveDeliveryRole keys on it.
+    const messageId = explicitMessageId ?? generateUUID();
     const hasImages = !!images && images.length > 0;
     // Validate base64 size up-front so users get the same early "resize image"
     // error returned by the live-session persistence path instead of a late,

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -272,6 +272,26 @@ export class JobQueueRepository {
   }
 
   /**
+   * Cancel (delete) every ACTIVE (pending/processing) `message_delivery` job
+   * across ALL sessions. Used at daemon startup when message-delivery v2 is
+   * OFF (the `HYPERNEO_MESSAGE_DELIVERY_V2=0` rollback) so jobs left over from a
+   * prior v2-on run don't linger — new messages take the legacy inline path, so
+   * any surviving durable job would either be driven by the (still-registered)
+   * v2 handler or sit stale. Cancelling them hands their `sdk_messages` rows
+   * (still `enqueued`/`consumed`) to the legacy replay + orphan-recovery
+   * backstops. Returns the count cancelled.
+   */
+  cancelAllMessageDelivery(queue: string = 'message_delivery'): number {
+    const res = this.db
+      .prepare(
+        `DELETE FROM job_queue
+           WHERE queue = ? AND status IN ('pending', 'processing')`
+      )
+      .run(queue);
+    return res.changes;
+  }
+
+  /**
    * Cancel active jobs and return their message UUIDs so lifecycle callers can
    * terminalize the matching persisted prompts instead of leaving hidden
    * `enqueued` rows behind.

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -272,26 +272,6 @@ export class JobQueueRepository {
   }
 
   /**
-   * Cancel (delete) every ACTIVE (pending/processing) `message_delivery` job
-   * across ALL sessions. Used at daemon startup when message-delivery v2 is
-   * OFF (the `HYPERNEO_MESSAGE_DELIVERY_V2=0` rollback) so jobs left over from a
-   * prior v2-on run don't linger — new messages take the legacy inline path, so
-   * any surviving durable job would either be driven by the (still-registered)
-   * v2 handler or sit stale. Cancelling them hands their `sdk_messages` rows
-   * (still `enqueued`/`consumed`) to the legacy replay + orphan-recovery
-   * backstops. Returns the count cancelled.
-   */
-  cancelAllMessageDelivery(queue: string = 'message_delivery'): number {
-    const res = this.db
-      .prepare(
-        `DELETE FROM job_queue
-           WHERE queue = ? AND status IN ('pending', 'processing')`
-      )
-      .run(queue);
-    return res.changes;
-  }
-
-  /**
    * Cancel active jobs and return their message UUIDs so lifecycle callers can
    * terminalize the matching persisted prompts instead of leaving hidden
    * `enqueued` rows behind.

--- a/packages/daemon/src/storage/repositories/job-queue-repository.ts
+++ b/packages/daemon/src/storage/repositories/job-queue-repository.ts
@@ -366,6 +366,29 @@ export class JobQueueRepository {
     return out;
   }
 
+  /**
+   * True if the session has a pending/processing message_delivery TURN job.
+   * Used to detect a "legacy-owned" turn: while v2 is default-on, QueryModeHandler
+   * still replays deferred/enqueued rows directly through MessageQueue, so a
+   * session can be `processing` a live SDK turn with NO active v2 turn row. A new
+   * v2 injection there would otherwise be classified as a fresh turn (the index
+   * sees no v2 turn) and race the legacy turn. Read-only indexed SELECT. (Codex P1.)
+   */
+  hasActiveTurnDelivery(sessionId: string): boolean {
+    const row = this.db
+      .prepare(
+        `SELECT 1 AS one
+           FROM job_queue
+          WHERE queue = 'message_delivery'
+            AND json_extract(payload, '$.sessionId') = ?
+            AND json_extract(payload, '$.role') = 'turn'
+            AND status IN ('pending', 'processing')
+          LIMIT 1`
+      )
+      .get(sessionId) as { one: number } | null;
+    return row != null;
+  }
+
   complete(
     jobId: string,
     result?: Record<string, unknown>,

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1891,6 +1891,29 @@ export class SDKMessageRepository {
     return row.id;
   }
 
+  /**
+   * Flip a pending delivery row to `deferred` by UUID. Used when a retry reaches
+   * the deferred branch (target busy / rate-limited / parent-limited) holding an
+   * existing `enqueued` row (e.g. a `failed` row just reopened). Without this the
+   * row stays `enqueued` and QueryModeHandler's deferred replay — which selects
+   * only `send_status='deferred'` — never picks it up, so the handoff is lost on
+   * an idle parent-limited session. Mirrors {@link reopenDeliveryByUuid}; only
+   * flips rows still pending delivery. (Codex P1.)
+   */
+  markDeliveryDeferredByUuid(sessionId: string, uuid: string): string | null {
+    const row = this.db
+      .prepare(
+        `SELECT id FROM sdk_messages
+           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
+             AND send_status IN ('enqueued', 'submitted')
+           ORDER BY timestamp ASC LIMIT 1`
+      )
+      .get(sessionId, uuid) as { id: string } | undefined;
+    if (!row) return null;
+    this.updateMessageStatus([row.id], 'deferred');
+    return row.id;
+  }
+
   private parseUserMessageRow(
     row: { sdk_message: string; timestamp: string },
     uuid: string

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1865,6 +1865,32 @@ export class SDKMessageRepository {
     return row.id;
   }
 
+  /**
+   * Flip a previously-`failed` delivery row back to `enqueued` so a retry can
+   * re-drive it — the counterpart of {@link markDeliveryFailedByUuid} for the
+   * crash-retry path. A prior attempt whose durable enqueue threw terminalized
+   * the row; the caller (e.g. long-horizon external-event delivery) is now
+   * retrying with the same idempotency key, and the message-delivery handler
+   * skips `failed` rows, so the row must be reopened before a new job is
+   * enqueued. Only reopens `failed` rows — a `consumed` row already ran its
+   * turn (must not be re-driven). Returns the flipped db id, else null.
+   */
+  reopenDeliveryByUuid(sessionId: string, uuid: string): string | null {
+    const row = this.db
+      .prepare(
+        `SELECT id FROM sdk_messages
+           WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
+             AND send_status = 'failed'
+           ORDER BY timestamp ASC LIMIT 1`
+      )
+      .get(sessionId, uuid) as { id: string } | undefined;
+    if (!row) return null;
+    // updateMessageStatus([id], 'enqueued') only flips the status (the
+    // turn-assignment/counter logic fires solely on consumed/failed).
+    this.updateMessageStatus([row.id], 'enqueued');
+    return row.id;
+  }
+
   private parseUserMessageRow(
     row: { sdk_message: string; timestamp: string },
     uuid: string

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1897,15 +1897,17 @@ export class SDKMessageRepository {
    * existing `enqueued` row (e.g. a `failed` row just reopened). Without this the
    * row stays `enqueued` and QueryModeHandler's deferred replay — which selects
    * only `send_status='deferred'` — never picks it up, so the handoff is lost on
-   * an idle parent-limited session. Mirrors {@link reopenDeliveryByUuid}; only
-   * flips rows still pending delivery. (Codex P1.)
+   * an idle parent-limited session. Only flips `enqueued` rows — NOT `submitted`
+   * (ACP): a submitted prompt already reached the subprocess, and deferring it
+   * would leave SDKMessageHandler unable to match its acceptance, so the row
+   * replays later and the handoff executes twice. (Codex P1.)
    */
   markDeliveryDeferredByUuid(sessionId: string, uuid: string): string | null {
     const row = this.db
       .prepare(
         `SELECT id FROM sdk_messages
            WHERE session_id = ? AND message_type = 'user' AND sdk_uuid = ?
-             AND send_status IN ('enqueued', 'submitted')
+             AND send_status = 'enqueued'
            ORDER BY timestamp ASC LIMIT 1`
       )
       .get(sessionId, uuid) as { id: string } | undefined;

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -1766,6 +1766,41 @@ describe('AgentSession', () => {
       expect(clearSpy).not.toHaveBeenCalled();
     });
 
+    it('executeRateLimitAutoRetry suppresses the waiter drain when startQueryAndEnqueue throws (Codex P1)', async () => {
+      // The retry catch must NOT drain: returning false makes the watchdog
+      // schedule another startup attempt for this same episode, so the old
+      // prompt is still slated for replay — draining would complete the durable
+      // job and free the active-turn slot mid-retry. Every setIdle in the retry
+      // path is suppressed; the waiter is released only on supersession.
+      const setIdleSpy = mock(async (_opts?: { suppressDeliveryWaiters?: boolean }) => {});
+      agentSession.stateManager.setIdle = setIdleSpy;
+      // biome-ignore lint: test mock access
+      (agentSession as unknown as Record<string, unknown>).rateLimitWatchdog = {
+        isSuperseded: () => false, // episode still active → retry proceeds
+        clearPendingCooldown: () => {}, // startQueryAndEnqueue (generation provided) clears the timer
+      };
+      // biome-ignore lint: test mock access
+      (agentSession as unknown as Record<string, unknown>).lifecycleManager = {
+        startQueryAndEnqueue: mock(async () => {
+          throw new Error('startup failed');
+        }),
+      };
+      const result = await (
+        agentSession as unknown as {
+          executeRateLimitAutoRetry: (
+            msg: { uuid: string; content: string } | null,
+            gen?: number
+          ) => Promise<boolean>;
+        }
+      ).executeRateLimitAutoRetry({ uuid: 'msg-1', content: 'hi' }, 7);
+      expect(result).toBe(false);
+      // The catch's setIdle (and the try's) are both suppressed — no drain.
+      expect(setIdleSpy).toHaveBeenCalled();
+      for (const call of setIdleSpy.mock.calls) {
+        expect(call[0]).toEqual({ suppressDeliveryWaiters: true });
+      }
+    });
+
     it('only clears the timer for a recovery re-enqueue (generation provided)', async () => {
       // An internal recovery re-enqueue is the SAME episode — clear only the
       // timer, don't bump the generation (which would self-abort the in-flight

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -1012,6 +1012,72 @@ describe('AgentSession', () => {
       expect(jobQueue.enqueue).toHaveBeenCalled();
     });
 
+    it('deliverChatMessage cancels a rate-limit cooldown for a replacement chat even when classified as a steer', async () => {
+      // During rate_limit_cooldown the prior durable turn still occupies the
+      // active-turn slot, so the replacement is classified as a steer. It must
+      // STILL cancel the cooldown or the watchdog's timer replays the stale
+      // prompt instead of letting the user's replacement take over. (Codex P1.)
+      let turnAttempt = 0;
+      const jobQueue = {
+        enqueue: mock(() => {
+          turnAttempt++;
+          if (turnAttempt === 1) {
+            // First (turn) insert hits the active-turn unique index → re-insert as steer.
+            throw new Error('UNIQUE constraint failed: job_queue.uq_message_delivery_active_turn');
+          }
+          return { id: 'job' };
+        }),
+        getActiveDeliveryRole: mock(() => null),
+      };
+      mockDb.getJobQueueRepo = mock(() => jobQueue);
+      const cancelSpy = mock(() => {});
+      // biome-ignore lint: test mock access
+      (agentSession as unknown as Record<string, unknown>).rateLimitWatchdog = {
+        cancel: cancelSpy,
+      };
+      agentSession.stateManager.setQueuedIfIdle = mock(async () => false);
+      await agentSession.stateManager.setRateLimitCooldown({
+        retryCount: 0,
+        maxRetries: 5,
+        retryAt: Date.now() + 60_000,
+      });
+
+      await agentSession.deliverChatMessage('cooldown-replacement');
+
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+      // A steer does not claim the queued marker (only the turn owner does).
+      expect(agentSession.stateManager.setQueuedIfIdle).not.toHaveBeenCalled();
+    });
+
+    it('deliverChatMessage does NOT bump the watchdog generation for a steer into a live turn', async () => {
+      // A normal steer feeds a LIVE turn; cancelling here would bump the episode
+      // generation and desync the rate-limit episode from the active turn's
+      // turn-end waiter tag (P1-2), stranding it on a later 429. Only a turn, or
+      // a steer during rate_limit_cooldown, may cancel.
+      let turnAttempt = 0;
+      const jobQueue = {
+        enqueue: mock(() => {
+          turnAttempt++;
+          if (turnAttempt === 1) {
+            throw new Error('UNIQUE constraint failed: job_queue.uq_message_delivery_active_turn');
+          }
+          return { id: 'job' };
+        }),
+        getActiveDeliveryRole: mock(() => null),
+      };
+      mockDb.getJobQueueRepo = mock(() => jobQueue);
+      const cancelSpy = mock(() => {});
+      // biome-ignore lint: test mock access
+      (agentSession as unknown as Record<string, unknown>).rateLimitWatchdog = {
+        cancel: cancelSpy,
+      };
+      agentSession.stateManager.setQueuedIfIdle = mock(async () => false);
+
+      await agentSession.deliverChatMessage('live-steer');
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+    });
+
     it('resetQuery should delegate to lifecycleManager', async () => {
       const resetSpy = mock(async () => ({ success: true }));
       // biome-ignore lint: test mock access

--- a/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
@@ -30,6 +30,7 @@ describe('AskUserQuestionHandler', () => {
   let setProcessingSpy: ReturnType<typeof mock>;
   let setIdleSpy: ReturnType<typeof mock>;
   let getStateSpy: ReturnType<typeof mock>;
+  let releaseIdleWaitersSpy: ReturnType<typeof mock>;
   let updateQuestionDraftSpy: ReturnType<typeof mock>;
   let updateSessionSpy: ReturnType<typeof mock>;
   let enqueueWithIdSpy: ReturnType<typeof mock>;
@@ -68,6 +69,7 @@ describe('AskUserQuestionHandler', () => {
       currentState = { status: 'idle' };
     });
     getStateSpy = mock(() => currentState);
+    releaseIdleWaitersSpy = mock(() => {});
     updateQuestionDraftSpy = mock(async () => {});
 
     mockStateManager = {
@@ -75,6 +77,7 @@ describe('AskUserQuestionHandler', () => {
       setProcessing: setProcessingSpy,
       setIdle: setIdleSpy,
       getState: getStateSpy,
+      releaseIdleWaiters: releaseIdleWaitersSpy,
       updateQuestionDraft: updateQuestionDraftSpy,
     } as unknown as ProcessingStateManager;
 
@@ -224,6 +227,39 @@ describe('AskUserQuestionHandler', () => {
       await expect(
         handler.handleQuestionResponse('tool-123', [{ questionIndex: 0, selectedLabels: ['A'] }])
       ).rejects.toThrow('agent is not waiting for input');
+    });
+
+    it('releases the durable turn waiter if the injected_as_tool_result publication rejects (Codex P1)', async () => {
+      // The publish sits between the suppressed idle and the reinjection try; a
+      // rejecting subscriber would stop execution before the reinjection catch's
+      // terminal idle, leaving the suppressed waiter pending (the question is
+      // already resolved, so nothing retries it). The wrap releases the waiter.
+      const pendingQuestion: PendingUserQuestion = {
+        toolUseId: 'tool-123',
+        questions: [
+          {
+            question: 'What do you want?',
+            header: 'Choice',
+            options: [
+              { label: 'A', description: 'A' },
+              { label: 'B', description: 'B' },
+            ],
+            multiSelect: false,
+          },
+        ],
+        askedAt: Date.now(),
+      };
+      currentState = { status: 'waiting_for_input', pendingQuestion };
+      (emitSpy as ReturnType<typeof mock>).mockImplementation(async (event: string) => {
+        if (event === 'question.injected_as_tool_result') {
+          throw new Error('subscriber rejected');
+        }
+      });
+
+      await expect(
+        handler.handleQuestionResponse('tool-123', [{ questionIndex: 0, selectedLabels: ['A'] }])
+      ).rejects.toThrow('subscriber rejected');
+      expect(releaseIdleWaitersSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should queue answer + inject tool_result when no pending resolver (post-restart)', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
@@ -97,6 +97,10 @@ describe('EventSubscriptionSetup', () => {
       queryModeHandler: mockQueryModeHandler,
       resetQuery: mock(async () => ({ success: true })),
       startQueryAndEnqueue: mock(async () => {}),
+      // AgentSession provides this in production (v2 default-on). Including it
+      // here exercises the real message.persisted branch instead of silently
+      // falling through to startQueryAndEnqueue merely because the mock omitted it.
+      deliverChatMessage: mock(async () => {}),
     };
 
     setup = new EventSubscriptionSetup(mockContext);
@@ -311,7 +315,11 @@ describe('EventSubscriptionSetup', () => {
     });
 
     describe('message.persisted handler', () => {
-      it('should call startQueryAndEnqueue with messageId and content', async () => {
+      it('v2 default routes through deliverChatMessage, not startQueryAndEnqueue', async () => {
+        // With v2 default-on and deliverChatMessage wired (production state), an
+        // ordinary persisted message enqueues a durable job_queue row instead of
+        // driving the query inline. Asserting startQueryAndEnqueue here would only
+        // pass because the mock omitted deliverChatMessage — masking the real path.
         setup.setup();
 
         const callback = registeredCallbacks.get('message.persisted')!;
@@ -321,8 +329,29 @@ describe('EventSubscriptionSetup', () => {
           messageContent: 'Hello',
         });
 
-        // Note: User messages in the DB serve as rewind points - no separate checkpoint tracking needed
+        expect(mockContext.deliverChatMessage).toHaveBeenCalledWith('msg-123');
+        expect(mockContext.startQueryAndEnqueue).not.toHaveBeenCalled();
+      });
+
+      it('opt-out (HYPERNEO_MESSAGE_DELIVERY_V2=0) falls back to startQueryAndEnqueue', async () => {
+        const previous = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+        process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '0';
+        try {
+          setup.setup();
+
+          const callback = registeredCallbacks.get('message.persisted')!;
+          await callback({
+            sessionId: 'test-session-id',
+            messageId: 'msg-123',
+            messageContent: 'Hello',
+          });
+        } finally {
+          if (previous === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+          else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previous;
+        }
+
         expect(mockContext.startQueryAndEnqueue).toHaveBeenCalledWith('msg-123', 'Hello');
+        expect(mockContext.deliverChatMessage).not.toHaveBeenCalled();
       });
 
       it('should skip query start when persistence already delivered synchronously', async () => {
@@ -337,6 +366,7 @@ describe('EventSubscriptionSetup', () => {
         });
 
         expect(mockContext.startQueryAndEnqueue).not.toHaveBeenCalled();
+        expect(mockContext.deliverChatMessage).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
@@ -263,6 +263,69 @@ describe('EventSubscriptionSetup', () => {
         expect(row.sendStatus).toBe('failed');
         raw.close();
       });
+
+      it('handleInterrupt({preserveDeliveryJobs:true}) keeps requeued delivery jobs for restart (Codex P1)', async () => {
+        // Daemon shutdown requeues in-flight message_delivery rows for the next
+        // boot BEFORE stopping sessions; the shutdown stop path
+        // (stopSessionPreserveDb) must NOT then cancel them. handleInterrupt with
+        // preserveDeliveryJobs skips the durable-job cancel while still aborting
+        // the in-flight query. (The default user-interrupt path cancels — see
+        // the test above.)
+        const raw = new BunDatabase(':memory:');
+        createTables(raw);
+        const jobQueueRepo = new JobQueueRepository(raw);
+        const sdkRepo = new SDKMessageRepository(raw);
+        const sessionId = 'test-session-id';
+        const messageUuid = '22222222-3333-4444-5555-666666666666';
+
+        raw
+          .prepare(
+            `INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status, sdk_uuid)
+             VALUES (?, ?, 'user', ?, ?, 'enqueued', ?)`
+          )
+          .run(
+            'db-msg-2',
+            sessionId,
+            JSON.stringify({ uuid: messageUuid }),
+            new Date().toISOString(),
+            messageUuid
+          );
+        deliverMessage(jobQueueRepo, sessionId, messageUuid, { origin: 'space_inject' });
+        expect((raw.prepare(`SELECT COUNT(*) AS n FROM job_queue`).get() as { n: number }).n).toBe(
+          1
+        );
+
+        const realInterruptHandler = new InterruptHandler({
+          session: mockContext.session,
+          messageHub: { event: () => {} } as never,
+          messageQueue: { size: () => 0, clear: () => {}, stop: () => {} } as never,
+          stateManager: {
+            getState: () => ({ status: 'processing', phase: 'streaming' }),
+            setInterrupted: async () => {},
+            setIdle: async () => {},
+          } as never,
+          logger: { warn: () => {}, error: () => {}, info: () => {}, debug: () => {} } as never,
+          db: {
+            getJobQueueRepo: () => jobQueueRepo,
+            getSDKMessageRepo: () => sdkRepo,
+          } as never,
+          queryObject: null,
+          queryPromise: null,
+          queryAbortController: null,
+        });
+
+        await realInterruptHandler.handleInterrupt({ preserveDeliveryJobs: true });
+
+        // The job + its enqueued SDK row survive — preserved for restart reclaim.
+        expect((raw.prepare(`SELECT COUNT(*) AS n FROM job_queue`).get() as { n: number }).n).toBe(
+          1
+        );
+        const row = raw
+          .prepare(`SELECT send_status AS sendStatus FROM sdk_messages WHERE id = 'db-msg-2'`)
+          .get() as { sendStatus: string };
+        expect(row.sendStatus).toBe('enqueued');
+        raw.close();
+      });
     });
 
     describe('agent.resetRequest handler', () => {

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
@@ -262,6 +262,51 @@ describe('ProcessingStateManager', () => {
     });
   });
 
+  describe('onIdleCallback ordering (deferred restart)', () => {
+    test('fires the callback BEFORE draining delivery waiters (ownership held through the restart)', async () => {
+      // A deferred restart (settings change) runs as the onIdleCallback. It must
+      // run BEFORE the waiters drain, or driveDeliveryTurn completes + frees the
+      // active-turn slot while the restart is still stopping/starting the query
+      // — a message arriving then starts a new turn concurrent with the restart.
+      let waiterResolvedAtCallback = true;
+      let waiterResolved = false;
+      void manager.waitForIdleTransition().promise.then(() => {
+        waiterResolved = true;
+      });
+      manager.setOnIdleCallback(async () => {
+        // At callback time the waiter must still be pending — drain is deferred.
+        waiterResolvedAtCallback = waiterResolved;
+      });
+
+      await manager.setIdle();
+      await Promise.resolve();
+
+      expect(waiterResolvedAtCallback).toBe(false); // NOT drained during the callback
+      expect(waiterResolved).toBe(true); // drained after the callback completed
+    });
+
+    test('a reentrant setIdle during the callback does not re-fire it or drain early', async () => {
+      // The callback's restart drives its own idle (reentrant setIdle). The guard
+      // must prevent a double restart AND keep the drain deferred to the outer
+      // call (a reentrant drain would defeat the ordering above).
+      let fires = 0;
+      let outerResolved = false;
+      void manager.waitForIdleTransition().promise.then(() => {
+        outerResolved = true;
+      });
+      manager.setOnIdleCallback(async () => {
+        fires += 1;
+        await manager.setIdle(); // reentrant idle from the restart's stop/start
+      });
+
+      await manager.setIdle();
+      await Promise.resolve();
+
+      expect(fires).toBe(1); // reentrant idle did NOT re-fire the callback
+      expect(outerResolved).toBe(true); // outer call drained after the callback
+    });
+  });
+
   describe('setQueued', () => {
     test('transitions to queued state', async () => {
       await manager.setQueued('msg-123');

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
@@ -210,6 +210,56 @@ describe('ProcessingStateManager', () => {
       await expect(failingManager.setIdle()).rejects.toThrow('publish failed');
       expect(resolved).toBe(true);
     });
+
+    test('releaseIdleWaiters(gen) resolves only the matching episode, not a newer turn', async () => {
+      // The race this guards: a superseded rate-limit retry (episode gen 0)
+      // releases its turn-end waiter so its abandoned job doesn't hang — but a
+      // NEWER turn (gen 1, armed after a cancel/reset bumped the generation) must
+      // NOT have its waiter resolved, or its durable job completes prematurely and
+      // frees the active-turn slot for a competing turn. driveDeliveryTurn tags
+      // each waiter with the rate-limit generation at arm time; the superseded
+      // retry releases only its own gen.
+      let oldResolved = false;
+      let newResolved = false;
+      void manager.waitForIdleTransition(0).promise.then(() => {
+        oldResolved = true;
+      });
+      void manager.waitForIdleTransition(1).promise.then(() => {
+        newResolved = true;
+      });
+
+      manager.releaseIdleWaiters(0); // superseded gen-0 retry releases its own
+      // releaseIdleWaiters is synchronous; flush the resolution microtask before
+      // asserting (the .then handlers run on the next microtask tick).
+      await Promise.resolve();
+
+      expect(oldResolved).toBe(true);
+      expect(newResolved).toBe(false);
+
+      // The newer turn's waiter still resolves on a real terminal idle.
+      await manager.setIdle();
+      expect(newResolved).toBe(true);
+    });
+
+    test('releaseIdleWaiters() with no generation resolves all waiters (unscoped fallback)', async () => {
+      // Omitting the generation (a release site that has no episode context)
+      // resolves every armed waiter — preserving the original drain-all behavior
+      // for callers that don't track a generation.
+      let aResolved = false;
+      let bResolved = false;
+      void manager.waitForIdleTransition(0).promise.then(() => {
+        aResolved = true;
+      });
+      void manager.waitForIdleTransition(5).promise.then(() => {
+        bResolved = true;
+      });
+
+      manager.releaseIdleWaiters();
+      await Promise.resolve();
+
+      expect(aResolved).toBe(true);
+      expect(bResolved).toBe(true);
+    });
   });
 
   describe('setQueued', () => {

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
@@ -156,7 +156,7 @@ describe('ProcessingStateManager', () => {
   describe('waitForIdleTransition', () => {
     test('resolves on the next plain setIdle (terminal turn-end)', async () => {
       let resolved = false;
-      void manager.waitForIdleTransition().then(() => {
+      void manager.waitForIdleTransition().promise.then(() => {
         resolved = true;
       });
       expect(resolved).toBe(false);
@@ -170,12 +170,44 @@ describe('ProcessingStateManager', () => {
       // ACP, AskUserQuestion restart) suppresses the drain so the durable
       // delivery job isn't completed while the prompt is still being retried.
       let resolved = false;
-      void manager.waitForIdleTransition().then(() => {
+      void manager.waitForIdleTransition().promise.then(() => {
         resolved = true;
       });
       await manager.setIdle({ suppressDeliveryWaiters: true });
       expect(resolved).toBe(false);
       await manager.setIdle();
+      expect(resolved).toBe(true);
+    });
+
+    test('cancel() removes the waiter so it never resolves (failure/park path)', async () => {
+      // driveDeliveryTurn cancels its turn-end waiter on the blocked (park) and
+      // query-didn't-start paths so waiters don't accumulate across reclaims.
+      let resolved = false;
+      const handle = manager.waitForIdleTransition();
+      void handle.promise.then(() => {
+        resolved = true;
+      });
+      handle.cancel();
+      await manager.setIdle(); // a terminal idle must NOT resolve a cancelled waiter
+      expect(resolved).toBe(false);
+    });
+
+    test('drains waiters even when idle-state publication throws', async () => {
+      // Resilient drain (setIdle try/finally): the state is persisted before
+      // publish, so a publish failure must still release a waiting turn.
+      const failingBus = {
+        publish: mock(async () => {
+          throw new Error('publish failed');
+        }),
+        publishAsync: mock(async () => {}),
+        subscribe: mock(() => () => {}),
+      } as unknown as InternalEventBus<any>;
+      const failingManager = new ProcessingStateManager(sessionId, failingBus, createMockDb());
+      let resolved = false;
+      void failingManager.waitForIdleTransition().promise.then(() => {
+        resolved = true;
+      });
+      await expect(failingManager.setIdle()).rejects.toThrow('publish failed');
       expect(resolved).toBe(true);
     });
   });

--- a/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/processing-state-manager.test.ts
@@ -153,6 +153,33 @@ describe('ProcessingStateManager', () => {
     });
   });
 
+  describe('waitForIdleTransition', () => {
+    test('resolves on the next plain setIdle (terminal turn-end)', async () => {
+      let resolved = false;
+      void manager.waitForIdleTransition().then(() => {
+        resolved = true;
+      });
+      expect(resolved).toBe(false);
+      await manager.setIdle();
+      expect(resolved).toBe(true);
+    });
+
+    test('does NOT resolve on a suppressed (retry mid-point) setIdle, then does on a terminal one', async () => {
+      // The contract every retry-path setIdle site depends on: a retry
+      // mid-point (QueryRunner startup/message-not-found/transient, rate-limit,
+      // ACP, AskUserQuestion restart) suppresses the drain so the durable
+      // delivery job isn't completed while the prompt is still being retried.
+      let resolved = false;
+      void manager.waitForIdleTransition().then(() => {
+        resolved = true;
+      });
+      await manager.setIdle({ suppressDeliveryWaiters: true });
+      expect(resolved).toBe(false);
+      await manager.setIdle();
+      expect(resolved).toBe(true);
+    });
+  });
+
   describe('setQueued', () => {
     test('transitions to queued state', async () => {
       await manager.setQueued('msg-123');

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -712,6 +712,34 @@ describe('QueryLifecycleManager', () => {
       expect(startStreamingCalled).toBe(false);
     });
 
+    test('no-restart reset drains delivery waiters; restart reset suppresses them (Codex P1)', async () => {
+      // A no-restart reset is a TERMINAL idle (no startStreamingQuery follows):
+      // the turn-end waiter must drain or driveDeliveryTurn hangs `processing`,
+      // blocking the active-turn slot. A restart reset is a retry mid-point (the
+      // query re-starts immediately after) → suppress the drain. The
+      // post-stop setIdle gates suppressDeliveryWaiters on restartAfter.
+      mockContext.queryObject = {
+        interrupt: mock(async () => {}),
+      } as unknown as QueryLifecycleManagerContext['queryObject'];
+      mockContext.queryPromise = Promise.resolve();
+
+      manager = new QueryLifecycleManager(mockContext);
+      await manager.reset({ restartAfter: false });
+      expect(setIdleSpy).toHaveBeenCalledWith({ suppressDeliveryWaiters: false });
+
+      // The first reset's stop() nulls queryObject/queryPromise; re-establish a
+      // running query so the restart half exercises the post-stop setIdle (not
+      // the no-query early-return path). Isolate the spy across halves.
+      setIdleSpy.mockClear();
+      mockContext.queryObject = {
+        interrupt: mock(async () => {}),
+      } as unknown as QueryLifecycleManagerContext['queryObject'];
+      mockContext.queryPromise = Promise.resolve();
+      manager = new QueryLifecycleManager(mockContext);
+      await manager.reset({ restartAfter: true });
+      expect(setIdleSpy).toHaveBeenCalledWith({ suppressDeliveryWaiters: true });
+    });
+
     test('returns error on failure', async () => {
       const failingContext = createMockContext({
         queryObject: {

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -572,6 +572,26 @@ describe('QueryLifecycleManager', () => {
       expect(releaseIdleWaitersSpy).toHaveBeenCalledTimes(1);
     });
 
+    test('does NOT release waiters when restart fails before the old query is stopped (Codex P1)', async () => {
+      // A failure before stop() — here a session.errorClear subscriber rejecting
+      // — leaves the original SDK query still running. Releasing the waiter would
+      // complete the delivery job and free the active-turn slot mid-turn. Only
+      // release once the suppressed idle is reached (stop succeeded).
+      const failingContext = createMockContext({
+        internalEventBus: {
+          publish: mock(async () => {
+            throw new Error('errorClear subscriber rejected');
+          }),
+          publishAsync: mock(async () => {}),
+          subscribe: mock(() => () => {}),
+        } as unknown as QueryLifecycleManagerContext['internalEventBus'],
+      });
+      const failingManager = new QueryLifecycleManager(failingContext);
+
+      await expect(failingManager.restart()).rejects.toThrow('Query restart failed');
+      expect(releaseIdleWaitersSpy).not.toHaveBeenCalled();
+    });
+
     test('throws on stop failure with meaningful message', async () => {
       const failingContext = createMockContext({
         queryObject: {
@@ -757,6 +777,26 @@ describe('QueryLifecycleManager', () => {
       manager = new QueryLifecycleManager(mockContext);
       await manager.reset({ restartAfter: true });
       expect(setIdleSpy).toHaveBeenCalledWith({ suppressDeliveryWaiters: true });
+    });
+
+    test('a restartAfter reset that fails replacement startup releases the waiter (Codex P1)', async () => {
+      // The suppressed idle (restartAfter) deferred the drain to the restart;
+      // if cache-clear / resume-choice / startStreamingQuery then throws, the
+      // catch must release the waiter or the durable turn hangs `processing`.
+      const failingContext = createMockContext({
+        queryObject: {
+          interrupt: mock(async () => {}),
+        } as unknown as QueryLifecycleManagerContext['queryObject'],
+        queryPromise: Promise.resolve(),
+        startStreamingQuery: async () => {
+          throw new Error('Start failed');
+        },
+      });
+      const failingManager = new QueryLifecycleManager(failingContext);
+
+      const result = await failingManager.reset({ restartAfter: true });
+      expect(result.success).toBe(false);
+      expect(releaseIdleWaitersSpy).toHaveBeenCalledTimes(1);
     });
 
     test('returns error on failure', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -41,6 +41,7 @@ describe('QueryLifecycleManager', () => {
   let setIdleSpy: ReturnType<typeof mock>;
   let setQueuedSpy: ReturnType<typeof mock>;
   let getStateSpy: ReturnType<typeof mock>;
+  let releaseIdleWaitersSpy: ReturnType<typeof mock>;
   let resetCircuitBreakerSpy: ReturnType<typeof mock>;
   let getInterruptPromiseSpy: ReturnType<typeof mock>;
   let handleErrorSpy: ReturnType<typeof mock>;
@@ -87,6 +88,7 @@ describe('QueryLifecycleManager', () => {
     setIdleSpy = mock(async () => {});
     setQueuedSpy = mock(async () => {});
     getStateSpy = mock(() => ({ status: 'idle' }));
+    releaseIdleWaitersSpy = mock(() => {});
     resetCircuitBreakerSpy = mock(() => {});
     getInterruptPromiseSpy = mock(() => null);
     handleErrorSpy = mock(async () => {});
@@ -124,6 +126,7 @@ describe('QueryLifecycleManager', () => {
         setIdle: setIdleSpy,
         setQueued: setQueuedSpy,
         getState: getStateSpy,
+        releaseIdleWaiters: releaseIdleWaitersSpy,
       } as unknown as ProcessingStateManager,
       messageHandler: {
         resetCircuitBreaker: resetCircuitBreakerSpy,
@@ -551,6 +554,22 @@ describe('QueryLifecycleManager', () => {
       const failingManager = new QueryLifecycleManager(failingContext);
 
       await expect(failingManager.restart()).rejects.toThrow('Query restart failed: Start failed');
+    });
+
+    test('releases delivery waiters when restart fails before a replacement query starts (Codex P1)', async () => {
+      // The post-stop setIdle suppresses the waiter drain (the turn continues in
+      // the restarted query). If startStreamingQuery throws, no replacement is
+      // established — release the waiter so the durable turn doesn't hang
+      // `processing` and block the active-turn slot.
+      const failingContext = createMockContext({
+        startStreamingQuery: async () => {
+          throw new Error('Start failed');
+        },
+      });
+      const failingManager = new QueryLifecycleManager(failingContext);
+
+      await expect(failingManager.restart()).rejects.toThrow('Query restart failed');
+      expect(releaseIdleWaitersSpy).toHaveBeenCalledTimes(1);
     });
 
     test('throws on stop failure with meaningful message', async () => {

--- a/packages/daemon/tests/unit/1-core/session/message-persistence.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/message-persistence.test.ts
@@ -97,7 +97,11 @@ describe('MessagePersistence', () => {
     );
   });
 
-  it('persists idle immediate as enqueued and waits for queue insertion', async () => {
+  // v2 is the default: dispatch is deferred to the durable message_delivery
+  // handler (the `message.persisted` subscriber routes to deliverChatMessage).
+  // persist must persist the row and publish the event, but must NOT drive the
+  // query inline.
+  it('persists idle immediate as enqueued and defers dispatch to the durable handler', async () => {
     await persistence.persist({
       sessionId: 'test-session-id',
       messageId: 'msg-1',
@@ -111,7 +115,7 @@ describe('MessagePersistence', () => {
       undefined
     );
     expect(messageHubEventSpy).not.toHaveBeenCalled();
-    expect(mockAgentSession.startQueryAndEnqueue).toHaveBeenCalledWith('msg-1', 'hello idle');
+    expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
     expect(internalEventBusPublishSpy).toHaveBeenCalledWith('messages.statusChanged', {
       sessionId: 'test-session-id',
       messageIds: ['db-msg-1'],
@@ -124,12 +128,12 @@ describe('MessagePersistence', () => {
         messageId: 'msg-1',
         sendStatus: 'enqueued',
         deliveryMode: 'immediate',
-        skipQueryStart: true,
+        skipQueryStart: false,
       })
     );
   });
 
-  it('persists busy immediate as enqueued and does not immediately echo', async () => {
+  it('persists busy immediate as enqueued and defers dispatch', async () => {
     processingStateSpy.mockReturnValue({ status: 'processing' });
 
     await persistence.persist({
@@ -144,15 +148,14 @@ describe('MessagePersistence', () => {
       'enqueued',
       undefined
     );
-    expect(messageHubEventSpy).not.toHaveBeenCalled();
-    expect(mockAgentSession.startQueryAndEnqueue).toHaveBeenCalledWith('msg-2', 'hello busy');
+    expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
     expect(internalEventBusPublishSpy).toHaveBeenCalledWith(
       'message.persisted',
       expect.objectContaining({
         messageId: 'msg-2',
         sendStatus: 'enqueued',
         deliveryMode: 'immediate',
-        skipQueryStart: true,
+        skipQueryStart: false,
       })
     );
   });
@@ -180,7 +183,7 @@ describe('MessagePersistence', () => {
     expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
   });
 
-  it('falls back idle defer to enqueued immediate and dispatches', async () => {
+  it('falls back idle defer to enqueued immediate and defers dispatch', async () => {
     processingStateSpy.mockReturnValue({ status: 'idle' });
 
     await persistence.persist({
@@ -196,17 +199,14 @@ describe('MessagePersistence', () => {
       'enqueued',
       undefined
     );
-    expect(mockAgentSession.startQueryAndEnqueue).toHaveBeenCalledWith(
-      'msg-4',
-      'next turn while idle'
-    );
+    expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
     expect(internalEventBusPublishSpy).toHaveBeenCalledWith(
       'message.persisted',
       expect.objectContaining({
         messageId: 'msg-4',
         sendStatus: 'enqueued',
         deliveryMode: 'immediate',
-        skipQueryStart: true,
+        skipQueryStart: false,
       })
     );
   });
@@ -227,46 +227,51 @@ describe('MessagePersistence', () => {
     expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
   });
 
-  it('publishes v2 persisted before queued ownership is assigned by turn insertion', async () => {
+  // Opt-out rollback path: HYPERNEO_MESSAGE_DELIVERY_V2=0 restores the legacy
+  // inline dispatch (startQueryAndEnqueue) so a regression can be rolled back
+  // without a redeploy.
+  it('opt-out (HYPERNEO_MESSAGE_DELIVERY_V2=0) dispatches inline via startQueryAndEnqueue', async () => {
     const previous = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
-    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '1';
+    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '0';
 
     try {
       await persistence.persist({
         sessionId: 'test-session-id',
-        messageId: 'msg-v2',
-        content: 'durable turn',
+        messageId: 'msg-legacy',
+        content: 'inline dispatch',
       });
     } finally {
       if (previous === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
       else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previous;
     }
 
-    expect(mockAgentSession.stateManager.setQueuedIfIdle).not.toHaveBeenCalled();
-    expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
-    expect(mockInternalEventBus.publish).toHaveBeenCalledWith(
+    expect(mockAgentSession.startQueryAndEnqueue).toHaveBeenCalledWith(
+      'msg-legacy',
+      'inline dispatch'
+    );
+    expect(internalEventBusPublishSpy).toHaveBeenCalledWith(
       'message.persisted',
-      expect.objectContaining({ messageId: 'msg-v2' })
+      expect.objectContaining({
+        messageId: 'msg-legacy',
+        sendStatus: 'enqueued',
+        deliveryMode: 'immediate',
+        skipQueryStart: true,
+      })
     );
   });
 
-  it('does not downgrade a busy v2 session from processing to queued', async () => {
-    const previous = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
-    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '1';
+  it('does not downgrade a busy session from processing to queued', async () => {
     processingStateSpy.mockReturnValue({ status: 'processing' });
 
-    try {
-      await persistence.persist({
-        sessionId: 'test-session-id',
-        messageId: 'msg-v2-steer',
-        content: 'durable steer',
-      });
-    } finally {
-      if (previous === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
-      else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previous;
-    }
+    await persistence.persist({
+      sessionId: 'test-session-id',
+      messageId: 'msg-busy',
+      content: 'durable steer',
+    });
 
+    // persist defers to the durable handler; it must not touch queued state itself.
     expect(mockAgentSession.stateManager.setQueuedIfIdle).not.toHaveBeenCalled();
+    expect(mockAgentSession.startQueryAndEnqueue).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -805,42 +805,42 @@ describe('processor — exempt pass + onDead (#2587/#2595)', () => {
 describe('delivery consumption signal (long-horizon delivered = consumed)', () => {
   it('waitForDeliveryConsumption resolves when signalDeliveryConsumed fires for the UUID', async () => {
     let resolved = false;
-    const handle = waitForDeliveryConsumption('consume-1');
+    const handle = waitForDeliveryConsumption('sess', 'consume-1');
     void handle.promise.then(() => {
       resolved = true;
     });
     expect(resolved).toBe(false);
-    signalDeliveryConsumed('consume-1');
+    signalDeliveryConsumed('sess', 'consume-1');
     await Promise.resolve(); // flush the resolution microtask
     expect(resolved).toBe(true);
   });
 
   it('cancel() removes the waiter so a later signal does not resolve it', async () => {
     let resolved = false;
-    const handle = waitForDeliveryConsumption('consume-2');
+    const handle = waitForDeliveryConsumption('sess', 'consume-2');
     void handle.promise.then(() => {
       resolved = true;
     });
     handle.cancel();
-    signalDeliveryConsumed('consume-2'); // no waiter left — must not resolve
+    signalDeliveryConsumed('sess', 'consume-2'); // no waiter left — must not resolve
     await Promise.resolve();
     expect(resolved).toBe(false);
   });
 
   it('signalDeliveryConsumed is a no-op when no waiter is armed (e.g. consumption before any caller registers)', () => {
-    expect(() => signalDeliveryConsumed('consume-orphan')).not.toThrow();
+    expect(() => signalDeliveryConsumed('sess', 'consume-orphan')).not.toThrow();
   });
 
   it('multiple waiters for the same UUID all resolve on one signal', async () => {
     let a = false;
     let b = false;
-    void waitForDeliveryConsumption('consume-3').promise.then(() => {
+    void waitForDeliveryConsumption('sess', 'consume-3').promise.then(() => {
       a = true;
     });
-    void waitForDeliveryConsumption('consume-3').promise.then(() => {
+    void waitForDeliveryConsumption('sess', 'consume-3').promise.then(() => {
       b = true;
     });
-    signalDeliveryConsumed('consume-3');
+    signalDeliveryConsumed('sess', 'consume-3');
     await Promise.resolve();
     expect(a).toBe(true);
     expect(b).toBe(true);
@@ -891,6 +891,7 @@ describe('awaitDeliveryConsumption — terminalize a fresh job on timeout (no-st
     const terminalize = mock(() => {});
     await expect(
       awaitDeliveryConsumption({
+        sessionId: 'sess',
         messageUuid: 'fresh-timeout',
         deliver,
         terminalizeOnTimeout: terminalize,
@@ -902,10 +903,11 @@ describe('awaitDeliveryConsumption — terminalize a fresh job on timeout (no-st
 
   it('does NOT call terminalizeOnTimeout when consumption is signalled in time', async () => {
     const deliver = mock(async () => {
-      signalDeliveryConsumed('fresh-consumed');
+      signalDeliveryConsumed('sess', 'fresh-consumed');
     });
     const terminalize = mock(() => {});
     await awaitDeliveryConsumption({
+      sessionId: 'sess',
       messageUuid: 'fresh-consumed',
       deliver,
       terminalizeOnTimeout: terminalize,

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -11,12 +11,13 @@
  * See docs/features/message-delivery-v2.md §13.
  */
 
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, mock } from 'bun:test';
 import { Database } from '../../../../src/storage/sqlite-compat';
 import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository';
 import { runMigration182 } from '../../../../src/storage/schema/migrations';
 import { MESSAGE_DELIVERY } from '../../../../src/lib/job-queue-constants';
 import {
+  awaitDeliveryConsumption,
   deliverAndMarkQueued,
   deliverMessage,
   drainDeliveryWaitersOnTerminalSDKMessage,
@@ -872,5 +873,43 @@ describe('drainDeliveryWaitersOnTerminalSDKMessage (handleSDKMessage-catch gatin
       type: 'stream_event',
     } as SDKMessage);
     expect(setIdle).not.toHaveBeenCalled();
+  });
+});
+
+describe('awaitDeliveryConsumption — terminalize a fresh job on timeout (no-stable-id dedup)', () => {
+  const prev = process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS;
+  beforeAll(() => {
+    process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS = '20';
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS;
+    else process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS = prev;
+  });
+
+  it('calls terminalizeOnTimeout + rejects when consumption is not signalled (fresh job)', async () => {
+    const deliver = mock(async () => {});
+    const terminalize = mock(() => {});
+    await expect(
+      awaitDeliveryConsumption({
+        messageUuid: 'fresh-timeout',
+        deliver,
+        terminalizeOnTimeout: terminalize,
+      })
+    ).rejects.toThrow('not consumed within timeout');
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(terminalize).toHaveBeenCalledTimes(1); // terminalized so a retry won't duplicate
+  });
+
+  it('does NOT call terminalizeOnTimeout when consumption is signalled in time', async () => {
+    const deliver = mock(async () => {
+      signalDeliveryConsumed('fresh-consumed');
+    });
+    const terminalize = mock(() => {});
+    await awaitDeliveryConsumption({
+      messageUuid: 'fresh-consumed',
+      deliver,
+      terminalizeOnTimeout: terminalize,
+    });
+    expect(terminalize).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -17,6 +17,7 @@ import { JobQueueRepository } from '../../../../src/storage/repositories/job-que
 import { runMigration182 } from '../../../../src/storage/schema/migrations';
 import { MESSAGE_DELIVERY } from '../../../../src/lib/job-queue-constants';
 import {
+  deliverAndMarkQueued,
   deliverMessage,
   drainDeliveryWaitersOnTerminalSDKMessage,
   isUniqueConstraintError,
@@ -164,6 +165,47 @@ describe('message-delivery v2 — substrate (job_queue)', () => {
       );
       expect(isUniqueConstraintError(new Error('some other error'))).toBe(false);
       expect(isUniqueConstraintError('not an error')).toBe(false);
+    });
+  });
+
+  describe('deliverAndMarkQueued — legacy-owned turn guard (default-on coexistence)', () => {
+    it('forces a steer when the session is processing a legacy turn with no active v2 turn row (Codex P1)', async () => {
+      // v2 is default-on but QueryModeHandler still replays deferred/enqueued rows
+      // directly through MessageQueue, so a session can be `processing` a live SDK
+      // turn with NO active v2 turn row. The index would classify this injection
+      // as a fresh turn (racing the legacy turn); the guard forces a steer so it
+      // parks behind the legacy turn and promotes only once that turn ends.
+      const { repo } = setupRepo();
+      expect(repo.hasActiveTurnDelivery(SESSION)).toBe(false); // sanity: fresh repo, no v2 turn
+      await deliverAndMarkQueued({
+        jobQueue: repo,
+        stateManager: {
+          getState: () => ({ status: 'processing' }),
+          setQueuedIfIdle: async () => false,
+        },
+        sessionId: SESSION,
+        messageUuid: 'msg-legacy',
+        origin: 'chat',
+      });
+      const jobs = jobsFor(repo, SESSION);
+      expect(jobs).toHaveLength(1);
+      expect((jobs[0].payload as { role: string }).role).toBe('steer');
+    });
+
+    it('classifies as a turn when the session is idle (no legacy turn)', async () => {
+      const { repo } = setupRepo();
+      await deliverAndMarkQueued({
+        jobQueue: repo,
+        stateManager: {
+          getState: () => ({ status: 'idle' }),
+          setQueuedIfIdle: async () => false,
+        },
+        sessionId: SESSION,
+        messageUuid: 'msg-idle',
+        origin: 'chat',
+      });
+      const jobs = jobsFor(repo, SESSION);
+      expect((jobs[0].payload as { role: string }).role).toBe('turn');
     });
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -19,6 +19,8 @@ import { MESSAGE_DELIVERY } from '../../../../src/lib/job-queue-constants';
 import {
   deliverMessage,
   isUniqueConstraintError,
+  signalDeliveryConsumed,
+  waitForDeliveryConsumption,
   type MessageDeliverySession,
   type DriveTurnOutcome,
   type FeedSteerOutcome,
@@ -752,5 +754,50 @@ describe('processor — exempt pass + onDead (#2587/#2595)', () => {
     expect(dead).toHaveLength(1);
     expect(dead[0].status).toBe('dead');
     await processor.stop();
+  });
+});
+
+describe('delivery consumption signal (long-horizon delivered = consumed)', () => {
+  it('waitForDeliveryConsumption resolves when signalDeliveryConsumed fires for the UUID', async () => {
+    let resolved = false;
+    const handle = waitForDeliveryConsumption('consume-1');
+    void handle.promise.then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(false);
+    signalDeliveryConsumed('consume-1');
+    await Promise.resolve(); // flush the resolution microtask
+    expect(resolved).toBe(true);
+  });
+
+  it('cancel() removes the waiter so a later signal does not resolve it', async () => {
+    let resolved = false;
+    const handle = waitForDeliveryConsumption('consume-2');
+    void handle.promise.then(() => {
+      resolved = true;
+    });
+    handle.cancel();
+    signalDeliveryConsumed('consume-2'); // no waiter left — must not resolve
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+  });
+
+  it('signalDeliveryConsumed is a no-op when no waiter is armed (e.g. consumption before any caller registers)', () => {
+    expect(() => signalDeliveryConsumed('consume-orphan')).not.toThrow();
+  });
+
+  it('multiple waiters for the same UUID all resolve on one signal', async () => {
+    let a = false;
+    let b = false;
+    void waitForDeliveryConsumption('consume-3').promise.then(() => {
+      a = true;
+    });
+    void waitForDeliveryConsumption('consume-3').promise.then(() => {
+      b = true;
+    });
+    signalDeliveryConsumed('consume-3');
+    await Promise.resolve();
+    expect(a).toBe(true);
+    expect(b).toBe(true);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -845,6 +845,32 @@ describe('delivery consumption signal (long-horizon delivered = consumed)', () =
     expect(a).toBe(true);
     expect(b).toBe(true);
   });
+
+  it('a waiter for (sess-A, uuid-X) stays PENDING when sess-B signals the same UUID (cross-session scoping)', async () => {
+    // Guards the r23 scoping fix: the registry is keyed by (session, UUID), not
+    // UUID alone, so a multi-target delivery fanning the same MessageRecord out
+    // to several agents can't let one session's consumption signal resolve
+    // another session's waiter.
+    let aResolved = false;
+    let bResolved = false;
+    void waitForDeliveryConsumption('sess-A', 'shared-uuid').promise.then(() => {
+      aResolved = true;
+    });
+    void waitForDeliveryConsumption('sess-B', 'shared-uuid').promise.then(() => {
+      bResolved = true;
+    });
+
+    signalDeliveryConsumed('sess-B', 'shared-uuid'); // only sess-B's waiter resolves
+    await Promise.resolve();
+
+    expect(bResolved).toBe(true);
+    expect(aResolved).toBe(false); // sess-A's waiter is untouched
+
+    // sess-A's waiter still resolves on ITS OWN signal.
+    signalDeliveryConsumed('sess-A', 'shared-uuid');
+    await Promise.resolve();
+    expect(aResolved).toBe(true);
+  });
 });
 
 describe('drainDeliveryWaitersOnTerminalSDKMessage (handleSDKMessage-catch gating)', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -18,6 +18,7 @@ import { runMigration182 } from '../../../../src/storage/schema/migrations';
 import { MESSAGE_DELIVERY } from '../../../../src/lib/job-queue-constants';
 import {
   deliverMessage,
+  drainDeliveryWaitersOnTerminalSDKMessage,
   isUniqueConstraintError,
   signalDeliveryConsumed,
   waitForDeliveryConsumption,
@@ -28,6 +29,7 @@ import {
 import { createMessageDeliveryHandler } from '../../../../src/lib/job-handlers/message-delivery.handler';
 import { JobQueueProcessor } from '../../../../src/storage/job-queue-processor';
 import type { Job } from '../../../../src/storage/repositories/job-queue-repository';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
 
 const SESSION = 'sess-conformance';
 
@@ -799,5 +801,34 @@ describe('delivery consumption signal (long-horizon delivered = consumed)', () =
     await Promise.resolve();
     expect(a).toBe(true);
     expect(b).toBe(true);
+  });
+});
+
+describe('drainDeliveryWaitersOnTerminalSDKMessage (handleSDKMessage-catch gating)', () => {
+  // Covers both runners' handleSDKMessage catch blocks (Claude query-runner +
+  // ACP acp-query-runner), which both route through this helper. A non-terminal
+  // message throw must NOT free the active-turn slot mid-turn; only the final
+  // `result` does. (Codex P1.)
+
+  it('calls setIdle (drains) when the throwing message is the final result', async () => {
+    const setIdle = mock(async () => {});
+    await drainDeliveryWaitersOnTerminalSDKMessage({ setIdle }, { type: 'result' } as SDKMessage);
+    expect(setIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call setIdle for a non-terminal (assistant) message throw', async () => {
+    const setIdle = mock(async () => {});
+    await drainDeliveryWaitersOnTerminalSDKMessage({ setIdle }, {
+      type: 'assistant',
+    } as SDKMessage);
+    expect(setIdle).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call setIdle for a stream_event / non-result message', async () => {
+    const setIdle = mock(async () => {});
+    await drainDeliveryWaitersOnTerminalSDKMessage({ setIdle }, {
+      type: 'stream_event',
+    } as SDKMessage);
+    expect(setIdle).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-delivery-v2.test.ts
@@ -125,6 +125,35 @@ describe('message-delivery v2 — substrate (job_queue)', () => {
       expect(turns).toHaveLength(2);
     });
 
+    it('is idempotent per UUID — a second deliverMessage for the same UUID is a no-op', () => {
+      // The reset path can persist + deliver the same UUID twice (the replacement
+      // session is created before the old one is cleaned up). Without the
+      // getActiveDeliveryRole guard, the second call would insert a steer for the
+      // UUID the first inserted as a turn → the prompt reaches the SDK twice.
+      const role1 = deliverMessage(repo, SESSION, 'dup', { origin: 'chat' });
+      const role2 = deliverMessage(repo, SESSION, 'dup', { origin: 'chat' });
+      expect(role1).toBe('turn');
+      expect(role2).toBe('turn'); // returns the existing role, no second insert
+      const dup = jobsFor(repo, SESSION).filter(
+        (j) => (j.payload as { messageUuid: string }).messageUuid === 'dup'
+      );
+      expect(dup).toHaveLength(1);
+    });
+
+    it('idempotency returns the existing steer role, not a fresh insert', () => {
+      deliverMessage(repo, SESSION, 'turn', { origin: 'chat' });
+      // 'steer-uuid' becomes a steer because a turn is active.
+      const role1 = deliverMessage(repo, SESSION, 'steer-uuid', { origin: 'chat' });
+      expect(role1).toBe('steer');
+      // A second call for the same steer UUID must return 'steer', not insert again.
+      const role2 = deliverMessage(repo, SESSION, 'steer-uuid', { origin: 'chat' });
+      expect(role2).toBe('steer');
+      const steers = jobsFor(repo, SESSION).filter(
+        (j) => (j.payload as { messageUuid: string }).messageUuid === 'steer-uuid'
+      );
+      expect(steers).toHaveLength(1);
+    });
+
     it('isUniqueConstraintError detects SQLite UNIQUE failures', () => {
       expect(isUniqueConstraintError(new Error('UNIQUE constraint failed: job_queue.queue'))).toBe(
         true

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -452,4 +452,29 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
     expect(session.saveUserMessage).not.toHaveBeenCalled();
     expect(session.jobQueueEnqueue).toHaveBeenCalled();
   });
+
+  it('a retry finding an existing CONSUMED row skips resetContextPerTurn (no /clear of the just-delivered handoff)', async () => {
+    // A crash after the delivery job completed but before markDelivered retries
+    // the same stable id. The slot has resetContextPerTurn + prior context, so
+    // it WOULD /clear — but the consumed check runs first (hoisted above the
+    // clear) and returns, so the context holding the just-delivered handoff is
+    // not rotated away. (Codex P1.)
+    const { manager, session } = makeManager({
+      slotResets: true,
+      deliveryContent: { sendStatus: 'consumed' },
+    });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.saveUserMessage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -53,6 +53,7 @@ function makeManager(opts: {
   // deliverMessage jobQueue calls.
   const jobQueueEnqueue = mock(() => ({ id: 'job-1' }));
   const reopenDeliveryByUuid = mock(() => null);
+  const markDeliveryDeferredByUuid = mock(() => null);
 
   function makeSession(o: MockSessionOptions) {
     return {
@@ -85,6 +86,7 @@ function makeManager(opts: {
         getDeliveryContent: () => opts.deliveryContent ?? null,
         reopenDeliveryByUuid,
         markDeliveryFailedByUuid: () => null,
+        markDeliveryDeferredByUuid,
       }),
       // The resetContextPerTurn gate calls hasActiveDeliveryJob (→ getJobQueueRepo
       // .activeDeliveryMessageUuids) regardless of the delivery path. Return a
@@ -135,6 +137,7 @@ function makeManager(opts: {
       saveUserMessage,
       jobQueueEnqueue,
       reopenDeliveryByUuid,
+      markDeliveryDeferredByUuid,
     },
   };
 }
@@ -476,5 +479,28 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
 
     expect(session.clearMock).not.toHaveBeenCalled();
     expect(session.saveUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('a failed-row retry that hits the deferred branch marks the row deferred (replay-selectable)', async () => {
+    // A prior attempt's enqueue failed (→ row 'failed'); a retry while the
+    // target is in rate_limit_cooldown reaches the deferred branch. The row was
+    // reopened to 'enqueued' — the deferred branch must flip it to 'deferred'
+    // or QueryModeHandler's replay (send_status='deferred' only) never selects
+    // it and the handoff is lost. (Codex P1.)
+    const { manager, session } = makeManager({ deliveryContent: { sendStatus: 'failed' } });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'rate_limit_cooldown' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.reopenDeliveryByUuid).toHaveBeenCalledTimes(1); // failed → enqueued
+    expect(session.markDeliveryDeferredByUuid).toHaveBeenCalledTimes(1); // enqueued → deferred
+    expect(session.saveUserMessage).not.toHaveBeenCalled(); // row reused, no duplicate
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -33,6 +33,12 @@ function makeManager(opts: {
   nodeMissing?: boolean;
   nodeEmptyAgents?: boolean;
   hasActiveDeliveryJob?: boolean;
+  /**
+   * Controls the v2 idempotent-persist guard: the sendStatus getDeliveryContent
+   * returns for the message (undefined ⇒ no existing row → fresh persist). Used
+   * by the v2 dedup describe to exercise the consumed/failed/enqueued branches.
+   */
+  deliveryContent?: { sendStatus: string };
 }): {
   manager: TaskAgentManager;
   session: Record<string, ReturnType<typeof mock>>;
@@ -42,6 +48,11 @@ function makeManager(opts: {
   const enqueueMock = mock(async () => {});
   const getProcessingState = mock(() => ({ status: 'idle' }));
   const saveUserMessage = mock(() => 'db-id');
+  // v2 durable-delivery plumbing (harmless under the legacy path, which never
+  // reaches these repos): the dedup guard's getDeliveryContent + the
+  // deliverMessage jobQueue calls.
+  const jobQueueEnqueue = mock(() => ({ id: 'job-1' }));
+  const reopenDeliveryByUuid = mock(() => null);
 
   function makeSession(o: MockSessionOptions) {
     return {
@@ -68,13 +79,23 @@ function makeManager(opts: {
     db: {
       getDatabase: () => ({}),
       saveUserMessage,
+      getSDKMessageRepo: () => ({
+        // The v2 dedup guard: return the configured prior outcome, or null when
+        // no row exists yet (the first-inject case).
+        getDeliveryContent: () => opts.deliveryContent ?? null,
+        reopenDeliveryByUuid,
+        markDeliveryFailedByUuid: () => null,
+      }),
       // The resetContextPerTurn gate calls hasActiveDeliveryJob (→ getJobQueueRepo
       // .activeDeliveryMessageUuids) regardless of the delivery path. Return a
       // pending job when the test opts in, so the gate's BLOCKING branch (don't
-      // clear while a durable turn is pending) is exercised.
+      // clear while a durable turn is pending) is exercised. enqueue +
+      // getActiveDeliveryRole back the v2 deliverMessage chokepoint.
       getJobQueueRepo: () => ({
         activeDeliveryMessageUuids: () =>
           new Set<string>(opts.hasActiveDeliveryJob ? ['pending-job'] : []),
+        enqueue: jobQueueEnqueue,
+        getActiveDeliveryRole: () => null,
       }),
     },
     internalEventBus: {
@@ -106,7 +127,15 @@ function makeManager(opts: {
   const manager = new TaskAgentManager(config);
   return {
     manager,
-    session: { clearMock, ensureStartedMock, enqueueMock, getProcessingState, saveUserMessage },
+    session: {
+      clearMock,
+      ensureStartedMock,
+      enqueueMock,
+      getProcessingState,
+      saveUserMessage,
+      jobQueueEnqueue,
+      reopenDeliveryByUuid,
+    },
   };
 }
 
@@ -359,5 +388,68 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     const locks = (manager as unknown as { sessionInjectLocks: Map<string, unknown> })
       .sessionInjectLocks;
     expect(locks.size).toBe(0);
+  });
+});
+
+describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => {
+  // The sibling describe opts into the legacy path to test the clear decision;
+  // here v2 runs default-on so the durable-delivery dedup guard is exercised.
+  // saveUserMessage mints a fresh row id each call, so a flush retry reusing the
+  // pending-row id must NOT insert a second sdk_messages row or re-drive a
+  // consumed turn — it checks the existing row first (mirrors the LTA +
+  // Space-agent injectors).
+  const previousFlag = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+  beforeAll(() => {
+    delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+  });
+  afterAll(() => {
+    if (previousFlag !== undefined) process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previousFlag;
+    else delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+  });
+
+  function liveSession(session: {
+    ensureStartedMock: ReturnType<typeof mock>;
+    clearMock: ReturnType<typeof mock>;
+    enqueueMock: ReturnType<typeof mock>;
+  }): AgentSession {
+    return {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+  }
+
+  it('first inject persists the row and enqueues a durable job', async () => {
+    const { manager, session } = makeManager({}); // no existing row
+    indexSession(manager, liveSession(session));
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.saveUserMessage).toHaveBeenCalledTimes(1);
+    expect(session.jobQueueEnqueue).toHaveBeenCalled();
+  });
+
+  it('a retry finding an existing CONSUMED row does not re-persist or re-enqueue (no re-drive)', async () => {
+    const { manager, session } = makeManager({ deliveryContent: { sendStatus: 'consumed' } });
+    indexSession(manager, liveSession(session));
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.saveUserMessage).not.toHaveBeenCalled();
+    expect(session.jobQueueEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('a retry finding an existing FAILED row reopens it and re-enqueues without a duplicate row', async () => {
+    const { manager, session } = makeManager({ deliveryContent: { sendStatus: 'failed' } });
+    indexSession(manager, liveSession(session));
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.reopenDeliveryByUuid).toHaveBeenCalledTimes(1);
+    // The row already exists (failed) — reuse it, don't insert a second.
+    expect(session.saveUserMessage).not.toHaveBeenCalled();
+    expect(session.jobQueueEnqueue).toHaveBeenCalled();
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -32,6 +32,7 @@ function makeManager(opts: {
   slotResets?: boolean;
   nodeMissing?: boolean;
   nodeEmptyAgents?: boolean;
+  hasActiveDeliveryJob?: boolean;
 }): {
   manager: TaskAgentManager;
   session: Record<string, ReturnType<typeof mock>>;
@@ -68,9 +69,13 @@ function makeManager(opts: {
       getDatabase: () => ({}),
       saveUserMessage,
       // The resetContextPerTurn gate calls hasActiveDeliveryJob (→ getJobQueueRepo
-      // .activeDeliveryMessageUuids) regardless of the delivery path; return empty
-      // so the gate evaluates as if no durable turn is pending.
-      getJobQueueRepo: () => ({ activeDeliveryMessageUuids: () => new Set<string>() }),
+      // .activeDeliveryMessageUuids) regardless of the delivery path. Return a
+      // pending job when the test opts in, so the gate's BLOCKING branch (don't
+      // clear while a durable turn is pending) is exercised.
+      getJobQueueRepo: () => ({
+        activeDeliveryMessageUuids: () =>
+          new Set<string>(opts.hasActiveDeliveryJob ? ['pending-job'] : []),
+      }),
     },
     internalEventBus: {
       subscribe: mock(() => () => {}),
@@ -144,6 +149,29 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
 
     expect(session.clearMock).toHaveBeenCalledTimes(1);
     // The handoff is still delivered and persisted (UI thread continuity).
+    expect(session.saveUserMessage).toHaveBeenCalled();
+    expect(session.enqueueMock).toHaveBeenCalled();
+  });
+
+  it('does NOT clear when a durable turn is already pending for the session', async () => {
+    const { manager, session } = makeManager({ slotResets: true, hasActiveDeliveryJob: true });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    // A durable turn is pending (activeDeliveryMessageUuids non-empty) — the
+    // resetContextPerTurn gate must BLOCK the clear so it doesn't race the
+    // pending v2 turn, even though the slot is reset-enabled + idle + has prior
+    // context (the conditions that would otherwise clear).
+    expect(session.clearMock).not.toHaveBeenCalled();
+    // The handoff is still delivered and persisted.
     expect(session.saveUserMessage).toHaveBeenCalled();
     expect(session.enqueueMock).toHaveBeenCalled();
   });

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, mock, beforeAll, afterAll } from 'bun:test';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { signalDeliveryConsumed } from '../../../../src/lib/agent/message-delivery';
 
 const SESSION_ID = 'reviewer-session-1';
 const RUN_ID = 'run-1';
@@ -51,7 +52,14 @@ function makeManager(opts: {
   // v2 durable-delivery plumbing (harmless under the legacy path, which never
   // reaches these repos): the dedup guard's getDeliveryContent + the
   // deliverMessage jobQueue calls.
-  const jobQueueEnqueue = mock(() => ({ id: 'job-1' }));
+  // Test simplification: signal SDK consumption at enqueue time so the v2
+  // consumption-await in injectMessageIntoSession resolves (production signals
+  // from the bridge on the SDK's onSent; these tests don't drive a real turn).
+  const jobQueueEnqueue = mock((args: { payload?: { messageUuid?: string } }) => {
+    const uuid = args?.payload?.messageUuid;
+    if (uuid) signalDeliveryConsumed(uuid);
+    return { id: 'job-1' };
+  });
   const reopenDeliveryByUuid = mock(() => null);
   const markDeliveryDeferredByUuid = mock(() => null);
 

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -12,7 +12,7 @@
  * in agent-session-clear-context.test.ts; here clearConversationContext is
  * mocked so we assert purely on the DECISION to invoke it.
  */
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it, mock, beforeAll, afterAll } from 'bun:test';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
@@ -67,6 +67,10 @@ function makeManager(opts: {
     db: {
       getDatabase: () => ({}),
       saveUserMessage,
+      // The resetContextPerTurn gate calls hasActiveDeliveryJob (→ getJobQueueRepo
+      // .activeDeliveryMessageUuids) regardless of the delivery path; return empty
+      // so the gate evaluates as if no durable turn is pending.
+      getJobQueueRepo: () => ({ activeDeliveryMessageUuids: () => new Set<string>() }),
     },
     internalEventBus: {
       subscribe: mock(() => () => {}),
@@ -110,6 +114,19 @@ function indexSession(manager: TaskAgentManager, session: AgentSession): void {
 }
 
 describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
+  // These tests validate the resetContextPerTurn CLEAR decision, which is
+  // delivery-mechanism agnostic (the clear runs before the v2/legacy branch).
+  // Opt into the legacy inline path so the mock session — which has no
+  // stateManager and only a gate-level jobQueue stub — exercises the clear
+  // decision rather than the durable-delivery plumbing.
+  const previousFlag = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+  beforeAll(() => {
+    process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '0';
+  });
+  afterAll(() => {
+    if (previousFlag === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+    else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previousFlag;
+  });
   it('clears SDK context before a task handoff to a resetContextPerTurn slot with prior context', async () => {
     const { manager, session } = makeManager({ slotResets: true });
     // Build a session that already has prior SDK context (a prior turn ran).

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -55,11 +55,13 @@ function makeManager(opts: {
   // Test simplification: signal SDK consumption at enqueue time so the v2
   // consumption-await in injectMessageIntoSession resolves (production signals
   // from the bridge on the SDK's onSent; these tests don't drive a real turn).
-  const jobQueueEnqueue = mock((args: { payload?: { messageUuid?: string } }) => {
-    const uuid = args?.payload?.messageUuid;
-    if (uuid) signalDeliveryConsumed(uuid);
-    return { id: 'job-1' };
-  });
+  const jobQueueEnqueue = mock(
+    (args: { payload?: { sessionId?: string; messageUuid?: string } }) => {
+      const uuid = args?.payload?.messageUuid;
+      if (uuid) signalDeliveryConsumed(args!.payload!.sessionId!, uuid);
+      return { id: 'job-1' };
+    }
+  );
   const reopenDeliveryByUuid = mock(() => null);
   const markDeliveryDeferredByUuid = mock(() => null);
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -909,8 +909,10 @@ describe('SpaceRuntimeService', () => {
         })),
         listBySpaceId: mock(() => []),
       } as unknown as SpaceAgentManager;
+      const { reactiveDb } = buildDurableDeliveryReactiveDb();
       const svc = new SpaceRuntimeService({
         ...buildConfigWithSession(sessionManager, spaceManager),
+        reactiveDb,
         spaceAgentManager,
         spaceAgentInboxRepo: {} as SpaceRuntimeServiceConfig['spaceAgentInboxRepo'],
       });
@@ -1065,8 +1067,10 @@ describe('SpaceRuntimeService', () => {
         })),
         update: mock(() => {}),
       } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const { reactiveDb } = buildDurableDeliveryReactiveDb();
       const svc = new SpaceRuntimeService({
         ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
         longHorizonAgentRepo,
       });
 
@@ -1198,6 +1202,90 @@ describe('SpaceRuntimeService', () => {
         expect.objectContaining({ uuid: 'delivery-1', type: 'user' }),
         'enqueued'
       );
+    });
+
+    test('long-horizon delivery terminalizes the persisted row if durable enqueue throws', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({ id: sessionId, metadata: {}, config: {} })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'mcp-agent',
+          displayName: 'MCP Agent',
+          templateKey: null,
+          status: 'active',
+          sessionId: null,
+          instructions: 'Do work.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          provider: null,
+          settingSources: null,
+          toolPermissions: {},
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+
+      // A reactiveDb whose durable-enqueue throws, simulating a transient SQLite
+      // failure at the persist→deliver boundary (the window P1 guards).
+      const markDeliveryFailedByUuid = mock(() => null);
+      const reactiveDb = {
+        db: {
+          saveUserMessage: mock(() => 'db-msg'),
+          getSDKMessageRepo: () => ({ markDeliveryFailedByUuid }),
+          getJobQueueRepo: () => ({
+            getActiveDeliveryRole: () => null,
+            enqueue: () => {
+              throw new Error('sqlite locked');
+            },
+          }),
+        },
+      } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
+
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
+        longHorizonAgentRepo,
+      });
+
+      // The throw propagates out of deliverLongHorizonExternalEvent (no internal
+      // catch wraps injectLongTermAgentMessage).
+      await expect(
+        (
+          svc as unknown as {
+            deliverLongHorizonExternalEvent(args: {
+              spaceId: string;
+              agentId: string;
+              message: string;
+              idempotencyKey: string;
+            }): Promise<{ delivered: boolean }>;
+          }
+        ).deliverLongHorizonExternalEvent({
+          spaceId: mockSpace.id,
+          agentId: 'lh-agent-1',
+          message: 'event payload',
+          idempotencyKey: 'delivery-1',
+        })
+      ).rejects.toThrow('sqlite locked');
+
+      // The row was saved 'enqueued' before the throw; the catch must terminalize
+      // it so it is not stranded ownerless and replayed as an orphan on restart.
+      expect(markDeliveryFailedByUuid).toHaveBeenCalledWith(sessionId, 'delivery-1');
     });
 
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -570,6 +570,10 @@ describe('SpaceRuntimeService', () => {
       const reactiveDb = {
         db: {
           saveUserMessage,
+          getSDKMessageRepo: () => ({
+            getDeliveryContent: () => null, // first attempt — no existing row
+            markDeliveryFailedByUuid: () => null,
+          }),
           getJobQueueRepo: () => ({
             getActiveDeliveryRole: () => null,
             enqueue: () => ({ id: 'job-1' }),
@@ -1247,7 +1251,10 @@ describe('SpaceRuntimeService', () => {
       const reactiveDb = {
         db: {
           saveUserMessage: mock(() => 'db-msg'),
-          getSDKMessageRepo: () => ({ markDeliveryFailedByUuid }),
+          getSDKMessageRepo: () => ({
+            getDeliveryContent: () => null, // first attempt
+            markDeliveryFailedByUuid,
+          }),
           getJobQueueRepo: () => ({
             getActiveDeliveryRole: () => null,
             enqueue: () => {
@@ -1286,6 +1293,86 @@ describe('SpaceRuntimeService', () => {
       // The row was saved 'enqueued' before the throw; the catch must terminalize
       // it so it is not stranded ownerless and replayed as an orphan on restart.
       expect(markDeliveryFailedByUuid).toHaveBeenCalledWith(sessionId, 'delivery-1');
+    });
+
+    test('long-horizon crash-retry does not re-save or re-drive a terminal message', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({ id: sessionId, metadata: {}, config: {} })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'mcp-agent',
+          displayName: 'MCP Agent',
+          templateKey: null,
+          status: 'active',
+          sessionId: null,
+          instructions: 'Do work.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          provider: null,
+          settingSources: null,
+          toolPermissions: {},
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+
+      // The message already reached a terminal status (consumed) on a prior
+      // attempt. A crash-retry with the same idempotency key must NOT insert a
+      // duplicate sdk_messages row or re-enqueue a job that re-drives it.
+      const saveUserMessage = mock(() => 'db-msg');
+      const enqueue = mock(() => ({ id: 'job-1' }));
+      const reactiveDb = {
+        db: {
+          saveUserMessage,
+          getSDKMessageRepo: () => ({
+            getDeliveryContent: () => ({ content: 'event payload', sendStatus: 'consumed' }),
+            markDeliveryFailedByUuid: () => null,
+          }),
+          getJobQueueRepo: () => ({ getActiveDeliveryRole: () => null, enqueue }),
+        },
+      } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
+
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
+        longHorizonAgentRepo,
+      });
+
+      const result = await (
+        svc as unknown as {
+          deliverLongHorizonExternalEvent(args: {
+            spaceId: string;
+            agentId: string;
+            message: string;
+            idempotencyKey: string;
+          }): Promise<{ delivered: boolean }>;
+        }
+      ).deliverLongHorizonExternalEvent({
+        spaceId: mockSpace.id,
+        agentId: 'lh-agent-1',
+        message: 'event payload',
+        idempotencyKey: 'delivery-1',
+      });
+
+      expect(result).toEqual({ delivered: true });
+      expect(saveUserMessage).not.toHaveBeenCalled(); // no duplicate row
+      expect(enqueue).not.toHaveBeenCalled(); // no re-drive
     });
 
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -10,7 +10,17 @@
  * - setTaskAgentManager(): wires TaskAgentManager into the underlying SpaceRuntime
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from 'bun:test';
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+  mock,
+  type Mock,
+} from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
@@ -137,6 +147,22 @@ function buildLongHorizonAgent(
 describe('SpaceRuntimeService', () => {
   let spaceManager: SpaceManager;
   let service: SpaceRuntimeService;
+
+  // v2 long-horizon delivery awaits the durable job's SDK consumption before
+  // confirming the source record. These tests don't drive a real SDK turn, so
+  // the wait would hit its timeout; shorten it so the suite stays fast. The
+  // dedicated consumption test signals explicitly and ignores this.
+  const previousConsumptionTimeout = process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS;
+  beforeAll(() => {
+    process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS = '50';
+  });
+  afterAll(() => {
+    if (previousConsumptionTimeout === undefined) {
+      delete process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS;
+    } else {
+      process.env.HYPERNEO_DELIVERY_CONSUMPTION_TIMEOUT_MS = previousConsumptionTimeout;
+    }
+  });
 
   beforeEach(() => {
     spaceManager = createMockSpaceManager(mockSpace);

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -609,9 +609,9 @@ describe('SpaceRuntimeService', () => {
             // delivery is acknowledged. (Production signals from the bridge on
             // the SDK's onSent; these tests don't drive a real turn.) The
             // dedicated timeout test uses a repo that does NOT signal.
-            enqueue: (args: { payload?: { messageUuid?: string } }) => {
+            enqueue: (args: { payload?: { sessionId?: string; messageUuid?: string } }) => {
               const uuid = args?.payload?.messageUuid;
-              if (uuid) signalDeliveryConsumed(uuid);
+              if (uuid) signalDeliveryConsumed(args!.payload!.sessionId!, uuid);
               return { id: 'job-1' };
             },
           }),
@@ -1462,9 +1462,9 @@ describe('SpaceRuntimeService', () => {
       const saveUserMessage = mock(() => 'db-msg');
       // Signal consumption at enqueue so the consumption-await resolves (test
       // simplification — see buildDurableDeliveryReactiveDb).
-      const enqueue = mock((args: { payload?: { messageUuid?: string } }) => {
+      const enqueue = mock((args: { payload?: { sessionId?: string; messageUuid?: string } }) => {
         const uuid = args?.payload?.messageUuid;
-        if (uuid) signalDeliveryConsumed(uuid);
+        if (uuid) signalDeliveryConsumed(args!.payload!.sessionId!, uuid);
         return { id: 'job-1' };
       });
       const reopenDeliveryByUuid = mock(() => 'db-id');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -554,6 +554,31 @@ describe('SpaceRuntimeService', () => {
       };
     }
 
+    /**
+     * A reactiveDb whose db façade records durable delivery: a saveUserMessage
+     * spy + an inert jobQueue repo. injectLongTermAgentMessage now persists the
+     * message via saveUserMessage then enqueues a message_delivery job via
+     * deliverMessage (v2), so long-horizon delivery tests assert on
+     * saveUserMessage (the durable persist) instead of the removed inline
+     * session.messageQueue.enqueueWithId feed.
+     */
+    function buildDurableDeliveryReactiveDb(): {
+      reactiveDb: SpaceRuntimeServiceConfig['reactiveDb'];
+      saveUserMessage: ReturnType<typeof mock>;
+    } {
+      const saveUserMessage = mock(() => 'db-msg');
+      const reactiveDb = {
+        db: {
+          saveUserMessage,
+          getJobQueueRepo: () => ({
+            getActiveDeliveryRole: () => null,
+            enqueue: () => ({ id: 'job-1' }),
+          }),
+        },
+      } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
+      return { reactiveDb, saveUserMessage };
+    }
+
     test('attaches MCP server and system prompt to the space:chat session (merge, not replace)', async () => {
       const session = makeSession();
       const sessionManager = makeSessionManager(session);
@@ -818,8 +843,10 @@ describe('SpaceRuntimeService', () => {
         })),
         update: mock(() => {}),
       } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const { reactiveDb, saveUserMessage } = buildDurableDeliveryReactiveDb();
       const svc = new SpaceRuntimeService({
         ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
         longHorizonAgentRepo,
         spaceAgentInboxRepo:
           inboxRepo as unknown as SpaceRuntimeServiceConfig['spaceAgentInboxRepo'],
@@ -845,9 +872,12 @@ describe('SpaceRuntimeService', () => {
 
       expect(deliveredSessionId).toBe(sessionId);
       expect(inboxRepo.enqueue).not.toHaveBeenCalled();
-      expect(createdSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
-        expect.stringMatching(/^msg_/),
-        'hello'
+      // injectLongTermAgentMessage persists durably + enqueues a message_delivery
+      // job (v2); assert the durable persist instead of the removed inline feed.
+      expect(saveUserMessage).toHaveBeenCalledWith(
+        sessionId,
+        expect.objectContaining({ uuid: expect.stringMatching(/^msg_/), type: 'user' }),
+        'enqueued'
       );
     });
 
@@ -948,8 +978,10 @@ describe('SpaceRuntimeService', () => {
         })),
         update: mock(() => {}),
       } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const { reactiveDb, saveUserMessage } = buildDurableDeliveryReactiveDb();
       const svc = new SpaceRuntimeService({
         ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
         longHorizonAgentRepo,
       });
 
@@ -986,9 +1018,10 @@ describe('SpaceRuntimeService', () => {
           }),
         })
       );
-      expect(createdSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
-        'delivery-1',
-        'event payload'
+      expect(saveUserMessage).toHaveBeenCalledWith(
+        sessionId,
+        expect.objectContaining({ uuid: 'delivery-1', type: 'user' }),
+        'enqueued'
       );
     });
 
@@ -1109,8 +1142,10 @@ describe('SpaceRuntimeService', () => {
         })),
         update: mock(() => {}),
       } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      const { reactiveDb, saveUserMessage } = buildDurableDeliveryReactiveDb();
       const svc = new SpaceRuntimeService({
         ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
         longHorizonAgentRepo,
       });
 
@@ -1158,9 +1193,10 @@ describe('SpaceRuntimeService', () => {
       };
       expect(updateCall.systemPrompt.append).toContain('Use updated tools.');
       expect(updateCall.systemPrompt.append).toContain(LONG_HORIZON_SCHEDULING_GUARDRAIL);
-      expect(existingSession.messageQueue.enqueueWithId).toHaveBeenCalledWith(
-        'delivery-1',
-        'event payload'
+      expect(saveUserMessage).toHaveBeenCalledWith(
+        sessionId,
+        expect.objectContaining({ uuid: 'delivery-1', type: 'user' }),
+        'enqueued'
       );
     });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -40,6 +40,7 @@ import type { SpaceTaskRepository } from '../../../../src/storage/repositories/s
 import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import type { SessionManager } from '../../../../src/lib/session-manager.ts';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import { signalDeliveryConsumed } from '../../../../src/lib/agent/message-delivery';
 import type { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import type {
   McpServerConfig,
@@ -603,7 +604,16 @@ describe('SpaceRuntimeService', () => {
           }),
           getJobQueueRepo: () => ({
             getActiveDeliveryRole: () => null,
-            enqueue: () => ({ id: 'job-1' }),
+            // Test simplification: signal SDK consumption at enqueue time so
+            // injectLongTermAgentMessage's consumption-await resolves and the
+            // delivery is acknowledged. (Production signals from the bridge on
+            // the SDK's onSent; these tests don't drive a real turn.) The
+            // dedicated timeout test uses a repo that does NOT signal.
+            enqueue: (args: { payload?: { messageUuid?: string } }) => {
+              const uuid = args?.payload?.messageUuid;
+              if (uuid) signalDeliveryConsumed(uuid);
+              return { id: 'job-1' };
+            },
           }),
         },
       } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
@@ -1448,7 +1458,13 @@ describe('SpaceRuntimeService', () => {
       // must reopen it (→ enqueued) and re-enqueue the job — not treat `failed`
       // as success and silently drop the delivery.
       const saveUserMessage = mock(() => 'db-msg');
-      const enqueue = mock(() => ({ id: 'job-1' }));
+      // Signal consumption at enqueue so the consumption-await resolves (test
+      // simplification — see buildDurableDeliveryReactiveDb).
+      const enqueue = mock((args: { payload?: { messageUuid?: string } }) => {
+        const uuid = args?.payload?.messageUuid;
+        if (uuid) signalDeliveryConsumed(uuid);
+        return { id: 'job-1' };
+      });
       const reopenDeliveryByUuid = mock(() => 'db-id');
       const reactiveDb = {
         db: {
@@ -1488,6 +1504,87 @@ describe('SpaceRuntimeService', () => {
       expect(saveUserMessage).not.toHaveBeenCalled(); // row already exists — no dup
       expect(reopenDeliveryByUuid).toHaveBeenCalledWith(sessionId, 'delivery-1'); // un-failed
       expect(enqueue).toHaveBeenCalled(); // re-driven
+    });
+
+    test('long-horizon delivery not consumed within the timeout rejects — no premature delivered (Codex P1)', async () => {
+      // If the durable job stays parked/retrying past the consumption timeout,
+      // the delivery must NOT be acknowledged (the job may yet dead-letter).
+      // injectLongTermAgentMessage rejects; deliverLongHorizonExternalEvent
+      // propagates so the caller retries the source record.
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({ id: sessionId, metadata: {}, config: {} })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'mcp-agent',
+          displayName: 'MCP Agent',
+          templateKey: null,
+          status: 'active',
+          sessionId: null,
+          instructions: 'Do work.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          provider: null,
+          settingSources: null,
+          toolPermissions: {},
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+      // enqueue succeeds but does NOT signal consumption (no real SDK turn) →
+      // the consumption-await hits its (shortened) timeout and rejects.
+      const reactiveDb = {
+        db: {
+          saveUserMessage: mock(() => 'db-msg'),
+          getSDKMessageRepo: () => ({
+            getDeliveryContent: () => null,
+            markDeliveryFailedByUuid: () => null,
+            reopenDeliveryByUuid: () => null,
+          }),
+          getJobQueueRepo: () => ({
+            getActiveDeliveryRole: () => null,
+            enqueue: () => ({ id: 'job-1' }),
+          }),
+        },
+      } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
+        longHorizonAgentRepo,
+      });
+
+      await expect(
+        (
+          svc as unknown as {
+            deliverLongHorizonExternalEvent(args: {
+              spaceId: string;
+              agentId: string;
+              message: string;
+              idempotencyKey: string;
+            }): Promise<{ delivered: boolean }>;
+          }
+        ).deliverLongHorizonExternalEvent({
+          spaceId: mockSpace.id,
+          agentId: 'lh-agent-1',
+          message: 'event payload',
+          idempotencyKey: 'delivery-timeout',
+        })
+      ).rejects.toThrow('not consumed within timeout');
     });
 
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -573,6 +573,7 @@ describe('SpaceRuntimeService', () => {
           getSDKMessageRepo: () => ({
             getDeliveryContent: () => null, // first attempt — no existing row
             markDeliveryFailedByUuid: () => null,
+            reopenDeliveryByUuid: () => null,
           }),
           getJobQueueRepo: () => ({
             getActiveDeliveryRole: () => null,
@@ -1254,6 +1255,7 @@ describe('SpaceRuntimeService', () => {
           getSDKMessageRepo: () => ({
             getDeliveryContent: () => null, // first attempt
             markDeliveryFailedByUuid,
+            reopenDeliveryByUuid: () => null,
           }),
           getJobQueueRepo: () => ({
             getActiveDeliveryRole: () => null,
@@ -1337,12 +1339,14 @@ describe('SpaceRuntimeService', () => {
       // duplicate sdk_messages row or re-enqueue a job that re-drives it.
       const saveUserMessage = mock(() => 'db-msg');
       const enqueue = mock(() => ({ id: 'job-1' }));
+      const reopenDeliveryByUuid = mock(() => null);
       const reactiveDb = {
         db: {
           saveUserMessage,
           getSDKMessageRepo: () => ({
             getDeliveryContent: () => ({ content: 'event payload', sendStatus: 'consumed' }),
             markDeliveryFailedByUuid: () => null,
+            reopenDeliveryByUuid,
           }),
           getJobQueueRepo: () => ({ getActiveDeliveryRole: () => null, enqueue }),
         },
@@ -1373,6 +1377,91 @@ describe('SpaceRuntimeService', () => {
       expect(result).toEqual({ delivered: true });
       expect(saveUserMessage).not.toHaveBeenCalled(); // no duplicate row
       expect(enqueue).not.toHaveBeenCalled(); // no re-drive
+      expect(reopenDeliveryByUuid).not.toHaveBeenCalled(); // consumed ≠ retryable
+    });
+
+    test('long-horizon crash-retry reopens a failed row and re-enqueues it', async () => {
+      const sessionId = longTermAgentSessionId(mockSpace.id, 'lh-agent-1');
+      const createdSession = {
+        ...makeSession(),
+        getSessionData: mock(() => ({ id: sessionId, metadata: {}, config: {} })),
+        ensureQueryStarted: mock(async () => {}),
+        messageQueue: { enqueueWithId: mock(async () => {}) },
+      } as unknown as AgentSession;
+      const sessionManager = makeSessionManager(null);
+      (
+        sessionManager.createSession as Mock<typeof sessionManager.createSession>
+      ).mockImplementation(async () => sessionId);
+      (sessionManager.getSessionAsync as Mock<typeof sessionManager.getSessionAsync>)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createdSession);
+      const longHorizonAgentRepo = {
+        getById: mock(() => ({
+          id: 'lh-agent-1',
+          spaceId: mockSpace.id,
+          handle: 'mcp-agent',
+          displayName: 'MCP Agent',
+          templateKey: null,
+          status: 'active',
+          sessionId: null,
+          instructions: 'Do work.',
+          autonomyLevel: null,
+          model: null,
+          thinkingLevel: null,
+          provider: null,
+          settingSources: null,
+          toolPermissions: {},
+          createdAt: NOW,
+          updatedAt: NOW,
+        })),
+        update: mock(() => {}),
+      } as unknown as SpaceRuntimeServiceConfig['longHorizonAgentRepo'];
+
+      // A prior attempt's durable enqueue threw and terminalized this row
+      // (send_status='failed'). The handler skips `failed` rows, so the retry
+      // must reopen it (→ enqueued) and re-enqueue the job — not treat `failed`
+      // as success and silently drop the delivery.
+      const saveUserMessage = mock(() => 'db-msg');
+      const enqueue = mock(() => ({ id: 'job-1' }));
+      const reopenDeliveryByUuid = mock(() => 'db-id');
+      const reactiveDb = {
+        db: {
+          saveUserMessage,
+          getSDKMessageRepo: () => ({
+            getDeliveryContent: () => ({ content: 'event payload', sendStatus: 'failed' }),
+            markDeliveryFailedByUuid: () => null,
+            reopenDeliveryByUuid,
+          }),
+          getJobQueueRepo: () => ({ getActiveDeliveryRole: () => null, enqueue }),
+        },
+      } as unknown as SpaceRuntimeServiceConfig['reactiveDb'];
+
+      const svc = new SpaceRuntimeService({
+        ...buildConfigWithSession(sessionManager, createMockSpaceManager(mockSpace)),
+        reactiveDb,
+        longHorizonAgentRepo,
+      });
+
+      const result = await (
+        svc as unknown as {
+          deliverLongHorizonExternalEvent(args: {
+            spaceId: string;
+            agentId: string;
+            message: string;
+            idempotencyKey: string;
+          }): Promise<{ delivered: boolean }>;
+        }
+      ).deliverLongHorizonExternalEvent({
+        spaceId: mockSpace.id,
+        agentId: 'lh-agent-1',
+        message: 'event payload',
+        idempotencyKey: 'delivery-1',
+      });
+
+      expect(result).toEqual({ delivered: true });
+      expect(saveUserMessage).not.toHaveBeenCalled(); // row already exists — no dup
+      expect(reopenDeliveryByUuid).toHaveBeenCalledWith(sessionId, 'delivery-1'); // un-failed
+      expect(enqueue).toHaveBeenCalled(); // re-driven
     });
 
     test('session.reset re-provisions reset long-term Space agents before query replay', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -915,9 +915,11 @@ describe('SpaceRuntimeService', () => {
       expect(inboxRepo.enqueue).not.toHaveBeenCalled();
       // injectLongTermAgentMessage persists durably + enqueues a message_delivery
       // job (v2); assert the durable persist instead of the removed inline feed.
+      // The delivery now reuses the message record's stable id ('message-1') so a
+      // consumption-timeout retry doesn't mint a second durable job. (Codex P1.)
       expect(saveUserMessage).toHaveBeenCalledWith(
         sessionId,
-        expect.objectContaining({ uuid: expect.stringMatching(/^msg_/), type: 'user' }),
+        expect.objectContaining({ uuid: 'message-1', type: 'user' }),
         'enqueued'
       );
     });

--- a/packages/daemon/tests/unit/lib/job-handlers/message-delivery-dead-letter.test.ts
+++ b/packages/daemon/tests/unit/lib/job-handlers/message-delivery-dead-letter.test.ts
@@ -46,6 +46,17 @@ const CHAT_PAYLOAD: MessageDeliveryPayload = {
   parentToolUseId: null,
 };
 
+// A mid-turn handoff to a running node session is a space_inject STEER (not the
+// node's kickoff turn). It must NOT emit session.error — only a dead-lettered
+// kickoff (turn) marks the execution blocked. (Codex P1.)
+const SPACE_INJECT_STEER_PAYLOAD: MessageDeliveryPayload = {
+  sessionId: 'sess-1',
+  messageUuid: 'uuid-3',
+  role: 'steer',
+  origin: 'space_inject',
+  parentToolUseId: null,
+};
+
 describe('settleMessageDeliveryDeadLetter (onDead → session.error → settle ordering)', () => {
   it('for a space_inject kickoff, publishes session.error BEFORE settling the queued marker', async () => {
     // The settlement idle would let registerCompletionCallback read the
@@ -71,6 +82,18 @@ describe('settleMessageDeliveryDeadLetter (onDead → session.error → settle o
 
     expect(calls).not.toContain('sessionError');
     expect(settlement.publishSessionError).not.toHaveBeenCalled();
+    expect(calls).toContain('settle');
+  });
+
+  it('does NOT publish session.error for a space_inject STEER (mid-turn handoff, not the kickoff)', async () => {
+    // A mid-turn handoff to a running node session is a space_inject steer; the
+    // node's kickoff + current turn already succeeded, so its dead-letter must
+    // not fire the completion callback's error path and block the execution.
+    const { settlement, calls } = recordingSettlement();
+    await settleMessageDeliveryDeadLetter(SPACE_INJECT_STEER_PAYLOAD, settlement);
+
+    expect(settlement.publishSessionError).not.toHaveBeenCalled();
+    expect(calls).not.toContain('sessionError');
     expect(calls).toContain('settle');
   });
 

--- a/packages/daemon/tests/unit/lib/job-handlers/message-delivery-dead-letter.test.ts
+++ b/packages/daemon/tests/unit/lib/job-handlers/message-delivery-dead-letter.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, mock } from 'bun:test';
+import {
+  DEAD_LETTER_SESSION_ERROR,
+  settleMessageDeliveryDeadLetter,
+  type MessageDeliveryDeadLetterSettlement,
+} from '../../../../src/lib/job-handlers/message-delivery-dead-letter';
+import type { MessageDeliveryPayload } from '../../../../src/lib/agent/message-delivery';
+
+/** A settlement that records the call order so the test can assert sequencing. */
+function recordingSettlement(markFailedResult: string | null = 'db-1'): {
+  settlement: MessageDeliveryDeadLetterSettlement;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const settlement: MessageDeliveryDeadLetterSettlement = {
+    markDeliveryFailedByUuid: mock(() => {
+      calls.push('markFailed');
+      return markFailedResult;
+    }),
+    publishStatusChanged: mock(async () => {
+      calls.push('statusChanged');
+    }),
+    publishSessionError: mock(async () => {
+      calls.push('sessionError');
+    }),
+    settleSkippedDelivery: mock(async () => {
+      calls.push('settle');
+    }),
+  };
+  return { settlement, calls };
+}
+
+const SPACE_INJECT_PAYLOAD: MessageDeliveryPayload = {
+  sessionId: 'sess-1',
+  messageUuid: 'uuid-1',
+  role: 'turn',
+  origin: 'space_inject',
+  parentToolUseId: null,
+};
+
+const CHAT_PAYLOAD: MessageDeliveryPayload = {
+  sessionId: 'sess-1',
+  messageUuid: 'uuid-2',
+  role: 'turn',
+  origin: 'chat',
+  parentToolUseId: null,
+};
+
+describe('settleMessageDeliveryDeadLetter (onDead → session.error → settle ordering)', () => {
+  it('for a space_inject kickoff, publishes session.error BEFORE settling the queued marker', async () => {
+    // The settlement idle would let registerCompletionCallback read the
+    // dead-letter as success; session.error (awaited first) fires the error
+    // path so the execution is marked blocked instead. (Codex P1.)
+    const { settlement, calls } = recordingSettlement();
+    await settleMessageDeliveryDeadLetter(SPACE_INJECT_PAYLOAD, settlement);
+
+    const errorIndex = calls.indexOf('sessionError');
+    const settleIndex = calls.indexOf('settle');
+    expect(errorIndex).toBeGreaterThanOrEqual(0);
+    expect(settleIndex).toBeGreaterThanOrEqual(0);
+    expect(errorIndex).toBeLessThan(settleIndex); // session.error strictly before settle
+    expect(settlement.publishSessionError).toHaveBeenCalledWith(
+      'sess-1',
+      DEAD_LETTER_SESSION_ERROR
+    );
+  });
+
+  it('for a non-space_inject delivery, does NOT publish session.error (only mark + status + settle)', async () => {
+    const { settlement, calls } = recordingSettlement();
+    await settleMessageDeliveryDeadLetter(CHAT_PAYLOAD, settlement);
+
+    expect(calls).not.toContain('sessionError');
+    expect(settlement.publishSessionError).not.toHaveBeenCalled();
+    expect(calls).toContain('settle');
+  });
+
+  it('terminalizes the row + broadcasts the status flip before settling', async () => {
+    const { settlement, calls } = recordingSettlement('db-flip');
+    await settleMessageDeliveryDeadLetter(SPACE_INJECT_PAYLOAD, settlement);
+
+    expect(settlement.markDeliveryFailedByUuid).toHaveBeenCalledWith('sess-1', 'uuid-1');
+    expect(settlement.publishStatusChanged).toHaveBeenCalledWith('sess-1', ['db-flip']);
+    // markFailed → statusChanged → sessionError → settle
+    expect(calls).toEqual(['markFailed', 'statusChanged', 'sessionError', 'settle']);
+  });
+
+  it('still settles when the row was already terminal (markFailed returns null — no status broadcast)', async () => {
+    const { settlement, calls } = recordingSettlement(null);
+    await settleMessageDeliveryDeadLetter(SPACE_INJECT_PAYLOAD, settlement);
+
+    expect(settlement.publishStatusChanged).not.toHaveBeenCalled();
+    expect(calls).toEqual(['markFailed', 'sessionError', 'settle']);
+  });
+});


### PR DESCRIPTION
Flips message-delivery v2 to default-on (opt out via `HYPERNEO_MESSAGE_DELIVERY_V2=0`) and routes the Space-agent, long-term-agent, and `injectMessageIntoSession` kickoff paths through the durable `deliverMessage` chokepoint instead of the inline `ensureQueryStarted`+`enqueueWithId`, giving all primary message delivery atomic single-owner semantics. `resetContextPerTurn` is gated on no active delivery job to avoid racing a pending v2 turn; rate-limit and defer kickoffs stay on the legacy path. `recoverOrphanedConsumedMessages` is kept as the crash backstop for the remaining legacy replay/retry paths — a follow-up migrates those and then deletes it.

Verified: all daemon shards green, the v2 substrate gains `getActiveDeliveryRole` UUID-idempotency tests, and the dev server boots clean with the message-delivery processor active. `bun run check` has one pre-existing `check:test-quality` failure in `provider-registry.test.ts` (confirmed on clean `dev`, unrelated to this change).