### PR TITLE
feat(space): add gate hook version reload diagnostics

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -57,7 +57,10 @@ import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-man
 import { evaluateGate, type GateEvalResult, type GateScriptExecutorFn } from './gate-evaluator';
 import type { GateScriptContext } from './gate-script-executor';
 import { executeGateScript } from './gate-script-executor';
-import { getBuiltInGateScript } from '../workflows/built-in-workflows';
+import {
+  logTemplateGateScriptReload,
+  resolveTemplateGateScript,
+} from '../workflows/built-in-workflows';
 import { getEffectiveGate } from './gate-features';
 import { RATE_LIMIT_MIN_BACKOFF_MS } from './rate-limit-detector';
 import { GateRetryScheduler } from './gate-retry-scheduler';
@@ -1546,13 +1549,18 @@ export class ChannelRouter {
     // was baked in at seed time. This ensures that template script updates (bug
     // fixes, new fallback logic, etc.) take immediate effect for all running
     // workflow instances without requiring a resync.
-    let gateDef = storedGateDef;
-    if (workflow.templateName) {
-      const liveScript = getBuiltInGateScript(workflow.templateName, gateId);
-      if (liveScript && storedGateDef.script) {
-        gateDef = { ...storedGateDef, script: liveScript };
-      }
-    }
+    const { gate: liveTemplateGate, status: gateScriptStatus } = resolveTemplateGateScript(
+      storedGateDef,
+      workflow
+    );
+    logTemplateGateScriptReload({
+      log,
+      status: gateScriptStatus,
+      templateName: workflow.templateName,
+      gateId,
+      runId,
+    });
+    let gateDef = liveTemplateGate;
     gateDef = getEffectiveGate(gateDef, workflow, sourceNodeName);
 
     // Load runtime data from DB; fall back to computed defaults from fields

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -59,6 +59,7 @@ import type { GateScriptContext } from './gate-script-executor';
 import { executeGateScript } from './gate-script-executor';
 import {
   gateScriptDiagnosticKey,
+  isGateScriptStatusEmitting,
   logTemplateGateScriptReload,
   resolveTemplateGateScript,
   sharedGateScriptDiagnosticLedger,
@@ -1426,6 +1427,17 @@ export class ChannelRouter {
     const effectiveGateDef = getEffectiveGate(gateDef, workflow, sourceNodeName);
     if (effectiveGateDef.validator) return true;
     if (effectiveGateDef.script && (workflow.templateName || !gateDef.script)) return true;
+    // Known limitation (gate-script reload diagnostics, follow-up): the checks
+    // above use getEffectiveGate (the feature registry), which does NOT reflect
+    // a script supplied purely via the built-in template reload path
+    // (getBuiltInGateScript, applied in doEvaluateGate). So a template that
+    // ADDS a script to a previously-scriptless, cached-open, non-cyclic gate
+    // would not force re-evaluation here, and the live-ignored-no-stored
+    // diagnostic would be bypassed on that cached path. Unreachable today — no
+    // built-in template ships a script gate — and the reachable
+    // live-removed-stored-script case (stored gate already carries a script) IS
+    // re-evaluated by the line above. When a template reintroduces a script
+    // gate, consult getBuiltInGateScript here so the cache invalidates.
     // Known limitation (deferred, #835 follow-up): forcing re-evaluation here
     // bypasses the cache READ, but a prior cacheGateOpened() entry is NOT cleared
     // when the re-evaluation returns closed. allWorkflowGatesOpen() (the
@@ -1556,8 +1568,10 @@ export class ChannelRouter {
       workflow
     );
     // Persistent mismatches (e.g. live-ignored-no-stored) would otherwise warn on
-    // every gate evaluation/retry; dedupe to once per run+gate+status.
+    // every gate evaluation/retry; dedupe to once per run+gate+status. Only
+    // emitting statuses touch the ledger so quiet statuses don't consume capacity.
     if (
+      isGateScriptStatusEmitting(gateScriptStatus) &&
       sharedGateScriptDiagnosticLedger.shouldEmit(
         gateScriptDiagnosticKey(runId, gateId, gateScriptStatus)
       )

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -58,8 +58,10 @@ import { evaluateGate, type GateEvalResult, type GateScriptExecutorFn } from './
 import type { GateScriptContext } from './gate-script-executor';
 import { executeGateScript } from './gate-script-executor';
 import {
+  gateScriptDiagnosticKey,
   logTemplateGateScriptReload,
   resolveTemplateGateScript,
+  sharedGateScriptDiagnosticLedger,
 } from '../workflows/built-in-workflows';
 import { getEffectiveGate } from './gate-features';
 import { RATE_LIMIT_MIN_BACKOFF_MS } from './rate-limit-detector';
@@ -1553,13 +1555,21 @@ export class ChannelRouter {
       storedGateDef,
       workflow
     );
-    logTemplateGateScriptReload({
-      log,
-      status: gateScriptStatus,
-      templateName: workflow.templateName,
-      gateId,
-      runId,
-    });
+    // Persistent mismatches (e.g. live-ignored-no-stored) would otherwise warn on
+    // every gate evaluation/retry; dedupe to once per run+gate+status.
+    if (
+      sharedGateScriptDiagnosticLedger.shouldEmit(
+        gateScriptDiagnosticKey(runId, gateId, gateScriptStatus)
+      )
+    ) {
+      logTemplateGateScriptReload({
+        log,
+        status: gateScriptStatus,
+        templateName: workflow.templateName,
+        gateId,
+        runId,
+      });
+    }
     let gateDef = liveTemplateGate;
     gateDef = getEffectiveGate(gateDef, workflow, sourceNodeName);
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -80,7 +80,10 @@ import {
   type SpaceWorkflowManager,
 } from '../managers/space-workflow-manager';
 import { MAX_AGENT_SLOT_EVENT_INTERESTS } from '../export-format';
-import { getBuiltInGateScript } from '../workflows/built-in-workflows';
+import {
+  logTemplateGateScriptReload,
+  resolveTemplateGateScript,
+} from '../workflows/built-in-workflows';
 import { getEffectiveGate } from './gate-features';
 import { deliveryModeFromFailureReason } from './delivery-mode';
 import { CompletionDetector } from './completion-detector';
@@ -6185,11 +6188,18 @@ export class SpaceRuntime {
         reason: `Gate "${channel.gateId}" not found — channel "${channel.id}" is closed (misconfiguration)`,
       };
     }
-    let gate = storedGate;
-    if (workflow.templateName) {
-      const liveScript = getBuiltInGateScript(workflow.templateName, storedGate.id);
-      if (liveScript && storedGate.script) gate = { ...storedGate, script: liveScript };
-    }
+    const { gate: liveTemplateGate, status: gateScriptStatus } = resolveTemplateGateScript(
+      storedGate,
+      workflow
+    );
+    logTemplateGateScriptReload({
+      log,
+      status: gateScriptStatus,
+      templateName: workflow.templateName,
+      gateId: storedGate.id,
+      runId,
+    });
+    let gate = liveTemplateGate;
     gate = getEffectiveGate(gate, workflow, sourceName ?? channel.from);
     const gateDataRepo = new GateDataRepository(this.config.db);
     const gateDataRecord = gateDataRepo.get(runId, gate.id);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -81,8 +81,10 @@ import {
 } from '../managers/space-workflow-manager';
 import { MAX_AGENT_SLOT_EVENT_INTERESTS } from '../export-format';
 import {
+  gateScriptDiagnosticKey,
   logTemplateGateScriptReload,
   resolveTemplateGateScript,
+  sharedGateScriptDiagnosticLedger,
 } from '../workflows/built-in-workflows';
 import { getEffectiveGate } from './gate-features';
 import { deliveryModeFromFailureReason } from './delivery-mode';
@@ -6192,13 +6194,19 @@ export class SpaceRuntime {
       storedGate,
       workflow
     );
-    logTemplateGateScriptReload({
-      log,
-      status: gateScriptStatus,
-      templateName: workflow.templateName,
-      gateId: storedGate.id,
-      runId,
-    });
+    if (
+      sharedGateScriptDiagnosticLedger.shouldEmit(
+        gateScriptDiagnosticKey(runId, storedGate.id, gateScriptStatus)
+      )
+    ) {
+      logTemplateGateScriptReload({
+        log,
+        status: gateScriptStatus,
+        templateName: workflow.templateName,
+        gateId: storedGate.id,
+        runId,
+      });
+    }
     let gate = liveTemplateGate;
     gate = getEffectiveGate(gate, workflow, sourceName ?? channel.from);
     const gateDataRepo = new GateDataRepository(this.config.db);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -82,6 +82,7 @@ import {
 import { MAX_AGENT_SLOT_EVENT_INTERESTS } from '../export-format';
 import {
   gateScriptDiagnosticKey,
+  isGateScriptStatusEmitting,
   logTemplateGateScriptReload,
   resolveTemplateGateScript,
   sharedGateScriptDiagnosticLedger,
@@ -6195,6 +6196,7 @@ export class SpaceRuntime {
       workflow
     );
     if (
+      isGateScriptStatusEmitting(gateScriptStatus) &&
       sharedGateScriptDiagnosticLedger.shouldEmit(
         gateScriptDiagnosticKey(runId, storedGate.id, gateScriptStatus)
       )

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1399,18 +1399,28 @@ export function getBuiltInGateScript(templateName: string, gateId: string): Gate
 export type TemplateGateScriptStatus =
   /** The workflow was not seeded from a built-in template — no reload. */
   | 'no-template'
-  /** The template defines no script for this gate — nothing to reload. */
+  /**
+   * Neither the template nor the stored gate has a script for this gate — a
+   * deliberately scriptless (field/validator-only) gate. Nothing to reload.
+   */
   | 'no-live-script'
   /**
    * The template carries a live script for this gate, but the stored gate has
-   * no script. The live script is NOT applied (a scriptless gate may be a
-   * deliberately field/validator-only gate), so the template update silently
+   * no script. The live script is NOT applied, so the template update silently
    * fails to take effect until the workflow is resynced. Surfaced as a warning.
    */
   | 'live-ignored-no-stored'
-  /** The stored script source matches the live template — no-op reload. */
+  /**
+   * The template no longer defines a script for this gate, but the stored gate
+   * still carries one (e.g. a gate retired to a built-in validator, like the
+   * old review-posted-gate bash script). The stored — now retired — script
+   * keeps executing because template restamping preserves existing scripts.
+   * Surfaced as a warning so operators resync and stop running the retired script.
+   */
+  | 'live-removed-stored-script'
+  /** The stored script matches the live template across all executable fields — no-op. */
   | 'in-sync'
-  /** The live template script source differs from the stored script — reloaded (drift). */
+  /** The live template script differs from the stored script — reloaded (drift). */
   | 'reloaded';
 
 export interface ResolvedTemplateGateScript {
@@ -1454,14 +1464,88 @@ export function applyTemplateGateScript(
   storedGate: Gate,
   liveScript: GateScript | undefined
 ): ResolvedTemplateGateScript {
-  if (!liveScript) return { gate: storedGate, status: 'no-live-script' };
+  if (!liveScript) {
+    // Distinguish a template that has REMOVED a script the stored gate still
+    // carries (retired script still executing) from a genuinely scriptless gate.
+    return {
+      gate: storedGate,
+      status: storedGate.script ? 'live-removed-stored-script' : 'no-live-script',
+    };
+  }
   if (!storedGate.script) return { gate: storedGate, status: 'live-ignored-no-stored' };
-  const drifted = liveScript.source !== storedGate.script.source;
+  // The effective gate substitutes the entire live script object, so a reload
+  // changes behavior whenever ANY executable field differs — not just `source`.
+  // Comparing interpreter/timeoutMs too surfaces operational changes (e.g. a
+  // timeout bump or interpreter switch) as reloads instead of mislabeling them
+  // in-sync.
+  const drifted = gateScriptsDiffer(liveScript, storedGate.script);
   return {
     gate: { ...storedGate, script: liveScript },
     status: drifted ? 'reloaded' : 'in-sync',
   };
 }
+
+/**
+ * Whether two gate scripts differ in any field that affects execution
+ * (`source`, `interpreter`, `timeoutMs`). Used to decide the reload diagnostic.
+ */
+function gateScriptsDiffer(a: GateScript, b: GateScript): boolean {
+  return a.source !== b.source || a.interpreter !== b.interpreter || a.timeoutMs !== b.timeoutMs;
+}
+
+/**
+ * Stable identity for a gate-script diagnostic, used to deduplicate emissions
+ * across repeated gate evaluations (a persistent mismatch otherwise warns on
+ * every retry/delivery attempt). Combines the run, gate, and status so a
+ * status transition (e.g. after a resync) re-emits.
+ */
+export function gateScriptDiagnosticKey(
+  runId: string | undefined,
+  gateId: string,
+  status: TemplateGateScriptStatus
+): string {
+  return `${runId ?? ''}|${gateId}|${status}`;
+}
+
+/**
+ * Bounded dedup ledger for gate-script reload diagnostics. Gate evaluation runs
+ * on every channel delivery and retries while blocked, so a persistent
+ * mismatch (e.g. `live-ignored-no-stored`) would otherwise flood the logs. Each
+ * (run, gate, status) diagnostic is emitted at most once; the ledger is capped
+ * so a very long-lived process cannot grow it without bound — once the cap is
+ * reached it stops recording and emits every call, degrading to the pre-dedup
+ * behavior rather than consuming memory.
+ */
+export class GateScriptDiagnosticLedger {
+  private readonly seen = new Set<string>();
+  private readonly cap: number;
+
+  constructor(capacity = 8192) {
+    this.cap = capacity;
+  }
+
+  /** Returns true the first time this key is seen (and records it). */
+  shouldEmit(key: string): boolean {
+    if (this.seen.has(key)) return false;
+    if (this.seen.size >= this.cap) return true;
+    this.seen.add(key);
+    return true;
+  }
+
+  /** Clear recorded keys. Intended for tests that need a deterministic ledger. */
+  reset(): void {
+    this.seen.clear();
+  }
+}
+
+/**
+ * Process-wide shared ledger for gate-script reload diagnostics. Gate
+ * evaluation runs across multiple transient {@link ChannelRouter} instances
+ * (one per delivery in some paths) as well as long-lived ones, so the dedup
+ * state must outlive any single router. Keys include the run id (globally
+ * unique), so there is no cross-run collision; the ledger cap bounds memory.
+ */
+export const sharedGateScriptDiagnosticLedger = new GateScriptDiagnosticLedger();
 
 /**
  * Minimal logger surface {@link logTemplateGateScriptReload} needs. Accepts the
@@ -1473,10 +1557,13 @@ export interface TemplateGateScriptReloadLogger {
 }
 
 /**
- * Emit reload diagnostics for a resolved template gate script. Warns on the
- * silent-ignore footgun (live script present, stored gate scriptless) and logs
- * drift at debug level; stays quiet for the common in-sync / no-template /
- * no-live-script paths to avoid hot-path noise during every gate evaluation.
+ * Emit reload diagnostics for a resolved template gate script. Warns on the two
+ * silent footguns — a live script ignored because the stored gate is scriptless
+ * (`live-ignored-no-stored`), and a live template that has removed a script the
+ * stored gate still runs (`live-removed-stored-script`) — and logs drift at
+ * debug level (`reloaded`). Stays quiet for the common no-template /
+ * no-live-script / in-sync paths. Callers should deduplicate via a
+ * {@link GateScriptDiagnosticLedger} so persistent mismatches do not flood.
  */
 export function logTemplateGateScriptReload(args: {
   log: TemplateGateScriptReloadLogger;
@@ -1496,10 +1583,18 @@ export function logTemplateGateScriptReload(args: {
     );
     return;
   }
+  if (status === 'live-removed-stored-script') {
+    log.warn(
+      `Gate "${gateId}"${where}: built-in template "${tmpl}" no longer defines a gate script, but ` +
+        'the stored gate still carries one — the retired stored script is still executing. Resync ' +
+        'the workflow from the template to stop running it.'
+    );
+    return;
+  }
   if (status === 'reloaded') {
     log.debug(
       `Gate "${gateId}"${where}: reloaded gate script from live template "${tmpl}" ` +
-        '(stored script source differed from the template).'
+        '(stored script differed from the template).'
     );
   }
 }

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1400,8 +1400,8 @@ export type TemplateGateScriptStatus =
   /** The workflow was not seeded from a built-in template — no reload. */
   | 'no-template'
   /**
-   * Neither the template nor the stored gate has a script for this gate — a
-   * deliberately scriptless (field/validator-only) gate. Nothing to reload.
+   * The template defines no live script for this gate (or the gate is not
+   * reached via a template). Nothing to reload; the stored gate is used as-is.
    */
   | 'no-live-script'
   /**
@@ -1410,14 +1410,6 @@ export type TemplateGateScriptStatus =
    * fails to take effect until the workflow is resynced. Surfaced as a warning.
    */
   | 'live-ignored-no-stored'
-  /**
-   * The template no longer defines a script for this gate, but the stored gate
-   * still carries one (e.g. a gate retired to a built-in validator, like the
-   * old review-posted-gate bash script). The stored — now retired — script
-   * keeps executing because template restamping preserves existing scripts.
-   * Surfaced as a warning so operators resync and stop running the retired script.
-   */
-  | 'live-removed-stored-script'
   /** The stored script matches the live template across all executable fields — no-op. */
   | 'in-sync'
   /** The live template script differs from the stored script — reloaded (drift). */
@@ -1457,21 +1449,13 @@ export function resolveTemplateGateScript(
 /**
  * Pure decision core of {@link resolveTemplateGateScript}: combine a stored
  * gate with an optional live template script. Extracted so the live-script
- * branches (`no-live-script`, `live-ignored-no-stored`, `in-sync`, `reloaded`)
- * are unit-testable without mutating the built-in template registry.
+ * branches are unit-testable without mutating the built-in template registry.
  */
 export function applyTemplateGateScript(
   storedGate: Gate,
   liveScript: GateScript | undefined
 ): ResolvedTemplateGateScript {
-  if (!liveScript) {
-    // Distinguish a template that has REMOVED a script the stored gate still
-    // carries (retired script still executing) from a genuinely scriptless gate.
-    return {
-      gate: storedGate,
-      status: storedGate.script ? 'live-removed-stored-script' : 'no-live-script',
-    };
-  }
+  if (!liveScript) return { gate: storedGate, status: 'no-live-script' };
   if (!storedGate.script) return { gate: storedGate, status: 'live-ignored-no-stored' };
   // The effective gate substitutes the entire live script object, so a reload
   // changes behavior whenever ANY executable field differs — not just `source`.
@@ -1548,6 +1532,23 @@ export class GateScriptDiagnosticLedger {
 export const sharedGateScriptDiagnosticLedger = new GateScriptDiagnosticLedger();
 
 /**
+ * The statuses for which {@link logTemplateGateScriptReload} actually emits a
+ * log line. Single source of truth so call sites can avoid consuming dedup
+ * ledger capacity for the quiet statuses (`no-template` / `no-live-script` /
+ * `in-sync`) that never log — otherwise ordinary traffic would fill the ledger
+ * and a later mismatch would flood again.
+ */
+const GATE_SCRIPT_EMITTING_STATUSES: ReadonlySet<TemplateGateScriptStatus> = new Set([
+  'live-ignored-no-stored',
+  'reloaded',
+]);
+
+/** Whether a status produces a log line in {@link logTemplateGateScriptReload}. */
+export function isGateScriptStatusEmitting(status: TemplateGateScriptStatus): boolean {
+  return GATE_SCRIPT_EMITTING_STATUSES.has(status);
+}
+
+/**
  * Minimal logger surface {@link logTemplateGateScriptReload} needs. Accepts the
  * daemon {@link Logger} or any compatible test double.
  */
@@ -1557,13 +1558,15 @@ export interface TemplateGateScriptReloadLogger {
 }
 
 /**
- * Emit reload diagnostics for a resolved template gate script. Warns on the two
- * silent footguns — a live script ignored because the stored gate is scriptless
- * (`live-ignored-no-stored`), and a live template that has removed a script the
- * stored gate still runs (`live-removed-stored-script`) — and logs drift at
- * debug level (`reloaded`). Stays quiet for the common no-template /
- * no-live-script / in-sync paths. Callers should deduplicate via a
- * {@link GateScriptDiagnosticLedger} so persistent mismatches do not flood.
+ * Emit reload diagnostics for a resolved template gate script:
+ * - `live-ignored-no-stored` (WARN): the template defines a script but the
+ *   stored gate has none — an unambiguous footgun, since the template update
+ *   cannot take effect without a resync.
+ * - `reloaded` (DEBUG): the live template script differs from the stored one.
+ *
+ * Stays quiet for `no-template` / `no-live-script` / `in-sync`. Callers should
+ * gate the dedup ledger on {@link isGateScriptStatusEmitting} so persistent
+ * mismatches do not flood and quiet statuses do not consume ledger capacity.
  */
 export function logTemplateGateScriptReload(args: {
   log: TemplateGateScriptReloadLogger;
@@ -1573,6 +1576,7 @@ export function logTemplateGateScriptReload(args: {
   runId?: string;
 }): void {
   const { log, status, templateName, gateId, runId } = args;
+  if (!isGateScriptStatusEmitting(status)) return;
   const where = runId ? ` in run ${runId}` : '';
   const tmpl = templateName ?? '?';
   if (status === 'live-ignored-no-stored') {
@@ -1583,20 +1587,10 @@ export function logTemplateGateScriptReload(args: {
     );
     return;
   }
-  if (status === 'live-removed-stored-script') {
-    log.warn(
-      `Gate "${gateId}"${where}: built-in template "${tmpl}" no longer defines a gate script, but ` +
-        'the stored gate still carries one — the retired stored script is still executing. Resync ' +
-        'the workflow from the template to stop running it.'
-    );
-    return;
-  }
-  if (status === 'reloaded') {
-    log.debug(
-      `Gate "${gateId}"${where}: reloaded gate script from live template "${tmpl}" ` +
-        '(stored script differed from the template).'
-    );
-  }
+  log.debug(
+    `Gate "${gateId}"${where}: reloaded gate script from live template "${tmpl}" ` +
+      '(stored script differed from the template).'
+  );
 }
 
 /**

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1392,6 +1392,119 @@ export function getBuiltInGateScript(templateName: string, gateId: string): Gate
 }
 
 /**
+ * Outcome of resolving a stored gate's script against its built-in template's
+ * live definition. Reported by {@link resolveTemplateGateScript} and consumed
+ * by the reload diagnostics at the gate-evaluation call sites.
+ */
+export type TemplateGateScriptStatus =
+  /** The workflow was not seeded from a built-in template — no reload. */
+  | 'no-template'
+  /** The template defines no script for this gate — nothing to reload. */
+  | 'no-live-script'
+  /**
+   * The template carries a live script for this gate, but the stored gate has
+   * no script. The live script is NOT applied (a scriptless gate may be a
+   * deliberately field/validator-only gate), so the template update silently
+   * fails to take effect until the workflow is resynced. Surfaced as a warning.
+   */
+  | 'live-ignored-no-stored'
+  /** The stored script source matches the live template — no-op reload. */
+  | 'in-sync'
+  /** The live template script source differs from the stored script — reloaded (drift). */
+  | 'reloaded';
+
+export interface ResolvedTemplateGateScript {
+  gate: Gate;
+  status: TemplateGateScriptStatus;
+}
+
+/**
+ * Resolve the effective gate definition for evaluation, swapping in the live
+ * built-in template's gate script whenever both the template and the stored
+ * gate carry a script. This is the single source of truth for the "always use
+ * the current template's gate script" reload behavior that was previously
+ * inlined (and duplicated) at the two gate-evaluation sites
+ * (channel-router `doEvaluateGate` and space-runtime restart-recovery).
+ *
+ * Effective-gate behavior is identical to the former inline logic: when both
+ * scripts exist, the live template script is applied. The returned status is
+ * purely diagnostic, distinguishing a real source change (`reloaded`) from a
+ * no-op reload (`in-sync`) and — importantly — flagging the silent footgun
+ * where a live script exists but the stored gate is scriptless
+ * (`live-ignored-no-stored`).
+ */
+export function resolveTemplateGateScript(
+  storedGate: Gate,
+  workflow: SpaceWorkflow
+): ResolvedTemplateGateScript {
+  if (!workflow.templateName) return { gate: storedGate, status: 'no-template' };
+  return applyTemplateGateScript(
+    storedGate,
+    getBuiltInGateScript(workflow.templateName, storedGate.id)
+  );
+}
+
+/**
+ * Pure decision core of {@link resolveTemplateGateScript}: combine a stored
+ * gate with an optional live template script. Extracted so the live-script
+ * branches (`no-live-script`, `live-ignored-no-stored`, `in-sync`, `reloaded`)
+ * are unit-testable without mutating the built-in template registry.
+ */
+export function applyTemplateGateScript(
+  storedGate: Gate,
+  liveScript: GateScript | undefined
+): ResolvedTemplateGateScript {
+  if (!liveScript) return { gate: storedGate, status: 'no-live-script' };
+  if (!storedGate.script) return { gate: storedGate, status: 'live-ignored-no-stored' };
+  const drifted = liveScript.source !== storedGate.script.source;
+  return {
+    gate: { ...storedGate, script: liveScript },
+    status: drifted ? 'reloaded' : 'in-sync',
+  };
+}
+
+/**
+ * Minimal logger surface {@link logTemplateGateScriptReload} needs. Accepts the
+ * daemon {@link Logger} or any compatible test double.
+ */
+export interface TemplateGateScriptReloadLogger {
+  warn(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+}
+
+/**
+ * Emit reload diagnostics for a resolved template gate script. Warns on the
+ * silent-ignore footgun (live script present, stored gate scriptless) and logs
+ * drift at debug level; stays quiet for the common in-sync / no-template /
+ * no-live-script paths to avoid hot-path noise during every gate evaluation.
+ */
+export function logTemplateGateScriptReload(args: {
+  log: TemplateGateScriptReloadLogger;
+  status: TemplateGateScriptStatus;
+  templateName?: string;
+  gateId: string;
+  runId?: string;
+}): void {
+  const { log, status, templateName, gateId, runId } = args;
+  const where = runId ? ` in run ${runId}` : '';
+  const tmpl = templateName ?? '?';
+  if (status === 'live-ignored-no-stored') {
+    log.warn(
+      `Gate "${gateId}"${where}: built-in template "${tmpl}" defines a gate script, but the stored ` +
+        'gate has no script — the template script update is NOT applied and will not take effect ' +
+        'until the workflow is resynced from the template.'
+    );
+    return;
+  }
+  if (status === 'reloaded') {
+    log.debug(
+      `Gate "${gateId}"${where}: reloaded gate script from live template "${tmpl}" ` +
+        '(stored script source differed from the template).'
+    );
+  }
+}
+
+/**
  * Returns all built-in workflow templates.
  *
  * The returned objects have empty `id` and `spaceId` fields and use role names

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -59,6 +59,8 @@ import {
   mergeChannelsFromTemplate,
   mergeNodeStructuralFieldsFromTemplate,
   applyTemplateGateScript,
+  GateScriptDiagnosticLedger,
+  gateScriptDiagnosticKey,
   getBuiltInGateScript,
   getBuiltInWorkflows,
   logTemplateGateScriptReload,
@@ -4781,19 +4783,36 @@ describe('resolveTemplateGateScript() + applyTemplateGateScript()', () => {
     expect(result.gate).toBe(gate);
   });
 
-  test('returns no-live-script when the template has no script for this gate', () => {
-    // CODING_WORKFLOW's review-posted-gate is a validator gate with no script,
-    // so the template carries no live script for it.
-    const gate = makeGate(LIVE_SCRIPT);
+  test('returns no-live-script for a genuinely scriptless gate under a template', () => {
+    // Stored gate has no script and the template carries none for it either.
+    const gate = makeGate(undefined);
     const result = resolveTemplateGateScript(gate, makeWorkflow(CODING_WORKFLOW.name));
     expect(result.status).toBe('no-live-script');
     expect(result.gate).toBe(gate);
   });
 
-  test('applyTemplateGateScript: no-live-script when no live script is supplied', () => {
+  test('returns live-removed-stored-script when the template dropped a script the stored gate still has', () => {
+    // Mirrors review-posted-gate: an older seeded gate still carries the retired
+    // bash script while the template no longer defines one for it.
     const gate = makeGate(LIVE_SCRIPT);
+    const result = resolveTemplateGateScript(gate, makeWorkflow(CODING_WORKFLOW.name));
+    expect(result.status).toBe('live-removed-stored-script');
+    // Effective gate keeps the stored (retired) script — behavior unchanged.
+    expect(result.gate).toBe(gate);
+    expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
+  });
+
+  test('applyTemplateGateScript: no-live-script for a scriptless stored gate with no live script', () => {
+    const gate = makeGate(undefined);
     const result = applyTemplateGateScript(gate, undefined);
     expect(result.status).toBe('no-live-script');
+    expect(result.gate).toBe(gate);
+  });
+
+  test('applyTemplateGateScript: live-removed-stored-script when stored has a script but no live script', () => {
+    const gate = makeGate(LIVE_SCRIPT);
+    const result = applyTemplateGateScript(gate, undefined);
+    expect(result.status).toBe('live-removed-stored-script');
     expect(result.gate).toBe(gate);
   });
 
@@ -4806,14 +4825,14 @@ describe('resolveTemplateGateScript() + applyTemplateGateScript()', () => {
     expect(result.gate.script).toBeUndefined();
   });
 
-  test('applyTemplateGateScript: in-sync when the stored source matches the live source', () => {
+  test('applyTemplateGateScript: in-sync when all executable fields match', () => {
     const stored = makeGate({ ...LIVE_SCRIPT });
     const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
     expect(result.status).toBe('in-sync');
     expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
   });
 
-  test('applyTemplateGateScript: reloaded when the stored source differs (drift)', () => {
+  test('applyTemplateGateScript: reloaded when only the source differs (drift)', () => {
     const stale: GateScript = { ...LIVE_SCRIPT, source: 'echo stale drifted' };
     const stored = makeGate(stale);
     const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
@@ -4821,6 +4840,20 @@ describe('resolveTemplateGateScript() + applyTemplateGateScript()', () => {
     // Effective gate uses the live template script, not the stale stored one.
     expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
     expect(result.gate.script).not.toBe(stored.script);
+  });
+
+  test('applyTemplateGateScript: reloaded when only the interpreter differs', () => {
+    const stored = makeGate({ ...LIVE_SCRIPT, interpreter: 'node' });
+    const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
+    expect(result.status).toBe('reloaded');
+    expect(result.gate.script?.interpreter).toBe(LIVE_SCRIPT.interpreter);
+  });
+
+  test('applyTemplateGateScript: reloaded when only the timeout differs', () => {
+    const stored = makeGate({ ...LIVE_SCRIPT, timeoutMs: 99999 });
+    const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
+    expect(result.status).toBe('reloaded');
+    expect(result.gate.script?.timeoutMs).toBe(LIVE_SCRIPT.timeoutMs);
   });
 });
 
@@ -4851,6 +4884,22 @@ describe('logTemplateGateScriptReload()', () => {
     expect(calls[0].message).toContain('Coding');
     expect(calls[0].message).toContain('run-42');
     expect(calls[0].message).toContain('NOT applied');
+  });
+
+  test('warns on live-removed-stored-script (template dropped a script the stored gate still runs)', () => {
+    const { log, calls } = makeLogger();
+    logTemplateGateScriptReload({
+      log,
+      status: 'live-removed-stored-script',
+      templateName: 'Coding',
+      gateId: 'review-posted-gate',
+      runId: 'run-7',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('warn');
+    expect(calls[0].message).toContain('review-posted-gate');
+    expect(calls[0].message).toContain('no longer defines a gate script');
+    expect(calls[0].message).toContain('still executing');
   });
 
   test('logs drift at debug level for reloaded', () => {
@@ -4885,6 +4934,43 @@ describe('logTemplateGateScriptReload()', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].message).toContain('g1');
     expect(calls[0].message).toContain('?');
+  });
+});
+
+describe('gateScriptDiagnosticKey() + GateScriptDiagnosticLedger', () => {
+  test('gateScriptDiagnosticKey combines runId, gateId, and status (empty runId when absent)', () => {
+    expect(gateScriptDiagnosticKey('run-1', 'g', 'reloaded')).toBe('run-1|g|reloaded');
+    expect(gateScriptDiagnosticKey(undefined, 'g', 'in-sync')).toBe('|g|in-sync');
+  });
+
+  test('ledger emits once per key and again for a different key or status', () => {
+    const ledger = new GateScriptDiagnosticLedger();
+    const key = gateScriptDiagnosticKey('run-1', 'g', 'live-ignored-no-stored');
+    expect(ledger.shouldEmit(key)).toBe(true);
+    expect(ledger.shouldEmit(key)).toBe(false); // deduped
+    // Same run+gate, different status (e.g. after a resync) re-emits.
+    expect(ledger.shouldEmit(gateScriptDiagnosticKey('run-1', 'g', 'in-sync'))).toBe(true);
+    // Different run re-emits.
+    expect(ledger.shouldEmit(gateScriptDiagnosticKey('run-2', 'g', 'live-ignored-no-stored'))).toBe(
+      true
+    );
+  });
+
+  test('ledger stops growing past its capacity (emits without recording once full)', () => {
+    const ledger = new GateScriptDiagnosticLedger(2);
+    expect(ledger.shouldEmit('a')).toBe(true);
+    expect(ledger.shouldEmit('b')).toBe(true);
+    // At capacity: emits but does not record, so memory is bounded.
+    expect(ledger.shouldEmit('c')).toBe(true);
+    expect(ledger.shouldEmit('c')).toBe(true); // not recorded, so still true
+  });
+
+  test('ledger.reset() clears recorded keys', () => {
+    const ledger = new GateScriptDiagnosticLedger();
+    const key = gateScriptDiagnosticKey('run-x', 'g', 'reloaded');
+    expect(ledger.shouldEmit(key)).toBe(true);
+    ledger.reset();
+    expect(ledger.shouldEmit(key)).toBe(true);
   });
 });
 

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -63,6 +63,7 @@ import {
   gateScriptDiagnosticKey,
   getBuiltInGateScript,
   getBuiltInWorkflows,
+  isGateScriptStatusEmitting,
   logTemplateGateScriptReload,
   mergeGateStructuralFieldsFromTemplate,
   resolveTemplateGateScript,
@@ -4791,29 +4792,24 @@ describe('resolveTemplateGateScript() + applyTemplateGateScript()', () => {
     expect(result.gate).toBe(gate);
   });
 
-  test('returns live-removed-stored-script when the template dropped a script the stored gate still has', () => {
-    // Mirrors review-posted-gate: an older seeded gate still carries the retired
-    // bash script while the template no longer defines one for it.
+  test('returns no-live-script when the template has no live script (stored gate may still carry one)', () => {
+    // No live script is resolvable for this gate. A stored gate that still
+    // carries a script (e.g. a retired template script, or an operator-added
+    // custom script) is NOT flagged here: that case is ambiguous and cannot be
+    // distinguished from a legitimate customization at runtime, so it stays the
+    // quiet no-live-script rather than risking a false "resync" warning.
     const gate = makeGate(LIVE_SCRIPT);
     const result = resolveTemplateGateScript(gate, makeWorkflow(CODING_WORKFLOW.name));
-    expect(result.status).toBe('live-removed-stored-script');
-    // Effective gate keeps the stored (retired) script — behavior unchanged.
-    expect(result.gate).toBe(gate);
-    expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
-  });
-
-  test('applyTemplateGateScript: no-live-script for a scriptless stored gate with no live script', () => {
-    const gate = makeGate(undefined);
-    const result = applyTemplateGateScript(gate, undefined);
     expect(result.status).toBe('no-live-script');
     expect(result.gate).toBe(gate);
   });
 
-  test('applyTemplateGateScript: live-removed-stored-script when stored has a script but no live script', () => {
-    const gate = makeGate(LIVE_SCRIPT);
-    const result = applyTemplateGateScript(gate, undefined);
-    expect(result.status).toBe('live-removed-stored-script');
-    expect(result.gate).toBe(gate);
+  test('applyTemplateGateScript: no-live-script for any stored gate when no live script is supplied', () => {
+    // Scriptless stored gate, no live script.
+    expect(applyTemplateGateScript(makeGate(undefined), undefined).status).toBe('no-live-script');
+    // Stored gate WITH a script but no live script — still no-live-script (see
+    // the resolveTemplateGateScript test above for why this is not flagged).
+    expect(applyTemplateGateScript(makeGate(LIVE_SCRIPT), undefined).status).toBe('no-live-script');
   });
 
   test('applyTemplateGateScript: live-ignored-no-stored footgun (live script present, stored scriptless)', () => {
@@ -4886,22 +4882,6 @@ describe('logTemplateGateScriptReload()', () => {
     expect(calls[0].message).toContain('NOT applied');
   });
 
-  test('warns on live-removed-stored-script (template dropped a script the stored gate still runs)', () => {
-    const { log, calls } = makeLogger();
-    logTemplateGateScriptReload({
-      log,
-      status: 'live-removed-stored-script',
-      templateName: 'Coding',
-      gateId: 'review-posted-gate',
-      runId: 'run-7',
-    });
-    expect(calls).toHaveLength(1);
-    expect(calls[0].level).toBe('warn');
-    expect(calls[0].message).toContain('review-posted-gate');
-    expect(calls[0].message).toContain('no longer defines a gate script');
-    expect(calls[0].message).toContain('still executing');
-  });
-
   test('logs drift at debug level for reloaded', () => {
     const { log, calls } = makeLogger();
     logTemplateGateScriptReload({
@@ -4938,6 +4918,17 @@ describe('logTemplateGateScriptReload()', () => {
 });
 
 describe('gateScriptDiagnosticKey() + GateScriptDiagnosticLedger', () => {
+  test('isGateScriptStatusEmitting is true only for statuses that log', () => {
+    // Only these consume ledger capacity at the call sites.
+    for (const status of ['live-ignored-no-stored', 'reloaded'] as const) {
+      expect(isGateScriptStatusEmitting(status)).toBe(true);
+    }
+    // Quiet statuses must not consume the ledger.
+    for (const status of ['no-template', 'no-live-script', 'in-sync'] as const) {
+      expect(isGateScriptStatusEmitting(status)).toBe(false);
+    }
+  });
+
   test('gateScriptDiagnosticKey combines runId, gateId, and status (empty runId when absent)', () => {
     expect(gateScriptDiagnosticKey('run-1', 'g', 'reloaded')).toBe('run-1|g|reloaded');
     expect(gateScriptDiagnosticKey(undefined, 'g', 'in-sync')).toBe('|g|in-sync');

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -20,7 +20,14 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { SpaceWorkerAgent, SpaceWorkflow, WorkflowHook, WorkflowNode } from '@hyperneo/shared';
+import type {
+  Gate,
+  GateScript,
+  SpaceWorkerAgent,
+  SpaceWorkflow,
+  WorkflowHook,
+  WorkflowNode,
+} from '@hyperneo/shared';
 import {
   exportWorkflow,
   validateExportedWorkflow,
@@ -51,9 +58,12 @@ import {
   LEGACY_CODING_TEMPLATE_IDENTITIES,
   mergeChannelsFromTemplate,
   mergeNodeStructuralFieldsFromTemplate,
+  applyTemplateGateScript,
   getBuiltInGateScript,
   getBuiltInWorkflows,
+  logTemplateGateScriptReload,
   mergeGateStructuralFieldsFromTemplate,
+  resolveTemplateGateScript,
   PLAN_AND_DECOMPOSE_WORKFLOW,
   validateWorkflowTemplateGateWriters,
   type WorkflowMigrationWarning,
@@ -4722,6 +4732,159 @@ describe('getBuiltInGateScript()', () => {
       ...getBuiltInWorkflows().flatMap((w) => w.gates ?? []),
     ].find((g) => g.id === 'review-posted-gate');
     expect(gate?.validator).toEqual({ kind: 'built_in', id: 'review_posted' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTemplateGateScript() + logTemplateGateScriptReload()
+// ---------------------------------------------------------------------------
+// The reload helper is the single source of truth for "always evaluate with the
+// current template gate script." These tests pin its effective-gate behavior
+// (identical to the former inline logic) and each diagnostic status, including
+// the silent footgun where a live script is ignored because the stored gate is
+// scriptless.
+
+describe('resolveTemplateGateScript() + applyTemplateGateScript()', () => {
+  const LIVE_SCRIPT: GateScript = { interpreter: 'bash', source: 'echo live', timeoutMs: 5000 };
+
+  function makeGate(script?: GateScript): Gate {
+    return {
+      id: 'test-gate',
+      fields: [{ name: 'pr_url', type: 'string', writers: ['*'], check: { op: 'exists' } }],
+      ...(script ? { script } : {}),
+      resetOnCycle: false,
+    };
+  }
+
+  function makeWorkflow(templateName?: string): SpaceWorkflow {
+    return {
+      id: 'wf',
+      spaceId: 'space',
+      name: 'Workflow',
+      handle: 'workflow',
+      description: '',
+      nodes: [],
+      startNodeId: '',
+      endNodeId: '',
+      tags: [],
+      channels: [],
+      createdAt: 0,
+      updatedAt: 0,
+      ...(templateName ? { templateName } : {}),
+    };
+  }
+
+  test('returns no-template and the stored gate when the workflow has no templateName', () => {
+    const gate = makeGate(LIVE_SCRIPT);
+    const result = resolveTemplateGateScript(gate, makeWorkflow(undefined));
+    expect(result.status).toBe('no-template');
+    expect(result.gate).toBe(gate);
+  });
+
+  test('returns no-live-script when the template has no script for this gate', () => {
+    // CODING_WORKFLOW's review-posted-gate is a validator gate with no script,
+    // so the template carries no live script for it.
+    const gate = makeGate(LIVE_SCRIPT);
+    const result = resolveTemplateGateScript(gate, makeWorkflow(CODING_WORKFLOW.name));
+    expect(result.status).toBe('no-live-script');
+    expect(result.gate).toBe(gate);
+  });
+
+  test('applyTemplateGateScript: no-live-script when no live script is supplied', () => {
+    const gate = makeGate(LIVE_SCRIPT);
+    const result = applyTemplateGateScript(gate, undefined);
+    expect(result.status).toBe('no-live-script');
+    expect(result.gate).toBe(gate);
+  });
+
+  test('applyTemplateGateScript: live-ignored-no-stored footgun (live script present, stored scriptless)', () => {
+    const scriptlessGate = makeGate(undefined);
+    const result = applyTemplateGateScript(scriptlessGate, LIVE_SCRIPT);
+    expect(result.status).toBe('live-ignored-no-stored');
+    // The live script is NOT applied — the stored gate stays scriptless.
+    expect(result.gate).toBe(scriptlessGate);
+    expect(result.gate.script).toBeUndefined();
+  });
+
+  test('applyTemplateGateScript: in-sync when the stored source matches the live source', () => {
+    const stored = makeGate({ ...LIVE_SCRIPT });
+    const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
+    expect(result.status).toBe('in-sync');
+    expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
+  });
+
+  test('applyTemplateGateScript: reloaded when the stored source differs (drift)', () => {
+    const stale: GateScript = { ...LIVE_SCRIPT, source: 'echo stale drifted' };
+    const stored = makeGate(stale);
+    const result = applyTemplateGateScript(stored, LIVE_SCRIPT);
+    expect(result.status).toBe('reloaded');
+    // Effective gate uses the live template script, not the stale stored one.
+    expect(result.gate.script?.source).toBe(LIVE_SCRIPT.source);
+    expect(result.gate.script).not.toBe(stored.script);
+  });
+});
+
+describe('logTemplateGateScriptReload()', () => {
+  function makeLogger() {
+    const calls: { level: 'warn' | 'debug'; message: string }[] = [];
+    return {
+      log: {
+        warn: (...args: unknown[]) => calls.push({ level: 'warn', message: args.join(' ') }),
+        debug: (...args: unknown[]) => calls.push({ level: 'debug', message: args.join(' ') }),
+      },
+      calls,
+    };
+  }
+
+  test('warns on the live-ignored-no-stored footgun and includes the gate id and template', () => {
+    const { log, calls } = makeLogger();
+    logTemplateGateScriptReload({
+      log,
+      status: 'live-ignored-no-stored',
+      templateName: 'Coding',
+      gateId: 'review-posted-gate',
+      runId: 'run-42',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('warn');
+    expect(calls[0].message).toContain('review-posted-gate');
+    expect(calls[0].message).toContain('Coding');
+    expect(calls[0].message).toContain('run-42');
+    expect(calls[0].message).toContain('NOT applied');
+  });
+
+  test('logs drift at debug level for reloaded', () => {
+    const { log, calls } = makeLogger();
+    logTemplateGateScriptReload({
+      log,
+      status: 'reloaded',
+      templateName: 'Coding',
+      gateId: 'g1',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('debug');
+    expect(calls[0].message).toContain('g1');
+    expect(calls[0].message).toContain('reloaded');
+  });
+
+  test('stays quiet for the common no-template / no-live-script / in-sync paths', () => {
+    for (const status of ['no-template', 'no-live-script', 'in-sync'] as const) {
+      const { log, calls } = makeLogger();
+      logTemplateGateScriptReload({ log, status, templateName: 'Coding', gateId: 'g1' });
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  test('tolerates a missing templateName and runId in the warning', () => {
+    const { log, calls } = makeLogger();
+    logTemplateGateScriptReload({
+      log,
+      status: 'live-ignored-no-stored',
+      gateId: 'g1',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toContain('g1');
+    expect(calls[0].message).toContain('?');
   });
 });
 


### PR DESCRIPTION
Implements Forge proposal `a17267ae`: add gate hook version reload diagnostics.

The "always evaluate with the current built-in template's gate script" reload behavior was duplicated inline at two gate-evaluation sites (channel-router `doEvaluateGate` and space-runtime restart-recovery), with no visibility when a template script update silently failed to apply. This extracts it into a single `resolveTemplateGateScript` helper (with a pure `applyTemplateGateScript` decision core) and emits diagnostics at both sites: a **warn** on the silent footgun where a live template script is ignored because the stored gate is scriptless, and a **debug** log when a drifted script is reloaded. Effective-gate behavior is identical to before — the new status is purely diagnostic.

Verified: typecheck, oxlint, and knip clean; the `0-shared-handlers-workflow`, `5-space-agent-other`, `5-space-runtime-a`, and `5-space-runtime-b` daemon shards all pass green with the 10 new unit tests.