### PR TITLE
docs(design): address Codex review on in-app browser design

### DIFF
--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -2,7 +2,8 @@
 
 > **Status:** Exploratory design. Not implemented. This document captures a
 > design discussion and a recommended approach; it does not describe shipped
-> behaviour.
+> behaviour. Revised after automated review (Codex) to surface prerequisites
+> that the first draft understated — see [Open Questions](#open-questions).
 
 ## Goal
 
@@ -45,7 +46,7 @@ This distinction decides which option below is viable.
 | Option | Engine | Cross-platform | Robustness | New code |
 |--------|--------|----------------|------------|----------|
 | **1. Lite injection harness** | Tauri OS webview + `initialization_script`, no CDP | ✅ all OS webviews | Low–medium (hits injection ceiling) | Medium |
-| **2. Playwright + CDP screencast** ✅ SELECTED | Headless Chromium, frames streamed into the UI | ✅ (Chromium is uniform) | High | Medium (mostly wiring) |
+| **2. Playwright + CDP screencast** ✅ SELECTED | Headless Chromium, frames streamed into the UI | ✅ (Chromium is uniform) | High | Medium–high (see bridge prerequisite) |
 | **3. Full CDP on embedded browser** | CEF / `deno desktop` CEF backend | Partial | High | High + depends on unexposed CDP |
 
 ### Option 1 — Lite injection harness (no CDP)
@@ -102,11 +103,16 @@ defeats the small-binary rationale of Tauri's OS webview.
 ### Why Option 2
 
 Every hard problem — trusted input, screenshots, multi-context, cross-platform
-consistency, defensive sites — is already solved by the CDP layer Playwright
-provides. Option 2 adds a frame stream and an input forwarder on top of an
-engine HyperNeo already runs, reuses the existing playwright/chrome-devtools-mcp
-tooling, and produces a pane that works in the browser **and** Tauri because it
-is just a web component over the existing WebSocket transport.
+consistency, defensive sites — is solved by the CDP layer Playwright provides.
+Option 2 adds a frame stream and an input forwarder on top of that engine, and
+produces a pane that works in the browser **and** Tauri because it is just a web
+component over the existing WebSocket transport.
+
+> **Caveat the first draft missed:** the pane must show the *same* browser the
+> agent is driving. HyperNeo's existing browser skills each own isolated
+> browsers and do not expose their `Page`/CDP to the daemon, so "reuse" is not
+> automatic — it requires a [shared-browser bridge](#shared-browser-bridge),
+> which is the central prerequisite of this design.
 
 ## Selected Approach: CDP Screencast
 
@@ -128,23 +134,24 @@ free.
 ```
 ┌──────────────────────── HyperNeo app window (Tauri shell, unchanged) ─────────────────────┐
 │  Preact UI (OS webview)                                                                     │
-│   └─ <BrowserPane>  ── draws JPEG frames to <canvas>                                        │
-│        ▲ user mouse/key          │ frames                                                    │
-│        │                          ▼                                                           │
+│   └─ <BrowserPane sessionId=…>  ── draws JPEG frames to <canvas>                            │
+│        ▲ user mouse/key            │ frames (per-session channel)                            │
+│        │                            ▼                                                        │
 │        │       MessageHub WebSocket (existing transport)                                      │
-│        │                          ▲                                                           │
-│        │          ┌───────────────┴────────────────┐                                          │
-│        │          │  daemon: BrowserEngineService   │                                          │
-│        │          │   • holds Playwright + CDP sesn │                                          │
-│        │          │   • screencast loop             │                                          │
-│        │          │   • input router                │                                          │
-│        │          │   • agent action primitives     │                                          │
-│        │          └───────────────┬────────────────┘                                          │
-│        │                          │ CDP                                                        │
-│        │                          ▼                                                            │
-│        │          ┌─────────────────────────────────┐                                         │
-│        └─────────▶│  headless Chromium (Playwright) │  ← real rendering, trusted input         │
-│                   └─────────────────────────────────┘                                         │
+│        │                            ▲                                                        │
+│        │          ┌──────────────────┴───────────────┐                                       │
+│        │          │  daemon: BrowserEngineService      │                                       │
+│        │          │   • owns the ONE shared Chromium   │                                       │
+│        │          │   • per-page CDP session + screencast │                                   │
+│        │          │   • backpressure-gated frame loop  │                                       │
+│        │          │   • input router (per active page) │                                       │
+│        │          │   • agent action primitives (MCP)  │                                       │
+│        │          └──────────────────┬───────────────┘                                       │
+│        │                           │ CDP                                                       │
+│        │                           ▼                                                           │
+│        │          ┌──────────────────────────────────┐                                        │
+│        └─────────▶│  shared headless Chromium         │ ← the agent's tools ALSO drive this    │
+│                   └──────────────────────────────────┘   (via the bridge, not a second one)   │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -153,14 +160,47 @@ There are **two distinct webviews** to keep separate in the mental model: the
 (headless Chromium, shown as pixels on a canvas). One renders an image of the
 other; they are not the same thing.
 
+### Shared browser bridge
+
+The single most important prerequisite, which the first draft understated:
+**the pane must depict the browser the agent is actually driving — not a second,
+unrelated browser.** Today each browser tool owns an isolated browser it does
+not expose:
+
+- `playwright` launches `playwright-cli` via `npx` in its own process.
+- `playwright-interactive` creates browser handles inside a `js_repl` session.
+- `chrome-devtools-mcp` owns an isolated MCP-managed browser.
+
+A `BrowserEngineService` that independently launched Chromium would render a
+page the agent never touches; pane input would target the wrong page; the human
+would "take over" a browser the agent isn't using. Two viable bridges resolve
+this — pick one (see [Open Questions](#open-questions)):
+
+1. **Service-owned single browser (replace).** `BrowserEngineService` owns the
+   one Chromium. The agent's browser actions are reimplemented as MCP tools
+   backed by the service (navigate/click/type/screenshot/AX-tree), replacing the
+   three existing skills for sessions that want an in-app pane. The service
+   exposes the `Page`/CDP to both the agent tools and the screencast loop, so
+   there is exactly one browser. Cleanest model; most new code.
+2. **Tool-owned, service attaches (bridge).** One existing tool (most naturally
+   `chrome-devtools-mcp`, which is already CDP-native) exposes its CDP
+   debugging endpoint. `BrowserEngineService` connects to that endpoint over CDP
+   (`browserType.connectOverCDP`) and runs the screencast/input loop against the
+   tool's pages. Least new code; couples the service to the tool's lifecycle and
+   requires the tool to publish its CDP endpoint.
+
+Either way, the invariant is: **one Chromium per browser session, shared by the
+agent's actions and the pane.** The component map below assumes the
+service-owned model unless noted.
+
 ### Component map (proposed; not yet implemented)
 
 | Piece | Proposed location | Notes |
 |---|---|---|
-| Headless Chromium + Playwright | daemon process | Reuses the playwright skill's Chromium; run headless |
-| CDP broker (screencast + input + agent actions) | `packages/daemon/src/lib/browser/` (`BrowserEngineService`) | Holds `newCDPSession(page)`, runs the frame loop, forwards input |
-| Transport | MessageHub WS — new channels `browser.frame` (pub), `browser.input` / `browser.action` (RPC) | Mirrors how `messages.bySession` already streams |
-| Renderer | Preact `<BrowserPane>` in `packages/web` | `<canvas>` + input capture |
+| Shared headless Chromium + Playwright | daemon process (`BrowserEngineService`) | One browser per session, driven by both agent tools and the pane (see bridge above) |
+| CDP broker (screencast + input + agent actions) | `packages/daemon/src/lib/browser/` | Holds `newCDPSession(page)` **per page**, runs the backpressure-gated frame loop, routes input to the active page |
+| Transport | MessageHub WS — **per-session channels** `browser.frame:<sessionId>` (pub), `browser.input:<sessionId>` / `browser.action:<sessionId>` (RPC) | Pane must join the specific session channel; frames are never broadcast across sessions (prevents leaking another session's authenticated pixels) |
+| Renderer | Preact `<BrowserPane sessionId>` in `packages/web` | Joins the session channel, renders to `<canvas>`, captures + forwards user input |
 | Tauri shell | `packages/desktop` — **unchanged** | No Rust changes; the pane is just another web component |
 
 The crucial line: **the Tauri Rust shell changes nothing.** No new Rust, no
@@ -168,11 +208,12 @@ webview reparenting, no platform-specific glue.
 
 ### Data flow: watch the agent browse
 
-The agent calls an MCP tool (navigate/click/type) → daemon → Playwright acts.
-Simultaneously a screencast is always running:
+The agent calls an MCP tool (navigate/click/type) → daemon → Playwright acts on
+the shared browser. Simultaneously a screencast is running for the **active
+page**:
 
 ```ts
-// one-time, on browser-session start (raw CDP via Playwright)
+// per page, on activation (raw CDP via Playwright)
 const cdp = await page.context().newCDPSession(page);
 await cdp.send('Page.startScreencast', {
   format: 'jpeg',
@@ -181,33 +222,91 @@ await cdp.send('Page.startScreencast', {
   maxHeight: 800,
 });
 
+let clientInFlight = false;          // backpressure: at most one frame un-acked by the client
+let newestPending: Frame | null = null;
+
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
-  hub.publish('browser.frame', { jpeg: data, metadata }); // → <BrowserPane> canvas
-  cdp.send('Page.screencastFrameAck', { sessionId });      // must ack to get next frame
+  newestPending = { jpeg: data, metadata };          // drop stale intermediates; keep newest only
+  if (!clientInFlight) dispatchToClient(sessionId);  // send only when the client is ready
 });
+
+function dispatchToClient(cdpSessionId: string) {
+  if (!newestPending) return;
+  clientInFlight = true;
+  const frame = newestPending;
+  newestPending = null;
+  hub.publish(`browser.frame:${sessionId}`, frame, { onConsumed: () => {
+    clientInFlight = false;
+    cdp.send('Page.screencastFrameAck', { sessionId: cdpSessionId }); // ack CDP AFTER the client consumed
+    if (newestPending) dispatchToClient(cdpSessionId);                // drain the newest pending
+  }});
+}
 ```
 
 Frames flow daemon → WS → canvas at roughly 10–30 fps depending on quality/size.
 Stop with `Page.stopScreencast`.
 
+#### Backpressure (required)
+
+`Page.screencastFrameAck` is CDP's **only** flow-control point — acknowledging
+every frame immediately makes Chromium produce JPEGs as fast as it can, piling
+them onto the same WebSocket that carries chat and input RPCs. The loop above
+keeps **at most one frame in flight to the client** (dropping stale
+intermediates) and **acks CDP only after the client reports consumption**, not
+on enqueue. Without this, a slow client/network causes stale video, delayed
+takeover input, and unbounded memory growth.
+
 ### Data flow: human drives (or takes over)
 
-The user clicks the pane at canvas pixel `(cx, cy)`; the component converts to
-CSS page coords and forwards through **Playwright's high-level API**, which
-handles devicePixelRatio and produces trusted events:
+The user clicks the pane at canvas pixel `(cx, cy)`. Coordinates are mapped from
+the **decoded frame dimensions and `screencastFrame` metadata** (not a naive
+viewport ratio — that breaks under letterboxing, page zoom, or mobile
+emulation), then forwarded through **Playwright's input API** so events are
+trusted:
 
 ```ts
-// forward via Playwright — it does the coordinate + trusted-event math for you
-const cssX = cx * (pageViewportWidth  / canvasDisplayWidth);
-const cssY = cy * (pageViewportHeight / canvasDisplayHeight);
-await page.mouse.click(cssX, cssY);
-await page.keyboard.type(text);
+// metadata carries: pageScaleFactor, deviceWidth, deviceHeight, scrollOffsetX, scrollOffsetY
+// frame decoded to frameW×frameH; drawn at displayW×displayH inside the canvas with letterbox (offX, offY)
+const fx = cx - offX, fy = cy - offY;                                  // 1. remove letterbox
+const cssX = (fx / displayW) * metadata.deviceWidth  / metadata.pageScaleFactor + metadata.scrollOffsetX;
+const cssY = (fy / displayH) * metadata.deviceHeight / metadata.pageScaleFactor + metadata.scrollOffsetY;
+await page.mouse.click(cssX, cssY);                                    // trusted event
 ```
 
-Key simplification: **screencast needs raw CDP, but input does not.** Route
-human/agent input through `page.mouse` / `page.keyboard` and Playwright handles
-coordinates + trusted-event dispatch correctly. Only touch `Input.dispatch*`
-directly if bypassing Playwright.
+Playwright dispatches exactly the coordinates it receives — it does **not**
+correct the UI→frame transform — so the mapping must be derived from the frame
+metadata before calling it.
+
+#### Keyboard event protocol (required)
+
+`page.keyboard.type(text)` only inserts a text string; it cannot reproduce
+Tab, Enter, Escape, Backspace, arrow keys, modifier shortcuts, held modifiers,
+or IME composition — all common during login and form navigation. Human input
+must use a real keyboard event protocol, not completed text:
+
+| Client event | Playwright call |
+|---|---|
+| `keydown` / `keyup` with `key`, `code`, `modifiers` | `page.keyboard.down(key)` / `page.keyboard.up(key)` |
+| Named-key press (Enter, Tab, Escape, arrows, shortcuts) | `page.keyboard.press('Enter' \| 'Tab' \| …)` |
+| Text / IME composition | `page.keyboard.type(text)` or CDP `Input.insertText` for composition |
+
+The client sends `keydown`/`keyup`/`text` events with modifiers; the broker
+maps them to the Playwright calls above. Focus management (which element
+receives input) follows the active page's focused element.
+
+### Tab/page lifecycle (required)
+
+`newCDPSession(page)` is bound to **one** target; it does not follow tab
+switches, popups, or `target="_blank"` navigations. For multi-tab to work (which
+the design cites as a reason for choosing this approach), the broker must:
+
+- Open a CDP session **per page** (`Target.attachedToTarget` / Playwright's
+  page-collection events).
+- Start a screencast only for the **active** page; stop or suppress inactive
+  streams (otherwise every tab encodes frames).
+- On activation change, **atomically** switch both rendering (which frame stream
+  the pane subscribes to) and input routing (which `page` receives
+  mouse/keyboard) so video and takeover never target different tabs.
 
 ### Agent observation (what the model sees)
 
@@ -235,9 +334,11 @@ does not. These must be handled by design, not by accident:
    that persistence naively, **passwords can be captured to disk** — as
    typed-input logs, or as frame pixels (especially if anyone toggles "show
    password"). Sensitive-page frames and keystrokes must be **excluded from
-   recording by design**.
+   recording by design**. The per-session channel routing also matters here:
+   frames must never be broadcast across sessions, or one session's pane could
+   render another session's authenticated pixels.
 
-3. **The agent can read the authenticated session.** The same headless Chromium
+3. **The agent can read the authenticated session.** The same shared Chromium
    the human types into is *also* drivable by the agent over the same CDP
    session. The moment a human logs in, the agent (and any code with CDP access)
    can run
@@ -263,10 +364,25 @@ does not. These must be handled by design, not by accident:
 | Aspect | Notes |
 |---|---|
 | Latency | Screencast is watchable but not instant — a frame or two of round-trip. Fine for watching an agent; not a daily-driver browser. Tunable via quality/maxWidth. |
-| Ships Chromium | Playwright's Chromium is a lazy first-use download (same one the playwright skill already fetches). Base app stays on the OS webview; only browser-use sessions pull it. |
+| Ships Chromium | **Not free in release builds.** Playwright is currently only a CLI *dev* dependency, and the interactive skill requires manually installing both the package and the browser executable — so a compiled daemon sidecar has neither on a clean user machine. Landing this requires a real packaging strategy (see below), not lazy first-use download. |
 | Two webviews | App UI (OS webview) vs. depicted browser (Chromium as pixels). Keep them distinct. |
 | Input ownership | Decide arbitration: when the agent is mid-action and the user clicks, does it queue or interrupt? Make human input able to pause/override; don't leave it implicit. |
 | Sandboxing | The Chromium executes agent-influenced code on arbitrary sites. Sandbox it: separate context/profile, no shared credentials with the host app, ideally network/FS restrictions. |
+
+### Chromium packaging for release builds
+
+Because Playwright is a dev-only dependency today, a packaged desktop install
+will **not** obtain Chromium by lazy download on first launch. The
+implementation must define one of:
+
+- **Bundle** Playwright's Chromium into the desktop release artifact (adds ~150 MB
+  to the installer; offline-friendly; pinned version).
+- **First-run installer** that downloads Playwright + the browser binary on
+  first use, with progress UI, retry/checksum verification, and a defined
+  failure path (degraded mode that disables browser-use but keeps the app
+  usable).
+
+Either choice belongs in the implementation surface before this feature ships.
 
 ## Proposed Implementation Surface
 
@@ -274,27 +390,51 @@ All proposed, none present today:
 
 | File / area | Change |
 |---|---|
-| `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — launches headless Chromium, holds CDP session, runs screencast loop, forwards input, exposes agent action primitives |
-| MessageHub channels (new) | `browser.frame` (pub/sub frame stream), `browser.input` (human input), `browser.action` (agent tool calls) |
-| `packages/web` (new component) | Preact `<BrowserPane>` — subscribes to frame stream, renders to `<canvas>`, captures + forwards user input |
-| `packages/skills` (existing) | `playwright` / `playwright-interactive` / `chrome-devtools-mcp` — engine reused, surfaced through the new pane |
+| `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — owns the shared Chromium, holds per-page CDP sessions, runs the backpressure-gated screencast loop, routes input to the active page, exposes agent action primitives (MCP) |
+| Existing browser skills (`playwright`, `playwright-interactive`, `chrome-devtools-mcp`) | Either reimplemented on the service, or (bridge option) `chrome-devtools-mcp` exposes its CDP endpoint for the service to attach — see [Shared browser bridge](#shared-browser-bridge) |
+| MessageHub channels (new, per-session) | `browser.frame:<sessionId>` (pub/sub frame stream, backpressure-gated), `browser.input:<sessionId>` (human input), `browser.action:<sessionId>` (agent tool calls) |
+| `packages/web` (new component) | Preact `<BrowserPane sessionId>` — joins the session channel, renders to `<canvas>`, maps pointer coords from frame metadata, forwards the keyboard event protocol |
 | `packages/desktop` (existing) | **No changes** — pane is a web component |
+| Release packaging | Bundle or first-run-install Playwright + Chromium (see above) |
 
 ### Suggested spike (validation slice)
 
-Before wiring into the real UI, validate the latency and coordinate-math feel
-with a minimal slice that needs no Tauri:
+Before wiring into the real UI, validate the latency, coordinate-math, and
+backpressure feel with a minimal slice that needs no Tauri and assumes the
+service-owned bridge:
 
-1. A daemon service that launches headless Chromium and runs the screencast loop.
-2. A standalone HTML page (`<BrowserPane>` prototype, no Tauri) that renders the
-   frame stream and forwards clicks.
+1. A daemon service that launches one headless Chromium, owns a per-page CDP
+   session, and runs the backpressure-gated screencast loop.
+2. The agent's actions exposed as MCP tools against that same Chromium.
+3. A standalone HTML page (`<BrowserPane>` prototype, no Tauri) that joins the
+   session channel, renders the frame stream, maps clicks from frame metadata,
+   and forwards the keyboard event protocol.
 
-Enough to confirm the fps/coordinate feel, then wire into the real UI and the
-desktop shell.
+Enough to confirm the fps/coordinate/backpressure feel, then wire into the real
+UI and the desktop shell.
 
 ## Open Questions
 
+The review surfaced several prerequisites the first draft treated as solved.
+Resolved in this revision (specified, not yet implemented):
+
+- **Shared-browser bridge** — pane must depict the agent's browser; choose
+  service-owned (replace) vs. tool-owned (attach to `chrome-devtools-mcp`'s CDP).
+- **Per-session frame channels** — frames routed only to the joined session.
+- **Screencast backpressure** — at most one frame in flight; ack CDP after
+  client consumption.
+- **Tab/page lifecycle** — per-page CDP sessions; atomic switch of render +
+  input on activation change.
+- **Keyboard event protocol** — keydown/keyup/press/text/composition, not just
+  `type(text)`.
+- **Pointer mapping from frame metadata** — not a naive viewport ratio.
+- **Chromium packaging for release** — bundle vs. first-run installer.
+
+Still open:
+
+- **Bridge choice** — service-owned (replace) vs. tool-owned (attach). The
+  central decision; affects how much of the existing skill code is rewritten.
 - **Input arbitration semantics** — queue vs. interrupt when human and agent both act.
 - **Recording exclusion mechanism** — how sensitive-page frames and keystrokes are identified and excluded from rewind/persistence.
 - **Credential policy** — whether the agent may read authenticated sessions at all, or only for an explicit allowlist of origins.
-- **Chromium lifecycle** — whether the headless Chromium is spawned/managed by the daemon or, optionally, by the Tauri shell.
+- **Chromium lifecycle** — whether the shared Chromium is spawned/managed by the daemon or, optionally, by the Tauri shell.

--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -234,76 +234,93 @@ fire-and-forget (there is no `onConsumed` hook), so backpressure is enforced via
 an **explicit client→daemon ACK**:
 
 ```ts
-// per page, on activation. Method is a STABLE string; scoping is the channel.
-// INVARIANT: every CDP frame received is acked exactly once — either after the
-// client ACKs the forwarded frame, or immediately when it is dropped (superseded,
-// ACK-timeout, or session teardown). Without this, leaked CDP flow-control slots
-// eventually stall frame delivery.
+// ILLUSTRATIVE — see "Screencast correctness rules" below for the binding contract.
+// State is keyed per (sessionId, pageId); MessageHub keeps ONE handler per request
+// method, so browser.frameAck is registered once at service startup and routed by
+// CallContext.sessionId + frameId (never re-registered per page).
 const cdp = await page.context().newCDPSession(page);
 await cdp.send('Page.startScreencast', { format: 'jpeg', quality: 70, maxWidth: 1280, maxHeight: 800 });
 
-let inflight: { frameId: string; cdpSessionId: string } | null = null;
-let newest: { frame: Frame; cdpSessionId: string } | null = null;
-
+interface Stream {
+  inflight: { frameId: string; cdpSessionId: string; timer: Timer } | null;
+  newest: { frame: Frame; cdpSessionId: string } | null;
+}
+const streams = new Map<string, Stream>();                 // key: `${sessionId}:${pageId}`
 const ackCdp = (id: string) => cdp.send('Page.screencastFrameAck', { sessionId: id });
 
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
-  if (newest) ackCdp(newest.cdpSessionId);   // supersede: ack the queued frame we're about to drop
-  newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch }, cdpSessionId: sessionId };
-  if (!inflight) dispatch();
+  const s = streams.get(key)!;
+  if (s.newest) ackCdp(s.newest.cdpSessionId);            // supersede: ack + drop the queued frame
+  s.newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch }, cdpSessionId: sessionId };
+  if (!s.inflight) dispatch(s);
 });
 
-function dispatch() {
-  if (!newest) return;
-  inflight = { frameId: newest.frame.frameId, cdpSessionId: newest.cdpSessionId };
-  const f = newest.frame; newest = null;
-  gateway.publish('browser.frame', f, sessionChannel);   // fire-and-forget; NO onConsumed exists
-  armAckTimeout(inflight.frameId, () => {                 // timeout: abandon + ack CDP, then resume
-    ackCdp(inflight!.cdpSessionId);
-    inflight = null;
-    if (newest) dispatch();
-  });
+function dispatch(s: Stream) {
+  if (!s.newest) return;
+  const { frameId, cdpSessionId } = { frameId: s.newest.frame.frameId, cdpSessionId: s.newest.cdpSessionId };
+  const timer = setTimeout(() => {                        // captured by frameId; cleared on resolve
+    if (s.inflight?.frameId !== frameId) return;          // already resolved by ACK/teardown
+    ackCdp(cdpSessionId); s.inflight = null; if (s.newest) dispatch(s);
+  }, ACK_TIMEOUT_MS);
+  s.inflight = { frameId, cdpSessionId, timer };
+  gateway.publish('browser.frame', s.newest.frame, sessionChannel);  // event: session:<id> channel
+  s.newest = null;
 }
 
-hub.handle('browser.frameAck', ({ frameId }) => {         // explicit ACK: how the daemon learns consumption
-  if (inflight?.frameId !== frameId) return;
-  ackCdp(inflight.cdpSessionId);
-  inflight = null;
-  if (newest) dispatch();
+// Registered ONCE at startup; request scope is the RAW session id (see rules):
+hub.handle('browser.frameAck', ({ frameId }, ctx) => {
+  const s = streams.get(`${ctx.sessionId}:${activePageId(ctx.sessionId)}`); if (!s?.inflight) return;
+  if (s.inflight.frameId !== frameId) return;             // stale ACK for an already-resolved frame
+  clearTimeout(s.inflight.timer); ackCdp(s.inflight.cdpSessionId); s.inflight = null;
+  if (s.newest) dispatch(s);
 });
 
-// teardown / pane disconnect: ack whatever we're still holding, then drop it
-onSessionLeave(() => { if (inflight) { ackCdp(inflight.cdpSessionId); inflight = null; } });
+// teardown / pane leave: ack BOTH retained frames, clear the timer, drop state
+onSessionLeave(sid => { for (const s of streamsFor(sid)) {
+  if (s.inflight) { clearTimeout(s.inflight.timer); ackCdp(s.inflight.cdpSessionId); }
+  if (s.newest) ackCdp(s.newest.cdpSessionId);
+  s.inflight = s.newest = null;
+}});
 ```
 
 Frames flow daemon → WS → canvas at roughly 10–30 fps depending on quality/size.
 Stop with `Page.stopScreencast`.
 
-#### Frame ACK protocol (required)
+#### Screencast correctness rules (required)
 
-`Page.screencastFrameAck` is CDP's **only** flow-control point, and MessageHub
-events are fire-and-forget — so the daemon cannot know a frame was consumed
-unless the client tells it. The protocol:
+`Page.screencastFrameAck` is CDP's only flow-control point, MessageHub events are
+fire-and-forget (no `onConsumed`), and MessageHub keeps a single handler per
+request method. These invariants are the binding contract for the loop above:
 
-- Each frame carries a unique `frameId`. After the pane draws it, the pane sends
-  a `browser.frameAck { frameId }` request. The daemon acks CDP
-  (`Page.screencastFrameAck`) **only on receipt** — never on enqueue. This keeps
-  at most one frame in flight to the client and drops stale intermediates.
-- **Ack every CDP frame exactly once (required).** `screencastFrameAck` is CDP's
-  only flow-control point, and Chromium emits frames into bounded slots — so
-  every received frame must be acked, including ones the daemon *drops*: a
-  superseded queued frame is acked when overwritten; the in-flight frame is
-  acked on ACK-timeout and on teardown/disconnect. The loop above enforces this
-  via `ackCdp(...)` on each of those paths. Missing any one leaks slots and
-  stalls delivery.
-- **Disconnect:** when the pane's socket closes (or leaves the session channel),
-  the daemon acks and drops `inflight` then resumes dispatch — otherwise it
-  would wait forever for an ACK from a gone client.
-- **Timeout:** if no ACK arrives within N ms, ack and drop `inflight` and resume,
-  so a dropped ACK cannot permanently stall the stream.
+- **Ack every CDP frame exactly once.** Each received frame must be acked — the
+  forwarded frame after the client ACKs it; a superseded queued frame when
+  overwritten; the in-flight frame on ACK-timeout, teardown, or pane disconnect.
+  Missing any one leaks a bounded slot and stalls delivery.
+- **One service-level `browser.frameAck` handler.** Register it once at startup
+  and route by `CallContext.sessionId` + `frameId`; per-page registration would
+  overwrite MessageHub's single handler-per-method slot.
+- **Cancel timers on resolve.** Capture the `frameId` a timeout belongs to and
+  `clearTimeout` it on ACK/teardown/disconnect; a stale timer must never ack or
+  clear a newer frame.
+- **Teardown acks both retained frames.** On pane leave / page close / session
+  end, ack `inflight` (clearing its timer) **and** `newest`, then drop both.
+- **Late-subscriber activation snapshot.** `browser.activated` is fire-and-forget
+  and MessageHub does not replay it. When a pane registers or reconnects, the
+  daemon returns the current `{ pageId, epoch }` before streaming, so a pane
+  mounting after a switch knows the epoch it must match.
+- **Pane guards its channel.** A client may have joined several `session:*`
+  channels and MessageHub dispatches by method name, so the pane's frame and
+  activation handlers must explicitly require `context.channel === 'session:<sessionId>'`.
+- **Requests use the raw session id; events use the channel string.**
+  `MessageHub.request` writes `options.channel` into the wire message's
+  `sessionId` field, which `getSessionAsync` then resolves — so request methods
+  (`browser.frameAck` / `browser.input` / `browser.action`) must be scoped with
+  the **raw** HyperNeo session id, while the `session:<id>` string is reserved
+  for **event** routing (`browser.frame`, `browser.activated`) only. Conflating
+  them makes every request fail session lookup.
 - **Multiple subscribers:** if more than one pane can subscribe to a session
-  (e.g. desktop + browser tab), require an ACK from each, or explicitly document
-  a single-subscriber-per-session assumption. State this in the implementation.
+  (e.g. desktop + browser tab), require an ACK from each, or document a
+  single-subscriber-per-session assumption.
 
 ### Data flow: human drives (or takes over)
 
@@ -336,14 +353,17 @@ above:
 | button down | `page.mouse.down({ button, clickCount })` |
 | button up | `page.mouse.up({ button, clickCount })` |
 | wheel | `page.mouse.wheel(deltaX, deltaY)` |
-| modifier hold (Ctrl/Shift/Alt/Meta) | `page.keyboard.down(modifier)` **before** the mouse action; `page.keyboard.up(modifier)` **after** |
+| modifier hold (Ctrl/Shift/Alt/Meta) | `page.keyboard.down(modifier)` at gesture start; `page.keyboard.up(modifier)` at gesture end |
 
 Compose click/drag from down→(move)→up at the client; the broker forwards each
-transition. **Modifier state is held via synchronized `keyboard.down`/`up`
-around the mouse action** — Playwright's `mouse.down`/`mouse.up` do not accept a
-`modifiers` option; they inherit modifier state from preceding `keyboard.down`
-calls. (For precise control, dispatch raw CDP `Input.dispatchMouseEvent` with its
-modifier bitmask instead.)
+transition. **Modifiers are held across the entire gesture, not per mouse
+event.** For a Ctrl-drag, `keyboard.down('Control')` precedes the move/down/up
+sequence and `keyboard.up('Control')` follows the final button-up, so the page
+sees consistent modifier state throughout (releasing after each mouse action
+would drop it mid-gesture). Maintain a pressed-modifier set keyed to the client's
+keydown/keyup. Playwright's `mouse.down`/`mouse.up` take no `modifiers` option —
+they inherit from preceding `keyboard.down` calls — or use raw CDP
+`Input.dispatchMouseEvent` with its modifier bitmask on every pointer event.
 
 #### Keyboard-event protocol (required)
 
@@ -468,6 +488,12 @@ clean user machine. The implementation must pick one and wire it end-to-end:
 
 Either belongs in the implementation surface before this feature ships.
 
+**Standalone CLI distributions too.** The bundle path covers only the Tauri
+release; HyperNeo's separately compiled `hyperneo` CLI binaries can also host the
+web UI and would still have no Chromium on a clean machine. Extend whichever
+strategy is chosen to the standalone CLI artifacts, or require the first-run
+installer for every non-desktop distribution.
+
 ## Proposed Implementation Surface
 
 All proposed, none present today:
@@ -517,6 +543,12 @@ Round-3 (mechanism correctness):
 - **Activation out-of-band + epoch on input** — `browser.activated {pageId, epoch}` event sent before repointing input; `browser.input` carries the displayed `epoch` and the daemon rejects mismatches, for an atomic tab switch.
 - **Log redaction** — `browser.input` / `browser.frame` payloads redacted in MessageHub debug/trace logs (passwords, IME text, authenticated pixels).
 - **Pointer modifiers** — held via synchronized `keyboard.down`/`up` (or CDP `Input.dispatchMouseEvent` bitmask), since Playwright `mouse.down`/`up` have no `modifiers` option.
+
+Round-4 (transport invariants and distribution):
+
+- **Screencast loop invariants** — single service-level ACK handler routed by session + frameId; timers cancelled on resolve; teardown acks both inflight and newest; late subscribers get an activation snapshot; pane guards its channel; requests use the raw session id, events use the `session:<id>` channel string.
+- **Whole-gesture modifiers** — held across the full pointer gesture, not per mouse event.
+- **Chromium in CLI distributions** — bundle/first-run strategy extended to standalone CLI artifacts, not just the desktop release.
 
 Still open:
 

--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -2,16 +2,19 @@
 
 > **Status:** Exploratory design. Not implemented. This document captures a
 > design discussion and a recommended approach; it does not describe shipped
-> behaviour. Revised after automated review (Codex) to surface prerequisites
-> that the first draft understated — see [Open Questions](#open-questions).
+> behaviour. Revised twice after automated review (Codex) — the second pass
+> checked the design against HyperNeo's actual source (MessageHub transport,
+> `chrome-devtools-mcp` lifecycle, the Playwright dependency, the desktop
+> bundle) and corrected several API-level inaccuracies. See
+> [Open Questions](#open-questions).
 
 ## Goal
 
 Render the browser that an agent drives **inside the HyperNeo app UI**, so a
 human can watch the agent browse in real time and optionally take over
-(clicking, typing, logging in) through the same pane. Reuse HyperNeo's existing
-Playwright tooling as the automation engine rather than reinventing a protocol
-layer. The pane must work both in the web UI and in the Tauri desktop shell.
+(clicking, typing, logging in) through the same pane. Reuse a CDP-driven
+Chromium as the automation engine rather than reinventing a protocol layer. The
+pane must work both in the web UI and in the Tauri desktop shell.
 
 ## Context
 
@@ -46,7 +49,7 @@ This distinction decides which option below is viable.
 | Option | Engine | Cross-platform | Robustness | New code |
 |--------|--------|----------------|------------|----------|
 | **1. Lite injection harness** | Tauri OS webview + `initialization_script`, no CDP | ✅ all OS webviews | Low–medium (hits injection ceiling) | Medium |
-| **2. Playwright + CDP screencast** ✅ SELECTED | Headless Chromium, frames streamed into the UI | ✅ (Chromium is uniform) | High | Medium–high (see bridge prerequisite) |
+| **2. Playwright + CDP screencast** ✅ SELECTED | Headless Chromium, frames streamed into the UI | ✅ (Chromium is uniform) | High | High (see prerequisites) |
 | **3. Full CDP on embedded browser** | CEF / `deno desktop` CEF backend | Partial | High | High + depends on unexposed CDP |
 
 ### Option 1 — Lite injection harness (no CDP)
@@ -108,11 +111,11 @@ Option 2 adds a frame stream and an input forwarder on top of that engine, and
 produces a pane that works in the browser **and** Tauri because it is just a web
 component over the existing WebSocket transport.
 
-> **Caveat the first draft missed:** the pane must show the *same* browser the
-> agent is driving. HyperNeo's existing browser skills each own isolated
-> browsers and do not expose their `Page`/CDP to the daemon, so "reuse" is not
-> automatic — it requires a [shared-browser bridge](#shared-browser-bridge),
-> which is the central prerequisite of this design.
+> The pane must show the *same* browser the agent is driving, and that browser
+> must live for the whole HyperNeo session — not one agent query. Those two
+> constraints drive the [shared-browser bridge](#shared-browser-bridge) and the
+> [daemon-lifetime ownership](#browser-lifetime-and-teardown) prerequisites
+> below.
 
 ## Selected Approach: CDP Screencast
 
@@ -132,26 +135,31 @@ free.
 ### Architecture
 
 ```
-┌──────────────────────── HyperNeo app window (Tauri shell, unchanged) ─────────────────────┐
-│  Preact UI (OS webview)                                                                     │
-│   └─ <BrowserPane sessionId=…>  ── draws JPEG frames to <canvas>                            │
-│        ▲ user mouse/key            │ frames (per-session channel)                            │
-│        │                            ▼                                                        │
-│        │       MessageHub WebSocket (existing transport)                                      │
-│        │                            ▲                                                        │
-│        │          ┌──────────────────┴───────────────┐                                       │
-│        │          │  daemon: BrowserEngineService      │                                       │
-│        │          │   • owns the ONE shared Chromium   │                                       │
-│        │          │   • per-page CDP session + screencast │                                   │
-│        │          │   • backpressure-gated frame loop  │                                       │
-│        │          │   • input router (per active page) │                                       │
-│        │          │   • agent action primitives (MCP)  │                                       │
-│        │          └──────────────────┬───────────────┘                                       │
-│        │                           │ CDP                                                       │
-│        │                           ▼                                                           │
-│        │          ┌──────────────────────────────────┐                                        │
-│        └─────────▶│  shared headless Chromium         │ ← the agent's tools ALSO drive this    │
-│                   └──────────────────────────────────┘   (via the bridge, not a second one)   │
+┌──────────────────────── HyperNeo app window (Tauri shell) ──────────────────────────────┐
+│  Preact UI (OS webview)                                                                   │
+│   └─ <BrowserPane sessionId=…>  ── draws JPEG frames to <canvas>                          │
+│        ▲ user mouse/key             │ frames + frameAck (session channel)                 │
+│        │                             ▼                                                     │
+│        │       MessageHub WebSocket (existing transport)                                    │
+│        │       method: "browser.frame" (pub)  |  "browser.frameAck"/"browser.input"/      │
+│        │                                            "browser.action" (req)                 │
+│        │                             ▲                                                     │
+│        │          ┌──────────────────┴───────────────┐                                     │
+│        │          │  daemon: BrowserEngineService      │                                     │
+│        │          │   • owns the ONE daemon-lifetime   │                                     │
+│        │          │     Chromium (per HyperNeo session)│                                     │
+│        │          │   • per-page CDP session + screencast │                                 │
+│        │          │   • backpressure-gated frame loop  │                                     │
+│        │          │     keyed on explicit client ACKs  │                                     │
+│        │          │   • epoch-tagged frames + input    │                                     │
+│        │          │     router (per active page)       │                                     │
+│        │          │   • agent action primitives (MCP)  │                                     │
+│        │          └──────────────────┬───────────────┘                                     │
+│        │                           │ CDP                                                     │
+│        │                           ▼                                                         │
+│        │          ┌──────────────────────────────────┐                                      │
+│        └─────────▶│  shared headless Chromium         │ ← agent's tools ALSO drive this       │
+│                   └──────────────────────────────────┘   (via the bridge; daemon-owned)      │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -162,151 +170,186 @@ other; they are not the same thing.
 
 ### Shared browser bridge
 
-The single most important prerequisite, which the first draft understated:
-**the pane must depict the browser the agent is actually driving — not a second,
-unrelated browser.** Today each browser tool owns an isolated browser it does
-not expose:
-
-- `playwright` launches `playwright-cli` via `npx` in its own process.
-- `playwright-interactive` creates browser handles inside a `js_repl` session.
-- `chrome-devtools-mcp` owns an isolated MCP-managed browser.
-
-A `BrowserEngineService` that independently launched Chromium would render a
-page the agent never touches; pane input would target the wrong page; the human
-would "take over" a browser the agent isn't using. Two viable bridges resolve
-this — pick one (see [Open Questions](#open-questions)):
+The pane must depict the browser the agent is actually driving — not a second,
+unrelated browser. Today each browser tool owns an isolated browser it does not
+expose: `playwright` drives `@playwright/cli` via `npx`/global install,
+`playwright-interactive` creates handles inside a `js_repl` session, and
+`chrome-devtools-mcp` owns an isolated MCP-managed browser. A
+`BrowserEngineService` that independently launched Chromium would render a page
+the agent never touches. Resolving this requires one of:
 
 1. **Service-owned single browser (replace).** `BrowserEngineService` owns the
-   one Chromium. The agent's browser actions are reimplemented as MCP tools
-   backed by the service (navigate/click/type/screenshot/AX-tree), replacing the
-   three existing skills for sessions that want an in-app pane. The service
-   exposes the `Page`/CDP to both the agent tools and the screencast loop, so
-   there is exactly one browser. Cleanest model; most new code.
-2. **Tool-owned, service attaches (bridge).** One existing tool (most naturally
-   `chrome-devtools-mcp`, which is already CDP-native) exposes its CDP
-   debugging endpoint. `BrowserEngineService` connects to that endpoint over CDP
-   (`browserType.connectOverCDP`) and runs the screencast/input loop against the
-   tool's pages. Least new code; couples the service to the tool's lifecycle and
-   requires the tool to publish its CDP endpoint.
+   one Chromium and the agent's browser actions are reimplemented as MCP tools
+   backed by the service. The service exposes `Page`/CDP to both the agent tools
+   and the screencast loop. Cleanest model; most new code. **Recommended** — see
+   lifetime note below.
+2. **Persistent broker + per-query attach.** A daemon-lifetime broker owns the
+   Chromium; the per-query MCP process (e.g. a reworked `chrome-devtools-mcp`)
+   attaches to the broker's CDP endpoint each turn. Least reimplementation of
+   agent actions; requires the MCP tool to be reworked to attach rather than
+   spawn its own browser.
 
-Either way, the invariant is: **one Chromium per browser session, shared by the
-agent's actions and the pane.** The component map below assumes the
-service-owned model unless noted.
+Either way, the invariant is: **one Chromium per HyperNeo session, shared by the
+agent's actions and the pane.** The naive "attach to `chrome-devtools-mcp`'s own
+CDP endpoint" does **not** work on its own — see [Browser lifetime and
+teardown](#browser-lifetime-and-teardown).
+
+### Browser lifetime and teardown
+
+HyperNeo supplies MCP servers (including `chrome-devtools-mcp`) as SDK-owned
+stdio configuration, and the SDK spawns that subprocess **per query/turn**. A
+browser owned by that per-query process is torn down or replaced at the end of
+the turn — so it cannot host a pane that is meant to last the whole HyperNeo
+session (with its authenticated state). Therefore:
+
+- **Ownership must be daemon-lifetime**, not per-query. Either the service owns
+  the Chromium directly (bridge option 1), or a persistent daemon broker owns it
+  and per-query MCP processes attach (bridge option 2). This rules out the naive
+  "attach to `chrome-devtools-mcp`" bridge.
+- **Teardown is part of the surface.** Because the service owns one Chromium per
+  session, archive / delete / hard-reset of a HyperNeo session must close that
+  session's pages, CDP sessions, browser process/context, listeners, and the
+  credential-bearing profile — otherwise session churn leaves orphaned Chromium
+  processes and credential-bearing profiles until daemon exit. Add teardown
+  hooks for archive/delete/reset and for global daemon shutdown, with an explicit
+  profile-retention policy (e.g. delete the profile on session delete, retain on
+  archive).
 
 ### Component map (proposed; not yet implemented)
 
 | Piece | Proposed location | Notes |
 |---|---|---|
-| Shared headless Chromium + Playwright | daemon process (`BrowserEngineService`) | One browser per session, driven by both agent tools and the pane (see bridge above) |
-| CDP broker (screencast + input + agent actions) | `packages/daemon/src/lib/browser/` | Holds `newCDPSession(page)` **per page**, runs the backpressure-gated frame loop, routes input to the active page |
-| Transport | MessageHub WS — **per-session channels** `browser.frame:<sessionId>` (pub), `browser.input:<sessionId>` / `browser.action:<sessionId>` (RPC) | Pane must join the specific session channel; frames are never broadcast across sessions (prevents leaking another session's authenticated pixels) |
-| Renderer | Preact `<BrowserPane sessionId>` in `packages/web` | Joins the session channel, renders to `<canvas>`, captures + forwards user input |
-| Tauri shell | `packages/desktop` — **unchanged** | No Rust changes; the pane is just another web component |
-
-The crucial line: **the Tauri Rust shell changes nothing.** No new Rust, no
-webview reparenting, no platform-specific glue.
+| Shared headless Chromium + Playwright | daemon (`BrowserEngineService`) | One daemon-lifetime browser per session; **requires adding a pinned `playwright` runtime dep to `packages/daemon`** (see below) |
+| CDP broker | `packages/daemon/src/lib/browser/` | Per-page CDP sessions, backpressure-gated frame loop keyed on client ACKs, epoch-tagged frames, input router to active page |
+| Transport | MessageHub — **method `browser.frame`** (pub) scoped by a **session channel**; request methods `browser.frameAck`, `browser.input`, `browser.action` | Method is a plain string (MessageHub forbids colons in methods); session scoping is the `channel` option (`session:<id>`), never baked into the method. Events are fire-and-forget — consumption is signalled by the explicit `browser.frameAck` request |
+| Renderer | Preact `<BrowserPane sessionId>` in `packages/web` | Joins the session channel, renders to `<canvas>`, sends `browser.frameAck` after draw, forwards pointer/keyboard via request methods |
+| Tauri shell | `packages/desktop` | Rust webview code unchanged. **For the Chromium-bundle path**, the Tauri config (`externalBin`) and `build-sidecar.sh` must add Chromium's executable + resources (see [Chromium packaging](#chromium-packaging-for-release-builds)) |
 
 ### Data flow: watch the agent browse
 
-The agent calls an MCP tool (navigate/click/type) → daemon → Playwright acts on
-the shared browser. Simultaneously a screencast is running for the **active
-page**:
+The agent calls an MCP tool → daemon → Playwright acts on the shared browser.
+Simultaneously a screencast runs for the **active page**. MessageHub events are
+fire-and-forget (there is no `onConsumed` hook), so backpressure is enforced via
+an **explicit client→daemon ACK**:
 
 ```ts
-// per page, on activation (raw CDP via Playwright)
+// per page, on activation. Method is a STABLE string; scoping is the channel.
 const cdp = await page.context().newCDPSession(page);
-await cdp.send('Page.startScreencast', {
-  format: 'jpeg',
-  quality: 70,
-  maxWidth: 1280,
-  maxHeight: 800,
-});
+await cdp.send('Page.startScreencast', { format: 'jpeg', quality: 70, maxWidth: 1280, maxHeight: 800 });
 
-let clientInFlight = false;          // backpressure: at most one frame un-acked by the client
-let newestPending: Frame | null = null;
+let inflight: { frameId: string; cdpSessionId: string } | null = null;
+let newest: { frame: Frame; cdpSessionId: string } | null = null;
 
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
-  newestPending = { jpeg: data, metadata };          // drop stale intermediates; keep newest only
-  if (!clientInFlight) dispatchToClient(sessionId);  // send only when the client is ready
+  newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch }, cdpSessionId: sessionId };
+  if (!inflight) dispatch();            // send only when nothing is in flight to the client
 });
 
-function dispatchToClient(cdpSessionId: string) {
-  if (!newestPending) return;
-  clientInFlight = true;
-  const frame = newestPending;
-  newestPending = null;
-  hub.publish(`browser.frame:${sessionId}`, frame, { onConsumed: () => {
-    clientInFlight = false;
-    cdp.send('Page.screencastFrameAck', { sessionId: cdpSessionId }); // ack CDP AFTER the client consumed
-    if (newestPending) dispatchToClient(cdpSessionId);                // drain the newest pending
-  }});
+function dispatch() {
+  if (!newest) return;
+  inflight = { frameId: newest.frame.frameId, cdpSessionId: newest.cdpSessionId };
+  const f = newest.frame; newest = null;
+  gateway.publish('browser.frame', f, sessionChannel);   // fire-and-forget; NO onConsumed exists
+  armAckTimeout(inflight.frameId);                       // resume if the ACK never comes
 }
+
+// Explicit ACK request — this is how the daemon learns the frame was consumed:
+hub.handle('browser.frameAck', ({ frameId }) => {
+  if (inflight?.frameId !== frameId) return;
+  cdp.send('Page.screencastFrameAck', { sessionId: inflight.cdpSessionId }); // ack CDP AFTER client ACK
+  inflight = null;
+  if (newest) dispatch();                                                   // drain newest pending
+});
 ```
 
 Frames flow daemon → WS → canvas at roughly 10–30 fps depending on quality/size.
 Stop with `Page.stopScreencast`.
 
-#### Backpressure (required)
+#### Frame ACK protocol (required)
 
-`Page.screencastFrameAck` is CDP's **only** flow-control point — acknowledging
-every frame immediately makes Chromium produce JPEGs as fast as it can, piling
-them onto the same WebSocket that carries chat and input RPCs. The loop above
-keeps **at most one frame in flight to the client** (dropping stale
-intermediates) and **acks CDP only after the client reports consumption**, not
-on enqueue. Without this, a slow client/network causes stale video, delayed
-takeover input, and unbounded memory growth.
+`Page.screencastFrameAck` is CDP's **only** flow-control point, and MessageHub
+events are fire-and-forget — so the daemon cannot know a frame was consumed
+unless the client tells it. The protocol:
+
+- Each frame carries a unique `frameId`. After the pane draws it, the pane sends
+  a `browser.frameAck { frameId }` request. The daemon acks CDP
+  (`Page.screencastFrameAck`) **only on receipt** — never on enqueue. This keeps
+  at most one frame in flight and drops stale intermediates.
+- **Disconnect:** when the pane's socket closes (or leaves the session channel),
+  the daemon drops `inflight` and resumes dispatch, otherwise it would wait
+  forever for an ACK from a gone client.
+- **Timeout:** if no ACK arrives within N ms, drop `inflight` and resume, so a
+  dropped ACK cannot permanently stall the stream.
+- **Multiple subscribers:** if more than one pane can subscribe to a session
+  (e.g. desktop + browser tab), require an ACK from each, or explicitly document
+  a single-subscriber-per-session assumption. State this in the implementation.
 
 ### Data flow: human drives (or takes over)
 
-The user clicks the pane at canvas pixel `(cx, cy)`. Coordinates are mapped from
-the **decoded frame dimensions and `screencastFrame` metadata** (not a naive
-viewport ratio — that breaks under letterboxing, page zoom, or mobile
-emulation), then forwarded through **Playwright's input API** so events are
-trusted:
+The user interacts with the pane. Coordinates are mapped from the **decoded
+frame dimensions and `screencastFrame` metadata**, then forwarded through
+Playwright so events are trusted. **Critically, Playwright mouse coordinates are
+CSS pixels relative to the viewport, not the document** — so the document scroll
+offset must **not** be added (the screencast already depicts the current
+viewport; adding scroll would click the wrong place on any scrolled page):
 
 ```ts
-// metadata carries: pageScaleFactor, deviceWidth, deviceHeight, scrollOffsetX, scrollOffsetY
-// frame decoded to frameW×frameH; drawn at displayW×displayH inside the canvas with letterbox (offX, offY)
-const fx = cx - offX, fy = cy - offY;                                  // 1. remove letterbox
-const cssX = (fx / displayW) * metadata.deviceWidth  / metadata.pageScaleFactor + metadata.scrollOffsetX;
-const cssY = (fy / displayH) * metadata.deviceHeight / metadata.pageScaleFactor + metadata.scrollOffsetY;
-await page.mouse.click(cssX, cssY);                                    // trusted event
+// metadata: pageScaleFactor, deviceWidth, deviceHeight (the viewport). scrollOffsetX/Y is
+// informational ONLY — do NOT add it (Playwright wants viewport-relative coords).
+// frame decoded to frameW×frameH; drawn at displayW×displayH with letterbox (offX, offY).
+const fx = cx - offX, fy = cy - offY;                                        // 1. remove letterbox
+const cssX = (fx / displayW) * metadata.deviceWidth  / metadata.pageScaleFactor;   // → viewport CSS px
+const cssY = (fy / displayH) * metadata.deviceHeight / metadata.pageScaleFactor;
 ```
 
-Playwright dispatches exactly the coordinates it receives — it does **not**
-correct the UI→frame transform — so the mapping must be derived from the frame
-metadata before calling it.
+#### Pointer-event protocol (required)
 
-#### Keyboard event protocol (required)
-
-`page.keyboard.type(text)` only inserts a text string; it cannot reproduce
-Tab, Enter, Escape, Backspace, arrow keys, modifier shortcuts, held modifiers,
-or IME composition — all common during login and form navigation. Human input
-must use a real keyboard event protocol, not completed text:
+Forwarding only `page.mouse.click` does not give real human takeover — it
+cannot reproduce scroll, drag, hover, or press-and-hold. Forward the full set,
+each with button + modifier state and the same viewport-coordinate transform
+above:
 
 | Client event | Playwright call |
 |---|---|
-| `keydown` / `keyup` with `key`, `code`, `modifiers` | `page.keyboard.down(key)` / `page.keyboard.up(key)` |
-| Named-key press (Enter, Tab, Escape, arrows, shortcuts) | `page.keyboard.press('Enter' \| 'Tab' \| …)` |
-| Text / IME composition | `page.keyboard.type(text)` or CDP `Input.insertText` for composition |
+| move | `page.mouse.move(cssX, cssY)` |
+| button down | `page.mouse.down({ button, modifiers })` |
+| button up | `page.mouse.up({ button, modifiers })` |
+| wheel | `page.mouse.wheel(deltaX, deltaY)` |
 
-The client sends `keydown`/`keyup`/`text` events with modifiers; the broker
-maps them to the Playwright calls above. Focus management (which element
-receives input) follows the active page's focused element.
+Compose click/drag from down→(move)→up at the client; the broker forwards each
+transition.
 
-### Tab/page lifecycle (required)
+#### Keyboard-event protocol (required)
 
-`newCDPSession(page)` is bound to **one** target; it does not follow tab
-switches, popups, or `target="_blank"` navigations. For multi-tab to work (which
-the design cites as a reason for choosing this approach), the broker must:
+`page.keyboard.type(text)` only inserts a text string — it cannot do Tab, Enter,
+Escape, arrows, modifiers, shortcuts, or IME. Use a real keyboard protocol, and
+keep the key-event and text-insertion paths **mutually exclusive for printable
+keys** so they are not double-inserted (Playwright's `keyboard.down('a')`
+already produces the `a` input for a printable key; feeding the same key to
+`type`/`insertText` afterwards inserts it again):
 
-- Open a CDP session **per page** (`Target.attachedToTarget` / Playwright's
-  page-collection events).
-- Start a screencast only for the **active** page; stop or suppress inactive
-  streams (otherwise every tab encodes frames).
-- On activation change, **atomically** switch both rendering (which frame stream
-  the pane subscribes to) and input routing (which `page` receives
-  mouse/keyboard) so video and takeover never target different tabs.
+| Client event | Playwright call | Notes |
+|---|---|---|
+| non-printing / control key (Tab, Enter, arrows, Esc, modifiers, shortcuts) | `page.keyboard.press('Tab' \| 'Enter' \| …)` or `down`/`up` | keydown/keyup with modifiers |
+| printable text | `page.keyboard.type(text)` **or** `keyboard.down`/`up` per key — not both | pick one path per key |
+| IME composition / commit | CDP `Input.insertText` (or `imeSetComposition`) | suppress the duplicate text event |
+
+Focus follows the active page's focused element.
+
+### Tab/page lifecycle and epoch tagging (required)
+
+`newCDPSession(page)` is bound to one target; it does not follow tab switches,
+popups, or `target="_blank"` navigations. For multi-tab (a cited reason for
+choosing this approach) the broker must:
+
+- Open a CDP session **per page** and screencast only the **active** page (stop
+  or suppress inactive streams so every tab does not encode).
+- **Tag every frame with `pageId` + `epoch`** (epoch increments on activation
+  change). A tab switch cannot be made atomic merely by stopping the old
+  screencast and repointing input — a stale frame from the old tab may already
+  be in the WS pipeline and render after input has begun routing to the new page.
+  The pane discards frames and **disables input until it renders the first frame
+  of the new epoch**, which makes the render + input switch atomic.
 
 ### Agent observation (what the model sees)
 
@@ -326,63 +369,61 @@ does not. These must be handled by design, not by accident:
 
 1. **Credentials transit the app stack.** Keystrokes flow pane → WS → daemon →
    CDP → Chromium. The daemon process (and anything reading the WS) is inside
-   the credential trust boundary. This is a real expansion vs. a normal browser,
-   where keystrokes stay inside the browser process.
-
+   the credential trust boundary — broader than a normal browser, where
+   keystrokes stay inside the browser process.
 2. **Recording / rewind is the dangerous one.** HyperNeo persists messages and
-   has rewind/checkpoints. If screencast frames or input events are wired into
-   that persistence naively, **passwords can be captured to disk** — as
-   typed-input logs, or as frame pixels (especially if anyone toggles "show
-   password"). Sensitive-page frames and keystrokes must be **excluded from
-   recording by design**. The per-session channel routing also matters here:
-   frames must never be broadcast across sessions, or one session's pane could
-   render another session's authenticated pixels.
-
-3. **The agent can read the authenticated session.** The same shared Chromium
-   the human types into is *also* drivable by the agent over the same CDP
-   session. The moment a human logs in, the agent (and any code with CDP access)
-   can run
+   has rewind/checkpoints. If frames or input events are wired into that
+   persistence naively, **passwords can be captured to disk** — as input logs or
+   as frame pixels (especially if anyone toggles "show password"). Sensitive-page
+   frames and keystrokes must be **excluded from recording by design**, and the
+   per-session channel routing must never broadcast frames across sessions (one
+   session's pane must not render another's authenticated pixels).
+3. **The agent can read the authenticated session.** The same shared Chromium is
+   also drivable by the agent over the same CDP session. Once a human logs in,
+   the agent (and any code with CDP access) can run
    `page.evaluate(() => document.querySelector('input[type=password]').value)`,
    read cookies via `page.context().cookies()`, read `localStorage`, or
-   screenshot the page. A normal browser walls the page off from the app; this
-   architecture **deliberately bridges them**. For a personal single-user tool
-   that is often the intent (the agent should reuse the human's session), but it
-   must be a conscious decision — there is no isolation between "what the human
-   typed" and "what the agent can see."
-
-4. **Isolate the Chromium.** Use a dedicated Playwright browser context/profile.
-   Do not share cookies or credentials with the host app or the user's main
-   browser profile unless intended.
-
+   screenshot. This is intentional for a single-user tool (the agent reuses the
+   human's session) but must be a conscious decision — there is no isolation
+   between "what the human typed" and "what the agent can see."
+4. **Isolate the Chromium.** Dedicated Playwright browser context/profile per
+   session; do not share cookies or credentials with the host app or the user's
+   main browser profile unless intended. Tie profile lifetime to session
+   lifecycle ([Browser lifetime and teardown](#browser-lifetime-and-teardown)).
 5. **No OS-keychain autofill by default.** A headless Chromium has no system
    keychain and an empty profile, so password managers will not fill. The human
    types the password, and it then lives in the Chromium's cookies/profile until
-   cleared.
+   the session's teardown policy clears it.
 
 ## Tradeoffs
 
 | Aspect | Notes |
 |---|---|
 | Latency | Screencast is watchable but not instant — a frame or two of round-trip. Fine for watching an agent; not a daily-driver browser. Tunable via quality/maxWidth. |
-| Ships Chromium | **Not free in release builds.** Playwright is currently only a CLI *dev* dependency, and the interactive skill requires manually installing both the package and the browser executable — so a compiled daemon sidecar has neither on a clean user machine. Landing this requires a real packaging strategy (see below), not lazy first-use download. |
+| New runtime dependency | `packages/daemon` does **not** depend on Playwright today (only `packages/cli` and `packages/e2e` do; the skill uses `@playwright/cli` via npx/global). This feature must **add a pinned `playwright` runtime dependency to the daemon** — not treat an existing dev dependency as packaging-only — so `BrowserEngineService` can import it and the bundle/checksum has a locked version. |
+| Ships Chromium | Not free in release builds. Requires a real packaging strategy (see below). |
 | Two webviews | App UI (OS webview) vs. depicted browser (Chromium as pixels). Keep them distinct. |
 | Input ownership | Decide arbitration: when the agent is mid-action and the user clicks, does it queue or interrupt? Make human input able to pause/override; don't leave it implicit. |
-| Sandboxing | The Chromium executes agent-influenced code on arbitrary sites. Sandbox it: separate context/profile, no shared credentials with the host app, ideally network/FS restrictions. |
+| Sandboxing | The Chromium executes agent-influenced code on arbitrary sites. Sandbox it: per-session context/profile, no shared credentials with the host app, ideally network/FS restrictions. |
 
 ### Chromium packaging for release builds
 
-Because Playwright is a dev-only dependency today, a packaged desktop install
-will **not** obtain Chromium by lazy download on first launch. The
-implementation must define one of:
+The daemon has no Playwright today and the compiled desktop sidecar bundles only
+the `hyperneo` executable, so Chromium will **not** appear by lazy download on a
+clean user machine. The implementation must pick one and wire it end-to-end:
 
-- **Bundle** Playwright's Chromium into the desktop release artifact (adds ~150 MB
-  to the installer; offline-friendly; pinned version).
+- **Bundle** Playwright's Chromium into the desktop release. This is **not**
+  transparent for `packages/desktop`: the Tauri config (`externalBin`) and
+  `build-sidecar.sh` currently bundle only the `hyperneo` sidecar, so they must
+  add Chromium's executable + resource tree, locate it at runtime, and thread it
+  through the platform release/signing pipeline. (The Rust webview code itself
+  can stay unchanged.)
 - **First-run installer** that downloads Playwright + the browser binary on
-  first use, with progress UI, retry/checksum verification, and a defined
-  failure path (degraded mode that disables browser-use but keeps the app
-  usable).
+  first use, with progress UI, retry/checksum verification against the locked
+  version, and a defined failure path (degraded mode that disables browser-use
+  but keeps the app usable).
 
-Either choice belongs in the implementation surface before this feature ships.
+Either belongs in the implementation surface before this feature ships.
 
 ## Proposed Implementation Surface
 
@@ -390,51 +431,47 @@ All proposed, none present today:
 
 | File / area | Change |
 |---|---|
-| `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — owns the shared Chromium, holds per-page CDP sessions, runs the backpressure-gated screencast loop, routes input to the active page, exposes agent action primitives (MCP) |
-| Existing browser skills (`playwright`, `playwright-interactive`, `chrome-devtools-mcp`) | Either reimplemented on the service, or (bridge option) `chrome-devtools-mcp` exposes its CDP endpoint for the service to attach — see [Shared browser bridge](#shared-browser-bridge) |
-| MessageHub channels (new, per-session) | `browser.frame:<sessionId>` (pub/sub frame stream, backpressure-gated), `browser.input:<sessionId>` (human input), `browser.action:<sessionId>` (agent tool calls) |
-| `packages/web` (new component) | Preact `<BrowserPane sessionId>` — joins the session channel, renders to `<canvas>`, maps pointer coords from frame metadata, forwards the keyboard event protocol |
-| `packages/desktop` (existing) | **No changes** — pane is a web component |
-| Release packaging | Bundle or first-run-install Playwright + Chromium (see above) |
+| `packages/daemon/package.json` | Add a pinned `playwright` runtime dependency |
+| `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — owns the daemon-lifetime shared Chromium, per-page CDP sessions, backpressure-gated frame loop keyed on `browser.frameAck`, epoch-tagged frames, input router, agent action primitives (MCP) |
+| Existing browser skills | Reimplemented on the service (replace) **or** reworked to attach to a persistent daemon broker (attach) — see [Shared browser bridge](#shared-browser-bridge). The naive attach to `chrome-devtools-mcp` does not survive a query boundary. |
+| MessageHub (new) | Method `browser.frame` (pub, session channel); request methods `browser.frameAck`, `browser.input`, `browser.action` (all session-scoped). No `onConsumed` — ACKs are explicit. |
+| Session lifecycle | Teardown hooks on archive/delete/hard-reset + daemon shutdown: close pages, CDP sessions, browser, listeners, credential-bearing profile; profile-retention policy |
+| `packages/web` (new component) | Preact `<BrowserPane sessionId>` — joins session channel, renders to `<canvas>`, sends `browser.frameAck`, maps pointer coords from frame metadata, forwards pointer + keyboard protocols, suppresses input across epoch changes |
+| `packages/desktop` (config/build only) | For the bundle path: add Chromium to `externalBin`/bundle + `build-sidecar.sh`; locate at runtime; release/signing. Rust webview code unchanged. |
 
 ### Suggested spike (validation slice)
 
-Before wiring into the real UI, validate the latency, coordinate-math, and
-backpressure feel with a minimal slice that needs no Tauri and assumes the
-service-owned bridge:
+Validate latency, coordinate-math, backpressure, and epoch behavior with a
+minimal slice (no Tauri, service-owned bridge):
 
-1. A daemon service that launches one headless Chromium, owns a per-page CDP
-   session, and runs the backpressure-gated screencast loop.
-2. The agent's actions exposed as MCP tools against that same Chromium.
-3. A standalone HTML page (`<BrowserPane>` prototype, no Tauri) that joins the
-   session channel, renders the frame stream, maps clicks from frame metadata,
-   and forwards the keyboard event protocol.
+1. A daemon service that owns one headless Chromium, opens per-page CDP
+   sessions, and runs the ACK-gated screencast loop.
+2. Agent actions exposed as MCP tools against that same Chromium.
+3. A standalone HTML page (`<BrowserPane>` prototype) that joins the session
+   channel, renders frames, ACKs them, maps clicks from frame metadata,
+   forwards pointer + keyboard, and honours epoch tags.
 
-Enough to confirm the fps/coordinate/backpressure feel, then wire into the real
-UI and the desktop shell.
+Enough to confirm the feel, then wire into the real UI and the desktop shell.
 
 ## Open Questions
 
-The review surfaced several prerequisites the first draft treated as solved.
 Resolved in this revision (specified, not yet implemented):
 
-- **Shared-browser bridge** — pane must depict the agent's browser; choose
-  service-owned (replace) vs. tool-owned (attach to `chrome-devtools-mcp`'s CDP).
-- **Per-session frame channels** — frames routed only to the joined session.
-- **Screencast backpressure** — at most one frame in flight; ack CDP after
-  client consumption.
-- **Tab/page lifecycle** — per-page CDP sessions; atomic switch of render +
-  input on activation change.
-- **Keyboard event protocol** — keydown/keyup/press/text/composition, not just
-  `type(text)`.
-- **Pointer mapping from frame metadata** — not a naive viewport ratio.
-- **Chromium packaging for release** — bundle vs. first-run installer.
+- **Shared-browser bridge** — pane depicts the agent's browser; service-owned (replace) vs. persistent broker + per-query attach.
+- **Daemon-lifetime ownership + teardown** — the browser must outlive one query; session teardown closes browser + profile.
+- **MessageHub wiring** — stable `browser.frame` method + session channel; explicit `browser.frameAck` request (no `onConsumed`); disconnect/timeout/multi-subscriber defined.
+- **Screencast backpressure** — at most one frame in flight; ack CDP after client ACK.
+- **Tab/page lifecycle + epoch tagging** — per-page CDP sessions; frames carry `pageId`/`epoch`; pane suppresses input across epoch change for an atomic switch.
+- **Pointer protocol** — move/down/up/wheel, viewport-relative coords (no scroll offset), letterbox-corrected.
+- **Keyboard protocol** — keydown/keyup/press/text mutually exclusive for printable keys; `insertText` for composition.
+- **Playwright runtime dependency** — add pinned dep to `packages/daemon`.
+- **Chromium packaging** — bundle (with desktop config/build changes) vs. first-run installer.
 
 Still open:
 
-- **Bridge choice** — service-owned (replace) vs. tool-owned (attach). The
-  central decision; affects how much of the existing skill code is rewritten.
+- **Bridge choice** — service-owned (replace) vs. persistent broker (attach). The central decision; drives how much existing skill code is rewritten.
+- **Multi-subscriber frame ACK semantics** — ACK-from-all vs. single-subscriber-per-session assumption.
 - **Input arbitration semantics** — queue vs. interrupt when human and agent both act.
 - **Recording exclusion mechanism** — how sensitive-page frames and keystrokes are identified and excluded from rewind/persistence.
 - **Credential policy** — whether the agent may read authenticated sessions at all, or only for an explicit allowlist of origins.
-- **Chromium lifecycle** — whether the shared Chromium is spawned/managed by the daemon or, optionally, by the Tauri shell.
+- **Chromium lifecycle host** — daemon-managed vs. (optionally) Tauri-shell-managed.

--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -251,7 +251,7 @@ const ackCdp = (id: string) => cdp.send('Page.screencastFrameAck', { sessionId: 
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
   const s = streams.get(key)!;
   if (s.newest) ackCdp(s.newest.cdpSessionId);            // supersede: ack + drop the queued frame
-  s.newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch }, cdpSessionId: sessionId };
+  s.newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch, seq: nextSeq() }, cdpSessionId: sessionId };
   if (!s.inflight) dispatch(s);
 });
 
@@ -269,8 +269,8 @@ function dispatch(s: Stream) {
 
 // Registered ONCE at startup; request scope is the RAW session id (see rules):
 hub.handle('browser.frameAck', ({ frameId }, ctx) => {
-  const s = streams.get(`${ctx.sessionId}:${activePageId(ctx.sessionId)}`); if (!s?.inflight) return;
-  if (s.inflight.frameId !== frameId) return;             // stale ACK for an already-resolved frame
+  const s = streamByFrameId(ctx.sessionId, frameId);      // search ALL the session's page streams
+  if (!s?.inflight || s.inflight.frameId !== frameId) return;  // not found, or stale/resolved
   clearTimeout(s.inflight.timer); ackCdp(s.inflight.cdpSessionId); s.inflight = null;
   if (s.newest) dispatch(s);
 });
@@ -321,6 +321,19 @@ request method. These invariants are the binding contract for the loop above:
 - **Multiple subscribers:** if more than one pane can subscribe to a session
   (e.g. desktop + browser tab), require an ACK from each, or document a
   single-subscriber-per-session assumption.
+- **Route ACKs by frameId across all page streams.** The ACK'd frame may belong
+  to a page that is no longer active (it was in flight during a tab switch), so
+  look the owning stream up by `frameId` across the session's pages — selecting
+  the active page would reject a valid ACK and leak its CDP slot until timeout.
+- **Monotonic frame sequence.** Each frame carries a monotonic `seq`; the pane
+  discards any decode/draw completion whose `seq` is older than the latest frame
+  it displayed, so a slow decode of an older frame cannot overwrite a newer one
+  within the same epoch (MessageHub does not serialize async event handlers, so
+  the epoch check alone cannot catch this).
+- **Reset held input state on interrupt.** On pane disconnect, blur, teardown, or
+  epoch change, release every held modifier and mouse button and clear the
+  per-client pressed-state set — otherwise a gesture interrupted between down and
+  up leaves Playwright (and the next action) with a stuck Ctrl/Shift/button.
 
 ### Data flow: human drives (or takes over)
 
@@ -549,6 +562,12 @@ Round-4 (transport invariants and distribution):
 - **Screencast loop invariants** — single service-level ACK handler routed by session + frameId; timers cancelled on resolve; teardown acks both inflight and newest; late subscribers get an activation snapshot; pane guards its channel; requests use the raw session id, events use the `session:<id>` channel string.
 - **Whole-gesture modifiers** — held across the full pointer gesture, not per mouse event.
 - **Chromium in CLI distributions** — bundle/first-run strategy extended to standalone CLI artifacts, not just the desktop release.
+
+Round-5 (P2 robustness):
+
+- **ACK routing by frameId** — across all the session's page streams, not the active page (handles in-flight frames during tab switches).
+- **Monotonic frame sequence** — pane discards stale decodes so a slow older frame can't overwrite a newer one within an epoch.
+- **Input-state reset on interrupt** — held modifiers/buttons released on disconnect/blur/teardown/epoch change.
 
 Still open:
 

--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -2,10 +2,11 @@
 
 > **Status:** Exploratory design. Not implemented. This document captures a
 > design discussion and a recommended approach; it does not describe shipped
-> behaviour. Revised twice after automated review (Codex) — the second pass
-> checked the design against HyperNeo's actual source (MessageHub transport,
-> `chrome-devtools-mcp` lifecycle, the Playwright dependency, the desktop
-> bundle) and corrected several API-level inaccuracies. See
+> behaviour. Revised three times after automated review (Codex). Round 2 checked
+> the design against HyperNeo's actual source (MessageHub transport,
+> `chrome-devtools-mcp` lifecycle, the Playwright dependency, the desktop bundle)
+> and corrected API-level inaccuracies; round 3 tightened the screencast ack
+> invariant, activation/epoch handling, log redaction, and pointer modifiers. See
 > [Open Questions](#open-questions).
 
 ## Goal
@@ -234,15 +235,22 @@ an **explicit client→daemon ACK**:
 
 ```ts
 // per page, on activation. Method is a STABLE string; scoping is the channel.
+// INVARIANT: every CDP frame received is acked exactly once — either after the
+// client ACKs the forwarded frame, or immediately when it is dropped (superseded,
+// ACK-timeout, or session teardown). Without this, leaked CDP flow-control slots
+// eventually stall frame delivery.
 const cdp = await page.context().newCDPSession(page);
 await cdp.send('Page.startScreencast', { format: 'jpeg', quality: 70, maxWidth: 1280, maxHeight: 800 });
 
 let inflight: { frameId: string; cdpSessionId: string } | null = null;
 let newest: { frame: Frame; cdpSessionId: string } | null = null;
 
+const ackCdp = (id: string) => cdp.send('Page.screencastFrameAck', { sessionId: id });
+
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
+  if (newest) ackCdp(newest.cdpSessionId);   // supersede: ack the queued frame we're about to drop
   newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch }, cdpSessionId: sessionId };
-  if (!inflight) dispatch();            // send only when nothing is in flight to the client
+  if (!inflight) dispatch();
 });
 
 function dispatch() {
@@ -250,16 +258,22 @@ function dispatch() {
   inflight = { frameId: newest.frame.frameId, cdpSessionId: newest.cdpSessionId };
   const f = newest.frame; newest = null;
   gateway.publish('browser.frame', f, sessionChannel);   // fire-and-forget; NO onConsumed exists
-  armAckTimeout(inflight.frameId);                       // resume if the ACK never comes
+  armAckTimeout(inflight.frameId, () => {                 // timeout: abandon + ack CDP, then resume
+    ackCdp(inflight!.cdpSessionId);
+    inflight = null;
+    if (newest) dispatch();
+  });
 }
 
-// Explicit ACK request — this is how the daemon learns the frame was consumed:
-hub.handle('browser.frameAck', ({ frameId }) => {
+hub.handle('browser.frameAck', ({ frameId }) => {         // explicit ACK: how the daemon learns consumption
   if (inflight?.frameId !== frameId) return;
-  cdp.send('Page.screencastFrameAck', { sessionId: inflight.cdpSessionId }); // ack CDP AFTER client ACK
+  ackCdp(inflight.cdpSessionId);
   inflight = null;
-  if (newest) dispatch();                                                   // drain newest pending
+  if (newest) dispatch();
 });
+
+// teardown / pane disconnect: ack whatever we're still holding, then drop it
+onSessionLeave(() => { if (inflight) { ackCdp(inflight.cdpSessionId); inflight = null; } });
 ```
 
 Frames flow daemon → WS → canvas at roughly 10–30 fps depending on quality/size.
@@ -274,12 +288,19 @@ unless the client tells it. The protocol:
 - Each frame carries a unique `frameId`. After the pane draws it, the pane sends
   a `browser.frameAck { frameId }` request. The daemon acks CDP
   (`Page.screencastFrameAck`) **only on receipt** — never on enqueue. This keeps
-  at most one frame in flight and drops stale intermediates.
+  at most one frame in flight to the client and drops stale intermediates.
+- **Ack every CDP frame exactly once (required).** `screencastFrameAck` is CDP's
+  only flow-control point, and Chromium emits frames into bounded slots — so
+  every received frame must be acked, including ones the daemon *drops*: a
+  superseded queued frame is acked when overwritten; the in-flight frame is
+  acked on ACK-timeout and on teardown/disconnect. The loop above enforces this
+  via `ackCdp(...)` on each of those paths. Missing any one leaks slots and
+  stalls delivery.
 - **Disconnect:** when the pane's socket closes (or leaves the session channel),
-  the daemon drops `inflight` and resumes dispatch, otherwise it would wait
-  forever for an ACK from a gone client.
-- **Timeout:** if no ACK arrives within N ms, drop `inflight` and resume, so a
-  dropped ACK cannot permanently stall the stream.
+  the daemon acks and drops `inflight` then resumes dispatch — otherwise it
+  would wait forever for an ACK from a gone client.
+- **Timeout:** if no ACK arrives within N ms, ack and drop `inflight` and resume,
+  so a dropped ACK cannot permanently stall the stream.
 - **Multiple subscribers:** if more than one pane can subscribe to a session
   (e.g. desktop + browser tab), require an ACK from each, or explicitly document
   a single-subscriber-per-session assumption. State this in the implementation.
@@ -312,12 +333,17 @@ above:
 | Client event | Playwright call |
 |---|---|
 | move | `page.mouse.move(cssX, cssY)` |
-| button down | `page.mouse.down({ button, modifiers })` |
-| button up | `page.mouse.up({ button, modifiers })` |
+| button down | `page.mouse.down({ button, clickCount })` |
+| button up | `page.mouse.up({ button, clickCount })` |
 | wheel | `page.mouse.wheel(deltaX, deltaY)` |
+| modifier hold (Ctrl/Shift/Alt/Meta) | `page.keyboard.down(modifier)` **before** the mouse action; `page.keyboard.up(modifier)` **after** |
 
 Compose click/drag from down→(move)→up at the client; the broker forwards each
-transition.
+transition. **Modifier state is held via synchronized `keyboard.down`/`up`
+around the mouse action** — Playwright's `mouse.down`/`mouse.up` do not accept a
+`modifiers` option; they inherit modifier state from preceding `keyboard.down`
+calls. (For precise control, dispatch raw CDP `Input.dispatchMouseEvent` with its
+modifier bitmask instead.)
 
 #### Keyboard-event protocol (required)
 
@@ -346,10 +372,18 @@ choosing this approach) the broker must:
   or suppress inactive streams so every tab does not encode).
 - **Tag every frame with `pageId` + `epoch`** (epoch increments on activation
   change). A tab switch cannot be made atomic merely by stopping the old
-  screencast and repointing input — a stale frame from the old tab may already
-  be in the WS pipeline and render after input has begun routing to the new page.
-  The pane discards frames and **disables input until it renders the first frame
-  of the new epoch**, which makes the render + input switch atomic.
+  screencast and repointing input — a stale old-epoch frame may already be in the
+  WS pipeline and arrive *before* the first new-epoch frame.
+- **Announce activation out-of-band, and stamp input with epoch (required).**
+  Because a frame is the wrong carrier for the *first* signal of a new epoch,
+  the daemon sends an explicit `browser.activated { pageId, epoch }` event the
+  instant it switches the active page — before any frame for the new page and
+  before it repoints input. The pane bumps its expected epoch on receipt and
+  disables input until it renders the first frame whose `epoch` matches.
+  Independently, every `browser.input` request carries the pane's currently
+  displayed `epoch`, and the daemon **rejects inputs whose epoch ≠ the active
+  epoch** — a belt-and-suspenders guard against the stale-frame race. Together
+  these make the render + input switch atomic.
 
 ### Agent observation (what the model sees)
 
@@ -394,6 +428,15 @@ does not. These must be handled by design, not by accident:
    keychain and an empty profile, so password managers will not fill. The human
    types the password, and it then lives in the Chromium's cookies/profile until
    the session's teardown policy clears it.
+6. **Redact browser traffic from MessageHub logs (required).** MessageHub logs
+   full inbound/outbound message objects at `LOG_LEVEL=debug`/`trace`
+   (`packages/shared/src/message-hub/message-hub.ts`). Routed naively,
+   `browser.input` would log passwords and IME text and `browser.frame` would
+   log authenticated page pixels as base64 — and excluding them from
+   rewind/persistence does **not** prevent that disclosure. Add method-specific
+   payload redaction or suppression for `browser.input` / `browser.frame`
+   (e.g. log only metadata, never the payload) before this traffic is routed
+   through MessageHub.
 
 ## Tradeoffs
 
@@ -434,7 +477,8 @@ All proposed, none present today:
 | `packages/daemon/package.json` | Add a pinned `playwright` runtime dependency |
 | `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — owns the daemon-lifetime shared Chromium, per-page CDP sessions, backpressure-gated frame loop keyed on `browser.frameAck`, epoch-tagged frames, input router, agent action primitives (MCP) |
 | Existing browser skills | Reimplemented on the service (replace) **or** reworked to attach to a persistent daemon broker (attach) — see [Shared browser bridge](#shared-browser-bridge). The naive attach to `chrome-devtools-mcp` does not survive a query boundary. |
-| MessageHub (new) | Method `browser.frame` (pub, session channel); request methods `browser.frameAck`, `browser.input`, `browser.action` (all session-scoped). No `onConsumed` — ACKs are explicit. |
+| MessageHub (new) | Method `browser.frame` (pub, session channel) + `browser.activated` (pub, epoch/page announcement); request methods `browser.frameAck`, `browser.input` (carrying displayed `epoch`), `browser.action` — all session-scoped. No `onConsumed` — ACKs are explicit. Every CDP frame acked exactly once. |
+| MessageHub logging | Method-specific redaction for `browser.input`/`browser.frame` so debug/trace logs never carry passwords, IME text, or authenticated page pixels |
 | Session lifecycle | Teardown hooks on archive/delete/hard-reset + daemon shutdown: close pages, CDP sessions, browser, listeners, credential-bearing profile; profile-retention policy |
 | `packages/web` (new component) | Preact `<BrowserPane sessionId>` — joins session channel, renders to `<canvas>`, sends `browser.frameAck`, maps pointer coords from frame metadata, forwards pointer + keyboard protocols, suppresses input across epoch changes |
 | `packages/desktop` (config/build only) | For the bundle path: add Chromium to `externalBin`/bundle + `build-sidecar.sh`; locate at runtime; release/signing. Rust webview code unchanged. |
@@ -466,6 +510,13 @@ Resolved in this revision (specified, not yet implemented):
 - **Keyboard protocol** — keydown/keyup/press/text mutually exclusive for printable keys; `insertText` for composition.
 - **Playwright runtime dependency** — add pinned dep to `packages/daemon`.
 - **Chromium packaging** — bundle (with desktop config/build changes) vs. first-run installer.
+
+Round-3 (mechanism correctness):
+
+- **CDP frame acking** — every received frame acked exactly once: forwarded frames on client ACK, dropped frames (superseded / ACK-timeout / teardown) immediately.
+- **Activation out-of-band + epoch on input** — `browser.activated {pageId, epoch}` event sent before repointing input; `browser.input` carries the displayed `epoch` and the daemon rejects mismatches, for an atomic tab switch.
+- **Log redaction** — `browser.input` / `browser.frame` payloads redacted in MessageHub debug/trace logs (passwords, IME text, authenticated pixels).
+- **Pointer modifiers** — held via synchronized `keyboard.down`/`up` (or CDP `Input.dispatchMouseEvent` bitmask), since Playwright `mouse.down`/`up` have no `modifiers` option.
 
 Still open:
 

--- a/docs/design/in-app-browser.md
+++ b/docs/design/in-app-browser.md
@@ -235,32 +235,35 @@ an **explicit client→daemon ACK**:
 
 ```ts
 // ILLUSTRATIVE — see "Screencast correctness rules" below for the binding contract.
-// State is keyed per (sessionId, pageId); MessageHub keeps ONE handler per request
-// method, so browser.frameAck is registered once at service startup and routed by
-// CallContext.sessionId + frameId (never re-registered per page).
+// State is keyed per (sessionId, pageId); EACH Stream owns its page's CDP client,
+// so an ACK always releases the ORIGINATING page's slot (a frame ACK'd after a
+// tab switch belongs to a now-inactive page). MessageHub keeps ONE handler per
+// request method, so browser.frameAck is registered once and routed by session +
+// frameId.
 const cdp = await page.context().newCDPSession(page);
-await cdp.send('Page.startScreencast', { format: 'jpeg', quality: 70, maxWidth: 1280, maxHeight: 800 });
 
 interface Stream {
+  cdp: typeof cdp;                                       // owning CDP client for THIS page
   inflight: { frameId: string; cdpSessionId: string; timer: Timer } | null;
   newest: { frame: Frame; cdpSessionId: string } | null;
 }
-const streams = new Map<string, Stream>();                 // key: `${sessionId}:${pageId}`
-const ackCdp = (id: string) => cdp.send('Page.screencastFrameAck', { sessionId: id });
+const streams = new Map<string, Stream>();               // key: `${sessionId}:${pageId}`
+const ackCdp = (s: Stream, id: string) => s.cdp.send('Page.screencastFrameAck', { sessionId: id });
 
+await cdp.send('Page.startScreencast', { format: 'jpeg', quality: 70, maxWidth: 1280, maxHeight: 800 });
 cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
   const s = streams.get(key)!;
-  if (s.newest) ackCdp(s.newest.cdpSessionId);            // supersede: ack + drop the queued frame
+  if (s.newest) ackCdp(s, s.newest.cdpSessionId);        // supersede: ack + drop the queued frame
   s.newest = { frame: { jpeg: data, metadata, frameId: randomUUID(), pageId, epoch, seq: nextSeq() }, cdpSessionId: sessionId };
   if (!s.inflight) dispatch(s);
 });
 
 function dispatch(s: Stream) {
   if (!s.newest) return;
-  const { frameId, cdpSessionId } = { frameId: s.newest.frame.frameId, cdpSessionId: s.newest.cdpSessionId };
+  const frameId = s.newest.frame.frameId, cdpSessionId = s.newest.cdpSessionId;
   const timer = setTimeout(() => {                        // captured by frameId; cleared on resolve
     if (s.inflight?.frameId !== frameId) return;          // already resolved by ACK/teardown
-    ackCdp(cdpSessionId); s.inflight = null; if (s.newest) dispatch(s);
+    ackCdp(s, cdpSessionId); s.inflight = null; if (s.newest) dispatch(s);
   }, ACK_TIMEOUT_MS);
   s.inflight = { frameId, cdpSessionId, timer };
   gateway.publish('browser.frame', s.newest.frame, sessionChannel);  // event: session:<id> channel
@@ -271,14 +274,14 @@ function dispatch(s: Stream) {
 hub.handle('browser.frameAck', ({ frameId }, ctx) => {
   const s = streamByFrameId(ctx.sessionId, frameId);      // search ALL the session's page streams
   if (!s?.inflight || s.inflight.frameId !== frameId) return;  // not found, or stale/resolved
-  clearTimeout(s.inflight.timer); ackCdp(s.inflight.cdpSessionId); s.inflight = null;
+  clearTimeout(s.inflight.timer); ackCdp(s, s.inflight.cdpSessionId); s.inflight = null;
   if (s.newest) dispatch(s);
 });
 
-// teardown / pane leave: ack BOTH retained frames, clear the timer, drop state
+// teardown / pane leave: ack BOTH retained frames on every stream, clear timers
 onSessionLeave(sid => { for (const s of streamsFor(sid)) {
-  if (s.inflight) { clearTimeout(s.inflight.timer); ackCdp(s.inflight.cdpSessionId); }
-  if (s.newest) ackCdp(s.newest.cdpSessionId);
+  if (s.inflight) { clearTimeout(s.inflight.timer); ackCdp(s, s.inflight.cdpSessionId); }
+  if (s.newest) ackCdp(s, s.newest.cdpSessionId);
   s.inflight = s.newest = null;
 }});
 ```
@@ -305,9 +308,11 @@ request method. These invariants are the binding contract for the loop above:
 - **Teardown acks both retained frames.** On pane leave / page close / session
   end, ack `inflight` (clearing its timer) **and** `newest`, then drop both.
 - **Late-subscriber activation snapshot.** `browser.activated` is fire-and-forget
-  and MessageHub does not replay it. When a pane registers or reconnects, the
-  daemon returns the current `{ pageId, epoch }` before streaming, so a pane
-  mounting after a switch knows the epoch it must match.
+  and MessageHub does not replay it, and `channel.join` returns only an ack — so
+  the pane must complete an explicit `browser.activationSnapshot` request on
+  mount/reconnect **before** consuming the stream, returning the current
+  `{ pageId, epoch }` (and the latest frame). A pane mounting after a switch then
+  knows the epoch it must match.
 - **Pane guards its channel.** A client may have joined several `session:*`
   channels and MessageHub dispatches by method name, so the pane's frame and
   activation handlers must explicitly require `context.channel === 'session:<sessionId>'`.
@@ -470,6 +475,14 @@ does not. These must be handled by design, not by accident:
    payload redaction or suppression for `browser.input` / `browser.frame`
    (e.g. log only metadata, never the payload) before this traffic is routed
    through MessageHub.
+7. **Secure the persistent broker's CDP endpoint (required for bridge option 2).**
+   A CDP endpoint grants complete control of the authenticated browser — cookies,
+   storage, screenshots, arbitrary page evaluation — and raw Chromium
+   remote-debugging has no application-level auth. Require a loopback-only (or
+   OS-permissioned) transport behind an authenticated broker/proxy; never bind it
+   broadly or log the endpoint. Any local process — or any network peer if it is
+   exposed beyond loopback — could otherwise attach alongside the MCP process and
+   steal the session.
 
 ## Tradeoffs
 
@@ -516,7 +529,7 @@ All proposed, none present today:
 | `packages/daemon/package.json` | Add a pinned `playwright` runtime dependency |
 | `packages/daemon/src/lib/browser/` (new) | `BrowserEngineService` — owns the daemon-lifetime shared Chromium, per-page CDP sessions, backpressure-gated frame loop keyed on `browser.frameAck`, epoch-tagged frames, input router, agent action primitives (MCP) |
 | Existing browser skills | Reimplemented on the service (replace) **or** reworked to attach to a persistent daemon broker (attach) — see [Shared browser bridge](#shared-browser-bridge). The naive attach to `chrome-devtools-mcp` does not survive a query boundary. |
-| MessageHub (new) | Method `browser.frame` (pub, session channel) + `browser.activated` (pub, epoch/page announcement); request methods `browser.frameAck`, `browser.input` (carrying displayed `epoch`), `browser.action` — all session-scoped. No `onConsumed` — ACKs are explicit. Every CDP frame acked exactly once. |
+| MessageHub (new) | Events: `browser.frame` + `browser.activated` (pub, `session:<id>` channel). Requests (raw session-id scope): `browser.activationSnapshot` (handshake on mount → `{ pageId, epoch }`), `browser.frameAck`, `browser.input` (carrying displayed `epoch`), `browser.action`. No `onConsumed` — ACKs explicit. |
 | MessageHub logging | Method-specific redaction for `browser.input`/`browser.frame` so debug/trace logs never carry passwords, IME text, or authenticated page pixels |
 | Session lifecycle | Teardown hooks on archive/delete/hard-reset + daemon shutdown: close pages, CDP sessions, browser, listeners, credential-bearing profile; profile-retention policy |
 | `packages/web` (new component) | Preact `<BrowserPane sessionId>` — joins session channel, renders to `<canvas>`, sends `browser.frameAck`, maps pointer coords from frame metadata, forwards pointer + keyboard protocols, suppresses input across epoch changes |
@@ -569,6 +582,13 @@ Round-5 (P2 robustness):
 - **Monotonic frame sequence** — pane discards stale decodes so a slow older frame can't overwrite a newer one within an epoch.
 - **Input-state reset on interrupt** — held modifiers/buttons released on disconnect/blur/teardown/epoch change.
 
+Round-6 (transport correctness + scope):
+
+- **Owning CDP client per stream** — each Stream stores its page's CDP session; ACKs route through it so a post-switch ACK releases the originating page's slot.
+- **Concrete activation handshake** — `browser.activationSnapshot` request completed on mount before streaming (`channel.join` returns only an ack).
+- **Secured CDP endpoint** — loopback-only + authenticated broker for the persistent-broker option.
+- **Persistent-profile rehydration** and **clipboard bridge** — logged as open questions (new scope).
+
 Still open:
 
 - **Bridge choice** — service-owned (replace) vs. persistent broker (attach). The central decision; drives how much existing skill code is rewritten.
@@ -577,3 +597,5 @@ Still open:
 - **Recording exclusion mechanism** — how sensitive-page frames and keystrokes are identified and excluded from rewind/persistence.
 - **Credential policy** — whether the agent may read authenticated sessions at all, or only for an explicit allowlist of origins.
 - **Chromium lifecycle host** — daemon-managed vs. (optionally) Tauri-shell-managed.
+- **Persistent-profile rehydration** — daemon-lifetime Chromium dies on restart/upgrade; define a stable per-session user-data dir with lazy reopen so authenticated state survives a daemon restart, plus restart-recovery and cleanup.
+- **Clipboard bridge** — copy/paste does not cross the remote-browser ↔ user-machine boundary (`page.keyboard` paste reads the daemon host's clipboard, not the user's). Define consent-aware copy/paste payloads between pane and broker, with the same sensitive-input log redaction.


### PR DESCRIPTION
Follow-up to #2433 (merged). Revises `docs/design/in-app-browser.md` to address all 7 Codex review comments.

**What changed**
- **P1 — Shared-browser bridge:** the pane must depict the browser the agent actually drives. Existing skills own isolated browsers and don't expose `Page`/CDP to the daemon, so the service must own the single shared Chromium (replace) or attach to a tool-exposed CDP endpoint (bridge). Added as the central prerequisite.
- **P1 — Backpressure:** screencast loop keeps at most one frame in flight and acks CDP only after the client reports consumption (was acking on enqueue).
- **P2 — Per-session frame channels:** `browser.frame:<sessionId>`; panes join one session so a session can't render another's authenticated pixels.
- **P2 — Tab/page lifecycle:** per-page CDP sessions; atomic switch of render + input on activation change.
- **P2 — Keyboard event protocol:** keydown/keyup/press/text/composition instead of only `type(text)`.
- **P2 — Pointer mapping:** derived from decoded frame dims + `screencastFrame` metadata + letterbox offset, not a naive viewport ratio.
- **P2 — Chromium packaging:** Playwright is a dev-only dependency today, so release builds need an explicit bundle or first-run-install strategy (not lazy download).

Docs only; still exploratory, not implemented. Requesting a re-review from Codex.