### PR TITLE
test: hash-split shard runner for directory-based test sharding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Validate online test matrix coverage
         run: bash scripts/validate-online-test-matrix.sh
 
+      - name: Validate daemon shard configuration
+        run: |
+          bash scripts/lib/shard-split.sh --self-test
+          ./scripts/test-daemon.sh --verify
+
       - name: Validate space task RPC handler tests
         run: bun run check:space-task-handler-tests
 

--- a/scripts/lib/shard-split.sh
+++ b/scripts/lib/shard-split.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# lib/shard-split.sh — Reusable directory-based test sharding by stable hash.
+#
+# Why this exists
+# ---------------
+# When a test directory outgrows a single shard, the usual fix is to split it
+# into several shards and *hand-list* which file goes where. Hand-lists rot:
+# every new test file must be added by name to the right list, and any file
+# someone forgets to list is silently dropped from CI (the daemon unit
+# 5-space/runtime split dropped 11 real test files for months before this).
+#
+# This file provides one reusable mechanism instead:
+#
+#     "directory = shard, and split an oversized directory into N sub-shards by
+#      a stable hash of the file path."
+#
+# A file's bucket is  stableHash(repoRootRelativePath) % N. Because the hash key
+# is the path relative to the repo root, the assignment is identical on every
+# developer machine and CI runner regardless of filesystem glob order, and —
+# critically — adding or removing a file only ever moves that one file. Every
+# existing file keeps its bucket, so re-running is stable and rebalancing is a
+# one-number edit (raise N to add a shard, lower it to merge). No file list is
+# ever maintained by hand.
+#
+# Portability
+# -----------
+# Written for bash 3.2 (macOS default /bin/bash): no associative arrays, no
+# globstar. The hash uses POSIX `cksum`, whose CRC algorithm is specified by
+# POSIX and identical across BSD (macOS) and GNU (Linux) — so the same path
+# hashes to the same integer everywhere.
+#
+# Dependencies: bash 3.2+, cksum (POSIX), awk, sort, cut, wc.
+#
+# Usage
+# -----
+#   source scripts/lib/shard-split.sh
+#
+#   # Print every file in bucket <bucket_index> (0-based, must be < split_count)
+#   # when a directory is split into <split_count> shards. <glob>... are bash
+#   # globs relative to any base; list one glob per directory level, e.g.
+#   #   dir/*.test.ts dir/sub/*.test.ts
+#   shard_split_bucket <repo_root> <split_count> <bucket_index> <glob>...
+#
+#   # Print the total number of files matched across all globs (for audits and
+#   # for choosing <split_count> when rebalancing).
+#   shard_split_count <repo_root> <glob>...
+#
+#   # Print "<bucket>\t<count>" for each bucket — a quick balance check.
+#   shard_split_report <repo_root> <split_count> <glob>...
+#
+# Output of shard_split_bucket is absolute, repo-root-prefixed paths
+# (e.g. /path/to/repo/packages/.../foo.test.ts), sorted by hash for stability,
+# ready to pass straight to vitest.
+#
+# Self-test (no args to source; run directly to test the mechanism):
+#   bash scripts/lib/shard-split.sh --self-test
+
+# Compute a stable, portable integer hash for a string. POSIX `cksum` prints
+# "<crc> <byte-count>"; we keep the crc. Same input → same integer everywhere.
+__shard_stable_hash() {
+	printf '%s' "$1" | cksum | awk '{print $1}'
+}
+
+# Internal: expand every glob, hash each matched file, and emit one line per file:
+#   "<10-digit-hash>\t<bucket>\t<repo-root-relative-path>"
+# Lines are sorted and de-duplicated. <bucket> is hash % split_count.
+__shard_emit() {
+	local repo_root="$1" split_count="$2"
+	shift 2
+	local globs=("$@")
+	local glob f rel hash
+
+	for glob in "${globs[@]}"; do
+		# Unquoted: let bash expand the glob. The `[ -f ]` guard below skips
+		# non-matches (a literal pattern left over when nothing matches) and
+		# directories, so no nullglob/shopt is needed — this keeps the helper
+		# free of shell-option side effects.
+		for f in $glob; do
+			[ -f "$f" ] || continue
+			# Hash the repo-root-relative path so the key is machine-independent.
+			rel="${f#"$repo_root"/}"
+			hash=$(__shard_stable_hash "$rel")
+			# Zero-pad the hash to 10 digits (cksum crc max is 4294967295) so
+			# the upcoming `sort` orders it numerically, not lexically.
+			printf '%010d\t%d\t%s\n' "$hash" "$((hash % split_count))" "$rel"
+		done
+	done
+}
+
+shard_split_bucket() {
+	local repo_root="$1" split_count="$2" bucket_index="$3"
+	shift 3
+
+	# Validate arguments explicitly — this routes CI test files, so a bad value
+	# should fail loudly rather than silently run an empty or wrong shard.
+	local int_re='^[0-9]+$'
+	[[ "$split_count" =~ $int_re ]] || { echo "shard_split_bucket: split_count must be a positive integer, got '$split_count'" >&2; return 2; }
+	[[ "$bucket_index" =~ $int_re ]] || { echo "shard_split_bucket: bucket_index must be a non-negative integer, got '$bucket_index'" >&2; return 2; }
+	[ "$split_count" -ge 1 ] || { echo "shard_split_bucket: split_count must be >= 1, got '$split_count'" >&2; return 2; }
+	[ "$bucket_index" -lt "$split_count" ] || { echo "shard_split_bucket: bucket_index $bucket_index out of range [0,$((split_count - 1))] for split_count $split_count" >&2; return 2; }
+	[ "$#" -ge 1 ] || { echo "shard_split_bucket: at least one glob is required" >&2; return 2; }
+
+	# sort -u dedupes files matched by overlapping globs and orders by hash.
+	# awk keeps only this bucket and re-prefixes the repo root for absolute paths.
+	__shard_emit "$repo_root" "$split_count" "$@" \
+		| sort -u \
+		| awk -F '\t' -v b="$bucket_index" -v root="$repo_root" '$2 == b { printf "%s/%s\n", root, $3 }'
+}
+
+shard_split_count() {
+	local repo_root="$1"
+	shift
+	[ "$#" -ge 1 ] || { echo "shard_split_count: at least one glob is required" >&2; return 2; }
+	# split_count=1 puts every file in bucket 0; counting lines = total matched.
+	__shard_emit "$repo_root" 1 "$@" | sort -u | wc -l | tr -d ' '
+}
+
+shard_split_report() {
+	local repo_root="$1" split_count="$2"
+	shift 2
+	[[ "$split_count" =~ ^[0-9]+$ ]] && [ "$split_count" -ge 1 ] || { echo "shard_split_report: split_count must be a positive integer, got '$split_count'" >&2; return 2; }
+	[ "$#" -ge 1 ] || { echo "shard_split_report: at least one glob is required" >&2; return 2; }
+	# Bucket column (field 2), tallied per bucket; emit 0 for empty buckets too.
+	__shard_emit "$repo_root" "$split_count" "$@" \
+		| sort -u \
+		| cut -f2 \
+		| sort -n \
+		| uniq -c \
+		| awk -v n="$split_count" 'BEGIN { for (i = 0; i < n; i++) c[i] = 0 } { c[$2] = $1 } END { for (i = 0; i < n; i++) printf "%d\t%d\n", i, c[i] }'
+}
+
+# ─── Self-test ──────────────────────────────────────────────────────────────
+# Run with: bash scripts/lib/shard-split.sh --self-test
+# Exits non-zero on any failure. Uses a temp fixture tree; cleans up on exit.
+__shard_self_test() {
+	local failures=0
+	pass() { printf '  ok   %s\n' "$1"; }
+	fail() { printf '  FAIL %s\n' "$1" >&2; failures=$((failures + 1)); }
+
+	# assert <pass-msg> <fail-msg> <test-command...>
+	# Wraps a condition so the pass/fail helpers are called via a real if/else
+	# (avoids the `[ A ] && pass || fail` anti-pattern, where a failing `pass`
+	# would wrongly trigger `fail`).
+	assert() {
+		local ok_msg="$1" bad_msg="$2"
+		shift 2
+		if "$@"; then pass "$ok_msg"; else fail "$bad_msg"; fi
+	}
+
+	# Portable temp dir (macOS mktemp wants a -t template; GNU does not).
+	local root
+	root=$(mktemp -d 2>/dev/null || mktemp -d -t shardselftest) || { echo "self-test: could not create temp dir" >&2; return 1; }
+	trap 'rm -rf "$root"' RETURN
+
+	# Fixture: mirror a monorepo layout so repo-root-relative paths are realistic.
+	mkdir -p "$root/packages/x/tests/runtime/sub"
+	local f
+	for f in alpha bravo charlie delta echo foxtrot golf hotel india juliett; do
+		printf 'describe(%s, () => {})\n' "$f" > "$root/packages/x/tests/runtime/$f.test.ts"
+	done
+	for f in kafka lima mike; do
+		printf 'describe(%s, () => {})\n' "$f" > "$root/packages/x/tests/runtime/sub/$f.test.ts"
+	done
+	# Literal glob patterns (fully quoted); the helpers expand them internally.
+	local glob1="$root/packages/x/tests/runtime/*.test.ts"
+	local glob2="$root/packages/x/tests/runtime/sub/*.test.ts"
+
+	# 1. count reports every matched file (10 top-level + 3 sub = 13).
+	local total
+	total=$(shard_split_count "$root" "$glob1" "$glob2")
+	assert "count covers all 13 files" "count=$total, expected 13" [ "$total" -eq 13 ]
+
+	# 2. union of all buckets == every file, with no duplicates and no gaps
+	#    (the core guarantee that defeats silent file-drop regressions).
+	local n=3 i=0 union union_unique bucket_files
+	union=""
+	while [ "$i" -lt "$n" ]; do
+		bucket_files=$(shard_split_bucket "$root" "$n" "$i" "$glob1" "$glob2")
+		union+="$bucket_files"$'\n'
+		i=$((i + 1))
+	done
+	union_unique=$(printf '%s' "$union" | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
+	assert "3-way union covers all 13 files exactly once" "union_unique=$union_unique, expected 13" [ "$union_unique" -eq 13 ]
+
+	# 3. report sums to the total and emits one line per bucket.
+	local report sum
+	report=$(shard_split_report "$root" "$n" "$glob1" "$glob2")
+	sum=$(printf '%s' "$report" | awk '{s+=$2} END{print s}')
+	# Count non-empty lines: $(...) strips the trailing newline, so a bare wc -l
+	# undercounts by one. grep -c . counts actual data rows.
+	local lines
+	lines=$(printf '%s\n' "$report" | grep -c .)
+	assert "report bucket counts sum to 13" "report sum=$sum, expected 13" [ "$sum" -eq 13 ]
+	assert "report emits one line per bucket ($n)" "report lines=$lines, expected $n" [ "$lines" -eq "$n" ]
+
+	# 4. determinism: the same bucket resolves identically across calls and the
+	#    hash itself is a stable non-negative 32-bit integer.
+	local h1 h2
+	h1=$(__shard_stable_hash "packages/x/tests/runtime/alpha.test.ts")
+	h2=$(__shard_stable_hash "packages/x/tests/runtime/alpha.test.ts")
+	assert "hash is deterministic across calls" "hash not deterministic ($h1 vs $h2)" [ "$h1" = "$h2" ]
+	if [[ "$h1" =~ ^[0-9]+$ ]] && [ "$h1" -ge 0 ] && [ "$h1" -le 4294967295 ]; then
+		pass "hash is a 32-bit integer"
+	else
+		fail "hash out of uint32 range: '$h1'"
+	fi
+	local b1 b2
+	b1=$(shard_split_bucket "$root" "$n" 0 "$glob1" "$glob2" | wc -l | tr -d ' ')
+	b2=$(shard_split_bucket "$root" "$n" 0 "$glob1" "$glob2" | wc -l | tr -d ' ')
+	assert "bucket resolution is deterministic" "bucket size differs across calls ($b1 vs $b2)" [ "$b1" = "$b2" ]
+
+	# 5. N=1 puts every file in bucket 0.
+	local one
+	one=$(shard_split_bucket "$root" 1 0 "$glob1" "$glob2" | wc -l | tr -d ' ')
+	assert "N=1 places all 13 files in bucket 0" "N=1 bucket0=$one, expected 13" [ "$one" -eq 13 ]
+
+	# 6. stability under addition: adding a new file never moves an existing
+	#    file's bucket (the hash-only assignment is order-independent). This is
+	#    the property that lets new files auto-route with no manual edit.
+	local before after moved
+	before=$(shard_split_bucket "$root" "$n" 1 "$glob1" "$glob2" | sed "s|^$root/||" | sort)
+	printf 'describe(november, () => {})\n' > "$root/packages/x/tests/runtime/november.test.ts"
+	after=$(shard_split_bucket "$root" "$n" 1 "$glob1" "$glob2" | sed "s|^$root/||" | sort)
+	# Existing files are those present before AND after; none may change presence.
+	moved=$(comm -23 <(printf '%s\n' "$before") <(printf '%s\n' "$after"))
+	assert "adding a file does not move existing files out of their bucket" "files dropped from bucket on add: $moved" [ -z "$moved" ]
+
+	# 7. argument validation rejects out-of-range buckets and non-integers.
+	if shard_split_bucket "$root" 2 2 "$glob1" >/dev/null 2>&1; then
+		fail "bucket_index == split_count should be rejected"
+	else
+		pass "bucket_index == split_count is rejected"
+	fi
+	if shard_split_bucket "$root" 0 0 "$glob1" >/dev/null 2>&1; then
+		fail "split_count=0 should be rejected"
+	else
+		pass "split_count=0 is rejected"
+	fi
+
+	echo ""
+	if [ "$failures" -eq 0 ]; then
+		echo "shard-split self-test: all checks passed"
+		return 0
+	fi
+	echo "shard-split self-test: $failures CHECK(S) FAILED" >&2
+	return 1
+}
+
+# When executed directly (not sourced) with --self-test, run the self-test.
+# BASH_SOURCE[0] == $0 only when the file is run, not sourced.
+if [[ "${1:-}" == "--self-test" && "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+	__shard_self_test
+	exit $?
+fi

--- a/scripts/test-daemon.sh
+++ b/scripts/test-daemon.sh
@@ -41,16 +41,20 @@ source "$REPO_ROOT/scripts/lib/shard-split.sh"
 # ── Hash-split shard configuration ──────────────────────────────────────────
 # Oversized directories are split into N buckets by stableHash(repo-root-relative
 # path) % N (see scripts/lib/shard-split.sh), so a new test file auto-routes to a
-# bucket with NO manual file list. Rebalance a directory by editing ONLY its
-# split count below.
+# bucket with NO manual file list. The file LIST is the only thing eliminated —
+# rebalancing is editing one number (the split count) plus adding/removing the
+# matching -a/-b/… shard entry, never editing individual files (see below).
 #
 # One line per split. Format:  <prefix>|<split_count>|<globs>
 #   <prefix>       public shard-name prefix; buckets are <prefix>-a, -b, -c, …
 #                  with the suffix letter mapping to a 0-based bucket index
 #                  (a→0, b→1, … up to z→25).
-#   <split_count>  N — THE one number to edit when rebalancing.
+#   <split_count>  N — the number to edit when rebalancing.
 #   <globs>        ';'-separated bash globs (relative to $TEST_ROOT) whose union
-#                  is the directory's complete test set.
+#                  is the directory's complete test set. Daemon vitest also runs
+#                  `*_test.ts`, so list that glob too wherever such files exist
+#                  (--verify's find cross-check covers both suffixes and will
+#                  flag a missing one).
 #
 # Changing N also means adding/removing the matching -a/-b/… entry in the SHARDS
 # list below and in the CI matrix at .github/workflows/main.yml — but a FILE LIST
@@ -65,6 +69,15 @@ shard_suffix_to_index() {
 	[ "${#s}" -eq 1 ] || return 1
 	case "$s" in [a-z]) ;; *) return 1 ;; esac
 	echo $(( $(printf '%d' "'$s") - 97 ))
+}
+
+# Inverse of shard_suffix_to_index: 0→a, 1→b, … (valid for 0..25). Used by
+# --verify to derive the expected shard name for a bucket index.
+shard_index_to_suffix() {
+	local i="$1"
+	local letters="abcdefghijklmnopqrstuvwxyz"
+	[[ "$i" =~ ^[0-9]+$ ]] && [ "$i" -ge 0 ] && [ "$i" -le 25 ] || return 1
+	printf '%s' "${letters:i:1}"
 }
 
 # Resolve a hash-split shard name (e.g. 5-space-runtime-a) to its bucket's files.
@@ -91,13 +104,21 @@ hash_split_resolve() {
 
 # Validate the shard configuration without running any tests:
 #   - every shard in SHARDS resolves to at least one existing file;
-#   - every hash-split's globs capture its directory tree exactly (an independent
-#     `find` count must match the hashed count — guards against a glob silently
-#     missing new files/subdirs) and buckets partition that set with no overlap;
-#   - per-bucket balance is reported for visibility.
+#   - each hash-split's split_count is consistent with SHARDS (every bucket
+#     -a/-b/… has a SHARDS entry, and none is stale) — catches a rebalance that
+#     bumps N without wiring in the new bucket, which would silently drop a
+#     whole bucket from CI;
+#   - each hash-split's globs capture its directory tree exactly. The cross-check
+#     uses an independent `find` over BOTH daemon test suffixes (*.test.ts and
+#     *_test.ts, matching vitest.config) so its net is strictly wider than the
+#     spec globs — a file the globs miss (new suffix, new subdir) shows up as
+#     find_count != total and fails --verify;
+#   - buckets partition that set with no overlap;
+#   - per-bucket balance is reported, and an empty bucket is warned about.
 # Exits non-zero on any error. Used by CI (see .github/workflows/main.yml).
 verify_shards() {
 	local errors=0
+	local warnings=0
 	local shard paths p
 
 	echo "Verifying daemon shard configuration..."
@@ -118,11 +139,51 @@ verify_shards() {
 		done
 	done
 
-	# 2. Each hash-split partitions its directory tree completely and evenly.
+	# 2. Each hash-split is internally consistent and covers its directory tree.
 	local spec prefix count globs
 	for spec in "${HASH_SPLIT_SPECS[@]}"; do
 		IFS='|' read -r prefix count globs <<<"$spec"
 
+		# 2a. split_count ↔ SHARDS consistency. Derive the expected bucket shard
+		# names (prefix-a … prefix-<letter(count-1)>) and require each to be in
+		# SHARDS, with no stray prefix-* entries. Otherwise bumping N silently
+		# drops a bucket from CI (the union check below is an identity and won't
+		# catch it). The CI-matrix half of the sync can't be checked from here.
+		local bi=0 expected=() suffix ename found
+		while [ "$bi" -lt "$count" ]; do
+			if suffix=$(shard_index_to_suffix "$bi"); then
+				expected+=("$prefix-$suffix")
+			else
+				echo "  ERROR: '$prefix' split_count=$count exceeds the a-z bucket range" >&2
+				errors=$((errors + 1))
+				break
+			fi
+			bi=$((bi + 1))
+		done
+		if [ "${#expected[@]}" -gt 0 ]; then
+			for ename in "${expected[@]}"; do
+				if ! printf '%s\n' "${SHARDS[@]}" | grep -qxF "$ename"; then
+					echo "  ERROR: '$ename' is missing from SHARDS (split_count=$count for '$prefix'). Add it + the CI matrix entry, or lower split_count." >&2
+					errors=$((errors + 1))
+				fi
+			done
+			for shard in "${SHARDS[@]}"; do
+				case "$shard" in
+					"$prefix"-*)
+						found=0
+						for ename in "${expected[@]}"; do [ "$ename" = "$shard" ] && found=1 && break; done
+						if [ "$found" -eq 0 ]; then
+							echo "  ERROR: SHARDS has '$shard' but split_count=$count for '$prefix'. Remove it or raise split_count." >&2
+							errors=$((errors + 1))
+						fi
+						;;
+				esac
+			done
+		fi
+
+		# 2b. Globs capture the directory tree. Expand globs and the directories
+		# they scope; the find cross-check enumerates BOTH daemon test suffixes so
+		# its net is wider than the spec globs.
 		local abs=() g dirs=()
 		local IFS=';'
 		for g in $globs; do
@@ -132,15 +193,16 @@ verify_shards() {
 
 		local total find_count
 		total=$(shard_split_count "$REPO_ROOT" "${abs[@]}")
-		# Independent enumeration: a glob that silently misses new files or a new
-		# subdir shows up here (find_count != total). -type f excludes the dirs.
-		find_count=$(find "${dirs[@]}" -type f -name '*.test.ts' | sort -u | wc -l | tr -d ' ')
+		# Independent enumeration over both *.test.ts and *_test.ts (vitest runs
+		# both); -type f excludes the directories themselves. A glob that misses
+		# a new file/suffix/subdir surfaces as find_count != total.
+		find_count=$(find "${dirs[@]}" -type f \( -name '*.test.ts' -o -name '*_test.ts' \) | sort -u | wc -l | tr -d ' ')
 		if [ "$find_count" -ne "$total" ]; then
-			echo "  ERROR: $prefix globs match $total file(s) but find reports $find_count — a glob is missing files" >&2
+			echo "  ERROR: '$prefix' globs match $total file(s) but find reports $find_count (both suffixes) — a glob is missing files (e.g. a *_test.ts)" >&2
 			errors=$((errors + 1))
 		fi
 
-		# Union of all buckets must equal the total (no file dropped, none doubled).
+		# 2c. Union of all buckets must equal the total (no file dropped/doubled).
 		local i=0 union=""
 		while [ "$i" -lt "$count" ]; do
 			union+=$(shard_split_bucket "$REPO_ROOT" "$count" "$i" "${abs[@]}")$'\n'
@@ -149,12 +211,20 @@ verify_shards() {
 		local union_unique
 		union_unique=$(printf '%s' "$union" | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
 		if [ "$union_unique" -ne "$total" ]; then
-			echo "  ERROR: $prefix buckets cover $union_unique/$total files (expected exact coverage)" >&2
+			echo "  ERROR: '$prefix' buckets cover $union_unique/$total files (expected exact coverage)" >&2
 			errors=$((errors + 1))
 		fi
 
+		# 2d. Report balance; warn on empty buckets (a CI shard would run nothing).
+		local rep zero z
+		rep=$(shard_split_report "$REPO_ROOT" "$count" "${abs[@]}")
 		printf '  %-18s %d-way split, %d files:\n' "$prefix" "$count" "$total"
-		shard_split_report "$REPO_ROOT" "$count" "${abs[@]}" | awk -F'\t' '{printf "      bucket %s: %s file(s)\n", $1, $2}'
+		printf '%s\n' "$rep" | awk -F'\t' '{printf "      bucket %s: %s file(s)\n", $1, $2}'
+		zero=$(printf '%s\n' "$rep" | awk -F'\t' '$2 == 0 {print $1}')
+		for z in $zero; do
+			echo "  WARNING: '$prefix' bucket $z resolved to 0 files — a CI shard would run nothing" >&2
+			warnings=$((warnings + 1))
+		done
 	done
 
 	if [ "$errors" -gt 0 ]; then
@@ -163,7 +233,11 @@ verify_shards() {
 		exit 1
 	fi
 	echo ""
-	echo "Shard configuration OK."
+	if [ "$warnings" -gt 0 ]; then
+		echo "Shard configuration OK with $warnings warning(s)."
+	else
+		echo "Shard configuration OK."
+	fi
 }
 
 # Split storage migration tests dynamically so new files are picked up without
@@ -390,7 +464,9 @@ for shard in "${RUN_SHARDS[@]}"; do
 	rm -f "$JUNIT_FILE" "$LOG_FILE"
 	TEST_PATHS=($(shard_paths "$shard"))
 	if [ "${#TEST_PATHS[@]}" -eq 0 ]; then
-		echo "Unknown daemon test shard: $shard" >&2
+		echo "Shard '$shard' resolved to 0 test files." >&2
+		echo "  (Unknown shard name, or a hash-split bucket that is empty.)" >&2
+		echo "  Known shards: ${SHARDS[*]}" >&2
 		exit 1
 	fi
 

--- a/scripts/test-daemon.sh
+++ b/scripts/test-daemon.sh
@@ -144,11 +144,11 @@ verify_shards() {
 	for spec in "${HASH_SPLIT_SPECS[@]}"; do
 		IFS='|' read -r prefix count globs <<<"$spec"
 
-		# 2a. split_count ↔ SHARDS consistency. Derive the expected bucket shard
-		# names (prefix-a … prefix-<letter(count-1)>) and require each to be in
-		# SHARDS, with no stray prefix-* entries. Otherwise bumping N silently
-		# drops a bucket from CI (the union check below is an identity and won't
-		# catch it). The CI-matrix half of the sync can't be checked from here.
+		# 2a. split_count ↔ SHARDS + CI-matrix consistency. Derive the expected
+		# bucket shard names (prefix-a … prefix-<letter(count-1)>) and require
+		# each to be in SHARDS AND in the CI matrix workflow file, with no stray
+		# prefix-* entries in SHARDS. Otherwise bumping N silently drops a bucket
+		# from CI (the union check below is an identity and won't catch it).
 		local bi=0 expected=() suffix ename found
 		while [ "$bi" -lt "$count" ]; do
 			if suffix=$(shard_index_to_suffix "$bi"); then
@@ -160,10 +160,19 @@ verify_shards() {
 			fi
 			bi=$((bi + 1))
 		done
+		local workflow="$REPO_ROOT/.github/workflows/main.yml"
 		if [ "${#expected[@]}" -gt 0 ]; then
 			for ename in "${expected[@]}"; do
 				if ! printf '%s\n' "${SHARDS[@]}" | grep -qxF "$ename"; then
 					echo "  ERROR: '$ename' is missing from SHARDS (split_count=$count for '$prefix'). Add it + the CI matrix entry, or lower split_count." >&2
+					errors=$((errors + 1))
+				fi
+				# Best-effort: every scheduled bucket must also be wired into the
+				# CI matrix. Greps the workflow file (a matrix entry is a literal
+				# shard name, never a substring of another), so a missing entry
+				# fails --verify instead of silently skipping a bucket in CI.
+				if [ -f "$workflow" ] && ! grep -qF "$ename" "$workflow"; then
+					echo "  ERROR: '$ename' is in SHARDS but missing from the CI matrix in .github/workflows/main.yml" >&2
 					errors=$((errors + 1))
 				fi
 			done

--- a/scripts/test-daemon.sh
+++ b/scripts/test-daemon.sh
@@ -161,18 +161,31 @@ verify_shards() {
 			bi=$((bi + 1))
 		done
 		local workflow="$REPO_ROOT/.github/workflows/main.yml"
+		# Parse the active shard matrix once: extract the `shard: [...]` flow
+		# sequence and normalize to one token per line. Membership is checked
+		# against THIS parsed list (grep -qxF per token), never by grepping the
+		# whole file — a commented-out matrix entry (`# 5-space-runtime-b`) must
+		# not satisfy the check, or CI silently drops the bucket.
+		local matrix_tokens=""
+		if [ -f "$workflow" ]; then
+			matrix_tokens=$(grep -E '^[[:space:]]*shard:[[:space:]]*\[' "$workflow" \
+				| head -n1 \
+				| sed -E 's/^[^[]*\[//; s/\].*$//' \
+				| tr ',' '\n' \
+				| sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+		fi
+		if [ -z "$matrix_tokens" ]; then
+			echo "  ERROR: could not parse a 'shard: [...]' matrix in $workflow -- --verify can't confirm CI wiring" >&2
+			errors=$((errors + 1))
+		fi
 		if [ "${#expected[@]}" -gt 0 ]; then
 			for ename in "${expected[@]}"; do
 				if ! printf '%s\n' "${SHARDS[@]}" | grep -qxF "$ename"; then
 					echo "  ERROR: '$ename' is missing from SHARDS (split_count=$count for '$prefix'). Add it + the CI matrix entry, or lower split_count." >&2
 					errors=$((errors + 1))
 				fi
-				# Best-effort: every scheduled bucket must also be wired into the
-				# CI matrix. Greps the workflow file (a matrix entry is a literal
-				# shard name, never a substring of another), so a missing entry
-				# fails --verify instead of silently skipping a bucket in CI.
-				if [ -f "$workflow" ] && ! grep -qF "$ename" "$workflow"; then
-					echo "  ERROR: '$ename' is in SHARDS but missing from the CI matrix in .github/workflows/main.yml" >&2
+				if [ -n "$matrix_tokens" ] && ! printf '%s\n' "$matrix_tokens" | grep -qxF "$ename"; then
+					echo "  ERROR: '$ename' is in SHARDS but missing from the active shard matrix in .github/workflows/main.yml" >&2
 					errors=$((errors + 1))
 				fi
 			done

--- a/scripts/test-daemon.sh
+++ b/scripts/test-daemon.sh
@@ -9,6 +9,7 @@
 #   ./scripts/test-daemon.sh 5-space-runtime-a # Run a single shard
 #   ./scripts/test-daemon.sh --rerun        # Rerun only previously failing files
 #   ./scripts/test-daemon.sh --show-failures # Show failure details from last run
+#   ./scripts/test-daemon.sh --verify       # Validate shard config without running tests
 
 set -uo pipefail
 
@@ -33,6 +34,138 @@ FAILURES_FILE="$RESULTS_DIR/failures.txt"
 PRELOAD="$REPO_ROOT/packages/daemon/tests/unit/setup.ts"
 TEST_ROOT="$REPO_ROOT/packages/daemon/tests/unit"
 
+# Reusable directory sharding by stable hash (no hand-listed file lists).
+# shellcheck disable=SC1091 # path is dynamic via $REPO_ROOT
+source "$REPO_ROOT/scripts/lib/shard-split.sh"
+
+# ── Hash-split shard configuration ──────────────────────────────────────────
+# Oversized directories are split into N buckets by stableHash(repo-root-relative
+# path) % N (see scripts/lib/shard-split.sh), so a new test file auto-routes to a
+# bucket with NO manual file list. Rebalance a directory by editing ONLY its
+# split count below.
+#
+# One line per split. Format:  <prefix>|<split_count>|<globs>
+#   <prefix>       public shard-name prefix; buckets are <prefix>-a, -b, -c, …
+#                  with the suffix letter mapping to a 0-based bucket index
+#                  (a→0, b→1, … up to z→25).
+#   <split_count>  N — THE one number to edit when rebalancing.
+#   <globs>        ';'-separated bash globs (relative to $TEST_ROOT) whose union
+#                  is the directory's complete test set.
+#
+# Changing N also means adding/removing the matching -a/-b/… entry in the SHARDS
+# list below and in the CI matrix at .github/workflows/main.yml — but a FILE LIST
+# is never edited by hand. Validate any change with: ./scripts/test-daemon.sh --verify
+HASH_SPLIT_SPECS=(
+	"5-space-runtime|2|5-space/runtime/*.test.ts;5-space/runtime/connectors/*.test.ts"
+)
+
+# Map a hash-split shard's suffix letter to a 0-based bucket index (a→0 … z→25).
+shard_suffix_to_index() {
+	local s="$1"
+	[ "${#s}" -eq 1 ] || return 1
+	case "$s" in [a-z]) ;; *) return 1 ;; esac
+	echo $(( $(printf '%d' "'$s") - 97 ))
+}
+
+# Resolve a hash-split shard name (e.g. 5-space-runtime-a) to its bucket's files.
+# Prints absolute test paths and returns 0 on a match, 1 if $1 is not a hash split.
+hash_split_resolve() {
+	local shard="$1"
+	local spec prefix count globs suffix bucket
+	for spec in "${HASH_SPLIT_SPECS[@]}"; do
+		IFS='|' read -r prefix count globs <<<"$spec"
+		case "$shard" in
+			"$prefix"-*)
+				suffix="${shard#"$prefix"-}"
+				bucket=$(shard_suffix_to_index "$suffix") || return 1
+				local abs=() g
+				local IFS=';'
+				for g in $globs; do abs+=("$TEST_ROOT/$g"); done
+				shard_split_bucket "$REPO_ROOT" "$count" "$bucket" "${abs[@]}"
+				return $?
+				;;
+		esac
+	done
+	return 1
+}
+
+# Validate the shard configuration without running any tests:
+#   - every shard in SHARDS resolves to at least one existing file;
+#   - every hash-split's globs capture its directory tree exactly (an independent
+#     `find` count must match the hashed count — guards against a glob silently
+#     missing new files/subdirs) and buckets partition that set with no overlap;
+#   - per-bucket balance is reported for visibility.
+# Exits non-zero on any error. Used by CI (see .github/workflows/main.yml).
+verify_shards() {
+	local errors=0
+	local shard paths p
+
+	echo "Verifying daemon shard configuration..."
+
+	# 1. Every declared shard resolves to at least one existing path.
+	for shard in "${SHARDS[@]}"; do
+		paths=($(shard_paths "$shard"))
+		if [ "${#paths[@]}" -eq 0 ]; then
+			echo "  ERROR: shard '$shard' resolved to 0 files" >&2
+			errors=$((errors + 1))
+			continue
+		fi
+		for p in "${paths[@]}"; do
+			if [ ! -e "$p" ]; then
+				echo "  ERROR: shard '$shard' references missing path: $p" >&2
+				errors=$((errors + 1))
+			fi
+		done
+	done
+
+	# 2. Each hash-split partitions its directory tree completely and evenly.
+	local spec prefix count globs
+	for spec in "${HASH_SPLIT_SPECS[@]}"; do
+		IFS='|' read -r prefix count globs <<<"$spec"
+
+		local abs=() g dirs=()
+		local IFS=';'
+		for g in $globs; do
+			abs+=("$TEST_ROOT/$g")
+			dirs+=("$TEST_ROOT/$(dirname "$g")")
+		done
+
+		local total find_count
+		total=$(shard_split_count "$REPO_ROOT" "${abs[@]}")
+		# Independent enumeration: a glob that silently misses new files or a new
+		# subdir shows up here (find_count != total). -type f excludes the dirs.
+		find_count=$(find "${dirs[@]}" -type f -name '*.test.ts' | sort -u | wc -l | tr -d ' ')
+		if [ "$find_count" -ne "$total" ]; then
+			echo "  ERROR: $prefix globs match $total file(s) but find reports $find_count — a glob is missing files" >&2
+			errors=$((errors + 1))
+		fi
+
+		# Union of all buckets must equal the total (no file dropped, none doubled).
+		local i=0 union=""
+		while [ "$i" -lt "$count" ]; do
+			union+=$(shard_split_bucket "$REPO_ROOT" "$count" "$i" "${abs[@]}")$'\n'
+			i=$((i + 1))
+		done
+		local union_unique
+		union_unique=$(printf '%s' "$union" | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
+		if [ "$union_unique" -ne "$total" ]; then
+			echo "  ERROR: $prefix buckets cover $union_unique/$total files (expected exact coverage)" >&2
+			errors=$((errors + 1))
+		fi
+
+		printf '  %-18s %d-way split, %d files:\n' "$prefix" "$count" "$total"
+		shard_split_report "$REPO_ROOT" "$count" "${abs[@]}" | awk -F'\t' '{printf "      bucket %s: %s file(s)\n", $1, $2}'
+	done
+
+	if [ "$errors" -gt 0 ]; then
+		echo ""
+		echo "FAILED: $errors shard configuration error(s)." >&2
+		exit 1
+	fi
+	echo ""
+	echo "Shard configuration OK."
+}
+
 # Split storage migration tests dynamically so new files are picked up without
 # editing this script. Bash glob order is deterministic.
 migration_shard_paths() {
@@ -56,6 +189,14 @@ migration_shard_paths() {
 
 # Map shard name to one or more test paths. Shards are balanced by CI wall time.
 shard_paths() {
+	# Hash-split shards (e.g. 5-space-runtime-a/b) are resolved dynamically by
+	# stable hash — no hand-listed files. See HASH_SPLIT_SPECS above.
+	local resolved
+	if resolved=$(hash_split_resolve "$1"); then
+		printf '%s\n' "$resolved"
+		return 0
+	fi
+
 	case "$1" in
 	0-shared-handlers-workflow)
 		# Under Vitest each test file is module-isolated, so the old "shared first"
@@ -89,49 +230,8 @@ shard_paths() {
 	5-space-agent-other)
 		printf '%s\n' "$TEST_ROOT/5-space"/*.test.ts "$TEST_ROOT/5-space/agent" "$TEST_ROOT/5-space/other"
 		;;
-	5-space-runtime-a)
-		printf '%s\n' \
-			"$TEST_ROOT/5-space/runtime/prompt-too-long-recovery.test.ts" \
-			"$TEST_ROOT/5-space/runtime/prompt-too-long-replay.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-worktree-manager.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-tick-loop.test.ts" \
-			"$TEST_ROOT/5-space/runtime/task-dependency-enforcement.test.ts" \
-			"$TEST_ROOT/5-space/runtime/last-message-classifier.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-stalled-recovery.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-edge-cases.test.ts" \
-			"$TEST_ROOT/5-space/runtime/task-draft-status.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-agent-task-creation-flow.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-agent-autonomy.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-llm-workflow-selection.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-disabled-workflow.test.ts" \
-			"$TEST_ROOT/5-space/runtime/reply-routing-registry.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-orphan-question.test.ts"
-		;;
-	5-space-runtime-b)
-		printf '%s\n' \
-			"$TEST_ROOT/5-space/runtime/space-agent-tools.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-external-events.test.ts" \
-			"$TEST_ROOT/5-space/runtime/github-subscription-pattern.test.ts" \
-			"$TEST_ROOT/5-space/runtime/long-horizon-subscription-pattern.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-event-driven-gate-evaluation.test.ts" \
-			"$TEST_ROOT/5-space/runtime/external-event-delivery-e2e.test.ts" \
-			"$TEST_ROOT/5-space/runtime/parse-pr-url.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-workflow.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-notifications.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-completion.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-rehydration.test.ts" \
-			"$TEST_ROOT/5-space/runtime/post-approval-router.test.ts" \
-			"$TEST_ROOT/5-space/runtime/post-approval-routing-integration.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-dispatch-post-approval.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-runtime-service.test.ts" \
-			"$TEST_ROOT/5-space/runtime/task-status-transitions.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-slug.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-chat-agent.test.ts" \
-			"$TEST_ROOT/5-space/runtime/space-mcp-session-policy.test.ts" \
-			"$TEST_ROOT/5-space/runtime/topic-trie.test.ts" \
-			"$TEST_ROOT/5-space/runtime/connectors"
-		;;
+	# 5-space-runtime-a/b are resolved by hash_split_resolve above (stable hash
+	# over the full 5-space/runtime tree, so no file is ever hand-listed or dropped).
 	*)
 		return 1
 		;;
@@ -142,6 +242,7 @@ shard_paths() {
 COVERAGE=false
 RERUN=false
 SHOW_FAILURES=false
+VERIFY=false
 TARGET_SHARD=""
 
 for arg in "$@"; do
@@ -149,9 +250,18 @@ for arg in "$@"; do
 	--coverage)       COVERAGE=true ;;
 	--rerun)          RERUN=true ;;
 	--show-failures)  SHOW_FAILURES=true ;;
+	--verify)         VERIFY=true ;;
 	*)                TARGET_SHARD="$arg" ;;
 	esac
 done
+
+# --- Verify shard configuration (no tests run) ---
+# Exits after validating that every shard resolves and every hash-split covers
+# its directory. Used by CI to guard against silent file-drop regressions.
+if [ "$VERIFY" = true ]; then
+	verify_shards
+	exit $?
+fi
 
 mkdir -p "$RESULTS_DIR"
 


### PR DESCRIPTION
Task #911. Adds a reusable directory-sharding helper (`scripts/lib/shard-split.sh`) that partitions a directory into N buckets by `stableHash(repo-relative-path) % N`, so new test files auto-route with no hand-listed file list and rebalancing is a one-number edit. Wires it into `scripts/test-daemon.sh` (documented `HASH_SPLIT_SPECS` config block + `--verify`) and gates the config in CI.

Proof of mechanism: converts the previously hand-listed `5-space-runtime-a/b` split. Those hand-lists had rotted and silently dropped 11 test files / 188 test cases (e.g. `workflow-hook-engine`, `space-runtime-terminal-error-recovery`) from daemon unit CI; the hash split now covers all 52 runtime files (612 + 1039 tests, 0 failures).