### PR TITLE
feat(shared): enforce per-client subscription cap (ingress fan-out guardrail) [#899]

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -511,6 +511,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     const router = new MessageHubRouter({
       logger: console,
       debug: config.nodeEnv === 'development',
+      // Ingress fan-out guardrail (task #899): per-client subscription cap,
+      // env-overridable via HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT (default 128).
+      maxSubscriptionsPerClient: config.maxSubscriptionsPerClient,
     });
 
     // 2. Initialize MessageHub (protocol layer)

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT } from '@hyperneo/shared';
 import { getDataDir } from './lib/data-dir';
 
 // Bun automatically loads .env files from the current working directory at startup
@@ -24,6 +25,13 @@ export interface Config {
   maxTokens: number;
   temperature: number;
   maxSessions: number;
+  /**
+   * Per-client real-time subscription cap (ingress fan-out guardrail, task #899).
+   * Overridable via HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT; defaults to
+   * DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT (128). Falls back to the default on
+   * invalid input so the cap fails closed rather than silently disabling.
+   */
+  maxSubscriptionsPerClient: number;
   nodeEnv: string;
   workspaceRoot?: string; // Optional default workspace root (from HYPERNEO_WORKSPACE_ROOT env)
   disableWorktrees?: boolean; // For testing - disables git worktree creation
@@ -47,6 +55,16 @@ function hyperneoEnv(name: string): string | undefined {
   return process.env[`HYPERNEO_${name}`];
 }
 
+/**
+ * Parse a positive-integer env override, returning `fallback` for missing or
+ * invalid input so guardrails fail closed (default) instead of going unset.
+ */
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export function getConfig(overrides?: ConfigOverrides): Config {
   const nodeEnv = process.env.NODE_ENV || 'development';
 
@@ -68,6 +86,10 @@ export function getConfig(overrides?: ConfigOverrides): Config {
     maxTokens: parseInt(process.env.MAX_TOKENS || '8192'),
     temperature: parseFloat(process.env.TEMPERATURE || '1.0'),
     maxSessions: parseInt(process.env.MAX_SESSIONS || '10'),
+    maxSubscriptionsPerClient: parsePositiveInt(
+      hyperneoEnv('MAX_SUBSCRIPTIONS_PER_CLIENT'),
+      DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT
+    ),
     nodeEnv,
     workspaceRoot: overrides?.workspaceRoot ?? hyperneoEnv('WORKSPACE_ROOT'),
     disableWorktrees: hyperneoEnv('DISABLE_WORKTREES') === '1',

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -58,11 +58,17 @@ function hyperneoEnv(name: string): string | undefined {
 /**
  * Parse a positive-integer env override, returning `fallback` for missing or
  * invalid input so guardrails fail closed (default) instead of going unset.
+ *
+ * Validates the COMPLETE value rather than just a numeric prefix: bare
+ * `parseInt` would accept `"1000000oops"` (→ 1000000, silently disabling a
+ * guardrail) and `"1e3"` (→ 1, breaking clients after one subscribe).
  */
 function parsePositiveInt(raw: string | undefined, fallback: number): number {
-  if (raw === undefined || raw === '') return fallback;
+  if (raw === undefined) return fallback;
+  // Require a pure digit string (no prefix, no exponent, no decimals, no sign).
+  if (!/^[0-9]+$/.test(raw.trim())) return fallback;
   const parsed = parseInt(raw, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+  return parsed > 0 ? parsed : fallback;
 }
 
 export function getConfig(overrides?: ConfigOverrides): Config {

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -3872,21 +3872,9 @@ export function setupLiveQueryHandlers(
       throw new Error('liveQuery.subscribe requires a WebSocket connection (clientId absent)');
     }
 
-    // 1b. Ingress fan-out guardrail: refuse BEFORE any work (no snapshot side
-    // effects, no teardown of existing subscriptions) when the client is at the
-    // per-client subscription cap.  Mirrors the structured MESSAGE_TOO_LARGE
-    // refusal pattern (#2423) so the client can react to the precise code.
-    // See task #899 / incident #2414.
+    // Router reference for the per-client subscription guardrail below and the
+    // handle tracking at the success path. See task #899 / incident #2414.
     const router = messageHub.getRouter();
-    if (router) {
-      const capacity = router.checkSubscriptionCapacity(clientId);
-      if (!capacity.ok) {
-        throw new MessageHubHandlerError(
-          `liveQuery.subscribe: subscription cap reached for client (${capacity.current}/${capacity.limit}); subscribe to fewer queries or close other views`,
-          ErrorCode.TOO_MANY_SUBSCRIPTIONS
-        );
-      }
-    }
 
     // 2. Resolve query from registry
     const namedQuery = activeRegistry.get(queryName);
@@ -4006,6 +3994,7 @@ export function setupLiveQueryHandlers(
 
     // 6. Handle subscriptionId collision — dispose existing handle silently
     const existing = clientSubs.get(subscriptionId);
+    const isReplacement = !!existing;
     if (existing) {
       log.debug(
         `liveQuery.subscribe: replacing subscription ${subscriptionId} for client ${clientId}`
@@ -4016,6 +4005,23 @@ export function setupLiveQueryHandlers(
       // re-acquires one at the success path below, so release the old here to
       // keep the router counter in sync with the live handle count.
       router?.releaseClientSubscription(clientId);
+    }
+
+    // 6b. Ingress fan-out guardrail: refuse a NEW subscription when the client
+    // is at the per-client cap. This runs AFTER collision handling so a
+    // replacement (same subscriptionId) is allowed even at the cap — it does
+    // not increase fan-out (e.g. GlobalStore reuses stable subscriptionIds on
+    // refresh) — and BEFORE the LiveQueryEngine subscribe so refusal has no
+    // snapshot side effects and tears down nothing. Mirrors the structured
+    // MESSAGE_TOO_LARGE refusal pattern (#2423). See task #899 / incident #2414.
+    if (router && !isReplacement) {
+      const capacity = router.checkSubscriptionCapacity(clientId);
+      if (!capacity.ok) {
+        throw new MessageHubHandlerError(
+          `liveQuery.subscribe: subscription cap reached for client (${capacity.current}/${capacity.limit}); subscribe to fewer queries or close other views`,
+          ErrorCode.TOO_MANY_SUBSCRIPTIONS
+        );
+      }
     }
 
     // 7. Subscribe to LiveQueryEngine

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -16,7 +16,13 @@ import type {
   LiveQueryUnsubscribeResponse,
   MessageHub,
 } from '@hyperneo/shared';
-import { createEventMessage, parseJson, parseJsonOptional } from '@hyperneo/shared';
+import {
+  createEventMessage,
+  ErrorCode,
+  MessageHubHandlerError,
+  parseJson,
+  parseJsonOptional,
+} from '@hyperneo/shared';
 import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
 import type { LiveQueryEngine, LiveQueryHandle, QueryDiff } from '../../storage/live-query';
 import type { TableChangeScope } from '../../storage/reactive-database';
@@ -3866,6 +3872,22 @@ export function setupLiveQueryHandlers(
       throw new Error('liveQuery.subscribe requires a WebSocket connection (clientId absent)');
     }
 
+    // 1b. Ingress fan-out guardrail: refuse BEFORE any work (no snapshot side
+    // effects, no teardown of existing subscriptions) when the client is at the
+    // per-client subscription cap.  Mirrors the structured MESSAGE_TOO_LARGE
+    // refusal pattern (#2423) so the client can react to the precise code.
+    // See task #899 / incident #2414.
+    const router = messageHub.getRouter();
+    if (router) {
+      const capacity = router.checkSubscriptionCapacity(clientId);
+      if (!capacity.ok) {
+        throw new MessageHubHandlerError(
+          `liveQuery.subscribe: subscription cap reached for client (${capacity.current}/${capacity.limit}); subscribe to fewer queries or close other views`,
+          ErrorCode.TOO_MANY_SUBSCRIPTIONS
+        );
+      }
+    }
+
     // 2. Resolve query from registry
     const namedQuery = activeRegistry.get(queryName);
     if (!namedQuery) {
@@ -3990,6 +4012,10 @@ export function setupLiveQueryHandlers(
       );
       existing.dispose();
       clientSubs.delete(subscriptionId);
+      // The replaced handle held a subscription slot; the new subscribe
+      // re-acquires one at the success path below, so release the old here to
+      // keep the router counter in sync with the live handle count.
+      router?.releaseClientSubscription(clientId);
     }
 
     // 7. Subscribe to LiveQueryEngine
@@ -4078,6 +4104,8 @@ export function setupLiveQueryHandlers(
             const subs = subscriptions.get(clientId);
             subs?.delete(subscriptionId);
             if (subs?.size === 0) subscriptions.delete(clientId);
+            // Tracked handle disposed mid-flight — release its slot.
+            router.releaseClientSubscription(clientId);
           }
           return;
         }
@@ -4099,6 +4127,8 @@ export function setupLiveQueryHandlers(
               subs.delete(subscriptionId);
               if (subs.size === 0) subscriptions.delete(clientId);
             }
+            // Tracked handle disposed mid-flight — release its slot.
+            router.releaseClientSubscription(clientId);
           }
         }
       },
@@ -4123,6 +4153,7 @@ export function setupLiveQueryHandlers(
     }
 
     // 8. Track the handle
+    router?.addClientSubscription(clientId);
     clientSubs.set(subscriptionId, handle);
     log.debug(
       `liveQuery.subscribe: registered subscription ${subscriptionId} for client ${clientId}, query=${queryName}`
@@ -4149,6 +4180,8 @@ export function setupLiveQueryHandlers(
       handle.dispose();
       clientSubs!.delete(subscriptionId);
       if (clientSubs!.size === 0) subscriptions.delete(clientId);
+      // Release the slot the now-disposed handle held.
+      messageHub.getRouter()?.releaseClientSubscription(clientId);
       log.debug(
         `liveQuery.unsubscribe: disposed subscription ${subscriptionId} for client ${clientId}`
       );

--- a/packages/daemon/tests/unit/1-core/core/config.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/config.test.ts
@@ -81,6 +81,18 @@ describe('getConfig', () => {
 
     process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '-5';
     expect(getConfig().maxSubscriptionsPerClient).toBe(128);
+
+    // Partial parses must NOT be accepted: a numeric prefix or scientific
+    // notation would otherwise misconfigure the cap (1000000 disables it; 1e3
+    // breaks clients after one subscribe).
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '1000000oops';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
+
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '1e3';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
+
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '12.5';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
   });
 
   test('HYPERNEO_PORT sets the port', () => {

--- a/packages/daemon/tests/unit/1-core/core/config.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/config.test.ts
@@ -30,6 +30,7 @@ describe('getConfig', () => {
     delete process.env.MAX_TOKENS;
     delete process.env.TEMPERATURE;
     delete process.env.MAX_SESSIONS;
+    delete process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT;
     process.env.NODE_ENV = 'production';
 
     const config = getConfig();
@@ -42,6 +43,8 @@ describe('getConfig', () => {
     expect(config.maxTokens).toBe(8192);
     expect(config.temperature).toBe(1.0);
     expect(config.maxSessions).toBe(10);
+    // Ingress fan-out guardrail default (task #899)
+    expect(config.maxSubscriptionsPerClient).toBe(128);
     expect(config.nodeEnv).toBe('production');
   });
 
@@ -53,6 +56,7 @@ describe('getConfig', () => {
     process.env.MAX_TOKENS = '4096';
     process.env.TEMPERATURE = '0.5';
     process.env.MAX_SESSIONS = '20';
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '256';
     process.env.NODE_ENV = 'production';
 
     const config = getConfig();
@@ -64,6 +68,19 @@ describe('getConfig', () => {
     expect(config.maxTokens).toBe(4096);
     expect(config.temperature).toBe(0.5);
     expect(config.maxSessions).toBe(20);
+    expect(config.maxSubscriptionsPerClient).toBe(256);
+  });
+
+  test('HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT fails closed to the default on invalid input', () => {
+    // A guardrail must not silently disable itself on bad input.
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = 'not-a-number';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
+
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '0';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
+
+    process.env.HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT = '-5';
+    expect(getConfig().maxSubscriptionsPerClient).toBe(128);
   });
 
   test('HYPERNEO_PORT sets the port', () => {

--- a/packages/daemon/tests/unit/1-core/lib/websocket-server-transport.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/websocket-server-transport.test.ts
@@ -6,7 +6,8 @@
 
 import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
 import { WebSocketServerTransport } from '../../../../src/lib/websocket-server-transport';
-import type { MessageHubRouter, ClientConnection, HubMessage } from '@hyperneo/shared';
+import { MessageHubRouter } from '@hyperneo/shared';
+import type { ClientConnection, HubMessage } from '@hyperneo/shared';
 
 describe('WebSocketServerTransport', () => {
   let transport: WebSocketServerTransport;
@@ -139,6 +140,36 @@ describe('WebSocketServerTransport', () => {
       transport.unregisterClient(clientId);
 
       expect(connectionHandler).toHaveBeenCalledWith('disconnected', undefined);
+    });
+
+    it('reconciles the real router subscription counter on disconnect (task #899)', async () => {
+      // End-to-end: the daemon live-query disconnect handler only disposes
+      // handles; it relies on the transport calling router.unregisterConnection
+      // to reset the per-client subscription counter. Prove that coupling holds
+      // against a real MessageHubRouter.
+      const realRouter = new MessageHubRouter();
+      const realTransport = new WebSocketServerTransport({
+        router: realRouter,
+        name: 'real-router-transport',
+        staleTimeout: 5000,
+        staleCheckInterval: 1000,
+      });
+      try {
+        const mockWs = createMockWebSocket();
+        const clientId = realTransport.registerClient(mockWs, 'test-session-123');
+
+        // Simulate a client holding several live-query subscriptions.
+        realRouter.addClientSubscription(clientId);
+        realRouter.addClientSubscription(clientId);
+        expect(realRouter.getClientSubscriptionCount(clientId)).toBe(2);
+
+        realTransport.unregisterClient(clientId);
+
+        // Counter reconciled to zero — no leaked slots after disconnect.
+        expect(realRouter.getClientSubscriptionCount(clientId)).toBe(0);
+      } finally {
+        await realTransport.close();
+      }
     });
   });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -126,6 +126,11 @@ function createMockHub() {
         });
         return { ok: true } as const;
       }),
+      // Ingress fan-out guardrail stubs (task #899): no cap in this suite.
+      checkSubscriptionCapacity: mock(() => ({ ok: true })),
+      addClientSubscription: mock(() => {}),
+      releaseClientSubscription: mock(() => {}),
+      getClientSubscriptionCount: mock(() => 0),
     })),
     onClientDisconnect: mock(() => () => {}),
   } as unknown as MessageHub;

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { MessageHub } from '@hyperneo/shared';
+import { ErrorCode, MessageHubHandlerError } from '@hyperneo/shared';
 import { setupLiveQueryHandlers } from '../../../../src/lib/rpc-handlers/live-query-handlers';
 import { LiveQueryEngine } from '../../../../src/storage/live-query';
 import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
@@ -39,7 +40,7 @@ interface SentMessage {
   };
 }
 
-function createMockSetup() {
+function createMockSetup(opts: { subscriptionCap?: number } = {}) {
   const handlers = new Map<string, RequestHandler>();
   let disconnectHandler: ((clientId: string) => void) | null = null;
   const sentMessages: SentMessage[] = [];
@@ -47,6 +48,11 @@ function createMockSetup() {
     | { ok: true }
     | { ok: false; reason: 'send_failed' | 'message_too_large' } = { ok: true };
   let routerEnabled = true;
+
+  // Functional per-client subscription counter mirroring MessageHubRouter, so
+  // the over-cap refusal path can be exercised (default: no limit).
+  const subscriptionCap = opts.subscriptionCap ?? Number.POSITIVE_INFINITY;
+  const subscriptionCounts = new Map<string, number>();
 
   const mockRouter = {
     sendToClient: mock((clientId: string, message: unknown) => {
@@ -57,6 +63,23 @@ function createMockSetup() {
       sentMessages.push({ clientId, message: message as SentMessage['message'] });
       return sendToClientResult;
     }),
+    checkSubscriptionCapacity: mock((clientId: string) => {
+      const current = subscriptionCounts.get(clientId) ?? 0;
+      if (current >= subscriptionCap) {
+        return { ok: false, reason: 'too_many_subscriptions', limit: subscriptionCap, current };
+      }
+      return { ok: true };
+    }),
+    addClientSubscription: mock((clientId: string) => {
+      subscriptionCounts.set(clientId, (subscriptionCounts.get(clientId) ?? 0) + 1);
+    }),
+    releaseClientSubscription: mock((clientId: string) => {
+      const current = subscriptionCounts.get(clientId);
+      if (current === undefined) return;
+      if (current <= 1) subscriptionCounts.delete(clientId);
+      else subscriptionCounts.set(clientId, current - 1);
+    }),
+    getClientSubscriptionCount: mock((clientId: string) => subscriptionCounts.get(clientId) ?? 0),
   };
 
   const hub = {
@@ -574,5 +597,116 @@ describe('setupLiveQueryHandlers', () => {
       expect(v).toBeGreaterThanOrEqual(prevVersion);
       prevVersion = v;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ingress fan-out guardrail: per-client subscription cap (task #899 / #2414).
+// An unbounded-subscribe page must fail fast with a structured
+// TOO_MANY_SUBSCRIPTIONS error instead of silently accumulating handlers.
+// ---------------------------------------------------------------------------
+describe('setupLiveQueryHandlers: per-client subscription cap', () => {
+  let db: BunDatabase;
+  let reactiveDb: ReactiveDatabase;
+  let engine: LiveQueryEngine;
+  let setup: ReturnType<typeof createMockSetup>;
+
+  beforeEach(() => {
+    db = createDb();
+    reactiveDb = createReactiveDatabase({ getDatabase: () => db } as never);
+    engine = new LiveQueryEngine(db, reactiveDb);
+    setup = createMockSetup({ subscriptionCap: 2 });
+    setupLiveQueryHandlers(setup.hub, engine, db);
+    insertMcpServer(db, 'mcp-1', 'alpha');
+  });
+
+  afterEach(() => {
+    engine.dispose();
+    db.close();
+  });
+
+  test('refuses the over-cap subscribe with a structured TOO_MANY_SUBSCRIPTIONS error', async () => {
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-2',
+    });
+
+    // The third subscribe is refused — fail fast at the boundary, before any
+    // snapshot/handler work, mirroring the #2423 MESSAGE_TOO_LARGE pattern.
+    const err = await setup
+      .callHandler('liveQuery.subscribe', {
+        queryName: 'mcpServers.global',
+        params: [],
+        subscriptionId: 'sub-3',
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MessageHubHandlerError);
+    expect((err as MessageHubHandlerError).code).toBe(ErrorCode.TOO_MANY_SUBSCRIPTIONS);
+  });
+
+  test('prior subscriptions remain intact after an over-cap refusal (graceful, no teardown)', async () => {
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-2',
+    });
+
+    // Refuse sub-3; this must not evict sub-1 or sub-2.
+    await expect(
+      setup.callHandler('liveQuery.subscribe', {
+        queryName: 'mcpServers.global',
+        params: [],
+        subscriptionId: 'sub-3',
+      })
+    ).rejects.toThrow();
+
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
+
+    // The surviving subscriptions still receive deltas.
+    setup.sentMessages.length = 0;
+    insertMcpServer(db, 'mcp-2', 'beta');
+    reactiveDb.notifyChange('app_mcp_servers');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const deltas = setup.sentMessages.filter((m) => m.message.method === 'liveQuery.delta');
+    expect(deltas.length).toBe(2);
+  });
+
+  test('unsubscribe frees a slot so a new subscribe succeeds again', async () => {
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-2',
+    });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
+
+    await setup.callHandler('liveQuery.unsubscribe', { subscriptionId: 'sub-1' });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(1);
+
+    // A new subscribe reclaims the freed slot.
+    const result = await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-3',
+    });
+    expect(result).toEqual({ ok: true });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
@@ -709,4 +709,93 @@ describe('setupLiveQueryHandlers: per-client subscription cap', () => {
     expect(result).toEqual({ ok: true });
     expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
   });
+
+  test('replacement of an existing subscriptionId is allowed at the cap (no fan-out increase)', async () => {
+    // Fill to the cap.
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-2',
+    });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
+
+    // Re-subscribing an existing id is a replacement (net-zero fan-out) and must
+    // succeed even at the cap — e.g. GlobalStore reuses stable subscriptionIds
+    // on refresh. The old slot is released, the new one acquired.
+    const replaced = await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    expect(replaced).toEqual({ ok: true });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
+
+    // A genuinely-new id is still refused at the cap.
+    const err = await setup
+      .callHandler('liveQuery.subscribe', {
+        queryName: 'mcpServers.global',
+        params: [],
+        subscriptionId: 'sub-new',
+      })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MessageHubHandlerError);
+    expect((err as MessageHubHandlerError).code).toBe(ErrorCode.TOO_MANY_SUBSCRIPTIONS);
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(2);
+  });
+
+  test('a snapshot-delivery failure aborts without consuming a subscription slot', async () => {
+    // Force the synchronous snapshot delivery to fail (e.g. client vanished).
+    setup.setDetailedSendResult({ ok: false, reason: 'send_failed' });
+
+    const result = await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+
+    // The handler returns ok (not a protocol error from the client's view) but
+    // must NOT have tracked the subscription — the slot is freed for reuse.
+    expect(result).toEqual({ ok: true });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(0);
+  });
+
+  test('a delta message_too_large failure releases the tracked slot (async release path)', async () => {
+    // Snapshot succeeds so the subscription is tracked (count = 1).
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(1);
+
+    // Make the next delivery (the delta) too large, then mutate to fire a delta.
+    setup.setDetailedSendResult({ ok: false, reason: 'message_too_large' });
+    insertMcpServer(db, 'mcp-2', 'beta');
+    reactiveDb.notifyChange('app_mcp_servers');
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The failed delta disposes the tracked handle and releases its slot.
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(0);
+  });
+
+  test('a delta send_failed failure releases the tracked slot (async release path)', async () => {
+    await setup.callHandler('liveQuery.subscribe', {
+      queryName: 'mcpServers.global',
+      params: [],
+      subscriptionId: 'sub-1',
+    });
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(1);
+
+    setup.setDetailedSendResult({ ok: false, reason: 'send_failed' });
+    insertMcpServer(db, 'mcp-3', 'gamma');
+    reactiveDb.notifyChange('app_mcp_servers');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(setup.mockRouter.getClientSubscriptionCount('client-1')).toBe(0);
+  });
 });

--- a/packages/shared/src/message-hub/message-hub.ts
+++ b/packages/shared/src/message-hub/message-hub.ts
@@ -58,6 +58,23 @@ export class MessageHubResponseError extends Error {
 }
 
 /**
+ * Error a request handler can throw to produce a STRUCTURED error response
+ * carrying a specific {@link ErrorCode}. Without this, the hub maps every
+ * handler throw to `HANDLER_ERROR`; wrapping the cause here lets the original
+ * code (e.g. `TOO_MANY_SUBSCRIPTIONS`) reach the client so it can react
+ * precisely — mirroring the structured `MESSAGE_TOO_LARGE` refusal pattern.
+ */
+export class MessageHubHandlerError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string
+  ) {
+    super(message);
+    this.name = 'MessageHubHandlerError';
+  }
+}
+
+/**
  * MessageHub class
  * Core implementation of unified messaging system
  *
@@ -569,11 +586,18 @@ export class MessageHub {
       resultMsg._transportName = message._transportName;
       await this.sendResponseToClient(resultMsg, clientId);
     } catch (error) {
+      // Preserve a structured code thrown via MessageHubHandlerError so callers
+      // can fail fast with a precise ErrorCode (e.g. TOO_MANY_SUBSCRIPTIONS);
+      // plain throws still map to HANDLER_ERROR as before.
+      const code =
+        error instanceof MessageHubHandlerError && error.code
+          ? error.code
+          : ErrorCode.HANDLER_ERROR;
       const errorMsg = createErrorResponseMessage({
         method: message.method,
         error: {
           message: error instanceof Error ? error.message : String(error),
-          code: ErrorCode.HANDLER_ERROR,
+          code,
         },
         sessionId: message.sessionId,
         requestId: message.id,

--- a/packages/shared/src/message-hub/protocol.ts
+++ b/packages/shared/src/message-hub/protocol.ts
@@ -240,6 +240,9 @@ export enum ErrorCode {
   NOT_CONNECTED = 'NOT_CONNECTED',
   MESSAGE_TOO_LARGE = 'MESSAGE_TOO_LARGE',
 
+  // Ingress fan-out guardrail: per-client subscription limit exceeded
+  TOO_MANY_SUBSCRIPTIONS = 'TOO_MANY_SUBSCRIPTIONS',
+
   // General errors
   INTERNAL_ERROR = 'INTERNAL_ERROR',
   UNAUTHORIZED = 'UNAUTHORIZED',

--- a/packages/shared/src/message-hub/router.ts
+++ b/packages/shared/src/message-hub/router.ts
@@ -55,9 +55,28 @@ export interface MessageHubRouterOptions {
   debug?: boolean;
   /** Maximum UTF-8 bytes allowed for one outbound wire message. */
   maxMessageSize?: number;
+  /**
+   * Maximum concurrent real-time subscriptions (e.g. live queries) a single
+   * client may hold. Enforced router-side as an ingress fan-out guardrail: a
+   * client that tries to subscribe beyond the cap is refused with a structured
+   * `TOO_MANY_SUBSCRIPTIONS` error instead of silently accumulating handlers
+   * and stalling (see task #899 / incident #2414).
+   *
+   * Tuned below observed fan-out (790 subscribes on one task page) so real
+   * regressions trip loudly in dev, while leaving headroom for a busy tab.
+   * @default 128
+   */
+  maxSubscriptionsPerClient?: number;
 }
 
 export const DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE = 40 * 1024 * 1024;
+
+/**
+ * Default per-client subscription cap. ~6x below the 790-subscribe task-page
+ * fan-out that motivated this guardrail (#2414), with headroom for a tab that
+ * loads many sessions. Override via {@link MessageHubRouterOptions.maxSubscriptionsPerClient}.
+ */
+export const DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT = 128;
 
 export type SendToClientResult =
   | { ok: true }
@@ -65,6 +84,19 @@ export type SendToClientResult =
       ok: false;
       reason: 'unavailable' | 'serialization_failed' | 'message_too_large' | 'send_failed';
     };
+
+/**
+ * Result of a per-client subscription capacity check.
+ *
+ * `checkSubscriptionCapacity` is read-only: it never mutates the counter, so a
+ * caller that decides not to track the subscription does not need to release.
+ * Callers must pair a passing check with {@link MessageHubRouter.addClientSubscription}
+ * once the subscription is actually tracked, and {@link MessageHubRouter.releaseClientSubscription}
+ * when it is disposed.
+ */
+export type SubscriptionCapacityResult =
+  | { ok: true }
+  | { ok: false; reason: 'too_many_subscriptions'; limit: number; current: number };
 
 /**
  * Client information
@@ -98,14 +130,25 @@ export class MessageHubRouter {
   private clients: Map<string, ClientInfo> = new Map(); // Now keyed by clientId
   private channelManager: ChannelManager = new ChannelManager();
 
+  /**
+   * Per-client active subscription counts (ingress fan-out guardrail).
+   * Mirrors the daemon's live-query handle map; maintained by callers via
+   * {@link addClientSubscription} / {@link releaseClientSubscription} and reset on
+   * disconnect via {@link unregisterConnection}.
+   */
+  private clientSubscriptionCounts: Map<string, number> = new Map();
+
   private logger: RouterLogger;
   private debug: boolean;
   private readonly maxMessageSize: number;
+  private readonly maxSubscriptionsPerClient: number;
 
   constructor(options: MessageHubRouterOptions = {}) {
     this.logger = options.logger || console;
     this.debug = options.debug || false;
     this.maxMessageSize = options.maxMessageSize ?? DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE;
+    this.maxSubscriptionsPerClient =
+      options.maxSubscriptionsPerClient ?? DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT;
   }
 
   private byteLength(value: string): number {
@@ -207,6 +250,10 @@ export class MessageHubRouter {
 
     // Clean up channel membership
     this.channelManager.removeClient(clientId);
+
+    // Reset the subscription counter: the daemon disposes the client's handles
+    // on disconnect, so any per-handle release that was missed is reconciled here.
+    this.clientSubscriptionCounts.delete(clientId);
 
     this.clients.delete(clientId);
     this.log(`Client unregistered: ${info.clientId}`);
@@ -350,6 +397,66 @@ export class MessageHubRouter {
    */
   getClientIds(): string[] {
     return Array.from(this.clients.keys());
+  }
+
+  // -------------------------------------------------------------------------
+  // Per-client subscription guardrail (ingress fan-out cap)
+  // See task #899 / incident #2414: without this, opening a high-fan-out page
+  // silently accumulated one handler per subscription and stalled the client.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Read-only capacity check. Returns `{ ok: false }` when the client is at the
+   * cap, so the caller can refuse the subscribe with a structured
+   * `TOO_MANY_SUBSCRIPTIONS` error BEFORE doing any work (no snapshot side
+   * effects, no teardown of existing subscriptions). Does NOT mutate state.
+   */
+  checkSubscriptionCapacity(clientId: string): SubscriptionCapacityResult {
+    const current = this.clientSubscriptionCounts.get(clientId) ?? 0;
+    if (current >= this.maxSubscriptionsPerClient) {
+      this.logger.warn(
+        `[MessageHubRouter] Subscription cap exceeded for client ${clientId}: ` +
+          `${current}/${this.maxSubscriptionsPerClient} active; refusing further subscribes`
+      );
+      return {
+        ok: false,
+        reason: 'too_many_subscriptions',
+        limit: this.maxSubscriptionsPerClient,
+        current,
+      };
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Record one active subscription for a client. Call exactly once when the
+   * subscription is actually tracked (after a passing {@link checkSubscriptionCapacity}).
+   */
+  addClientSubscription(clientId: string): void {
+    const next = (this.clientSubscriptionCounts.get(clientId) ?? 0) + 1;
+    this.clientSubscriptionCounts.set(clientId, next);
+  }
+
+  /**
+   * Release one subscription slot for a client. Floors at zero so a stray
+   * release (e.g. a handle disposed before it was tracked) cannot drive the
+   * count negative and silently widen the cap.
+   */
+  releaseClientSubscription(clientId: string): void {
+    const current = this.clientSubscriptionCounts.get(clientId);
+    if (current === undefined) return;
+    if (current <= 1) {
+      this.clientSubscriptionCounts.delete(clientId);
+    } else {
+      this.clientSubscriptionCounts.set(clientId, current - 1);
+    }
+  }
+
+  /**
+   * Current active subscription count for a client (0 if none tracked).
+   */
+  getClientSubscriptionCount(clientId: string): number {
+    return this.clientSubscriptionCounts.get(clientId) ?? 0;
   }
 
   /**

--- a/packages/shared/src/message-hub/types.ts
+++ b/packages/shared/src/message-hub/types.ts
@@ -209,12 +209,6 @@ export interface MessageHubOptions {
   cacheTTL?: number;
 
   /**
-   * Maximum subscriptions per client (router-side)
-   * @default 1000
-   */
-  maxSubscriptionsPerClient?: number;
-
-  /**
    * Maximum event handler nesting depth (prevents infinite recursion)
    * @default 10
    */

--- a/packages/shared/tests/message-hub-subscription-cap.test.ts
+++ b/packages/shared/tests/message-hub-subscription-cap.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { ErrorCode, MessageType, createRequestMessage } from '../src/message-hub/protocol';
+import {
+  DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT,
+  type ClientConnection,
+  MessageHubRouter,
+  type RouterLogger,
+} from '../src/message-hub/router';
+import { MessageHub, MessageHubHandlerError } from '../src/message-hub/message-hub';
+import type { ConnectionState, HubMessage, IMessageTransport } from '../src/message-hub/types';
+import { generateUUID } from '../src/utils';
+
+/**
+ * Ingress fan-out guardrail: per-client subscription cap (task #899 / incident #2414).
+ *
+ * Before this guardrail, `maxSubscriptionsPerClient` was declared but never
+ * enforced, so a high-fan-out page silently accumulated one handler per
+ * subscribe (790 on one task page) and stalled the client past the 10s RPC
+ * timeout. These tests characterize the now-enforced behavior: over-cap
+ * subscribes fail fast with a structured error, existing subscriptions are
+ * preserved, and dev mode warns loudly.
+ */
+
+// Minimal mock connection (matches the pattern in message-hub-router.test.ts)
+function createMockConnection(id?: string): ClientConnection {
+  return {
+    id: id || generateUUID(),
+    send: () => {},
+    isOpen: () => true,
+  };
+}
+
+/** Logger that records warn calls so tests can assert the dev-mode warning. */
+function createRecordingLogger(): RouterLogger & { warns: string[] } {
+  const warns: string[] = [];
+  return {
+    warns,
+    log: () => {},
+    warn: (msg: string) => warns.push(msg),
+    error: () => {},
+  };
+}
+
+describe('MessageHubRouter subscription cap (ingress fan-out guardrail)', () => {
+  describe('default', () => {
+    test('is tuned below the observed 790-subscribe task-page fan-out (#2414)', () => {
+      // A guardrail default that sits above the incident would not trip on the
+      // regression it exists to catch.
+      expect(DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT).toBeLessThan(790);
+      expect(DEFAULT_MAX_SUBSCRIPTIONS_PER_CLIENT).toBe(128);
+    });
+  });
+
+  describe('checkSubscriptionCapacity', () => {
+    let router: MessageHubRouter;
+    let logger: ReturnType<typeof createRecordingLogger>;
+    const CAP = 4;
+
+    beforeEach(() => {
+      logger = createRecordingLogger();
+      router = new MessageHubRouter({ logger, maxSubscriptionsPerClient: CAP });
+      router.registerConnection(createMockConnection('client-A'));
+    });
+
+    test('allows up to the cap, then refuses the next with a structured result', () => {
+      for (let i = 0; i < CAP; i++) {
+        const check = router.checkSubscriptionCapacity('client-A');
+        expect(check.ok).toBe(true);
+        router.addClientSubscription('client-A');
+      }
+
+      // The (cap+1)th subscribe is refused — fail fast at the boundary.
+      const over = router.checkSubscriptionCapacity('client-A');
+      expect(over.ok).toBe(false);
+      if (!over.ok) {
+        expect(over.reason).toBe('too_many_subscriptions');
+        expect(over.limit).toBe(CAP);
+        expect(over.current).toBe(CAP);
+      }
+    });
+
+    test('logs a dev-mode warning when the cap is exceeded', () => {
+      for (let i = 0; i < CAP; i++) {
+        router.addClientSubscription('client-A');
+      }
+      router.checkSubscriptionCapacity('client-A');
+      expect(logger.warns.length).toBe(1);
+      expect(logger.warns[0]).toContain('client-A');
+      expect(logger.warns[0]).toContain(`${CAP}/${CAP}`);
+    });
+
+    test('check is read-only: a refused check does not change the count', () => {
+      for (let i = 0; i < CAP; i++) router.addClientSubscription('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(CAP);
+
+      // Repeated capacity checks must not drift the counter (a caller that
+      // checks then decides not to subscribe must not need to release).
+      router.checkSubscriptionCapacity('client-A');
+      router.checkSubscriptionCapacity('client-A');
+      router.checkSubscriptionCapacity('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(CAP);
+    });
+  });
+
+  describe('graceful refusal (no teardown of existing subscriptions)', () => {
+    let router: MessageHubRouter;
+    const CAP = 3;
+
+    beforeEach(() => {
+      router = new MessageHubRouter({ maxSubscriptionsPerClient: CAP });
+      router.registerConnection(createMockConnection('client-A'));
+    });
+
+    test('prior subscriptions remain intact after an over-cap refusal', () => {
+      for (let i = 0; i < CAP; i++) router.addClientSubscription('client-A');
+      const before = router.getClientSubscriptionCount('client-A');
+
+      // Simulate the daemon's refusal path: check fails, caller does NOT add.
+      const check = router.checkSubscriptionCapacity('client-A');
+      expect(check.ok).toBe(false);
+
+      // The cap held — refusing the new subscribe did not evict any existing one.
+      expect(router.getClientSubscriptionCount('client-A')).toBe(before);
+      expect(router.getClientSubscriptionCount('client-A')).toBe(CAP);
+    });
+
+    test('releasing a slot recovers capacity (refusal is not a hard teardown)', () => {
+      for (let i = 0; i < CAP; i++) router.addClientSubscription('client-A');
+      expect(router.checkSubscriptionCapacity('client-A').ok).toBe(false);
+
+      // An existing subscription is closed (e.g. user navigates away from a view).
+      router.releaseClientSubscription('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(CAP - 1);
+
+      // A new subscribe can now succeed again.
+      expect(router.checkSubscriptionCapacity('client-A').ok).toBe(true);
+      router.addClientSubscription('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(CAP);
+    });
+
+    test('release floors at zero so a stray release cannot widen the cap', () => {
+      router.addClientSubscription('client-A');
+      router.releaseClientSubscription('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(0);
+
+      // Extra releases on a client with no tracked subscriptions are a no-op.
+      router.releaseClientSubscription('client-A');
+      router.releaseClientSubscription('client-A');
+      expect(router.getClientSubscriptionCount('client-A')).toBe(0);
+
+      // And capacity is still correctly reported as available.
+      expect(router.checkSubscriptionCapacity('client-A').ok).toBe(true);
+    });
+  });
+
+  describe('per-client isolation and disconnect reset', () => {
+    test('the cap is enforced independently per client', () => {
+      const router = new MessageHubRouter({ maxSubscriptionsPerClient: 2 });
+      router.registerConnection(createMockConnection('A'));
+      router.registerConnection(createMockConnection('B'));
+
+      router.addClientSubscription('A');
+      router.addClientSubscription('A');
+      router.addClientSubscription('B');
+
+      // A is full, B still has headroom.
+      expect(router.checkSubscriptionCapacity('A').ok).toBe(false);
+      expect(router.checkSubscriptionCapacity('B').ok).toBe(true);
+    });
+
+    test('unregisterConnection resets that client’s counter (reconciles on disconnect)', () => {
+      const router = new MessageHubRouter({ maxSubscriptionsPerClient: 2 });
+      router.registerConnection(createMockConnection('A'));
+      router.addClientSubscription('A');
+      router.addClientSubscription('A');
+      expect(router.checkSubscriptionCapacity('A').ok).toBe(false);
+
+      router.unregisterConnection('A');
+
+      // Counter is gone; a re-registration starts from a clean slate.
+      expect(router.getClientSubscriptionCount('A')).toBe(0);
+      router.registerConnection(createMockConnection('A'));
+      expect(router.checkSubscriptionCapacity('A').ok).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hub error-response plumbing: a MessageHubHandlerError carries its ErrorCode
+// onto the wire so the daemon's over-cap refusal reaches the client as a
+// structured TOO_MANY_SUBSCRIPTIONS (mirroring #2423's MESSAGE_TOO_LARGE).
+// ---------------------------------------------------------------------------
+
+class CapMockTransport implements IMessageTransport {
+  readonly name = 'cap-mock-transport';
+  public sentMessages: HubMessage[] = [];
+  private handlers: Set<(m: HubMessage) => void> = new Set();
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+  async connect(): Promise<void> {}
+  async disconnect(): Promise<void> {}
+  async send(message: HubMessage): Promise<void> {
+    this.sentMessages.push(message);
+  }
+  onMessage(h: (m: HubMessage) => void): () => void {
+    this.handlers.add(h);
+    return () => this.handlers.delete(h);
+  }
+  onConnectionChange(): () => void {
+    return () => {};
+  }
+  getState(): ConnectionState {
+    return 'connected';
+  }
+  isReady(): boolean {
+    return true;
+  }
+  simulate(message: HubMessage): void {
+    for (const h of this.handlers) h(message);
+  }
+}
+
+describe('MessageHub structured handler error', () => {
+  test('preserves a MessageHubHandlerError code on the error response', async () => {
+    const hub = new MessageHub({ defaultSessionId: 's' });
+    const transport = new CapMockTransport();
+    hub.registerTransport(transport);
+    await transport.connect();
+
+    hub.onRequest('test.tooMany', () => {
+      throw new MessageHubHandlerError(
+        'subscription cap reached (4/4)',
+        ErrorCode.TOO_MANY_SUBSCRIPTIONS
+      );
+    });
+
+    const req = createRequestMessage({ method: 'test.tooMany', data: {}, sessionId: 's' });
+    transport.simulate(req);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const err = transport.sentMessages.find(
+      (m) => m.type === MessageType.RESPONSE && m.requestId === req.id && m.error
+    );
+    expect(err).toBeDefined();
+    expect(err?.errorCode).toBe(ErrorCode.TOO_MANY_SUBSCRIPTIONS);
+    expect(err?.error).toContain('4/4');
+
+    hub.cleanup();
+  });
+
+  test('a plain thrown Error still maps to HANDLER_ERROR (unchanged behavior)', async () => {
+    const hub = new MessageHub({ defaultSessionId: 's' });
+    const transport = new CapMockTransport();
+    hub.registerTransport(transport);
+    await transport.connect();
+
+    hub.onRequest('test.plain', () => {
+      throw new Error('boom');
+    });
+
+    const req = createRequestMessage({ method: 'test.plain', data: {}, sessionId: 's' });
+    transport.simulate(req);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const err = transport.sentMessages.find(
+      (m) => m.type === MessageType.RESPONSE && m.requestId === req.id && m.error
+    );
+    expect(err).toBeDefined();
+    expect(err?.errorCode).toBe(ErrorCode.HANDLER_ERROR);
+
+    hub.cleanup();
+  });
+});


### PR DESCRIPTION
Enforces the declared-but-unenforced `maxSubscriptionsPerClient` so an unbounded-subscribe page (the 790-subscribes-on-one-task-page regression, #2414) fails fast with a structured `TOO_MANY_SUBSCRIPTIONS` error instead of silently accumulating one handler per subscribe and stalling past the 10s RPC timeout.

The cap lives in `MessageHubRouter` (default 128, ~6x below the incident with headroom for a busy tab): it tracks a per-client subscription count, checks capacity before any work so refusal has no snapshot side effects, and keeps prior subscriptions intact (graceful refusal, not teardown). Replacements of an existing `subscriptionId` are allowed at the cap (net-zero fan-out); only genuinely-new subscribes are refused. The daemon `liveQuery.subscribe` handler refuses via a new `MessageHubHandlerError`/`ErrorCode.TOO_MANY_SUBSCRIPTIONS` that the hub preserves onto the wire, mirroring #2423's `MESSAGE_TOO_LARGE`. The cap is env-tunable via `HYPERNEO_MAX_SUBSCRIPTIONS_PER_CLIENT` (fails closed to the default on bad input).

Covered by a shared characterization test (cap trip, prior-intact, dev warning, per-client isolation, disconnect reset, structured-error round-trip) and daemon integration tests (refusal with code, replacement at cap, prior subs still receive deltas, async delta-failure release, snapshot-abort leaves count 0, unsubscribe frees a slot, disconnect reconciliation, config default/override/fail-closed).

Deferred to follow-up task #934 (web-client observability): surfacing `TOO_MANY_SUBSCRIPTIONS` in `session-store.ts` + a `too_many_subscriptions` branch in `session-load-error.ts`.