### PR TITLE
feat(space): read-only list_subscriptions diagnostic tool [#908]

### DIFF
--- a/packages/daemon/src/lib/external-events/topic-trie.ts
+++ b/packages/daemon/src/lib/external-events/topic-trie.ts
@@ -71,6 +71,23 @@ export class TopicTrie<T> {
   }
 
   /**
+   * Return every stored value (across all patterns). Read-only enumeration
+   * used by diagnostics (e.g. listing active subscriptions for a run) — not a
+   * matching path. Each value is responsible for carrying its own topic/pattern
+   * (the trie keys by path and does not reconstruct the original pattern here).
+   */
+  values(): T[] {
+    const out: T[] = [];
+    const walk = (node: TrieNode<T>): void => {
+      if (node.values) out.push(...node.values);
+      for (const child of node.exactChildren.values()) walk(child);
+      for (const child of node.globChildren.values()) walk(child);
+    };
+    walk(this.root);
+    return out;
+  }
+
+  /**
    * Count all stored values matching a predicate.
    */
   count(predicate: (value: T) => boolean): number {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1143,6 +1143,18 @@ export class SpaceRuntimeService {
   }
 
   /**
+   * Read-only subscription diagnostic (Task #908). Delegates to
+   * {@link SpaceRuntime.listSubscriptions}; `spaceId` guards cross-space access.
+   */
+  listSubscriptions(
+    workflowRunId: string,
+    spaceId: string,
+    nodeId?: string
+  ): ReturnType<SpaceRuntime['listSubscriptions']> {
+    return this.runtime.listSubscriptions(workflowRunId, spaceId, nodeId);
+  }
+
+  /**
    * Stop all active work for a space: terminates running agent sessions and
    * cancels all in-progress/open tasks and active workflow runs.
    *

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -429,10 +429,13 @@ interface SubscriptionPersistedRow {
  * An active in-memory trie entry — the live cross-check layer, NEVER the
  * answer on its own. `source` reconciles it against durable state:
  * `'declared'` (a workflow-definition interest backs this static entry),
- * `'persisted'` (a table row backs this dynamic entry), or `'orphan'` (in the
+ * `'persisted'` (a table row backs this dynamic entry), `'orphan'` (in the
  * trie with no durable backing — indicates drift, e.g. a stale trie entry left
- * by a partial rehydrate or a mid-run definition-version change; benign in the
- * upgrade window, worth investigating if it persists in steady state).
+ * by a partial rehydrate, a mid-run definition-version change, or a static
+ * entry surviving on a terminal/non-canonical task; benign in the upgrade
+ * window, worth investigating if it persists in steady state), or `'unknown'`
+ * (a static entry whose declaration layer could not be loaded — backing is
+ * unverifiable, so it is neither confirmed nor reported as drift).
  */
 interface SubscriptionActiveEntry {
   nodeId: string;
@@ -440,7 +443,7 @@ interface SubscriptionActiveEntry {
   taskId: string;
   topic: string;
   subscriptionKind: 'static' | 'dynamic';
-  source: 'declared' | 'persisted' | 'orphan';
+  source: 'declared' | 'persisted' | 'orphan' | 'unknown';
 }
 
 interface SubscriptionListResult {
@@ -1438,6 +1441,7 @@ export class SpaceRuntime {
       return { success: false, error: `Workflow run ${workflowRunId} is not in this space.` };
     }
     const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run) ?? null;
+    const definitionResolved = workflow !== null;
     const nodeFilter = nodeId ?? null;
     // Whether static interests should currently be materialized in the trie.
     // Mirrors registerRunInterestsFromWorkflow, which skips static re-materialization
@@ -1518,14 +1522,31 @@ export class SpaceRuntime {
         source: 'orphan' as const,
       }));
 
-    // Reconcile durable ↔ trie via normalized keys. Static keys are task-
-    // independent (declared interests are slot-level); dynamic keys include the
-    // taskId so two tasks sharing a slot+topic can't cross-match.
+    // Reconcile durable ↔ trie via normalized keys.
+    //
+    // Dynamic keys include the taskId so two tasks sharing a slot+topic can't
+    // cross-match. Static declaration is slot-level (no task), but a static trie
+    // entry only "effectively" backs a declaration when the definition loaded
+    // (definitionResolved), the canonical task is non-terminal
+    // (staticMaterializable), AND the entry belongs to the canonical task — a
+    // duplicate/superseded task's static entry is stale. When the definition
+    // itself is unavailable, a static entry's backing is unverifiable, reported
+    // as `source: 'unknown'` (neither drift nor confirmed) rather than a false
+    // `orphan`.
+    const canonicalTaskId = canonicalTask?.id ?? null;
     const activeStaticKeys = new Set<string>();
     const activeDynamicKeys = new Set<string>();
     for (const entry of active) {
       if (entry.subscriptionKind === 'static') {
-        activeStaticKeys.add(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic));
+        if (
+          definitionResolved &&
+          staticMaterializable &&
+          (!canonicalTaskId || entry.taskId === canonicalTaskId)
+        ) {
+          activeStaticKeys.add(
+            subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic)
+          );
+        }
       } else {
         activeDynamicKeys.add(
           subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
@@ -1547,24 +1568,25 @@ export class SpaceRuntime {
     }
     let orphanActive = 0;
     for (const entry of active) {
-      // A static entry is "backed" only while the canonical task is non-terminal:
-      // on a done/archived/cancelled task the lifecycle clears static interests,
-      // so any surviving static entry is stale cleanup (counted as orphan) rather
-      // than a legitimate declared interest. Without this, a terminal task with a
-      // leftover static entry reads zero across every mismatch count.
-      const backed =
-        entry.subscriptionKind === 'static'
-          ? staticMaterializable &&
-            declaredKeys.has(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic))
-          : persistedKeys.has(
-              subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
-            );
-      entry.source = backed
-        ? entry.subscriptionKind === 'static'
-          ? 'declared'
-          : 'persisted'
-        : 'orphan';
-      if (!backed) orphanActive += 1;
+      if (entry.subscriptionKind === 'static') {
+        if (!definitionResolved) {
+          entry.source = 'unknown';
+          continue; // declaration layer unavailable — can't classify, don't count
+        }
+        const canonicalOwned = !canonicalTaskId || entry.taskId === canonicalTaskId;
+        const backed =
+          staticMaterializable &&
+          canonicalOwned &&
+          declaredKeys.has(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic));
+        entry.source = backed ? 'declared' : 'orphan';
+        if (!backed) orphanActive += 1;
+      } else {
+        const backed = persistedKeys.has(
+          subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
+        );
+        entry.source = backed ? 'persisted' : 'orphan';
+        if (!backed) orphanActive += 1;
+      }
     }
 
     return {
@@ -1572,7 +1594,7 @@ export class SpaceRuntime {
       result: {
         workflowRunId,
         nodeId: nodeFilter,
-        definitionResolved: workflow !== null,
+        definitionResolved,
         declared,
         persisted,
         active,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -388,6 +388,82 @@ function isLongHorizonSubscriptionTarget(
   return target.kind === 'long_horizon_agent';
 }
 
+// ---------------------------------------------------------------------------
+// listSubscriptions — read-only diagnostic result (Task #908)
+// ---------------------------------------------------------------------------
+
+/**
+ * A declared static event interest, re-derived from the workflow definition
+ * (durable). `topic` and `topicFrom` are mutually exclusive. `active` is a live
+ * cross-check against the in-memory trie: true iff a `static` trie entry exists
+ * for this slot + topic. `topicFrom` interests are inert until their resolver
+ * ships, so they report `active: false` and are excluded from the mismatch
+ * count (they are known-not-active by design, not drift).
+ */
+export interface SubscriptionDeclaredInterest {
+  nodeId: string;
+  nodeName: string;
+  agentName: string;
+  topic: string | null;
+  topicFrom: { source: 'primaryLink'; pattern: string } | null;
+  label: string | null;
+  active: boolean;
+}
+
+/**
+ * A persisted dynamic subscription row from `space_workflow_event_subscriptions`
+ * (durable). `active` is a live cross-check: true iff a `dynamic` trie entry
+ * exists for this slot + topic.
+ */
+export interface SubscriptionPersistedRow {
+  nodeId: string;
+  agentName: string;
+  taskId: string;
+  topic: string;
+  createdAt: number;
+  updatedAt: number;
+  active: boolean;
+}
+
+/**
+ * An active in-memory trie entry — the live cross-check layer, NEVER the
+ * answer on its own. `source` reconciles it against durable state:
+ * `'declared'` (a workflow-definition interest backs this static entry),
+ * `'persisted'` (a table row backs this dynamic entry), or `'orphan'` (in the
+ * trie with no durable backing — indicates drift that should not happen).
+ */
+export interface SubscriptionActiveEntry {
+  nodeId: string;
+  agentName: string;
+  taskId: string;
+  topic: string;
+  subscriptionKind: 'static' | 'dynamic';
+  source: 'declared' | 'persisted' | 'orphan';
+}
+
+export interface SubscriptionListResult {
+  workflowRunId: string;
+  /** nodeId filter applied, or null when the whole run is returned. */
+  nodeId: string | null;
+  declared: SubscriptionDeclaredInterest[];
+  persisted: SubscriptionPersistedRow[];
+  active: SubscriptionActiveEntry[];
+  /** Reconciliation counts derived from the three layers. */
+  mismatches: {
+    /** Declared concrete-topic interests with no matching active static entry. */
+    declaredNotActive: number;
+    /** Persisted rows with no matching active dynamic entry. */
+    persistedNotActive: number;
+    /** Active entries with no durable backing (static w/o declared, dynamic w/o persisted). */
+    orphanActive: number;
+  };
+}
+
+// Normalized reconciliation key: slot (node + agent) + lowercased topic.
+function subscriptionReconcileKey(nodeId: string, agentName: string, topic: string): string {
+  return `${nodeId}|${agentName.toLowerCase()}|${topic.toLowerCase()}`;
+}
+
 interface PendingExternalEvent {
   event: ExternalEventPublishedPayload;
   deliveryKey: string;
@@ -1302,6 +1378,148 @@ export class SpaceRuntime {
           target.subscriptionKind === subscriptionKind &&
           (target.topic ?? '').toLowerCase() === normalizedTopic
       );
+  }
+
+  /**
+   * Read-only diagnostic snapshot of a run's external-event subscriptions across
+   * three layers (Task #908):
+   *   1. `declared`  — static interests from the workflow definition (durable).
+   *   2. `persisted` — dynamic rows from `space_workflow_event_subscriptions` (durable).
+   *   3. `active`    — in-memory trie entries (live cross-check ONLY).
+   *
+   * The durable layers (1 + 2) are the source of truth; the trie (3) is never
+   * the answer, only a sanity check — each active entry is reconciled against
+   * durable state so declared-vs-active drift surfaces as `source: 'orphan'`,
+   * and durable rows missing from the trie surface via `active: false` plus the
+   * `mismatches` counts. For task #896 this returns "Coding node has no declared
+   * PR-event interest" from durable data alone.
+   *
+   * `spaceId` guards cross-space access: a run in another space is rejected.
+   */
+  listSubscriptions(
+    workflowRunId: string,
+    spaceId: string,
+    nodeId?: string
+  ): { success: true; result: SubscriptionListResult } | { success: false; error: string } {
+    const run = this.config.workflowRunRepo.getRun(workflowRunId);
+    if (!run) {
+      return { success: false, error: `Workflow run not found: ${workflowRunId}` };
+    }
+    if (run.spaceId !== spaceId) {
+      return { success: false, error: `Workflow run ${workflowRunId} is not in this space.` };
+    }
+    const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run) ?? null;
+    const nodeFilter = nodeId ?? null;
+
+    // Layer 1 — declared static interests, re-derived from the definition.
+    const declared: SubscriptionDeclaredInterest[] = [];
+    if (workflow) {
+      for (const node of workflow.nodes) {
+        if (nodeFilter && node.id !== nodeFilter) continue;
+        let agents: ReturnType<typeof resolveNodeAgents>;
+        try {
+          agents = resolveNodeAgents(node);
+        } catch {
+          continue; // malformed node — nothing to declare.
+        }
+        for (const agent of agents) {
+          for (const interest of agent.eventInterests ?? []) {
+            const topic = typeof interest.topic === 'string' ? interest.topic : null;
+            declared.push({
+              nodeId: node.id,
+              nodeName: node.name,
+              agentName: agent.name,
+              topic,
+              topicFrom: interest.topicFrom ?? null,
+              label: interest.label ?? null,
+              // topicFrom interests are inert (no resolver yet) → never active.
+              active: false,
+            });
+          }
+        }
+      }
+    }
+
+    // Layer 2 — persisted dynamic rows.
+    const persisted: SubscriptionPersistedRow[] = this.workflowEventSubscriptionRepo
+      .listByRun(workflowRunId)
+      .filter((row) => !nodeFilter || row.nodeId === nodeFilter)
+      .map((row) => ({
+        nodeId: row.nodeId,
+        agentName: row.agentName,
+        taskId: row.taskId,
+        topic: row.topic,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        active: false,
+      }));
+
+    // Layer 3 — active in-memory trie entries (workflow targets for this run).
+    const active: SubscriptionActiveEntry[] = this.topicTrie
+      .values()
+      .filter(
+        (target): target is WorkflowSubscriptionTarget =>
+          isWorkflowSubscriptionTarget(target) && target.workflowRunId === workflowRunId
+      )
+      .filter((target) => !nodeFilter || target.nodeId === nodeFilter)
+      .map((target) => ({
+        nodeId: target.nodeId,
+        agentName: target.agentName,
+        taskId: target.taskId,
+        topic: target.topic ?? '',
+        subscriptionKind: target.subscriptionKind ?? 'dynamic',
+        source: 'orphan' as const,
+      }));
+
+    // Reconcile durable ↔ trie via normalized slot+topic keys.
+    const activeStaticKeys = new Set<string>();
+    const activeDynamicKeys = new Set<string>();
+    for (const entry of active) {
+      const key = subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic);
+      if (entry.subscriptionKind === 'static') activeStaticKeys.add(key);
+      else activeDynamicKeys.add(key);
+    }
+    const declaredKeys = new Set<string>();
+    for (const d of declared) {
+      if (d.topic === null) continue; // topicFrom is not reconcilable yet.
+      const key = subscriptionReconcileKey(d.nodeId, d.agentName, d.topic);
+      declaredKeys.add(key);
+      d.active = activeStaticKeys.has(key);
+    }
+    const persistedKeys = new Set<string>();
+    for (const p of persisted) {
+      const key = subscriptionReconcileKey(p.nodeId, p.agentName, p.topic);
+      persistedKeys.add(key);
+      p.active = activeDynamicKeys.has(key);
+    }
+    let orphanActive = 0;
+    for (const entry of active) {
+      const key = subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic);
+      const backed =
+        entry.subscriptionKind === 'static' ? declaredKeys.has(key) : persistedKeys.has(key);
+      entry.source = backed
+        ? entry.subscriptionKind === 'static'
+          ? 'declared'
+          : 'persisted'
+        : 'orphan';
+      if (!backed) orphanActive += 1;
+    }
+
+    return {
+      success: true,
+      result: {
+        workflowRunId,
+        nodeId: nodeFilter,
+        declared,
+        persisted,
+        active,
+        mismatches: {
+          declaredNotActive: declared.filter((d) => d.topic !== null && !d.active).length,
+          persistedNotActive: persisted.filter((p) => !p.active).length,
+          orphanActive,
+        },
+      },
+    };
   }
 
   refreshLongHorizonSubscription(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -400,7 +400,7 @@ function isLongHorizonSubscriptionTarget(
  * ships, so they report `active: false` and are excluded from the mismatch
  * count (they are known-not-active by design, not drift).
  */
-export interface SubscriptionDeclaredInterest {
+interface SubscriptionDeclaredInterest {
   nodeId: string;
   nodeName: string;
   agentName: string;
@@ -415,7 +415,7 @@ export interface SubscriptionDeclaredInterest {
  * (durable). `active` is a live cross-check: true iff a `dynamic` trie entry
  * exists for this slot + topic.
  */
-export interface SubscriptionPersistedRow {
+interface SubscriptionPersistedRow {
   nodeId: string;
   agentName: string;
   taskId: string;
@@ -430,9 +430,11 @@ export interface SubscriptionPersistedRow {
  * answer on its own. `source` reconciles it against durable state:
  * `'declared'` (a workflow-definition interest backs this static entry),
  * `'persisted'` (a table row backs this dynamic entry), or `'orphan'` (in the
- * trie with no durable backing — indicates drift that should not happen).
+ * trie with no durable backing — indicates drift, e.g. a stale trie entry left
+ * by a partial rehydrate or a mid-run definition-version change; benign in the
+ * upgrade window, worth investigating if it persists in steady state).
  */
-export interface SubscriptionActiveEntry {
+interface SubscriptionActiveEntry {
   nodeId: string;
   agentName: string;
   taskId: string;
@@ -441,7 +443,7 @@ export interface SubscriptionActiveEntry {
   source: 'declared' | 'persisted' | 'orphan';
 }
 
-export interface SubscriptionListResult {
+interface SubscriptionListResult {
   workflowRunId: string;
   /** nodeId filter applied, or null when the whole run is returned. */
   nodeId: string | null;
@@ -450,7 +452,11 @@ export interface SubscriptionListResult {
   active: SubscriptionActiveEntry[];
   /** Reconciliation counts derived from the three layers. */
   mismatches: {
-    /** Declared concrete-topic interests with no matching active static entry. */
+    /**
+     * Declared concrete-topic interests with no matching active static entry.
+     * Suppressed for terminal-task runs (see listSubscriptions): their static
+     * interests are intentionally cleared by the task lifecycle.
+     */
     declaredNotActive: number;
     /** Persisted rows with no matching active dynamic entry. */
     persistedNotActive: number;
@@ -1395,6 +1401,13 @@ export class SpaceRuntime {
    * PR-event interest" from durable data alone.
    *
    * `spaceId` guards cross-space access: a run in another space is rejected.
+   *
+   * `declaredNotActive` only fires when a static entry *should* be live — i.e.
+   * the run's canonical task is non-terminal. For a terminal task
+   * (`done`/`archived`/`cancelled`) `registerRunInterestsFromWorkflow`
+   * deliberately clears static interests, so their `active: false` is expected
+   * lifecycle cleanup, not drift (the count is suppressed there to keep the
+   * headline signal honest for the common "investigate a finished run" case).
    */
   listSubscriptions(
     workflowRunId: string,
@@ -1410,6 +1423,19 @@ export class SpaceRuntime {
     }
     const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run) ?? null;
     const nodeFilter = nodeId ?? null;
+    // Whether static interests should currently be materialized in the trie.
+    // Mirrors registerRunInterestsFromWorkflow, which skips static re-materialization
+    // when the canonical task is absent or terminal (its interests were cleared by the
+    // task lifecycle). When false, declared `active: false` is expected, not drift.
+    const canonicalTask = this.pickCanonicalTaskForRun(
+      run,
+      this.config.taskRepo.listByWorkflowRun(run.id)
+    );
+    const staticMaterializable =
+      !!canonicalTask &&
+      canonicalTask.status !== 'done' &&
+      canonicalTask.status !== 'archived' &&
+      canonicalTask.status !== 'cancelled';
 
     // Layer 1 — declared static interests, re-derived from the definition.
     const declared: SubscriptionDeclaredInterest[] = [];
@@ -1455,13 +1481,18 @@ export class SpaceRuntime {
       }));
 
     // Layer 3 — active in-memory trie entries (workflow targets for this run).
+    // values() walks the whole per-space trie, so this is O(total subscriptions
+    // in the space); acceptable for an occasionally-invoked diagnostic. A
+    // run-indexed trie structure can be added later if this is ever called in a
+    // loop or spaces grow large.
     const active: SubscriptionActiveEntry[] = this.topicTrie
       .values()
       .filter(
         (target): target is WorkflowSubscriptionTarget =>
-          isWorkflowSubscriptionTarget(target) && target.workflowRunId === workflowRunId
+          isWorkflowSubscriptionTarget(target) &&
+          target.workflowRunId === workflowRunId &&
+          (!nodeFilter || target.nodeId === nodeFilter)
       )
-      .filter((target) => !nodeFilter || target.nodeId === nodeFilter)
       .map((target) => ({
         nodeId: target.nodeId,
         agentName: target.agentName,
@@ -1514,7 +1545,11 @@ export class SpaceRuntime {
         persisted,
         active,
         mismatches: {
-          declaredNotActive: declared.filter((d) => d.topic !== null && !d.active).length,
+          // Only count as drift when a static entry should be live; for terminal
+          // tasks static interests are intentionally cleared (see above).
+          declaredNotActive: staticMaterializable
+            ? declared.filter((d) => d.topic !== null && !d.active).length
+            : 0,
           persistedNotActive: persisted.filter((p) => !p.active).length,
           orphanActive,
         },

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -447,6 +447,13 @@ interface SubscriptionListResult {
   workflowRunId: string;
   /** nodeId filter applied, or null when the whole run is returned. */
   nodeId: string | null;
+  /**
+   * Whether the run's workflow definition resolved. When false, `declared` is
+   * empty NOT because nothing is declared but because the definition could not
+   * be loaded (e.g. a deleted/stale definition) — so the caller does not
+   * misread an unavailable durable layer as "node declares no subscriptions."
+   */
+  definitionResolved: boolean;
   declared: SubscriptionDeclaredInterest[];
   persisted: SubscriptionPersistedRow[];
   active: SubscriptionActiveEntry[];
@@ -465,9 +472,18 @@ interface SubscriptionListResult {
   };
 }
 
-// Normalized reconciliation key: slot (node + agent) + lowercased topic.
-function subscriptionReconcileKey(nodeId: string, agentName: string, topic: string): string {
-  return `${nodeId}|${agentName.toLowerCase()}|${topic.toLowerCase()}`;
+// Normalized reconciliation key: slot (node + agent) + lowercased topic, plus
+// an optional taskId. Static declaration has no task (interests are slot-level
+// in the workflow definition), so static keys omit it; dynamic rows/targets
+// both carry taskId and include it so two tasks sharing a slot+topic can't
+// cross-match (which would mask the persisted↔active drift this tool surfaces).
+function subscriptionReconcileKey(
+  nodeId: string,
+  agentName: string,
+  topic: string,
+  taskId?: string
+): string {
+  return `${nodeId}|${agentName.toLowerCase()}|${topic.toLowerCase()}${taskId ? `|${taskId}` : ''}`;
 }
 
 interface PendingExternalEvent {
@@ -1502,13 +1518,19 @@ export class SpaceRuntime {
         source: 'orphan' as const,
       }));
 
-    // Reconcile durable ↔ trie via normalized slot+topic keys.
+    // Reconcile durable ↔ trie via normalized keys. Static keys are task-
+    // independent (declared interests are slot-level); dynamic keys include the
+    // taskId so two tasks sharing a slot+topic can't cross-match.
     const activeStaticKeys = new Set<string>();
     const activeDynamicKeys = new Set<string>();
     for (const entry of active) {
-      const key = subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic);
-      if (entry.subscriptionKind === 'static') activeStaticKeys.add(key);
-      else activeDynamicKeys.add(key);
+      if (entry.subscriptionKind === 'static') {
+        activeStaticKeys.add(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic));
+      } else {
+        activeDynamicKeys.add(
+          subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
+        );
+      }
     }
     const declaredKeys = new Set<string>();
     for (const d of declared) {
@@ -1519,15 +1541,18 @@ export class SpaceRuntime {
     }
     const persistedKeys = new Set<string>();
     for (const p of persisted) {
-      const key = subscriptionReconcileKey(p.nodeId, p.agentName, p.topic);
+      const key = subscriptionReconcileKey(p.nodeId, p.agentName, p.topic, p.taskId);
       persistedKeys.add(key);
       p.active = activeDynamicKeys.has(key);
     }
     let orphanActive = 0;
     for (const entry of active) {
-      const key = subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic);
       const backed =
-        entry.subscriptionKind === 'static' ? declaredKeys.has(key) : persistedKeys.has(key);
+        entry.subscriptionKind === 'static'
+          ? declaredKeys.has(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic))
+          : persistedKeys.has(
+              subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
+            );
       entry.source = backed
         ? entry.subscriptionKind === 'static'
           ? 'declared'
@@ -1541,6 +1566,7 @@ export class SpaceRuntime {
       result: {
         workflowRunId,
         nodeId: nodeFilter,
+        definitionResolved: workflow !== null,
         declared,
         persisted,
         active,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1547,9 +1547,15 @@ export class SpaceRuntime {
     }
     let orphanActive = 0;
     for (const entry of active) {
+      // A static entry is "backed" only while the canonical task is non-terminal:
+      // on a done/archived/cancelled task the lifecycle clears static interests,
+      // so any surviving static entry is stale cleanup (counted as orphan) rather
+      // than a legitimate declared interest. Without this, a terminal task with a
+      // leftover static entry reads zero across every mismatch count.
       const backed =
         entry.subscriptionKind === 'static'
-          ? declaredKeys.has(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic))
+          ? staticMaterializable &&
+            declaredKeys.has(subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic))
           : persistedKeys.has(
               subscriptionReconcileKey(entry.nodeId, entry.agentName, entry.topic, entry.taskId)
             );

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -5474,6 +5474,19 @@ export class TaskAgentManager {
       );
       return jsonResult(result);
     };
+    const onListSubscriptions = async (args: { workflowRunId?: string; nodeId?: string }) => {
+      try {
+        const result = this.config.spaceRuntimeService.listSubscriptions(
+          args.workflowRunId ?? workflowRunId,
+          spaceId,
+          args.nodeId
+        );
+        return jsonResult(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult({ success: false, error: message });
+      }
+    };
     const onCreateStandaloneTask = async (args: {
       title: string;
       description: string;
@@ -5657,6 +5670,7 @@ export class TaskAgentManager {
       onArchiveTask,
       onSubscribeExternalEvent,
       onUnsubscribeExternalEvent,
+      onListSubscriptions,
       artifactRepo: this.config.artifactRepo,
       artifactProfile: this.config.artifactProfile,
       taskRepo: this.config.taskRepo,

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -204,6 +204,47 @@ export const ListDeliveriesSchema = z.object({
 export type ListDeliveriesInput = z.infer<typeof ListDeliveriesSchema>;
 
 // ---------------------------------------------------------------------------
+// list_subscriptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_subscriptions` input.
+ *
+ * Read-only diagnostic that snapshots a workflow run's external-event
+ * subscriptions across three layers — so an agent can answer "is this node
+ * actually subscribed to these events?" from durable state, without raw SQL:
+ *
+ *   1. `declared`  — static interests from the workflow definition (durable).
+ *   2. `persisted` — dynamic rows from `space_workflow_event_subscriptions`
+ *      (durable; the PR 5 table).
+ *   3. `active`    — in-memory trie entries, shown ONLY as a live cross-check.
+ *
+ * The durable layers (1 + 2) are the source of truth; the trie (3) is never the
+ * answer. Each active entry is reconciled against durable state
+ * (`source: 'declared' | 'persisted' | 'orphan'`), and durable rows missing
+ * from the trie surface as `active: false` plus a `mismatches` summary — so a
+ * declared-vs-active discrepancy is immediately visible. Always scoped to the
+ * current space; defaults to this workflow run.
+ */
+export const ListSubscriptionsSchema = z.object({
+  workflowRunId: z
+    .string()
+    .min(1)
+    .describe(
+      'Filter to a single workflow run. Defaults to this workflow run. ' +
+        'Pass an explicit value to inspect another run in the same Space.'
+    )
+    .optional(),
+  nodeId: z
+    .string()
+    .min(1)
+    .describe('Filter to a single workflow node (matches declared/persisted/active entries).')
+    .optional(),
+});
+
+export type ListSubscriptionsInput = z.infer<typeof ListSubscriptionsSchema>;
+
+// ---------------------------------------------------------------------------
 // save_artifact
 // ---------------------------------------------------------------------------
 
@@ -579,6 +620,7 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
   subscribe_pr_events: SubscribePrEventsSchema,
   get_external_event: GetExternalEventSchema,
   list_deliveries: ListDeliveriesSchema,
+  list_subscriptions: ListSubscriptionsSchema,
   restore_node_agent: RestoreNodeAgentSchema,
   list_tasks: ListTasksSchema,
   get_task: GetTaskSchema,

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -87,6 +87,7 @@ import {
   SubscribePrEventsSchema,
   GetExternalEventSchema,
   ListDeliveriesSchema,
+  ListSubscriptionsSchema,
 } from './node-agent-tool-schemas';
 import type {
   ListPeersInput,
@@ -109,6 +110,7 @@ import type {
   SubscribePrEventsInput,
   GetExternalEventInput,
   ListDeliveriesInput,
+  ListSubscriptionsInput,
 } from './node-agent-tool-schemas';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceTask } from '@hyperneo/shared';
@@ -380,6 +382,12 @@ export interface NodeAgentToolsConfig {
   onSubscribeExternalEvent?: (args: SubscribeExternalEventInput) => Promise<ToolResult>;
   /** Optional callback for dynamic external-event unsubscription requests. */
   onUnsubscribeExternalEvent?: (args: UnsubscribeExternalEventInput) => Promise<ToolResult>;
+  /**
+   * Optional callback for the read-only `list_subscriptions` diagnostic. Returns
+   * the declared / persisted / active subscription layers for a run. Read-only —
+   * never mutates subscription state.
+   */
+  onListSubscriptions?: (args: ListSubscriptionsInput) => Promise<ToolResult>;
   /**
    * Optional callback for \`publish_task\`. When provided, node agents can
    * publish draft tasks (transition draft → open) without the broader
@@ -1756,6 +1764,28 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
       return jsonResult({ success: true, deliveries });
     },
 
+    /**
+     * Read-only diagnostic: snapshot a workflow run's external-event
+     * subscriptions across three layers — declared (workflow definition),
+     * persisted (PR 5 table), and active (in-memory trie, cross-check only) —
+     * so an agent can confirm whether a node is actually wired to receive a
+     * class of events from durable state alone. Durable layers are the source of
+     * truth; the trie is a sanity check, with declared-vs-active drift surfaced
+     * via per-entry `source`/`active` flags and a `mismatches` summary.
+     */
+    async list_subscriptions(args: ListSubscriptionsInput): Promise<ToolResult> {
+      if (!config.onListSubscriptions) {
+        return jsonResult({
+          success: false,
+          error: 'Subscription diagnostics are not available.',
+        });
+      }
+      return config.onListSubscriptions({
+        workflowRunId: args.workflowRunId,
+        nodeId: args.nodeId,
+      });
+    },
+
     async approve_task(args: ApproveTaskInput): Promise<ToolResult> {
       if (!config.onApproveTask) {
         return jsonResult({
@@ -2115,6 +2145,21 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
               'Events are delivered to this node-agent session as messages. The coder node typically calls this.',
             SubscribePrEventsSchema.shape,
             (args) => handlers.subscribe_pr_events(args)
+          ),
+        ]
+      : []),
+    ...(config.onListSubscriptions
+      ? [
+          tool(
+            'list_subscriptions',
+            "Read-only diagnostic: snapshot this workflow run's external-event subscriptions across three layers — " +
+              'declared (workflow definition, durable), persisted (the dynamic subscription table, durable), and ' +
+              'active (in-memory trie, a live cross-check only). Use this to confirm whether a node is actually ' +
+              'wired to receive a class of events, and to surface declared-vs-active drift. The durable layers ' +
+              'are the source of truth; the trie is never the answer. Defaults to this workflow run; pass ' +
+              '`nodeId` to scope to one node.',
+            ListSubscriptionsSchema.shape,
+            (args) => handlers.list_subscriptions(args)
           ),
         ]
       : []),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -2153,11 +2153,11 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
           tool(
             'list_subscriptions',
             "Read-only diagnostic: snapshot this workflow run's external-event subscriptions across three layers — " +
-              'declared (workflow definition, durable), persisted (the dynamic subscription table, durable), and ' +
-              'active (in-memory trie, a live cross-check only). Use this to confirm whether a node is actually ' +
-              'wired to receive a class of events, and to surface declared-vs-active drift. The durable layers ' +
-              'are the source of truth; the trie is never the answer. Defaults to this workflow run; pass ' +
-              '`nodeId` to scope to one node.',
+              'declared (static interests in the workflow definition, durable), persisted (the dynamic subscription ' +
+              'table, durable), and active (in-memory trie, a live cross-check only). Use this to confirm whether ' +
+              'a node is actually wired to receive a class of events, and to surface declared-vs-active drift. ' +
+              'The durable layers are the source of truth; the trie is never the answer. Defaults to this ' +
+              'workflow run; pass `nodeId` to scope to one node.',
             ListSubscriptionsSchema.shape,
             (args) => handlers.list_subscriptions(args)
           ),

--- a/packages/daemon/src/storage/repositories/space-workflow-event-subscription-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-event-subscription-repository.ts
@@ -140,6 +140,21 @@ export class SpaceWorkflowEventSubscriptionRepository {
     this.db.prepare(`DELETE FROM space_workflow_event_subscriptions WHERE task_id = ?`).run(taskId);
   }
 
+  /**
+   * All dynamic subscriptions for a single run. Backs the `list_subscriptions`
+   * diagnostic tool's durable layer (the per-space rebuild uses
+   * {@link listBySpace}). Ordered by `created_at` for stable output.
+   */
+  listByRun(workflowRunId: string): SpaceWorkflowEventSubscription[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM space_workflow_event_subscriptions
+		 WHERE workflow_run_id = ? ORDER BY created_at ASC`
+      )
+      .all(workflowRunId) as Record<string, unknown>[];
+    return rows.map(rowToSubscription);
+  }
+
   /** All subscriptions for a space — drives the per-space trie rebuild. */
   listBySpace(spaceId: string): SpaceWorkflowEventSubscription[] {
     const rows = this.db

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -3071,6 +3071,99 @@ describe('node-agent-tools: list_deliveries', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: list_subscriptions
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: list_subscriptions', () => {
+  let ctx: TestCtx;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  afterEach(() => {
+    ctx.db.close();
+  });
+
+  test('delegates to onListSubscriptions, defaulting to the current run', async () => {
+    const calls: Array<{ workflowRunId?: string; nodeId?: string }> = [];
+    const handlers = createNodeAgentToolHandlers(
+      makeConfig(ctx, {
+        onListSubscriptions: async (args) => {
+          calls.push(args);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ success: true, declared: [], persisted: [] }),
+              },
+            ],
+          };
+        },
+      })
+    );
+
+    const result = await handlers.list_subscriptions({});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(true);
+    // No args → callback receives the session's current run, no node filter.
+    expect(calls).toEqual([{ workflowRunId: undefined, nodeId: undefined }]);
+  });
+
+  test('forwards workflowRunId and nodeId overrides', async () => {
+    const calls: Array<{ workflowRunId?: string; nodeId?: string }> = [];
+    const handlers = createNodeAgentToolHandlers(
+      makeConfig(ctx, {
+        onListSubscriptions: async (args) => {
+          calls.push(args);
+          return { content: [{ type: 'text', text: JSON.stringify({ success: true }) }] };
+        },
+      })
+    );
+
+    await handlers.list_subscriptions({
+      workflowRunId: 'run-other',
+      nodeId: 'node-review',
+    });
+
+    expect(calls).toEqual([{ workflowRunId: 'run-other', nodeId: 'node-review' }]);
+  });
+
+  test('returns unavailable when onListSubscriptions is not wired', async () => {
+    const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
+
+    const result = await handlers.list_subscriptions({});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.error).toContain('not available');
+  });
+
+  test('createNodeAgentMcpServer registers list_subscriptions only when the callback is wired', () => {
+    const withoutCallback = createNodeAgentMcpServer(makeConfig(ctx));
+    const withoutRegistered = Object.keys(
+      (withoutCallback as unknown as { instance: { _registeredTools: Record<string, unknown> } })
+        .instance._registeredTools
+    );
+    expect(withoutRegistered).not.toContain('list_subscriptions');
+
+    const withCallback = createNodeAgentMcpServer(
+      makeConfig(ctx, {
+        onListSubscriptions: async () => ({
+          content: [{ type: 'text', text: JSON.stringify({ success: true }) }],
+        }),
+      })
+    );
+    const withRegistered = Object.keys(
+      (withCallback as unknown as { instance: { _registeredTools: Record<string, unknown> } })
+        .instance._registeredTools
+    );
+    expect(withRegistered).toContain('list_subscriptions');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: createNodeAgentMcpServer (factory)
 // ---------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -3140,6 +3140,53 @@ describe('node-agent-tools: list_subscriptions', () => {
     expect(data.error).toContain('not available');
   });
 
+  test('a realistic result envelope survives the jsonResult round-trip', async () => {
+    // End-to-end pass-through: the structured {success, result:{declared, persisted,
+    // active, mismatches}} envelope the callback returns is what the agent receives.
+    const handlers = createNodeAgentToolHandlers(
+      makeConfig(ctx, {
+        onListSubscriptions: async () => ({
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                result: {
+                  workflowRunId: ctx.workflowRunId,
+                  nodeId: null,
+                  declared: [
+                    {
+                      nodeId: 'code',
+                      agentName: 'coder',
+                      topic: 'github/o/r/issues/*',
+                      active: true,
+                    },
+                  ],
+                  persisted: [],
+                  active: [],
+                  mismatches: { declaredNotActive: 0, persistedNotActive: 0, orphanActive: 0 },
+                },
+              }),
+            },
+          ],
+        }),
+      })
+    );
+
+    const result = await handlers.list_subscriptions({});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.success).toBe(true);
+    expect(data.result.workflowRunId).toBe(ctx.workflowRunId);
+    expect(data.result.declared).toHaveLength(1);
+    expect(data.result.declared[0]).toMatchObject({ topic: 'github/o/r/issues/*', active: true });
+    expect(data.result.mismatches).toEqual({
+      declaredNotActive: 0,
+      persistedNotActive: 0,
+      orphanActive: 0,
+    });
+  });
+
   test('createNodeAgentMcpServer registers list_subscriptions only when the callback is wired', () => {
     const withoutCallback = createNodeAgentMcpServer(makeConfig(ctx));
     const withoutRegistered = Object.keys(

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
@@ -178,6 +178,7 @@ describe('SpaceRuntime.listSubscriptions', () => {
     const { result } = res;
 
     // Layer 1 — declared static interest from the definition, now active.
+    expect(result.definitionResolved).toBe(true);
     expect(result.declared).toHaveLength(1);
     expect(result.declared[0]).toMatchObject({
       nodeId: 'code',
@@ -477,7 +478,9 @@ describe('SpaceRuntime.listSubscriptions', () => {
 
   test('a run whose workflow definition no longer resolves reports declared empty without crashing', () => {
     // Simulate getWorkflowForRun → null (e.g. a stale/removed definition) by
-    // stubbing the workflow manager. Persisted + active still reconcile.
+    // stubbing the workflow manager. Persisted + active still reconcile, and the
+    // empty `declared` layer is flagged as unavailable (definitionResolved:false)
+    // so it is not misread as "the node declares no subscriptions."
     const runtime = makeRuntime({
       spaceWorkflowManager: { getWorkflowForRun: () => null } as unknown as typeof workflowManager,
     });
@@ -487,8 +490,48 @@ describe('SpaceRuntime.listSubscriptions', () => {
     const res = runtime.listSubscriptions(runId, SPACE_ID);
     expect(res.success).toBe(true);
     if (!res.success) return;
+    expect(res.result.definitionResolved).toBe(false);
     expect(res.result.declared).toEqual([]);
     expect(res.result.persisted).toHaveLength(1);
     expect(res.result.persisted[0].active).toBe(true);
+  });
+
+  test('dynamic reconciliation is scoped by taskId — sibling tasks do not cross-match', () => {
+    // A run with two tasks sharing node + agent + topic. The persisted table and
+    // the trie both key on taskId, so the reconcile key must too — otherwise an
+    // active trie entry for task A would mark task B's persisted row active,
+    // masking the persisted/active drift this tool exists to expose.
+    const runtime = makeRuntime();
+    const { runId, taskId: taskA } = createRun();
+    const taskB = taskRepo.createTask({
+      spaceId: SPACE_ID,
+      workflowRunId: runId,
+      title: 'B',
+      description: '',
+      status: 'in_progress',
+    }).id;
+    const topic = 'github/owner/repo/pull_request/42.*';
+    // Task A: registered (write-through → trie + table). Task B: persisted only.
+    runtime.registerSubscription(runId, taskA, 'code', 'coder', topic);
+    subscriptionRepo.upsert({
+      spaceId: SPACE_ID,
+      workflowRunId: runId,
+      taskId: taskB,
+      nodeId: 'code',
+      agentName: 'coder',
+      topic,
+      subscriptionKind: 'dynamic',
+    });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const byTask = new Map(res.result.persisted.map((p) => [p.taskId, p]));
+    expect(byTask.get(taskA)?.active).toBe(true); // has a matching trie entry
+    expect(byTask.get(taskB)?.active).toBe(false); // no trie entry for task B
+    expect(res.result.mismatches.persistedNotActive).toBe(1);
+    // Task A's active entry is backed; task B has no active entry at all.
+    expect(res.result.active).toHaveLength(1);
+    expect(res.result.active[0].source).toBe('persisted');
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
@@ -438,6 +438,68 @@ describe('SpaceRuntime.listSubscriptions', () => {
     expect(res.result.mismatches.orphanActive).toBe(1);
   });
 
+  test('a static entry is "unknown" (not orphan) when the definition cannot be loaded', () => {
+    // If getWorkflowForRun returns null while a static entry is still in the
+    // trie, the declaration layer is unavailable — not absent — so the entry's
+    // backing is unverifiable. Report source:'unknown' and do not count it as
+    // drift (a false orphan would mislead).
+    const runtime = makeRuntime({
+      spaceWorkflowManager: { getWorkflowForRun: () => null } as unknown as typeof workflowManager,
+    });
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    // Materialize the static entry (registerRunInterests needs no workflow def),
+    // then inspect via the stubbed runtime whose definition won't resolve.
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.definitionResolved).toBe(false);
+    expect(res.result.active).toHaveLength(1);
+    expect(res.result.active[0].source).toBe('unknown');
+    expect(res.result.mismatches.orphanActive).toBe(0);
+  });
+
+  test('a static entry on a non-canonical task is orphan, not declared', () => {
+    // A run with a duplicate/superseded task: a static entry registered for the
+    // non-canonical task must not mark the slot's declaration active or be
+    // labeled declared. Only the canonical task's static entries back a
+    // declaration; the stale entry surfaces as orphan.
+    const runtime = makeRuntime();
+    const {
+      workflow,
+      runId,
+      taskId: canonicalId,
+    } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    // Create a second, non-canonical task (different title → not picked as canonical).
+    const dupTask = taskRepo.createTask({
+      spaceId: SPACE_ID,
+      workflowRunId: runId,
+      title: 'Duplicate',
+      description: '',
+      status: 'in_progress',
+    }).id;
+    expect(dupTask).not.toBe(canonicalId);
+    // Register the static interest under the duplicate task only.
+    runtime.registerRunInterests(runId, dupTask, workflow.nodes);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    // The duplicate's static entry is drift, not a backing for the declaration.
+    expect(res.result.active).toHaveLength(1);
+    expect(res.result.active[0].taskId).toBe(dupTask);
+    expect(res.result.active[0].source).toBe('orphan');
+    expect(res.result.mismatches.orphanActive).toBe(1);
+    // And the slot's declared interest is NOT marked active by the stale entry.
+    expect(res.result.declared[0].active).toBe(false);
+    expect(res.result.mismatches.declaredNotActive).toBe(1);
+  });
+
   test('multiple static interests on the same slot do not collapse', () => {
     const runtime = makeRuntime();
     const { workflow, runId, taskId } = createRun({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
@@ -377,4 +377,118 @@ describe('SpaceRuntime.listSubscriptions', () => {
     if (res.success) return;
     expect(res.error).toContain('not found');
   });
+
+  // -------------------------------------------------------------------------
+  // Edge cases & review-feedback coverage
+  // -------------------------------------------------------------------------
+
+  test('P1: a terminal-task run does not report cleared static interests as drift', () => {
+    // registerRunInterestsFromWorkflow skips static re-materialization for a
+    // terminal canonical task (its static interests are cleared by the task
+    // lifecycle). listSubscriptions must NOT count those as declaredNotActive —
+    // their active:false is expected cleanup, not drift.
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+
+    // Baseline: active run → declared interest is live, no drift.
+    let res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.declared[0].active).toBe(true);
+    expect(res.result.mismatches.declaredNotActive).toBe(0);
+
+    // Task completes → lifecycle clears its interests from the trie.
+    taskRepo.updateTask(taskId, { status: 'done' });
+    runtime.clearTaskInterests(taskId);
+
+    res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    // Declared is still re-derived from the definition (the run DID declare it),
+    // but it is no longer in the trie. Crucially, the mismatch count stays 0.
+    expect(res.result.declared).toHaveLength(1);
+    expect(res.result.declared[0].active).toBe(false);
+    expect(res.result.mismatches.declaredNotActive).toBe(0);
+  });
+
+  test('multiple static interests on the same slot do not collapse', () => {
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [
+        { topic: 'github/owner/repo/issues/*' },
+        { topic: 'github/owner/repo/pull_request/*.*' },
+      ],
+    });
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.declared).toHaveLength(2);
+    expect(res.result.declared.every((d) => d.active)).toBe(true);
+    expect(res.result.mismatches.declaredNotActive).toBe(0);
+  });
+
+  test('reconciliation is case-insensitive across declared and the trie', () => {
+    const runtime = makeRuntime();
+    const { runId, taskId } = createRun();
+    // Register a dynamic subscription with one casing; the reconcile key
+    // lowercases both sides, so the persisted↔active match must hold.
+    runtime.registerSubscription(
+      runId,
+      taskId,
+      'code',
+      'coder',
+      'GitHub/Owner/Repo/Pull_Request/1.*'
+    );
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.persisted[0].active).toBe(true);
+    expect(res.result.active[0].source).toBe('persisted');
+    expect(res.result.mismatches).toEqual({
+      declaredNotActive: 0,
+      persistedNotActive: 0,
+      orphanActive: 0,
+    });
+  });
+
+  test('idempotent registerRunInterests re-registration does not double-count active', () => {
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+    // registerRunInterests clears-and-reinserts static interests for the run;
+    // re-calling it must not leave duplicate trie entries.
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.active.filter((a) => a.subscriptionKind === 'static')).toHaveLength(1);
+    expect(res.result.declared).toHaveLength(1);
+    expect(res.result.declared[0].active).toBe(true);
+  });
+
+  test('a run whose workflow definition no longer resolves reports declared empty without crashing', () => {
+    // Simulate getWorkflowForRun → null (e.g. a stale/removed definition) by
+    // stubbing the workflow manager. Persisted + active still reconcile.
+    const runtime = makeRuntime({
+      spaceWorkflowManager: { getWorkflowForRun: () => null } as unknown as typeof workflowManager,
+    });
+    const { runId, taskId } = createRun();
+    runtime.registerSubscription(runId, taskId, 'code', 'coder', 'github/owner/repo/issues/*');
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.declared).toEqual([]);
+    expect(res.result.persisted).toHaveLength(1);
+    expect(res.result.persisted[0].active).toBe(true);
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
@@ -1,0 +1,380 @@
+/**
+ * SpaceRuntime.listSubscriptions — read-only diagnostic (Task #908, PR 6).
+ *
+ * The tool snapshots a run's external-event subscriptions across three layers:
+ *   1. `declared`  — static interests from the workflow definition (durable).
+ *   2. `persisted` — dynamic rows from `space_workflow_event_subscriptions` (durable).
+ *   3. `active`    — in-memory trie entries (live cross-check ONLY).
+ *
+ * Durable layers (1 + 2) are the source of truth; the trie (3) is never the
+ * answer. These tests cover all three layers, the declared/persisted/orphan
+ * reconciliation, the nodeId filter, and the cross-space guard.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { SpaceWorkflow } from '@hyperneo/shared';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { CodingArtifactProfile } from '../../../../src/lib/space/workflows/coding-artifact-profile.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceWorkflowEventSubscriptionRepository } from '../../../../src/storage/repositories/space-workflow-event-subscription-repository.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+
+const SPACE_ID = 'space-list-1';
+const AGENT_ID = 'agent-list-1';
+
+function makeDb(): BunDatabase {
+  const db = new BunDatabase(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  runMigrations(db, () => {});
+  return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+  db.prepare(
+    `INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+  ).run(spaceId, `/tmp/${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+  db.prepare(
+    `INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+  ).run(agentId, spaceId, `Agent ${agentId}`, Date.now(), Date.now());
+}
+
+describe('SpaceRuntime.listSubscriptions', () => {
+  let db: BunDatabase;
+  let workflowRunRepo: SpaceWorkflowRunRepository;
+  let taskRepo: SpaceTaskRepository;
+  let workflowManager: SpaceWorkflowManager;
+  let spaceManager: SpaceManager;
+  let agentManager: SpaceAgentManager;
+  let subscriptionRepo: SpaceWorkflowEventSubscriptionRepository;
+
+  function makeRuntime(overrides?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+    const artifactProfile = new CodingArtifactProfile({ db });
+    return new SpaceRuntime({
+      db,
+      spaceManager,
+      spaceAgentManager: agentManager,
+      spaceWorkflowManager: workflowManager,
+      workflowRunRepo,
+      taskRepo,
+      nodeExecutionRepo: new NodeExecutionRepository(db),
+      artifactProfile,
+      ...overrides,
+    });
+  }
+
+  /** Create a workflow + a (pending) run with a canonical in_progress task. */
+  function createRun(
+    options: {
+      coderInterests?: Array<{
+        topic?: string;
+        topicFrom?: { source: 'primaryLink'; pattern: string };
+        label?: string;
+      }>;
+      reviewerInterests?: Array<{ topic?: string }>;
+      spaceId?: string;
+    } = {}
+  ): { workflow: SpaceWorkflow; runId: string; taskId: string } {
+    const spaceId = options.spaceId ?? SPACE_ID;
+    const workflow = workflowManager.createWorkflow({
+      spaceId,
+      name: `Workflow-${Math.random()}`,
+      description: '',
+      nodes: [
+        {
+          id: 'code',
+          name: 'Code',
+          agents: [
+            {
+              agentId: AGENT_ID,
+              name: 'coder',
+              ...(options.coderInterests ? { eventInterests: options.coderInterests } : {}),
+            },
+          ],
+        },
+        {
+          id: 'review',
+          name: 'Review',
+          agents: [
+            {
+              agentId: AGENT_ID,
+              name: 'reviewer',
+              ...(options.reviewerInterests ? { eventInterests: options.reviewerInterests } : {}),
+            },
+          ],
+        },
+      ],
+      transitions: [],
+      startNodeId: 'code',
+      rules: [],
+      tags: [],
+    });
+    const run = workflowRunRepo.createRun({
+      spaceId,
+      workflowId: workflow.id,
+      title: 'List Run',
+    });
+    const task = taskRepo.createTask({
+      spaceId,
+      workflowRunId: run.id,
+      title: 'List Run',
+      description: '',
+      status: 'in_progress',
+    });
+    return { workflow, runId: run.id, taskId: task.id };
+  }
+
+  beforeEach(() => {
+    db = makeDb();
+    seedSpaceRow(db, SPACE_ID);
+    seedSpaceRow(db, 'space-other');
+    seedAgentRow(db, AGENT_ID, SPACE_ID);
+    workflowRunRepo = new SpaceWorkflowRunRepository(db);
+    taskRepo = new SpaceTaskRepository(db);
+    workflowManager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+    spaceManager = new SpaceManager(db);
+    agentManager = new SpaceAgentManager(new SpaceAgentRepository(db));
+    subscriptionRepo = new SpaceWorkflowEventSubscriptionRepository(db);
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {
+      /* ignore */
+    }
+  });
+
+  test('returns all three layers reconciled when declared + dynamic are active', () => {
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*', label: 'issue events' }],
+    });
+    // Materialize the static interest into the trie.
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+    // Add a dynamic subscription (write-through: trie + table).
+    const dynamicTopic = 'github/owner/repo/pull_request/42.*';
+    expect(runtime.registerSubscription(runId, taskId, 'code', 'coder', dynamicTopic).success).toBe(
+      true
+    );
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    // Layer 1 — declared static interest from the definition, now active.
+    expect(result.declared).toHaveLength(1);
+    expect(result.declared[0]).toMatchObject({
+      nodeId: 'code',
+      nodeName: 'Code',
+      agentName: 'coder',
+      topic: 'github/owner/repo/issues/*',
+      label: 'issue events',
+      active: true,
+    });
+
+    // Layer 2 — persisted dynamic row, active in the trie.
+    expect(result.persisted).toHaveLength(1);
+    expect(result.persisted[0]).toMatchObject({
+      nodeId: 'code',
+      agentName: 'coder',
+      taskId,
+      topic: dynamicTopic,
+      active: true,
+    });
+
+    // Layer 3 — active trie entries, each backed by durable state.
+    expect(result.active).toHaveLength(2);
+    const staticActive = result.active.find((a) => a.subscriptionKind === 'static');
+    const dynamicActive = result.active.find((a) => a.subscriptionKind === 'dynamic');
+    expect(staticActive?.source).toBe('declared');
+    expect(staticActive?.topic).toBe('github/owner/repo/issues/*');
+    expect(dynamicActive?.source).toBe('persisted');
+    expect(dynamicActive?.topic).toBe(dynamicTopic);
+
+    // No drift.
+    expect(result.mismatches).toEqual({
+      declaredNotActive: 0,
+      persistedNotActive: 0,
+      orphanActive: 0,
+    });
+  });
+
+  test('#896 scenario: a node with no declared PR-event interest shows declared empty from durable data', () => {
+    const runtime = makeRuntime();
+    const { runId, taskId } = createRun({
+      // coder has an issue interest but NO pull_request interest declared.
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID, 'code');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    // From durable data alone: the Code node declares only issue events — no
+    // PR-event interest. That is the diagnosis the investigation needed.
+    const declaredTopics = result.declared.map((d) => d.topic);
+    expect(declaredTopics).not.toContain(expect.stringContaining('pull_request'));
+    expect(declaredTopics).toEqual(['github/owner/repo/issues/*']);
+    // Nothing is active yet (static not materialized).
+    expect(result.mismatches.declaredNotActive).toBe(1);
+  });
+
+  test('declared-but-not-active surfaces when static interests are not materialized', () => {
+    const runtime = makeRuntime();
+    const { runId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    // Deliberately do NOT call registerRunInterests — the definition declares
+    // the interest, but the trie has not materialized it (e.g. a run whose
+    // static rebuild has not run / has been cleared).
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    expect(result.declared).toHaveLength(1);
+    expect(result.declared[0].active).toBe(false);
+    expect(result.active).toEqual([]);
+    expect(result.mismatches.declaredNotActive).toBe(1);
+    expect(result.mismatches.orphanActive).toBe(0);
+  });
+
+  test('persisted-but-not-active surfaces a durable row missing from the trie', () => {
+    const runtime = makeRuntime();
+    const { runId, taskId } = createRun();
+    // Persist a dynamic row directly (bypassing the runtime), so the table has
+    // it but the trie does not — e.g. mid-rehydrate before the trie rebuild.
+    subscriptionRepo.upsert({
+      spaceId: SPACE_ID,
+      workflowRunId: runId,
+      taskId,
+      nodeId: 'code',
+      agentName: 'coder',
+      topic: 'github/owner/repo/pull_request/7.*',
+      subscriptionKind: 'dynamic',
+    });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    expect(result.persisted).toHaveLength(1);
+    expect(result.persisted[0].active).toBe(false);
+    expect(result.active).toEqual([]);
+    expect(result.mismatches.persistedNotActive).toBe(1);
+  });
+
+  test('orphan active entry surfaces a trie target with no durable backing', () => {
+    const runtime = makeRuntime();
+    const { runId, taskId } = createRun();
+    // registerSubscription is write-through (trie + table) → backed.
+    runtime.registerSubscription(
+      runId,
+      taskId,
+      'code',
+      'coder',
+      'github/owner/repo/pull_request/42.*'
+    );
+    // Now wipe only the durable row, leaving a trie entry with no backing —
+    // simulating drift between the table and the trie.
+    subscriptionRepo.deleteByRun(runId);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    expect(result.persisted).toEqual([]);
+    expect(result.active).toHaveLength(1);
+    expect(result.active[0].subscriptionKind).toBe('dynamic');
+    expect(result.active[0].source).toBe('orphan');
+    expect(result.mismatches.orphanActive).toBe(1);
+  });
+
+  test('topicFrom declared interest is listed but excluded from the mismatch count', () => {
+    const runtime = makeRuntime();
+    const { runId } = createRun({
+      coderInterests: [
+        {
+          topicFrom: {
+            source: 'primaryLink',
+            pattern: 'github/{owner}/{repo}/pull_request/{number}.*',
+          },
+        },
+      ],
+    });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    expect(result.declared).toHaveLength(1);
+    expect(result.declared[0].topic).toBeNull();
+    expect(result.declared[0].topicFrom).toEqual({
+      source: 'primaryLink',
+      pattern: 'github/{owner}/{repo}/pull_request/{number}.*',
+    });
+    // topicFrom is inert (no resolver yet) → not active, but NOT a drift signal.
+    expect(result.declared[0].active).toBe(false);
+    expect(result.mismatches.declaredNotActive).toBe(0);
+  });
+
+  test('nodeId filter scopes all three layers to one node', () => {
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+      reviewerInterests: [{ topic: 'github/owner/repo/pull_request/*.*' }],
+    });
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID, 'review');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const { result } = res;
+
+    expect(result.nodeId).toBe('review');
+    expect(result.declared).toHaveLength(1);
+    expect(result.declared[0].nodeId).toBe('review');
+    expect(result.declared[0].agentName).toBe('reviewer');
+    expect(result.active).toHaveLength(1);
+    expect(result.active[0].nodeId).toBe('review');
+  });
+
+  test('rejects a run in another space', () => {
+    const runtime = makeRuntime();
+    const { runId } = createRun({ spaceId: 'space-other' });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error).toContain('not in this space');
+  });
+
+  test('returns an error for an unknown run', () => {
+    const runtime = makeRuntime();
+    const res = runtime.listSubscriptions('run-does-not-exist', SPACE_ID);
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error).toContain('not found');
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-list-subscriptions.test.ts
@@ -415,6 +415,29 @@ describe('SpaceRuntime.listSubscriptions', () => {
     expect(res.result.mismatches.declaredNotActive).toBe(0);
   });
 
+  test('a terminal task with a leftover static trie entry surfaces it as orphan', () => {
+    // Inverse of the P1 case: if the lifecycle cleanup misses a static entry on
+    // a terminal task, that stale entry must NOT be hidden — declaredNotActive
+    // stays suppressed (terminal), but the surviving entry is reclassified as
+    // orphan and counted so the drift is still visible.
+    const runtime = makeRuntime();
+    const { workflow, runId, taskId } = createRun({
+      coderInterests: [{ topic: 'github/owner/repo/issues/*' }],
+    });
+    runtime.registerRunInterests(runId, taskId, workflow.nodes);
+    // Mark terminal WITHOUT clearing the trie (simulates a failed/partial cleanup).
+    taskRepo.updateTask(taskId, { status: 'done' });
+
+    const res = runtime.listSubscriptions(runId, SPACE_ID);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.result.mismatches.declaredNotActive).toBe(0); // terminal → suppressed
+    expect(res.result.active).toHaveLength(1);
+    expect(res.result.active[0].subscriptionKind).toBe('static');
+    expect(res.result.active[0].source).toBe('orphan');
+    expect(res.result.mismatches.orphanActive).toBe(1);
+  });
+
   test('multiple static interests on the same slot do not collapse', () => {
     const runtime = makeRuntime();
     const { workflow, runId, taskId } = createRun({


### PR DESCRIPTION
PR 6 of the external-event subscription refactor (depends on #904 / PR 5). Adds a read-only `list_subscriptions` MCP tool that snapshots a run's external-event subscriptions across three layers — **declared** (workflow definition), **persisted** (the PR 5 table), and **active** (in-memory trie, cross-check only) — so an agent can answer "is this node actually subscribed to these events?" from durable state alone. The durable layers are the source of truth; the trie is shown only as a sanity check, with each active entry reconciled against durable state (`source: declared|persisted|orphan`) and durable rows missing from the trie surfaced via `active: false` plus a `mismatches` summary. For task #896 this would have shown "Coding node has no declared PR-event interest" from durable data alone.

Additive plumbing: `TopicTrie.values()` (diagnostic enumeration), `SpaceWorkflowEventSubscriptionRepository.listByRun()` (run-scoped read — PR 5 removed it as unused; now needed), `SpaceRuntime.listSubscriptions()` (three-layer snapshot + reconciliation, run/node scoped, space guarded), the `list_subscriptions` node-agent tool, and the `SpaceRuntimeService` facade + `TaskAgentManager` wiring. Unit tests cover all three layers, the declared/persisted/orphan reconciliation, the nodeId filter, the cross-space guard, and the #896 scenario.