### PR TITLE
feat(delivery): expose message delivery state in the UI [#862]

### DIFF
--- a/docs/features/message-delivery-v2.md
+++ b/docs/features/message-delivery-v2.md
@@ -558,3 +558,13 @@ submitted) rows for their delivery badge, but only SETTLED (consumed/failed)
 user rows become `turnUserMessageId` sentinels — `saveUserMessageCore` withholds
 a conversation anchor until the row settles, and subsequent assistant rows must
 not inherit a pending prompt's id as their turn.
+
+### Interrupt / revoke reactivity
+
+`handleInterrupt` (cancel-everything path) and `revokePendingDelivery` both
+write through the raw db — cancelling `job_queue` rows and flipping `sdk_messages`
+statuses — and both now `notifyChange('sdk_messages' | 'job_queue')` session-scoped
+after the lock closes, so the widened delivery feeds drop the queued/retrying
+badge immediately instead of staying stuck until an unrelated write or reconnect.
+`message_delivery` jobs' payloads carry `sessionId`, which the processor derives
+into the change scope.

--- a/docs/features/message-delivery-v2.md
+++ b/docs/features/message-delivery-v2.md
@@ -537,3 +537,24 @@ re-deliveries), so they do not duplicate `reconcileStrandedDeliveries`:
 
 Per the task's "remove only demonstrably redundant workarounds; retain
 Space-specific orchestration semantics," these are retained.
+
+### Reactivity scoping (review hardening)
+
+The retry signal makes `job_queue` a dependency of every transcript/task feed.
+To avoid every unrelated job (schedules, cleanup, polling, workflow) re-running
+all open feeds, the change notifiers are scoped:
+
+- `messageDeliveryProcessor.setChangeNotifier` notifies `job_queue` SESSION-scoped
+  (derived from the delivery job payload's `sessionId`), so only that session's
+  feed re-evaluates — the retry-signal reactivity stays correct.
+- The generic `JobQueueProcessor` (non-delivery lanes) passes the scope through
+  when a job payload carries `sessionId`/`taskId`; the app-level generic notifier
+  is a no-op for `job_queue` since no feed depends on it outside `message_delivery`.
+
+### Turn anchoring (full feed)
+
+The full `spaceTaskMessages.byTask` feed emits pending (deferred/enqueued/
+submitted) rows for their delivery badge, but only SETTLED (consumed/failed)
+user rows become `turnUserMessageId` sentinels — `saveUserMessageCore` withholds
+a conversation anchor until the row settles, and subsequent assistant rows must
+not inherit a pending prompt's id as their turn.

--- a/docs/features/message-delivery-v2.md
+++ b/docs/features/message-delivery-v2.md
@@ -454,3 +454,86 @@ but by hardening it.
   skips = duplicates prevented; `stillEnqueued` = re-drive; `noContent`), and
   residual-window latency P50/P99. Because at-least-once accepts duplicates,
   these metrics are how we know when the accepted failure actually happens.
+
+## 17. Phase 4 — delivery state in the UI (task #862)
+
+Phase 3 made delivery ownership durable and recoverable but kept the lifecycle
+hidden: a user message was invisible in the transcript until it reached
+`consumed` (or `failed`), so users inferred "stuck" state from system/init
+messages. Phase 4 surfaces the lifecycle explicitly and retires nothing the
+generic reconciler does not already cover.
+
+### Delivery status model
+
+A shared `MessageDeliveryStatus` (`queued | processing | retrying | delivered |
+failed`) is mapped from `send_status` (+ the active `message_delivery` job's
+`retry_count` for `retrying`) by `sendStatusToDeliveryStatus` in
+`packages/shared`. The mapping:
+
+| `send_status` | active job `retry_count > 0`? | `MessageDeliveryStatus` |
+|---------------|-------------------------------|-------------------------|
+| `deferred`    | no / yes                      | `queued` / `retrying`   |
+| `enqueued`    | no / yes                      | `queued` / `retrying`   |
+| `submitted`   | no / yes                      | `processing` / `retrying` |
+| `consumed`    | —                             | `delivered`             |
+| `failed`      | —                             | `failed`                |
+
+### Feed changes
+
+`messages.bySession` and `spaceTaskMessages.byTask(.compact)` now:
+
+- **Widen visibility** so `deferred`/`enqueued`/`submitted` user rows appear
+  (previously filtered to `consumed`/`failed`). Daemon-side reads
+  (`SDKMessageRepository.getSDKMessages`) keep the old filter, so prompt context
+  and rewind see only settled rows — only the web transcript feed widens.
+- **Emit `deliveryStatus`** (ordinary chat) / the full lifecycle (Space threads,
+  expanded from `delivered`/`failed`) via the shared mapper.
+- **Surface retrying** through a session-scoped `EXISTS` against the active
+  `message_delivery` job (`retry_count > 0`), bounded by
+  `idx_message_delivery_session_active`.
+
+The widened feed also gives a natural **optimistic echo with no web-side
+optimistic insert**: the persisted `enqueued` row appears within milliseconds of
+send via the reactive-DB flush, then transitions in place by its stable row id.
+A `send_status` UPDATE emits an `updated` delta on the SAME row — never a
+duplicate `added` — so retry / state changes update the one visible message
+(covered end-to-end by `live-query-delivery-status.test.ts`).
+
+### UI
+
+`SDKUserMessage` renders a `DeliveryStateBadge` for `queued` / `processing` /
+`retrying` / `failed`; `delivered` hides the badge to avoid noisy indicators on
+normal fast delivery. `DeliveryStateBadge` is generalized to cover both
+`MessageDeliveryStatus` and `ActorMessageDeliveryState` so the chat and Space
+thread surfaces share one visual language.
+
+### Steer-consumed propagation (item 11)
+
+A steer's SDK-consumed signal is `onSent`. `feedDeliverySteer` already flips
+`send_status → consumed` synchronously at `onSent` (phase 3, item 12) and
+publishes `messages.statusChanged`; the reactive DB detects the column change
+and the widened feed now shows the steer row transitioning `queued → processing
+→ delivered` rather than appearing only after consumption. No additional emit
+is needed — the certain/consumed state is terminal for delivery under the
+at-least-once model. (ACP's consume boundary is acceptance, handled by
+`markMessageAccepted`, unchanged.)
+
+### Wake / recovery audit (items 6 + 7)
+
+Audited the Space runtime for wake/retry logic now potentially redundant given
+the generic reconciler. Conclusion: **no demonstrably redundant mechanism
+remains** — the agent-level duplicate (`recoverOrphanedConsumedMessages`) was
+already decommissioned in phase 3. The surviving Space recovery paths each own
+a distinct failure mode and inject *system*-origin messages (not stranded-user
+re-deliveries), so they do not duplicate `reconcileStrandedDeliveries`:
+
+- non-terminal-idle **nudge** / runtime **nag** / terminal-error **continue** —
+  an agent that went idle or errored mid-work (no stranded user message to
+  re-deliver; the reconciler has nothing to act on);
+- **restart-notice** — post-restart rehydration;
+- **external-event digest requeue** (`requeuePersistedPendingDeliveries`) — the
+  separate external-event delivery store, not the `message_delivery` lane;
+- `/compact` injection.
+
+Per the task's "remove only demonstrably redundant workarounds; retain
+Space-specific orchestration semantics," these are retained.

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -378,9 +378,15 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     // message_delivery job). The generic processor handles every non-delivery
     // lane (schedules, cleanup, polling, workflow) — notifying `job_queue` there
     // would re-run all open transcript queries on every unrelated job, so it is
-    // a no-op. The message_delivery processor notifies session-scoped so only
-    // that session's feed re-evaluates.
+    // a no-op.
+    //
+    // INVARIANT: no non-delivery live query subscribes to `job_queue` today. If
+    // one ever does, give the generic notifier a session/task scope (the
+    // processor already threads it from job payloads) instead of making it a
+    // no-op, so unrelated lanes don't re-run open feeds.
     jobProcessor.setChangeNotifier(() => {});
+    // The message_delivery processor notifies session-scoped so only that
+    // session's feed re-evaluates on a delivery job transition.
     messageDeliveryProcessor.setChangeNotifier((table, scope) => {
       reactiveDb.notifyChange(table, scope);
     });

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -373,11 +373,16 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
     //       One-shot shutdown polling with hard timeout; not a recurring task.
     //   • ProcessWatchdog timer (process-watchdog.ts)
     //       Last-resort OS process leak safety net; intentionally independent from the job queue.
-    jobProcessor.setChangeNotifier((table) => {
-      reactiveDb.notifyChange(table);
-    });
-    messageDeliveryProcessor.setChangeNotifier((table) => {
-      reactiveDb.notifyChange(table);
+    // Task #862 (review P2): the transcript/task feeds depend on `job_queue`
+    // ONLY for the message_delivery retry signal (the EXISTS vs an active
+    // message_delivery job). The generic processor handles every non-delivery
+    // lane (schedules, cleanup, polling, workflow) — notifying `job_queue` there
+    // would re-run all open transcript queries on every unrelated job, so it is
+    // a no-op. The message_delivery processor notifies session-scoped so only
+    // that session's feed re-evaluates.
+    jobProcessor.setChangeNotifier(() => {});
+    messageDeliveryProcessor.setChangeNotifier((table, scope) => {
+      reactiveDb.notifyChange(table, scope);
     });
     let sessionManager: SessionManager | null = null;
     let taskAgentManager: TaskAgentManager | null = null;

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -947,6 +947,14 @@ export class AgentSession
       this.db.getJobQueueRepo().cancelDelivery(this.session.id, result.uuid);
       const removedFromMemory = this.messageQueue.remove(result.uuid);
       await this.stateManager.clearQueuedIfOwnedBy(result.uuid);
+      // Task #862 (review P2): both `deferEnqueuedUserMessage` (enqueued →
+      // deferred) and `cancelDelivery` (deletes the active job) write through
+      // the raw db with no notify, so the widened feed would keep showing
+      // "retrying" (deliveryRetry stays 1) after Move to Next. Notify both
+      // tables so `sdk_messages` (the new deferred status) and `job_queue` (the
+      // gone active job) re-evaluate.
+      this.db.notifyChange?.('sdk_messages', { sessionId: this.session.id });
+      this.db.notifyChange?.('job_queue', { sessionId: this.session.id });
       return {
         changed: true as const,
         dbId: result.dbId,

--- a/packages/daemon/src/lib/agent/interrupt-handler.ts
+++ b/packages/daemon/src/lib/agent/interrupt-handler.ts
@@ -105,6 +105,14 @@ export class InterruptHandler {
           }
         }
       });
+      // Task #862 (review P1): both cancelForSessionWithMessages (raw DELETE on
+      // job_queue) and markDeliveryFailedByUuid (raw UPDATE on sdk_messages) write
+      // without a notify, so after interrupting a pending/enqueued message (or an
+      // in-flight steer job) the queued/retrying badge would stay stuck until an
+      // unrelated write or reconnect. Notify both tables (session-scoped) so the
+      // widened delivery feeds re-evaluate immediately.
+      this.ctx.db.notifyChange?.('sdk_messages', { sessionId: session.id });
+      this.ctx.db.notifyChange?.('job_queue', { sessionId: session.id });
     }
 
     const currentState = stateManager.getState();

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2029,12 +2029,23 @@ sdk_rows_numbered AS (
 ),
 sdk_rows_with_pos AS (
   -- Mark this row's own rowPos as the carry-forward sentinel when it's a
-  -- user row; otherwise NULL. Combined with the MAX() window below this
-  -- lets us forward-fill the latest user-row position per session without
-  -- a per-row correlated subquery or a second ROW_NUMBER() pass.
+  -- TERMINAL user row (consumed/failed); otherwise NULL. Combined with the
+  -- MAX() window below this lets us forward-fill the latest user-row position
+  -- per session without a per-row correlated subquery or a second ROW_NUMBER()
+  -- pass.
+  --
+  -- Task #862 (review P2): only settled user rows anchor a conversation turn.
+  -- A deferred/enqueued/submitted prompt is emitted (for its delivery badge)
+  -- but saveUserMessageCore deliberately withholds a new conversation anchor
+  -- until the row becomes consumed/failed, so a pending row must NOT become the
+  -- turnId that subsequent assistant rows inherit.
   SELECT
     n.*,
-    CASE WHEN n.messageType = 'user' THEN n.rowPos ELSE NULL END AS thisUserRowPos
+    CASE
+      WHEN n.messageType = 'user' AND n.deliveryState IN ('delivered', 'failed')
+        THEN n.rowPos
+      ELSE NULL
+    END AS thisUserRowPos
   FROM sdk_rows_numbered n
 ),
 -- Forward-fill the latest user-row position seen in each session up to and

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -16,7 +16,12 @@ import type {
   LiveQueryUnsubscribeResponse,
   MessageHub,
 } from '@hyperneo/shared';
-import { createEventMessage, parseJson, parseJsonOptional } from '@hyperneo/shared';
+import {
+  createEventMessage,
+  parseJson,
+  parseJsonOptional,
+  sendStatusToDeliveryStatus,
+} from '@hyperneo/shared';
 import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
 import type { LiveQueryEngine, LiveQueryHandle, QueryDiff } from '../../storage/live-query';
 import type { TableChangeScope } from '../../storage/reactive-database';
@@ -203,7 +208,10 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
   const turnUserMessageId =
     typeof row.turnUserMessageId === 'string' ? row.turnUserMessageId : null;
   const origin = typeof row.origin === 'string' ? row.origin : null;
-  const deliveryState = messageType === 'user' && row.deliveryState === 'failed' ? 'failed' : null;
+  // Task #862: pass through the full user-message delivery lifecycle
+  // (queued / processing / retrying / delivered / failed) computed SQL-side.
+  const deliveryState =
+    messageType === 'user' && typeof row.deliveryState === 'string' ? row.deliveryState : null;
   // Optional backward-compat field from older compact-query variants.
   // Current compact SQL no longer emits this, but keep tolerant parsing so
   // historical rows/tests and alternate query variants remain safe.
@@ -1944,7 +1952,24 @@ sdk_rows_raw AS (
     sm.message_type AS messageType,
     sm.sdk_message AS content,
     sm.origin AS origin,
-    CASE WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'failed' WHEN sm.message_type = 'user' THEN 'delivered' ELSE NULL END AS deliveryState,
+    CASE
+      WHEN sm.message_type != 'user' THEN NULL
+      WHEN COALESCE(sm.send_status, 'consumed') = 'failed' THEN 'failed'
+      WHEN COALESCE(sm.send_status, 'consumed') = 'consumed' THEN 'delivered'
+      WHEN COALESCE(sm.send_status, 'consumed') IN ('deferred', 'enqueued', 'submitted')
+           AND EXISTS (
+             SELECT 1
+             FROM job_queue jq
+             WHERE jq.queue = 'message_delivery'
+               AND jq.status IN ('pending', 'processing')
+               AND json_extract(jq.payload, '$.sessionId') = sm.session_id
+               AND json_extract(jq.payload, '$.messageUuid') = sm.sdk_uuid
+               AND jq.retry_count > 0
+           )
+      THEN 'retrying'
+      WHEN COALESCE(sm.send_status, 'consumed') = 'submitted' THEN 'processing'
+      ELSE 'queued'
+    END AS deliveryState,
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
     sm.parent_tool_use_id AS parentToolUseId,
     sm.is_renderable AS isRenderable,
@@ -1963,8 +1988,7 @@ sdk_rows_raw AS (
    AND sne.rn = 1
   LEFT JOIN space_agents sa
     ON sa.id = COALESCE(sne.agent_id, json_extract(s_kind.metadata, '$.promptProvenance.agentId'))
-  WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
-    AND (
+  WHERE (
       sm.message_type != 'system'
       OR sm.message_subtype_norm != 'informational'
       OR NOT json_valid(sm.sdk_message)
@@ -2240,7 +2264,24 @@ sdk_rows AS (
     sm.message_type AS messageType,
     sm.sdk_message AS content,
     sm.origin AS origin,
-    CASE WHEN sm.message_type = 'user' AND sm.send_status = 'failed' THEN 'failed' WHEN sm.message_type = 'user' THEN 'delivered' ELSE NULL END AS deliveryState,
+    CASE
+      WHEN sm.message_type != 'user' THEN NULL
+      WHEN COALESCE(sm.send_status, 'consumed') = 'failed' THEN 'failed'
+      WHEN COALESCE(sm.send_status, 'consumed') = 'consumed' THEN 'delivered'
+      WHEN COALESCE(sm.send_status, 'consumed') IN ('deferred', 'enqueued', 'submitted')
+           AND EXISTS (
+             SELECT 1
+             FROM job_queue jq
+             WHERE jq.queue = 'message_delivery'
+               AND jq.status IN ('pending', 'processing')
+               AND json_extract(jq.payload, '$.sessionId') = sm.session_id
+               AND json_extract(jq.payload, '$.messageUuid') = sm.sdk_uuid
+               AND jq.retry_count > 0
+           )
+      THEN 'retrying'
+      WHEN COALESCE(sm.send_status, 'consumed') = 'submitted' THEN 'processing'
+      ELSE 'queued'
+    END AS deliveryState,
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
     sm.parent_tool_use_id AS parentToolUseId,
     sm.is_renderable AS isRenderable,
@@ -2257,7 +2298,6 @@ sdk_rows AS (
    AND sne.rn = 1
   LEFT JOIN space_agents sa ON sa.id = sne.agent_id
   WHERE sm.conversation_turn_index >= rt.minTurn
-    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
     AND (
       sm.message_type != 'system'
       OR sm.message_subtype_norm != 'informational'
@@ -3251,11 +3291,30 @@ WITH top_level AS (
     timestamp,
     send_status,
     origin,
-    rowid
+    rowid,
+    -- Active-delivery retry signal for the "retrying" UI state (task #862):
+    -- true when a pending/processing message_delivery job for this session
+    -- references the row's canonical uuid AND has already been retried
+    -- (retry_count > 0). Scoped to this session's active jobs (few) via the
+    -- partial index idx_message_delivery_session_active; one bounded lookup.
+    EXISTS (
+      SELECT 1
+      FROM job_queue jq
+      WHERE jq.queue = 'message_delivery'
+        AND jq.status IN ('pending', 'processing')
+        AND json_extract(jq.payload, '$.sessionId') = ?1
+        AND json_extract(jq.payload, '$.messageUuid') = sdk_messages.sdk_uuid
+        AND jq.retry_count > 0
+    ) AS deliveryRetry
   FROM sdk_messages
   WHERE session_id = ?1
     AND parent_tool_use_id IS NULL
-    AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
+    -- Task #862: surface ALL user-message delivery states (deferred / enqueued
+    -- / submitted / consumed / failed) so the UI can badge queued / processing
+    -- / retrying explicitly instead of inferring from system/init. Daemon-side
+    -- reads (SDKMessageRepository.getSDKMessages) keep the consumed/failed
+    -- visibility filter, so prompt context / rewind are unaffected; only the
+    -- web transcript feed widens.
     AND message_subtype_norm NOT IN (${EXCLUDED_FROM_PAGINATION_SQL_LIST})
     AND (
       message_type != 'system'
@@ -3315,12 +3374,20 @@ subagent AS (
     sm.timestamp AS timestamp,
     sm.send_status AS send_status,
     sm.origin AS origin,
-    sm.rowid AS rowid
+    sm.rowid AS rowid,
+    EXISTS (
+      SELECT 1
+      FROM job_queue jq
+      WHERE jq.queue = 'message_delivery'
+        AND jq.status IN ('pending', 'processing')
+        AND json_extract(jq.payload, '$.sessionId') = ?1
+        AND json_extract(jq.payload, '$.messageUuid') = sm.sdk_uuid
+        AND jq.retry_count > 0
+    ) AS deliveryRetry
   FROM sdk_messages sm
   WHERE sm.session_id = ?1
     AND sm.parent_tool_use_id IN (SELECT id FROM tool_use_ids)
     AND sm.message_subtype_norm != 'thinking_tokens'
-    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 )
 SELECT
   id,
@@ -3328,7 +3395,8 @@ SELECT
   CAST((julianday(timestamp) - 2440587.5) * 86400000 AS INTEGER)    AS timestamp,
   send_status                                                       AS sendStatus,
   origin                                                            AS origin,
-  rowid                                                             AS rowid
+  rowid                                                             AS rowid,
+  deliveryRetry                                                     AS deliveryRetry
 FROM top_level
 UNION ALL
 SELECT
@@ -3337,7 +3405,8 @@ SELECT
   CAST((julianday(timestamp) - 2440587.5) * 86400000 AS INTEGER)    AS timestamp,
   send_status                                                       AS sendStatus,
   origin                                                            AS origin,
-  rowid                                                             AS rowid
+  rowid                                                             AS rowid,
+  deliveryRetry                                                     AS deliveryRetry
 FROM subagent
 ORDER BY timestamp ASC, rowid ASC
 `.trim();
@@ -3351,9 +3420,10 @@ ORDER BY timestamp ASC, rowid ASC
  *     preserved so any SDK-level `origin?: SDKMessageOrigin` object gets
  *     stripped in favour of the app's `MessageOrigin` string.
  *   - Attach `timestamp` (epoch ms, computed SQL-side).
- *   - Attach `sendStatus` only when the DB column equals `'failed'`, so the UI
- *     can render the retry affordance without carrying 'consumed' through the
- *     message stream.
+ *   - Attach `deliveryStatus` (task #862) for user messages — the user-facing
+ *     delivery lifecycle (queued / processing / retrying / delivered / failed),
+ *     mapped from `send_status` + the active-job retry signal via the shared
+ *     `sendStatusToDeliveryStatus`. Non-user rows get no delivery state.
  *   - Attach `id` so client-side LiveQuery diffing is stable even when the
  *     SDK message lacks a `uuid`.
  */
@@ -3378,8 +3448,12 @@ function mapMessageRow(row: Record<string, unknown>): Record<string, unknown> {
     rowid: typeof row.rowid === 'number' ? row.rowid : Number(row.rowid ?? 0),
     origin: row.origin != null ? row.origin : undefined,
   };
-  if (row.sendStatus === 'failed') {
-    extras.sendStatus = 'failed';
+  // Only user messages carry a delivery lifecycle. SQLite EXISTS returns 0/1.
+  if (parsed.type === 'user') {
+    const deliveryStatus = sendStatusToDeliveryStatus(row.sendStatus as string | null, {
+      retrying: Number(row.deliveryRetry ?? 0) > 0,
+    });
+    if (deliveryStatus) extras.deliveryStatus = deliveryStatus;
   }
 
   return { ...parsed, ...extras };

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -2299,7 +2299,18 @@ sdk_rows AS (
    AND sne.session_id = sm.session_id
    AND sne.rn = 1
   LEFT JOIN space_agents sa ON sa.id = sne.agent_id
-  WHERE sm.conversation_turn_index >= rt.minTurn
+  WHERE (
+    sm.conversation_turn_index >= rt.minTurn
+    OR (
+      -- Task #862 (review P2): include active nonterminal user rows
+      -- (deferred/enqueued/submitted) independently of the recent-turn cutoff.
+      -- A message queued to a dormant agent whose last turn index is old would
+      -- otherwise be dropped from the compact feed until it settles, defeating
+      -- the delivery-state UI for exactly the long multi-agent case it exists for.
+      sm.message_type = 'user'
+      AND COALESCE(sm.send_status, 'consumed') NOT IN ('consumed', 'failed')
+    )
+  )
     AND (
       sm.message_type != 'system'
       OR sm.message_subtype_norm != 'informational'
@@ -2708,6 +2719,10 @@ user_entries AS (
   FROM active_rows ar
   JOIN sdk_messages base ON base.id = ar.id
   WHERE ar.messageType = 'user'
+    -- Task #862 (review P2): a deferred prompt is explicitly waiting for the
+    -- next turn -- keep it in the main thread, but don't show it in the live
+    -- active-turn roster as input "inside" the active turn.
+    AND COALESCE(base.send_status, 'consumed') != 'deferred'
     AND json_valid(ar.content)
     -- Skip user rows whose content is exclusively tool_result blocks (or
     -- mixes tool_result with empty/whitespace-only text blocks). Such rows

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -123,6 +123,7 @@ export class Database {
   private goalAutomationCursorRepo!: GoalAutomationCursorRepository;
   private providerRepo!: ProviderRepository;
   private shortIdAllocator!: ShortIdAllocator;
+  private reactiveDb?: ReactiveDatabase;
 
   constructor(dbPath: string) {
     this.core = new DatabaseCore(dbPath);
@@ -132,8 +133,19 @@ export class Database {
     return this.core.getDbPath();
   }
 
+  /**
+   * Notify the live-query layer that a table changed, when this facade is
+   * wired to a {@link ReactiveDatabase}. Used by code paths that mutate a table
+   * through the raw db (e.g. `revokePendingDelivery` defer+cancel) so the
+   * widened delivery feed re-evaluates. No-op when not wired.
+   */
+  notifyChange(table: string, scope?: { sessionId?: string; taskId?: string }): void {
+    this.reactiveDb?.notifyChange(table, scope);
+  }
+
   async initialize(reactiveDb: ReactiveDatabase): Promise<void> {
     await this.core.initialize();
+    this.reactiveDb = reactiveDb;
 
     // Initialize repositories with the raw BunDatabase instance
     const db = this.core.getDb();

--- a/packages/daemon/src/storage/job-queue-processor.ts
+++ b/packages/daemon/src/storage/job-queue-processor.ts
@@ -1,6 +1,15 @@
 import type { Job, JobQueueRepository, PayloadMatch } from './repositories/job-queue-repository';
+import type { TableChangeScope } from './reactive-database';
 
 export type JobHandler = (job: Job) => Promise<Record<string, unknown> | void>;
+
+/** Derive a reactive change scope from a job's payload, when it carries one. */
+function scopeFromJob(job: Job): TableChangeScope | undefined {
+  const sessionId = typeof job.payload?.sessionId === 'string' ? job.payload.sessionId : undefined;
+  const taskId = typeof job.payload?.taskId === 'string' ? job.payload.taskId : undefined;
+  if (!sessionId && !taskId) return undefined;
+  return { ...(sessionId ? { sessionId } : {}), ...(taskId ? { taskId } : {}) };
+}
 
 export interface JobQueueProcessorOptions {
   pollIntervalMs?: number;
@@ -52,7 +61,7 @@ export class JobQueueProcessor {
   // be starved by — nor starve — capped jobs. Both count toward `stop()` drain.
   private inFlightExempt = 0;
   private running = false;
-  private changeNotifier: ((table: string) => void) | null = null;
+  private changeNotifier: ((table: string, scope?: TableChangeScope) => void) | null = null;
   private readonly pollIntervalMs: number;
   private readonly maxConcurrent: number;
   private readonly staleThresholdMs: number;
@@ -159,17 +168,18 @@ export class JobQueueProcessor {
     if (exempt) this.inFlightExempt++;
     else this.inFlightCapped++;
     const reg = this.handlers.get(job.queue);
+    const scope = scopeFromJob(job);
     try {
       if (!reg) {
         this.repo.fail(job.id, `No handler registered for queue: ${job.queue}`);
-        this.notifyChange();
+        this.notifyChange(scope);
         return;
       }
       const result = await reg.handler(job);
       // message_delivery parks/promotes by requeueing the job itself; the
       // auto-complete here is then a no-op (row no longer 'processing').
       this.repo.complete(job.id, result ?? undefined, job.claimToken);
-      this.notifyChange();
+      this.notifyChange(scope);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const updated = this.repo.fail(job.id, message, job.claimToken);
@@ -180,20 +190,20 @@ export class JobQueueProcessor {
           // A dead-letter side-effect must never break the processor loop.
         }
       }
-      this.notifyChange();
+      this.notifyChange(scope);
     } finally {
       if (exempt) this.inFlightExempt--;
       else this.inFlightCapped--;
     }
   }
 
-  setChangeNotifier(notifier: (table: string) => void): void {
+  setChangeNotifier(notifier: (table: string, scope?: TableChangeScope) => void): void {
     this.changeNotifier = notifier;
   }
 
-  private notifyChange(): void {
+  private notifyChange(scope?: TableChangeScope): void {
     if (this.changeNotifier) {
-      this.changeNotifier('job_queue');
+      this.changeNotifier('job_queue', scope);
     }
   }
 

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -11,6 +11,7 @@ import type { Database as BunDatabase } from '../sqlite-compat';
 import { generateUUID, sendStatusToDeliveryStatus } from '@hyperneo/shared';
 import type {
   MessageContent,
+  MessageDeliveryStatus,
   MessageOrigin,
   HyperNeoActionMessage,
   ChatMessage,
@@ -659,7 +660,7 @@ export class SDKMessageRepository {
     sinceRowid?: number
   ): {
     messages: Array<
-      ChatMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+      ChatMessage & { timestamp: number; origin?: MessageOrigin; deliveryStatus?: MessageDeliveryStatus }
     >;
     hasMore: boolean;
   } {
@@ -744,7 +745,7 @@ export class SDKMessageRepository {
     sinceRowid?: number
   ): {
     messages: Array<
-      ChatMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+      ChatMessage & { timestamp: number; origin?: MessageOrigin; deliveryStatus?: MessageDeliveryStatus }
     >;
     hasMore: boolean;
   } {
@@ -927,7 +928,11 @@ export class SDKMessageRepository {
     // tracking message provenance in HyperNeo). The runtime values are always correct.
     return {
       messages: [...topLevelMessages, ...subagentMessages] as Array<
-        SDKMessage & { timestamp: number; origin?: MessageOrigin; sendStatus?: string }
+        SDKMessage & {
+          timestamp: number;
+          origin?: MessageOrigin;
+          deliveryStatus?: MessageDeliveryStatus;
+        }
       >,
       hasMore,
     };

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Database as BunDatabase } from '../sqlite-compat';
-import { generateUUID } from '@hyperneo/shared';
+import { generateUUID, sendStatusToDeliveryStatus } from '@hyperneo/shared';
 import type {
   MessageContent,
   MessageOrigin,
@@ -845,8 +845,16 @@ export class SDKMessageRepository {
         // DB origin wins; undefined explicitly clears any SDK-level origin object.
         origin: r.origin != null ? (r.origin as MessageOrigin) : undefined,
       };
-      if (r.send_status === 'failed') {
-        extra.sendStatus = 'failed';
+      // Task #862: emit the same delivery lifecycle the LiveQuery feed exposes,
+      // so the `messages` RPC / initial-load / pagination / export payloads match
+      // the feed's wire shape. This path has no job_queue join, so the "retrying"
+      // state is not detectable here (the feed covers it); user rows reaching this
+      // path are virtually always settled (consumed/failed) anyway.
+      if (sdkMessage.type === 'user') {
+        const deliveryStatus = sendStatusToDeliveryStatus(
+          r.send_status as string | null | undefined
+        );
+        if (deliveryStatus) extra.deliveryStatus = deliveryStatus;
       }
       messages.push({ ...sdkMessage, ...extra } as SDKMessage & { timestamp: number });
       if (messages.length >= limit) break;

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1333,6 +1333,14 @@ export class SDKMessageRepository {
     message: SDKMessage,
     countsTowardsBadge: boolean
   ): void {
+    // Task #862 (review P1): the outbox commits the user row via
+    // `saveUserMessageCore` (raw db, bypassing the reactive proxy) and the badge
+    // notify only fires when the row counts toward the badge — an `enqueued`
+    // row does not. Always notify `sdk_messages` so the widened
+    // `messages.bySession` feed is re-evaluated on the initial commit and the
+    // queued/processing row is surfaced immediately (not after a later status
+    // mutation happens to notify).
+    this.reactiveDb?.notifyChange('sdk_messages', { sessionId });
     if (countsTowardsBadge) this.notifySessionsChanged(sessionId);
     this.upsertMessageSearchRow(id);
   }

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -660,7 +660,11 @@ export class SDKMessageRepository {
     sinceRowid?: number
   ): {
     messages: Array<
-      ChatMessage & { timestamp: number; origin?: MessageOrigin; deliveryStatus?: MessageDeliveryStatus }
+      ChatMessage & {
+        timestamp: number;
+        origin?: MessageOrigin;
+        deliveryStatus?: MessageDeliveryStatus;
+      }
     >;
     hasMore: boolean;
   } {
@@ -745,7 +749,11 @@ export class SDKMessageRepository {
     sinceRowid?: number
   ): {
     messages: Array<
-      ChatMessage & { timestamp: number; origin?: MessageOrigin; deliveryStatus?: MessageDeliveryStatus }
+      ChatMessage & {
+        timestamp: number;
+        origin?: MessageOrigin;
+        deliveryStatus?: MessageDeliveryStatus;
+      }
     >;
     hasMore: boolean;
   } {

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -983,6 +983,20 @@ describe('AgentSession', () => {
       expect(cancelDeliverySpy).toHaveBeenCalledWith(mockSession.id, 'uuid-1');
     });
 
+    it('revokePendingDelivery notifies the delivery feeds after defer+cancel (#862 review P2)', async () => {
+      const deferSpy = mock(() => ({ dbId: 'db-1', uuid: 'uuid-1' }));
+      const cancelDeliverySpy = mock(() => true);
+      const notifySpy = mock(() => {});
+      mockDb.deferEnqueuedUserMessage = deferSpy;
+      mockDb.getJobQueueRepo = mock(() => ({ cancelDelivery: cancelDeliverySpy }));
+      mockDb.notifyChange = notifySpy;
+
+      await agentSession.revokePendingDelivery('db-1', 'defer');
+
+      expect(notifySpy).toHaveBeenCalledWith('sdk_messages', { sessionId: mockSession.id });
+      expect(notifySpy).toHaveBeenCalledWith('job_queue', { sessionId: mockSession.id });
+    });
+
     it('deliverChatMessage preserves a legacy-owned processing turn', async () => {
       const jobQueue = {
         enqueue: mock(() => ({ id: 'job' })),

--- a/packages/daemon/tests/unit/1-core/agent/interrupt-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/interrupt-handler.test.ts
@@ -220,6 +220,26 @@ describe('InterruptHandler', () => {
       expect(callOrder).toEqual(['cancel', 'setInterrupted']);
     });
 
+    it('notifies the delivery feeds (sdk_messages + job_queue) after cancelling deliveries (#862 review P1)', async () => {
+      // cancelForSessionWithMessages (raw DELETE job_queue) and
+      // markDeliveryFailedByUuid (raw UPDATE sdk_messages) write without a
+      // notify, so without the explicit notifyChange the queued/retrying badge
+      // would stay stuck after an interrupt until an unrelated write/reconnect.
+      const notifySpy = mock(() => {});
+      cancelForSessionSpy = mock(() => ['turn-uuid']);
+      mockDb = {
+        getJobQueueRepo: mock(() => ({ cancelForSessionWithMessages: cancelForSessionSpy })),
+        getSDKMessageRepo: mock(() => ({ markDeliveryFailedByUuid: markFailedSpy })),
+        notifyChange: notifySpy,
+      } as unknown as InterruptHandlerContext['db'];
+      handler = createHandler({ db: mockDb });
+
+      await handler.handleInterrupt();
+
+      expect(notifySpy).toHaveBeenCalledWith('sdk_messages', { sessionId: 'test-session-id' });
+      expect(notifySpy).toHaveBeenCalledWith('job_queue', { sessionId: 'test-session-id' });
+    });
+
     it('cancels durable deliveries even when the session is already idle', async () => {
       getStateSpy.mockReturnValue({ status: 'idle', phase: 'idle' });
       cancelForSessionSpy = mock(() => ['pre-claim-uuid']);

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -1087,6 +1087,56 @@ describe('NAMED_QUERY_REGISTRY', () => {
       }
     });
 
+    test('a pending user row does not become the turnId for subsequent assistant rows (full feed)', () => {
+      // Task #862 (review P2): the widened full feed emits a pending prompt, but
+      // it must NOT anchor a conversation turn — saveUserMessageCore withholds
+      // the anchor until consumed/failed. Subsequent assistant rows must keep
+      // inheriting the last SETTLED user row's id as turnUserMessageId.
+      const workflowRunId = 'wr-stm-sentinel';
+      const sessionIdValue = 'session-stm-sentinel';
+      const taskId = insertSpaceTask({
+        id: 'task-stm-sentinel',
+        workflowRunId,
+        status: 'in_progress',
+      });
+      sessionTaskIds.set(sessionIdValue, taskId);
+      const userPayload = (uuid: string) => ({
+        type: 'user',
+        uuid,
+        message: { role: 'user', content: 'x' },
+      });
+      // Settled anchor establishes the turn.
+      insertSdkMessageAt(
+        'anchor',
+        sessionIdValue,
+        now + 1000,
+        'user',
+        'consumed',
+        'human',
+        null,
+        userPayload('u-anchor')
+      );
+      // Pending prompt — emitted for its badge but not a turn sentinel.
+      insertSdkMessageAt(
+        'pending',
+        sessionIdValue,
+        now + 2000,
+        'user',
+        'enqueued',
+        'human',
+        null,
+        userPayload('u-pending')
+      );
+      // Assistant row produced after the pending prompt.
+      insertSdkMessageAt('assist', sessionIdValue, now + 3000, 'assistant', 'consumed', 'system');
+
+      const entry = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask')!;
+      const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+      const assistRow = rows.find((r) => r.id === 'assist');
+      expect(assistRow).toBeTruthy();
+      expect(assistRow!.turnUserMessageId).toBe('anchor');
+    });
+
     test('actorMessages.byTask does not fan out SDK rows across node execution history', () => {
       const workflowRunId = 'wr-actor-sdk';
       const nodeSessionId = 'node-agent-actor-sdk';

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -1017,6 +1017,76 @@ describe('NAMED_QUERY_REGISTRY', () => {
       expect(mapped[0].severity).toBe('error');
     });
 
+    test('spaceTaskMessages.byTask maps user-message send_status to the delivery lifecycle + retrying', () => {
+      const workflowRunId = 'wr-stm-delivery';
+      const sessionIdValue = 'session-stm-delivery';
+      const taskId = insertSpaceTask({
+        id: 'task-stm-delivery',
+        workflowRunId,
+        status: 'in_progress',
+      });
+      sessionTaskIds.set(sessionIdValue, taskId);
+      const userPayload = (uuid: string) => ({
+        type: 'user',
+        uuid,
+        message: { role: 'user', content: [{ type: 'text', text: 'handoff' }] },
+      });
+      // One user message per send_status; stamp sdk_uuid so the retry EXISTS can match.
+      const cases: Array<{ id: string; uuid: string; sendStatus: string; expected: string }> = [
+        {
+          id: 'stm-consumed',
+          uuid: 'u-stm-consumed',
+          sendStatus: 'consumed',
+          expected: 'delivered',
+        },
+        { id: 'stm-deferred', uuid: 'u-stm-deferred', sendStatus: 'deferred', expected: 'queued' },
+        { id: 'stm-enqueued', uuid: 'u-stm-enqueued', sendStatus: 'enqueued', expected: 'queued' },
+        {
+          id: 'stm-submitted',
+          uuid: 'u-stm-submitted',
+          sendStatus: 'submitted',
+          expected: 'processing',
+        },
+        { id: 'stm-failed', uuid: 'u-stm-failed', sendStatus: 'failed', expected: 'failed' },
+        { id: 'stm-retry', uuid: 'u-stm-retry', sendStatus: 'enqueued', expected: 'retrying' },
+      ];
+      for (const c of cases) {
+        insertSdkMessageAt(
+          c.id,
+          sessionIdValue,
+          now + 1000,
+          'user',
+          c.sendStatus,
+          'human',
+          null,
+          userPayload(c.uuid)
+        );
+        db.prepare(`UPDATE sdk_messages SET sdk_uuid = ? WHERE id = ?`).run(c.uuid, c.id);
+      }
+      // An active message_delivery job with retry_count > 0 → the retry row reads "retrying".
+      db.prepare(
+        `INSERT INTO job_queue (id, queue, status, payload, retry_count, max_retries, run_at, created_at)
+         VALUES (?, 'message_delivery', 'pending', ?, 1, 8, ?, ?)`
+      ).run(
+        'job-stm-retry',
+        JSON.stringify({
+          sessionId: sessionIdValue,
+          messageUuid: 'u-stm-retry',
+          role: 'turn',
+          origin: 'space_inject',
+        }),
+        now,
+        now
+      );
+
+      const byId = new Map(queryMessages(taskId).map((r) => [r.id as string, r]));
+      for (const c of cases) {
+        expect((byId.get(c.id) as Record<string, unknown> | undefined)?.deliveryState).toBe(
+          c.expected
+        );
+      }
+    });
+
     test('actorMessages.byTask does not fan out SDK rows across node execution history', () => {
       const workflowRunId = 'wr-actor-sdk';
       const nodeSessionId = 'node-agent-actor-sdk';
@@ -2576,6 +2646,64 @@ describe('NAMED_QUERY_REGISTRY', () => {
 
         expect(rows).toHaveLength(1);
         expect(rows[0].origin).toBe('system');
+      });
+
+      test('maps user-message send_status to the delivery lifecycle + retrying (compact feed)', () => {
+        const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+        insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+        const userPayload = (uuid: string) => ({
+          type: 'user',
+          uuid,
+          message: { role: 'user', content: 'handoff' },
+        });
+        const cases: Array<{ id: string; uuid: string; sendStatus: string; expected: string }> = [
+          {
+            id: 'c-delivered',
+            uuid: 'u-c-delivered',
+            sendStatus: 'consumed',
+            expected: 'delivered',
+          },
+          { id: 'c-queued', uuid: 'u-c-queued', sendStatus: 'enqueued', expected: 'queued' },
+          {
+            id: 'c-processing',
+            uuid: 'u-c-processing',
+            sendStatus: 'submitted',
+            expected: 'processing',
+          },
+          { id: 'c-failed', uuid: 'u-c-failed', sendStatus: 'failed', expected: 'failed' },
+          { id: 'c-retry', uuid: 'u-c-retry', sendStatus: 'enqueued', expected: 'retrying' },
+        ];
+        for (const c of cases) {
+          insertSdkMessageAt(c.id, sessionId, now + 1000, userPayload(c.uuid), 'user');
+          // The compact helper hardcodes send_status='consumed' + no sdk_uuid;
+          // stamp both so the mapping + retry EXISTS behave like production.
+          db.prepare(`UPDATE sdk_messages SET send_status = ?, sdk_uuid = ? WHERE id = ?`).run(
+            c.sendStatus,
+            c.uuid,
+            c.id
+          );
+        }
+        db.prepare(
+          `INSERT INTO job_queue (id, queue, status, payload, retry_count, max_retries, run_at, created_at)
+           VALUES (?, 'message_delivery', 'pending', ?, 1, 8, ?, ?)`
+        ).run(
+          'job-c-retry',
+          JSON.stringify({
+            sessionId,
+            messageUuid: 'u-c-retry',
+            role: 'turn',
+            origin: 'space_inject',
+          }),
+          now,
+          now
+        );
+
+        const byId = new Map(queryCompact(taskId).map((r) => [r.id as string, r]));
+        for (const c of cases) {
+          expect((byId.get(c.id) as Record<string, unknown> | undefined)?.deliveryState).toBe(
+            c.expected
+          );
+        }
       });
 
       test('keeps anchor + last-assistant summary + result per conversation turn', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -2648,6 +2648,55 @@ describe('NAMED_QUERY_REGISTRY', () => {
         expect(rows[0].origin).toBe('system');
       });
 
+      test('includes a queued prompt to a dormant session even when its turn is older than the recent-turn cutoff', () => {
+        // Task #862 (review P2): a message queued to a session whose last turn
+        // index is older than the compact feed's recent-turn window would be
+        // dropped entirely (conversation_turn_index < rt.minTurn). The OR clause
+        // must include active nonterminal user rows independently of the cutoff.
+        const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+        insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+        // Session A: a settled anchor establishes turn 1, then a queued prompt
+        // inherits the session's turn (1) because nonterminal rows are not anchors.
+        insertSdkMessageAt(
+          'a-anchor',
+          sessionId,
+          now + 1000,
+          { type: 'user', uuid: 'u-a-anchor', message: { role: 'user', content: 'go' } },
+          'user'
+        );
+        insertSdkMessageAt(
+          'a-queued',
+          sessionId,
+          now + 2000,
+          { type: 'user', uuid: 'u-a-queued', message: { role: 'user', content: 'queued' } },
+          'user'
+        );
+        db.prepare(
+          `UPDATE sdk_messages SET send_status = 'enqueued', sdk_uuid = 'u-a-queued' WHERE id = 'a-queued'`
+        ).run();
+
+        // Session B (node agent on the same task) pushes the task-wide turn count
+        // past the 100-turn recent window, so rt.minTurn > 1.
+        const sessionB = 'sess-dormant-b';
+        insertSession(sessionB, 'worker', '{"status":"processing"}');
+        sessionTaskIds.set(sessionB, taskId);
+        for (let i = 0; i < 100; i += 1) {
+          insertSdkMessageAt(
+            `b-anchor-${i}`,
+            sessionB,
+            now + 3000 + i,
+            { type: 'user', uuid: `u-b-${i}`, message: { role: 'user', content: `b${i}` } },
+            'user'
+          );
+        }
+
+        const rows = queryCompact(taskId);
+        const queued = rows.find((r) => r.id === 'a-queued');
+        expect(queued).toBeTruthy();
+        expect((queued as Record<string, unknown>).deliveryState).toBe('queued');
+      });
+
       test('maps user-message send_status to the delivery lifecycle + retrying (compact feed)', () => {
         const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
         insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
@@ -3446,6 +3495,68 @@ describe('NAMED_QUERY_REGISTRY', () => {
         // No closed-turn (turn 1) entries leak through.
         const previews = entries.map((e) => String(e.preview ?? e.text ?? ''));
         expect(previews).not.toContain('closed-text');
+      });
+
+      test('keeps an in-turn prompt in the active roster but excludes a deferred one', async () => {
+        // Task #862 (review P2): a deferred prompt is explicitly waiting for the
+        // next turn — it must stay in the main thread but NOT appear in the live
+        // active-turn roster as input "inside" the active turn. An enqueued
+        // (in-turn) prompt should still appear.
+        const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+        insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+        // Active turn 1 (no result yet).
+        insertSdkMessageAt(
+          'u1',
+          sessionId,
+          now + 1000,
+          { type: 'user', uuid: 'u1', message: { role: 'user', content: 'go' } },
+          'user'
+        );
+        // Enqueued → in the active turn, belongs in the roster.
+        insertSdkMessageAt(
+          'u-enq',
+          sessionId,
+          now + 2000,
+          { type: 'user', uuid: 'u-enq', message: { role: 'user', content: 'enq' } },
+          'user'
+        );
+        db.prepare(
+          `UPDATE sdk_messages SET send_status = 'enqueued', sdk_uuid = 'u-enq' WHERE id = 'u-enq'`
+        ).run();
+        // Deferred → waiting for the next turn, must be excluded from the roster.
+        insertSdkMessageAt(
+          'u-def',
+          sessionId,
+          now + 3000,
+          { type: 'user', uuid: 'u-def', message: { role: 'user', content: 'def' } },
+          'user'
+        );
+        db.prepare(
+          `UPDATE sdk_messages SET send_status = 'deferred', sdk_uuid = 'u-def' WHERE id = 'u-def'`
+        ).run();
+        // A non-terminal agent row makes turn 1 the active roster turn.
+        insertSdkMessageAt(
+          'a1',
+          sessionId,
+          now + 4000,
+          {
+            type: 'assistant',
+            uuid: 'a1',
+            message: { content: [{ type: 'text', text: 'working' }] },
+          },
+          'assistant'
+        );
+
+        const rows = (await runEntries(taskId)) as Array<{
+          blockType: string;
+          uuid: string;
+        }>;
+        const userUuids = rows
+          .filter((r) => r.blockType === '__user_message' || r.blockType === '__user_replay')
+          .map((r) => r.uuid);
+        expect(userUuids).toContain('u-enq');
+        expect(userUuids).not.toContain('u-def');
       });
 
       test('emits no summary when the latest turn is closed', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -219,7 +219,7 @@ describe('messages.bySession — SQL behavior', () => {
     expect(rows[0].uuid).toBe('u1');
   });
 
-  test('excludes user messages with send_status deferred or enqueued', () => {
+  test('surfaces every user-message delivery state (queued/processing/delivered/failed)', () => {
     insertSdkMessage(db, {
       id: 'm-consumed',
       sessionId: 's1',
@@ -245,18 +245,32 @@ describe('messages.bySession — SQL behavior', () => {
       sendStatus: 'enqueued',
     });
     insertSdkMessage(db, {
+      id: 'm-submitted',
+      sessionId: 's1',
+      messageType: 'user',
+      sdkMessage: { type: 'user', uuid: 'u5', message: { content: 'submitted' } },
+      timestamp: '2024-01-01 00:00:04',
+      sendStatus: 'submitted',
+    });
+    insertSdkMessage(db, {
       id: 'm-failed',
       sessionId: 's1',
       messageType: 'user',
       sdkMessage: { type: 'user', uuid: 'u4', message: { content: 'failed' } },
-      timestamp: '2024-01-01 00:00:04',
+      timestamp: '2024-01-01 00:00:05',
       sendStatus: 'failed',
     });
 
     const rows = query(db, 's1', 100);
-    const uuids = rows.map((r) => r.uuid as string).sort();
-    // consumed and failed are kept; deferred and enqueued are dropped.
-    expect(uuids).toEqual(['u1', 'u4']);
+    const byUuid = new Map(rows.map((r) => [r.uuid as string, r]));
+    // Task #862: all user rows are now visible (no longer filtered to
+    // consumed/failed) and each carries its mapped delivery lifecycle.
+    expect([...byUuid.keys()].sort()).toEqual(['u1', 'u2', 'u3', 'u4', 'u5']);
+    expect(byUuid.get('u1')!.deliveryStatus).toBe('delivered');
+    expect(byUuid.get('u2')!.deliveryStatus).toBe('queued');
+    expect(byUuid.get('u3')!.deliveryStatus).toBe('queued');
+    expect(byUuid.get('u5')!.deliveryStatus).toBe('processing');
+    expect(byUuid.get('u4')!.deliveryStatus).toBe('failed');
   });
 
   test('orders by timestamp ASC, id ASC', () => {
@@ -1011,7 +1025,7 @@ describe('messages.bySession — mapRow', () => {
     expect(row.origin).toBeUndefined();
   });
 
-  test('attaches sendStatus only when DB column is "failed"', () => {
+  test('attaches deliveryStatus for user messages mapped from send_status', () => {
     insertSdkMessage(db, {
       id: 'm-ok',
       sessionId: 's1',
@@ -1032,7 +1046,9 @@ describe('messages.bySession — mapRow', () => {
     const rows = query(db, 's1', 10);
     const okRow = rows.find((r) => r.uuid === 'u-ok')!;
     const failRow = rows.find((r) => r.uuid === 'u-fail')!;
-    expect('sendStatus' in okRow).toBe(false);
-    expect(failRow.sendStatus).toBe('failed');
+    // Task #862: consumed → delivered, failed → failed. Non-user rows would
+    // carry no deliveryStatus; user rows always carry their mapped state.
+    expect(okRow.deliveryStatus).toBe('delivered');
+    expect(failRow.deliveryStatus).toBe('failed');
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -63,7 +63,7 @@ interface InsertSdkMessageArgs {
   sdkMessage: Record<string, unknown>;
   /** ISO timestamp (stored TEXT). Default is a fixed known value. */
   timestamp?: string;
-  sendStatus?: 'deferred' | 'enqueued' | 'consumed' | 'failed';
+  sendStatus?: 'deferred' | 'enqueued' | 'submitted' | 'consumed' | 'failed';
   origin?: 'human' | 'system' | null;
   taskId?: string | null;
 }
@@ -73,10 +73,11 @@ function insertSdkMessage(db: BunDatabase, args: InsertSdkMessageArgs): void {
     typeof args.sdkMessage.parent_tool_use_id === 'string'
       ? args.sdkMessage.parent_tool_use_id
       : null;
+  const sdkUuid = typeof args.sdkMessage.uuid === 'string' ? args.sdkMessage.uuid : null;
   db.prepare(
     `INSERT INTO sdk_messages
-		 (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, parent_tool_use_id, task_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		 (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, parent_tool_use_id, task_id, sdk_uuid)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     args.id,
     args.sessionId,
@@ -87,7 +88,39 @@ function insertSdkMessage(db: BunDatabase, args: InsertSdkMessageArgs): void {
     args.sendStatus ?? 'consumed',
     args.origin ?? null,
     parentToolUseId,
-    args.taskId ?? null
+    args.taskId ?? null,
+    sdkUuid
+  );
+}
+
+/** Insert a message_delivery job_queue row (task #862 retry-signal tests). */
+function insertDeliveryJob(
+  db: BunDatabase,
+  args: {
+    id: string;
+    sessionId: string;
+    messageUuid: string;
+    status?: 'pending' | 'processing' | 'completed' | 'failed' | 'dead';
+    retryCount?: number;
+    role?: 'turn' | 'steer';
+  }
+): void {
+  db.prepare(
+    `INSERT INTO job_queue
+       (id, queue, status, payload, retry_count, max_retries, run_at, created_at)
+     VALUES (?, 'message_delivery', ?, ?, ?, 8, ?, ?)`
+  ).run(
+    args.id,
+    args.status ?? 'pending',
+    JSON.stringify({
+      sessionId: args.sessionId,
+      messageUuid: args.messageUuid,
+      role: args.role ?? 'turn',
+      origin: 'chat',
+    }),
+    args.retryCount ?? 0,
+    Date.now(),
+    Date.now()
   );
 }
 
@@ -1050,5 +1083,71 @@ describe('messages.bySession — mapRow', () => {
     // carry no deliveryStatus; user rows always carry their mapped state.
     expect(okRow.deliveryStatus).toBe('delivered');
     expect(failRow.deliveryStatus).toBe('failed');
+  });
+
+  test('marks a non-terminal user message "retrying" when its delivery job has retry_count > 0', () => {
+    insertSdkMessage(db, {
+      id: 'm-enq',
+      sessionId: 's1',
+      messageType: 'user',
+      sdkMessage: { type: 'user', uuid: 'u-enq', message: { content: 'enqueued' } },
+      timestamp: '2024-01-01 00:00:01',
+      sendStatus: 'enqueued',
+    });
+    insertSdkMessage(db, {
+      id: 'm-sub',
+      sessionId: 's1',
+      messageType: 'user',
+      sdkMessage: { type: 'user', uuid: 'u-sub', message: { content: 'submitted' } },
+      timestamp: '2024-01-01 00:00:02',
+      sendStatus: 'submitted',
+    });
+
+    // No active retry jobs yet → plain queued / processing.
+    let byUuid = new Map(query(db, 's1', 10).map((r) => [r.uuid as string, r]));
+    expect(byUuid.get('u-enq')!.deliveryStatus).toBe('queued');
+    expect(byUuid.get('u-sub')!.deliveryStatus).toBe('processing');
+
+    // A reclaim re-drove both (active job, retry_count > 0) → retrying.
+    insertDeliveryJob(db, {
+      id: 'job-enq',
+      sessionId: 's1',
+      messageUuid: 'u-enq',
+      status: 'pending',
+      retryCount: 1,
+    });
+    insertDeliveryJob(db, {
+      id: 'job-sub',
+      sessionId: 's1',
+      messageUuid: 'u-sub',
+      status: 'processing',
+      retryCount: 2,
+      role: 'steer',
+    });
+
+    byUuid = new Map(query(db, 's1', 10).map((r) => [r.uuid as string, r]));
+    expect(byUuid.get('u-enq')!.deliveryStatus).toBe('retrying');
+    expect(byUuid.get('u-sub')!.deliveryStatus).toBe('retrying');
+  });
+
+  test('a delivery job with retry_count 0 does not mark the message retrying', () => {
+    insertSdkMessage(db, {
+      id: 'm-fresh',
+      sessionId: 's1',
+      messageType: 'user',
+      sdkMessage: { type: 'user', uuid: 'u-fresh', message: { content: 'fresh' } },
+      timestamp: '2024-01-01 00:00:01',
+      sendStatus: 'enqueued',
+    });
+    insertDeliveryJob(db, {
+      id: 'job-fresh',
+      sessionId: 's1',
+      messageUuid: 'u-fresh',
+      status: 'pending',
+      retryCount: 0,
+    });
+
+    const [row] = query(db, 's1', 10);
+    expect(row.deliveryStatus).toBe('queued');
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/job-queue-processor.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/job-queue-processor.test.ts
@@ -523,5 +523,37 @@ describe('JobQueueProcessor', () => {
 
       expect(notified.length).toBe(0);
     });
+
+    it('passes a session-scoped change for jobs whose payload carries a sessionId', async () => {
+      // Task #862 (review P2): the message_delivery notifier must be
+      // session-scoped so a delivery job only re-evaluates that session's
+      // transcript feed, not every open one.
+      const scopes: Array<Record<string, string> | undefined> = [];
+      processor.setChangeNotifier((_table, scope) => scopes.push(scope));
+      processor.register('message_delivery', async () => {});
+
+      repo.enqueue({
+        queue: 'message_delivery',
+        payload: { sessionId: 'sess-a', messageUuid: 'u-1', role: 'turn' },
+      });
+      await processor.tick();
+      await flush();
+
+      expect(scopes.length).toBeGreaterThan(0);
+      expect(scopes[0]).toEqual({ sessionId: 'sess-a' });
+    });
+
+    it('notifies without a scope for jobs whose payload has no sessionId', async () => {
+      const scopes: Array<Record<string, string> | undefined> = [];
+      processor.setChangeNotifier((_table, scope) => scopes.push(scope));
+      processor.register('schedule', async () => {});
+
+      repo.enqueue({ queue: 'schedule', payload: { scheduleId: 's1' } });
+      await processor.tick();
+      await flush();
+
+      expect(scopes.length).toBeGreaterThan(0);
+      expect(scopes[0]).toBeUndefined();
+    });
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/live-query-delivery-status.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/live-query-delivery-status.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Delivery-status reactive-pipeline integration tests (task #862).
+ *
+ * End-to-end through Database facade → ReactiveDatabase → LiveQueryEngine:
+ * a `send_status` transition on a user message must emit an UPDATED delta on
+ * the SAME row (never a duplicate ADD), so a retry / state change updates the
+ * one visible message rather than adding another. This is the guarantee that
+ * lets the widened `messages.bySession` feed show queued → processing →
+ * delivered without producing duplicate user bubbles.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+import { Database } from '../../../../src/storage/index';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../../src/storage/live-query';
+import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
+import type { QueryDiff } from '../../../../src/storage/live-query';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+
+interface MessageRow {
+  id: string;
+  sendStatus: string | null;
+  deliveryRetry: number;
+}
+
+function makeTempDbPath(): string {
+  return join(
+    tmpdir(),
+    `live-query-delivery-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+}
+
+function makeUserMessage(uuid: string, content: string): SDKMessage {
+  return {
+    type: 'user',
+    uuid,
+    message: { role: 'user', content: [{ type: 'text', text: content }] },
+  } as SDKMessage;
+}
+
+describe('messages.bySession delivery-status reactive pipeline', () => {
+  let dbPath: string;
+  let db: Database;
+  let bunDb: BunDatabase;
+  let reactiveDb: ReactiveDatabase;
+  let engine: LiveQueryEngine;
+  const sessionId = 'sess-delivery';
+
+  // The registered query SQL (params: sessionId, limit). Subscribing at this
+  // layer yields raw rows (id / sendStatus / deliveryRetry); the send_status →
+  // deliveryStatus mapping is covered by the unit tests.
+  const SQL = NAMED_QUERY_REGISTRY.get('messages.bySession')!.sql;
+
+  beforeEach(async () => {
+    dbPath = makeTempDbPath();
+    db = new Database(dbPath);
+    reactiveDb = createReactiveDatabase(db);
+    await db.initialize(reactiveDb);
+    bunDb = db.getDatabase();
+    engine = new LiveQueryEngine(bunDb, reactiveDb);
+
+    bunDb
+      .prepare(
+        `INSERT INTO sessions (id, title, created_at, last_active_at, status, config, metadata)
+         VALUES (?, ?, datetime('now'), datetime('now'), 'active', '{}', '{}')`
+      )
+      .run(sessionId, 'Delivery Session');
+  });
+
+  afterEach(() => {
+    engine.dispose();
+    try {
+      db.close();
+    } catch {
+      // already closed
+    }
+    try {
+      rmSync(dbPath, { force: true });
+      rmSync(dbPath + '-wal', { force: true });
+      rmSync(dbPath + '-shm', { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  /** Flush the LiveQueryEngine microtask so pending deltas are emitted. */
+  async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  test('a send_status transition emits an UPDATED delta on the same row (no duplicate)', async () => {
+    const diffs: QueryDiff<MessageRow>[] = [];
+    engine.subscribe<MessageRow>(SQL, [sessionId, 100], (diff) => diffs.push(diff));
+    await flush();
+    expect(diffs[0].type).toBe('snapshot');
+    expect(diffs[0].rows).toHaveLength(0);
+
+    // 1) Save enqueued (via the reactive proxy so it notifies) — added row.
+    const rowId = reactiveDb.db.saveUserMessage(
+      sessionId,
+      makeUserMessage('u-1', 'hello'),
+      'enqueued'
+    );
+    await flush();
+
+    const addedDelta = diffs[1];
+    expect(addedDelta.type).toBe('delta');
+    expect(addedDelta.added?.length).toBe(1);
+    expect(addedDelta.added?.[0].id).toBe(rowId);
+    expect(addedDelta.added?.[0].sendStatus).toBe('enqueued');
+
+    // 2) Flip to submitted — same row id, UPDATED (not a second added row).
+    bunDb.prepare(`UPDATE sdk_messages SET send_status = 'submitted' WHERE id = ?`).run(rowId);
+    reactiveDb.notifyChange('sdk_messages');
+    await flush();
+
+    const submittedDelta = diffs[2];
+    expect(submittedDelta.type).toBe('delta');
+    expect(submittedDelta.updated?.length).toBe(1);
+    expect(submittedDelta.updated?.[0].id).toBe(rowId);
+    expect(submittedDelta.updated?.[0].sendStatus).toBe('submitted');
+    expect(submittedDelta.added ?? []).toHaveLength(0);
+
+    // 3) Flip to consumed — same row id again, UPDATED.
+    bunDb.prepare(`UPDATE sdk_messages SET send_status = 'consumed' WHERE id = ?`).run(rowId);
+    reactiveDb.notifyChange('sdk_messages');
+    await flush();
+
+    const consumedDelta = diffs[3];
+    expect(consumedDelta.updated?.length).toBe(1);
+    expect(consumedDelta.updated?.[0].id).toBe(rowId);
+    expect(consumedDelta.updated?.[0].sendStatus).toBe('consumed');
+    expect(consumedDelta.added ?? []).toHaveLength(0);
+
+    // Across the whole lifecycle exactly one row id was ever added — the
+    // transitions updated it in place rather than producing duplicate bubbles.
+    const allAddedIds = diffs
+      .filter((d) => d.type === 'delta')
+      .flatMap((d) => (d.added ?? []).map((r) => r.id));
+    expect(allAddedIds).toEqual([rowId]);
+  });
+
+  test('the snapshot after a reconnect reconciles to the latest send_status (single row)', async () => {
+    // Persist a message and advance it to consumed before any subscription
+    // (state landed while the client was disconnected).
+    const rowId = reactiveDb.db.saveUserMessage(
+      sessionId,
+      makeUserMessage('u-2', 'reconcile'),
+      'enqueued'
+    );
+    bunDb.prepare(`UPDATE sdk_messages SET send_status = 'consumed' WHERE id = ?`).run(rowId);
+
+    // Now subscribe (reconnect) — the snapshot reflects the final state.
+    const diffs: QueryDiff<MessageRow>[] = [];
+    engine.subscribe<MessageRow>(SQL, [sessionId, 100], (diff) => diffs.push(diff));
+    await flush();
+
+    expect(diffs[0].type).toBe('snapshot');
+    const rows = diffs[0].rows!;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(rowId);
+    expect(rows[0].sendStatus).toBe('consumed');
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/live-query-delivery-status.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/live-query-delivery-status.test.ts
@@ -42,6 +42,37 @@ function makeUserMessage(uuid: string, content: string): SDKMessage {
   } as SDKMessage;
 }
 
+/** Insert a message_delivery job_queue row (task #862 retry-signal tests). */
+function insertDeliveryJob(
+  db: BunDatabase,
+  args: {
+    id: string;
+    sessionId: string;
+    messageUuid: string;
+    status?: 'pending' | 'processing' | 'completed' | 'failed' | 'dead';
+    retryCount?: number;
+    role?: 'turn' | 'steer';
+  }
+): void {
+  db.prepare(
+    `INSERT INTO job_queue
+       (id, queue, status, payload, retry_count, max_retries, run_at, created_at)
+     VALUES (?, 'message_delivery', ?, ?, ?, 8, ?, ?)`
+  ).run(
+    args.id,
+    args.status ?? 'pending',
+    JSON.stringify({
+      sessionId: args.sessionId,
+      messageUuid: args.messageUuid,
+      role: args.role ?? 'turn',
+      origin: 'chat',
+    }),
+    args.retryCount ?? 0,
+    Date.now(),
+    Date.now()
+  );
+}
+
 describe('messages.bySession delivery-status reactive pipeline', () => {
   let dbPath: string;
   let db: Database;
@@ -165,5 +196,43 @@ describe('messages.bySession delivery-status reactive pipeline', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].id).toBe(rowId);
     expect(rows[0].sendStatus).toBe('consumed');
+  });
+
+  test('a job_queue retry transition re-evaluates the feed (job_queue is a feed dependency)', async () => {
+    // The "retrying" state comes from an EXISTS vs job_queue. The query's table
+    // extraction must register job_queue as a dependency so a job transition
+    // (notified by messageDeliveryProcessor → reactiveDb.notifyChange('job_queue'))
+    // re-evaluates messages.bySession and emits a delta on the matching message.
+    const rowId = reactiveDb.db.saveUserMessage(
+      sessionId,
+      makeUserMessage('u-job', 'retry me'),
+      'enqueued'
+    );
+
+    const diffs: QueryDiff<MessageRow>[] = [];
+    engine.subscribe<MessageRow>(SQL, [sessionId, 100], (diff) => diffs.push(diff));
+    await flush();
+    expect(diffs[0].type).toBe('snapshot');
+    expect(diffs[0].rows![0].deliveryRetry).toBe(0);
+
+    // A reclaim re-drove the message — active job, retry_count > 0.
+    insertDeliveryJob(bunDb, {
+      id: 'job-retry',
+      sessionId,
+      messageUuid: 'u-job',
+      status: 'pending',
+      retryCount: 1,
+    });
+    // Simulate messageDeliveryProcessor.setChangeNotifier → notifyChange('job_queue').
+    reactiveDb.notifyChange('job_queue');
+    await flush();
+
+    const retryDelta = diffs[1];
+    expect(retryDelta.type).toBe('delta');
+    expect(retryDelta.updated?.length).toBe(1);
+    expect(retryDelta.updated?.[0].id).toBe(rowId);
+    expect(retryDelta.updated?.[0].deliveryRetry).toBe(1);
+    // The same row was updated, not duplicated.
+    expect(retryDelta.added ?? []).toHaveLength(0);
   });
 });

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -21,6 +21,7 @@ export * from './types/github.ts';
 export * from './types/space.ts';
 export * from './artifact-shapes.ts';
 export * from './types/actor-message-projection.ts';
+export * from './types/message-delivery.ts';
 export * from './types/task-milestone.ts';
 export * from './types/evolution.ts';
 export * from './evolution-preflight.ts';

--- a/packages/shared/src/types/message-delivery.ts
+++ b/packages/shared/src/types/message-delivery.ts
@@ -1,0 +1,67 @@
+/**
+ * User-facing message-delivery lifecycle for a persisted SDK user message.
+ *
+ * Task #862 (phase 4 of message-delivery reliability): surfaces the durable
+ * delivery state established in #859–#861 so users can distinguish queued /
+ * processing / retrying / failed messages explicitly, rather than inferring
+ * state from system/init messages.
+ *
+ * Derived from the raw `sdk_messages.send_status` column plus, for the
+ * "retrying" state, the active `message_delivery` job's `retry_count`. The
+ * mapping lives in {@link sendStatusToDeliveryStatus} so the daemon feed and
+ * any UI consumer share one source of truth.
+ *
+ * This is intentionally separate from {@link ActorMessageDeliveryState}: that
+ * type describes inter-actor handoff projections (with semantic states like
+ * `expired` / `skipped`), whereas this describes a single user message's
+ * delivery through the durable at-least-once pipeline.
+ */
+export type MessageDeliveryStatus =
+  | 'queued' // persisted, waiting to be claimed / deferred to a later turn
+  | 'processing' // fed into the active SDK turn (submitted)
+  | 'retrying' // non-terminal, re-driven after a stall (active job retry_count > 0)
+  | 'delivered' // consumed by the SDK — terminal success
+  | 'failed'; // terminal failure
+
+/**
+ * The raw `sdk_messages.send_status` column values. NULL (SDK / action rows)
+ * is treated as `'consumed'` everywhere it is read.
+ */
+export type MessageSendStatus = 'deferred' | 'enqueued' | 'submitted' | 'consumed' | 'failed';
+
+/**
+ * Map a raw `send_status` (plus an optional active-job retry signal) to the
+ * user-facing {@link MessageDeliveryStatus}.
+ *
+ * Returns `null` only for an unrecognised value; callers are expected to gate
+ * the result on `message_type = 'user'` so non-user rows (assistant / system /
+ * result, whose NULL `send_status` coalesces to `'consumed'`) do not get a
+ * spurious `'delivered'` badge.
+ *
+ * Note that `'delivered'` (consumed) is mapped rather than hidden here: the UI
+ * decides whether to render a badge for it (by default it does not, to avoid
+ * noisy indicators on normal fast delivery — task #862 item 3).
+ *
+ * @param sendStatus Raw `sdk_messages.send_status` (NULL/undefined coalesces to `'consumed'`).
+ * @param options.retrying True when an active `message_delivery` job for this
+ *   message has `retry_count > 0` (the message is being re-driven after a stall).
+ */
+export function sendStatusToDeliveryStatus(
+  sendStatus: MessageSendStatus | string | null | undefined,
+  options?: { retrying?: boolean }
+): MessageDeliveryStatus | null {
+  const retrying = options?.retrying === true;
+  switch (sendStatus ?? 'consumed') {
+    case 'deferred':
+    case 'enqueued':
+      return retrying ? 'retrying' : 'queued';
+    case 'submitted':
+      return retrying ? 'retrying' : 'processing';
+    case 'consumed':
+      return 'delivered';
+    case 'failed':
+      return 'failed';
+    default:
+      return null;
+  }
+}

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -110,6 +110,12 @@ function UserMessageDeliveryBadge({
   );
 }
 
+/** True when a user message's delivery is terminal (settled) and rewind-safe. */
+function isDeliveryTerminal(status: MessageDeliveryStatus | undefined): boolean {
+  if (!status) return true; // legacy row without delivery metadata — treat as settled
+  return status === 'delivered' || status === 'failed';
+}
+
 interface Props {
   message: UserMessage;
   onEdit?: () => void;
@@ -397,6 +403,10 @@ export function SDKUserMessage({
         onRewind &&
         sessionId &&
         message.uuid &&
+        // Task #862 (review P1): only allow rewind on terminal (settled)
+        // deliveries — a queued/processing/retrying row's active message_delivery
+        // job would otherwise keep executing after the rewind deletes it.
+        isDeliveryTerminal(message.deliveryStatus) &&
         (rewindingMessageUuid === message.uuid ? (
           <Spinner size="sm" color="border-amber-500" />
         ) : (

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -5,11 +5,13 @@
  */
 
 import type { SDKMessage } from '@hyperneo/shared/sdk/sdk.d.ts';
+import type { MessageDeliveryStatus } from '@hyperneo/shared';
 import { useEffect, useState } from 'preact/hooks';
 import { toast } from '../../lib/toast.ts';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
 import { cn, copyToClipboard } from '../../lib/utils.ts';
 import { Dropdown } from '../ui/Dropdown.tsx';
+import { DeliveryStateBadge } from '../ui/DeliveryStateBadge.tsx';
 import { IconButton } from '../ui/IconButton.tsx';
 import { Spinner } from '../ui/Spinner.tsx';
 import { Tooltip } from '../ui/Tooltip.tsx';
@@ -70,8 +72,43 @@ function renderMessageText(
   );
 }
 
-type UserMessage = Extract<SDKMessage, { type: 'user' }> & { sendStatus?: string };
+type UserMessage = Extract<SDKMessage, { type: 'user' }> & {
+  /** User-facing delivery lifecycle from sdk_messages.send_status (task #862). */
+  deliveryStatus?: MessageDeliveryStatus;
+};
 type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }>;
+
+/**
+ * Per-status copy for the user-message delivery badge (task #862). "delivered"
+ * is intentionally NOT rendered here (the caller hides it) to avoid noisy
+ * indicators on normal fast delivery.
+ */
+const DELIVERY_BADGE_COPY: Record<
+  Exclude<MessageDeliveryStatus, 'delivered'>,
+  { label: string; tooltip: string }
+> = {
+  queued: { label: 'queued', tooltip: 'Waiting to be delivered' },
+  processing: { label: 'sending', tooltip: 'Sending to the active turn' },
+  retrying: { label: 'retrying', tooltip: 'Delivery stalled — retrying' },
+  failed: {
+    label: 'not delivered',
+    tooltip: 'Message was not delivered — the server crashed before Claude responded',
+  },
+};
+
+function UserMessageDeliveryBadge({
+  status,
+}: {
+  status: Exclude<MessageDeliveryStatus, 'delivered'>;
+}) {
+  const copy = DELIVERY_BADGE_COPY[status];
+  if (!copy) return null;
+  return (
+    <Tooltip content={copy.tooltip} position="left">
+      <DeliveryStateBadge state={status} label={copy.label} test-id="user-delivery-state" />
+    </Tooltip>
+  );
+}
 
 interface Props {
   message: UserMessage;
@@ -351,13 +388,8 @@ export function SDKUserMessage({
         </Tooltip>
       )}
 
-      {message.sendStatus === 'failed' && (
-        <Tooltip
-          content="Message was not delivered — the server crashed before Claude responded"
-          position="left"
-        >
-          <span class="text-xs px-2 py-0.5 bg-red-500/20 text-red-400 rounded">not delivered</span>
-        </Tooltip>
+      {message.deliveryStatus && message.deliveryStatus !== 'delivered' && (
+        <UserMessageDeliveryBadge status={message.deliveryStatus} />
       )}
 
       {/* Rewind button - only for non-replay user messages with valid UUID */}

--- a/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
+++ b/packages/web/src/components/sdk/SyntheticMessageBlock.tsx
@@ -23,12 +23,11 @@
  *   placement as the human bubble for visual consistency).
  */
 
-import type { ActorMessageDeliveryState } from '@hyperneo/shared';
 import type { SDKMessage } from '@hyperneo/shared/sdk/sdk.d.ts';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import { SpaceTaskThreadMessageActions } from '../space/thread/SpaceTaskThreadMessageActions.tsx';
-import { DeliveryStateBadge } from '../ui/DeliveryStateBadge.tsx';
+import { DeliveryStateBadge, type DeliveryBadgeState } from '../ui/DeliveryStateBadge.tsx';
 
 type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }>;
 
@@ -53,7 +52,7 @@ interface Props {
   /** Optional shorter label for the TO badge (defaults to `toAgent`). */
   toShort?: string;
   /** Optional delivery state for synthetic actor messages. */
-  deliveryState?: ActorMessageDeliveryState | null;
+  deliveryState?: DeliveryBadgeState | null;
   /** When provided, an "open in session" icon appears in the actions row. */
   onOpenSession?: () => void;
   /** When provided, a session-info dropdown appears in the actions row,

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -523,6 +523,26 @@ describe('SDKUserMessage', () => {
       expect(container.textContent).toContain('sending');
     });
 
+    it('should show "retrying" badge with stalled-delivery copy when deliveryStatus is retrying', async () => {
+      const message = {
+        ...createTextMessage('Hello world'),
+        deliveryStatus: 'retrying' as const,
+      };
+
+      const { container } = render(<SDKUserMessage message={message} />);
+
+      const badge = container.querySelector('[data-testid="user-delivery-state"]');
+      expect(badge).toBeTruthy();
+      expect(badge?.textContent).toContain('retrying');
+
+      // The stalled-delivery hint lives in the badge's hover tooltip. mouseenter
+      // is non-bubbling, so fire it on the Tooltip wrapper (the badge's parent).
+      fireEvent.mouseEnter(badge!.parentElement!);
+      await waitFor(() => {
+        expect(container.textContent).toContain('Delivery stalled — retrying');
+      });
+    });
+
     it('should NOT show a badge when deliveryStatus is delivered (avoid noise)', () => {
       const message = {
         ...createTextMessage('Hello world'),

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -565,6 +565,44 @@ describe('SDKUserMessage', () => {
     });
   });
 
+  describe('Rewind gating', () => {
+    const renderWithRewind = (deliveryStatus?: string) =>
+      render(
+        <SDKUserMessage
+          message={{
+            ...createTextMessage('Hello world'),
+            ...(deliveryStatus ? { deliveryStatus } : {}),
+          }}
+          onRewind={() => {}}
+          sessionId="s1"
+        />
+      );
+
+    it('shows the rewind button for terminal delivered messages', () => {
+      const { container } = renderWithRewind('delivered');
+      expect(container.querySelector('[title="Rewind to here"]')).toBeTruthy();
+    });
+
+    it('shows the rewind button for terminal failed messages', () => {
+      const { container } = renderWithRewind('failed');
+      expect(container.querySelector('[title="Rewind to here"]')).toBeTruthy();
+    });
+
+    it('shows the rewind button when deliveryStatus is absent (legacy settled row)', () => {
+      const { container } = renderWithRewind();
+      expect(container.querySelector('[title="Rewind to here"]')).toBeTruthy();
+    });
+
+    it.each([
+      'queued',
+      'processing',
+      'retrying',
+    ])('hides the rewind button for nonterminal %s delivery', (status) => {
+      const { container } = renderWithRewind(status);
+      expect(container.querySelector('[title="Rewind to here"]')).toBeFalsy();
+    });
+  });
+
   describe('Styling', () => {
     it('should be right-aligned (user messages)', () => {
       const message = createTextMessage('Hello');

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -489,11 +489,11 @@ describe('SDKUserMessage', () => {
     });
   });
 
-  describe('Send Status', () => {
-    it('should show "not delivered" badge when sendStatus is failed', () => {
+  describe('Delivery Status', () => {
+    it('should show "not delivered" badge when deliveryStatus is failed', () => {
       const message = {
         ...createTextMessage('Hello world'),
-        sendStatus: 'failed',
+        deliveryStatus: 'failed' as const,
       };
 
       const { container } = render(<SDKUserMessage message={message} />);
@@ -501,12 +501,47 @@ describe('SDKUserMessage', () => {
       expect(container.textContent).toContain('not delivered');
     });
 
-    it('should not show "not delivered" badge when sendStatus is absent', () => {
+    it('should show "queued" badge when deliveryStatus is queued', () => {
+      const message = {
+        ...createTextMessage('Hello world'),
+        deliveryStatus: 'queued' as const,
+      };
+
+      const { container } = render(<SDKUserMessage message={message} />);
+
+      expect(container.textContent).toContain('queued');
+    });
+
+    it('should show "sending" badge when deliveryStatus is processing', () => {
+      const message = {
+        ...createTextMessage('Hello world'),
+        deliveryStatus: 'processing' as const,
+      };
+
+      const { container } = render(<SDKUserMessage message={message} />);
+
+      expect(container.textContent).toContain('sending');
+    });
+
+    it('should NOT show a badge when deliveryStatus is delivered (avoid noise)', () => {
+      const message = {
+        ...createTextMessage('Hello world'),
+        deliveryStatus: 'delivered' as const,
+      };
+
+      const { container } = render(<SDKUserMessage message={message} />);
+
+      expect(container.textContent).not.toContain('delivered');
+      expect(container.textContent).not.toContain('not delivered');
+    });
+
+    it('should not show a badge when deliveryStatus is absent', () => {
       const message = createTextMessage('Hello world');
 
       const { container } = render(<SDKUserMessage message={message} />);
 
       expect(container.textContent).not.toContain('not delivered');
+      expect(container.textContent).not.toContain('queued');
     });
   });
 

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -23,7 +23,7 @@
  */
 
 import type { SDKMessage } from '@hyperneo/shared/sdk/sdk.d.ts';
-import type { ActiveTurnSummary, ActivityEntry, ActorMessageDeliveryState } from '@hyperneo/shared';
+import type { ActiveTurnSummary, ActivityEntry, MessageDeliveryStatus } from '@hyperneo/shared';
 import {
   isSDKAssistantMessage,
   isSDKCompactBoundary,
@@ -318,7 +318,7 @@ interface MessageFeedTurn {
   /** Recipient session id — same role as `CompletedFeedTurn.sessionId`. */
   sessionId: string | null;
   /** User-message delivery state, shown as a small send-state badge. */
-  deliveryState?: ActorMessageDeliveryState | null;
+  deliveryState?: MessageDeliveryStatus | null;
   /** SDK message UUID, used to deep-link the slide-over. */
   highlightMessageUuid?: string;
   replacementStatus?: MessageReplacementStatus;

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -1,4 +1,5 @@
 import type { SDKMessage } from '@hyperneo/shared/sdk/sdk.d.ts';
+import type { MessageDeliveryStatus } from '@hyperneo/shared';
 import {
   type ContentBlock,
   hasRenderableThinking,
@@ -41,7 +42,7 @@ export interface ParsedThreadRow {
   createdAt: number;
   turnIndex?: number;
   turnHiddenMessageCount?: number;
-  deliveryState?: 'delivered' | 'failed' | null;
+  deliveryState?: MessageDeliveryStatus | null;
   message: SDKMessage | null;
   fallbackText: string | null;
   replacementStatus?: MessageReplacementStatus;

--- a/packages/web/src/components/ui/DeliveryStateBadge.tsx
+++ b/packages/web/src/components/ui/DeliveryStateBadge.tsx
@@ -1,22 +1,38 @@
-import type { ActorMessageDeliveryState } from '@hyperneo/shared';
+import type { ActorMessageDeliveryState, MessageDeliveryStatus } from '@hyperneo/shared';
 import { cn } from '../../lib/utils';
 
-const DELIVERY_STATE_CLASSES: Record<ActorMessageDeliveryState, string> = {
+/**
+ * Every delivery-state label the badge can render — the union of
+ * {@link MessageDeliveryStatus} (user-message lifecycle, task #862) and
+ * {@link ActorMessageDeliveryState} (inter-actor handoff projections). The two
+ * domains overlap (queued / delivered / failed) but each contributes distinct
+ * states; one canonical badge keeps the visual language consistent everywhere.
+ */
+export type DeliveryBadgeState = MessageDeliveryStatus | ActorMessageDeliveryState;
+
+const DELIVERY_STATE_CLASSES: Record<DeliveryBadgeState, string> = {
+  // MessageDeliveryStatus
   queued: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+  processing: 'border-sky-500/40 bg-sky-500/10 text-sky-200',
+  retrying: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
   delivered: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
   failed: 'border-red-500/45 bg-red-500/10 text-red-200',
+  // ActorMessageDeliveryState (additional)
   expired: 'border-red-500/45 bg-red-500/10 text-red-200',
   skipped: 'border-gray-500/40 bg-gray-500/10 text-gray-300',
 };
 
 interface DeliveryStateBadgeProps {
-  state?: ActorMessageDeliveryState | null;
+  state?: DeliveryBadgeState | null;
+  /** Override the label text (defaults to the state name). */
+  label?: string;
   class?: string;
   'test-id'?: string;
 }
 
 export function DeliveryStateBadge({
   state,
+  label,
   class: className = '',
   'test-id': testId = 'delivery-state-badge',
 }: DeliveryStateBadgeProps) {
@@ -30,7 +46,7 @@ export function DeliveryStateBadge({
       )}
       data-testid={testId}
     >
-      {state}
+      {label ?? state}
     </span>
   );
 }

--- a/packages/web/src/components/ui/DeliveryStateBadge.tsx
+++ b/packages/web/src/components/ui/DeliveryStateBadge.tsx
@@ -14,7 +14,9 @@ const DELIVERY_STATE_CLASSES: Record<DeliveryBadgeState, string> = {
   // MessageDeliveryStatus
   queued: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
   processing: 'border-sky-500/40 bg-sky-500/10 text-sky-200',
-  retrying: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+  // Retrying is more urgent than a plain queue — amber is reserved for queued,
+  // so retrying reads as amber-on-orange to stand out.
+  retrying: 'border-orange-500/50 bg-orange-500/15 text-orange-200',
   delivered: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
   failed: 'border-red-500/45 bg-red-500/10 text-red-200',
   // ActorMessageDeliveryState (additional)

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -5,6 +5,7 @@ import type {
   LiveQueryDeltaEvent,
   LiveQueryErrorEvent,
   LiveQuerySnapshotEvent,
+  MessageDeliveryStatus,
 } from '@hyperneo/shared';
 import { useMessageHub } from './useMessageHub';
 
@@ -22,8 +23,8 @@ export interface SpaceTaskThreadMessageRow {
   createdAt: number;
   /** Message origin from the DB (human, system). Used to classify sender in the thread UI. */
   origin?: string | null;
-  /** User-message delivery state from sdk_messages.send_status, normalized for UI badges. */
-  deliveryState?: 'delivered' | 'failed' | null;
+  /** User-message delivery lifecycle from sdk_messages.send_status (task #862). */
+  deliveryState?: MessageDeliveryStatus | null;
   parentToolUseId?: string | null;
   /**
    * Server-computed turn index (per session) for compact thread grouping.

--- a/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
+++ b/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
@@ -524,6 +524,56 @@ describe('SessionStore - Comprehensive Coverage', () => {
       expect(sessionStore.sdkMessages.value.some((m) => m.uuid === 'msg-added')).toBe(true);
     });
 
+    it('re-sorts updated rows when a delivery-status update moves their timestamp', async () => {
+      const hub = installLiveQueryHub();
+      await sessionStore.select('session-1');
+      const subId = hub.subscriptionId!;
+
+      // Snapshot in (timestamp, rowid) order: A then B.
+      hub.fire('liveQuery.snapshot', {
+        subscriptionId: subId,
+        rows: [
+          {
+            id: 'row-a',
+            uuid: 'u-a',
+            type: 'user',
+            timestamp: 100,
+            rowid: 1,
+            content: 'A',
+          },
+          {
+            id: 'row-b',
+            uuid: 'u-b',
+            type: 'user',
+            timestamp: 200,
+            rowid: 2,
+            content: 'B',
+          },
+        ],
+      });
+
+      // A delivery-status update moves A's timestamp past B (queued → consumed
+      // re-timestamps the row). The store must re-sort by (timestamp, rowid).
+      hub.fire('liveQuery.delta', {
+        subscriptionId: subId,
+        added: [],
+        updated: [
+          {
+            id: 'row-a',
+            uuid: 'u-a',
+            type: 'user',
+            timestamp: 300,
+            rowid: 1,
+            content: 'A',
+          },
+        ],
+        removed: [],
+      });
+
+      const order = sessionStore.sdkMessages.value.map((m) => (m as { uuid?: string }).uuid);
+      expect(order).toEqual(['u-b', 'u-a']);
+    });
+
     it('ignores snapshot/delta events for a different subscriptionId', async () => {
       const hub = installLiveQueryHub();
       await sessionStore.select('session-1');

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -137,6 +137,13 @@ const rowTimestamp = (m: ChatMessage): number => (m as MessageRow).timestamp || 
 const rowRowid = (m: ChatMessage): number => (m as MessageRow).rowid ?? 0;
 const rowId = (m: ChatMessage): unknown => (m as MessageRow).id;
 
+/** Sort by the daemon's `(timestamp, rowid)` transcript cursor. */
+function sortByTimestampRowid(messages: ChatMessage[]): ChatMessage[] {
+  return [...messages].sort(
+    (a, b) => rowTimestamp(a) - rowTimestamp(b) || rowRowid(a) - rowRowid(b)
+  );
+}
+
 /**
  * Tolerance for comparing pagination-boundary timestamps across the two server
  * paths that feed the transcript. `message.sdkMessages` computes epoch-ms via
@@ -983,6 +990,10 @@ export class SessionStore {
         }
         return m;
       });
+      // Task #862 (review P2): a delivery-status update (e.g. queued → consumed)
+      // moves the row's timestamp, so the replaced rows may no longer be in
+      // transcript order — re-sort by the daemon's (timestamp, rowid) cursor.
+      if (changed) next = sortByTimestampRowid(next);
     }
 
     if (event.added?.length) {
@@ -997,11 +1008,7 @@ export class SessionStore {
       }
       if (trulyNew.length) {
         changed = true;
-        next = [...next, ...trulyNew].sort(
-          (a, b) =>
-            ((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
-            ((b as ChatMessage & { timestamp?: number }).timestamp || 0)
-        );
+        next = sortByTimestampRowid([...next, ...trulyNew]);
       }
       this._syncCommandsFromSDKMessages(trulyNew);
     }


### PR DESCRIPTION
Phase 4 of message-delivery reliability. Surfaces the durable `send_status` lifecycle (`deferred`/`enqueued`/`submitted`/`consumed`/`failed`) to users as explicit delivery badges (`queued`/`processing`/`retrying`/`delivered`/`failed`) instead of inferring state from system/init messages.

Shared `MessageDeliveryStatus` type + `sendStatusToDeliveryStatus` mapper drive both the `messages.bySession` (ordinary chat) and `spaceTaskMessages` (Space thread) feeds. The feeds now show `deferred`/`enqueued`/`submitted` user rows and map `send_status` + the active `message_delivery` job `retry_count` (for `retrying`); daemon-side reads keep the old `consumed`/`failed` filter so prompt context and rewind are unaffected. The widened feed also gives a natural optimistic echo — the persisted `enqueued` row appears within ms of send via the reactive-DB flush and transitions in place by stable row id (no web-side optimistic insert, no duplicate bubble on retry/transition).

`SDKUserMessage` renders a badge for queued/processing/retrying/failed and hides it for delivered (avoid noise); Space threads expand from delivered/failed to the full lifecycle. Steer-consumed propagation (item 11) is satisfied by the existing synchronous consumed-flip at `onSent` plus the now-visible feed. The Space wake/recovery audit (items 6/7) found no demonstrably redundant mechanisms — the agent-level duplicate was already removed in #861, and the surviving Space recovery paths (nudge/nag/terminal-error-continue/restart-notice/external-event requeue) each own a distinct failure mode — so none were removed.

Verified: unit + reactive-pipeline integration tests for the feed mapping, retry signal, and no-duplicate transitions; web component tests for the badges; daemon+web typecheck/lint/knip; `make build`; dev-server boot smoke test. `bun run check` has one pre-existing `check:test-quality` failure in an untouched provider test (`provider-registry.test.ts`), unrelated to this work. Full interactive browser verification of a Space handoff + controlled stale-delivery recovery is left for QA/review (needs a live Space + credentials).