### PR TITLE
feat(space): track real agent activity on node executions [#943]

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -1176,7 +1176,12 @@ export class SDKMessageHandler {
     for (const block of content) {
       if (block.type !== 'tool_result') continue;
       await internalEventBus.publish('sdk.toolUse.consumed', {
-        sessionId: message.session_id ?? this.ctx.session.id,
+        // Use the application session.id (as sdk.toolUse.created does), NOT
+        // message.session_id (the SDK conversation ID, a.k.a. session.sdkSessionId):
+        // node_executions.agent_session_id stores the app id, so consumers that
+        // resolve the event to an execution (e.g. lastActivityAt tracking) would
+        // otherwise miss every tool-result event.
+        sessionId: this.ctx.session.id,
         toolUseId: block.tool_use_id,
         timestamp: Date.now(),
       });

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -634,7 +634,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   // Not started yet: TaskAgentManager is created next and injected before start().
   // sessionManager and internalEventBus are injected so space:chat:${spaceId} sessions are
   // provisioned with MCP tools and system prompts on startup and on space.created.
-  const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
+  const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase(), deps.reactiveDb);
   // Reply Routing Registry — shared between space-agent-tools (register)
   // and task-agent-tools / node-agent-tools (lookup).
   const replyRoutingRegistry = new ReplyRoutingRegistry();

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -566,7 +566,8 @@ SELECT
   created_at       AS createdAt,
   started_at       AS startedAt,
   completed_at     AS completedAt,
-  updated_at       AS updatedAt
+  updated_at       AS updatedAt,
+  last_activity_at AS lastActivityAt
 FROM node_executions
 WHERE workflow_run_id = ?
 ORDER BY created_at ASC, id ASC

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -279,7 +279,8 @@ export class SpaceRuntimeService {
   constructor(private readonly config: SpaceRuntimeServiceConfig) {
     // Ensure nodeExecutionRepo is available — create from db if not provided.
     this.nodeExecutionRepo =
-      this.config.nodeExecutionRepo ?? new NodeExecutionRepository(this.config.db);
+      this.config.nodeExecutionRepo ??
+      new NodeExecutionRepository(this.config.db, this.config.reactiveDb);
     // Durable workflow event subscription store — single shared instance for
     // the runtime's topic trie to rebuild from on rehydrate. Created here (and
     // passed into the runtime) so the service and runtime share one repo; the

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2329,11 +2329,14 @@ export class SpaceRuntime {
 
       const preparedTarget = taskDecision.target;
       const currentExecution = this.getCurrentQueueableOrActiveExecution(preparedTarget);
-      // A `pull_request.synchronize` reaching a subscribed, deliverable target
-      // means a commit was just pushed to this node's PR branch — genuine agent
-      // progress that `updatedAt` would not capture. Refresh `lastActivityAt` so
-      // the stall detector does not misfire on an actively-pushing node.
-      this.stampCommitPushActivity(payload.topic, currentExecution);
+      // NOTE: a `pull_request.synchronize` event is intentionally NOT used to
+      // refresh lastActivityAt here. It is a PR-level event that fans out to
+      // EVERY subscribed target (coder + reviewer both subscribe to the run's
+      // PR), so stamping on it would mark idle co-subscribers active and
+      // suppress their stall nag. A node's OWN commit push is already captured
+      // — the push is a tool call (`git`/`gh`) on that node's session, which
+      // the sdk.toolUse activity source refreshes, correctly attributed to just
+      // the pushing node. An external push (human/bot) is not agent activity.
       if (preparedTarget.sessionId && this.isTargetSessionLive(preparedTarget.sessionId)) {
         // pauseSpace does not terminate sessions, so a live in_progress session
         // would otherwise be injected now, defeating the pause. Skip injection
@@ -2477,30 +2480,6 @@ export class SpaceRuntime {
       log.warn(
         `SpaceRuntime: failed to process external event ${payload.eventId} for ` +
           `${resolved.workflowRunId}/${resolved.nodeId}/${resolved.agentName}: ${formatCommandError(err)}`
-      );
-    }
-  }
-
-  /**
-   * Refresh `lastActivityAt` when a commit is pushed to a node's PR branch.
-   *
-   * GitHub's `pull_request` webhook with action `synchronize` is the only
-   * reliable "commit pushed to the PR head" signal that flows through the
-   * external-event pipeline (raw `push` webhooks carry no PR signal and are
-   * dropped). Its topic is `github/{owner}/{repo}/pull_request/{number}.synchronize`.
-   * Such an event reaching a subscribed, deliverable target means a commit landed
-   * on this node's PR — genuine progress that `updatedAt` would never capture.
-   * Best-effort: never throws into the delivery path.
-   */
-  private stampCommitPushActivity(topic: string, execution: NodeExecution | undefined): void {
-    if (!execution) return;
-    if (!topic.includes('/pull_request/') || !topic.endsWith('.synchronize')) return;
-    try {
-      this.config.nodeExecutionRepo.touchLastActivity(execution.id);
-    } catch (err) {
-      log.debug(
-        `SpaceRuntime: failed to stamp commit-push activity for execution ${execution.id}:`,
-        err
       );
     }
   }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7310,17 +7310,22 @@ export class SpaceRuntime {
       const isRuntimeNagMessage =
         lastMessage?.type === 'user' && lastMessage.dbId === state.lastRuntimeNagMessageId;
       const progressMessage = lastMessage && !isRuntimeNagMessage ? lastMessage : null;
-      // Prefer `lastActivityAt` — it advances on real agent work (tool calls,
-      // peer-message delivery, PR commit pushes) that `updatedAt` and even the
-      // last SDK-message timestamp miss. A node actively pushing commits or
-      // exchanging messages must not be misread as stuck. Falls back to the
-      // prior chain when no activity has been recorded yet.
+      // Use the NEWEST applicable progress timestamp, not a ??-chain: once
+      // lastActivityAt is set it must not shadow a MORE RECENT SDK message (or
+      // vice versa), or the detector could nag/restart an agent that just made
+      // progress. lastActivityAt captures tool/message/commit activity that the
+      // SDK-message timestamp misses; take the max of every available signal
+      // and fall back to the runtime's last action (or now) only when none is
+      // present.
+      const progressCandidates = [
+        execution.lastActivityAt,
+        progressMessage?.timestamp,
+        execution.startedAt,
+      ].filter((t): t is number => typeof t === 'number');
       const observedAt =
-        execution.lastActivityAt ??
-        progressMessage?.timestamp ??
-        execution.startedAt ??
-        state.lastActionAt ??
-        now;
+        progressCandidates.length > 0
+          ? Math.max(...progressCandidates)
+          : (state.lastActionAt ?? now);
       const thresholdMs = this.getAgentNoProgressThresholdMs(workflow, execution);
 
       if (state.lastSessionId !== execution.agentSessionId) {
@@ -8763,12 +8768,17 @@ export class SpaceRuntime {
         }
       }
 
+      // Newest applicable progress timestamp — see handleAliveStuckExecutions
+      // for why this is a max rather than a ??-chain (a stale lastActivityAt
+      // must not shadow a newer SDK message).
+      const progressCandidates = [
+        execution.lastActivityAt,
+        state.lastObservedProgressMessageAt,
+        progressMessage?.timestamp,
+        execution.startedAt,
+      ].filter((t): t is number => typeof t === 'number');
       const observedAt =
-        execution.lastActivityAt ??
-        state.lastObservedProgressMessageAt ??
-        progressMessage?.timestamp ??
-        execution.startedAt ??
-        Date.now();
+        progressCandidates.length > 0 ? Math.max(...progressCandidates) : Date.now();
       const thresholdMs = workflow
         ? this.getAgentNoProgressThresholdMs(workflow, execution)
         : (this.config.agentNoProgressThresholdMs ?? DEFAULT_AGENT_NO_PROGRESS_THRESHOLD_MS);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2329,6 +2329,11 @@ export class SpaceRuntime {
 
       const preparedTarget = taskDecision.target;
       const currentExecution = this.getCurrentQueueableOrActiveExecution(preparedTarget);
+      // A `pull_request.synchronize` reaching a subscribed, deliverable target
+      // means a commit was just pushed to this node's PR branch — genuine agent
+      // progress that `updatedAt` would not capture. Refresh `lastActivityAt` so
+      // the stall detector does not misfire on an actively-pushing node.
+      this.stampCommitPushActivity(payload.topic, currentExecution);
       if (preparedTarget.sessionId && this.isTargetSessionLive(preparedTarget.sessionId)) {
         // pauseSpace does not terminate sessions, so a live in_progress session
         // would otherwise be injected now, defeating the pause. Skip injection
@@ -2472,6 +2477,30 @@ export class SpaceRuntime {
       log.warn(
         `SpaceRuntime: failed to process external event ${payload.eventId} for ` +
           `${resolved.workflowRunId}/${resolved.nodeId}/${resolved.agentName}: ${formatCommandError(err)}`
+      );
+    }
+  }
+
+  /**
+   * Refresh `lastActivityAt` when a commit is pushed to a node's PR branch.
+   *
+   * GitHub's `pull_request` webhook with action `synchronize` is the only
+   * reliable "commit pushed to the PR head" signal that flows through the
+   * external-event pipeline (raw `push` webhooks carry no PR signal and are
+   * dropped). Its topic is `github/{owner}/{repo}/pull_request/{number}.synchronize`.
+   * Such an event reaching a subscribed, deliverable target means a commit landed
+   * on this node's PR — genuine progress that `updatedAt` would never capture.
+   * Best-effort: never throws into the delivery path.
+   */
+  private stampCommitPushActivity(topic: string, execution: NodeExecution | undefined): void {
+    if (!execution) return;
+    if (!topic.includes('/pull_request/') || !topic.endsWith('.synchronize')) return;
+    try {
+      this.config.nodeExecutionRepo.touchLastActivity(execution.id);
+    } catch (err) {
+      log.debug(
+        `SpaceRuntime: failed to stamp commit-push activity for execution ${execution.id}:`,
+        err
       );
     }
   }
@@ -7302,8 +7331,17 @@ export class SpaceRuntime {
       const isRuntimeNagMessage =
         lastMessage?.type === 'user' && lastMessage.dbId === state.lastRuntimeNagMessageId;
       const progressMessage = lastMessage && !isRuntimeNagMessage ? lastMessage : null;
+      // Prefer `lastActivityAt` — it advances on real agent work (tool calls,
+      // peer-message delivery, PR commit pushes) that `updatedAt` and even the
+      // last SDK-message timestamp miss. A node actively pushing commits or
+      // exchanging messages must not be misread as stuck. Falls back to the
+      // prior chain when no activity has been recorded yet.
       const observedAt =
-        progressMessage?.timestamp ?? execution.startedAt ?? state.lastActionAt ?? now;
+        execution.lastActivityAt ??
+        progressMessage?.timestamp ??
+        execution.startedAt ??
+        state.lastActionAt ??
+        now;
       const thresholdMs = this.getAgentNoProgressThresholdMs(workflow, execution);
 
       if (state.lastSessionId !== execution.agentSessionId) {
@@ -8747,6 +8785,7 @@ export class SpaceRuntime {
       }
 
       const observedAt =
+        execution.lastActivityAt ??
         state.lastObservedProgressMessageAt ??
         progressMessage?.timestamp ??
         execution.startedAt ??

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7310,22 +7310,23 @@ export class SpaceRuntime {
       const isRuntimeNagMessage =
         lastMessage?.type === 'user' && lastMessage.dbId === state.lastRuntimeNagMessageId;
       const progressMessage = lastMessage && !isRuntimeNagMessage ? lastMessage : null;
-      // Use the NEWEST applicable progress timestamp, not a ??-chain: once
-      // lastActivityAt is set it must not shadow a MORE RECENT SDK message (or
-      // vice versa), or the detector could nag/restart an agent that just made
-      // progress. lastActivityAt captures tool/message/commit activity that the
-      // SDK-message timestamp misses; take the max of every available signal
-      // and fall back to the runtime's last action (or now) only when none is
-      // present.
-      const progressCandidates = [
-        execution.lastActivityAt,
-        progressMessage?.timestamp,
-        execution.startedAt,
-      ].filter((t): t is number => typeof t === 'number');
+      // Use the NEWEST PROGRESS timestamp, not a ??-chain: once lastActivityAt
+      // is set it must not shadow a MORE RECENT SDK message (or vice versa), or
+      // the detector could nag/restart an agent that just made progress.
+      // lastActivityAt captures tool/message/commit activity that the SDK-message
+      // timestamp misses; take the max of the progress signals only.
+      // `startedAt` is deliberately EXCLUDED from the max — it is a session-
+      // lifecycle marker (re-stamped on restart/recovery), not progress, so
+      // including it would let a freshly-(re)started-but-still-stuck agent look
+      // fresh and suppress its restart. It remains a fallback for a brand-new
+      // session that has produced no progress signal yet.
+      const progressSignals = [execution.lastActivityAt, progressMessage?.timestamp].filter(
+        (t): t is number => typeof t === 'number'
+      );
       const observedAt =
-        progressCandidates.length > 0
-          ? Math.max(...progressCandidates)
-          : (state.lastActionAt ?? now);
+        progressSignals.length > 0
+          ? Math.max(...progressSignals)
+          : (execution.startedAt ?? state.lastActionAt ?? now);
       const thresholdMs = this.getAgentNoProgressThresholdMs(workflow, execution);
 
       if (state.lastSessionId !== execution.agentSessionId) {
@@ -8768,17 +8769,19 @@ export class SpaceRuntime {
         }
       }
 
-      // Newest applicable progress timestamp — see handleAliveStuckExecutions
-      // for why this is a max rather than a ??-chain (a stale lastActivityAt
-      // must not shadow a newer SDK message).
-      const progressCandidates = [
+      // Newest PROGRESS timestamp — see handleAliveStuckExecutions for why this
+      // is a max over progress signals only (a stale lastActivityAt must not
+      // shadow a newer SDK message; startedAt is a lifecycle marker excluded
+      // from the max and used only as a fallback).
+      const progressSignals = [
         execution.lastActivityAt,
         state.lastObservedProgressMessageAt,
         progressMessage?.timestamp,
-        execution.startedAt,
       ].filter((t): t is number => typeof t === 'number');
       const observedAt =
-        progressCandidates.length > 0 ? Math.max(...progressCandidates) : Date.now();
+        progressSignals.length > 0
+          ? Math.max(...progressSignals)
+          : (execution.startedAt ?? Date.now());
       const thresholdMs = workflow
         ? this.getAgentNoProgressThresholdMs(workflow, execution)
         : (this.config.agentNoProgressThresholdMs ?? DEFAULT_AGENT_NO_PROGRESS_THRESHOLD_MS);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -630,6 +630,11 @@ export class TaskAgentManager {
    */
   private rateLimitListenerUnsubs: Array<() => void> = [];
   /**
+   * Unsubs for the agent-activity listeners (SDK toolUse created/consumed) that
+   * refresh `NodeExecution.lastActivityAt`. Torn down in `cleanupAll()`.
+   */
+  private activityListenerUnsubs: Array<() => void> = [];
+  /**
    * Sub-sessions currently in a rate/usage-limit cooldown, keyed by parent
    * taskId → (sessionId → the session's own limit entry). A task with multiple
    * parallel node-agent sessions can have several limited at once; the task is
@@ -648,6 +653,7 @@ export class TaskAgentManager {
     this.auditLogRepo = new McpAuditLogRepository(this.config.db.getDatabase());
     this.subscribeToTaskArchiveEvents();
     this.subscribeToRateLimitEvents();
+    this.subscribeToActivityTracking();
   }
 
   *getTrackedAgentRootPids(): Iterable<number> {
@@ -805,6 +811,66 @@ export class TaskAgentManager {
         { subscriberName: 'TaskAgentManager.rateLimitResume' }
       )
     );
+  }
+
+  /**
+   * Subscribe to SDK tool-call/tool-result events to refresh
+   * `NodeExecution.lastActivityAt`.
+   *
+   * Tool activity is the strongest, most frequent "the agent is plainly working"
+   * signal and — crucially — it is never produced by the runtime's own recovery
+   * machinery (runtime nags are user messages with no tool_use), so subscribing
+   * here cannot create a feedback loop that defeats stall detection. An agent
+   * that responds to a nag with tool calls IS genuinely working, so advancing
+   * the activity timestamp in that case is correct.
+   *
+   * Each event is resolved to its node execution via the session→execution index
+   * and the dedicated `touchLastActivity` path is used so `updatedAt` (state-write
+   * semantic) is left untouched. Activity tracking must never throw into the
+   * caller; failures are logged at debug and swallowed.
+   */
+  private subscribeToActivityTracking(): void {
+    if (this.activityListenerUnsubs.length > 0) return;
+
+    this.activityListenerUnsubs.push(
+      this.config.internalEventBus.subscribe(
+        'sdk.toolUse.created',
+        (event) => {
+          this.recordActivityForSession(event.sessionId, event.timestamp);
+        },
+        { subscriberName: 'TaskAgentManager.activity:toolUseCreated' }
+      )
+    );
+
+    this.activityListenerUnsubs.push(
+      this.config.internalEventBus.subscribe(
+        'sdk.toolUse.consumed',
+        (event) => {
+          this.recordActivityForSession(event.sessionId, event.timestamp);
+        },
+        { subscriberName: 'TaskAgentManager.activity:toolUseConsumed' }
+      )
+    );
+  }
+
+  /**
+   * Advance `lastActivityAt` for whatever node execution owns `sessionId`.
+   *
+   * Shared by the SDK tool-event subscribers and the peer-message-delivery
+   * wrapper. Silent no-op when the session has no execution row (e.g. the
+   * post-approval merger session, or a session that was already torn down).
+   * Never throws — activity tracking is best-effort and must not break the
+   * surrounding delivery/event path.
+   */
+  private recordActivityForSession(sessionId: string, at: number = Date.now()): void {
+    try {
+      const execution = this.config.nodeExecutionRepo.getByAgentSessionId(sessionId);
+      if (execution) {
+        this.config.nodeExecutionRepo.touchLastActivity(execution.id, at);
+      }
+    } catch (err) {
+      log.debug(`TaskAgentManager: failed to record activity for session ${sessionId}:`, err);
+    }
   }
 
   /**
@@ -1350,6 +1416,7 @@ export class TaskAgentManager {
             startedAt: null,
             completedAt: null,
             updatedAt: 0,
+            lastActivityAt: null,
           };
         }
         if (prevExec?.agentSessionId) {
@@ -3383,6 +3450,8 @@ export class TaskAgentManager {
     }
     for (const unsub of this.rateLimitListenerUnsubs) unsub();
     this.rateLimitListenerUnsubs = [];
+    for (const unsub of this.activityListenerUnsubs) unsub();
+    this.activityListenerUnsubs = [];
     const taskIds = Array.from(this.subSessions.keys());
     await Promise.allSettled(taskIds.map((taskId) => this.shutdownTask(taskId)));
     log.info(`TaskAgentManager: cleanupAll complete (${taskIds.length} tasks shut down)`);
@@ -5058,6 +5127,14 @@ export class TaskAgentManager {
       workflowChannels: channels,
       messageInjector: async (targetSessionId, message) => {
         await this.injectSubSessionMessage(targetSessionId, message, true);
+        // A peer message was just delivered to this node-agent session — that is
+        // inbound activity, so refresh lastActivityAt. Runtime recovery nags do
+        // NOT take this path (they call injectSubSessionMessageWithOrigin
+        // directly, bypassing the router), so this cannot reset the stall
+        // detector's timer on the runtime's own nag. Stamped only after a
+        // successful inject; a throw above skips this so a failed delivery does
+        // not register as activity.
+        this.recordActivityForSession(targetSessionId);
       },
       activateTargetSession: (targetAgentName) =>
         this.activateTargetSessionsForMessage(taskId, workflowRunId, targetAgentName, {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -824,6 +824,12 @@ export class TaskAgentManager {
    * that responds to a nag with tool calls IS genuinely working, so advancing
    * the activity timestamp in that case is correct.
    *
+   * This source also captures a node's OWN commit pushes: a push is a tool call
+   * (`git`/`gh` via Bash) on that node's session, so it refreshes `lastActivityAt`
+   * for exactly the pushing node. A PR-level `pull_request.synchronize` event is
+   * deliberately NOT used — it fans out to every subscribed target and would mark
+   * idle co-subscribers active (see `deliverExternalEventToWorkflowTarget`).
+   *
    * Each event is resolved to its node execution via the session→execution index
    * and the dedicated `touchLastActivity` path is used so `updatedAt` (state-write
    * semantic) is left untouched. Activity tracking must never throw into the
@@ -838,7 +844,7 @@ export class TaskAgentManager {
         (event) => {
           this.recordActivityForSession(event.sessionId, event.timestamp);
         },
-        { subscriberName: 'TaskAgentManager.activity:toolUseCreated' }
+        { subscriberName: 'TaskAgentManager.activityToolUseCreated' }
       )
     );
 
@@ -848,7 +854,7 @@ export class TaskAgentManager {
         (event) => {
           this.recordActivityForSession(event.sessionId, event.timestamp);
         },
-        { subscriberName: 'TaskAgentManager.activity:toolUseConsumed' }
+        { subscriberName: 'TaskAgentManager.activityToolUseConsumed' }
       )
     );
   }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1789,6 +1789,14 @@ export class TaskAgentManager {
           undefined,
           row.id
         );
+        // A queued peer message was just delivered (the target was unavailable
+        // when it was sent, so it went through the pending queue rather than the
+        // router's immediate path). That is inbound activity — refresh
+        // lastActivityAt so peer-message activity is captured on this common
+        // activation/rehydration path too. Runtime recovery nags never reach
+        // here (they use injectRuntimeRecoveryMessage), so this cannot reset the
+        // stall detector's timer on the runtime's own nag.
+        this.recordActivityForSession(sessionId);
         repo.markDelivered(row.id, sessionId);
         this.emitPendingDelivered(row.id, sessionId, row);
       } catch (err) {

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -159,7 +159,7 @@ export class Database {
     this.goalRepo = new GoalRepository(db, reactiveDb, shortIdAllocator);
     this.taskRepo = new TaskRepository(db, reactiveDb, shortIdAllocator);
     this.spaceTaskRepo = new SpaceTaskRepository(db, reactiveDb);
-    this.nodeExecutionRepo = new NodeExecutionRepository(db);
+    this.nodeExecutionRepo = new NodeExecutionRepository(db, reactiveDb);
     this.jobQueueRepo = new JobQueueRepository(db);
     this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
     this.mcpEnablementRepo = new McpEnablementRepository(db, reactiveDb);

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -38,8 +38,8 @@ export class NodeExecutionRepository {
         `INSERT INTO node_executions
 				    (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
 				     agent_session_id, status, result, data, created_at, started_at,
-				     completed_at, updated_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				     completed_at, updated_at, last_activity_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -54,7 +54,8 @@ export class NodeExecutionRepository {
         now,
         null,
         null,
-        now
+        now,
+        null
       );
 
     return this.getById(id)!;
@@ -79,8 +80,8 @@ export class NodeExecutionRepository {
         `INSERT OR IGNORE INTO node_executions
 					    (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
 					     agent_session_id, status, result, data, created_at, started_at,
-					     completed_at, updated_at)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					     completed_at, updated_at, last_activity_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -95,7 +96,8 @@ export class NodeExecutionRepository {
         now,
         null,
         null,
-        now
+        now,
+        null
       );
 
     // If the insert was ignored (duplicate), return the existing record.
@@ -209,6 +211,10 @@ export class NodeExecutionRepository {
       fields.push('completed_at = ?');
       values.push(params.completedAt ?? null);
     }
+    if (params.lastActivityAt !== undefined) {
+      fields.push('last_activity_at = ?');
+      values.push(params.lastActivityAt ?? null);
+    }
 
     if (fields.length > 0) {
       fields.push('updated_at = ?');
@@ -235,6 +241,20 @@ export class NodeExecutionRepository {
    */
   updateSessionId(id: string, agentSessionId: string | null): NodeExecution | null {
     return this.update(id, { agentSessionId });
+  }
+
+  /**
+   * Record observed agent activity by advancing `last_activity_at` ONLY.
+   *
+   * This is the high-frequency path used by the agent-activity signal sources
+   * (SDK tool-call/tool-result, peer-message delivery, PR commit push). It
+   * deliberately does NOT touch `updated_at`, which retains its "last runtime
+   * state-write" semantic — the two columns measure different things and must
+   * not be coupled. Silent no-op for an unknown id (activity for a torn-down or
+   * not-yet-created row is dropped rather than thrown).
+   */
+  touchLastActivity(id: string, at: number = Date.now()): void {
+    this.db.prepare(`UPDATE node_executions SET last_activity_at = ? WHERE id = ?`).run(at, id);
   }
 
   /**
@@ -316,6 +336,7 @@ export class NodeExecutionRepository {
       startedAt: (row.started_at as number | null) ?? null,
       completedAt: (row.completed_at as number | null) ?? null,
       updatedAt: row.updated_at as number,
+      lastActivityAt: (row.last_activity_at as number | null) ?? null,
     };
   }
 }

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -21,9 +21,23 @@ import type {
   UpdateNodeExecutionParams,
 } from '@hyperneo/shared';
 import type { SQLiteValue } from '../types';
+import type { ReactiveDatabase } from '../reactive-database';
 
 export class NodeExecutionRepository {
-  constructor(private db: BunDatabase) {}
+  constructor(
+    private db: BunDatabase,
+    private reactiveDb?: ReactiveDatabase
+  ) {}
+
+  /**
+   * Notify the LiveQuery layer that node_executions changed. No-op when no
+   * reactive db is wired (e.g. tests). Called by every write path so
+   * `nodeExecutions.byRun` subscribers — including the lastActivityAt liveness
+   * signal — re-evaluate on activity/state writes, not just on full refetch.
+   */
+  private notify(): void {
+    this.reactiveDb?.notifyChange('node_executions');
+  }
 
   /**
    * Create a new node execution record.
@@ -58,6 +72,7 @@ export class NodeExecutionRepository {
         null
       );
 
+    this.notify();
     return this.getById(id)!;
   }
 
@@ -100,6 +115,7 @@ export class NodeExecutionRepository {
         null
       );
 
+    this.notify();
     // If the insert was ignored (duplicate), return the existing record.
     const inserted = this.getById(id);
     if (inserted) {
@@ -223,6 +239,7 @@ export class NodeExecutionRepository {
       this.db
         .prepare(`UPDATE node_executions SET ${fields.join(', ')} WHERE id = ?`)
         .run(...values);
+      this.notify();
     }
 
     return this.getById(id);
@@ -255,6 +272,7 @@ export class NodeExecutionRepository {
    */
   touchLastActivity(id: string, at: number = Date.now()): void {
     this.db.prepare(`UPDATE node_executions SET last_activity_at = ? WHERE id = ?`).run(at, id);
+    this.notify();
   }
 
   /**
@@ -262,6 +280,7 @@ export class NodeExecutionRepository {
    */
   delete(id: string): boolean {
     const result = this.db.prepare(`DELETE FROM node_executions WHERE id = ?`).run(id);
+    if (result.changes > 0) this.notify();
     return result.changes > 0;
   }
 
@@ -307,6 +326,7 @@ export class NodeExecutionRepository {
    */
   deleteByWorkflowRun(workflowRunId: string): void {
     this.db.prepare(`DELETE FROM node_executions WHERE workflow_run_id = ?`).run(workflowRunId);
+    this.notify();
   }
 
   /**

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -980,6 +980,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   // gate storage is obsolete. Idempotent via existence guards. Renumbered from
   // 187 (dev shipped M187–M189 for message-delivery-v2, #862).
   run(migrationMarkerKey(190), () => runMigration190(db));
+
+  // Migration 191: node_executions.last_activity_at — dedicated agent-activity
+  // signal (refreshed by tool calls / message delivery / commit pushes,
+  // independent of updated_at) so stall detection is not keyed off updated_at.
+  run(migrationMarkerKey(191), () => runMigration191(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -12369,5 +12374,34 @@ export function runMigration190(db: BunDatabase): void {
   db.exec(`DROP TABLE IF EXISTS gate_data`);
   if (tableHasColumn(db, 'space_workflows', 'gates')) {
     db.exec(`ALTER TABLE space_workflows DROP COLUMN gates`);
+  }
+}
+
+/**
+ * Migration 191: node_executions.last_activity_at — a dedicated agent-activity
+ * signal.
+ *
+ * `updated_at` advances only on runtime state-writes (status / session / data
+ * transitions) and so freezes while an agent is plainly working (pushing
+ * commits, exchanging messages, making tool calls) but no state transition
+ * occurs. That makes it unreliable as a liveness/activity signal, yet the
+ * runtime stall-detector and UI activity displays consume it as one — leading
+ * to misfires (active agents killed, or genuinely-stuck ones missed).
+ *
+ * `last_activity_at` is refreshed independently of `updated_at` by real agent
+ * work (SDK tool events, peer-message delivery, PR commit push) via
+ * `NodeExecutionRepository.touchLastActivity`, which intentionally does NOT
+ * bump `updated_at`. The stall-detector now keys off this column instead.
+ *
+ * Idempotent `ALTER TABLE ADD COLUMN` (no table rebuild). Existing rows are
+ * backfilled NULL; the detector treats NULL via its existing fallback chain, so
+ * pre-migration in-flight executions are not misclassified. Fresh DBs get the
+ * column here too (M74 creates the table without it; all migrations run on a
+ * fresh DB). (task #943.)
+ */
+export function runMigration191(db: BunDatabase): void {
+  if (!tableExists(db, 'node_executions')) return;
+  if (!tableHasColumn(db, 'node_executions', 'last_activity_at')) {
+    db.exec(`ALTER TABLE node_executions ADD COLUMN last_activity_at INTEGER`);
   }
 }

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -434,7 +434,11 @@ describe('SDKMessageHandler', () => {
       const message: SDKMessage = {
         type: 'user',
         uuid: 'tool-result-uuid',
-        session_id: 'test-session-id',
+        // The SDK conversation id (session.sdkSessionId) — deliberately DISTINCT
+        // from the application session.id ('test-session-id'). The consumed event
+        // must carry the app id so execution lookups (node_executions.agent_session_id)
+        // resolve; publishing the SDK conversation id would miss every tool-result.
+        session_id: 'sdk-conversation-id',
         message: {
           role: 'user',
           content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'ok' }],

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -12,6 +12,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
 import { createTables, runMigration74, runMigrations } from '../../../../src/storage/schema';
+import { runMigration191 } from '../../../../src/storage/schema/migrations';
 import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
 import {
   computeIsRenderable,
@@ -135,6 +136,35 @@ describe('NAMED_QUERY_REGISTRY', () => {
     expect([...NAMED_QUERY_REGISTRY.keys()]).not.toContain('goals.byRoom');
     expect([...NAMED_QUERY_REGISTRY.keys()]).not.toContain('mcpEnablement.byRoom');
     expect([...NAMED_QUERY_REGISTRY.keys()]).not.toContain('skills.byRoom');
+  });
+
+  // -------------------------------------------------------------------------
+  // nodeExecutions.byRun — projection includes lastActivityAt (#943)
+  // -------------------------------------------------------------------------
+
+  test('nodeExecutions.byRun projects lastActivityAt alongside updatedAt', () => {
+    // The shared setup (createTables + runMigration74) creates node_executions
+    // at the pre-#943 schema; bring the column up so the projection is real.
+    runMigration191(db);
+    const workflowRunId = 'run-nodeexec-projection';
+    const expectedActivity = now + 12_345;
+    db.exec(`
+      INSERT INTO node_executions (
+        id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+        agent_session_id, status, result, created_at, started_at,
+        completed_at, updated_at, last_activity_at
+      ) VALUES (
+        'exec-projection', '${workflowRunId}', 'node-1', 'coder', NULL,
+        NULL, 'in_progress', NULL, ${now}, ${now}, NULL, ${now}, ${expectedActivity}
+      )
+    `);
+
+    const entry = NAMED_QUERY_REGISTRY.get('nodeExecutions.byRun')!;
+    const rows = db.prepare(entry.sql).all(workflowRunId) as Record<string, unknown>[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveProperty('lastActivityAt', expectedActivity);
+    expect(rows[0]).toHaveProperty('updatedAt', now);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-node-execution-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-node-execution-handlers.test.ts
@@ -33,6 +33,7 @@ const mockExecutions: NodeExecution[] = [
     startedAt: NOW,
     completedAt: NOW + 5000,
     updatedAt: NOW + 5000,
+    lastActivityAt: NOW + 4000,
   },
   {
     id: 'exec-2',
@@ -47,6 +48,7 @@ const mockExecutions: NodeExecution[] = [
     startedAt: NOW + 6000,
     completedAt: null,
     updatedAt: NOW + 6000,
+    lastActivityAt: NOW + 7000,
   },
 ];
 
@@ -158,6 +160,10 @@ describe('space-node-execution-handlers', () => {
       expect(result.executions).toHaveLength(2);
       expect(result.executions[0].id).toBe('exec-1');
       expect(result.executions[1].id).toBe('exec-2');
+      // lastActivityAt is surfaced so UI liveness displays / external watchdogs
+      // can key off the real activity signal instead of updatedAt.
+      expect(result.executions[0].lastActivityAt).toBe(NOW + 4000);
+      expect(result.executions[1].lastActivityAt).toBe(NOW + 7000);
     });
 
     it('returns only executions matching the given workflowRunId', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
@@ -646,4 +646,49 @@ describe('NodeExecutionRepository', () => {
       expect(fetched.lastActivityAt).toBe(7_777_777);
     });
   });
+
+  describe('LiveQuery notifyChange', () => {
+    function makeReactiveRepo() {
+      const calls: Array<{ table: string; scope?: unknown }> = [];
+      const reactiveDb = {
+        notifyChange: (table: string, scope?: unknown) => calls.push({ table, scope }),
+      };
+      return {
+        repo: new NodeExecutionRepository(
+          db as unknown as Parameters<typeof NodeExecutionRepository.prototype.constructor>[0],
+          reactiveDb as unknown as Parameters<
+            typeof NodeExecutionRepository.prototype.constructor
+          >[1]
+        ),
+        calls,
+      };
+    }
+
+    it('touchLastActivity notifies node_executions so LiveQuery re-evaluates', () => {
+      const { repo: r, calls } = makeReactiveRepo();
+      const exec = createExecution();
+      r.touchLastActivity(exec.id, 1_700_000_000_000);
+      expect(calls).toEqual([{ table: 'node_executions', scope: undefined }]);
+    });
+
+    it('update() notifies node_executions on a real change', () => {
+      const { repo: r, calls } = makeReactiveRepo();
+      const exec = createExecution();
+      r.update(exec.id, { status: 'in_progress' });
+      expect(calls.some((c) => c.table === 'node_executions')).toBe(true);
+    });
+
+    it('create notifies node_executions', () => {
+      const { repo: r, calls } = makeReactiveRepo();
+      r.create({ workflowRunId, workflowNodeId: 'n-notify', agentName: 'coder', agentId });
+      expect(calls.some((c) => c.table === 'node_executions')).toBe(true);
+    });
+
+    it('notify is a silent no-op when no reactive db is wired', () => {
+      // The default `repo` has no reactiveDb — none of these may throw.
+      const exec = createExecution();
+      expect(() => repo.touchLastActivity(exec.id, 1)).not.toThrow();
+      expect(() => repo.update(exec.id, { status: 'idle' })).not.toThrow();
+    });
+  });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
@@ -577,4 +577,73 @@ describe('NodeExecutionRepository', () => {
       expect(nodeB.workflowNodeId).toBe('node-B');
     });
   });
+
+  describe('lastActivityAt / touchLastActivity', () => {
+    it('create initializes lastActivityAt to null (no activity yet)', () => {
+      const exec = createExecution();
+      expect(exec.lastActivityAt).toBeNull();
+    });
+
+    it('createOrIgnore initializes lastActivityAt to null', () => {
+      const exec = repo.createOrIgnore({
+        workflowRunId,
+        workflowNodeId: 'node-ci',
+        agentName: 'ci',
+        agentId,
+      });
+      expect(exec.lastActivityAt).toBeNull();
+    });
+
+    it('transition to in_progress does NOT auto-stamp lastActivityAt', () => {
+      // lastActivityAt is refreshed by activity sources (tool/message/commit),
+      // NOT by status transitions — so it must stay null on an in_progress write.
+      const exec = createExecution();
+      const updated = repo.update(exec.id, { status: 'in_progress' });
+      expect(updated!.lastActivityAt).toBeNull();
+    });
+
+    it('touchLastActivity advances last_activity_at', () => {
+      const exec = createExecution();
+      const stampedAt = 1_700_000_000_000;
+      repo.touchLastActivity(exec.id, stampedAt);
+      expect(repo.getById(exec.id)!.lastActivityAt).toBe(stampedAt);
+    });
+
+    it('touchLastActivity does NOT bump updated_at (state-write semantic preserved)', () => {
+      const exec = createExecution();
+      const originalUpdatedAt = exec.updatedAt;
+
+      // touchLastActivity must update only last_activity_at; updated_at stays.
+      repo.touchLastActivity(exec.id, 1_700_000_000_000);
+      const after = repo.getById(exec.id)!;
+      expect(after.lastActivityAt).toBe(1_700_000_000_000);
+      expect(after.updatedAt).toBe(originalUpdatedAt);
+    });
+
+    it('update({ lastActivityAt }) sets the field explicitly', () => {
+      const exec = createExecution();
+      const explicit = 5_000_000;
+      const updated = repo.update(exec.id, { lastActivityAt: explicit });
+      expect(updated!.lastActivityAt).toBe(explicit);
+    });
+
+    it('update({ lastActivityAt: null }) clears the field', () => {
+      const exec = createExecution();
+      repo.touchLastActivity(exec.id, 9_000_000);
+      expect(repo.getById(exec.id)!.lastActivityAt).toBe(9_000_000);
+      const updated = repo.update(exec.id, { lastActivityAt: null });
+      expect(updated!.lastActivityAt).toBeNull();
+    });
+
+    it('touchLastActivity is a silent no-op for an unknown id', () => {
+      expect(() => repo.touchLastActivity('nonexistent', 1_000)).not.toThrow();
+    });
+
+    it('round-trips lastActivityAt through listByWorkflowRun', () => {
+      const exec = createExecution({ agentName: 'coder' });
+      repo.touchLastActivity(exec.id, 7_777_777);
+      const fetched = repo.listByWorkflowRun(workflowRunId).find((e) => e.id === exec.id)!;
+      expect(fetched.lastActivityAt).toBe(7_777_777);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-external-events.test.ts
@@ -1014,6 +1014,52 @@ describe('SpaceRuntime external event subscriptions', () => {
     expect(deliveries[0]!.taskId).toBe(task.id);
   });
 
+  test('a shared-PR synchronize (commit push) does NOT stamp any co-subscriber lastActivityAt', async () => {
+    // Regression guard for the commit-push attribution bug (review P1):
+    // pull_request.synchronize is a PR-LEVEL event that fans out to EVERY
+    // subscriber (e.g. a coder run AND a reviewer run watching the same PR).
+    // lastActivityAt must not advance for any of them — a node's OWN push is
+    // already captured by its tool calls (the sdk.toolUse source, which is
+    // node-scoped), and a PR-level event cannot be attributed to one node.
+    // Stamping here would mark an idle co-subscriber active and suppress its
+    // stall nag for a full threshold window.
+    const PR_TOPIC = 'github/lsm/neokai/pull_request/42.*';
+
+    const { run: coderRun } = await startRunWithSubscription(PR_TOPIC, 'code');
+    const coderExec = nodeExecutionRepo.listByNode(coderRun.id, 'code')[0]!;
+    nodeExecutionRepo.update(coderExec.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-shared-coder',
+      startedAt: Date.now(),
+    });
+    tam.alive.add('session-shared-coder');
+
+    const { run: reviewerRun } = await startRunWithSubscription(PR_TOPIC, 'review');
+    const reviewerExec = nodeExecutionRepo.listByNode(reviewerRun.id, 'review')[0]!;
+    nodeExecutionRepo.update(reviewerExec.id, {
+      status: 'in_progress',
+      agentSessionId: 'session-shared-reviewer',
+      startedAt: Date.now(),
+    });
+    tam.alive.add('session-shared-reviewer');
+
+    await eventService.publish(
+      makeEvent({
+        topic: 'github/lsm/neokai/pull_request/42.synchronize',
+        payload: { action: 'synchronize', prNumber: 42, headSha: 'abc123' },
+      })
+    );
+
+    // Sanity: the fan-out reached at least the coder target, so the delivery
+    // path that USED to stamp ran (under the old code coderExec.lastActivityAt
+    // would now be non-null).
+    expect(injected.some((i) => i.sessionId === 'session-shared-coder')).toBe(true);
+    // Neither the pushing node's run NOR the co-subscribed reviewer run is
+    // stamped as active by the PR-level event.
+    expect(nodeExecutionRepo.getById(coderExec.id)!.lastActivityAt).toBeNull();
+    expect(nodeExecutionRepo.getById(reviewerExec.id)!.lastActivityAt).toBeNull();
+  });
+
   test('delivers matching events to an idle node-agent session', async () => {
     const { run } = await startRunWithSubscription();
     const execution = nodeExecutionRepo.listByNode(run.id, 'code')[0]!;

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1476,6 +1476,82 @@ describe('SpaceRuntime — tick loop correctness', () => {
       expect(state.nudgeCount).toBe(2);
       expect(state.failedNudgeCount).toBe(0);
     });
+
+    // -------------------------------------------------------------------------
+    // lastActivityAt-driven detection (task #943)
+    // -------------------------------------------------------------------------
+
+    test('does NOT nag an actively-working agent whose lastActivityAt is fresh', async () => {
+      // Reproduces the observed false-stall: an in_progress node whose
+      // startedAt and last SDK message are 20min stale (the OLD signals), but
+      // whose lastActivityAt is fresh because the agent is pushing commits /
+      // making tool calls / exchanging messages. The stall detector must key
+      // off lastActivityAt and NOT nag an agent that is plainly working.
+      const nags: Array<{ sessionId: string; message: string }> = [];
+      const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+        isSessionAlive: () => true,
+        getAgentSessionById: () => processingState('processing'),
+        injectRuntimeRecoveryMessage: async (sessionId, message) => {
+          nags.push({ sessionId, message });
+          return `runtime-nag:${sessionId}`;
+        },
+      });
+      const rt = new SpaceRuntime(buildConfig(tam, { agentNoProgressThresholdMs: 60_000 }));
+      const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+        { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+      ]);
+      const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+      nodeExecutionRepo.update(execution.id, {
+        status: 'in_progress',
+        agentSessionId: 'session:actively-working',
+        startedAt: Date.now() - 20 * 60_000,
+      });
+      // Old SDK message — under the pre-lastActivityAt logic this alone would nag.
+      saveAssistantMessage('session:actively-working', { minutesAgo: 20, toolUse: true });
+      // Fresh activity signal — agent just tooled/pushed/messaged.
+      nodeExecutionRepo.touchLastActivity(execution.id, Date.now());
+
+      await rt.executeTick();
+
+      expect(nags).toEqual([]);
+      expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('in_progress');
+    });
+
+    test('nags a genuinely-stuck agent whose lastActivityAt is stale', async () => {
+      // Counterpoint: when lastActivityAt IS stale (no tool calls, no messages,
+      // no commits for 20min) the detector must still fire — lastActivityAt is
+      // authoritative precisely because it is the real-activity signal.
+      const nags: Array<{ sessionId: string; message: string }> = [];
+      const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+        isSessionAlive: () => true,
+        getAgentSessionById: () => processingState('processing'),
+        injectRuntimeRecoveryMessage: async (sessionId, message) => {
+          nags.push({ sessionId, message });
+          return `runtime-nag:${sessionId}`;
+        },
+      });
+      const rt = new SpaceRuntime(buildConfig(tam, { agentNoProgressThresholdMs: 60_000 }));
+      const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+        { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+      ]);
+      const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+      nodeExecutionRepo.update(execution.id, {
+        status: 'in_progress',
+        agentSessionId: 'session:stuck',
+        startedAt: Date.now() - 20 * 60_000,
+      });
+      saveAssistantMessage('session:stuck', { minutesAgo: 20, toolUse: true });
+      // Stale activity — last genuine work was 20min ago.
+      nodeExecutionRepo.touchLastActivity(execution.id, Date.now() - 20 * 60_000);
+
+      await rt.executeTick();
+
+      expect(nags).toHaveLength(1);
+      expect(nags[0].sessionId).toBe('session:stuck');
+      expect(nags[0].message).toContain('[Runtime recovery notice]');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -1552,6 +1552,42 @@ describe('SpaceRuntime — tick loop correctness', () => {
       expect(nags[0].sessionId).toBe('session:stuck');
       expect(nags[0].message).toContain('[Runtime recovery notice]');
     });
+
+    test('does NOT nag when a recent SDK message is newer than a stale lastActivityAt', async () => {
+      // lastActivityAt is stale (an old tool call 20min ago) but a fresh SDK
+      // message shows the agent just made progress. The detector must take the
+      // NEWEST applicable timestamp — a stale lastActivityAt must not shadow a
+      // newer SDK message, or the agent gets nagged/restarted despite just
+      // having produced output. (Regression guard for the ??-chain ordering bug.)
+      const nags: Array<{ sessionId: string; message: string }> = [];
+      const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+        isSessionAlive: () => true,
+        getAgentSessionById: () => processingState('processing'),
+        injectRuntimeRecoveryMessage: async (sessionId, message) => {
+          nags.push({ sessionId, message });
+          return `runtime-nag:${sessionId}`;
+        },
+      });
+      const rt = new SpaceRuntime(buildConfig(tam, { agentNoProgressThresholdMs: 60_000 }));
+      const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+        { id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+      ]);
+      const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+      nodeExecutionRepo.update(execution.id, {
+        status: 'in_progress',
+        agentSessionId: 'session:recent-sdk',
+        startedAt: Date.now() - 20 * 60_000,
+      });
+      // Stale activity, fresh SDK message.
+      nodeExecutionRepo.touchLastActivity(execution.id, Date.now() - 20 * 60_000);
+      saveAssistantMessage('session:recent-sdk', { minutesAgo: 0, toolUse: true });
+
+      await rt.executeTick();
+
+      expect(nags).toEqual([]);
+      expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('in_progress');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-activity-listener.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-activity-listener.test.ts
@@ -15,6 +15,7 @@ import { SpaceRepository } from '../../../../src/storage/repositories/space-repo
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository';
 import { createDaemonInternalEventBus } from '../../../../src/lib/internal-event-bus';
 import { createSpaceTables } from '../../helpers/space-test-db';
 
@@ -26,6 +27,8 @@ describe('TaskAgentManager agent-activity listener', () => {
   let bus: ReturnType<typeof createDaemonInternalEventBus>;
   let manager: TaskAgentManager;
   let executionId: string;
+  let workflowRunId: string;
+  let spaceId: string;
   const subSessionId = 'worker-session-1';
 
   beforeEach(() => {
@@ -44,6 +47,7 @@ describe('TaskAgentManager agent-activity listener', () => {
       db as unknown as Parameters<typeof SpaceTaskRepository.prototype.constructor>[0]
     );
     const space = spaceRepo.createSpace({ workspacePath: '/w', slug: 's', name: 'S' });
+    spaceId = space.id;
     taskRepo.createTask({ spaceId: space.id, title: 'T', description: '' });
 
     // workflow + run for the node_executions FK.
@@ -54,6 +58,7 @@ describe('TaskAgentManager agent-activity listener', () => {
       )
       .run('wf-1', space.id, 'WF', now, now);
     const run = runRepo.createRun({ spaceId: space.id, workflowId: 'wf-1', title: 'R' });
+    workflowRunId = run.id;
 
     const exec = nodeExecutionRepo.create({
       workflowRunId: run.id,
@@ -139,5 +144,44 @@ describe('TaskAgentManager agent-activity listener', () => {
 
     // The unrelated execution is untouched.
     expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).toBeNull();
+  });
+
+  it('stamps lastActivityAt when a queued peer message is delivered via flushPendingMessagesForTarget', async () => {
+    // Queued peer messages (the target was unavailable when sent) are later
+    // drained by flushPendingMessagesForTarget, which calls injectSubSessionMessage
+    // directly — bypassing the router's immediate-delivery stamp. That common
+    // activation/rehydration path must also refresh lastActivityAt.
+    const pendingRepo = new PendingAgentMessageRepository(
+      db as unknown as Parameters<typeof PendingAgentMessageRepository.prototype.constructor>[0]
+    );
+    const manager2 = new TaskAgentManager({
+      db: { getDatabase: () => db },
+      taskRepo: { getTask: () => null } as never,
+      workflowRunRepo: { getRun: () => null } as never,
+      nodeExecutionRepo,
+      pendingMessageRepo: pendingRepo,
+      internalEventBus: bus,
+    } as unknown as TaskAgentManagerConfig);
+
+    pendingRepo.enqueue({
+      workflowRunId,
+      spaceId,
+      sourceAgentName: 'reviewer',
+      targetKind: 'node_agent',
+      targetAgentName: 'coder',
+      message: 'queued peer note',
+      workflowNodeId: 'node-1',
+    });
+    expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).toBeNull();
+
+    // Stub the inject so the queued delivery "succeeds" without a live session —
+    // the activity stamp is what's under test, not the inject mechanism.
+    (
+      manager2 as unknown as { injectSubSessionMessage: () => Promise<string> }
+    ).injectSubSessionMessage = async () => 'flushed-msg-id';
+
+    await manager2.flushPendingMessagesForTarget(workflowRunId, 'coder', subSessionId);
+
+    expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).not.toBeNull();
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-activity-listener.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-activity-listener.test.ts
@@ -1,0 +1,143 @@
+/**
+ * TaskAgentManager agent-activity listener tests.
+ *
+ * Verifies that SDK tool-call / tool-result events refresh
+ * NodeExecution.lastActivityAt through the real internalEventBus — the primary
+ * "agent is plainly working" signal — and that the refresh is best-effort (a
+ * session with no execution row is silently ignored, never thrown into the event
+ * path). Companion to task-agent-rate-limit-listener.test.ts.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from '../../../../src/storage/sqlite-compat';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager';
+import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { createDaemonInternalEventBus } from '../../../../src/lib/internal-event-bus';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('TaskAgentManager agent-activity listener', () => {
+  let db: Database;
+  let nodeExecutionRepo: NodeExecutionRepository;
+  let bus: ReturnType<typeof createDaemonInternalEventBus>;
+  let manager: TaskAgentManager;
+  let executionId: string;
+  const subSessionId = 'worker-session-1';
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSpaceTables(db);
+    const spaceRepo = new SpaceRepository(
+      db as unknown as Parameters<typeof SpaceRepository.prototype.constructor>[0]
+    );
+    const runRepo = new SpaceWorkflowRunRepository(
+      db as unknown as Parameters<typeof SpaceWorkflowRunRepository.prototype.constructor>[0]
+    );
+    nodeExecutionRepo = new NodeExecutionRepository(
+      db as unknown as Parameters<typeof NodeExecutionRepository.prototype.constructor>[0]
+    );
+    const taskRepo = new SpaceTaskRepository(
+      db as unknown as Parameters<typeof SpaceTaskRepository.prototype.constructor>[0]
+    );
+    const space = spaceRepo.createSpace({ workspacePath: '/w', slug: 's', name: 'S' });
+    taskRepo.createTask({ spaceId: space.id, title: 'T', description: '' });
+
+    // workflow + run for the node_executions FK.
+    const now = Date.now();
+    (db as unknown as { prepare: (sql: string) => { run: (...args: unknown[]) => void } })
+      .prepare(
+        `INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+      )
+      .run('wf-1', space.id, 'WF', now, now);
+    const run = runRepo.createRun({ spaceId: space.id, workflowId: 'wf-1', title: 'R' });
+
+    const exec = nodeExecutionRepo.create({
+      workflowRunId: run.id,
+      workflowNodeId: 'node-1',
+      agentName: 'coder',
+      agentSessionId: subSessionId,
+      status: 'in_progress',
+    });
+    executionId = exec.id;
+    // Sanity: lastActivityAt starts null and is only advanced by activity.
+    expect(exec.lastActivityAt).toBeNull();
+
+    bus = createDaemonInternalEventBus();
+
+    // Minimal config: db / taskRepo / nodeExecutionRepo / internalEventBus are
+    // what the constructor + activity listener touch. The rest are stubbed.
+    const config = {
+      db: { getDatabase: () => db },
+      taskRepo,
+      nodeExecutionRepo,
+      internalEventBus: bus,
+    } as unknown as TaskAgentManagerConfig;
+    manager = new TaskAgentManager(config);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('refreshes lastActivityAt on sdk.toolUse.created', async () => {
+    const ts = 1_700_000_000_000;
+    bus.publish('sdk.toolUse.created', {
+      sessionId: subSessionId,
+      toolUseId: 'tu-1',
+      toolName: 'bash',
+      timestamp: ts,
+    });
+    await flush();
+
+    expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).toBe(ts);
+  });
+
+  it('refreshes lastActivityAt on sdk.toolUse.consumed', async () => {
+    const ts = 1_700_000_000_001;
+    bus.publish('sdk.toolUse.consumed', {
+      sessionId: subSessionId,
+      toolUseId: 'tu-2',
+      timestamp: ts,
+    });
+    await flush();
+
+    expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).toBe(ts);
+  });
+
+  it('does not bump updated_at when refreshing lastActivityAt', async () => {
+    const before = nodeExecutionRepo.getById(executionId)!;
+    expect(before.lastActivityAt).toBeNull();
+
+    bus.publish('sdk.toolUse.created', {
+      sessionId: subSessionId,
+      toolUseId: 'tu-3',
+      toolName: 'bash',
+      timestamp: 1_700_000_000_002,
+    });
+    await flush();
+
+    const after = nodeExecutionRepo.getById(executionId)!;
+    expect(after.lastActivityAt).toBe(1_700_000_000_002);
+    // updated_at is the state-write timestamp and must be untouched by activity.
+    expect(after.updatedAt).toBe(before.updatedAt);
+  });
+
+  it('is a silent no-op for a session with no node execution row', async () => {
+    expect(() => {
+      bus.publish('sdk.toolUse.created', {
+        sessionId: 'orphan-session',
+        toolUseId: 'tu-x',
+        toolName: 'bash',
+        timestamp: 1_700_000_000_003,
+      });
+    }).not.toThrow();
+    await flush();
+
+    // The unrelated execution is untouched.
+    expect(nodeExecutionRepo.getById(executionId)!.lastActivityAt).toBeNull();
+  });
+});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -241,6 +241,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			started_at INTEGER,
 			completed_at INTEGER,
 			updated_at INTEGER NOT NULL,
+			last_activity_at INTEGER,
 			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE,
 			FOREIGN KEY (agent_id) REFERENCES space_agents(id) ON DELETE SET NULL
 		)

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1172,8 +1172,19 @@ export interface NodeExecution {
   startedAt: number | null;
   /** Timestamp when execution reached a terminal state; null until completed */
   completedAt: number | null;
-  /** Last update timestamp (milliseconds since epoch) */
+  /** Last update timestamp — advances on every runtime state-write (status/session/data transition). */
   updatedAt: number;
+  /**
+   * Last observed agent activity timestamp (milliseconds since epoch).
+   *
+   * Refreshed independently of `updatedAt` by real agent work — SDK tool-call /
+   * tool-result events, peer messages delivered to the session, and commits pushed
+   * to the node's PR branch — so it stays fresh while an agent is plainly working
+   * even when no runtime state transition occurs. This is the signal stall/timeout
+   * detection and UI liveness displays should key off; `updatedAt` is not a
+   * reliable liveness signal (it freezes at the last state change).
+   */
+  lastActivityAt: number | null;
 }
 
 /**
@@ -1200,6 +1211,12 @@ export interface UpdateNodeExecutionParams {
   data?: Record<string, unknown> | null;
   startedAt?: number | null;
   completedAt?: number | null;
+  /**
+   * Last agent-activity timestamp. Rarely set explicitly through `update()` —
+   * ongoing activity is recorded via the repository's dedicated activity-touch
+   * method so `updatedAt` (state-write) semantics are preserved.
+   */
+  lastActivityAt?: number | null;
 }
 
 // ============================================================================

--- a/packages/web/src/lib/__tests__/node-click-resolver.test.ts
+++ b/packages/web/src/lib/__tests__/node-click-resolver.test.ts
@@ -19,6 +19,7 @@ function nodeExec(overrides: Partial<NodeExecution> = {}): NodeExecution {
     startedAt: null,
     completedAt: null,
     updatedAt: 0,
+    lastActivityAt: null,
     ...overrides,
   };
 }

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -2601,6 +2601,7 @@ function makeNodeExecution(overrides: Partial<NodeExecution> = {}): NodeExecutio
     startedAt: overrides.startedAt ?? null,
     completedAt: overrides.completedAt ?? null,
     updatedAt: overrides.updatedAt ?? Date.now(),
+    lastActivityAt: overrides.lastActivityAt ?? null,
   };
 }
 


### PR DESCRIPTION
Adds `NodeExecution.lastActivityAt`, refreshed independently of `updatedAt` by two node-scoped signals that show an agent is actually working — SDK tool-call/tool-result events (which also capture a node's own commit pushes, since a push is a `git`/`gh` tool call on that node's session) and peer-message delivery. `touchLastActivity` advances only `last_activity_at`, so `updatedAt` keeps its "last runtime state-write" semantic and existing readers are unaffected.

Retargets the runtime stall detector (`handleAliveStuckExecutions`, plus the non-terminal-idle attention path) at `lastActivityAt`, with the prior timestamp chain as a fallback when null — so an in_progress agent whose `updatedAt` froze at session-start while pushing commits / replying / tooling is no longer misread as stuck, and a genuinely idle one still is. A PR-level `pull_request.synchronize` event is deliberately NOT used as an activity source: it fans out to every subscriber and cannot be attributed to a single node, so stamping it would falsely mark idle co-subscribers active (review P1). Surfaced via `nodeExecution.list` / `list_task_members`.