### PR TITLE
feat(space): rate-based dead-loop detection for workflow channels [#947]

### DIFF
--- a/packages/daemon/src/lib/client-event-bridge.ts
+++ b/packages/daemon/src/lib/client-event-bridge.ts
@@ -142,6 +142,11 @@ const SPACE_BRIDGE_MAPPINGS: BridgeMapping[] = [
     clientEvent: 'space.workflowRun.cyclesReset',
     channel: () => Channels.global(),
   },
+  {
+    event: 'space.workflowRun.deadLoop',
+    clientEvent: 'space.workflowRun.deadLoop',
+    channel: () => Channels.global(),
+  },
   // Space agent events → space-scoped
   {
     event: 'spaceAgent.created',

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -308,6 +308,17 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
     description: 'Cycle counters for workflow channels to prevent infinite loop execution.',
   },
   {
+    tableName: 'channel_cycle_events',
+    scopeJoin: {
+      localColumn: 'run_id',
+      joinTable: 'space_workflow_runs',
+      joinPkColumn: 'id',
+      scopeColumn: 'space_id',
+    },
+    blacklistedColumns: [],
+    description: 'Timestamped cyclic-channel traversal events for rate-based dead-loop detection.',
+  },
+  {
     tableName: 'workflow_run_artifacts',
     scopeJoin: {
       localColumn: 'run_id',

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -543,6 +543,33 @@ export interface SpaceWorkflowRunReopenedEvent {
   timestamp: string;
 }
 
+/**
+ * A cyclic channel between two agents has tripped the rate-based dead-loop
+ * detector — too many messages within a short rolling window. The send that
+ * would have exceeded the threshold was blocked. Emitted so the human sees the
+ * block in the UI rather than the send failing silently.
+ */
+export interface SpaceWorkflowRunDeadLoopEvent {
+  sessionId?: string;
+  namespaceId?: string;
+  spaceId: string;
+  runId: string;
+  /** Sending agent name. */
+  fromAgent: string;
+  /** Receiving agent name (or node name for fan-out). */
+  toTarget: string;
+  /** Index of the cyclic channel in the workflow's `channels` array. */
+  channelIndex: number;
+  /** Traversals recorded within the rolling window at the time of the trip. */
+  recentCount: number;
+  /** Max traversals permitted within the window (the threshold that was met). */
+  threshold: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+  reason: string;
+  timestamp: string;
+}
+
 /** A blocked execution is being automatically retried by the runtime. */
 export interface SpaceWorkflowRunRetryEvent {
   sessionId: string;
@@ -604,6 +631,7 @@ export interface SpaceEvents {
   'space.workflowRun.failed': SpaceWorkflowRunFailedEvent;
   'space.workflowRun.blocked': SpaceWorkflowRunBlockedEvent;
   'space.workflowRun.reopened': SpaceWorkflowRunReopenedEvent;
+  'space.workflowRun.deadLoop': SpaceWorkflowRunDeadLoopEvent;
   'space.workflowRun.retry': SpaceWorkflowRunRetryEvent;
   'space.workflowRun.needsAttention': SpaceWorkflowRunNeedsAttentionEvent;
   'space.task.awaitingApproval': SpaceTaskAwaitingApprovalEvent;

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -16,16 +16,17 @@ import { Logger } from '../logger';
 const log = new Logger('space-task-message-handlers');
 
 /**
- * Minimal interface for resetting per-channel cycle counters on a workflow run.
- * Implemented by `ChannelCycleRepository.resetAllForRun`.
+ * Minimal interface for resetting per-channel cycle state on a workflow run.
+ * Implemented by `ChannelCycleRepository.resetAllForRun`, which clears the
+ * rate-window event history for the run (lifting any active dead-loop block).
  *
  * Extracted so the RPC handler stays decoupled from the concrete repository
  * class and can be unit-tested with a lightweight mock.
  */
 export interface ChannelCycleResetter {
   /**
-   * Zero out `count` for every `channel_cycles` row belonging to `runId`.
-   * Returns the number of rows updated.
+   * Clear cyclic-channel dead-loop state for every channel in `runId`.
+   * Returns the number of event rows deleted (0 is valid — nothing to reset).
    */
   resetAllForRun(runId: string): number;
 }

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -390,16 +390,26 @@ export class SpaceTaskManager {
     // archives; the duplicate-reconcile archive path runs through
     // SpaceRuntime.updateTaskAndEmit with `archiveSource: 'system_reconcile'`
     // and detaches the run before it reaches here (correctly — the canonical
-    // task's run stays active, so it must not be cleared). Best-effort: a
-    // failure is logged, never aborts the already-committed archive.
+    // task's run stays active, so it must not be cleared).
+    //
+    // Clear only when EVERY task for the run is archived, mirroring
+    // ChannelRouter.isParentTaskArchived (a run is dead only when all its
+    // tasks are tombstoned). In one-task-per-run this is the first archive;
+    // for a legacy/inconsistent run with several tasks, clearing on the first
+    // archive would let a still-live sibling resume a runaway exchange with a
+    // fresh dead-loop budget. A run with zero tasks is left alone (no
+    // tombstone evidence — same as the router's empty-list rule). Best-effort:
+    // a failure is logged, never aborts the already-committed archive.
     if (newStatus === 'archived' && updated.workflowRunId) {
-      try {
-        new ChannelCycleRepository(this.db).resetAllForRun(updated.workflowRunId);
-      } catch (err) {
-        log.warn(
-          `Failed to clear dead-loop history for archived task "${taskId}" ` +
-            `run "${updated.workflowRunId}": ${err instanceof Error ? err.message : String(err)}`
-        );
+      const runTasks = this.taskRepo.listByWorkflowRunIncludingArchived(updated.workflowRunId);
+      if (runTasks.length > 0 && runTasks.every((t) => t.archivedAt != null)) {
+        try {
+          new ChannelCycleRepository(this.db).resetAllForRun(updated.workflowRunId);
+        } catch (err) {
+          log.warn(
+            `Failed to clear dead-loop history for archived run "${updated.workflowRunId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
     }
 

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -19,6 +19,7 @@ import type {
 import { isRateOrUsageLimited } from '@hyperneo/shared';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import { Logger } from '../../logger';
 import type { EvolutionScopeService } from '../evolution-scope-service';
 import { arraysEqual } from '../../utils/array-utils';
@@ -376,6 +377,29 @@ export class SpaceTaskManager {
         // Best-effort: unblock failures must not roll back the
         // already-committed done transition. The tick loop will
         // re-evaluate blocked dependents on the next cycle.
+      }
+    }
+
+    // Archive is the true task tombstone — ChannelRouter hard-blocks sends to
+    // an archived task, so its workflow run can never reopen. Drop the run's
+    // dead-loop event history now. This is the deliberate counterpart to
+    // keeping done/cancelled history: those are reopenable (a peer send flips
+    // the run back to `in_progress`), so they must retain their rolling-window
+    // state; archive is the one status where retention is pure table growth
+    // with no rate-gate value. This is the chokepoint for tool- and RPC-driven
+    // archives; the duplicate-reconcile archive path runs through
+    // SpaceRuntime.updateTaskAndEmit with `archiveSource: 'system_reconcile'`
+    // and detaches the run before it reaches here (correctly — the canonical
+    // task's run stays active, so it must not be cleared). Best-effort: a
+    // failure is logged, never aborts the already-committed archive.
+    if (newStatus === 'archived' && updated.workflowRunId) {
+      try {
+        new ChannelCycleRepository(this.db).resetAllForRun(updated.workflowRunId);
+      } catch (err) {
+        log.warn(
+          `Failed to clear dead-loop history for archived task "${taskId}" ` +
+            `run "${updated.workflowRunId}": ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
 

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -656,6 +656,11 @@ export class ChannelRouter {
         );
         throw new ActivationError(this.deadLoopReason(fromRole, toTarget));
       }
+      // The channel is not in a dead loop right now, so it has recovered —
+      // either the window aged out or a human touch cleared the history. Drop
+      // any stale dedupe entry so a *new* loop after recovery surfaces a fresh
+      // notification rather than being suppressed by the previous incident.
+      this.deadLoopNotifiedAt.delete(`${runId}:${channelIndex}`);
     }
 
     // ── 4. Lazy activation ─────────────────────────────────────────────────

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -8,7 +8,8 @@
  *
  * Action-level policy (validation, blocking, patching) is enforced by workflow
  * hooks at the MCP-action boundary before `send_message` reaches the router;
- * channels themselves are always open subject to topology and cycle caps.
+ * channels themselves are always open subject to topology and rate-based
+ * dead-loop detection on cyclic channels.
  *
  * Lazy node activation:
  * - activateNode() is idempotent: if active node_executions already exist for
@@ -26,6 +27,10 @@ import { POST_APPROVAL_TASK_AGENT_TARGET } from '../workflows/post-approval-vali
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import {
+  DEAD_LOOP_THRESHOLD,
+  DEAD_LOOP_WINDOW_MS,
+} from '../../../storage/repositories/channel-cycle-repository';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import {
   isReservedWorkflowAgentName,
@@ -117,8 +122,8 @@ export interface DeliveredMessage {
  * or workflow, a node that does not exist, or an attempted activation on a
  * run whose parent task has been archived.
  *
- * Also thrown by deliverMessage() when the iteration cap is exceeded on a
- * cyclic channel (an unrecoverable limit).
+ * Also thrown by deliverMessage() when a cyclic channel trips the rate-based
+ * dead-loop detector (a runaway tight ping-pong between two agents).
  */
 export class ActivationError extends Error {
   constructor(
@@ -162,11 +167,28 @@ export interface ChannelRouterConfig {
    */
   channelCycleRepo?: ChannelCycleRepository;
   /**
-   * Raw SQLite database handle.
-   * When provided, cycle counter increments on cyclic channels are performed
-   * in a single atomic transaction (`db.transaction()`).
-   * When omitted, operations are performed sequentially (still safe for most
-   * single-process use cases but not ACID-atomic on crash).
+   * Max cyclic-channel traversals permitted within the rolling dead-loop
+   * window before the channel is considered in a runaway loop. Defaults to
+   * {@link DEAD_LOOP_THRESHOLD} (15). A genuine long review spread over hours
+   * can never reach this rate; only a tight agent-to-agent ping-pong can.
+   */
+  deadLoopThreshold?: number;
+  /**
+   * Rolling window (ms) over which traversals are counted for dead-loop
+   * detection. Defaults to {@link DEAD_LOOP_WINDOW_MS} (5 minutes).
+   */
+  deadLoopWindowMs?: number;
+  /**
+   * Clock used for dead-loop windowing. Defaults to `Date.now`. Exposed so
+   * tests can simulate messages spread over hours versus a tight burst.
+   */
+  now?: () => number;
+  /**
+   * Raw SQLite database handle. Retained for configuration compatibility with
+   * the legacy lifetime-counter path; the rate-based dead-loop path uses plain
+   * SELECT/INSERT on the cycle repository (no transaction wrap is needed — an
+   * agent session processes one `send_message` at a time, so the check-then-
+   * record sequence is not racy in practice).
    */
   db?: BunDatabase;
   /**
@@ -232,6 +254,26 @@ export interface ChannelRouterConfig {
 
 export class ChannelRouter {
   constructor(private readonly config: ChannelRouterConfig) {}
+
+  /**
+   * Per-(run, channel) timestamp of the most recent dead-loop notification
+   * emitted from this router instance. Suppresses duplicate UI notifications
+   * when a blocked agent retries `send_message` repeatedly within the same
+   * window. Transient (in-memory); the router is rebuilt per agent session.
+   */
+  private readonly deadLoopNotifiedAt = new Map<string, number>();
+
+  private get deadLoopThreshold(): number {
+    return this.config.deadLoopThreshold ?? DEAD_LOOP_THRESHOLD;
+  }
+
+  private get deadLoopWindowMs(): number {
+    return this.config.deadLoopWindowMs ?? DEAD_LOOP_WINDOW_MS;
+  }
+
+  private now(): number {
+    return this.config.now ? this.config.now() : Date.now();
+  }
 
   // -------------------------------------------------------------------------
   // Public API
@@ -458,7 +500,8 @@ export class ChannelRouter {
    * Evaluation order:
    * 1. **Open topology** — when no channel is declared for the pair, delivery is
    *    always allowed (no restriction).
-   * 2. **Cycle cap** — for cyclic channels, blocks when the per-channel cap is reached.
+   * 2. **Dead-loop (rate) check** — for cyclic channels, blocks when the rolling
+   *    per-channel traversal rate has reached the dead-loop threshold.
    *
    * @param runId     - Workflow run ID
    * @param fromRole  - Sending agent name
@@ -478,19 +521,13 @@ export class ChannelRouter {
       // Open topology — no declared channel for this pair; delivery is unrestricted
       return { allowed: true };
     }
-    const { channel, index } = match;
+    const { index } = match;
 
     const channelIsCyclic = this.isChannelCyclicByIndex(index, workflow);
 
-    // ── Per-channel cycle cap check ──────────────────────────────────────
-    if (channelIsCyclic) {
-      const maxCycles = channel.maxCycles ?? 5;
-      if (this.isCycleCapReached(runId, index, maxCycles)) {
-        return {
-          allowed: false,
-          reason: `Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`,
-        };
-      }
+    // ── Rate-based dead-loop check ───────────────────────────────────────
+    if (channelIsCyclic && this.isDeadLoopReached(runId, index)) {
+      return { allowed: false, reason: this.deadLoopReason(fromRole, toTarget) };
     }
 
     return { allowed: true };
@@ -564,10 +601,13 @@ export class ChannelRouter {
    * - `toTarget` is a node name → fan-out to the node; all agent slots are
    *   activated (lazy-activated if not already active)
    *
-   * **Cyclic tracking:**
-   * - For cyclic channels, the per-channel cycle counter is incremented after
-   *   successful delivery.
-   * - If the cycle cap has been reached, throws `ActivationError`.
+   * **Cyclic tracking (rate-based dead-loop detection):**
+   * - For cyclic channels, each successful delivery is recorded as a
+   *   timestamped event.
+   * - If the rolling per-channel traversal rate has reached the dead-loop
+   *   threshold (a runaway tight ping-pong), throws `ActivationError` and
+   *   surfaces a `workflowRun.deadLoop` event so the human sees the block.
+   *   A genuine long review spread over hours never trips this.
    *
    * @param runId    - Workflow run ID
    * @param fromRole - Agent name of the sending agent (WorkflowNodeAgent.name)
@@ -576,7 +616,7 @@ export class ChannelRouter {
    * @returns DeliveredMessage descriptor; `activatedTasks` is set when the
    *   target node was lazily activated, undefined when it was already active
    * @throws ActivationError when the run, workflow, or target agent/node is not
-   *   found, or the cyclic cap is exceeded
+   *   found, or a cyclic channel trips the rate-based dead-loop detector
    */
   async deliverMessage(
     runId: string,
@@ -627,13 +667,23 @@ export class ChannelRouter {
       }
     }
 
-    // Cycle caps reject the send itself, so they are enforced before activation.
+    // Dead-loop (rate) detection rejects the send itself, so it is enforced
+    // before activation. Unlike the retired lifetime cap, this only trips on a
+    // runaway tight ping-pong — a long review spread over hours never will.
     if (channelIsCyclic && channel) {
-      const maxCycles = channel.maxCycles ?? 5;
-      if (this.isCycleCapReached(runId, channelIndex, maxCycles)) {
-        throw new ActivationError(
-          `Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`
+      const recentCount = this.recentCycleCount(runId, channelIndex);
+      if (recentCount >= this.deadLoopThreshold) {
+        // Surface the block to the human (UI) instead of failing silently,
+        // then reject the send.
+        await this.notifyDeadLoop(
+          run.spaceId,
+          runId,
+          fromRole,
+          toTarget,
+          channelIndex,
+          recentCount
         );
+        throw new ActivationError(this.deadLoopReason(fromRole, toTarget));
       }
     }
 
@@ -664,9 +714,9 @@ export class ChannelRouter {
       });
     }
 
-    // ── 5. Increment per-channel cycle count ─────────────────────────────
+    // ── 5. Record the cyclic traversal for rate-based dead-loop detection ─
     if (channelIsCyclic && channel) {
-      this.incrementCyclicChannel(runId, channelIndex, channel.maxCycles ?? 5);
+      this.recordCyclicTraversal(runId, channelIndex);
     }
 
     return {
@@ -777,47 +827,88 @@ export class ChannelRouter {
   }
 
   /**
-   * Checks whether a cyclic channel has reached its per-channel cycle cap.
+   * Number of cyclic-channel traversals recorded within the rolling dead-loop
+   * window for this (run, channel). Returns 0 when no cycle repository is
+   * configured (dead-loop detection disabled — e.g. standalone tests).
    */
-  private isCycleCapReached(runId: string, channelIndex: number, maxCycles: number): boolean {
-    if (!this.config.channelCycleRepo) return false;
-    const record = this.config.channelCycleRepo.get(runId, channelIndex);
-    return record ? record.count >= maxCycles : false;
+  private recentCycleCount(runId: string, channelIndex: number): number {
+    if (!this.config.channelCycleRepo) return 0;
+    return this.config.channelCycleRepo.countRecentCycleEvents(
+      runId,
+      channelIndex,
+      this.now(),
+      this.deadLoopWindowMs
+    );
   }
 
   /**
-   * Atomically increments the per-channel cycle counter.
-   *
-   * When `db` is in config: the increment runs in a single SQLite transaction.
-   * When `db` is absent: runs sequentially (safe for single-process).
-   *
-   * Throws `ActivationError` if the cycle cap was already reached at the time
-   * of the atomic increment (concurrent TOCTOU race).
+   * `true` when the cyclic channel has reached the dead-loop threshold within
+   * the rolling window. The upcoming traversal should be blocked.
    */
-  private incrementCyclicChannel(runId: string, channelIndex: number, maxCycles: number): void {
-    if (!this.config.channelCycleRepo) return;
+  private isDeadLoopReached(runId: string, channelIndex: number): boolean {
+    return this.recentCycleCount(runId, channelIndex) >= this.deadLoopThreshold;
+  }
 
-    if (this.config.db) {
-      const transaction = this.config.db.transaction(() =>
-        this.config.channelCycleRepo!.incrementCycleCount(runId, channelIndex, maxCycles)
-      );
-      const incremented = transaction();
-      if (!incremented) {
-        throw new ActivationError(
-          `Cyclic channel (index ${channelIndex}) reached the maximum cycle count (${maxCycles}) during delivery.`
-        );
-      }
-    } else {
-      const incremented = this.config.channelCycleRepo.incrementCycleCount(
+  /**
+   * Records one cyclic-channel traversal (timestamped event) after a successful
+   * delivery, so subsequent traversals' rate checks can see it. No-op when no
+   * cycle repository is configured.
+   */
+  private recordCyclicTraversal(runId: string, channelIndex: number): void {
+    this.config.channelCycleRepo?.recordCycleEvent(runId, channelIndex, this.now());
+  }
+
+  /**
+   * Human-readable dead-loop block reason shared by `canDeliver` and
+   * `deliverMessage`.
+   */
+  private deadLoopReason(fromRole: string, toTarget: string): string {
+    const threshold = this.deadLoopThreshold;
+    const windowMin = Math.round(this.deadLoopWindowMs / 60000);
+    return (
+      `Cyclic channel from "${fromRole}" to "${toTarget}" is in a dead loop: ` +
+      `${threshold} message round-trips within ${windowMin} minute(s). ` +
+      `Spread the exchange out or break the loop.`
+    );
+  }
+
+  /**
+   * Publish a `space.workflowRun.deadLoop` event so the human sees the blocked
+   * send in the UI (`SpaceAgentNotificationService` injects it into the Space
+   * Agent session). Deduped per (run, channel) within the window so a retrying
+   * agent does not spam the UI. Failures are swallowed — notification must not
+   * break delivery. No-op when no event bus is configured.
+   */
+  private async notifyDeadLoop(
+    spaceId: string,
+    runId: string,
+    fromRole: string,
+    toTarget: string,
+    channelIndex: number,
+    recentCount: number
+  ): Promise<void> {
+    if (!this.config.internalEventBus) return;
+    const key = `${runId}:${channelIndex}`;
+    const now = this.now();
+    const last = this.deadLoopNotifiedAt.get(key);
+    if (last !== undefined && now - last < this.deadLoopWindowMs) return;
+    this.deadLoopNotifiedAt.set(key, now);
+    try {
+      await this.config.internalEventBus.publish('space.workflowRun.deadLoop', {
+        namespaceId: 'global',
+        spaceId,
         runId,
+        fromAgent: fromRole,
+        toTarget,
         channelIndex,
-        maxCycles
-      );
-      if (!incremented) {
-        throw new ActivationError(
-          `Cyclic channel (index ${channelIndex}) reached the maximum cycle count (${maxCycles}) during delivery.`
-        );
-      }
+        recentCount,
+        threshold: this.deadLoopThreshold,
+        windowMs: this.deadLoopWindowMs,
+        reason: this.deadLoopReason(fromRole, toTarget),
+        timestamp: new Date(now).toISOString(),
+      } satisfies DaemonInternalEventMap['space.workflowRun.deadLoop'] & InternalEventPayload);
+    } catch {
+      // Swallow — surfacing must not break the delivery path.
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -19,7 +19,6 @@
  *   ChannelRouter only mutates node_executions and cycle state.
  */
 
-import type { Database as BunDatabase } from '../../../storage/sqlite-compat';
 import type { SpaceTask, SpaceWorkflow, WorkflowChannel, WorkflowNode } from '@hyperneo/shared';
 import { resolveNodeAgents, isChannelCyclic } from '@hyperneo/shared';
 import type { NodeExecution } from '@hyperneo/shared';
@@ -167,31 +166,6 @@ export interface ChannelRouterConfig {
    */
   channelCycleRepo?: ChannelCycleRepository;
   /**
-   * Max cyclic-channel traversals permitted within the rolling dead-loop
-   * window before the channel is considered in a runaway loop. Defaults to
-   * {@link DEAD_LOOP_THRESHOLD} (15). A genuine long review spread over hours
-   * can never reach this rate; only a tight agent-to-agent ping-pong can.
-   */
-  deadLoopThreshold?: number;
-  /**
-   * Rolling window (ms) over which traversals are counted for dead-loop
-   * detection. Defaults to {@link DEAD_LOOP_WINDOW_MS} (5 minutes).
-   */
-  deadLoopWindowMs?: number;
-  /**
-   * Clock used for dead-loop windowing. Defaults to `Date.now`. Exposed so
-   * tests can simulate messages spread over hours versus a tight burst.
-   */
-  now?: () => number;
-  /**
-   * Raw SQLite database handle. Retained for configuration compatibility with
-   * the legacy lifetime-counter path; the rate-based dead-loop path uses plain
-   * SELECT/INSERT on the cycle repository (no transaction wrap is needed — an
-   * agent session processes one `send_message` at a time, so the check-then-
-   * record sequence is not racy in practice).
-   */
-  db?: BunDatabase;
-  /**
    * Optional liveness probe for an agent session ID.
    *
    * Used during cyclic re-entry: when an existing terminal node_execution is
@@ -262,18 +236,6 @@ export class ChannelRouter {
    * window. Transient (in-memory); the router is rebuilt per agent session.
    */
   private readonly deadLoopNotifiedAt = new Map<string, number>();
-
-  private get deadLoopThreshold(): number {
-    return this.config.deadLoopThreshold ?? DEAD_LOOP_THRESHOLD;
-  }
-
-  private get deadLoopWindowMs(): number {
-    return this.config.deadLoopWindowMs ?? DEAD_LOOP_WINDOW_MS;
-  }
-
-  private now(): number {
-    return this.config.now ? this.config.now() : Date.now();
-  }
 
   // -------------------------------------------------------------------------
   // Public API
@@ -667,12 +629,21 @@ export class ChannelRouter {
       }
     }
 
-    // Dead-loop (rate) detection rejects the send itself, so it is enforced
-    // before activation. Unlike the retired lifetime cap, this only trips on a
-    // runaway tight ping-pong — a long review spread over hours never will.
+    // ── 3. Dead-loop gate (reserve the cyclic traversal before activation) ──
+    // Rate-based detection rejects the send itself, so it is enforced before
+    // any activation work. Unlike the retired lifetime cap, this only trips on
+    // a runaway tight ping-pong — a long review spread over hours never will.
+    // `reserveCycleEvent` prunes + counts + conditionally inserts in one
+    // synchronous sequence, so two concurrent agent sessions sharing this
+    // channel cannot both pass the threshold. The reservation is made before
+    // (not after) activation so the gate is authoritative; on the rare path
+    // where activation then fails, one extra reserved event biases safely
+    // toward blocking and prunes out after the window.
     if (channelIsCyclic && channel) {
-      const recentCount = this.recentCycleCount(runId, channelIndex);
-      if (recentCount >= this.deadLoopThreshold) {
+      const reservation = this.config.channelCycleRepo
+        ? this.config.channelCycleRepo.reserveCycleEvent(runId, channelIndex)
+        : { allowed: true, recentCount: 0 };
+      if (!reservation.allowed) {
         // Surface the block to the human (UI) instead of failing silently,
         // then reject the send.
         await this.notifyDeadLoop(
@@ -681,13 +652,13 @@ export class ChannelRouter {
           fromRole,
           toTarget,
           channelIndex,
-          recentCount
+          reservation.recentCount
         );
         throw new ActivationError(this.deadLoopReason(fromRole, toTarget));
       }
     }
 
-    // ── 3. Lazy activation ─────────────────────────────────────────────────
+    // ── 4. Lazy activation ─────────────────────────────────────────────────
     const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
     let activatedTasks: SpaceTask[] | undefined;
 
@@ -712,11 +683,6 @@ export class ChannelRouter {
         reopenBy: `agent:${fromRole}`,
         reopenReason: `peer send_message from "${fromRole}" to "${toTarget}"`,
       });
-    }
-
-    // ── 5. Record the cyclic traversal for rate-based dead-loop detection ─
-    if (channelIsCyclic && channel) {
-      this.recordCyclicTraversal(runId, channelIndex);
     }
 
     return {
@@ -827,35 +793,14 @@ export class ChannelRouter {
   }
 
   /**
-   * Number of cyclic-channel traversals recorded within the rolling dead-loop
-   * window for this (run, channel). Returns 0 when no cycle repository is
-   * configured (dead-loop detection disabled — e.g. standalone tests).
-   */
-  private recentCycleCount(runId: string, channelIndex: number): number {
-    if (!this.config.channelCycleRepo) return 0;
-    return this.config.channelCycleRepo.countRecentCycleEvents(
-      runId,
-      channelIndex,
-      this.now(),
-      this.deadLoopWindowMs
-    );
-  }
-
-  /**
-   * `true` when the cyclic channel has reached the dead-loop threshold within
-   * the rolling window. The upcoming traversal should be blocked.
+   * `true` when the cyclic channel is currently in a dead loop. Read-only check
+   * for `canDeliver` (a non-mutating query). Delivery itself must gate via
+   * `reserveCycleEvent` so the traversal is recorded atomically. Returns `false`
+   * when no cycle repository is configured (dead-loop detection disabled).
    */
   private isDeadLoopReached(runId: string, channelIndex: number): boolean {
-    return this.recentCycleCount(runId, channelIndex) >= this.deadLoopThreshold;
-  }
-
-  /**
-   * Records one cyclic-channel traversal (timestamped event) after a successful
-   * delivery, so subsequent traversals' rate checks can see it. No-op when no
-   * cycle repository is configured.
-   */
-  private recordCyclicTraversal(runId: string, channelIndex: number): void {
-    this.config.channelCycleRepo?.recordCycleEvent(runId, channelIndex, this.now());
+    if (!this.config.channelCycleRepo) return false;
+    return this.config.channelCycleRepo.isDeadLoopReached(runId, channelIndex);
   }
 
   /**
@@ -863,11 +808,10 @@ export class ChannelRouter {
    * `deliverMessage`.
    */
   private deadLoopReason(fromRole: string, toTarget: string): string {
-    const threshold = this.deadLoopThreshold;
-    const windowMin = Math.round(this.deadLoopWindowMs / 60000);
+    const windowMin = Math.round(DEAD_LOOP_WINDOW_MS / 60000);
     return (
       `Cyclic channel from "${fromRole}" to "${toTarget}" is in a dead loop: ` +
-      `${threshold} message round-trips within ${windowMin} minute(s). ` +
+      `${DEAD_LOOP_THRESHOLD} message round-trips within ${windowMin} minute(s). ` +
       `Spread the exchange out or break the loop.`
     );
   }
@@ -876,8 +820,20 @@ export class ChannelRouter {
    * Publish a `space.workflowRun.deadLoop` event so the human sees the blocked
    * send in the UI (`SpaceAgentNotificationService` injects it into the Space
    * Agent session). Deduped per (run, channel) within the window so a retrying
-   * agent does not spam the UI. Failures are swallowed — notification must not
-   * break delivery. No-op when no event bus is configured.
+   * agent does not spam the UI. No-op when no event bus is configured.
+   *
+   * The dedupe timestamp is recorded ONLY after a successful publish: if a
+   * subscriber handler throws, `publish` rethrows, we swallow it here, and —
+   * because we did not record dedupe — the next blocked send retries the
+   * notification. Recording dedupe before the publish would silently drop the
+   * block from the UI on any handler failure, which is exactly the silent
+   * failure this surfacing exists to prevent.
+   *
+   * Note: `publish` is awaited (consistent with `reopenRun`'s `safeNotify`),
+   * which couples `deliverMessage` to subscriber latency; a misbehaving handler
+   * could delay the send. Migrating to fire-and-forget `publishAsync` is a
+   * broader change that also affects `safeNotify` and is intentionally left out
+   * of scope here.
    */
   private async notifyDeadLoop(
     spaceId: string,
@@ -889,10 +845,9 @@ export class ChannelRouter {
   ): Promise<void> {
     if (!this.config.internalEventBus) return;
     const key = `${runId}:${channelIndex}`;
-    const now = this.now();
+    const now = Date.now();
     const last = this.deadLoopNotifiedAt.get(key);
-    if (last !== undefined && now - last < this.deadLoopWindowMs) return;
-    this.deadLoopNotifiedAt.set(key, now);
+    if (last !== undefined && now - last < DEAD_LOOP_WINDOW_MS) return;
     try {
       await this.config.internalEventBus.publish('space.workflowRun.deadLoop', {
         namespaceId: 'global',
@@ -902,13 +857,16 @@ export class ChannelRouter {
         toTarget,
         channelIndex,
         recentCount,
-        threshold: this.deadLoopThreshold,
-        windowMs: this.deadLoopWindowMs,
+        threshold: DEAD_LOOP_THRESHOLD,
+        windowMs: DEAD_LOOP_WINDOW_MS,
         reason: this.deadLoopReason(fromRole, toTarget),
         timestamp: new Date(now).toISOString(),
       } satisfies DaemonInternalEventMap['space.workflowRun.deadLoop'] & InternalEventPayload);
+      // Record dedupe only after the publish succeeded — see method doc.
+      this.deadLoopNotifiedAt.set(key, now);
     } catch {
-      // Swallow — surfacing must not break the delivery path.
+      // Swallow — surfacing must not break the delivery path. Dedupe is NOT
+      // recorded, so the next blocked send retries the notification.
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -116,6 +116,16 @@ export class SpaceAgentNotificationService {
         }
       ),
       this.internalEventBus.subscribe(
+        'space.workflowRun.deadLoop',
+        (event) => {
+          if (event.spaceId !== this.spaceId) return;
+          void this.notify(formatWorkflowRunDeadLoop(event, this.autonomyLevel));
+        },
+        {
+          subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.deadLoop`,
+        }
+      ),
+      this.internalEventBus.subscribe(
         'space.agent.crashed',
         (event) => {
           if (event.spaceId !== this.spaceId) return;
@@ -271,6 +281,45 @@ function formatWorkflowRunReopened(
     autonomyLevel,
   };
   return buildMessage('workflow_run_reopened', humanReadable, payload);
+}
+
+function formatWorkflowRunDeadLoop(
+  event: {
+    spaceId: string;
+    runId: string;
+    fromAgent: string;
+    toTarget: string;
+    channelIndex: number;
+    recentCount: number;
+    threshold: number;
+    windowMs: number;
+    reason: string;
+    timestamp: string;
+  },
+  autonomyLevel: SpaceAutonomyLevel
+): string {
+  const windowMin = Math.round(event.windowMs / 60000);
+  const humanReadable =
+    `Dead loop detected in workflow run ${event.runId} (space ${event.spaceId}): ` +
+    `agent "${event.fromAgent}" → "${event.toTarget}" sent ${event.recentCount} message round-trips ` +
+    `within ${windowMin} minute(s) (threshold ${event.threshold}), so the next send was blocked. ` +
+    `This looks like a runaway agent-to-agent ping-pong, not normal collaboration. ` +
+    `Investigate the two agents and break the loop.`;
+  const payload = {
+    kind: 'workflow_dead_loop',
+    spaceId: event.spaceId,
+    runId: event.runId,
+    fromAgent: event.fromAgent,
+    toTarget: event.toTarget,
+    channelIndex: event.channelIndex,
+    recentCount: event.recentCount,
+    threshold: event.threshold,
+    windowMs: event.windowMs,
+    reason: event.reason,
+    timestamp: event.timestamp,
+    autonomyLevel,
+  };
+  return buildMessage('workflow_dead_loop', humanReadable, payload);
 }
 
 function formatAgentCrash(

--- a/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-agent-notification-service.ts
@@ -117,9 +117,11 @@ export class SpaceAgentNotificationService {
       ),
       this.internalEventBus.subscribe(
         'space.workflowRun.deadLoop',
-        (event) => {
+        async (event) => {
           if (event.spaceId !== this.spaceId) return;
-          void this.notify(formatWorkflowRunDeadLoop(event, this.autonomyLevel));
+          // Await + propagate failures so the router's dedupe-after-success
+          // retry contract holds when the Space Agent session is unavailable.
+          await this.notifyStrict(formatWorkflowRunDeadLoop(event, this.autonomyLevel));
         },
         {
           subscriberName: `SpaceAgentNotificationService:${this.spaceId}:space.workflowRun.deadLoop`,
@@ -184,6 +186,22 @@ export class SpaceAgentNotificationService {
         `[SpaceAgentNotificationService] Failed to inject notification into session ${this.sessionId}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
+  }
+
+  /**
+   * Like {@link notify} but PROPAGATES injection failures instead of swallowing
+   * them. Used by the dead-loop subscriber: a failed injection must surface as
+   * a publish failure to `ChannelRouter.notifyDeadLoop` so its dedupe timestamp
+   * is NOT recorded (dedupe is set only after a successful publish), letting the
+   * next blocked send retry the notification once the Space Agent session
+   * recovers. Other notifications stay fire-and-forget — their publishers don't
+   * gate on delivery success.
+   */
+  private async notifyStrict(message: string): Promise<void> {
+    await this.sessionFactory.injectMessage(this.sessionId, message, {
+      deliveryMode: 'defer',
+      origin: 'system',
+    });
   }
 }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1266,10 +1266,17 @@ export class SpaceRuntimeService {
    * after rehydrate. The "after provisioning" sequencing is therefore
    * best-effort — whichever path wins the race fires first. Correctness is
    * enforced by `SpaceRuntime.recoveryDone`, which guarantees recovery runs
-   * exactly once regardless of caller order. The one observable gap — a
-   * `space.workflowRun.deadLoop` notification published by the pre-provisioning
-   * first tick reaching no subscriber — is closed by a post-provisioning
-   * `surfaceDeadLoopedRuns()` catch-up pass below.
+   * exactly once regardless of caller order.
+   *
+   * Known limitation: if the pre-provisioning first tick wins and recovery
+   * detects a dead-looped cyclic channel, the `space.workflowRun.deadLoop`
+   * event publishes before any `SpaceAgentNotificationService` subscriber
+   * exists and is dropped (the event is non-durable). The run is still
+   * surfaced as `blocked` via status polling + `workflow_run_blocked`, so the
+   * human sees the block; only the dead-loop-specific `[TASK_EVENT]` message
+   * can be lost in this narrow startup race. An earlier catch-up scan that
+   * re-emitted post-provisioning was removed — it was post-approval
+   * complexity for this rare edge and itself generated duplicate/retry issues.
    */
   start(): void {
     if (this.started) return;
@@ -1284,11 +1291,6 @@ export class SpaceRuntimeService {
     // comes from `SpaceRuntime.recoveryDone`, not this sequencing.
     this.provisioningPromise = (async () => {
       await this.provisionExistingSpaces();
-      // Re-surface dead-looped runs now that the per-space notification
-      // subscribers are wired — the runtime's first recovery tick may have
-      // fired before provisioning and published `space.workflowRun.deadLoop`
-      // with no subscriber (the event is non-durable).
-      await this.runtime.surfaceDeadLoopedRuns();
       await this.recoverLongTermAgentInbox();
       await this.recoverStalledWorkflowRuns();
     })().catch((err) => {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1261,7 +1261,10 @@ export class SpaceRuntimeService {
    * after rehydrate. The "after provisioning" sequencing is therefore
    * best-effort — whichever path wins the race fires first. Correctness is
    * enforced by `SpaceRuntime.recoveryDone`, which guarantees recovery runs
-   * exactly once regardless of caller order.
+   * exactly once regardless of caller order. The one observable gap — a
+   * `space.workflowRun.deadLoop` notification published by the pre-provisioning
+   * first tick reaching no subscriber — is closed by a post-provisioning
+   * `surfaceDeadLoopedRuns()` catch-up pass below.
    */
   start(): void {
     if (this.started) return;
@@ -1276,6 +1279,11 @@ export class SpaceRuntimeService {
     // comes from `SpaceRuntime.recoveryDone`, not this sequencing.
     this.provisioningPromise = (async () => {
       await this.provisionExistingSpaces();
+      // Re-surface dead-looped runs now that the per-space notification
+      // subscribers are wired — the runtime's first recovery tick may have
+      // fired before provisioning and published `space.workflowRun.deadLoop`
+      // with no subscriber (the event is non-durable).
+      await this.runtime.surfaceDeadLoopedRuns();
       await this.recoverLongTermAgentInbox();
       await this.recoverStalledWorkflowRuns();
     })().catch((err) => {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1227,11 +1227,11 @@ export class SpaceRuntimeService {
       // Clear run interests explicitly so a later space start (which drops the
       // hold cache) cannot match events against cancelled-run targets.
       this.runtime.clearRunInterests(run.id);
-      // Drop the cancelled run's dead-loop event history — this path bypasses
-      // SpaceRuntime.transitionRunStatusAndEmit (which does this for normal
-      // terminal transitions), so without it stop/cancel on a long-lived
-      // daemon would leak channel_cycle_events rows.
-      this.runtime.clearRunCycleEvents(run.id);
+      // Dead-loop event history is intentionally retained here: `cancelled` is
+      // reopenable, so a resumed run must keep its rolling-window history (a
+      // reopened runaway still has to trip the rate gate). Rows age out of the
+      // window and are pruned at startup; the owning task's archive is the true
+      // tombstone that clears them (SpaceTaskManager.setTaskStatus).
     }
 
     log.info(

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -2297,7 +2297,6 @@ export class SpaceRuntimeService {
       agentManager: this.config.spaceAgentManager,
       nodeExecutionRepo: this.nodeExecutionRepo,
       channelCycleRepo: this.config.channelCycleRepo,
-      db: this.config.db,
       isSessionAlive: taskAgentManager ? (sid) => taskAgentManager.isSessionAlive(sid) : undefined,
       cancelSessionById: taskAgentManager
         ? (sid) => taskAgentManager.cancelBySessionId(sid)

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1227,6 +1227,11 @@ export class SpaceRuntimeService {
       // Clear run interests explicitly so a later space start (which drops the
       // hold cache) cannot match events against cancelled-run targets.
       this.runtime.clearRunInterests(run.id);
+      // Drop the cancelled run's dead-loop event history — this path bypasses
+      // SpaceRuntime.transitionRunStatusAndEmit (which does this for normal
+      // terminal transitions), so without it stop/cancel on a long-lived
+      // daemon would leak channel_cycle_events rows.
+      this.runtime.clearRunCycleEvents(run.id);
     }
 
     log.info(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6206,6 +6206,21 @@ export class SpaceRuntime {
     if (this.recoveryDone) return;
     this.recoveryDone = true;
 
+    // Garbage-collect dead-loop event history older than the rolling window
+    // across all runs. Active cyclic channels are pruned lazily on every
+    // traversal; this bounds history for abandoned/stalled runs that are never
+    // traversed again. Once per daemon start is sufficient — abandoned-run
+    // events are static (no further traversals add rows).
+    try {
+      new ChannelCycleRepository(this.config.db).pruneAllOldEvents();
+    } catch (err) {
+      log.warn(
+        `SpaceRuntime.recoverStalledRuns: failed to prune old cycle events: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
     const spaces = await this.config.spaceManager.listSpaces(false);
     let blockedCount = 0;
     let completionPendingCount = 0;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4693,18 +4693,29 @@ export class SpaceRuntime {
     // are never traversed again). Blocked runs keep their history: they can be
     // reopened/retried, and a persisted dead-loop state must keep applying.
     if (nextStatus === 'done' || nextStatus === 'cancelled') {
-      try {
-        this.getCycleRepo().resetAllForRun(runId);
-      } catch (err) {
-        log.warn(
-          `[SpaceRuntime] failed to clear cycle events for terminal run ${runId}: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-      }
+      this.clearRunCycleEvents(runId);
     }
     await this.safeOnWorkflowRunUpdated(updated.spaceId, updated);
     return updated;
+  }
+
+  /**
+   * Clears a run's cyclic-channel dead-loop event history. Called on every
+   * terminal transition (done/cancelled) routed through
+   * {@link transitionRunStatusAndEmit}, and exposed so callers that cancel runs
+   * by other paths (e.g. `SpaceRuntimeService.stopActiveWork`) can do the same.
+   * Best-effort: a failure is logged, never thrown.
+   */
+  clearRunCycleEvents(runId: string): void {
+    try {
+      this.getCycleRepo().resetAllForRun(runId);
+    } catch (err) {
+      log.warn(
+        `[SpaceRuntime] failed to clear cycle events for terminal run ${runId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   /**
@@ -6623,8 +6634,9 @@ export class SpaceRuntime {
         // ChannelRouter surfacing) so it is not mistaken for a generic stall —
         // once per (run, channel) incident.
         if (cycleResult.deadLoop && !notifiedDeadLoopChannels.has(channelIndex)) {
-          notifiedDeadLoopChannels.add(channelIndex);
-          await this.notifyRecoveryDeadLoop(
+          // Record dedup only on a successful publish — a failed publish must
+          // remain retryable on the next stalled transition in this pass.
+          const notified = await this.notifyRecoveryDeadLoop(
             run,
             channel,
             channelIndex,
@@ -6632,6 +6644,7 @@ export class SpaceRuntime {
             targetNames,
             cycleResult.recentCount
           );
+          if (notified) notifiedDeadLoopChannels.add(channelIndex);
         }
         continue;
       }
@@ -6762,7 +6775,10 @@ export class SpaceRuntime {
    * Best-effort: publish a `space.workflowRun.deadLoop` event when restart
    * recovery finds a cyclic channel already in a dead loop, so the human sees
    * the block in the UI rather than a generic stall. Mirrors the live
-   * `ChannelRouter.notifyDeadLoop` surfacing. Failures are swallowed.
+   * `ChannelRouter.notifyDeadLoop` surfacing. Returns `true` on a successful
+   * publish, `false` when no bus is configured or the publish threw — callers
+   * use that to record dedup only on success (a failed publish must be
+   * retryable on the next pass, not permanently suppressed).
    */
   private async notifyRecoveryDeadLoop(
     run: SpaceWorkflowRun,
@@ -6771,8 +6787,8 @@ export class SpaceRuntime {
     fromAgent: string,
     toTargets: string[],
     recentCount: number
-  ): Promise<void> {
-    if (!this.internalEventBus) return;
+  ): Promise<boolean> {
+    if (!this.internalEventBus) return false;
     const channelLabel = channel.id ?? channelIndex;
     try {
       await this.internalEventBus.publish('space.workflowRun.deadLoop', {
@@ -6788,12 +6804,14 @@ export class SpaceRuntime {
         reason: `Cyclic channel "${channelLabel}" is in a dead loop (detected during restart recovery): ${recentCount} message round-trips within the rate window.`,
         timestamp: new Date().toISOString(),
       } satisfies DaemonInternalEventMap['space.workflowRun.deadLoop'] & InternalEventPayload);
+      return true;
     } catch (err) {
       log.warn(
         `[SpaceRuntime] deadLoop notify threw during recovery: ${
           err instanceof Error ? err.message : String(err)
         }`
       );
+      return false;
     }
   }
 
@@ -6823,10 +6841,20 @@ export class SpaceRuntime {
           if (this.surfacedDeadLoopChannels.has(key)) continue;
           const recentCount = cycleRepo.countRecentCycleEvents(run.id, i);
           if (recentCount < DEAD_LOOP_THRESHOLD) continue;
-          this.surfacedDeadLoopChannels.add(key);
           const channel = channels[i];
           const toTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
-          await this.notifyRecoveryDeadLoop(run, channel, i, channel.from, toTargets, recentCount);
+          // Record dedup only on a successful publish — a failed publish (e.g.
+          // session temporarily unavailable) must stay retryable on the next
+          // catch-up pass instead of being permanently suppressed.
+          const notified = await this.notifyRecoveryDeadLoop(
+            run,
+            channel,
+            i,
+            channel.from,
+            toTargets,
+            recentCount
+          );
+          if (notified) this.surfacedDeadLoopChannels.add(key);
         }
       }
     }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -160,6 +160,13 @@ export interface SpaceRuntimeConfig {
    * that need DB access from injected helpers.
    */
   dbPath?: string;
+  /**
+   * Channel cycle repository for rate-based dead-loop detection on cyclic
+   * channels. Injected (mirroring ChannelRouter / TaskAgentManager) so the repo
+   * can be mocked in recovery tests and a single instance is shared. Auto-built
+   * from `db` when not supplied.
+   */
+  channelCycleRepo?: ChannelCycleRepository;
   /** Space manager for listing spaces and fetching workspace paths */
   spaceManager: SpaceManager;
   /** Agent manager for resolving agents */
@@ -6216,7 +6223,7 @@ export class SpaceRuntime {
     // traversed again. Once per daemon start is sufficient — abandoned-run
     // events are static (no further traversals add rows).
     try {
-      new ChannelCycleRepository(this.config.db).pruneAllOldEvents();
+      this.getCycleRepo().pruneAllOldEvents();
     } catch (err) {
       log.warn(
         `SpaceRuntime.recoverStalledRuns: failed to prune old cycle events: ${
@@ -6692,6 +6699,15 @@ export class SpaceRuntime {
     return false;
   }
 
+  /**
+   * Resolves the channel cycle repository, preferring the injected instance
+   * (mockable, shared) and falling back to one built from `db` for callers that
+   * don't wire it (e.g. lightweight tests).
+   */
+  private getCycleRepo(): ChannelCycleRepository {
+    return this.config.channelCycleRepo ?? new ChannelCycleRepository(this.config.db);
+  }
+
   private evaluateRestartRecoveryCycle(
     runId: string,
     workflow: SpaceWorkflow,
@@ -6703,7 +6719,7 @@ export class SpaceRuntime {
     }
     // Rate-based dead-loop detection: block only a runaway tight ping-pong,
     // never a genuine extended review spread over time.
-    const cycleRepo = new ChannelCycleRepository(this.config.db);
+    const cycleRepo = this.getCycleRepo();
     const recentCount = cycleRepo.countRecentCycleEvents(runId, channelIndex);
     if (recentCount >= DEAD_LOOP_THRESHOLD) {
       return {
@@ -6762,7 +6778,7 @@ export class SpaceRuntime {
     channelIndex: number
   ): void {
     if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) return;
-    const cycleRepo = new ChannelCycleRepository(this.config.db);
+    const cycleRepo = this.getCycleRepo();
     cycleRepo.recordCycleEvent(runId, channelIndex);
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6663,13 +6663,13 @@ export class SpaceRuntime {
     if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) {
       return { open: true };
     }
-    const maxCycles = channel.maxCycles ?? 5;
+    // Rate-based dead-loop detection: block only a runaway tight ping-pong,
+    // never a genuine extended review spread over time.
     const cycleRepo = new ChannelCycleRepository(this.config.db);
-    const record = cycleRepo.get(runId, channelIndex);
-    if (record && record.count >= maxCycles) {
+    if (cycleRepo.isDeadLoopReached(runId, channelIndex)) {
       return {
         open: false,
-        reason: `Cyclic channel "${channel.id ?? channelIndex}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`,
+        reason: `Cyclic channel "${channel.id ?? channelIndex}" is in a dead loop (too many round-trips within the rate window).`,
       };
     }
     return { open: true };
@@ -6682,14 +6682,8 @@ export class SpaceRuntime {
     channelIndex: number
   ): void {
     if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) return;
-    const maxCycles = channel.maxCycles ?? 5;
     const cycleRepo = new ChannelCycleRepository(this.config.db);
-    const incremented = cycleRepo.incrementCycleCount(runId, channelIndex, maxCycles);
-    if (!incremented) {
-      log.warn(
-        `SpaceRuntime.recoverStalledRuns: cyclic channel "${channel.id ?? channelIndex}" reached maxCycles during recovery activation`
-      );
-    }
+    cycleRepo.recordCycleEvent(runId, channelIndex);
   }
 
   private matchesRestartRecoveryChannelSource(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4684,38 +4684,18 @@ export class SpaceRuntime {
     nextStatus: SpaceWorkflowRun['status']
   ): Promise<SpaceWorkflowRun> {
     const updated = this.config.workflowRunRepo.transitionStatus(runId, nextStatus);
-    // Terminal runs (done/cancelled) never traverse their cyclic channels
-    // again, so clear their dead-loop event history now. This bounds table
-    // growth for runs that complete AFTER startup — the startup
-    // pruneAllOldEvents GC only covers runs that already existed at boot, and
-    // abandoned post-startup runs would otherwise accumulate up to the
-    // threshold rows per cyclic channel with no lazy pruning (their channels
-    // are never traversed again). Blocked runs keep their history: they can be
-    // reopened/retried, and a persisted dead-loop state must keep applying.
-    if (nextStatus === 'done' || nextStatus === 'cancelled') {
-      this.clearRunCycleEvents(runId);
-    }
+    // done/cancelled are NOT cleared here. They are reopenable: a peer
+    // `send_message` flips the run back to `in_progress` (see ChannelRouter's
+    // reopen path and WorkflowRunStatusMachine), so a runaway exchange that
+    // crosses the terminal boundary must keep counting against the rolling
+    // dead-loop window — clearing it would hand a reopened run a fresh 15
+    // traversals within the same 5-minute window. The rate-window history is
+    // retained until the rows age out of the window (pruneAllOldEvents at
+    // startup) or the owning task is archived — the true tombstone and only
+    // status from which ChannelRouter hard-blocks further sends (cleared in
+    // SpaceTaskManager.setTaskStatus).
     await this.safeOnWorkflowRunUpdated(updated.spaceId, updated);
     return updated;
-  }
-
-  /**
-   * Clears a run's cyclic-channel dead-loop event history. Called on every
-   * terminal transition (done/cancelled) routed through
-   * {@link transitionRunStatusAndEmit}, and exposed so callers that cancel runs
-   * by other paths (e.g. `SpaceRuntimeService.stopActiveWork`) can do the same.
-   * Best-effort: a failure is logged, never thrown.
-   */
-  clearRunCycleEvents(runId: string): void {
-    try {
-      this.getCycleRepo().resetAllForRun(runId);
-    } catch (err) {
-      log.warn(
-        `[SpaceRuntime] failed to clear cycle events for terminal run ${runId}: ${
-          err instanceof Error ? err.message : String(err)
-        }`
-      );
-    }
   }
 
   /**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6565,6 +6565,11 @@ export class SpaceRuntime {
 
     const createdOrReset: string[] = [];
     const blockedReasons: string[] = [];
+    // A single persisted (run, channel) dead-loop incident must surface at most
+    // one recovery notification, even when multiple idle source executions or a
+    // wildcard source channel yield several stalled transitions for the same
+    // channel in one pass.
+    const notifiedDeadLoopChannels = new Set<number>();
 
     for (const {
       sourceExecution,
@@ -6582,8 +6587,10 @@ export class SpaceRuntime {
       if (!cycleResult.open) {
         blockedReasons.push(cycleResult.reason);
         // Surface a recovery-detected dead loop to the UI (mirrors the live
-        // ChannelRouter surfacing) so it is not mistaken for a generic stall.
-        if (cycleResult.deadLoop) {
+        // ChannelRouter surfacing) so it is not mistaken for a generic stall —
+        // once per (run, channel) incident.
+        if (cycleResult.deadLoop && !notifiedDeadLoopChannels.has(channelIndex)) {
+          notifiedDeadLoopChannels.add(channelIndex);
           await this.notifyRecoveryDeadLoop(
             run,
             channel,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -874,6 +874,14 @@ export class SpaceRuntime {
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   /** Single-flight guard to prevent overlapping executeTick() runs. */
   private tickInFlight = false;
+  /**
+   * Timestamp (ms) of the last periodic `channel_cycle_events` prune. Rows are
+   * pruned at most once per `DEAD_LOOP_WINDOW_MS` from `executeTick` so that
+   * history retained on reopenable done/cancelled runs (which are no longer
+   * traversed, so lazy per-channel pruning never runs) cannot grow the table
+   * without bound on a long-lived daemon. See {@link pruneExpiredCycleEvents}.
+   */
+  private lastGlobalCyclePruneAt = 0;
 
   /**
    * InternalEventBus for publishing typed Space domain events.
@@ -5119,6 +5127,13 @@ export class SpaceRuntime {
       // for a subscription) so they do not last forever when no matching
       // subscription, duplicate webhook, or restart occurs.
       this.expirePublishedExternalEventsPastTtl();
+
+      // Physically prune dead-loop event history older than the rolling window
+      // across ALL runs. Active runs lazy-prune their own channels on each
+      // traversal, but done/cancelled (reopenable) runs are never traversed
+      // again — without this periodic sweep their retained rows would accumulate
+      // until the next daemon restart. Throttled to once per window.
+      this.pruneExpiredCycleEvents();
     } finally {
       this.tickInFlight = false;
     }
@@ -6718,6 +6733,33 @@ export class SpaceRuntime {
    */
   private getCycleRepo(): ChannelCycleRepository {
     return this.config.channelCycleRepo ?? new ChannelCycleRepository(this.config.db);
+  }
+
+  /**
+   * Periodically prunes `channel_cycle_events` rows older than the rolling
+   * dead-loop window across every run. Active runs already lazy-prune their own
+   * (run, channel) on each traversal, but done/cancelled runs are reopenable and
+   * therefore retain their history while never being traversed again — so
+   * without this sweep they would leak rows until the next daemon restart (the
+   * one-shot startup prune only covers runs that existed at boot).
+   *
+   * Throttled to one pass per `DEAD_LOOP_WINDOW_MS`: rows older than the window
+   * are already excluded from the rate count, so deferring their physical
+   * deletion by up to a window is harmless and keeps the (full-scan) prune off
+   * the hot path. Best-effort — a failure is logged, never thrown.
+   */
+  pruneExpiredCycleEvents(now: number = Date.now()): void {
+    if (now - this.lastGlobalCyclePruneAt < DEAD_LOOP_WINDOW_MS) return;
+    this.lastGlobalCyclePruneAt = now;
+    try {
+      this.getCycleRepo().pruneAllOldEvents(now);
+    } catch (err) {
+      log.warn(
+        `[SpaceRuntime] periodic channel_cycle_events prune failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   private evaluateRestartRecoveryCycle(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -57,7 +57,11 @@ import type { ExternalEvent } from '../../external-events/types';
 import { validateGlobPattern } from '../../external-events/topic-validator';
 import { legacyGitHubTopic } from '../../external-events/github-subscription-pattern';
 import { composeLongHorizonSubscriptionPattern } from '../../external-events/long-horizon-subscription-pattern';
-import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import {
+  ChannelCycleRepository,
+  DEAD_LOOP_THRESHOLD,
+  DEAD_LOOP_WINDOW_MS,
+} from '../../../storage/repositories/channel-cycle-repository';
 import { normalizeMeaningfulTaskResult } from '../task-result-utils';
 import type { WorkflowArtifactProfile } from './artifact-profile';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
@@ -6577,6 +6581,18 @@ export class SpaceRuntime {
       );
       if (!cycleResult.open) {
         blockedReasons.push(cycleResult.reason);
+        // Surface a recovery-detected dead loop to the UI (mirrors the live
+        // ChannelRouter surfacing) so it is not mistaken for a generic stall.
+        if (cycleResult.deadLoop) {
+          await this.notifyRecoveryDeadLoop(
+            run,
+            channel,
+            channelIndex,
+            sourceExecution.agentName,
+            targetNames,
+            cycleResult.recentCount
+          );
+        }
         continue;
       }
       let activatedOnChannel = false;
@@ -6674,20 +6690,62 @@ export class SpaceRuntime {
     workflow: SpaceWorkflow,
     channel: WorkflowChannel,
     channelIndex: number
-  ): { open: true } | { open: false; reason: string } {
+  ): { open: true } | { open: false; deadLoop: true; reason: string; recentCount: number } {
     if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) {
       return { open: true };
     }
     // Rate-based dead-loop detection: block only a runaway tight ping-pong,
     // never a genuine extended review spread over time.
     const cycleRepo = new ChannelCycleRepository(this.config.db);
-    if (cycleRepo.isDeadLoopReached(runId, channelIndex)) {
+    const recentCount = cycleRepo.countRecentCycleEvents(runId, channelIndex);
+    if (recentCount >= DEAD_LOOP_THRESHOLD) {
       return {
         open: false,
+        deadLoop: true,
+        recentCount,
         reason: `Cyclic channel "${channel.id ?? channelIndex}" is in a dead loop (too many round-trips within the rate window).`,
       };
     }
     return { open: true };
+  }
+
+  /**
+   * Best-effort: publish a `space.workflowRun.deadLoop` event when restart
+   * recovery finds a cyclic channel already in a dead loop, so the human sees
+   * the block in the UI rather than a generic stall. Mirrors the live
+   * `ChannelRouter.notifyDeadLoop` surfacing. Failures are swallowed.
+   */
+  private async notifyRecoveryDeadLoop(
+    run: SpaceWorkflowRun,
+    channel: WorkflowChannel,
+    channelIndex: number,
+    fromAgent: string,
+    toTargets: string[],
+    recentCount: number
+  ): Promise<void> {
+    if (!this.internalEventBus) return;
+    const channelLabel = channel.id ?? channelIndex;
+    try {
+      await this.internalEventBus.publish('space.workflowRun.deadLoop', {
+        namespaceId: 'global',
+        spaceId: run.spaceId,
+        runId: run.id,
+        fromAgent,
+        toTarget: toTargets.length > 0 ? toTargets.join(',') : String(channelLabel),
+        channelIndex,
+        recentCount,
+        threshold: DEAD_LOOP_THRESHOLD,
+        windowMs: DEAD_LOOP_WINDOW_MS,
+        reason: `Cyclic channel "${channelLabel}" is in a dead loop (detected during restart recovery): ${recentCount} message round-trips within the rate window.`,
+        timestamp: new Date().toISOString(),
+      } satisfies DaemonInternalEventMap['space.workflowRun.deadLoop'] & InternalEventPayload);
+    } catch (err) {
+      log.warn(
+        `[SpaceRuntime] deadLoop notify threw during recovery: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   private recordRestartRecoveryCycleTraversal(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6178,13 +6178,6 @@ export class SpaceRuntime {
   private recoveryDone = false;
 
   /**
-   * Per-daemon `(runId, channelIndex)` keys of dead-loop notifications already
-   * re-surfaced by {@link surfaceDeadLoopedRuns}, so the post-provisioning
-   * catch-up pass emits each incident at most once even if called repeatedly.
-   */
-  private readonly surfacedDeadLoopChannels = new Set<string>();
-
-  /**
    * Scan every active space for `in_progress` workflow runs whose in-flight
    * state was orphaned by a daemon restart, and re-drive them so the tick loop
    * can finalize the run on its next pass.
@@ -6812,51 +6805,6 @@ export class SpaceRuntime {
         }`
       );
       return false;
-    }
-  }
-
-  /**
-   * Best-effort catch-up: re-emit `space.workflowRun.deadLoop` for every
-   * currently-dead-looped cyclic channel across active (in_progress/blocked)
-   * runs. Called once from `SpaceRuntimeService.start()` AFTER the per-space
-   * `SpaceAgentNotificationService` subscribers are wired, because the
-   * runtime's first recovery tick can win the documented startup race and
-   * publish the event before any subscriber exists (the event is non-durable,
-   * and `recoveryDone` would otherwise prevent a second recovery from
-   * re-emitting). Deduped per `(run, channel)` for the daemon lifetime.
-   */
-  async surfaceDeadLoopedRuns(): Promise<void> {
-    if (!this.internalEventBus) return;
-    const cycleRepo = this.getCycleRepo();
-    const spaces = await this.config.spaceManager.listSpaces(false);
-    for (const space of spaces) {
-      if (space.paused || space.stopped) continue;
-      for (const run of this.config.workflowRunRepo.getRehydratableRuns(space.id)) {
-        const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run);
-        const channels = workflow?.channels;
-        if (!channels) continue;
-        for (let i = 0; i < channels.length; i++) {
-          if (!isChannelCyclic(i, channels, workflow.nodes)) continue;
-          const key = `${run.id}:${i}`;
-          if (this.surfacedDeadLoopChannels.has(key)) continue;
-          const recentCount = cycleRepo.countRecentCycleEvents(run.id, i);
-          if (recentCount < DEAD_LOOP_THRESHOLD) continue;
-          const channel = channels[i];
-          const toTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
-          // Record dedup only on a successful publish — a failed publish (e.g.
-          // session temporarily unavailable) must stay retryable on the next
-          // catch-up pass instead of being permanently suppressed.
-          const notified = await this.notifyRecoveryDeadLoop(
-            run,
-            channel,
-            i,
-            channel.from,
-            toTargets,
-            recentCount
-          );
-          if (notified) this.surfacedDeadLoopChannels.add(key);
-        }
-      }
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4684,6 +4684,25 @@ export class SpaceRuntime {
     nextStatus: SpaceWorkflowRun['status']
   ): Promise<SpaceWorkflowRun> {
     const updated = this.config.workflowRunRepo.transitionStatus(runId, nextStatus);
+    // Terminal runs (done/cancelled) never traverse their cyclic channels
+    // again, so clear their dead-loop event history now. This bounds table
+    // growth for runs that complete AFTER startup — the startup
+    // pruneAllOldEvents GC only covers runs that already existed at boot, and
+    // abandoned post-startup runs would otherwise accumulate up to the
+    // threshold rows per cyclic channel with no lazy pruning (their channels
+    // are never traversed again). Blocked runs keep their history: they can be
+    // reopened/retried, and a persisted dead-loop state must keep applying.
+    if (nextStatus === 'done' || nextStatus === 'cancelled') {
+      try {
+        this.getCycleRepo().resetAllForRun(runId);
+      } catch (err) {
+        log.warn(
+          `[SpaceRuntime] failed to clear cycle events for terminal run ${runId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
     await this.safeOnWorkflowRunUpdated(updated.spaceId, updated);
     return updated;
   }
@@ -6148,6 +6167,13 @@ export class SpaceRuntime {
   private recoveryDone = false;
 
   /**
+   * Per-daemon `(runId, channelIndex)` keys of dead-loop notifications already
+   * re-surfaced by {@link surfaceDeadLoopedRuns}, so the post-provisioning
+   * catch-up pass emits each incident at most once even if called repeatedly.
+   */
+  private readonly surfacedDeadLoopChannels = new Set<string>();
+
+  /**
    * Scan every active space for `in_progress` workflow runs whose in-flight
    * state was orphaned by a daemon restart, and re-drive them so the tick loop
    * can finalize the run on its next pass.
@@ -6768,6 +6794,41 @@ export class SpaceRuntime {
           err instanceof Error ? err.message : String(err)
         }`
       );
+    }
+  }
+
+  /**
+   * Best-effort catch-up: re-emit `space.workflowRun.deadLoop` for every
+   * currently-dead-looped cyclic channel across active (in_progress/blocked)
+   * runs. Called once from `SpaceRuntimeService.start()` AFTER the per-space
+   * `SpaceAgentNotificationService` subscribers are wired, because the
+   * runtime's first recovery tick can win the documented startup race and
+   * publish the event before any subscriber exists (the event is non-durable,
+   * and `recoveryDone` would otherwise prevent a second recovery from
+   * re-emitting). Deduped per `(run, channel)` for the daemon lifetime.
+   */
+  async surfaceDeadLoopedRuns(): Promise<void> {
+    if (!this.internalEventBus) return;
+    const cycleRepo = this.getCycleRepo();
+    const spaces = await this.config.spaceManager.listSpaces(false);
+    for (const space of spaces) {
+      if (space.paused || space.stopped) continue;
+      for (const run of this.config.workflowRunRepo.getRehydratableRuns(space.id)) {
+        const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run);
+        const channels = workflow?.channels;
+        if (!channels) continue;
+        for (let i = 0; i < channels.length; i++) {
+          if (!isChannelCyclic(i, channels, workflow.nodes)) continue;
+          const key = `${run.id}:${i}`;
+          if (this.surfacedDeadLoopChannels.has(key)) continue;
+          const recentCount = cycleRepo.countRecentCycleEvents(run.id, i);
+          if (recentCount < DEAD_LOOP_THRESHOLD) continue;
+          this.surfacedDeadLoopChannels.add(key);
+          const channel = channels[i];
+          const toTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
+          await this.notifyRecoveryDeadLoop(run, channel, i, channel.from, toTargets, recentCount);
+        }
+      }
     }
   }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2937,7 +2937,6 @@ export class TaskAgentManager {
         agentManager: this.config.spaceAgentManager,
         nodeExecutionRepo: this.config.nodeExecutionRepo,
         channelCycleRepo: this.config.channelCycleRepo,
-        db: this.config.db.getDatabase(),
         isSessionAlive: (sid) => this.isSessionAlive(sid),
         cancelSessionById: (sid) => this.cancelBySessionId(sid),
         internalEventBus: this.config.internalEventBus,
@@ -5114,7 +5113,6 @@ export class TaskAgentManager {
       agentManager: this.config.spaceAgentManager,
       nodeExecutionRepo: this.config.nodeExecutionRepo,
       channelCycleRepo: this.config.channelCycleRepo,
-      db: this.config.db.getDatabase(),
       isSessionAlive: (sid) => this.isSessionAlive(sid),
       cancelSessionById: (sid) => this.cancelBySessionId(sid),
       // The merger sub-session has no node_execution row, so this router's

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -153,6 +153,11 @@ export class ChannelCycleRepository {
    * Called periodically (e.g. from `recoverStalledRuns`) so abandoned/stalled
    * runs whose channels are never traversed again still have their history
    * bounded. Returns the number of rows deleted.
+   *
+   * The DELETE filters on `sent_at` alone (a full scan of `channel_cycle_events`
+   * without the `(run_id, channel_index, sent_at)` index). That is intentional:
+   * the table is bounded to ~`threshold` rows per active channel per window by
+   * the lazy pruning on every traversal, so the scan stays cheap.
    */
   pruneAllOldEvents(now: number = Date.now(), retentionMs: number = DEAD_LOOP_WINDOW_MS): number {
     const result = this.db

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -1,12 +1,45 @@
 /**
  * Channel Cycle Repository
  *
- * Persistence layer for per-channel cycle counters, keyed by `(run_id, channel_index)`.
- * Each backward (cyclic) channel in a workflow run has its own counter and cap.
- * The counter is atomically incremented via an UPSERT with a cap guard.
+ * Persistence layer for per-channel cycle tracking, keyed by
+ * `(run_id, channel_index)`. Each backward (cyclic) channel in a workflow run
+ * has its own state.
+ *
+ * ## Dead-loop detection (rate-based, primary gate)
+ *
+ * A runaway tight ping-pong between two agents — the only thing worth blocking
+ * — is detected as a **rate**: more than {@link DEAD_LOOP_THRESHOLD} traversals
+ * of the same cyclic channel within a rolling {@link DEAD_LOOP_WINDOW_MS}
+ * window. This is recorded as one row per traversal in `channel_cycle_events`.
+ * A genuine extended review spread over hours can never accumulate that many
+ * traversals inside a single short window, so it never trips. The per-window
+ * count is recomputed (and old rows pruned) on every check.
+ *
+ * ## Lifetime counter (`channel_cycles`, observability only)
+ *
+ * The legacy `channel_cycles` table keeps a lifetime traversal count per
+ * channel. It is retained for observability and backward-compatibility with
+ * in-flight runs, but it is **no longer a blocking gate** — a long review must
+ * not be blocked merely for doing many rounds over time. Both stores are reset
+ * together on human touch (see {@link resetAllForRun}).
  */
 
 import type { Database as BunDatabase } from '../sqlite-compat';
+
+/**
+ * Maximum cyclic-channel traversals permitted within the rolling window before
+ * the channel is considered in a dead loop. With the default of 15, the 16th
+ * traversal inside the window trips the cap. A real inter-agent round trip
+ * (LLM turn + tool use + reply) takes well over a minute, so no legitimate
+ * exchange can approach this rate; only a runaway loop can.
+ */
+export const DEAD_LOOP_THRESHOLD = 15;
+
+/**
+ * Rolling window (ms) over which traversals are counted for dead-loop
+ * detection. Default 5 minutes.
+ */
+export const DEAD_LOOP_WINDOW_MS = 5 * 60 * 1000;
 
 export interface ChannelCycleRecord {
   runId: string;
@@ -80,18 +113,97 @@ export class ChannelCycleRepository {
   }
 
   /**
-   * Zeros every channel cycle counter for a run in a single statement.
+   * Zeros every channel cycle counter for a run in a single statement, and
+   * clears the rate-window event history for the run.
    *
-   * The cap measures "consecutive autonomous cycles without human oversight", so
-   * all channels reset together whenever the run regains human attention.
+   * Both the lifetime counter and the rate window measure "autonomous agent
+   * cycles without human oversight", so they reset together whenever the run
+   * regains human attention. Clearing the event history is what makes a human
+   * touch lift a dead-loop block: after reset, the per-window count is 0.
    *
-   * @returns Number of rows updated (0 is valid — no cyclic channels yet).
+   * @returns Number of `channel_cycles` rows updated (0 is valid — no cyclic
+   * channels yet). Event-row deletions are not counted here to preserve the
+   * existing return-value contract used for telemetry.
    */
   resetAllForRun(runId: string): number {
     const result = this.db
       .prepare('UPDATE channel_cycles SET count = 0, updated_at = ? WHERE run_id = ?')
       .run(Date.now(), runId);
+    // Clear the rate-window event history so a human touch lifts any active
+    // dead-loop block on this run.
+    this.db.prepare('DELETE FROM channel_cycle_events WHERE run_id = ?').run(runId);
     return result.changes;
+  }
+
+  // -------------------------------------------------------------------------
+  // Rate-based dead-loop detection (primary gate)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Records one cyclic-channel traversal as a timestamped event in
+   * `channel_cycle_events`. Call this AFTER a successful delivery/re-activation
+   * on a cyclic channel so the next traversal's rate check can see it.
+   *
+   * Also opportunistically prunes events older than the window so the table
+   * stays bounded over a long-running run.
+   */
+  recordCycleEvent(runId: string, channelIndex: number, now: number = Date.now()): void {
+    this.pruneCycleEvents(runId, channelIndex, now);
+    this.db
+      .prepare('INSERT INTO channel_cycle_events (run_id, channel_index, sent_at) VALUES (?, ?, ?)')
+      .run(runId, channelIndex, now);
+  }
+
+  /**
+   * Removes cyclic-channel events older than `now - windowMs`. Called as part
+   * of counting so the rate signal always reflects only the current window.
+   */
+  pruneCycleEvents(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): void {
+    this.db
+      .prepare(
+        'DELETE FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at < ?'
+      )
+      .run(runId, channelIndex, now - windowMs);
+  }
+
+  /**
+   * Returns the number of cyclic-channel traversals recorded within the rolling
+   * window `[now - windowMs, now]`, after pruning anything older. This is the
+   * rate-based dead-loop signal.
+   */
+  countRecentCycleEvents(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): number {
+    this.pruneCycleEvents(runId, channelIndex, now, windowMs);
+    const row = this.db
+      .prepare(
+        'SELECT COUNT(*) AS n FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at >= ?'
+      )
+      .get(runId, channelIndex, now - windowMs) as { n: number } | undefined;
+    return row?.n ?? 0;
+  }
+
+  /**
+   * Returns `true` when the cyclic channel is in a dead loop: the number of
+   * traversals within the rolling window has reached `threshold`. The upcoming
+   * traversal (the one that would exceed the threshold) should be blocked.
+   */
+  isDeadLoopReached(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    threshold: number = DEAD_LOOP_THRESHOLD,
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): boolean {
+    return this.countRecentCycleEvents(runId, channelIndex, now, windowMs) >= threshold;
   }
 }
 

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -73,7 +73,7 @@ export class ChannelCycleRepository {
   ): CycleReservation {
     const reserve = (): CycleReservation => {
       this.pruneOlder(runId, channelIndex, now - windowMs);
-      const recentCount = this.countSince(runId, channelIndex, now - windowMs);
+      const recentCount = this.countInWindow(runId, channelIndex, now - windowMs, now);
       if (recentCount >= threshold) return { allowed: false, recentCount };
       this.db
         .prepare(
@@ -134,7 +134,7 @@ export class ChannelCycleRepository {
     windowMs: number = DEAD_LOOP_WINDOW_MS
   ): number {
     this.pruneOlder(runId, channelIndex, now - windowMs);
-    return this.countSince(runId, channelIndex, now - windowMs);
+    return this.countInWindow(runId, channelIndex, now - windowMs, now);
   }
 
   /**
@@ -179,13 +179,18 @@ export class ChannelCycleRepository {
       .run(runId, channelIndex, cutoff);
   }
 
-  /** Counts events for a (run, channel) at or after `since` (no pruning). */
-  private countSince(runId: string, channelIndex: number, since: number): number {
+  /**
+   * Counts events for a (run, channel) within `[since, now]` (no pruning). The
+   * upper bound excludes future-dated rows (host clock moving backward across a
+   * restart, or events written under a later clock) so the channel recovers
+   * after the window instead of staying blocked until the clock catches up.
+   */
+  private countInWindow(runId: string, channelIndex: number, since: number, now: number): number {
     const row = this.db
       .prepare(
-        'SELECT COUNT(*) AS n FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at >= ?'
+        'SELECT COUNT(*) AS n FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at >= ? AND sent_at <= ?'
       )
-      .get(runId, channelIndex, since) as { n: number } | undefined;
+      .get(runId, channelIndex, since, now) as { n: number } | undefined;
     return row?.n ?? 0;
   }
 }

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -1,27 +1,28 @@
 /**
  * Channel Cycle Repository
  *
- * Persistence layer for per-channel cycle tracking, keyed by
- * `(run_id, channel_index)`. Each backward (cyclic) channel in a workflow run
- * has its own state.
+ * Persistence layer for rate-based dead-loop detection on cyclic (backward)
+ * workflow channels, keyed by `(run_id, channel_index)`.
  *
- * ## Dead-loop detection (rate-based, primary gate)
+ * ## Dead-loop detection (rate-based)
  *
- * A runaway tight ping-pong between two agents — the only thing worth blocking
- * — is detected as a **rate**: more than {@link DEAD_LOOP_THRESHOLD} traversals
- * of the same cyclic channel within a rolling {@link DEAD_LOOP_WINDOW_MS}
- * window. This is recorded as one row per traversal in `channel_cycle_events`.
- * A genuine extended review spread over hours can never accumulate that many
- * traversals inside a single short window, so it never trips. The per-window
- * count is recomputed (and old rows pruned) on every check.
+ * A runaway tight ping-pong between two agents — the only thing worth
+ * blocking — is detected as a **rate**: more than {@link DEAD_LOOP_THRESHOLD}
+ * traversals of the same cyclic channel within a rolling
+ * {@link DEAD_LOOP_WINDOW_MS} window. Each traversal is one timestamped row in
+ * `channel_cycle_events`. A genuine extended review spread over hours can never
+ * accumulate that many traversals inside a single short window, so it never
+ * trips. The per-window count is recomputed (and old rows pruned) on every
+ * check.
  *
- * ## Lifetime counter (`channel_cycles`, observability only)
+ * `channelCycleRepo.reserveCycleEvent` is the authoritative gate: it prunes,
+ * counts, and conditionally inserts in one synchronous sequence, so concurrent
+ * agent sessions sharing this table cannot both pass at the threshold (the
+ * check and the insert are not separated by an `await`).
  *
- * The legacy `channel_cycles` table keeps a lifetime traversal count per
- * channel. It is retained for observability and backward-compatibility with
- * in-flight runs, but it is **no longer a blocking gate** — a long review must
- * not be blocked merely for doing many rounds over time. Both stores are reset
- * together on human touch (see {@link resetAllForRun}).
+ * The legacy lifetime `channel_cycles` table (migration 69) is retained in the
+ * schema for backward-compatibility with in-flight runs but is no longer read
+ * or written by any code path — a lifetime count must not block a long review.
  */
 
 import type { Database as BunDatabase } from '../sqlite-compat';
@@ -41,160 +42,76 @@ export const DEAD_LOOP_THRESHOLD = 15;
  */
 export const DEAD_LOOP_WINDOW_MS = 5 * 60 * 1000;
 
-export interface ChannelCycleRecord {
-  runId: string;
-  channelIndex: number;
-  count: number;
-  maxCycles: number;
-  updatedAt: number;
+/** Outcome of an attempted cyclic-channel traversal reservation. */
+export interface CycleReservation {
+  /** `true` when the traversal was recorded (below the dead-loop threshold). */
+  allowed: boolean;
+  /** Traversals within the window after this reservation attempt. */
+  recentCount: number;
 }
 
 export class ChannelCycleRepository {
   constructor(private db: BunDatabase) {}
 
   /**
-   * Returns the cycle record for a specific channel in a run, or null if none exists.
+   * Authoritative dead-loop gate. Prunes out-of-window events, counts the
+   * remainder, and — only when the count is below `threshold` — inserts a new
+   * event for this traversal. Returns whether the traversal was allowed.
+   *
+   * The prune + count + conditional-insert sequence is synchronous (no `await`
+   * between the statements), so on a single shared SQLite connection it is
+   * atomic with respect to other agent sessions: two concurrent sends cannot
+   * both observe a sub-threshold count and both record. It is additionally
+   * wrapped in a transaction for explicitness.
    */
-  get(runId: string, channelIndex: number): ChannelCycleRecord | null {
-    const row = this.db
-      .prepare('SELECT * FROM channel_cycles WHERE run_id = ? AND channel_index = ?')
-      .get(runId, channelIndex) as ChannelCycleRow | null;
-    return row ? rowToRecord(row) : null;
-  }
-
-  /**
-   * Returns all cycle records for a given run, keyed by channel index.
-   */
-  getAllForRun(runId: string): Map<number, ChannelCycleRecord> {
-    const rows = this.db
-      .prepare('SELECT * FROM channel_cycles WHERE run_id = ?')
-      .all(runId) as ChannelCycleRow[];
-    const map = new Map<number, ChannelCycleRecord>();
-    for (const row of rows) {
-      const record = rowToRecord(row);
-      map.set(record.channelIndex, record);
+  reserveCycleEvent(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    threshold: number = DEAD_LOOP_THRESHOLD,
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): CycleReservation {
+    const reserve = (): CycleReservation => {
+      this.pruneOlder(runId, channelIndex, now - windowMs);
+      const recentCount = this.countSince(runId, channelIndex, now - windowMs);
+      if (recentCount >= threshold) return { allowed: false, recentCount };
+      this.db
+        .prepare(
+          'INSERT INTO channel_cycle_events (run_id, channel_index, sent_at) VALUES (?, ?, ?)'
+        )
+        .run(runId, channelIndex, now);
+      return { allowed: true, recentCount: recentCount + 1 };
+    };
+    // db.transaction is a no-op-safe wrapper on bun:sqlite; on the shared
+    // connection it makes the prune+count+insert visibly atomic.
+    if (typeof this.db.transaction === 'function') {
+      return this.db.transaction(reserve)();
     }
-    return map;
+    return reserve();
   }
 
   /**
-   * Atomically increments the cycle counter for a channel.
-   *
-   * On first call for a (run, channel) pair, inserts a new row with count=1.
-   * On subsequent calls, increments only if the current count is below the
-   * supplied `maxCycles` (not the persisted `max_cycles`), so raising the cap
-   * unblocks an in-flight run already at the old limit.
-   *
-   * @returns `true` if the counter was incremented, `false` if the cap was reached.
+   * Records a cyclic-channel traversal unconditionally. Used by the restart
+   * recovery path, which has already gated on `isDeadLoopReached` before
+   * activating. Also prunes out-of-window events to bound table growth.
    */
-  incrementCycleCount(runId: string, channelIndex: number, maxCycles: number): boolean {
-    const now = Date.now();
-    const result = this.db
-      .prepare(
-        `INSERT INTO channel_cycles (run_id, channel_index, count, max_cycles, updated_at)
-				 VALUES (?, ?, 1, ?, ?)
-				 ON CONFLICT (run_id, channel_index)
-				 DO UPDATE SET count = count + 1, max_cycles = ?, updated_at = ?
-				 WHERE count < ?`
-      )
-      .run(runId, channelIndex, maxCycles, now, maxCycles, now, maxCycles);
-    return result.changes > 0;
-  }
-
-  /**
-   * Resets the cycle counter for a specific channel back to 0.
-   */
-  reset(runId: string, channelIndex: number): void {
-    this.db
-      .prepare(
-        'UPDATE channel_cycles SET count = 0, updated_at = ? WHERE run_id = ? AND channel_index = ?'
-      )
-      .run(Date.now(), runId, channelIndex);
-  }
-
-  /**
-   * Zeros every channel cycle counter for a run in a single statement, and
-   * clears the rate-window event history for the run.
-   *
-   * Both the lifetime counter and the rate window measure "autonomous agent
-   * cycles without human oversight", so they reset together whenever the run
-   * regains human attention. Clearing the event history is what makes a human
-   * touch lift a dead-loop block: after reset, the per-window count is 0.
-   *
-   * @returns Number of `channel_cycles` rows updated (0 is valid — no cyclic
-   * channels yet). Event-row deletions are not counted here to preserve the
-   * existing return-value contract used for telemetry.
-   */
-  resetAllForRun(runId: string): number {
-    const result = this.db
-      .prepare('UPDATE channel_cycles SET count = 0, updated_at = ? WHERE run_id = ?')
-      .run(Date.now(), runId);
-    // Clear the rate-window event history so a human touch lifts any active
-    // dead-loop block on this run.
-    this.db.prepare('DELETE FROM channel_cycle_events WHERE run_id = ?').run(runId);
-    return result.changes;
-  }
-
-  // -------------------------------------------------------------------------
-  // Rate-based dead-loop detection (primary gate)
-  // -------------------------------------------------------------------------
-
-  /**
-   * Records one cyclic-channel traversal as a timestamped event in
-   * `channel_cycle_events`. Call this AFTER a successful delivery/re-activation
-   * on a cyclic channel so the next traversal's rate check can see it.
-   *
-   * Also opportunistically prunes events older than the window so the table
-   * stays bounded over a long-running run.
-   */
-  recordCycleEvent(runId: string, channelIndex: number, now: number = Date.now()): void {
-    this.pruneCycleEvents(runId, channelIndex, now);
+  recordCycleEvent(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): void {
+    this.pruneOlder(runId, channelIndex, now - windowMs);
     this.db
       .prepare('INSERT INTO channel_cycle_events (run_id, channel_index, sent_at) VALUES (?, ?, ?)')
       .run(runId, channelIndex, now);
   }
 
   /**
-   * Removes cyclic-channel events older than `now - windowMs`. Called as part
-   * of counting so the rate signal always reflects only the current window.
-   */
-  pruneCycleEvents(
-    runId: string,
-    channelIndex: number,
-    now: number = Date.now(),
-    windowMs: number = DEAD_LOOP_WINDOW_MS
-  ): void {
-    this.db
-      .prepare(
-        'DELETE FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at < ?'
-      )
-      .run(runId, channelIndex, now - windowMs);
-  }
-
-  /**
-   * Returns the number of cyclic-channel traversals recorded within the rolling
-   * window `[now - windowMs, now]`, after pruning anything older. This is the
-   * rate-based dead-loop signal.
-   */
-  countRecentCycleEvents(
-    runId: string,
-    channelIndex: number,
-    now: number = Date.now(),
-    windowMs: number = DEAD_LOOP_WINDOW_MS
-  ): number {
-    this.pruneCycleEvents(runId, channelIndex, now, windowMs);
-    const row = this.db
-      .prepare(
-        'SELECT COUNT(*) AS n FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at >= ?'
-      )
-      .get(runId, channelIndex, now - windowMs) as { n: number } | undefined;
-    return row?.n ?? 0;
-  }
-
-  /**
-   * Returns `true` when the cyclic channel is in a dead loop: the number of
-   * traversals within the rolling window has reached `threshold`. The upcoming
-   * traversal (the one that would exceed the threshold) should be blocked.
+   * Returns `true` when the cyclic channel is currently in a dead loop:
+   * traversals within the rolling window have reached `threshold`. Read-only
+   * (besides pruning out-of-window rows); use for non-mutating checks such as
+   * `canDeliver`. Delivery itself must use {@link reserveCycleEvent}.
    */
   isDeadLoopReached(
     runId: string,
@@ -205,26 +122,65 @@ export class ChannelCycleRepository {
   ): boolean {
     return this.countRecentCycleEvents(runId, channelIndex, now, windowMs) >= threshold;
   }
-}
 
-// ---------------------------------------------------------------------------
-// Internal
-// ---------------------------------------------------------------------------
+  /**
+   * Number of cyclic-channel traversals recorded within the rolling window
+   * `[now - windowMs, now]`, after pruning anything older.
+   */
+  countRecentCycleEvents(
+    runId: string,
+    channelIndex: number,
+    now: number = Date.now(),
+    windowMs: number = DEAD_LOOP_WINDOW_MS
+  ): number {
+    this.pruneOlder(runId, channelIndex, now - windowMs);
+    return this.countSince(runId, channelIndex, now - windowMs);
+  }
 
-interface ChannelCycleRow {
-  run_id: string;
-  channel_index: number;
-  count: number;
-  max_cycles: number;
-  updated_at: number;
-}
+  /**
+   * Clears the rate-window history for every channel in a run. This is the
+   * human-touch reset: after it, the per-window count is 0, so a human message
+   * lifts any active dead-loop block. Returns the number of events deleted
+   * (0 is valid — nothing to reset).
+   */
+  resetAllForRun(runId: string): number {
+    const result = this.db.prepare('DELETE FROM channel_cycle_events WHERE run_id = ?').run(runId);
+    return result.changes;
+  }
 
-function rowToRecord(row: ChannelCycleRow): ChannelCycleRecord {
-  return {
-    runId: row.run_id,
-    channelIndex: row.channel_index,
-    count: row.count,
-    maxCycles: row.max_cycles,
-    updatedAt: row.updated_at,
-  };
+  /**
+   * Garbage-collects events older than `now - retentionMs` across ALL runs.
+   * Called periodically (e.g. from `recoverStalledRuns`) so abandoned/stalled
+   * runs whose channels are never traversed again still have their history
+   * bounded. Returns the number of rows deleted.
+   */
+  pruneAllOldEvents(now: number = Date.now(), retentionMs: number = DEAD_LOOP_WINDOW_MS): number {
+    const result = this.db
+      .prepare('DELETE FROM channel_cycle_events WHERE sent_at < ?')
+      .run(now - retentionMs);
+    return result.changes;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  /** Deletes events for a (run, channel) older than `cutoff` (exclusive). */
+  private pruneOlder(runId: string, channelIndex: number, cutoff: number): void {
+    this.db
+      .prepare(
+        'DELETE FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at < ?'
+      )
+      .run(runId, channelIndex, cutoff);
+  }
+
+  /** Counts events for a (run, channel) at or after `since` (no pruning). */
+  private countSince(runId: string, channelIndex: number, since: number): number {
+    const row = this.db
+      .prepare(
+        'SELECT COUNT(*) AS n FROM channel_cycle_events WHERE run_id = ? AND channel_index = ? AND sent_at >= ?'
+      )
+      .get(runId, channelIndex, since) as { n: number } | undefined;
+    return row?.n ?? 0;
+  }
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -985,6 +985,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   // signal (refreshed by tool calls / message delivery / commit pushes,
   // independent of updated_at) so stall detection is not keyed off updated_at.
   run(migrationMarkerKey(191), () => runMigration191(db));
+
+  // Migration 192: channel_cycle_events — rate-based dead-loop detection.
+  run(migrationMarkerKey(192), () => runMigration192(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -12404,4 +12407,41 @@ export function runMigration191(db: BunDatabase): void {
   if (!tableHasColumn(db, 'node_executions', 'last_activity_at')) {
     db.exec(`ALTER TABLE node_executions ADD COLUMN last_activity_at INTEGER`);
   }
+}
+
+/**
+ * Migration 192: Rate-based dead-loop detection for cyclic workflow channels.
+ *
+ * Creates a `channel_cycle_events` table storing one timestamped row per
+ * traversal of a cyclic (backward) channel. Dead-loop detection counts these
+ * rows over a rolling time window (default >15 traversals per 5 minutes) so it
+ * catches a runaway tight ping-pong between two agents while never blocking a
+ * genuine extended review that is spread out over hours.
+ *
+ * The legacy `channel_cycles` lifetime counter (migration 69) is retained for
+ * observability but is no longer a blocking gate; it must not false-trip on
+ * long reviews. This new table is the primary dead-loop signal.
+ *
+ * Backward-compatible with in-flight runs: existing runs simply have an empty
+ * event history (count 0), so any run previously blocked by the lifetime cap
+ * becomes unblocked — which is correct, since those were overwhelmingly
+ * legitimate extended reviews (see PR #2473 / task #942).
+ */
+export function runMigration192(db: BunDatabase): void {
+  if (!tableExists(db, 'space_workflow_runs')) return;
+  if (tableExists(db, 'channel_cycle_events')) return;
+
+  db.exec(`
+		CREATE TABLE channel_cycle_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id TEXT NOT NULL,
+			channel_index INTEGER NOT NULL,
+			sent_at INTEGER NOT NULL,
+			FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+  db.exec(`
+		CREATE INDEX idx_channel_cycle_events_window
+		ON channel_cycle_events(run_id, channel_index, sent_at)
+	`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -12429,10 +12429,14 @@ export function runMigration191(db: BunDatabase): void {
  */
 export function runMigration192(db: BunDatabase): void {
   if (!tableExists(db, 'space_workflow_runs')) return;
-  if (tableExists(db, 'channel_cycle_events')) return;
 
+  // Create the table and its window index independently and idempotently. If
+  // the daemon exited after the CREATE TABLE but before the CREATE INDEX (and
+  // before the migration marker was written), re-running must still create the
+  // index — otherwise rate checks and pruning would scan the full cross-run
+  // event table indefinitely. IF NOT EXISTS makes both safe to re-run.
   db.exec(`
-		CREATE TABLE channel_cycle_events (
+		CREATE TABLE IF NOT EXISTS channel_cycle_events (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			run_id TEXT NOT NULL,
 			channel_index INTEGER NOT NULL,
@@ -12441,7 +12445,7 @@ export function runMigration192(db: BunDatabase): void {
 		)
 	`);
   db.exec(`
-		CREATE INDEX idx_channel_cycle_events_window
+		CREATE INDEX IF NOT EXISTS idx_channel_cycle_events_window
 		ON channel_cycle_events(run_id, channel_index, sent_at)
 	`);
 }

--- a/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
@@ -150,9 +150,9 @@ describe('ClientEventBridge', () => {
       bridge.start();
       bridge.start();
 
-      // 23 space + 4 session + 2 conn/auth + 1 config + 2 error = 32 unique events
+      // 24 space + 4 session + 2 conn/auth + 1 config + 2 error = 33 unique events
       // (context.updated has 2 handlers but is 1 unique event key)
-      expect(eventHandlers.size).toBe(32);
+      expect(eventHandlers.size).toBe(33);
     });
   });
 
@@ -163,8 +163,8 @@ describe('ClientEventBridge', () => {
       bridge.start();
       bridge.stop();
 
-      // 33 internalEventBus.subscribe calls total (context.updated has 2 handlers)
-      expect(unsubscribers.length).toBe(33);
+      // 34 internalEventBus.subscribe calls total (context.updated has 2 handlers)
+      expect(unsubscribers.length).toBe(34);
     });
   });
 

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -69,6 +69,7 @@ describe('scope-config', () => {
         'workflow_hook_state',
         'workflow_hook_result_artifacts',
         'channel_cycles',
+        'channel_cycle_events',
         'workflow_run_artifacts',
         'workflow_run_artifact_cache',
         'mcp_audit_log',
@@ -88,7 +89,7 @@ describe('scope-config', () => {
         'session_groups',
         'session_group_members',
       ]);
-      expect(names).toHaveLength(28);
+      expect(names).toHaveLength(29);
     });
 
     it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -2158,16 +2158,14 @@ describe('setupSpaceTaskMessageHandlers', () => {
       );
       const cycleRepo = new ChannelCycleRepository(sqlite);
 
-      // Simulate 4 autonomous Review→Coding cycles against the backward channel
-      // (channel index 1, maxCycles = 5). At this point the cap is 4/5 — one
-      // more cycle would hit the cap on the next call.
-      const MAX_CYCLES = 5;
+      // Simulate 4 autonomous Review→Coding traversals against the backward
+      // channel (channel index 1). The rate-based detector counts these in a
+      // rolling window; 4 is well below the threshold (15).
       const CHANNEL_INDEX = 1;
       for (let i = 0; i < 4; i++) {
-        const ok = cycleRepo.incrementCycleCount('run-cyc-1', CHANNEL_INDEX, MAX_CYCLES);
-        expect(ok).toBe(true);
+        cycleRepo.recordCycleEvent('run-cyc-1', CHANNEL_INDEX, now - i * 1000);
       }
-      expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(4);
+      expect(cycleRepo.countRecentCycleEvents('run-cyc-1', CHANNEL_INDEX)).toBe(4);
 
       // Wire handlers with the real repo as the ChannelCycleResetter.
       const mh = createMockMessageHub();
@@ -2207,13 +2205,12 @@ describe('setupSpaceTaskMessageHandlers', () => {
       });
       expect(result).toMatchObject({ ok: true });
 
-      // Cycle count must now be 0.
-      expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(0);
+      // The rate-window history must now be cleared.
+      expect(cycleRepo.countRecentCycleEvents('run-cyc-1', CHANNEL_INDEX)).toBe(0);
 
-      // A 5th autonomous cycle is now allowed — the cap guard succeeds again.
-      const fifth = cycleRepo.incrementCycleCount('run-cyc-1', CHANNEL_INDEX, MAX_CYCLES);
-      expect(fifth).toBe(true);
-      expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(1);
+      // A further autonomous traversal is recorded fresh after the reset.
+      cycleRepo.recordCycleEvent('run-cyc-1', CHANNEL_INDEX, now);
+      expect(cycleRepo.countRecentCycleEvents('run-cyc-1', CHANNEL_INDEX)).toBe(1);
 
       sqlite.close();
     });
@@ -2237,9 +2234,9 @@ describe('setupSpaceTaskMessageHandlers', () => {
         `INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES ('run-a2a', 'sp1', 'wf1', 'Run', 'in_progress', ${now}, ${now})`
       );
       const cycleRepo = new ChannelCycleRepository(sqlite);
-      cycleRepo.incrementCycleCount('run-a2a', 0, 5);
-      cycleRepo.incrementCycleCount('run-a2a', 0, 5);
-      const before = cycleRepo.get('run-a2a', 0)!.count;
+      cycleRepo.recordCycleEvent('run-a2a', 0, now);
+      cycleRepo.recordCycleEvent('run-a2a', 0, now);
+      const before = cycleRepo.countRecentCycleEvents('run-a2a', 0);
       expect(before).toBe(2);
 
       // Simulate the agent-to-agent path: the TaskAgentManager's
@@ -2254,7 +2251,7 @@ describe('setupSpaceTaskMessageHandlers', () => {
       await taskAgent.injectSubSessionMessage!('sess-some-agent', 'hello from an agent');
 
       // The counter must be UNCHANGED — the RPC reset path was never invoked.
-      expect(cycleRepo.get('run-a2a', 0)!.count).toBe(before);
+      expect(cycleRepo.countRecentCycleEvents('run-a2a', 0)).toBe(before);
 
       sqlite.close();
     });

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -108,6 +108,16 @@ describe('ChannelCycleRepository — windowed counting & pruning', () => {
     expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 6 * 60 * 1000, WINDOW)).toBe(0);
   });
 
+  test('future-dated events are excluded from the window (clock-skew safe)', () => {
+    // Simulate a backward clock jump across a restart: 15 events recorded
+    // "in the future" relative to the current `now`. The upper window bound
+    // excludes them, so the channel is not falsely dead-looped and recovers
+    // as the clock advances (instead of blocking until the clock catches up).
+    for (let i = 1; i <= 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 60_000);
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW)).toBe(0);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW)).toBe(false);
+  });
+
   test('isDeadLoopReached flips at the threshold (explicit threshold/window)', () => {
     for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000, 15, WINDOW)).toBe(false);

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -108,14 +108,16 @@ describe('ChannelCycleRepository — windowed counting & pruning', () => {
     expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 6 * 60 * 1000, WINDOW)).toBe(0);
   });
 
-  test('isDeadLoopReached flips at the threshold', () => {
+  test('isDeadLoopReached flips at the threshold (explicit threshold/window)', () => {
     for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000)).toBe(false);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000, 15, WINDOW)).toBe(false);
     repo.recordCycleEvent(RUN_ID_A, 1, NOW + 14_000);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(true);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
   });
 
   test('uses package defaults (15 / 5min) when threshold/window omitted', () => {
+    // Omits threshold/window args to exercise the DEAD_LOOP_THRESHOLD /
+    // DEAD_LOOP_WINDOW_MS defaults (distinct from the explicit-args test above).
     for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000)).toBe(false);
     repo.recordCycleEvent(RUN_ID_A, 1, NOW + 14_000);

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -118,6 +118,16 @@ describe('ChannelCycleRepository — windowed counting & pruning', () => {
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW)).toBe(false);
   });
 
+  test('exact window boundaries are inclusive on both ends', () => {
+    // sent_at == now - windowMs is counted (>= lower bound, survives prune via
+    // strict `<`); sent_at == now is counted (<= upper bound); one ms older than
+    // the lower bound is excluded.
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - WINDOW); // exactly on the lower edge
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW); // exactly on the upper edge
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - WINDOW - 1); // one ms too old (pruned)
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW, WINDOW)).toBe(2);
+  });
+
   test('isDeadLoopReached flips at the threshold (explicit threshold/window)', () => {
     for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000, 15, WINDOW)).toBe(false);

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -1,14 +1,16 @@
 /**
  * ChannelCycleRepository Unit Tests
  *
- * Covers:
- *   - incrementCycleCount: insert, update, cap-guard (existing behavior)
- *   - reset: per-channel reset (existing behavior)
- *   - resetAllForRun: new human-touch reset that zeroes every channel counter
- *     for a workflow run in a single statement (Task #101)
+ * Covers the rate-based dead-loop detection API:
+ *   - reserveCycleEvent: authoritative atomic gate (prune + count + conditional insert)
+ *   - recordCycleEvent: unconditional traversal record (recovery path)
+ *   - countRecentCycleEvents / isDeadLoopReached: read-only windowed count
+ *   - resetAllForRun: human-touch reset (clears event history, lifts a block)
+ *   - pruneAllOldEvents: cross-run GC for abandoned/stalled runs
  *
  * Uses an in-memory SQLite DB seeded with the full migration chain so FK
- * constraints (channel_cycles.run_id → space_workflow_runs.id) match production.
+ * constraints (channel_cycle_events.run_id → space_workflow_runs.id) match
+ * production.
  */
 
 import { describe, test, expect, beforeEach } from 'bun:test';
@@ -46,217 +48,125 @@ beforeEach(() => {
   repo = new ChannelCycleRepository(db);
 });
 
-describe('ChannelCycleRepository — incrementCycleCount', () => {
-  test('inserts a new row with count=1 on first call', () => {
-    const ok = repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    expect(ok).toBe(true);
-    const rec = repo.get(RUN_ID_A, 0);
-    expect(rec).not.toBeNull();
-    expect(rec!.count).toBe(1);
-    expect(rec!.maxCycles).toBe(5);
+// A fixed "now" and a 5-minute window keep the rate tests deterministic without
+// depending on real wall-clock time.
+const NOW = 1_700_000_000_000;
+const WINDOW = 5 * 60 * 1000;
+
+describe('ChannelCycleRepository — reserveCycleEvent (authoritative gate)', () => {
+  test('allows and records traversals below the threshold', () => {
+    let reservation;
+    for (let i = 0; i < 15; i++) {
+      reservation = repo.reserveCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+      expect(reservation.allowed).toBe(true);
+    }
+    expect(reservation!.recentCount).toBe(15);
   });
 
-  test('increments existing row while under cap', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
+  test('blocks the traversal that would exceed the threshold (no insert)', () => {
+    for (let i = 0; i < 15; i++) repo.reserveCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    // The 16th attempt within the window is blocked and records nothing.
+    const blocked = repo.reserveCycleEvent(RUN_ID_A, 1, NOW + 15_000);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.recentCount).toBe(15);
+    // Still exactly 15 recorded — the blocked attempt inserted no row.
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 15_000, WINDOW)).toBe(15);
   });
 
-  test('returns false and does not increment when cap is reached', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 2);
-    repo.incrementCycleCount(RUN_ID_A, 0, 2);
-    const third = repo.incrementCycleCount(RUN_ID_A, 0, 2);
-    expect(third).toBe(false);
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
-  });
-
-  test('unblocks a capped run when the supplied cap is raised above the persisted one', () => {
-    // Drive a channel to its cap of 6 (persisted max_cycles = 6).
-    for (let i = 0; i < 6; i++) repo.incrementCycleCount(RUN_ID_A, 0, 6);
-    expect(repo.get(RUN_ID_A, 0)).toEqual(expect.objectContaining({ count: 6, maxCycles: 6 }));
-
-    // At the old cap, further increments at cap=6 are rejected.
-    expect(repo.incrementCycleCount(RUN_ID_A, 0, 6)).toBe(false);
-
-    // Cap raised 6 → 50 (e.g. a template re-stamp). The increment guard must
-    // compare against the SUPPLIED cap, not the stale persisted max_cycles —
-    // otherwise an in-flight run blocked at the old limit can never resume.
-    // This is the motivating case for raising the Fullstack QA Loop cap.
-    expect(repo.incrementCycleCount(RUN_ID_A, 0, 50)).toBe(true);
-    expect(repo.get(RUN_ID_A, 0)).toEqual(expect.objectContaining({ count: 7, maxCycles: 50 }));
-  });
-});
-
-describe('ChannelCycleRepository — reset (single channel)', () => {
-  test('zeros count for a specific (run, channel) pair only', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_A, 1, 5);
-
-    repo.reset(RUN_ID_A, 0);
-
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
-    expect(repo.get(RUN_ID_A, 1)!.count).toBe(1); // untouched
-  });
-});
-
-describe('ChannelCycleRepository — resetAllForRun (human touch)', () => {
-  test('zeros count for every channel in the given run', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_A, 1, 5);
-    repo.incrementCycleCount(RUN_ID_A, 2, 5);
-
-    const rowsReset = repo.resetAllForRun(RUN_ID_A);
-
-    expect(rowsReset).toBe(3);
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
-    expect(repo.get(RUN_ID_A, 1)!.count).toBe(0);
-    expect(repo.get(RUN_ID_A, 2)!.count).toBe(0);
-  });
-
-  test('allows subsequent increments after reset (budget is refreshed)', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 2);
-    repo.incrementCycleCount(RUN_ID_A, 0, 2);
-    // Cap reached — next increment would return false.
-    expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(false);
-
-    repo.resetAllForRun(RUN_ID_A);
-
-    // After reset, the cap guard allows more increments.
-    expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(true);
-    expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(true);
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
-  });
-
-  test('does not affect other workflow runs', () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    repo.incrementCycleCount(RUN_ID_B, 0, 5);
-    repo.incrementCycleCount(RUN_ID_B, 0, 5);
-
-    repo.resetAllForRun(RUN_ID_A);
-
-    expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
-    expect(repo.get(RUN_ID_B, 0)!.count).toBe(2); // untouched
-  });
-
-  test('returns 0 when no channel rows exist for the run (human touch before any cyclic traversal)', () => {
-    const rowsReset = repo.resetAllForRun(RUN_ID_A);
-    expect(rowsReset).toBe(0);
-  });
-
-  test('updates updated_at when a row is reset', async () => {
-    repo.incrementCycleCount(RUN_ID_A, 0, 5);
-    const before = repo.get(RUN_ID_A, 0)!.updatedAt;
-
-    // Yield so Date.now() has a chance to advance (1ms resolution on most platforms).
-    await new Promise((resolve) => setTimeout(resolve, 2));
-
-    repo.resetAllForRun(RUN_ID_A);
-
-    const after = repo.get(RUN_ID_A, 0)!.updatedAt;
-    expect(after).toBeGreaterThan(before);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Rate-based dead-loop detection (primary gate) — channel_cycle_events
-// ---------------------------------------------------------------------------
-
-describe('ChannelCycleRepository — rate-based dead-loop detection', () => {
-  // A fixed "now" and a 5-minute window keep these tests deterministic without
-  // depending on real wall-clock time.
-  const NOW = 1_700_000_000_000;
-  const WINDOW = 5 * 60 * 1000;
-
-  test('recordCycleEvent stores timestamped traversals', () => {
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW);
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW + 1000);
-    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 2000, WINDOW)).toBe(2);
-  });
-
-  test('countRecentCycleEvents only counts traversals inside the window', () => {
-    // Two traversals well outside the window (an hour ago) ...
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60 * 60 * 1000);
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 30 * 60 * 1000);
-    // ... and three inside it.
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60_000);
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 30_000);
-    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 10_000);
-
-    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW, WINDOW)).toBe(3);
-  });
-
-  test('a genuine extended review spread over hours never trips the threshold', () => {
-    // Simulate 30 review round-trips on the same channel, each an hour apart —
-    // far more than the lifetime cap ever allowed, but spread over a whole day.
-    // The rolling 5-minute window must only ever see at most one at a time.
+  test('a genuine extended review spread over hours never trips', () => {
+    // 30 review round-trips on the same channel, each an hour apart — far more
+    // than any lifetime cap allowed, but spread over a whole day. The rolling
+    // 5-minute window must only ever see one at a time.
     for (let i = 0; i < 30; i++) {
       const t = NOW + i * 60 * 60 * 1000;
-      repo.recordCycleEvent(RUN_ID_A, 1, t);
-      // At every point in time, the windowed count stays tiny.
-      expect(repo.isDeadLoopReached(RUN_ID_A, 1, t, 15, WINDOW)).toBe(false);
+      expect(repo.reserveCycleEvent(RUN_ID_A, 1, t).allowed).toBe(true);
     }
   });
 
-  test('a tight ping-pong within the window trips the threshold', () => {
-    // 15 rapid traversals inside the window. After the 15th, the next attempt
-    // is blocked (the threshold is met).
-    for (let i = 0; i < 15; i++) {
-      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    }
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+  test('is isolated per channel index and per run', () => {
+    for (let i = 0; i < 15; i++) repo.reserveCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.reserveCycleEvent(RUN_ID_A, 1, NOW + 15_000).allowed).toBe(false);
+    // Different channel on the same run, and the same channel on a different
+    // run, are both still allowed.
+    expect(repo.reserveCycleEvent(RUN_ID_A, 2, NOW + 15_000).allowed).toBe(true);
+    expect(repo.reserveCycleEvent(RUN_ID_B, 1, NOW + 15_000).allowed).toBe(true);
   });
+});
 
-  test('isDeadLoopReached is false below the threshold', () => {
-    for (let i = 0; i < 14; i++) {
-      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    }
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000, 15, WINDOW)).toBe(false);
+describe('ChannelCycleRepository — windowed counting & pruning', () => {
+  test('countRecentCycleEvents only counts traversals inside the window', () => {
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60 * 60 * 1000); // an hour ago
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 30 * 60 * 1000); // 30 min ago
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60_000); // inside
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 10_000); // inside
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW, WINDOW)).toBe(2);
   });
 
   test('counting prunes events older than the window (bounded growth)', () => {
-    for (let i = 0; i < 40; i++) {
-      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000); // 40s span
-    }
-    // Counting at NOW + 6min prunes everything older than 5min and returns
-    // only the tail of the burst still inside the window.
-    const count = repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 6 * 60 * 1000, WINDOW);
-    expect(count).toBe(0);
+    for (let i = 0; i < 40; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000); // 40s span
+    // Counting 6 minutes later prunes the whole burst (all older than 5 min).
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 6 * 60 * 1000, WINDOW)).toBe(0);
   });
 
-  test('rate tracking is isolated per channel index', () => {
-    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
-    // A different channel on the same run is unaffected.
-    expect(repo.countRecentCycleEvents(RUN_ID_A, 2, NOW + 15_000, WINDOW)).toBe(0);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 2, NOW + 15_000, 15, WINDOW)).toBe(false);
-  });
-
-  test('rate tracking is isolated per run', () => {
-    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
-    expect(repo.isDeadLoopReached(RUN_ID_B, 1, NOW + 15_000, 15, WINDOW)).toBe(false);
-  });
-
-  test('resetAllForRun (human touch) clears the rate-window history and lifts a dead-loop block', () => {
-    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
-
-    repo.resetAllForRun(RUN_ID_A);
-
-    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 15_000, WINDOW)).toBe(0);
-    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(false);
-    // Other runs are untouched.
-    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_B, 1, NOW + i * 1000);
-    expect(repo.isDeadLoopReached(RUN_ID_B, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
-  });
-
-  test('uses package defaults when threshold/window omitted', () => {
-    // Sanity: defaults are the documented 15 / 5min.
+  test('isDeadLoopReached flips at the threshold', () => {
     for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000)).toBe(false);
     repo.recordCycleEvent(RUN_ID_A, 1, NOW + 14_000);
     expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(true);
+  });
+
+  test('uses package defaults (15 / 5min) when threshold/window omitted', () => {
+    for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000)).toBe(false);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW + 14_000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(true);
+  });
+});
+
+describe('ChannelCycleRepository — resetAllForRun (human touch)', () => {
+  test('clears the rate-window history and lifts a dead-loop block', () => {
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(true);
+
+    const deleted = repo.resetAllForRun(RUN_ID_A);
+    expect(deleted).toBe(15);
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 15_000, WINDOW)).toBe(0);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(false);
+    // The channel is deliverable again after the reset.
+    expect(repo.reserveCycleEvent(RUN_ID_A, 1, NOW + 15_000).allowed).toBe(true);
+  });
+
+  test('does not affect other workflow runs', () => {
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_B, 1, NOW + i * 1000);
+
+    repo.resetAllForRun(RUN_ID_A);
+
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(false);
+    expect(repo.isDeadLoopReached(RUN_ID_B, 1, NOW + 15_000)).toBe(true);
+  });
+
+  test('returns 0 when nothing is recorded for the run', () => {
+    expect(repo.resetAllForRun(RUN_ID_A)).toBe(0);
+  });
+});
+
+describe('ChannelCycleRepository — pruneAllOldEvents (cross-run GC)', () => {
+  test('deletes events older than the retention cutoff across all runs', () => {
+    // Run A: recent events (kept). Run B: stale events (GC'd).
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60_000);
+    repo.recordCycleEvent(RUN_ID_B, 1, NOW - 2 * WINDOW); // 10 min ago
+    repo.recordCycleEvent(RUN_ID_B, 2, NOW - 3 * WINDOW); // 15 min ago
+
+    const deleted = repo.pruneAllOldEvents(NOW);
+    expect(deleted).toBe(2);
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW, WINDOW)).toBe(1);
+    expect(repo.countRecentCycleEvents(RUN_ID_B, 1, NOW, WINDOW)).toBe(0);
+    expect(repo.countRecentCycleEvents(RUN_ID_B, 2, NOW, WINDOW)).toBe(0);
+  });
+
+  test('returns 0 when nothing is stale', () => {
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60_000);
+    expect(repo.pruneAllOldEvents(NOW)).toBe(0);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -158,3 +158,105 @@ describe('ChannelCycleRepository — resetAllForRun (human touch)', () => {
     expect(after).toBeGreaterThan(before);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rate-based dead-loop detection (primary gate) — channel_cycle_events
+// ---------------------------------------------------------------------------
+
+describe('ChannelCycleRepository — rate-based dead-loop detection', () => {
+  // A fixed "now" and a 5-minute window keep these tests deterministic without
+  // depending on real wall-clock time.
+  const NOW = 1_700_000_000_000;
+  const WINDOW = 5 * 60 * 1000;
+
+  test('recordCycleEvent stores timestamped traversals', () => {
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW + 1000);
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 2000, WINDOW)).toBe(2);
+  });
+
+  test('countRecentCycleEvents only counts traversals inside the window', () => {
+    // Two traversals well outside the window (an hour ago) ...
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60 * 60 * 1000);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 30 * 60 * 1000);
+    // ... and three inside it.
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 60_000);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 30_000);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW - 10_000);
+
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW, WINDOW)).toBe(3);
+  });
+
+  test('a genuine extended review spread over hours never trips the threshold', () => {
+    // Simulate 30 review round-trips on the same channel, each an hour apart —
+    // far more than the lifetime cap ever allowed, but spread over a whole day.
+    // The rolling 5-minute window must only ever see at most one at a time.
+    for (let i = 0; i < 30; i++) {
+      const t = NOW + i * 60 * 60 * 1000;
+      repo.recordCycleEvent(RUN_ID_A, 1, t);
+      // At every point in time, the windowed count stays tiny.
+      expect(repo.isDeadLoopReached(RUN_ID_A, 1, t, 15, WINDOW)).toBe(false);
+    }
+  });
+
+  test('a tight ping-pong within the window trips the threshold', () => {
+    // 15 rapid traversals inside the window. After the 15th, the next attempt
+    // is blocked (the threshold is met).
+    for (let i = 0; i < 15; i++) {
+      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    }
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+  });
+
+  test('isDeadLoopReached is false below the threshold', () => {
+    for (let i = 0; i < 14; i++) {
+      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    }
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000, 15, WINDOW)).toBe(false);
+  });
+
+  test('counting prunes events older than the window (bounded growth)', () => {
+    for (let i = 0; i < 40; i++) {
+      repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000); // 40s span
+    }
+    // Counting at NOW + 6min prunes everything older than 5min and returns
+    // only the tail of the burst still inside the window.
+    const count = repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 6 * 60 * 1000, WINDOW);
+    expect(count).toBe(0);
+  });
+
+  test('rate tracking is isolated per channel index', () => {
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+    // A different channel on the same run is unaffected.
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 2, NOW + 15_000, WINDOW)).toBe(0);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 2, NOW + 15_000, 15, WINDOW)).toBe(false);
+  });
+
+  test('rate tracking is isolated per run', () => {
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+    expect(repo.isDeadLoopReached(RUN_ID_B, 1, NOW + 15_000, 15, WINDOW)).toBe(false);
+  });
+
+  test('resetAllForRun (human touch) clears the rate-window history and lifts a dead-loop block', () => {
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+
+    repo.resetAllForRun(RUN_ID_A);
+
+    expect(repo.countRecentCycleEvents(RUN_ID_A, 1, NOW + 15_000, WINDOW)).toBe(0);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000, 15, WINDOW)).toBe(false);
+    // Other runs are untouched.
+    for (let i = 0; i < 15; i++) repo.recordCycleEvent(RUN_ID_B, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_B, 1, NOW + 15_000, 15, WINDOW)).toBe(true);
+  });
+
+  test('uses package defaults when threshold/window omitted', () => {
+    // Sanity: defaults are the documented 15 / 5min.
+    for (let i = 0; i < 14; i++) repo.recordCycleEvent(RUN_ID_A, 1, NOW + i * 1000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 14_000)).toBe(false);
+    repo.recordCycleEvent(RUN_ID_A, 1, NOW + 14_000);
+    expect(repo.isDeadLoopReached(RUN_ID_A, 1, NOW + 15_000)).toBe(true);
+  });
+});

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -47,6 +47,8 @@ import {
   PermanentSpawnError,
 } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import type { SpaceWorkflow, WorkflowChannel } from '@hyperneo/shared';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
 
 // ---------------------------------------------------------------------------
 // DB helpers
@@ -942,10 +944,10 @@ describe('ChannelRouter', () => {
     });
 
     // -----------------------------------------------------------------------
-    // Cyclic channels — iteration tracking
+    // Cyclic channels — rate-based dead-loop detection
     // -----------------------------------------------------------------------
 
-    test('cyclic channel: increments cycle count on successful delivery', async () => {
+    test('cyclic channel: records a traversal event on successful delivery', async () => {
       const channels: WorkflowChannel[] = [
         { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
         { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
@@ -968,20 +970,24 @@ describe('ChannelRouter', () => {
       workflowRunRepo.transitionStatus(run.id, 'in_progress');
 
       await router.deliverMessage(run.id, 'planner', 'coder', 'message 1');
-      expect(channelCycleRepo.get(run.id, 1)!.count).toBe(1);
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1)).toBe(1);
 
       for (const t of taskRepo.listByWorkflowRun(run.id)) {
         taskRepo.updateTask(t.id, { status: 'cancelled' });
       }
 
       await router.deliverMessage(run.id, 'planner', 'coder', 'message 2');
-      expect(channelCycleRepo.get(run.id, 1)!.count).toBe(2);
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1)).toBe(2);
     });
 
-    test('cyclic channel: throws ActivationError when cycle cap is reached', async () => {
+    test('cyclic channel: a long review spread over time never trips (lifetime cap no longer blocks)', async () => {
+      // Reproduces the PR #2473 / task #942 false-block: many review rounds on
+      // the same cyclic channel (here 11 — over the old maxCycles of 5), but
+      // spread out over hours. The retired lifetime cap blocked this; the
+      // rate-based detector must allow it.
       const channels: WorkflowChannel[] = [
         { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
-        { id: 'ch-bwd', from: 'Receiver', to: 'Sender', maxCycles: 2 },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender', maxCycles: 5 },
       ];
       const workflow = buildWorkflow(
         SPACE_ID,
@@ -996,22 +1002,176 @@ describe('ChannelRouter', () => {
       const run = workflowRunRepo.createRun({
         spaceId: SPACE_ID,
         workflowId: workflow.id,
-        title: 'Cycle Cap Run',
+        title: 'Long Review Run',
       });
       workflowRunRepo.transitionStatus(run.id, 'in_progress');
 
-      channelCycleRepo.incrementCycleCount(run.id, 1, 2);
-      channelCycleRepo.incrementCycleCount(run.id, 1, 2);
+      // 11 round-trips, 20 minutes apart. None cluster inside any 5-minute
+      // window, so the rolling rate stays well below the threshold (15).
+      const now = Date.now();
+      for (let i = 1; i <= 11; i++) {
+        channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 20 * 60 * 1000);
+      }
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1, now)).toBe(0);
 
-      await expect(
-        router.deliverMessage(run.id, 'planner', 'coder', 'over the limit')
-      ).rejects.toBeInstanceOf(ActivationError);
-      await expect(
-        router.deliverMessage(run.id, 'planner', 'coder', 'over the limit')
-      ).rejects.toThrow(/maximum cycle count/);
+      // Delivery proceeds — no false block.
+      const delivered = await router.deliverMessage(run.id, 'planner', 'coder', 'round 12');
+      expect(delivered.runId).toBe(run.id);
     });
 
-    test('non-cyclic channel: cycle count stays unchanged', async () => {
+    test('cyclic channel: throws ActivationError when a tight ping-pong trips the dead-loop threshold', async () => {
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Dead-Loop Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // 15 rapid traversals within the window → the next send trips.
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      await expect(
+        router.deliverMessage(run.id, 'planner', 'coder', 'runaway ping-pong')
+      ).rejects.toBeInstanceOf(ActivationError);
+      await expect(
+        router.deliverMessage(run.id, 'planner', 'coder', 'runaway ping-pong')
+      ).rejects.toThrow(/dead loop/);
+    });
+
+    test('cyclic channel: dead-loop trip surfaces a space.workflowRun.deadLoop event', async () => {
+      const bus = new InternalEventBus<DaemonInternalEventMap>();
+      const deadLoopEvents: DaemonInternalEventMap['space.workflowRun.deadLoop'][] = [];
+      const unsub = bus.subscribe(
+        'space.workflowRun.deadLoop',
+        (e) => {
+          deadLoopEvents.push(e);
+        },
+        { subscriberName: 'test-collector:space.workflowRun.deadLoop' }
+      );
+
+      const routerWithBus = new ChannelRouter({
+        taskRepo,
+        workflowRunRepo,
+        workflowManager,
+        agentManager,
+        channelCycleRepo,
+        db,
+        nodeExecutionRepo: new NodeExecutionRepository(db),
+        internalEventBus: bus,
+      });
+
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Surfacing Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      await expect(
+        routerWithBus.deliverMessage(run.id, 'planner', 'coder', 'runaway')
+      ).rejects.toThrow(/dead loop/);
+
+      expect(deadLoopEvents).toHaveLength(1);
+      const evt = deadLoopEvents[0];
+      expect(evt.fromAgent).toBe('planner');
+      expect(evt.toTarget).toBe('coder');
+      expect(evt.channelIndex).toBe(1);
+      expect(evt.recentCount).toBe(15);
+      expect(evt.threshold).toBe(15);
+
+      unsub();
+    });
+
+    test('cyclic channel: repeated blocked sends dedupe the dead-loop event within the window', async () => {
+      const bus = new InternalEventBus<DaemonInternalEventMap>();
+      const deadLoopEvents: DaemonInternalEventMap['space.workflowRun.deadLoop'][] = [];
+      const unsub = bus.subscribe(
+        'space.workflowRun.deadLoop',
+        (e) => {
+          deadLoopEvents.push(e);
+        },
+        { subscriberName: 'test-collector:space.workflowRun.deadLoop:dedupe' }
+      );
+
+      const routerWithBus = new ChannelRouter({
+        taskRepo,
+        workflowRunRepo,
+        workflowManager,
+        agentManager,
+        channelCycleRepo,
+        db,
+        nodeExecutionRepo: new NodeExecutionRepository(db),
+        internalEventBus: bus,
+      });
+
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Dedupe Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      // A retrying agent attempts the blocked send several times in a row.
+      for (let i = 0; i < 3; i++) {
+        await expect(
+          routerWithBus.deliverMessage(run.id, 'planner', 'coder', 'retry')
+        ).rejects.toThrow(/dead loop/);
+      }
+
+      // Only the first trip surfaces — the UI is not spammed.
+      expect(deadLoopEvents).toHaveLength(1);
+
+      unsub();
+    });
+
+    test('non-cyclic channel: records no traversal event', async () => {
       const channels: WorkflowChannel[] = [
         {
           from: 'coder',
@@ -1038,6 +1198,7 @@ describe('ChannelRouter', () => {
       await router.deliverMessage(run.id, 'coder', 'planner', 'non-cyclic message');
 
       expect(channelCycleRepo.get(run.id, 0)).toBeNull();
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 0)).toBe(0);
     });
   });
 
@@ -1109,7 +1270,7 @@ describe('ChannelRouter', () => {
       expect(result.allowed).toBe(true);
     });
 
-    test('cyclic channel: blocked when cycle count >= maxCycles', async () => {
+    test('cyclic channel: blocked when a tight ping-pong trips the dead-loop threshold', async () => {
       const channels: WorkflowChannel[] = [
         { id: 'ch-fwd', from: 'Node A', to: 'Node B' },
         { id: 'ch-bwd', from: 'Node B', to: 'Node A', maxCycles: 3 },
@@ -1127,20 +1288,22 @@ describe('ChannelRouter', () => {
       const run = workflowRunRepo.createRun({
         spaceId: SPACE_ID,
         workflowId: workflow.id,
-        title: 'Cycle Cap Run',
+        title: 'Dead-Loop canDeliver Run',
       });
       workflowRunRepo.transitionStatus(run.id, 'in_progress');
-      channelCycleRepo.incrementCycleCount(run.id, 1, 3);
-      channelCycleRepo.incrementCycleCount(run.id, 1, 3);
-      channelCycleRepo.incrementCycleCount(run.id, 1, 3);
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
 
       const result = await router.canDeliver(run.id, 'planner', 'coder');
       expect(result.allowed).toBe(false);
-      expect(result.reason).toMatch(/maximum cycle count/);
+      expect(result.reason).toMatch(/dead loop/);
     });
 
-    test('cyclic channel: allowed when below the cap', async () => {
-      const channels: WorkflowChannel[] = [];
+    test('cyclic channel: allowed below the dead-loop threshold', async () => {
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Node A', to: 'Node B' },
+        { id: 'ch-bwd', from: 'Node B', to: 'Node A' },
+      ];
       const workflow = buildWorkflow(
         SPACE_ID,
         workflowManager,
@@ -1154,11 +1317,12 @@ describe('ChannelRouter', () => {
       const run = workflowRunRepo.createRun({
         spaceId: SPACE_ID,
         workflowId: workflow.id,
-        title: 'Below Cap Run',
+        title: 'Below Threshold Run',
       });
       workflowRunRepo.transitionStatus(run.id, 'in_progress');
-      channelCycleRepo.incrementCycleCount(run.id, 1, 5);
-      channelCycleRepo.incrementCycleCount(run.id, 1, 5);
+      const now = Date.now();
+      // 14 recent traversals — one short of the threshold.
+      for (let i = 0; i < 14; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
 
       const result = await router.canDeliver(run.id, 'planner', 'coder');
       expect(result.allowed).toBe(true);

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1168,6 +1168,78 @@ describe('ChannelRouter', () => {
       unsub();
     });
 
+    test('cyclic channel: a new loop after a human-touch reset surfaces a fresh notification', async () => {
+      // Dedupe is cleared when a cyclic send is allowed again, so a distinct
+      // second incident after explicit human intervention is still surfaced.
+      const bus = new InternalEventBus<DaemonInternalEventMap>();
+      const deadLoopEvents: DaemonInternalEventMap['space.workflowRun.deadLoop'][] = [];
+      const unsub = bus.subscribe(
+        'space.workflowRun.deadLoop',
+        (e) => {
+          deadLoopEvents.push(e);
+        },
+        { subscriberName: 'test-collector:space.workflowRun.deadLoop:reset-reloop' }
+      );
+
+      const routerWithBus = new ChannelRouter({
+        taskRepo,
+        workflowRunRepo,
+        workflowManager,
+        agentManager,
+        channelCycleRepo,
+        nodeExecutionRepo: new NodeExecutionRepository(db),
+        internalEventBus: bus,
+      });
+
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Reset Reloop Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // First incident: block + notify.
+      const t0 = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, t0 - i * 1000);
+      await expect(
+        routerWithBus.deliverMessage(run.id, 'planner', 'coder', 'first loop')
+      ).rejects.toThrow(/dead loop/);
+      expect(deadLoopEvents).toHaveLength(1);
+
+      // Human touch clears the loop; the next send is allowed (and drops dedupe).
+      channelCycleRepo.resetAllForRun(run.id);
+      const delivered = await routerWithBus.deliverMessage(
+        run.id,
+        'planner',
+        'coder',
+        'after reset'
+      );
+      expect(delivered.runId).toBe(run.id);
+
+      // A second, distinct rapid loop must surface a FRESH notification.
+      const t1 = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, t1 - i * 1000);
+      await expect(
+        routerWithBus.deliverMessage(run.id, 'planner', 'coder', 'second loop')
+      ).rejects.toThrow(/dead loop/);
+      expect(deadLoopEvents).toHaveLength(2);
+
+      unsub();
+    });
+
     test('cyclic channel: human touch (resetAllForRun) lifts a dead-loop block', async () => {
       // Router-level coverage of the reset-on-human-touch contract — the repo
       // layer is covered separately in channel-cycle-repository.test.ts.

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1307,6 +1307,41 @@ describe('ChannelRouter', () => {
 
       expect(channelCycleRepo.countRecentCycleEvents(run.id, 0)).toBe(0);
     });
+
+    test('cyclic channel: a reservation persists when activation throws after reserve (self-healing)', async () => {
+      // Reserve-before-activation: if activation fails AFTER the reservation
+      // commits, one extra row remains. It biases safely toward blocking and
+      // ages out after the window — pin this documented edge.
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Coding', to: 'Review' },
+        { id: 'ch-bwd', from: 'Review', to: 'Coding' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Coding', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Review', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Orphan Reservation Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      // Delete the target agent so activation throws AFTER the cyclic
+      // reservation has already committed (target resolution still succeeds
+      // because resolveNodeAgents does not validate agent existence).
+      db.prepare(`DELETE FROM space_agents WHERE id = ?`).run(AGENT_CODER);
+
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1)).toBe(0);
+      await expect(router.deliverMessage(run.id, 'planner', 'coder', 'orphan')).rejects.toThrow();
+      // The reservation row persisted despite the activation failure.
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1)).toBe(1);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1435,6 +1435,48 @@ describe('ChannelRouter', () => {
       expect(result.allowed).toBe(true);
     });
 
+    test('canDeliver is read-only: it never records a traversal event', async () => {
+      // Locks the documented contract: canDeliver is a non-mutating query that
+      // may prune out-of-window rows but must never INSERT. Seeds straddle the
+      // window boundary so a regression that recorded on the query path would
+      // shift the in-window count.
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Node A', to: 'Node B' },
+        { id: 'ch-bwd', from: 'Node B', to: 'Node A' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Node B', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Read-only canDeliver Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      const now = Date.now();
+      const WINDOW = 5 * 60 * 1000;
+      channelCycleRepo.recordCycleEvent(run.id, 1, now - 10_000); // well inside
+      channelCycleRepo.recordCycleEvent(run.id, 1, now - (WINDOW - 1000)); // just inside the boundary
+      channelCycleRepo.recordCycleEvent(run.id, 1, now - (WINDOW + 1000)); // just outside (pruned)
+      const before = channelCycleRepo.countRecentCycleEvents(run.id, 1);
+      expect(before).toBe(2); // the two in-window events
+
+      // Repeated queries must not insert any new traversal.
+      for (let i = 0; i < 5; i++) {
+        const result = await router.canDeliver(run.id, 'planner', 'coder');
+        expect(result.allowed).toBe(true);
+      }
+
+      expect(channelCycleRepo.countRecentCycleEvents(run.id, 1)).toBe(before);
+    });
+
     test('non-cyclic channel: cycle count does not block delivery', async () => {
       const channels: WorkflowChannel[] = [
         {

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -202,7 +202,6 @@ describe('ChannelRouter', () => {
       workflowManager,
       agentManager,
       channelCycleRepo,
-      db,
       nodeExecutionRepo: new NodeExecutionRepository(db),
     });
   });
@@ -617,7 +616,6 @@ describe('ChannelRouter', () => {
         workflowManager,
         agentManager,
         channelCycleRepo,
-        db,
         nodeExecutionRepo,
         cancelSessionById: (sessionId) => cancelledSessions.push(sessionId),
       });
@@ -1070,7 +1068,6 @@ describe('ChannelRouter', () => {
         workflowManager,
         agentManager,
         channelCycleRepo,
-        db,
         nodeExecutionRepo: new NodeExecutionRepository(db),
         internalEventBus: bus,
       });
@@ -1104,6 +1101,7 @@ describe('ChannelRouter', () => {
 
       expect(deadLoopEvents).toHaveLength(1);
       const evt = deadLoopEvents[0];
+      expect(evt.spaceId).toBe(SPACE_ID);
       expect(evt.fromAgent).toBe('planner');
       expect(evt.toTarget).toBe('coder');
       expect(evt.channelIndex).toBe(1);
@@ -1130,7 +1128,6 @@ describe('ChannelRouter', () => {
         workflowManager,
         agentManager,
         channelCycleRepo,
-        db,
         nodeExecutionRepo: new NodeExecutionRepository(db),
         internalEventBus: bus,
       });
@@ -1171,6 +1168,45 @@ describe('ChannelRouter', () => {
       unsub();
     });
 
+    test('cyclic channel: human touch (resetAllForRun) lifts a dead-loop block', async () => {
+      // Router-level coverage of the reset-on-human-touch contract — the repo
+      // layer is covered separately in channel-cycle-repository.test.ts.
+      const channels: WorkflowChannel[] = [
+        { id: 'ch-fwd', from: 'Sender', to: 'Receiver' },
+        { id: 'ch-bwd', from: 'Receiver', to: 'Sender' },
+      ];
+      const workflow = buildWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: NODE_A, name: 'Sender', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+          { id: NODE_B, name: 'Receiver', agents: [{ agentId: AGENT_PLANNER, name: 'planner' }] },
+        ],
+        channels
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Reset Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) channelCycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      // Blocked before the human touch.
+      await expect(router.deliverMessage(run.id, 'planner', 'coder', 'blocked')).rejects.toThrow(
+        /dead loop/
+      );
+
+      // Human touch resets the run's cycle state.
+      channelCycleRepo.resetAllForRun(run.id);
+
+      // After reset, delivery succeeds again (the block is lifted).
+      const delivered = await router.deliverMessage(run.id, 'planner', 'coder', 'after reset');
+      expect(delivered.runId).toBe(run.id);
+    });
+
     test('non-cyclic channel: records no traversal event', async () => {
       const channels: WorkflowChannel[] = [
         {
@@ -1197,7 +1233,6 @@ describe('ChannelRouter', () => {
 
       await router.deliverMessage(run.id, 'coder', 'planner', 'non-cyclic message');
 
-      expect(channelCycleRepo.get(run.id, 0)).toBeNull();
       expect(channelCycleRepo.countRecentCycleEvents(run.id, 0)).toBe(0);
     });
   });

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -276,6 +276,42 @@ describe('SpaceAgentNotificationService', () => {
     });
   });
 
+  describe('space.workflowRun.deadLoop event', () => {
+    it('formats a dead-loop block with the agent pair and rate details', async () => {
+      const { factory, bus } = makeService();
+      await bus.publish('space.workflowRun.deadLoop', {
+        sessionId: 'global',
+        spaceId: SPACE_ID,
+        runId: 'run-dl',
+        fromAgent: 'reviewer',
+        toTarget: 'coder',
+        channelIndex: 1,
+        recentCount: 15,
+        threshold: 15,
+        windowMs: 5 * 60 * 1000,
+        reason: 'Cyclic channel from "reviewer" to "coder" is in a dead loop',
+        timestamp: TIMESTAMP,
+      });
+
+      const { message } = factory.calls[0];
+      expect(message).toContain('[TASK_EVENT] workflow_dead_loop');
+      expect(message).toContain('run-dl');
+      expect(message).toContain('"reviewer" → "coder"');
+      expect(message).toContain('15 message round-trips');
+      expect(message).toContain('within 5 minute(s)');
+      expect(message).toContain('next send was blocked');
+
+      const json = extractJson(message);
+      expect(json.kind).toBe('workflow_dead_loop');
+      expect(json.runId).toBe('run-dl');
+      expect(json.fromAgent).toBe('reviewer');
+      expect(json.toTarget).toBe('coder');
+      expect(json.recentCount).toBe(15);
+      expect(json.threshold).toBe(15);
+      expect(json.autonomyLevel).toBe(1);
+    });
+  });
+
   describe('space.agent.crashed event', () => {
     it('formats agent crash with [TASK_EVENT] prefix', async () => {
       const { factory, bus } = makeService();

--- a/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/space-agent-notification-service.test.ts
@@ -310,6 +310,28 @@ describe('SpaceAgentNotificationService', () => {
       expect(json.threshold).toBe(15);
       expect(json.autonomyLevel).toBe(1);
     });
+
+    it('propagates injection failure so the router can retry (unlike fire-and-forget events)', async () => {
+      // The dead-loop subscriber uses notifyStrict: a failed injection must
+      // surface as a publish rejection so ChannelRouter.notifyDeadLoop skips its
+      // dedupe timestamp and retries on the next blocked send.
+      const { bus } = makeService({ injectError: new Error('session unavailable') });
+      await expect(
+        bus.publish('space.workflowRun.deadLoop', {
+          sessionId: 'global',
+          spaceId: SPACE_ID,
+          runId: 'run-dl',
+          fromAgent: 'reviewer',
+          toTarget: 'coder',
+          channelIndex: 1,
+          recentCount: 15,
+          threshold: 15,
+          windowMs: 5 * 60 * 1000,
+          reason: 'dead loop',
+          timestamp: TIMESTAMP,
+        })
+      ).rejects.toThrow(/failed with 1 handler failure/);
+    });
   });
 
   describe('space.agent.crashed event', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1529,6 +1529,49 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(0);
     });
 
+    test('surfaceDeadLoopedRuns re-surfaces currently-dead-looped runs (post-provisioning catch-up)', async () => {
+      // The runtime's first recovery tick can fire before the SpaceAgent
+      // notification subscribers are wired; surfaceDeadLoopedRuns is the
+      // post-provisioning catch-up. It scans active runs and re-emits, deduped.
+      const workflow = buildLinearWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: STEP_A, name: 'Coding', agentId: AGENT },
+          { id: STEP_B, name: 'Review', agentId: AGENT },
+        ],
+        {
+          channels: [
+            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
+            { id: 'review-to-coding', from: 'Review', to: 'Coding' },
+          ],
+          endNodeId: STEP_B,
+        }
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Surface Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      const runtime = makeRuntime({ pendingMessageRepo: new PendingAgentMessageRepository(db) });
+      notifications = [];
+      await runtime.surfaceDeadLoopedRuns();
+
+      const deadLoopNotes = notifications.filter((n) => n.kind === 'workflow_run_dead_loop');
+      expect(deadLoopNotes).toHaveLength(1);
+      expect(deadLoopNotes[0].payload.runId).toBe(run.id);
+      expect(deadLoopNotes[0].payload.channelIndex).toBe(1);
+
+      // Deduped across calls for the daemon lifetime.
+      await runtime.surfaceDeadLoopedRuns();
+      expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(1);
+    });
+
     test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {
       const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
         { id: STEP_A, name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -49,6 +49,7 @@ import { ChannelCycleRepository } from '../../../../src/storage/repositories/cha
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import { PermanentSpawnError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
@@ -1527,6 +1528,66 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
       // Not a dead loop → no dead-loop notification.
       expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(0);
+    });
+
+    test('done/cancelled are reopenable → rate window retained; archiving the task clears it', async () => {
+      // Regression guard for the reopen/rate-window interaction: a run that
+      // reaches done/cancelled can be reopened by a peer send within the
+      // 5-minute window (ChannelRouter flips it back to `in_progress`), so its
+      // dead-loop history must survive the terminal transition — otherwise a
+      // reopened runaway gets a fresh 15 traversals in the same window. Only the
+      // true tombstone, task archive, may clear it.
+      const workflow = buildLinearWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: STEP_A, name: 'Coding', agentId: AGENT },
+          { id: STEP_B, name: 'Review', agentId: AGENT },
+        ],
+        {
+          channels: [
+            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
+            { id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 },
+          ],
+          endNodeId: STEP_B,
+        }
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Reopen retain',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+      const task = taskRepo.createTask({
+        spaceId: SPACE_ID,
+        title: 'Reopen retain',
+        description: '',
+        workflowRunId: run.id,
+        workflowNodeId: STEP_A,
+        status: 'in_progress',
+      });
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      for (let i = 0; i < 5; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(5);
+
+      const runtime = makeRuntime({
+        pendingMessageRepo: new PendingAgentMessageRepository(db),
+      });
+
+      // Cancel the run. done/cancelled are reopenable, so the rolling-window
+      // history must be retained across the terminal transition.
+      await runtime.cancelWorkflowRun(SPACE_ID, run.id);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('cancelled');
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(5);
+
+      // Archive the (now cancelled) task — the true tombstone, and the only
+      // status from which ChannelRouter hard-blocks further sends. setTaskStatus
+      // is the chokepoint for tool- and RPC-driven archives; the cleanup lives
+      // there, so archiving clears the retained window.
+      const taskManager = new SpaceTaskManager(db, SPACE_ID);
+      await taskManager.setTaskStatus(task.id, 'archived');
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(0);
     });
 
     test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -45,7 +45,10 @@ import {
   PendingAgentMessageRepository,
   DEFAULT_PENDING_MESSAGE_RETENTION_MS,
 } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
-import { ChannelCycleRepository } from '../../../../src/storage/repositories/channel-cycle-repository.ts';
+import {
+  ChannelCycleRepository,
+  DEAD_LOOP_WINDOW_MS,
+} from '../../../../src/storage/repositories/channel-cycle-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -1588,6 +1591,119 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       const taskManager = new SpaceTaskManager(db, SPACE_ID);
       await taskManager.setTaskStatus(task.id, 'archived');
       expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(0);
+    });
+
+    test('clearing run dead-loop history waits until ALL its tasks are archived', async () => {
+      // A legacy/inconsistent run can carry more than one task. ChannelRouter
+      // keeps the run reopenable until every task is archived, so the dead-loop
+      // cleanup must wait for the last task too — otherwise a still-live sibling
+      // could resume a runaway with a fresh budget.
+      const workflow = buildLinearWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: STEP_A, name: 'Coding', agentId: AGENT },
+          { id: STEP_B, name: 'Review', agentId: AGENT },
+        ],
+        {
+          channels: [
+            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
+            { id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 },
+          ],
+          endNodeId: STEP_B,
+        }
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Multi-task run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+      const taskA = taskRepo.createTask({
+        spaceId: SPACE_ID,
+        title: 'Multi-task A',
+        description: '',
+        workflowRunId: run.id,
+        workflowNodeId: STEP_A,
+        status: 'open',
+      });
+      const taskB = taskRepo.createTask({
+        spaceId: SPACE_ID,
+        title: 'Multi-task B',
+        description: '',
+        workflowRunId: run.id,
+        workflowNodeId: STEP_B,
+        status: 'open',
+      });
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      for (let i = 0; i < 3; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(3);
+
+      const taskManager = new SpaceTaskManager(db, SPACE_ID);
+      // Archive one of two tasks → a live sibling remains → history retained.
+      await taskManager.setTaskStatus(taskA.id, 'archived');
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(3);
+      // Archive the remaining task → all archived (true tombstone) → cleared.
+      await taskManager.setTaskStatus(taskB.id, 'archived');
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(0);
+    });
+
+    test('pruneExpiredCycleEvents drops window-aged retained history (throttled)', async () => {
+      // Reopenable done/cancelled runs are never traversed again, so their
+      // retained rows are never lazy-pruned. The periodic tick sweep must
+      // physically delete window-aged rows so the table cannot grow unbounded
+      // between restarts — without touching in-window rows.
+      const workflow = buildLinearWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: STEP_A, name: 'Coding', agentId: AGENT },
+          { id: STEP_B, name: 'Review', agentId: AGENT },
+        ],
+        {
+          channels: [
+            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
+            { id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 },
+          ],
+          endNodeId: STEP_B,
+        }
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Prune sweep',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+      taskRepo.createTask({
+        spaceId: SPACE_ID,
+        title: 'Prune sweep',
+        description: '',
+        workflowRunId: run.id,
+        workflowNodeId: STEP_A,
+        status: 'in_progress',
+      });
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      cycleRepo.recordCycleEvent(run.id, 1, now - 1000); // in-window (fresh)
+      cycleRepo.recordCycleEvent(run.id, 1, now - DEAD_LOOP_WINDOW_MS - 60_000); // stale
+
+      const runtime = makeRuntime({
+        pendingMessageRepo: new PendingAgentMessageRepository(db),
+      });
+      // Cancel the run (reopenable) → both rows retained.
+      await runtime.cancelWorkflowRun(SPACE_ID, run.id);
+
+      // First sweep drops only the stale row; the fresh row stays.
+      runtime.pruneExpiredCycleEvents(now);
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(1);
+
+      // Throttle: a second sweep inside the window is a no-op, so a newly
+      // seeded stale row survives until the next window. resetAllForRun returns
+      // the total deleted (fresh + the new stale row = 2), proving no prune.
+      cycleRepo.recordCycleEvent(run.id, 1, now - DEAD_LOOP_WINDOW_MS - 60_000);
+      runtime.pruneExpiredCycleEvents(now + 1000);
+      expect(cycleRepo.resetAllForRun(run.id)).toBe(2);
     });
 
     test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -174,6 +174,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
     'space.workflowRun.retry': 'task_retry',
     'space.workflowRun.needsAttention': 'workflow_run_needs_attention',
     'space.task.awaitingApproval': 'task_awaiting_approval',
+    'space.workflowRun.deadLoop': 'workflow_run_dead_loop',
   };
 
   const SPACE_ID = 'space-recovery-1';
@@ -1468,6 +1469,64 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       expect(findExec(run.id, STEP_B).status).toBe('idle');
       expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
       expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
+
+      // The dead loop is surfaced to the UI (not just logged as a generic stall).
+      const deadLoopNotes = notifications.filter((n) => n.kind === 'workflow_run_dead_loop');
+      expect(deadLoopNotes).toHaveLength(1);
+      expect(deadLoopNotes[0].payload.runId).toBe(run.id);
+      expect(deadLoopNotes[0].payload.recentCount).toBe(15);
+    });
+
+    test('cyclic channel one short of the dead-loop threshold → recovery activates and records exactly one traversal', async () => {
+      // Pins the recovery off-by-one: at 14 in-window traversals the channel is
+      // still open, so recovery activates the downstream node and records
+      // exactly one more traversal (14 → 15). At 15 it is closed — recorded 0,
+      // run blocked — covered by the test above.
+      const workflow = buildLinearWorkflow(
+        SPACE_ID,
+        workflowManager,
+        [
+          { id: STEP_A, name: 'Coding', agentId: AGENT },
+          { id: STEP_B, name: 'Review', agentId: AGENT },
+        ],
+        {
+          channels: [
+            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
+            { id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 },
+          ],
+          endNodeId: STEP_B,
+        }
+      );
+      const run = workflowRunRepo.createRun({
+        spaceId: SPACE_ID,
+        workflowId: workflow.id,
+        title: 'Boundary Run',
+      });
+      workflowRunRepo.transitionStatus(run.id, 'in_progress');
+      taskRepo.createTask({
+        spaceId: SPACE_ID,
+        title: 'Boundary Run',
+        description: '',
+        workflowRunId: run.id,
+        workflowNodeId: STEP_A,
+        status: 'in_progress',
+      });
+      seedExec(run.id, STEP_B, 'Review', 'idle');
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      for (let i = 0; i < 14; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
+
+      await makeRuntime({
+        pendingMessageRepo: new PendingAgentMessageRepository(db),
+      }).recoverStalledRuns();
+
+      // Channel was open → recovery activated Coding and recorded exactly one
+      // traversal (14 → 15). The run is recovered, not blocked.
+      expect(findExec(run.id, STEP_A)).toBeDefined();
+      expect(cycleRepo.countRecentCycleEvents(run.id, 1)).toBe(15);
+      expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+      // Not a dead loop → no dead-loop notification.
+      expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(0);
     });
 
     test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1529,49 +1529,6 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(0);
     });
 
-    test('surfaceDeadLoopedRuns re-surfaces currently-dead-looped runs (post-provisioning catch-up)', async () => {
-      // The runtime's first recovery tick can fire before the SpaceAgent
-      // notification subscribers are wired; surfaceDeadLoopedRuns is the
-      // post-provisioning catch-up. It scans active runs and re-emits, deduped.
-      const workflow = buildLinearWorkflow(
-        SPACE_ID,
-        workflowManager,
-        [
-          { id: STEP_A, name: 'Coding', agentId: AGENT },
-          { id: STEP_B, name: 'Review', agentId: AGENT },
-        ],
-        {
-          channels: [
-            { id: 'coding-to-review', from: 'Coding', to: 'Review' },
-            { id: 'review-to-coding', from: 'Review', to: 'Coding' },
-          ],
-          endNodeId: STEP_B,
-        }
-      );
-      const run = workflowRunRepo.createRun({
-        spaceId: SPACE_ID,
-        workflowId: workflow.id,
-        title: 'Surface Run',
-      });
-      workflowRunRepo.transitionStatus(run.id, 'in_progress');
-      const cycleRepo = new ChannelCycleRepository(db);
-      const now = Date.now();
-      for (let i = 0; i < 15; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
-
-      const runtime = makeRuntime({ pendingMessageRepo: new PendingAgentMessageRepository(db) });
-      notifications = [];
-      await runtime.surfaceDeadLoopedRuns();
-
-      const deadLoopNotes = notifications.filter((n) => n.kind === 'workflow_run_dead_loop');
-      expect(deadLoopNotes).toHaveLength(1);
-      expect(deadLoopNotes[0].payload.runId).toBe(run.id);
-      expect(deadLoopNotes[0].payload.channelIndex).toBe(1);
-
-      // Deduped across calls for the daemon lifetime.
-      await runtime.surfaceDeadLoopedRuns();
-      expect(notifications.filter((n) => n.kind === 'workflow_run_dead_loop')).toHaveLength(1);
-    });
-
     test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {
       const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
         { id: STEP_A, name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1421,7 +1421,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
     });
 
-    test('cyclic channel at maxCycles → run blocked', async () => {
+    test('cyclic channel in a dead loop → run blocked', async () => {
       const workflow = buildLinearWorkflow(
         SPACE_ID,
         workflowManager,
@@ -1440,19 +1440,25 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
       const run = workflowRunRepo.createRun({
         spaceId: SPACE_ID,
         workflowId: workflow.id,
-        title: 'Cycle cap handoff',
+        title: 'Dead-loop handoff',
       });
       workflowRunRepo.transitionStatus(run.id, 'in_progress');
       const task = taskRepo.createTask({
         spaceId: SPACE_ID,
-        title: 'Cycle cap handoff',
+        title: 'Dead-loop handoff',
         description: '',
         workflowRunId: run.id,
         workflowNodeId: STEP_A,
         status: 'in_progress',
       });
       seedExec(run.id, STEP_B, 'Review', 'idle');
-      new ChannelCycleRepository(db).incrementCycleCount(run.id, 1, 1);
+      // Seed a dead-loop state on the cyclic Review→Coding channel: 15 rapid
+      // traversals within the rate window. Recovery must refuse to re-activate
+      // it. (A single lifetime increment no longer blocks — only a true
+      // runaway rate does.)
+      const cycleRepo = new ChannelCycleRepository(db);
+      const now = Date.now();
+      for (let i = 0; i < 15; i++) cycleRepo.recordCycleEvent(run.id, 1, now - i * 1000);
 
       await makeRuntime({
         pendingMessageRepo: new PendingAgentMessageRepository(db),

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -225,6 +225,22 @@ export function createSpaceTables(db: BunDatabase): void {
 		)
 	`);
 
+  // One timestamped row per cyclic-channel traversal, used for rate-based
+  // dead-loop detection (rolling window count). See migration 192.
+  db.exec(`
+		CREATE TABLE IF NOT EXISTS channel_cycle_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id TEXT NOT NULL,
+			channel_index INTEGER NOT NULL,
+			sent_at INTEGER NOT NULL,
+			FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+  db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_channel_cycle_events_window
+		ON channel_cycle_events(run_id, channel_index, sent_at)
+	`);
+
   db.exec(`
 		CREATE TABLE IF NOT EXISTS node_executions (
 			id TEXT PRIMARY KEY,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -2098,9 +2098,19 @@ export interface WorkflowChannel {
    */
   to: string | string[];
   /**
-   * Maximum number of times this channel may be traversed in a single workflow run
-   * before delivery is blocked. Only meaningful for back-channels (cyclic edges).
-   * Defaults to 5 at runtime when the channel is cyclic and this field is absent.
+   * Formerly the maximum number of times this cyclic channel could be traversed
+   * per run before delivery was blocked.
+   *
+   * @deprecated Vestigial — no longer a blocking gate. This is the field
+   *   persisted on workflow definitions and surfaced in the visual editor, but
+   *   the runtime now ignores it: cyclic channels are protected by rate-based
+   *   dead-loop detection (`DEAD_LOOP_THRESHOLD` traversals within a rolling
+   *   `DEAD_LOOP_WINDOW_MS` window), which catches a runaway tight ping-pong
+   *   without false-tripping on a genuine extended review the way a lifetime
+   *   cap did (see PR #2479 / task #942). A configured `maxCycles` value has no
+   *   effect. The field is retained only for backward-compatibility with saved
+   *   configurations, template hashes, and imports; retiring it from the type
+   *   and editor is a separate follow-up.
    */
   maxCycles?: number;
   /** Optional human-readable label for display in the visual editor */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1875,10 +1875,18 @@ export interface Channel {
    */
   to: string | string[];
   /**
-   * Maximum number of times this channel may be traversed in a single workflow run
-   * before delivery is blocked. Only meaningful for backward (cyclic) channels —
-   * cyclicity is inferred from graph topology, not stored.
-   * Defaults to 5 at runtime when the channel is cyclic and this field is absent.
+   * Formerly the maximum number of times this cyclic channel could be traversed
+   * per run before delivery was blocked.
+   *
+   * @deprecated Vestigial — no longer a blocking gate. Cyclic channels are now
+   *   protected by rate-based dead-loop detection (`DEAD_LOOP_THRESHOLD`
+   *   traversals within a rolling `DEAD_LOOP_WINDOW_MS` window), which catches a
+   *   runaway tight ping-pong without false-tripping on a genuine extended
+   *   review the way a lifetime cap did (see PR #2479 / task #942). A configured
+   *   `maxCycles` value is **ignored** at runtime. The field is retained only so
+   *   saved workflow configurations, template hashes, and imports stay
+   *   backward-compatible; retiring it from the type and visual editor is a
+   *   separate follow-up.
    */
   maxCycles?: number;
   /** Optional human-readable label for display in the visual editor. */

--- a/scripts/check-db-schema-parity.ts
+++ b/scripts/check-db-schema-parity.ts
@@ -44,6 +44,7 @@ type IndexInfoRow = {
 };
 
 export const HELPER_SCHEMA_TABLES = [
+  'channel_cycle_events',
   'channel_cycles',
   'delivery_consumed_seq',
   'evolution_episodes',


### PR DESCRIPTION
Replaces the lifetime message-count cap on cyclic workflow channels with rate-based dead-loop detection: a channel now trips only on a runaway tight ping-pong (>15 traversals within a rolling 5-minute window), so a genuine extended review spread over hours (the PR #2473 / task #942 false-block) never trips. On a trip the send is still blocked but the block is surfaced as a visible `workflowRun.deadLoop` event → `[TASK_EVENT]` message in the Space Agent session (and bridged to the client) instead of failing silently. The legacy lifetime counter is kept for observability only; reset-on-human-touch now clears the rate-window history too.

**Note for review:** I retired the lifetime `maxCycles` as a blocking gate entirely (rate-only), rather than keeping it as a high backstop, because any real runaway trips the rate and a backstop number risks future false-trips. The built-in workflows still declare `maxCycles: 5` — now vestigial for blocking (harmless); left untouched to keep this change surgical.

Acceptance covered by tests: legit long review never trips (repo + router), tight burst trips + emits the event, dedupe on repeated blocked sends, reset-on-human-touch lifts the block, and the recovery path respects a dead-looped channel. Migration 193 (`channel_cycle_events`) is backward-compatible — in-flight runs get an empty event history (unblocked).
