### PR TITLE
fix(web): keep voice transcript when navigating away mid-transcription

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -362,12 +362,21 @@ export function setupSessionHandlers(
     // no window for a stale client snapshot or a cancelled debounce to lose the
     // transcript. The client just reads inputDraft, already merged. See
     // session.appendVoiceDraft for how the pending field is populated.
+    // The staging field is cleared ONLY when the entire staged value merged: a
+    // draft already at the character limit truncates it, and clearing then
+    // would deterministically lose the transcript the client's toast promised
+    // was saved — retain it instead so it survives until there is room.
     const beforeMerge = agentSession.getSessionData();
     const voicePending = beforeMerge.metadata?.inputDraftVoicePending;
     if (voicePending && voicePending.trim()) {
-      const merged = appendDraftText(beforeMerge.metadata?.inputDraft ?? '', voicePending);
+      const draft = beforeMerge.metadata?.inputDraft ?? '';
+      const merged = appendDraftText(draft, voicePending);
+      const fullyMerged =
+        merged === `${draft}${voicePending}` || merged === `${draft} ${voicePending}`;
       await sessionManager.updateSession(targetSessionId, {
-        metadata: { inputDraft: merged, inputDraftVoicePending: null },
+        metadata: fullyMerged
+          ? { inputDraft: merged, inputDraftVoicePending: null }
+          : { inputDraft: merged },
       } as Partial<Session>);
     }
 

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -373,11 +373,14 @@ export function setupSessionHandlers(
       const merged = appendDraftText(draft, voicePending);
       const fullyMerged =
         merged === `${draft}${voicePending}` || merged === `${draft} ${voicePending}`;
-      await sessionManager.updateSession(targetSessionId, {
-        metadata: fullyMerged
-          ? { inputDraft: merged, inputDraftVoicePending: null }
-          : { inputDraft: merged },
-      } as Partial<Session>);
+      // Only consume on a FULL merge. On a partial fit, write nothing and keep
+      // the staged transcript: writing the prefix would duplicate it once room
+      // appears and the merge retries.
+      if (fullyMerged) {
+        await sessionManager.updateSession(targetSessionId, {
+          metadata: { inputDraft: merged, inputDraftVoicePending: null },
+        } as Partial<Session>);
+      }
     }
 
     const session = agentSession.getSessionData();
@@ -468,7 +471,14 @@ export function setupSessionHandlers(
     }
     const session = sessionManager.getSessionFromDB(sessionId);
     if (!session) throw new Error('Session not found');
-    const pending = appendDraftText(session.metadata?.inputDraftVoicePending ?? '', text);
+    const existingPending = session.metadata?.inputDraftVoicePending ?? '';
+    const pending = appendDraftText(existingPending, text);
+    // Reject (rather than silently truncate) when the staged value is at the
+    // character limit and the new transcript cannot fit whole — the client
+    // reports the failure instead of claiming a save that dropped its tail.
+    const fits =
+      pending === `${existingPending}${text}` || pending === `${existingPending} ${text}`;
+    if (!fits) throw new Error('Pending voice draft is at the character limit');
     const updates: UpdateSessionRequest = { metadata: { inputDraftVoicePending: pending } };
     await sessionManager.updateSession(sessionId, updates as Partial<Session>);
     messageHub.event(
@@ -479,6 +489,32 @@ export function setupSessionHandlers(
       }
     );
     return { success: true };
+  });
+
+  // Atomically clear the input draft ONLY if it still equals `expected`. The
+  // unmounted voice send uses this to consume its click-time draft snapshot
+  // without wiping newer edits persisted after the snapshot (the user reopened
+  // the session, or another client saved). Read+write is one synchronous step
+  // (getFromDB + updateSession's DB write both run before the first `await`),
+  // so no concurrent draft save can land between the comparison and the clear.
+  messageHub.onRequest('session.clearInputDraftIf', async (data, _ctx) => {
+    const { sessionId, expected } = data as { sessionId: string; expected: string };
+    if (typeof expected !== 'string') throw new Error('Expected draft value is required');
+    const session = sessionManager.getSessionFromDB(sessionId);
+    if (!session) throw new Error('Session not found');
+    if ((session.metadata?.inputDraft ?? '').trim() !== expected.trim()) {
+      return { cleared: false };
+    }
+    const updates: UpdateSessionRequest = { metadata: { inputDraft: null } };
+    await sessionManager.updateSession(sessionId, updates as Partial<Session>);
+    messageHub.event(
+      'session.updated',
+      { ...updates, sessionId },
+      {
+        channel: `session:${sessionId}`,
+      }
+    );
+    return { cleared: true };
   });
 
   messageHub.onRequest('session.delete', async (data, _ctx) => {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -166,6 +166,40 @@ function toReplayContent(
   return null;
 }
 
+const INPUT_DRAFT_CHAR_LIMIT = 100_000;
+const CJK_SCRIPT = /[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}]/u;
+const ASCII_QUOTE = /['"`]/;
+
+// Mirrors the web composer's draft-insert spacing rules: suppress a separating
+// space when the preceding text ends in whitespace, an opening bracket/quote,
+// or nothing at all.
+function suppressLeadingSpace(before: string): boolean {
+  if (before.length === 0) return false;
+  const last = before.slice(-1);
+  if (/\s/.test(last)) return true;
+  if (/\p{Ps}|\p{Pi}/u.test(last)) return true;
+  if (ASCII_QUOTE.test(last)) {
+    const prev = before.slice(-2, -1);
+    return prev === '' || /\s/.test(prev);
+  }
+  return false;
+}
+
+/**
+ * Append `text` to an existing input draft, inserting a single separating space
+ * only when both sides are non-empty and neither boundary is CJK or a
+ * join-suppressing character. Capped to the composer's character limit.
+ */
+export function appendInputDraftText(existing: string, text: string): string {
+  const needsSpace =
+    existing.length > 0 &&
+    !suppressLeadingSpace(existing) &&
+    !/^\s/.test(text) &&
+    !CJK_SCRIPT.test(existing.slice(-1)) &&
+    !(text.length > 0 && CJK_SCRIPT.test(text[0]!));
+  return `${existing}${needsSpace ? ' ' : ''}${text}`.slice(0, INPUT_DRAFT_CHAR_LIMIT);
+}
+
 export function setupSessionHandlers(
   messageHub: MessageHub,
   sessionManager: SessionManager,
@@ -423,6 +457,34 @@ export function setupSessionHandlers(
 
     // Room channel broadcasts removed with legacy Room feature retirement.
 
+    return { success: true };
+  });
+
+  // Atomic server-side append to a session's input draft. The voice flow uses
+  // this when a transcription completes AFTER the composer unmounted (the user
+  // navigated to another session mid-transcription): the client cannot safely
+  // read-modify-write the draft, because a snapshot taken before navigation
+  // would clobber a draft the user edited after returning. Computing the append
+  // here keeps the read→write in one synchronous step (getFromDB and
+  // updateSession's DB write both run before the first `await`), so no
+  // concurrent draft write can land between them.
+  messageHub.onRequest('session.appendInputDraft', async (data, _ctx) => {
+    const { sessionId, text } = data as { sessionId: string; text: string };
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      throw new Error('Text to append is required');
+    }
+    const session = sessionManager.getSessionFromDB(sessionId);
+    if (!session) throw new Error('Session not found');
+    const appended = appendInputDraftText(session.metadata?.inputDraft ?? '', text);
+    const updates: UpdateSessionRequest = { metadata: { inputDraft: appended } };
+    await sessionManager.updateSession(sessionId, updates as Partial<Session>);
+    messageHub.event(
+      'session.updated',
+      { ...updates, sessionId },
+      {
+        channel: `session:${sessionId}`,
+      }
+    );
     return { success: true };
   });
 

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -22,7 +22,7 @@ import type {
 } from '@hyperneo/shared';
 import { normalizeThinkingLevel } from '@hyperneo/shared';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
-import { generateUUID } from '@hyperneo/shared';
+import { appendDraftText, generateUUID } from '@hyperneo/shared';
 import type { SessionManager } from '../session-manager';
 import type { CreateSessionRequest, UpdateSessionRequest } from '@hyperneo/shared';
 import { isSDKUserMessage } from '@hyperneo/shared/sdk/type-guards';
@@ -164,40 +164,6 @@ function toReplayContent(
   }
 
   return null;
-}
-
-const INPUT_DRAFT_CHAR_LIMIT = 100_000;
-const CJK_SCRIPT = /[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}]/u;
-const ASCII_QUOTE = /['"`]/;
-
-// Mirrors the web composer's draft-insert spacing rules: suppress a separating
-// space when the preceding text ends in whitespace, an opening bracket/quote,
-// or nothing at all.
-function suppressLeadingSpace(before: string): boolean {
-  if (before.length === 0) return false;
-  const last = before.slice(-1);
-  if (/\s/.test(last)) return true;
-  if (/\p{Ps}|\p{Pi}/u.test(last)) return true;
-  if (ASCII_QUOTE.test(last)) {
-    const prev = before.slice(-2, -1);
-    return prev === '' || /\s/.test(prev);
-  }
-  return false;
-}
-
-/**
- * Append `text` to an existing input draft, inserting a single separating space
- * only when both sides are non-empty and neither boundary is CJK or a
- * join-suppressing character. Capped to the composer's character limit.
- */
-export function appendInputDraftText(existing: string, text: string): string {
-  const needsSpace =
-    existing.length > 0 &&
-    !suppressLeadingSpace(existing) &&
-    !/^\s/.test(text) &&
-    !CJK_SCRIPT.test(existing.slice(-1)) &&
-    !(text.length > 0 && CJK_SCRIPT.test(text[0]!));
-  return `${existing}${needsSpace ? ' ' : ''}${text}`.slice(0, INPUT_DRAFT_CHAR_LIMIT);
 }
 
 export function setupSessionHandlers(
@@ -460,23 +426,25 @@ export function setupSessionHandlers(
     return { success: true };
   });
 
-  // Atomic server-side append to a session's input draft. The voice flow uses
-  // this when a transcription completes AFTER the composer unmounted (the user
-  // navigated to another session mid-transcription): the client cannot safely
-  // read-modify-write the draft, because a snapshot taken before navigation
-  // would clobber a draft the user edited after returning. Computing the append
-  // here keeps the read→write in one synchronous step (getFromDB and
-  // updateSession's DB write both run before the first `await`), so no
-  // concurrent draft write can land between them.
-  messageHub.onRequest('session.appendInputDraft', async (data, _ctx) => {
+  // Stage a voice transcript that completed AFTER its composer unmounted (the
+  // user navigated to another session mid-transcription) into a dedicated
+  // `inputDraftVoicePending` metadata field. We must NOT write the live
+  // inputDraft: the client's debounced draft save (useInputDraft) can still be
+  // holding a stale local snapshot and would clobber an append made to
+  // inputDraft. A separate field is never touched by those saves, so the
+  // transcript survives until useInputDraft merges it into the draft once on
+  // load. The read→write is one synchronous step (getFromDB + updateSession's
+  // DB write both run before the first `await`), so concurrent writers cannot
+  // interleave. Returns success/failure so the client's toast is honest.
+  messageHub.onRequest('session.appendVoiceDraft', async (data, _ctx) => {
     const { sessionId, text } = data as { sessionId: string; text: string };
     if (typeof text !== 'string' || text.trim().length === 0) {
       throw new Error('Text to append is required');
     }
     const session = sessionManager.getSessionFromDB(sessionId);
     if (!session) throw new Error('Session not found');
-    const appended = appendInputDraftText(session.metadata?.inputDraft ?? '', text);
-    const updates: UpdateSessionRequest = { metadata: { inputDraft: appended } };
+    const pending = appendDraftText(session.metadata?.inputDraftVoicePending ?? '', text);
+    const updates: UpdateSessionRequest = { metadata: { inputDraftVoicePending: pending } };
     await sessionManager.updateSession(sessionId, updates as Partial<Session>);
     messageHub.event(
       'session.updated',

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -355,6 +355,22 @@ export function setupSessionHandlers(
       throw new Error('Session not found');
     }
 
+    // Consume any staged voice transcript atomically: merge
+    // inputDraftVoicePending into inputDraft and clear the staging field in one
+    // synchronous write. Doing the merge server-side (rather than in the
+    // client's debounced useInputDraft hook) means there is a single writer and
+    // no window for a stale client snapshot or a cancelled debounce to lose the
+    // transcript. The client just reads inputDraft, already merged. See
+    // session.appendVoiceDraft for how the pending field is populated.
+    const beforeMerge = agentSession.getSessionData();
+    const voicePending = beforeMerge.metadata?.inputDraftVoicePending;
+    if (voicePending && voicePending.trim()) {
+      const merged = appendDraftText(beforeMerge.metadata?.inputDraft ?? '', voicePending);
+      await sessionManager.updateSession(targetSessionId, {
+        metadata: { inputDraft: merged, inputDraftVoicePending: null },
+      } as Partial<Session>);
+    }
+
     const session = agentSession.getSessionData();
 
     return {

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -618,8 +618,14 @@ export class SessionLifecycle {
         source: 'update',
         session: updates,
       })
-      .catch(() => {
-        // Subscriber failures are logged by the bus; persistence already succeeded.
+      .catch((err: unknown) => {
+        // Persistence already succeeded — the write stays valid. Log the failed
+        // subscriber though: the bus collects and throws without logging, and a
+        // silently failed state projection would leave consumers stale with no
+        // diagnostic trail.
+        this.logger.warn(
+          `session.updated publication failed after commit for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+        );
       });
   }
 

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -607,12 +607,20 @@ export class SessionLifecycle {
       agentSession.updateMetadata(updates);
     }
 
-    // FIX: Emit event via InternalEventBus<DaemonInternalEventMap> - include data for decoupled state management
-    await this.internalEventBus.publish('session.updated', {
-      sessionId,
-      source: 'update',
-      session: updates,
-    });
+    // FIX: Emit event via InternalEventBus<DaemonInternalEventMap> - include data for decoupled state management.
+    // Best-effort: the durable SQLite write above has already committed, so a
+    // failing subscriber must NOT reject this call — callers (e.g. the voice
+    // draft RPCs) would report a committed write as lost, and a client retry
+    // would duplicate the already-persisted value.
+    await this.internalEventBus
+      .publish('session.updated', {
+        sessionId,
+        source: 'update',
+        session: updates,
+      })
+      .catch(() => {
+        // Subscriber failures are logged by the bus; persistence already succeeded.
+      });
   }
 
   // =========================================================================

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -708,3 +708,79 @@ describe('Session RPC Handlers — models.list', () => {
     });
   });
 });
+
+describe('Session RPC Handlers — session.appendInputDraft', () => {
+  let messageHubData: ReturnType<typeof createMockMessageHub>;
+  let eventBus: ReturnType<typeof createMockInternalEventBus>;
+  let sessionManager: {
+    getSessionFromDB: ReturnType<typeof mock>;
+    updateSession: ReturnType<typeof mock>;
+  };
+  let existingDraft: string | null;
+  let sessionExists: boolean;
+
+  beforeEach(async () => {
+    messageHubData = createMockMessageHub();
+    eventBus = createMockInternalEventBus();
+    existingDraft = 'existing';
+    sessionExists = true;
+    sessionManager = {
+      getSessionFromDB: mock(() =>
+        sessionExists ? { id: 's1', metadata: { inputDraft: existingDraft } } : null
+      ),
+      updateSession: mock(async () => {}),
+    } as unknown as SessionManager;
+
+    const { setupSessionHandlers } = await import(
+      '../../../../src/lib/rpc-handlers/session-handlers'
+    );
+    setupSessionHandlers(messageHubData.hub, sessionManager, eventBus, {} as SpaceManager);
+  });
+
+  it('appends to the current draft with a separating space', async () => {
+    existingDraft = 'existing';
+    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    expect(handler).toBeDefined();
+    const result = (await handler!({ sessionId: 's1', text: 'hello world' }, {})) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(true);
+    expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
+      metadata: { inputDraft: 'existing hello world' },
+    });
+  });
+
+  it('does not insert a space across a CJK boundary', async () => {
+    existingDraft = '你好';
+    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    await handler!({ sessionId: 's1', text: '世界' }, {});
+    expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
+      metadata: { inputDraft: '你好世界' },
+    });
+  });
+
+  it('appends to an empty draft with no leading space', async () => {
+    existingDraft = null;
+    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    await handler!({ sessionId: 's1', text: 'hello' }, {});
+    expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
+      metadata: { inputDraft: 'hello' },
+    });
+  });
+
+  it('throws when the session does not exist and does not write', async () => {
+    sessionExists = false;
+    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    await expect(handler!({ sessionId: 'missing', text: 'hi' }, {})).rejects.toThrow(
+      'Session not found'
+    );
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects whitespace-only text before reading or writing the draft', async () => {
+    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    await expect(handler!({ sessionId: 's1', text: '   ' }, {})).rejects.toThrow();
+    expect(sessionManager.getSessionFromDB).not.toHaveBeenCalled();
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -785,6 +785,15 @@ describe('Session RPC Handlers — session.appendVoiceDraft', () => {
     expect(sessionManager.getSessionFromDB).not.toHaveBeenCalled();
     expect(sessionManager.updateSession).not.toHaveBeenCalled();
   });
+
+  it('rejects instead of truncating when the pending field is at the character limit', async () => {
+    existingPending = 'p'.repeat(100_000);
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
+    await expect(handler!({ sessionId: 's1', text: 'more' }, {})).rejects.toThrow(
+      'Pending voice draft is at the character limit'
+    );
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
 });
 
 describe('Session RPC Handlers — session.get voice draft merge', () => {
@@ -841,11 +850,63 @@ describe('Session RPC Handlers — session.get voice draft merge', () => {
     const fullDraft = 'x'.repeat(100_000);
     const handler = await setup({ inputDraft: fullDraft, inputDraftVoicePending: 'hello' });
     await handler!({ sessionId: 's1' }, {});
-    // The draft update lands, but the staging field is NOT cleared — clearing
-    // it here would deterministically lose the transcript the client's toast
-    // promised was saved. It retries on the next get.
+    // A partial merge writes NOTHING — writing the prefix would duplicate it
+    // once room appears and the merge retries. The staged transcript survives.
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('Session RPC Handlers — session.clearInputDraftIf', () => {
+  let messageHubData: ReturnType<typeof createMockMessageHub>;
+  let eventBus: ReturnType<typeof createMockInternalEventBus>;
+  let sessionManager: {
+    getSessionFromDB: ReturnType<typeof mock>;
+    updateSession: ReturnType<typeof mock>;
+  };
+  let persistedDraft: string | null;
+
+  beforeEach(async () => {
+    messageHubData = createMockMessageHub();
+    eventBus = createMockInternalEventBus();
+    persistedDraft = 'snapshot';
+    sessionManager = {
+      getSessionFromDB: mock(() => ({ id: 's1', metadata: { inputDraft: persistedDraft } })),
+      updateSession: mock(async () => {}),
+    } as unknown as SessionManager;
+    const { setupSessionHandlers } = await import(
+      '../../../../src/lib/rpc-handlers/session-handlers'
+    );
+    setupSessionHandlers(messageHubData.hub, sessionManager, eventBus, {} as SpaceManager);
+  });
+
+  it('clears the draft when it still equals the expected click-time snapshot', async () => {
+    const handler = messageHubData.handlers.get('session.clearInputDraftIf');
+    expect(handler).toBeDefined();
+    const result = (await handler!({ sessionId: 's1', expected: 'snapshot' }, {})) as {
+      cleared: boolean;
+    };
+    expect(result.cleared).toBe(true);
     expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
-      metadata: { inputDraft: fullDraft },
+      metadata: { inputDraft: null },
     });
+  });
+
+  it('does not clear when the persisted draft has newer edits', async () => {
+    persistedDraft = 'newer edits';
+    const handler = messageHubData.handlers.get('session.clearInputDraftIf');
+    const result = (await handler!({ sessionId: 's1', expected: 'snapshot' }, {})) as {
+      cleared: boolean;
+    };
+    expect(result.cleared).toBe(false);
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('trims both sides before comparing', async () => {
+    persistedDraft = '  snapshot  ';
+    const handler = messageHubData.handlers.get('session.clearInputDraftIf');
+    const result = (await handler!({ sessionId: 's1', expected: ' snapshot ' }, {})) as {
+      cleared: boolean;
+    };
+    expect(result.cleared).toBe(true);
   });
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -786,3 +786,54 @@ describe('Session RPC Handlers — session.appendVoiceDraft', () => {
     expect(sessionManager.updateSession).not.toHaveBeenCalled();
   });
 });
+
+describe('Session RPC Handlers — session.get voice draft merge', () => {
+  let messageHubData: ReturnType<typeof createMockMessageHub>;
+  let eventBus: ReturnType<typeof createMockInternalEventBus>;
+  let sessionManager: {
+    getSessionAsync: ReturnType<typeof mock>;
+    updateSession: ReturnType<typeof mock>;
+  };
+
+  async function setup(metadata: Record<string, unknown>) {
+    messageHubData = createMockMessageHub();
+    eventBus = createMockInternalEventBus();
+    // getSessionData() returns the same live object both before and after the
+    // merge so the handler reads the pending value, then re-reads for its
+    // response — mirroring the real in-memory agent session.
+    const sessionData = { id: 's1', metadata };
+    sessionManager = {
+      getSessionAsync: mock(async () => ({ getSessionData: () => sessionData })),
+      updateSession: mock(async () => {}),
+    } as unknown as SessionManager;
+    const { setupSessionHandlers } = await import(
+      '../../../../src/lib/rpc-handlers/session-handlers'
+    );
+    setupSessionHandlers(messageHubData.hub, sessionManager, eventBus, {} as SpaceManager);
+    return messageHubData.handlers.get('session.get');
+  }
+
+  it('merges a pending voice transcript into the draft and clears the staging field', async () => {
+    const handler = await setup({
+      inputDraft: 'existing',
+      inputDraftVoicePending: 'hello world',
+    });
+    expect(handler).toBeDefined();
+    await handler!({ sessionId: 's1' }, {});
+    expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
+      metadata: { inputDraft: 'existing hello world', inputDraftVoicePending: null },
+    });
+  });
+
+  it('leaves the draft untouched when there is no pending transcript', async () => {
+    const handler = await setup({ inputDraft: 'existing' });
+    await handler!({ sessionId: 's1' }, {});
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('ignores a whitespace-only pending transcript', async () => {
+    const handler = await setup({ inputDraft: 'existing', inputDraftVoicePending: '   ' });
+    await handler!({ sessionId: 's1' }, {});
+    expect(sessionManager.updateSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -709,24 +709,24 @@ describe('Session RPC Handlers — models.list', () => {
   });
 });
 
-describe('Session RPC Handlers — session.appendInputDraft', () => {
+describe('Session RPC Handlers — session.appendVoiceDraft', () => {
   let messageHubData: ReturnType<typeof createMockMessageHub>;
   let eventBus: ReturnType<typeof createMockInternalEventBus>;
   let sessionManager: {
     getSessionFromDB: ReturnType<typeof mock>;
     updateSession: ReturnType<typeof mock>;
   };
-  let existingDraft: string | null;
+  let existingPending: string | null;
   let sessionExists: boolean;
 
   beforeEach(async () => {
     messageHubData = createMockMessageHub();
     eventBus = createMockInternalEventBus();
-    existingDraft = 'existing';
+    existingPending = 'existing';
     sessionExists = true;
     sessionManager = {
       getSessionFromDB: mock(() =>
-        sessionExists ? { id: 's1', metadata: { inputDraft: existingDraft } } : null
+        sessionExists ? { id: 's1', metadata: { inputDraftVoicePending: existingPending } } : null
       ),
       updateSession: mock(async () => {}),
     } as unknown as SessionManager;
@@ -737,48 +737,50 @@ describe('Session RPC Handlers — session.appendInputDraft', () => {
     setupSessionHandlers(messageHubData.hub, sessionManager, eventBus, {} as SpaceManager);
   });
 
-  it('appends to the current draft with a separating space', async () => {
-    existingDraft = 'existing';
-    const handler = messageHubData.handlers.get('session.appendInputDraft');
+  it('appends the transcript to the pending voice-draft field with a separating space', async () => {
+    existingPending = 'existing';
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
     expect(handler).toBeDefined();
     const result = (await handler!({ sessionId: 's1', text: 'hello world' }, {})) as {
       success: boolean;
     };
     expect(result.success).toBe(true);
+    // Writes the dedicated pending field — never the live inputDraft, which the
+    // client's debounced saves could otherwise clobber.
     expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
-      metadata: { inputDraft: 'existing hello world' },
+      metadata: { inputDraftVoicePending: 'existing hello world' },
     });
   });
 
   it('does not insert a space across a CJK boundary', async () => {
-    existingDraft = '你好';
-    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    existingPending = '你好';
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
     await handler!({ sessionId: 's1', text: '世界' }, {});
     expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
-      metadata: { inputDraft: '你好世界' },
+      metadata: { inputDraftVoicePending: '你好世界' },
     });
   });
 
-  it('appends to an empty draft with no leading space', async () => {
-    existingDraft = null;
-    const handler = messageHubData.handlers.get('session.appendInputDraft');
+  it('appends with no leading space when nothing is pending', async () => {
+    existingPending = null;
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
     await handler!({ sessionId: 's1', text: 'hello' }, {});
     expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
-      metadata: { inputDraft: 'hello' },
+      metadata: { inputDraftVoicePending: 'hello' },
     });
   });
 
   it('throws when the session does not exist and does not write', async () => {
     sessionExists = false;
-    const handler = messageHubData.handlers.get('session.appendInputDraft');
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
     await expect(handler!({ sessionId: 'missing', text: 'hi' }, {})).rejects.toThrow(
       'Session not found'
     );
     expect(sessionManager.updateSession).not.toHaveBeenCalled();
   });
 
-  it('rejects whitespace-only text before reading or writing the draft', async () => {
-    const handler = messageHubData.handlers.get('session.appendInputDraft');
+  it('rejects whitespace-only text before reading or writing the pending field', async () => {
+    const handler = messageHubData.handlers.get('session.appendVoiceDraft');
     await expect(handler!({ sessionId: 's1', text: '   ' }, {})).rejects.toThrow();
     expect(sessionManager.getSessionFromDB).not.toHaveBeenCalled();
     expect(sessionManager.updateSession).not.toHaveBeenCalled();

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -836,4 +836,16 @@ describe('Session RPC Handlers — session.get voice draft merge', () => {
     await handler!({ sessionId: 's1' }, {});
     expect(sessionManager.updateSession).not.toHaveBeenCalled();
   });
+
+  it('retains the pending transcript when a full draft leaves no room for it', async () => {
+    const fullDraft = 'x'.repeat(100_000);
+    const handler = await setup({ inputDraft: fullDraft, inputDraftVoicePending: 'hello' });
+    await handler!({ sessionId: 's1' }, {});
+    // The draft update lands, but the staging field is NOT cleared — clearing
+    // it here would deterministically lose the transcript the client's toast
+    // promised was saved. It retries on the next get.
+    expect(sessionManager.updateSession).toHaveBeenCalledWith('s1', {
+      metadata: { inputDraft: fullDraft },
+    });
+  });
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -600,6 +600,14 @@ export interface SessionMetadata {
   workspaceInitialized?: boolean; // Flag to track if workspace (title + worktree) has been initialized
   lastContextInfo?: ContextInfo | null; // Last known context info (persisted)
   inputDraft?: string | null; // Draft input text (null to clear; persisted across sessions and devices)
+  /**
+   * Voice transcript that completed after its composer unmounted (the user
+   * navigated to another session mid-transcription). Held in a separate field
+   * so the client's debounced inputDraft saves — which carry a stale snapshot —
+   * can never clobber it; useInputDraft merges it into inputDraft once on load,
+   * then clears it. null/absent = nothing pending.
+   */
+  inputDraftVoicePending?: string | null;
   removedOutputs?: string[]; // UUIDs of messages whose tool_result outputs were removed from SDK session file
   resolvedQuestions?: Record<string, ResolvedQuestion>; // Resolved AskUserQuestion responses, keyed by toolUseId
   // Cost tracking: SDK reports cumulative cost per run, but resets on agent restart

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -62,3 +62,43 @@ export function generateUUID(): string {
     return v.toString(16);
   });
 }
+
+/** Composer/draft character cap shared by the web input and daemon draft writes. */
+export const DRAFT_CHAR_LIMIT = 100_000;
+
+const CJK_SCRIPT = /[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}]/u;
+const ASCII_QUOTE = /['"`]/;
+
+// Suppress a separating space when the preceding text ends in whitespace or an
+// opening bracket/quote (ASCII straight quotes count as opening only when they
+// follow whitespace or start-of-text).
+function suppressLeadingSpace(before: string): boolean {
+  if (before.length === 0) return false;
+  const last = before.slice(-1);
+  if (/\s/.test(last)) return true;
+  if (/\p{Ps}|\p{Pi}/u.test(last)) return true;
+  if (ASCII_QUOTE.test(last)) {
+    const prev = before.slice(-2, -1);
+    return prev === '' || /\s/.test(prev);
+  }
+  return false;
+}
+
+/**
+ * Append `text` to an existing draft string, inserting a single separating
+ * space only when both sides are non-empty and neither boundary is CJK or a
+ * join-suppressing character. CJK scripts need no inter-character space
+ * (你好 + 世界 -> 你好世界). Capped to the shared draft character limit.
+ *
+ * Shared so the daemon's atomic draft append and the client's pending-voice
+ * merge apply identical spacing rules.
+ */
+export function appendDraftText(existing: string, text: string): string {
+  const needsSpace =
+    existing.length > 0 &&
+    !suppressLeadingSpace(existing) &&
+    !/^\s/.test(text) &&
+    !CJK_SCRIPT.test(existing.slice(-1)) &&
+    !(text.length > 0 && CJK_SCRIPT.test(text[0] ?? ''));
+  return `${existing}${needsSpace ? ' ' : ''}${text}`.slice(0, DRAFT_CHAR_LIMIT);
+}

--- a/packages/shared/tests/utils.test.ts
+++ b/packages/shared/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { generateUUID, parseJson, parseJsonOptional } from '../src/utils.ts';
+import { appendDraftText, generateUUID, parseJson, parseJsonOptional } from '../src/utils.ts';
 
 describe('generateUUID', () => {
   test('generates valid UUID format', () => {
@@ -167,5 +167,42 @@ describe('parseJsonOptional', () => {
 
   test('returns undefined for empty string', () => {
     expect(parseJsonOptional('')).toBeUndefined();
+  });
+});
+
+describe('appendDraftText', () => {
+  test('appends with a separating space between two latin words', () => {
+    expect(appendDraftText('hello', 'world')).toBe('hello world');
+  });
+
+  test('does not prepend a space when existing is empty', () => {
+    expect(appendDraftText('', 'hello')).toBe('hello');
+  });
+
+  test('does not insert a space across a CJK boundary (either side)', () => {
+    expect(appendDraftText('你好', '世界')).toBe('你好世界');
+    expect(appendDraftText('hello', '世界')).toBe('hello世界');
+    expect(appendDraftText('你好', 'world')).toBe('你好world');
+  });
+
+  test('suppresses the space when existing already ends in whitespace', () => {
+    expect(appendDraftText('hello ', 'world')).toBe('hello world');
+    expect(appendDraftText('hello\n', 'world')).toBe('hello\nworld');
+  });
+
+  test('suppresses the space after an opening bracket or quote', () => {
+    expect(appendDraftText('note (', 'detail')).toBe('note (detail');
+    expect(appendDraftText('he said "', 'hi')).toBe('he said "hi');
+  });
+
+  test('keeps the space after sentence punctuation', () => {
+    expect(appendDraftText('Hello.', 'World')).toBe('Hello. World');
+    expect(appendDraftText('Stop!', 'go')).toBe('Stop! go');
+  });
+
+  test('caps the result at the draft character limit', () => {
+    const big = 'a'.repeat(100_000);
+    expect(appendDraftText(big, 'more').length).toBe(100_000);
+    expect(appendDraftText('x', 'y'.repeat(200_000)).length).toBe(100_000);
   });
 });

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -17,7 +17,6 @@ import type {
 } from '@hyperneo/shared';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { appendDraftText } from '@hyperneo/shared';
 import {
   useCommandAutocomplete,
   useFileAttachments,
@@ -100,6 +99,32 @@ function suppressLeadingSpace(before: string): boolean {
 // Matches InputTextarea's default maxChars; transcripts are capped to it so a
 // misbehaving backend cannot push the draft past the composer limit.
 const COMPOSER_CHAR_LIMIT = 100000;
+
+/**
+ * Splice `transcript` between the draft text before/after the caret (or
+ * selection — a selection gets replaced), applying the spacing/CJK rules at
+ * both boundaries and capping to the composer character limit. Shared by the
+ * live mounted insert and the unmounted delivery so both place the transcript
+ * identically.
+ */
+function buildTranscriptInsertion(before: string, after: string, transcript: string): string {
+  const needsLeadingSpace =
+    before.length > 0 &&
+    !suppressLeadingSpace(before) &&
+    !/^\s/.test(transcript) &&
+    !isCjk(before.slice(-1)) &&
+    !isCjk(transcript[0]);
+  const needsTrailingSpace =
+    after.length > 0 &&
+    !isNonJoiningBoundary(after[0]) &&
+    !/\s$/.test(transcript) &&
+    !isCjk(after[0]) &&
+    !isCjk(transcript.slice(-1));
+  const inserted = `${needsLeadingSpace ? ' ' : ''}${transcript}${needsTrailingSpace ? ' ' : ''}`;
+  const remaining = COMPOSER_CHAR_LIMIT - before.length - after.length;
+  const cappedInserted = remaining <= 0 ? '' : inserted.slice(0, remaining);
+  return before + cappedInserted + after;
+}
 
 function getPlaceholderForSessionType(sessionType?: SessionType): string {
   switch (sessionType) {
@@ -406,27 +431,9 @@ export default function MessageInput({
         Math.max(selectionStart, lastSelectionEndRef.current);
       const before = currentContent.slice(0, selectionStart);
       const after = currentContent.slice(selectionEnd);
-      const needsLeadingSpace =
-        before.length > 0 &&
-        !suppressLeadingSpace(before) &&
-        !/^\s/.test(transcript) &&
-        !isCjk(before.slice(-1)) &&
-        !isCjk(transcript[0]);
-      const needsTrailingSpace =
-        after.length > 0 &&
-        !isNonJoiningBoundary(after[0]) &&
-        !/\s$/.test(transcript) &&
-        !isCjk(after[0]) &&
-        !isCjk(transcript.slice(-1));
-      const inserted = `${needsLeadingSpace ? ' ' : ''}${transcript}${needsTrailingSpace ? ' ' : ''}`;
-      // Enforce the composer character limit (matches InputTextarea's maxChars)
-      // so a misbehaving backend cannot push a transcript past it via direct
-      // state update.
-      const remaining = COMPOSER_CHAR_LIMIT - before.length - after.length;
-      const cappedInserted = remaining <= 0 ? '' : inserted.slice(0, remaining);
-      const nextValue = before + cappedInserted + after;
+      const nextValue = buildTranscriptInsertion(before, after, transcript);
       setContent(nextValue);
-      const nextCursor = selectionStart + cappedInserted.length;
+      const nextCursor = selectionStart + (nextValue.length - before.length - after.length);
       setTimeout(() => {
         textareaInputRef.current?.focus();
         textareaInputRef.current?.setSelectionRange(nextCursor, nextCursor);
@@ -495,39 +502,72 @@ export default function MessageInput({
       transcript: string,
       mode: 'stay' | 'send' | 'queue',
       // Snapshot of the composer payload taken at click time (while still
-      // mounted). The unmounted delivery can't read the live draft/attachments,
-      // so it sends what was here when the user clicked — matching the mounted
-      // path, which submits the complete composer. The transcript is appended
-      // (the caret position is unknown once unmounted).
-      payload: { content: string; images?: MessageImage[] }
+      // mounted): the draft split at the captured caret/selection, plus
+      // images. The unmounted delivery can't read the live
+      // draft/attachments, so it sends what was here when the user clicked,
+      // matching the mounted path that submits the complete composer.
+      payload: { before: string; after: string; images?: MessageImage[] }
     ): Promise<{ ok: boolean; message: string }> => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return { ok: false, message: '' };
-      try {
-        if (mode === 'stay') {
-          await hub.request('session.appendVoiceDraft', {
-            sessionId: targetSessionId,
-            text: transcript,
-          });
+      const stageToDraft = async () => {
+        await hub.request('session.appendVoiceDraft', {
+          sessionId: targetSessionId,
+          text: transcript,
+        });
+      };
+      if (mode === 'stay') {
+        try {
+          await stageToDraft();
           return { ok: true, message: 'Voice transcript saved to the session draft' };
+        } catch {
+          return { ok: false, message: '' };
         }
-        const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
+      }
+      // Splice the transcript at the captured selection like the mounted path;
+      // if the composer was already at its character limit the transcript
+      // cannot fit — do not silently send an incomplete payload, retain the
+      // transcript in the pending draft field instead.
+      const content = buildTranscriptInsertion(payload.before, payload.after, transcript);
+      if (!content.includes(transcript)) {
+        try {
+          await stageToDraft();
+          return {
+            ok: true,
+            message: 'Composer draft is full — voice transcript saved to the session draft',
+          };
+        } catch {
+          return { ok: false, message: '' };
+        }
+      }
+      const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
+      try {
         await hub.request('message.send', {
           sessionId: targetSessionId,
-          content: appendDraftText(payload.content, transcript),
+          content,
           images: payload.images,
           deliveryMode,
         });
-        return {
-          ok: true,
-          message:
-            mode === 'queue'
-              ? 'Voice transcript queued for the next turn'
-              : 'Voice transcript sent',
-        };
       } catch {
         return { ok: false, message: '' };
       }
+      // Consume the click-time draft so reopening the session doesn't show —
+      // and re-send — text that was just delivered. Parity with the mounted
+      // submit, which clears the composer. Best-effort: a failure here doesn't
+      // undo the send above.
+      try {
+        await hub.request('session.update', {
+          sessionId: targetSessionId,
+          metadata: { inputDraft: null },
+        });
+      } catch {
+        /* ignore — the send already succeeded */
+      }
+      return {
+        ok: true,
+        message:
+          mode === 'queue' ? 'Voice transcript queued for the next turn' : 'Voice transcript sent',
+      };
     },
     []
   );
@@ -546,11 +586,23 @@ export default function MessageInput({
       // composer has since been re-targeted, the transcript is discarded with a
       // toast instead of landing in — or auto-sending to — another session.
       const targetSessionId = recordingSessionRef.current ?? sessionId;
-      // Snapshot the full outgoing payload NOW (mounted, click time). If the
-      // user navigates away during transcription, the unmounted delivery path
-      // can't read the live draft/attachments — it must send what was here when
-      // they clicked, matching the mounted path that submits the whole composer.
-      const payloadSnapshot = { content: contentRef.current, images: getImagesForSend() };
+      // Snapshot the full outgoing payload NOW (mounted, click time), split at
+      // the captured caret/selection exactly like insertTranscript would splice
+      // it — the textarea is already replaced by the recording panel, so fall
+      // back to the cursor refs snapshotted at recording start. If the user
+      // navigates away during transcription, the unmounted delivery path can't
+      // read the live draft/attachments — it must send what was here when they
+      // clicked, matching the mounted path that submits the whole composer.
+      const snapshotContent = textareaInputRef.current?.value ?? contentRef.current;
+      const snapshotStart = textareaInputRef.current?.selectionStart ?? lastCursorRef.current;
+      const snapshotEnd =
+        textareaInputRef.current?.selectionEnd ??
+        Math.max(snapshotStart, lastSelectionEndRef.current);
+      const payloadSnapshot = {
+        before: snapshotContent.slice(0, snapshotStart),
+        after: snapshotContent.slice(snapshotEnd),
+        images: getImagesForSend(),
+      };
       setIsTranscribing(true);
       try {
         const recording = await voiceRecorder.stop();
@@ -592,7 +644,10 @@ export default function MessageInput({
             payloadSnapshot
           );
           if (delivered.ok) toast.info(delivered.message);
-          else toast.error('Voice transcript could not be delivered — it was lost');
+          else
+            toast.error(
+              delivered.message || 'Voice transcript could not be delivered — it was lost'
+            );
         } else if (mountedRef.current) {
           // Backend heard nothing it could transcribe — say so instead of
           // silently returning to an empty composer.

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -105,9 +105,15 @@ const COMPOSER_CHAR_LIMIT = 100000;
  * selection — a selection gets replaced), applying the spacing/CJK rules at
  * both boundaries and capping to the composer character limit. Shared by the
  * live mounted insert and the unmounted delivery so both place the transcript
- * identically.
+ * identically. `fullyInserted` reports whether the whole transcript fit —
+ * never infer that from the result string, which may already contain the same
+ * phrase elsewhere in the draft.
  */
-function buildTranscriptInsertion(before: string, after: string, transcript: string): string {
+function buildTranscriptInsertion(
+  before: string,
+  after: string,
+  transcript: string
+): { value: string; fullyInserted: boolean } {
   const needsLeadingSpace =
     before.length > 0 &&
     !suppressLeadingSpace(before) &&
@@ -123,7 +129,10 @@ function buildTranscriptInsertion(before: string, after: string, transcript: str
   const inserted = `${needsLeadingSpace ? ' ' : ''}${transcript}${needsTrailingSpace ? ' ' : ''}`;
   const remaining = COMPOSER_CHAR_LIMIT - before.length - after.length;
   const cappedInserted = remaining <= 0 ? '' : inserted.slice(0, remaining);
-  return before + cappedInserted + after;
+  return {
+    value: before + cappedInserted + after,
+    fullyInserted: cappedInserted === inserted,
+  };
 }
 
 function getPlaceholderForSessionType(sessionType?: SessionType): string {
@@ -431,7 +440,7 @@ export default function MessageInput({
         Math.max(selectionStart, lastSelectionEndRef.current);
       const before = currentContent.slice(0, selectionStart);
       const after = currentContent.slice(selectionEnd);
-      const nextValue = buildTranscriptInsertion(before, after, transcript);
+      const { value: nextValue } = buildTranscriptInsertion(before, after, transcript);
       setContent(nextValue);
       const nextCursor = selectionStart + (nextValue.length - before.length - after.length);
       setTimeout(() => {
@@ -502,11 +511,18 @@ export default function MessageInput({
       transcript: string,
       mode: 'stay' | 'send' | 'queue',
       // Snapshot of the composer payload taken at click time (while still
-      // mounted): the draft split at the captured caret/selection, plus
-      // images. The unmounted delivery can't read the live
-      // draft/attachments, so it sends what was here when the user clicked,
-      // matching the mounted path that submits the complete composer.
-      payload: { before: string; after: string; images?: MessageImage[] }
+      // mounted): the draft split at the captured caret/selection, images, and
+      // the composer's own bound `onSend`. The unmounted delivery can't read
+      // the live draft/attachments — it sends what was here when the user
+      // clicked, through the SAME send function the mounted path uses (so
+      // worktree-choice setup, task-composer routing, and error handling all
+      // apply), rather than a bare message.send RPC that would bypass them.
+      payload: {
+        before: string;
+        after: string;
+        images?: MessageImage[];
+        send: MessageInputProps['onSend'];
+      }
     ): Promise<{ ok: boolean; message: string }> => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return { ok: false, message: '' };
@@ -527,9 +543,15 @@ export default function MessageInput({
       // Splice the transcript at the captured selection like the mounted path;
       // if the composer was already at its character limit the transcript
       // cannot fit — do not silently send an incomplete payload, retain the
-      // transcript in the pending draft field instead.
-      const content = buildTranscriptInsertion(payload.before, payload.after, transcript);
-      if (!content.includes(transcript)) {
+      // transcript in the pending draft field instead. fullyInserted comes
+      // from the insertion helper, not a substring search of the draft (which
+      // the same phrase elsewhere in the draft would defeat).
+      const { value: content, fullyInserted } = buildTranscriptInsertion(
+        payload.before,
+        payload.after,
+        transcript
+      );
+      if (!fullyInserted) {
         try {
           await stageToDraft();
           return {
@@ -541,27 +563,34 @@ export default function MessageInput({
         }
       }
       const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
+      let sent: void | boolean;
       try {
-        await hub.request('message.send', {
-          sessionId: targetSessionId,
-          content,
-          images: payload.images,
-          deliveryMode,
-        });
+        sent = await payload.send(content, payload.images, deliveryMode);
       } catch {
         return { ok: false, message: '' };
       }
+      if (sent === false) return { ok: false, message: '' };
       // Consume the click-time draft so reopening the session doesn't show —
       // and re-send — text that was just delivered. Parity with the mounted
-      // submit, which clears the composer. Best-effort: a failure here doesn't
-      // undo the send above.
-      try {
-        await hub.request('session.update', {
-          sessionId: targetSessionId,
-          metadata: { inputDraft: null },
-        });
-      } catch {
-        /* ignore — the send already succeeded */
+      // submit, which clears the composer. Clear ONLY if the persisted draft
+      // still matches the click-time snapshot: if the user edited it after we
+      // snapshotted (reopened the session, another client), their newer text
+      // wins. Best-effort — a failure here doesn't undo the send.
+      if ((payload.before + payload.after).trim().length > 0) {
+        try {
+          const response = await hub.request<{
+            session?: { metadata?: { inputDraft?: string | null } };
+          }>('session.get', { sessionId: targetSessionId });
+          const persisted = response.session?.metadata?.inputDraft ?? '';
+          if (persisted === payload.before + payload.after) {
+            await hub.request('session.update', {
+              sessionId: targetSessionId,
+              metadata: { inputDraft: null },
+            });
+          }
+        } catch {
+          /* ignore — the send already succeeded */
+        }
       }
       return {
         ok: true,
@@ -602,6 +631,10 @@ export default function MessageInput({
         before: snapshotContent.slice(0, snapshotStart),
         after: snapshotContent.slice(snapshotEnd),
         images: getImagesForSend(),
+        // The composer's own send function — invoked post-unmount through this
+        // closure, it reproduces the FULL mounted send semantics (worktree
+        // choice setup, task-composer routing) instead of a bare RPC.
+        send: onSend,
       };
       setIsTranscribing(true);
       try {
@@ -666,6 +699,7 @@ export default function MessageInput({
       deliverUnmountedTranscript,
       getImagesForSend,
       isTranscribing,
+      onSend,
       voiceRecorder,
       sessionId,
     ]

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -478,6 +478,47 @@ export default function MessageInput({
   // The session the CURRENT recording was started for (null when idle).
   const recordingSessionRef = useRef<string | null>(null);
 
+  // A transcription can complete AFTER the composer unmounted — the user clicked
+  // Send/Stop then navigated to another session while the (up to 125s) RPC was
+  // in flight. insertTranscript writes through the live draft signal + textarea,
+  // neither of which exists once the keyed ChatContainer is gone, so persist the
+  // transcript straight to the target session's server-side draft instead. That
+  // draft survives navigation and is reloaded by useInputDraft when they return,
+  // so the dictated text is waiting for them rather than silently dropped.
+  const persistTranscriptToDraft = useCallback(
+    async (targetSessionId: string, transcript: string) => {
+      const hub = connectionManager.getHubIfConnected();
+      if (!hub) return;
+      try {
+        const response = await hub.request<{ session?: { metadata?: { inputDraft?: string } } }>(
+          'session.get',
+          { sessionId: targetSessionId }
+        );
+        const existing = (response.session?.metadata?.inputDraft ?? '').trim();
+        // No live caret when unmounted, so append to the end of any existing
+        // draft using the same spacing/CJK rules as insertTranscript.
+        const needsSpace =
+          existing.length > 0 &&
+          !suppressLeadingSpace(existing) &&
+          !/^\s/.test(transcript) &&
+          !isCjk(existing.slice(-1)) &&
+          !isCjk(transcript[0]);
+        const merged = `${existing}${needsSpace ? ' ' : ''}${transcript}`.slice(
+          0,
+          COMPOSER_CHAR_LIMIT
+        );
+        await hub.request('session.update', {
+          sessionId: targetSessionId,
+          metadata: { inputDraft: merged },
+        });
+      } catch {
+        // Best-effort: if persistence fails there is no mounted UI to recover
+        // into, and the toast already told the user we saved it.
+      }
+    },
+    []
+  );
+
   const stopAndTranscribe = useCallback(
     // 'stay' leaves the transcript in the composer; 'send' auto-submits it
     // (immediate send, or steer when the agent is working); 'queue' defers it
@@ -520,6 +561,14 @@ export default function MessageInput({
           // Only queue an auto-send when the transcript produced text; the
           // effect below fires it after isTranscribing flips false.
           if (mode !== 'stay') pendingAutoSendRef.current = { sessionId: targetSessionId, mode };
+        } else if (transcript) {
+          // Composer unmounted (user navigated away) while this transcription
+          // was in flight. Persist the transcript to the target session's
+          // server-side draft so it survives navigation instead of being
+          // silently dropped. Auto-send can't fire with no mounted composer;
+          // for now the text lands as a ready-to-send draft.
+          void persistTranscriptToDraft(targetSessionId, transcript);
+          toast.info('Voice transcript saved to the session draft');
         } else if (mountedRef.current) {
           // Backend heard nothing it could transcribe — say so instead of
           // silently returning to an empty composer.
@@ -533,7 +582,7 @@ export default function MessageInput({
         setIsTranscribing(false);
       }
     },
-    [insertTranscript, isTranscribing, voiceRecorder, sessionId]
+    [insertTranscript, persistTranscriptToDraft, isTranscribing, voiceRecorder, sessionId]
   );
 
   // Cancel discards the recording AND its pinned target session.

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -533,13 +533,19 @@ export default function MessageInput({
           text: transcript,
         });
       };
-      if (mode === 'stay') {
+      // Last-resort preservation: stage the transcript into the pending draft
+      // field. Used for 'stay', for a composer too full to splice into, and as
+      // the fallback when the send path fails — never destroy the only copy.
+      const stageFallback = async (message: string): Promise<{ ok: boolean; message: string }> => {
         try {
           await stageToDraft();
-          return { ok: true, message: 'Voice transcript saved to the session draft' };
+          return { ok: true, message };
         } catch {
           return { ok: false, message: '' };
         }
+      };
+      if (mode === 'stay') {
+        return stageFallback('Voice transcript saved to the session draft');
       }
       // Splice the transcript at the captured selection like the mounted path;
       // if the composer was already at its character limit the transcript
@@ -553,24 +559,24 @@ export default function MessageInput({
         transcript
       );
       if (!fullyInserted) {
-        try {
-          await stageToDraft();
-          return {
-            ok: true,
-            message: 'Composer draft is full — voice transcript saved to the session draft',
-          };
-        } catch {
-          return { ok: false, message: '' };
-        }
+        return stageFallback(
+          'Composer draft is full — voice transcript saved to the session draft'
+        );
       }
       const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
       let sent: void | boolean;
       try {
         sent = await payload.send(content, payload.images, deliveryMode);
       } catch {
-        return { ok: false, message: '' };
+        // The send path failed (e.g. a task composer declining while its
+        // target agent is still starting). Preserve the only copy of the
+        // transcript by staging it into the session draft rather than
+        // destroying it.
+        return stageFallback('Voice send failed — transcript saved to the session draft');
       }
-      if (sent === false) return { ok: false, message: '' };
+      if (sent === false) {
+        return stageFallback('Voice send failed — transcript saved to the session draft');
+      }
       // Consume the click-time draft so reopening the session doesn't show —
       // and re-send — text that was just delivered. Parity with the mounted
       // submit, which clears the composer. The daemon-side clearInputDraftIf

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -525,9 +525,13 @@ export default function MessageInput({
         send: MessageInputProps['onSend'];
       }
     ): Promise<{ ok: boolean; message: string }> => {
-      const hub = connectionManager.getHubIfConnected();
-      if (!hub) return { ok: false, message: '' };
+      // NOTE: no upfront hub gate here. The captured `payload.send` owns its
+      // offline delivery (useSendMessage queues disconnected sends for retry),
+      // so a missing hub must not prevent attempting it — only the staging and
+      // clearing RPCs below require a connection.
       const stageToDraft = async () => {
+        const hub = connectionManager.getHubIfConnected();
+        if (!hub) throw new Error('Not connected');
         await hub.request('session.appendVoiceDraft', {
           sessionId: targetSessionId,
           text: transcript,
@@ -585,13 +589,16 @@ export default function MessageInput({
       // edits saved after the snapshot win. Best-effort: a failure here doesn't
       // undo the send.
       if (payload.full.trim().length > 0) {
-        try {
-          await hub.request('session.clearInputDraftIf', {
-            sessionId: targetSessionId,
-            expected: payload.full,
-          });
-        } catch {
-          /* ignore — the send already succeeded */
+        const hub = connectionManager.getHubIfConnected();
+        if (hub) {
+          try {
+            await hub.request('session.clearInputDraftIf', {
+              sessionId: targetSessionId,
+              expected: payload.full,
+            });
+          } catch {
+            /* ignore — the send already succeeded */
+          }
         }
       }
       return {

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -481,39 +481,22 @@ export default function MessageInput({
   // A transcription can complete AFTER the composer unmounted — the user clicked
   // Send/Stop then navigated to another session while the (up to 125s) RPC was
   // in flight. insertTranscript writes through the live draft signal + textarea,
-  // neither of which exists once the keyed ChatContainer is gone, so persist the
-  // transcript straight to the target session's server-side draft instead. That
-  // draft survives navigation and is reloaded by useInputDraft when they return,
-  // so the dictated text is waiting for them rather than silently dropped.
+  // neither of which exists once the keyed ChatContainer is gone. Delegate to the
+  // daemon's atomic `session.appendInputDraft` (not a client read-modify-write,
+  // which could clobber a draft the user edited after returning) and report
+  // success/failure so the toast never claims a save that did not happen.
   const persistTranscriptToDraft = useCallback(
-    async (targetSessionId: string, transcript: string) => {
+    async (targetSessionId: string, transcript: string): Promise<boolean> => {
       const hub = connectionManager.getHubIfConnected();
-      if (!hub) return;
+      if (!hub) return false;
       try {
-        const response = await hub.request<{ session?: { metadata?: { inputDraft?: string } } }>(
-          'session.get',
-          { sessionId: targetSessionId }
-        );
-        const existing = (response.session?.metadata?.inputDraft ?? '').trim();
-        // No live caret when unmounted, so append to the end of any existing
-        // draft using the same spacing/CJK rules as insertTranscript.
-        const needsSpace =
-          existing.length > 0 &&
-          !suppressLeadingSpace(existing) &&
-          !/^\s/.test(transcript) &&
-          !isCjk(existing.slice(-1)) &&
-          !isCjk(transcript[0]);
-        const merged = `${existing}${needsSpace ? ' ' : ''}${transcript}`.slice(
-          0,
-          COMPOSER_CHAR_LIMIT
-        );
-        await hub.request('session.update', {
+        await hub.request('session.appendInputDraft', {
           sessionId: targetSessionId,
-          metadata: { inputDraft: merged },
+          text: transcript,
         });
+        return true;
       } catch {
-        // Best-effort: if persistence fails there is no mounted UI to recover
-        // into, and the toast already told the user we saved it.
+        return false;
       }
     },
     []
@@ -563,12 +546,14 @@ export default function MessageInput({
           if (mode !== 'stay') pendingAutoSendRef.current = { sessionId: targetSessionId, mode };
         } else if (transcript) {
           // Composer unmounted (user navigated away) while this transcription
-          // was in flight. Persist the transcript to the target session's
-          // server-side draft so it survives navigation instead of being
-          // silently dropped. Auto-send can't fire with no mounted composer;
-          // for now the text lands as a ready-to-send draft.
-          void persistTranscriptToDraft(targetSessionId, transcript);
-          toast.info('Voice transcript saved to the session draft');
+          // was in flight. Append the transcript to the target session's draft
+          // atomically on the server so it survives navigation instead of being
+          // silently dropped. Auto-send can't fire with no mounted composer; for
+          // now the text lands as a ready-to-send draft. Await the result so the
+          // toast reflects whether the save actually happened.
+          const saved = await persistTranscriptToDraft(targetSessionId, transcript);
+          if (saved) toast.info('Voice transcript saved to the session draft');
+          else toast.error('Voice transcript could not be saved — it was lost');
         } else if (mountedRef.current) {
           // Backend heard nothing it could transcribe — say so instead of
           // silently returning to an empty composer.

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -481,16 +481,18 @@ export default function MessageInput({
   // A transcription can complete AFTER the composer unmounted — the user clicked
   // Send/Stop then navigated to another session while the (up to 125s) RPC was
   // in flight. insertTranscript writes through the live draft signal + textarea,
-  // neither of which exists once the keyed ChatContainer is gone. Delegate to the
-  // daemon's atomic `session.appendInputDraft` (not a client read-modify-write,
-  // which could clobber a draft the user edited after returning) and report
-  // success/failure so the toast never claims a save that did not happen.
+  // neither of which exists once the keyed ChatContainer is gone. Stage the
+  // transcript into the session's dedicated `inputDraftVoicePending` field (via
+  // `session.appendVoiceDraft`) — NOT the live inputDraft, which the client's
+  // debounced saves could clobber — and report success/failure so the toast
+  // never claims a save that did not happen. useInputDraft merges the pending
+  // field into the draft once when the session is next loaded.
   const persistTranscriptToDraft = useCallback(
     async (targetSessionId: string, transcript: string): Promise<boolean> => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return false;
       try {
-        await hub.request('session.appendInputDraft', {
+        await hub.request('session.appendVoiceDraft', {
           sessionId: targetSessionId,
           text: transcript,
         });

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -17,6 +17,7 @@ import type {
 } from '@hyperneo/shared';
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { appendDraftText } from '@hyperneo/shared';
 import {
   useCommandAutocomplete,
   useFileAttachments,
@@ -492,7 +493,13 @@ export default function MessageInput({
     async (
       targetSessionId: string,
       transcript: string,
-      mode: 'stay' | 'send' | 'queue'
+      mode: 'stay' | 'send' | 'queue',
+      // Snapshot of the composer payload taken at click time (while still
+      // mounted). The unmounted delivery can't read the live draft/attachments,
+      // so it sends what was here when the user clicked — matching the mounted
+      // path, which submits the complete composer. The transcript is appended
+      // (the caret position is unknown once unmounted).
+      payload: { content: string; images?: MessageImage[] }
     ): Promise<{ ok: boolean; message: string }> => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return { ok: false, message: '' };
@@ -507,7 +514,8 @@ export default function MessageInput({
         const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
         await hub.request('message.send', {
           sessionId: targetSessionId,
-          content: transcript,
+          content: appendDraftText(payload.content, transcript),
+          images: payload.images,
           deliveryMode,
         });
         return {
@@ -538,6 +546,11 @@ export default function MessageInput({
       // composer has since been re-targeted, the transcript is discarded with a
       // toast instead of landing in — or auto-sending to — another session.
       const targetSessionId = recordingSessionRef.current ?? sessionId;
+      // Snapshot the full outgoing payload NOW (mounted, click time). If the
+      // user navigates away during transcription, the unmounted delivery path
+      // can't read the live draft/attachments — it must send what was here when
+      // they clicked, matching the mounted path that submits the whole composer.
+      const payloadSnapshot = { content: contentRef.current, images: getImagesForSend() };
       setIsTranscribing(true);
       try {
         const recording = await voiceRecorder.stop();
@@ -572,7 +585,12 @@ export default function MessageInput({
           // — send/queue as a real message, stay staged into the pending field
           // (merged into the draft atomically by the daemon on next get) — so it
           // is never silently lost. Await so the toast reflects the outcome.
-          const delivered = await deliverUnmountedTranscript(targetSessionId, transcript, mode);
+          const delivered = await deliverUnmountedTranscript(
+            targetSessionId,
+            transcript,
+            mode,
+            payloadSnapshot
+          );
           if (delivered.ok) toast.info(delivered.message);
           else toast.error('Voice transcript could not be delivered — it was lost');
         } else if (mountedRef.current) {
@@ -588,7 +606,14 @@ export default function MessageInput({
         setIsTranscribing(false);
       }
     },
-    [insertTranscript, deliverUnmountedTranscript, isTranscribing, voiceRecorder, sessionId]
+    [
+      insertTranscript,
+      deliverUnmountedTranscript,
+      getImagesForSend,
+      isTranscribing,
+      voiceRecorder,
+      sessionId,
+    ]
   );
 
   // Cancel discards the recording AND its pinned target session.

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -478,27 +478,47 @@ export default function MessageInput({
   // The session the CURRENT recording was started for (null when idle).
   const recordingSessionRef = useRef<string | null>(null);
 
-  // A transcription can complete AFTER the composer unmounted — the user clicked
-  // Send/Stop then navigated to another session while the (up to 125s) RPC was
-  // in flight. insertTranscript writes through the live draft signal + textarea,
-  // neither of which exists once the keyed ChatContainer is gone. Stage the
-  // transcript into the session's dedicated `inputDraftVoicePending` field (via
-  // `session.appendVoiceDraft`) — NOT the live inputDraft, which the client's
-  // debounced saves could clobber — and report success/failure so the toast
-  // never claims a save that did not happen. useInputDraft merges the pending
-  // field into the draft once when the session is next loaded.
-  const persistTranscriptToDraft = useCallback(
-    async (targetSessionId: string, transcript: string): Promise<boolean> => {
+  // Deliver a transcript whose composer has already unmounted (the user clicked
+  // Send/Stop then navigated to another session while the up-to-125s RPC was in
+  // flight). Auto-send can't run with no mounted composer, so route by mode:
+  //  - send/queue: send straight to the session as a real message. No draft is
+  //    involved, so there is nothing for a stale client snapshot to clobber —
+  //    this is the reported "I clicked Send then switched sessions" case.
+  //  - stay: stage in the `inputDraftVoicePending` field; the daemon merges it
+  //    into the draft atomically on the next session.get.
+  // Reports success/failure so the toast never claims a delivery that did not
+  // happen.
+  const deliverUnmountedTranscript = useCallback(
+    async (
+      targetSessionId: string,
+      transcript: string,
+      mode: 'stay' | 'send' | 'queue'
+    ): Promise<{ ok: boolean; message: string }> => {
       const hub = connectionManager.getHubIfConnected();
-      if (!hub) return false;
+      if (!hub) return { ok: false, message: '' };
       try {
-        await hub.request('session.appendVoiceDraft', {
+        if (mode === 'stay') {
+          await hub.request('session.appendVoiceDraft', {
+            sessionId: targetSessionId,
+            text: transcript,
+          });
+          return { ok: true, message: 'Voice transcript saved to the session draft' };
+        }
+        const deliveryMode: MessageDeliveryMode = mode === 'queue' ? 'defer' : 'immediate';
+        await hub.request('message.send', {
           sessionId: targetSessionId,
-          text: transcript,
+          content: transcript,
+          deliveryMode,
         });
-        return true;
+        return {
+          ok: true,
+          message:
+            mode === 'queue'
+              ? 'Voice transcript queued for the next turn'
+              : 'Voice transcript sent',
+        };
       } catch {
-        return false;
+        return { ok: false, message: '' };
       }
     },
     []
@@ -548,14 +568,13 @@ export default function MessageInput({
           if (mode !== 'stay') pendingAutoSendRef.current = { sessionId: targetSessionId, mode };
         } else if (transcript) {
           // Composer unmounted (user navigated away) while this transcription
-          // was in flight. Append the transcript to the target session's draft
-          // atomically on the server so it survives navigation instead of being
-          // silently dropped. Auto-send can't fire with no mounted composer; for
-          // now the text lands as a ready-to-send draft. Await the result so the
-          // toast reflects whether the save actually happened.
-          const saved = await persistTranscriptToDraft(targetSessionId, transcript);
-          if (saved) toast.info('Voice transcript saved to the session draft');
-          else toast.error('Voice transcript could not be saved — it was lost');
+          // was in flight. Deliver the transcript directly to the target session
+          // — send/queue as a real message, stay staged into the pending field
+          // (merged into the draft atomically by the daemon on next get) — so it
+          // is never silently lost. Await so the toast reflects the outcome.
+          const delivered = await deliverUnmountedTranscript(targetSessionId, transcript, mode);
+          if (delivered.ok) toast.info(delivered.message);
+          else toast.error('Voice transcript could not be delivered — it was lost');
         } else if (mountedRef.current) {
           // Backend heard nothing it could transcribe — say so instead of
           // silently returning to an empty composer.
@@ -569,7 +588,7 @@ export default function MessageInput({
         setIsTranscribing(false);
       }
     },
-    [insertTranscript, persistTranscriptToDraft, isTranscribing, voiceRecorder, sessionId]
+    [insertTranscript, deliverUnmountedTranscript, isTranscribing, voiceRecorder, sessionId]
   );
 
   // Cancel discards the recording AND its pinned target session.

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -520,6 +520,7 @@ export default function MessageInput({
       payload: {
         before: string;
         after: string;
+        full: string;
         images?: MessageImage[];
         send: MessageInputProps['onSend'];
       }
@@ -572,22 +573,17 @@ export default function MessageInput({
       if (sent === false) return { ok: false, message: '' };
       // Consume the click-time draft so reopening the session doesn't show —
       // and re-send — text that was just delivered. Parity with the mounted
-      // submit, which clears the composer. Clear ONLY if the persisted draft
-      // still matches the click-time snapshot: if the user edited it after we
-      // snapshotted (reopened the session, another client), their newer text
-      // wins. Best-effort — a failure here doesn't undo the send.
-      if ((payload.before + payload.after).trim().length > 0) {
+      // submit, which clears the composer. The daemon-side clearInputDraftIf
+      // compares and clears ATOMICALLY and only when the persisted draft still
+      // equals the complete click-time snapshot (selection included) — newer
+      // edits saved after the snapshot win. Best-effort: a failure here doesn't
+      // undo the send.
+      if (payload.full.trim().length > 0) {
         try {
-          const response = await hub.request<{
-            session?: { metadata?: { inputDraft?: string | null } };
-          }>('session.get', { sessionId: targetSessionId });
-          const persisted = response.session?.metadata?.inputDraft ?? '';
-          if (persisted === payload.before + payload.after) {
-            await hub.request('session.update', {
-              sessionId: targetSessionId,
-              metadata: { inputDraft: null },
-            });
-          }
+          await hub.request('session.clearInputDraftIf', {
+            sessionId: targetSessionId,
+            expected: payload.full,
+          });
         } catch {
           /* ignore — the send already succeeded */
         }
@@ -630,6 +626,9 @@ export default function MessageInput({
       const payloadSnapshot = {
         before: snapshotContent.slice(0, snapshotStart),
         after: snapshotContent.slice(snapshotEnd),
+        // Complete click-time content (includes any selected text) — compared
+        // against the persisted draft by the atomic post-send clear.
+        full: snapshotContent,
         images: getImagesForSend(),
         // The composer's own send function — invoked post-unmount through this
         // closure, it reproduces the FULL mounted send semantics (worktree

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -128,19 +128,25 @@ describe('MessageInput — recording UI', () => {
     voiceCancel.mockClear();
     transcribeRequest.mockClear();
     hubRequest.mockClear();
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn(() => 0)
+    // Timer-backed rAF so deferred hook work actually runs and can be drained
+    // before the stubs are removed. A no-op stub leaves Preact cleanup pending
+    // until after unstubAllGlobals, where cancelAnimationFrame no longer exists
+    // — an unhandled ReferenceError that blocks CI even with green tests.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) =>
+      setTimeout(() => cb(0), 0)
     );
-    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal('cancelAnimationFrame', (id: ReturnType<typeof setTimeout>) => clearTimeout(id));
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockReturnValue({ matches: false }),
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    // Drain rAF-backed timers while the stubs are still installed so pending
+    // hook cleanups settle before unstubAllGlobals removes cancelAnimationFrame.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.unstubAllGlobals();
   });
 

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -170,7 +170,7 @@ describe('MessageInput — recording UI', () => {
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello world', undefined, 'immediate'));
   });
 
-  it('persists the transcript to the session draft when the composer unmounts mid-transcription', async () => {
+  it('appends the transcript to the session draft when the composer unmounts mid-transcription', async () => {
     // Slow transcription: resolve only after the composer has unmounted, so the
     // completion runs against mountedRef === false (the keyed ChatContainer is
     // gone), mirroring a user who clicks Send then navigates to another session.
@@ -179,14 +179,6 @@ describe('MessageInput — recording UI', () => {
       resolveTranscribe = resolve;
     });
     transcribeRequest.mockReturnValueOnce(transcribePromise);
-    // The target session already has a draft — the transcript must be appended
-    // to it, not replace it. Only voice.transcribe is deferred.
-    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
-      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
-      if (method === 'session.get')
-        return { session: { metadata: { inputDraft: 'existing draft' } } };
-      return {};
-    });
 
     const onSend = vi.fn(async () => {});
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
@@ -199,17 +191,50 @@ describe('MessageInput — recording UI', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     resolveTranscribe({ text: 'hello world' });
 
-    // The transcript is appended to s1's server-side draft — not silently lost.
+    // The transcript is appended server-side via the atomic append RPC — not
+    // silently lost, and no client read-modify-write that could clobber the
+    // draft. The spacing/merge lives in the daemon.
     await waitFor(() => {
-      const updateCall = hubRequest.mock.calls.find(([m]) => m === 'session.update');
-      expect(updateCall).toBeTruthy();
-      expect(updateCall[1]).toMatchObject({
-        sessionId: 's1',
-        metadata: { inputDraft: 'existing draft hello world' },
-      });
+      const appendCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendInputDraft');
+      expect(appendCall).toBeTruthy();
+      expect(appendCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
     });
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith('Voice transcript saved to the session draft')
+    );
     // No mounted composer to auto-submit through, so it is preserved as a draft
     // rather than sent. (Background send delivery is a follow-up.)
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure toast (not a false "saved") when draft persistence fails after unmount', async () => {
+    let resolveTranscribe!: (value: { text: string }) => void;
+    transcribeRequest.mockReturnValueOnce(
+      new Promise<{ text: string }>((resolve) => {
+        resolveTranscribe = resolve;
+      })
+    );
+    // The atomic append RPC fails (e.g. socket dropped) — the toast must NOT
+    // claim success, and there is no mounted composer to fall back to.
+    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
+      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
+      if (method === 'session.appendInputDraft') throw new Error('boom');
+      return {};
+    });
+
+    const onSend = vi.fn(async () => {});
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveTranscribe({ text: 'hello world' });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Voice transcript could not be saved — it was lost')
+    );
+    expect(toast.info).not.toHaveBeenCalled();
     expect(onSend).not.toHaveBeenCalled();
 
     // Restore the default dispatch so later tests aren't affected.

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -195,7 +195,7 @@ describe('MessageInput — recording UI', () => {
     // silently lost, and no client read-modify-write that could clobber the
     // draft. The spacing/merge lives in the daemon.
     await waitFor(() => {
-      const appendCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendInputDraft');
+      const appendCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
       expect(appendCall).toBeTruthy();
       expect(appendCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
     });
@@ -218,7 +218,7 @@ describe('MessageInput — recording UI', () => {
     // claim success, and there is no mounted composer to fall back to.
     hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
       if (method === 'voice.transcribe') return transcribeRequest(method, payload);
-      if (method === 'session.appendInputDraft') throw new Error('boom');
+      if (method === 'session.appendVoiceDraft') throw new Error('boom');
       return {};
     });
 

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -187,9 +187,15 @@ describe('MessageInput — recording UI', () => {
       })
     );
 
-    const onSend = vi.fn(async () => {});
-    // The user already typed some draft text before voice-Sending.
+    const onSend = vi.fn(async () => true);
+    // The user already typed some draft text before voice-Sending. The server
+    // draft still matches it, so the post-send clear applies.
     draft.value = 'note:';
+    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
+      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
+      if (method === 'session.get') return { session: { metadata: { inputDraft: 'note:' } } };
+      return {};
+    });
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
 
     fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
@@ -201,20 +207,16 @@ describe('MessageInput — recording UI', () => {
     resolveTranscribe({ text: 'hello world' });
 
     // send mode delivers the FULL click-time payload (draft + transcript
-    // spliced at the captured caret), not just the transcript. This harness
-    // never captures a caret (no input events fire), so the insertion point
-    // defaults to the start of the draft.
-    await waitFor(() => {
-      const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
-      expect(sendCall).toBeTruthy();
-      expect(sendCall[1]).toEqual({
-        sessionId: 's1',
-        content: 'hello world note:',
-        deliveryMode: 'immediate',
-      });
-    });
+    // spliced at the captured caret) through the composer's OWN captured
+    // onSend — so worktree-choice setup and task-composer routing apply, not a
+    // bare message.send RPC. This harness never captures a caret (no input
+    // events fire), so the insertion point defaults to the start of the draft.
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith('hello world note:', undefined, 'immediate')
+    );
     // The consumed click-time draft is cleared server-side (parity with the
-    // mounted submit clearing the composer) so reopening doesn't re-send it.
+    // mounted submit clearing the composer) because the persisted draft still
+    // matches the click-time snapshot — so reopening doesn't re-send it.
     await waitFor(() => {
       const clearCall = hubRequest.mock.calls.find(
         ([m, p]) => m === 'session.update' && p && p.metadata && p.metadata.inputDraft === null
@@ -222,9 +224,12 @@ describe('MessageInput — recording UI', () => {
       expect(clearCall).toBeTruthy();
     });
     await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Voice transcript sent'));
-    // The mounted composer's onSend is bypassed (no composer to drive it); the
-    // transcript is delivered directly via message.send instead.
-    expect(onSend).not.toHaveBeenCalled();
+
+    // Restore the default dispatch so later tests aren't affected.
+    hubRequest.mockImplementation(async (method: string, ...rest: unknown[]) => {
+      if (method === 'voice.transcribe') return transcribeRequest(method, ...rest);
+      return {};
+    });
   });
 
   it('retains the transcript in the pending draft instead of sending when the composer is at the character limit', async () => {
@@ -235,7 +240,7 @@ describe('MessageInput — recording UI', () => {
       })
     );
 
-    const onSend = vi.fn(async () => {});
+    const onSend = vi.fn(async () => true);
     // Draft already at the composer's 100k character limit.
     draft.value = 'x'.repeat(100_000);
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
@@ -253,8 +258,6 @@ describe('MessageInput — recording UI', () => {
         'Composer draft is full — voice transcript saved to the session draft'
       )
     );
-    const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
-    expect(sendCall).toBeFalsy();
     const stageCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
     expect(stageCall).toBeTruthy();
     expect(stageCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
@@ -299,15 +302,11 @@ describe('MessageInput — recording UI', () => {
         resolveTranscribe = resolve;
       })
     );
-    // The send RPC fails (e.g. socket dropped) — the toast must NOT claim
-    // success, and there is no mounted composer to fall back to.
-    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
-      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
-      if (method === 'message.send') throw new Error('boom');
-      return {};
+    // The composer's own send path fails (e.g. socket dropped) — the toast
+    // must NOT claim success, and there is no mounted composer to retry in.
+    const onSend = vi.fn(async () => {
+      throw new Error('boom');
     });
-
-    const onSend = vi.fn(async () => {});
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
 
     fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
@@ -322,13 +321,11 @@ describe('MessageInput — recording UI', () => {
       )
     );
     expect(toast.info).not.toHaveBeenCalled();
-    expect(onSend).not.toHaveBeenCalled();
-
-    // Restore the default dispatch so later tests aren't affected.
-    hubRequest.mockImplementation(async (method: string, ...rest: unknown[]) => {
-      if (method === 'voice.transcribe') return transcribeRequest(method, ...rest);
-      return {};
-    });
+    // The draft is NOT cleared when the send failed — the text is still staged.
+    const clearCall = hubRequest.mock.calls.find(
+      ([m, p]) => m === 'session.update' && p && p.metadata && p.metadata.inputDraft === null
+    );
+    expect(clearCall).toBeFalsy();
   });
 
   it('Cancel discards the recording without transcribing', async () => {

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -112,10 +112,11 @@ vi.mock('../../hooks', () => ({
 }));
 
 vi.mock('../../lib/connection-manager', () => ({
-  connectionManager: { getHubIfConnected: () => ({ request: hubRequest }) },
+  connectionManager: { getHubIfConnected: vi.fn(() => ({ request: hubRequest })) },
 }));
 
 import { toast } from '../../lib/toast.ts';
+import { connectionManager } from '../../lib/connection-manager.ts';
 import MessageInput from '../MessageInput';
 
 describe('MessageInput — recording UI', () => {
@@ -136,6 +137,11 @@ describe('MessageInput — recording UI', () => {
       setTimeout(() => cb(0), 0)
     );
     vi.stubGlobal('cancelAnimationFrame', (id: ReturnType<typeof setTimeout>) => clearTimeout(id));
+    // Default: hub connected. Individual tests may override (e.g. disconnect);
+    // mockReset drops any leaked override from a previous test.
+    vi.mocked(connectionManager.getHubIfConnected)
+      .mockReset()
+      .mockImplementation(() => ({ request: hubRequest }));
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockReturnValue({ matches: false }),
@@ -315,6 +321,35 @@ describe('MessageInput — recording UI', () => {
     // The draft is NOT cleared when the send failed — the text is still staged.
     const clearCall = hubRequest.mock.calls.find(([m]) => m === 'session.clearInputDraftIf');
     expect(clearCall).toBeFalsy();
+  });
+
+  it('still delivers through the captured onSend when the hub is disconnected', async () => {
+    // The socket drops AFTER the transcription response arrives but BEFORE
+    // delivery runs — the captured onSend owns offline queueing
+    // (useSendMessage), so delivery must still be attempted rather than
+    // reported as lost.
+    let resolveTranscribe!: (value: { text: string }) => void;
+    transcribeRequest.mockReturnValueOnce(
+      new Promise<{ text: string }>((resolve) => {
+        resolveTranscribe = resolve;
+      })
+    );
+
+    const onSend = vi.fn(async () => true);
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Disconnect only now — transcription already completed over the wire.
+    vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(null);
+    resolveTranscribe({ text: 'hello world' });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello world', undefined, 'immediate'));
+    await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Voice transcript sent'));
+    // No draft to consume (snapshot was empty) and no hub anyway — no clear RPC.
+    expect(hubRequest.mock.calls.find(([m]) => m === 'session.clearInputDraftIf')).toBeFalsy();
   });
 
   it('Cancel discards the recording without transcribing', async () => {

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -170,55 +170,88 @@ describe('MessageInput — recording UI', () => {
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello world', undefined, 'immediate'));
   });
 
-  it('appends the transcript to the session draft when the composer unmounts mid-transcription', async () => {
+  it('delivers the transcript as a sent message (send) when the composer unmounts mid-transcription', async () => {
     // Slow transcription: resolve only after the composer has unmounted, so the
     // completion runs against mountedRef === false (the keyed ChatContainer is
     // gone), mirroring a user who clicks Send then navigates to another session.
-    let resolveTranscribe!: (value: { text: string }) => void;
-    const transcribePromise = new Promise<{ text: string }>((resolve) => {
-      resolveTranscribe = resolve;
-    });
-    transcribeRequest.mockReturnValueOnce(transcribePromise);
-
-    const onSend = vi.fn(async () => {});
-    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
-
-    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
-    // Stop + transcribe request fire while the composer is still mounted...
-    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
-    // ...then the user navigates away BEFORE the slow transcription resolves.
-    unmount();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    resolveTranscribe({ text: 'hello world' });
-
-    // The transcript is appended server-side via the atomic append RPC — not
-    // silently lost, and no client read-modify-write that could clobber the
-    // draft. The spacing/merge lives in the daemon.
-    await waitFor(() => {
-      const appendCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
-      expect(appendCall).toBeTruthy();
-      expect(appendCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
-    });
-    await waitFor(() =>
-      expect(toast.info).toHaveBeenCalledWith('Voice transcript saved to the session draft')
-    );
-    // No mounted composer to auto-submit through, so it is preserved as a draft
-    // rather than sent. (Background send delivery is a follow-up.)
-    expect(onSend).not.toHaveBeenCalled();
-  });
-
-  it('surfaces a failure toast (not a false "saved") when draft persistence fails after unmount', async () => {
     let resolveTranscribe!: (value: { text: string }) => void;
     transcribeRequest.mockReturnValueOnce(
       new Promise<{ text: string }>((resolve) => {
         resolveTranscribe = resolve;
       })
     );
-    // The atomic append RPC fails (e.g. socket dropped) — the toast must NOT
-    // claim success, and there is no mounted composer to fall back to.
+
+    const onSend = vi.fn(async () => {});
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
+    // Stop + transcribe fire while the composer is still mounted...
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    // ...then the user navigates away BEFORE the slow transcription resolves.
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveTranscribe({ text: 'hello world' });
+
+    // send mode delivers straight to the session as a real message — no draft,
+    // so nothing for a stale client snapshot to clobber.
+    await waitFor(() => {
+      const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
+      expect(sendCall).toBeTruthy();
+      expect(sendCall[1]).toEqual({
+        sessionId: 's1',
+        content: 'hello world',
+        deliveryMode: 'immediate',
+      });
+    });
+    await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Voice transcript sent'));
+    // The mounted composer's onSend is bypassed (no composer to drive it); the
+    // transcript is delivered directly via message.send instead.
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('stages the transcript (stay) into the pending draft field when the composer unmounts mid-transcription', async () => {
+    let resolveTranscribe!: (value: { text: string }) => void;
+    transcribeRequest.mockReturnValueOnce(
+      new Promise<{ text: string }>((resolve) => {
+        resolveTranscribe = resolve;
+      })
+    );
+
+    const onSend = vi.fn(async () => {});
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    // 'Stop' (not Send) — the user wanted to edit before sending.
+    fireEvent.click(screen.getByLabelText('Stop recording and transcribe'));
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveTranscribe({ text: 'hello world' });
+
+    // stay stages into the pending field; the daemon merges it into the draft
+    // atomically on the next session.get.
+    await waitFor(() => {
+      const stageCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
+      expect(stageCall).toBeTruthy();
+      expect(stageCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
+    });
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith('Voice transcript saved to the session draft')
+    );
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure toast (not a false "sent") when the unmounted delivery fails', async () => {
+    let resolveTranscribe!: (value: { text: string }) => void;
+    transcribeRequest.mockReturnValueOnce(
+      new Promise<{ text: string }>((resolve) => {
+        resolveTranscribe = resolve;
+      })
+    );
+    // The send RPC fails (e.g. socket dropped) — the toast must NOT claim
+    // success, and there is no mounted composer to fall back to.
     hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
       if (method === 'voice.transcribe') return transcribeRequest(method, payload);
-      if (method === 'session.appendVoiceDraft') throw new Error('boom');
+      if (method === 'message.send') throw new Error('boom');
       return {};
     });
 
@@ -232,7 +265,9 @@ describe('MessageInput — recording UI', () => {
     resolveTranscribe({ text: 'hello world' });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('Voice transcript could not be saved — it was lost')
+      expect(toast.error).toHaveBeenCalledWith(
+        'Voice transcript could not be delivered — it was lost'
+      )
     );
     expect(toast.info).not.toHaveBeenCalled();
     expect(onSend).not.toHaveBeenCalled();

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -115,8 +115,8 @@ vi.mock('../../lib/connection-manager', () => ({
   connectionManager: { getHubIfConnected: () => ({ request: hubRequest }) },
 }));
 
-import MessageInput from '../MessageInput';
 import { toast } from '../../lib/toast.ts';
+import MessageInput from '../MessageInput';
 
 describe('MessageInput — recording UI', () => {
   beforeEach(() => {
@@ -168,6 +168,55 @@ describe('MessageInput — recording UI', () => {
     await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
     // The transcript ('hello world') is auto-submitted once transcription completes.
     await waitFor(() => expect(onSend).toHaveBeenCalledWith('hello world', undefined, 'immediate'));
+  });
+
+  it('persists the transcript to the session draft when the composer unmounts mid-transcription', async () => {
+    // Slow transcription: resolve only after the composer has unmounted, so the
+    // completion runs against mountedRef === false (the keyed ChatContainer is
+    // gone), mirroring a user who clicks Send then navigates to another session.
+    let resolveTranscribe!: (value: { text: string }) => void;
+    const transcribePromise = new Promise<{ text: string }>((resolve) => {
+      resolveTranscribe = resolve;
+    });
+    transcribeRequest.mockReturnValueOnce(transcribePromise);
+    // The target session already has a draft — the transcript must be appended
+    // to it, not replace it. Only voice.transcribe is deferred.
+    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
+      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
+      if (method === 'session.get')
+        return { session: { metadata: { inputDraft: 'existing draft' } } };
+      return {};
+    });
+
+    const onSend = vi.fn(async () => {});
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
+    // Stop + transcribe request fire while the composer is still mounted...
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    // ...then the user navigates away BEFORE the slow transcription resolves.
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveTranscribe({ text: 'hello world' });
+
+    // The transcript is appended to s1's server-side draft — not silently lost.
+    await waitFor(() => {
+      const updateCall = hubRequest.mock.calls.find(([m]) => m === 'session.update');
+      expect(updateCall).toBeTruthy();
+      expect(updateCall[1]).toMatchObject({
+        sessionId: 's1',
+        metadata: { inputDraft: 'existing draft hello world' },
+      });
+    });
+    // No mounted composer to auto-submit through, so it is preserved as a draft
+    // rather than sent. (Background send delivery is a follow-up.)
+    expect(onSend).not.toHaveBeenCalled();
+
+    // Restore the default dispatch so later tests aren't affected.
+    hubRequest.mockImplementation(async (method: string, ...rest: unknown[]) => {
+      if (method === 'voice.transcribe') return transcribeRequest(method, ...rest);
+      return {};
+    });
   });
 
   it('Cancel discards the recording without transcribing', async () => {

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -200,21 +200,64 @@ describe('MessageInput — recording UI', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     resolveTranscribe({ text: 'hello world' });
 
-    // send mode delivers the FULL click-time payload (draft + transcript), not
-    // just the transcript — matching the mounted path that submits the whole
-    // composer.
+    // send mode delivers the FULL click-time payload (draft + transcript
+    // spliced at the captured caret), not just the transcript. This harness
+    // never captures a caret (no input events fire), so the insertion point
+    // defaults to the start of the draft.
     await waitFor(() => {
       const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
       expect(sendCall).toBeTruthy();
       expect(sendCall[1]).toEqual({
         sessionId: 's1',
-        content: 'note: hello world',
+        content: 'hello world note:',
         deliveryMode: 'immediate',
       });
+    });
+    // The consumed click-time draft is cleared server-side (parity with the
+    // mounted submit clearing the composer) so reopening doesn't re-send it.
+    await waitFor(() => {
+      const clearCall = hubRequest.mock.calls.find(
+        ([m, p]) => m === 'session.update' && p && p.metadata && p.metadata.inputDraft === null
+      );
+      expect(clearCall).toBeTruthy();
     });
     await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Voice transcript sent'));
     // The mounted composer's onSend is bypassed (no composer to drive it); the
     // transcript is delivered directly via message.send instead.
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('retains the transcript in the pending draft instead of sending when the composer is at the character limit', async () => {
+    let resolveTranscribe!: (value: { text: string }) => void;
+    transcribeRequest.mockReturnValueOnce(
+      new Promise<{ text: string }>((resolve) => {
+        resolveTranscribe = resolve;
+      })
+    );
+
+    const onSend = vi.fn(async () => {});
+    // Draft already at the composer's 100k character limit.
+    draft.value = 'x'.repeat(100_000);
+    const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
+
+    fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
+    await waitFor(() => expect(transcribeRequest).toHaveBeenCalledTimes(1));
+    unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveTranscribe({ text: 'hello world' });
+
+    // Nothing fits — do not silently send an incomplete payload; retain the
+    // transcript in the pending draft field and say so.
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        'Composer draft is full — voice transcript saved to the session draft'
+      )
+    );
+    const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
+    expect(sendCall).toBeFalsy();
+    const stageCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
+    expect(stageCall).toBeTruthy();
+    expect(stageCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
     expect(onSend).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -289,8 +289,9 @@ describe('MessageInput — recording UI', () => {
         resolveTranscribe = resolve;
       })
     );
-    // The composer's own send path fails (e.g. socket dropped) — the toast
-    // must NOT claim success, and there is no mounted composer to retry in.
+    // The composer's own send path fails (e.g. a task composer declining while
+    // its target agent is still starting) — the transcript must be PRESERVED
+    // via the staging fallback rather than destroyed.
     const onSend = vi.fn(async () => {
       throw new Error('boom');
     });
@@ -303,11 +304,14 @@ describe('MessageInput — recording UI', () => {
     resolveTranscribe({ text: 'hello world' });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        'Voice transcript could not be delivered — it was lost'
+      expect(toast.info).toHaveBeenCalledWith(
+        'Voice send failed — transcript saved to the session draft'
       )
     );
-    expect(toast.info).not.toHaveBeenCalled();
+    // The only copy was staged into the pending field, not lost.
+    const stageCall = hubRequest.mock.calls.find(([m]) => m === 'session.appendVoiceDraft');
+    expect(stageCall).toBeTruthy();
+    expect(stageCall[1]).toEqual({ sessionId: 's1', text: 'hello world' });
     // The draft is NOT cleared when the send failed — the text is still staged.
     const clearCall = hubRequest.mock.calls.find(([m]) => m === 'session.clearInputDraftIf');
     expect(clearCall).toBeFalsy();

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -182,6 +182,8 @@ describe('MessageInput — recording UI', () => {
     );
 
     const onSend = vi.fn(async () => {});
+    // The user already typed some draft text before voice-Sending.
+    draft.value = 'note:';
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
 
     fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
@@ -192,14 +194,15 @@ describe('MessageInput — recording UI', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     resolveTranscribe({ text: 'hello world' });
 
-    // send mode delivers straight to the session as a real message — no draft,
-    // so nothing for a stale client snapshot to clobber.
+    // send mode delivers the FULL click-time payload (draft + transcript), not
+    // just the transcript — matching the mounted path that submits the whole
+    // composer.
     await waitFor(() => {
       const sendCall = hubRequest.mock.calls.find(([m]) => m === 'message.send');
       expect(sendCall).toBeTruthy();
       expect(sendCall[1]).toEqual({
         sessionId: 's1',
-        content: 'hello world',
+        content: 'note: hello world',
         deliveryMode: 'immediate',
       });
     });

--- a/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.voice-recording.test.tsx
@@ -188,14 +188,8 @@ describe('MessageInput — recording UI', () => {
     );
 
     const onSend = vi.fn(async () => true);
-    // The user already typed some draft text before voice-Sending. The server
-    // draft still matches it, so the post-send clear applies.
+    // The user already typed some draft text before voice-Sending.
     draft.value = 'note:';
-    hubRequest.mockImplementation(async (method: string, payload?: unknown) => {
-      if (method === 'voice.transcribe') return transcribeRequest(method, payload);
-      if (method === 'session.get') return { session: { metadata: { inputDraft: 'note:' } } };
-      return {};
-    });
     const { unmount } = render(<MessageInput sessionId="s1" onSend={onSend} />);
 
     fireEvent.click(screen.getByLabelText('Stop, transcribe and send'));
@@ -214,22 +208,15 @@ describe('MessageInput — recording UI', () => {
     await waitFor(() =>
       expect(onSend).toHaveBeenCalledWith('hello world note:', undefined, 'immediate')
     );
-    // The consumed click-time draft is cleared server-side (parity with the
-    // mounted submit clearing the composer) because the persisted draft still
-    // matches the click-time snapshot — so reopening doesn't re-send it.
+    // The consumed click-time draft is cleared ATOMICALLY server-side, only if
+    // the persisted draft still matches the complete click-time snapshot — so
+    // reopening doesn't re-send it, and newer edits elsewhere win.
     await waitFor(() => {
-      const clearCall = hubRequest.mock.calls.find(
-        ([m, p]) => m === 'session.update' && p && p.metadata && p.metadata.inputDraft === null
-      );
+      const clearCall = hubRequest.mock.calls.find(([m]) => m === 'session.clearInputDraftIf');
       expect(clearCall).toBeTruthy();
+      expect(clearCall[1]).toEqual({ sessionId: 's1', expected: 'note:' });
     });
     await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Voice transcript sent'));
-
-    // Restore the default dispatch so later tests aren't affected.
-    hubRequest.mockImplementation(async (method: string, ...rest: unknown[]) => {
-      if (method === 'voice.transcribe') return transcribeRequest(method, ...rest);
-      return {};
-    });
   });
 
   it('retains the transcript in the pending draft instead of sending when the composer is at the character limit', async () => {
@@ -322,9 +309,7 @@ describe('MessageInput — recording UI', () => {
     );
     expect(toast.info).not.toHaveBeenCalled();
     // The draft is NOT cleared when the send failed — the text is still staged.
-    const clearCall = hubRequest.mock.calls.find(
-      ([m, p]) => m === 'session.update' && p && p.metadata && p.metadata.inputDraft === null
-    );
+    const clearCall = hubRequest.mock.calls.find(([m]) => m === 'session.clearInputDraftIf');
     expect(clearCall).toBeFalsy();
   });
 

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -629,9 +629,18 @@ describe('useInputDraft', () => {
       expect(clearCalls).toEqual([]);
     });
 
-    it('retries an explicit draft deletion via the switch flush', async () => {
-      mockHub.request.mockResolvedValue({
-        session: { metadata: { inputDraft: 'loaded draft' } },
+    it('retries an explicit draft deletion via the switch flush when the clear failed', async () => {
+      // First null-clear (the user's deletion) fails; later calls succeed.
+      let deletionRejected = false;
+      mockHub.request.mockImplementation(async (method: string, payload: unknown) => {
+        if (method === 'session.get')
+          return { session: { metadata: { inputDraft: 'loaded draft' } } };
+        const meta = (payload as { metadata?: { inputDraft?: string | null } })?.metadata;
+        if (method === 'session.update' && meta && meta.inputDraft === null && !deletionRejected) {
+          deletionRejected = true;
+          throw new Error('offline');
+        }
+        return {};
       });
       vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
 
@@ -639,7 +648,6 @@ describe('useInputDraft', () => {
         initialProps: { sessionId: 'session-A' },
       });
 
-      // Load settles with content, then the user explicitly deletes the draft.
       await act(async () => {
         await vi.runAllTimersAsync();
       });
@@ -647,11 +655,14 @@ describe('useInputDraft', () => {
       act(() => {
         result.current.setContent('');
       });
+      // Let the (failing) immediate clear settle — the retry marker stays.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
       mockHub.request.mockClear();
 
-      // Switch away — the flush must retry inputDraft: null for session-A even
-      // though its last-known content is empty (it was an explicit deletion,
-      // not the transient pre-load '').
+      // Switch away — the flush retries inputDraft: null for session-A because
+      // the deletion was never confirmed.
       rerender({ sessionId: 'session-B' });
       await act(async () => {
         await vi.runAllTimersAsync();
@@ -661,6 +672,40 @@ describe('useInputDraft', () => {
         sessionId: 'session-A',
         metadata: { inputDraft: null },
       });
+    });
+
+    it('does not retry a deletion that was already confirmed', async () => {
+      mockHub.request.mockResolvedValue({
+        session: { metadata: { inputDraft: 'loaded draft' } },
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { result, rerender } = renderHook(({ sessionId }) => useInputDraft(sessionId), {
+        initialProps: { sessionId: 'session-A' },
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      act(() => {
+        result.current.setContent('');
+      });
+      // The immediate clear SUCCEEDS — the retry marker is dropped.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      mockHub.request.mockClear();
+
+      rerender({ sessionId: 'session-B' });
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // No flush retry: a newer draft saved elsewhere must survive.
+      const nullClears = mockHub.request.mock.calls.filter(
+        (call) => call[0] === 'session.update' && call[1]?.metadata?.inputDraft === null
+      );
+      expect(nullClears).toEqual([]);
     });
 
     it('should handle clear error gracefully', async () => {

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -591,6 +591,44 @@ describe('useInputDraft', () => {
       });
     });
 
+    it('re-arms the load guard when revisiting a session (A -> B -> A)', async () => {
+      // Each session.get gets its own deferred so we control resolution order.
+      const gets: Array<{ resolve: (value: unknown) => void }> = [];
+      mockHub.request.mockImplementation(() => {
+        let resolve!: (value: unknown) => void;
+        const promise = new Promise((r) => {
+          resolve = r;
+        });
+        gets.push({ resolve });
+        return promise;
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { rerender } = renderHook(({ sessionId }) => useInputDraft(sessionId), {
+        initialProps: { sessionId: 'session-A' },
+      });
+
+      // A's first load settles (marker = A).
+      await act(async () => {
+        gets[0]?.resolve({ session: { metadata: { inputDraft: 'a-draft' } } });
+        await vi.runAllTimersAsync();
+      });
+
+      // Switch to B (get pending), then back to A (get pending). The stale
+      // marker for A must have been invalidated — no empty-clear may fire for
+      // A while its fresh get is in flight.
+      rerender({ sessionId: 'session-B' });
+      rerender({ sessionId: 'session-A' });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      const clearCalls = mockHub.request.mock.calls.filter(
+        (call) => call[0] === 'session.update' && call[1]?.metadata?.inputDraft === null
+      );
+      expect(clearCalls).toEqual([]);
+    });
+
     it('should handle clear error gracefully', async () => {
       mockHub.request.mockResolvedValue({});
       mockHub.request.mockRejectedValue(new Error('Clear error'));

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -373,6 +373,12 @@ describe('useInputDraft', () => {
 
       const { result } = renderHook(() => useInputDraft('session-1'));
 
+      // Let the initial draft load settle — the transient pre-load '' must not
+      // trigger the immediate clear (it would wipe the server-side draft).
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
       act(() => {
         result.current.setContent('Some content');
       });
@@ -535,12 +541,51 @@ describe('useInputDraft', () => {
 
       const { result } = renderHook(() => useInputDraft('session-1'));
 
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
       act(() => {
         result.current.setContent('   ');
       });
 
       // Should clear immediately
       expect(mockHub.request).toHaveBeenCalledWith('session.update', {
+        sessionId: 'session-1',
+        metadata: { inputDraft: null },
+      });
+    });
+
+    it('does not send the mount-time empty clear before the initial load settles', async () => {
+      let resolveGet!: (value: unknown) => void;
+      mockHub.request.mockImplementation(() => {
+        let resolve!: (value: unknown) => void;
+        const promise = new Promise((r) => {
+          resolve = r;
+        });
+        resolveGet = resolve;
+        return promise;
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      renderHook(() => useInputDraft('session-1'));
+
+      // The initial load is still in flight and the signal is transiently ''.
+      // The save effect must NOT clear the server-side draft in that window.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(mockHub.request).not.toHaveBeenCalledWith('session.update', {
+        sessionId: 'session-1',
+        metadata: { inputDraft: null },
+      });
+
+      // Once the load settles, subsequent user deletions clear normally.
+      await act(async () => {
+        resolveGet({ session: { metadata: { inputDraft: 'saved' } } });
+        await vi.runAllTimersAsync();
+      });
+      expect(mockHub.request).not.toHaveBeenCalledWith('session.update', {
         sessionId: 'session-1',
         metadata: { inputDraft: null },
       });

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -241,6 +241,44 @@ describe('useInputDraft', () => {
       expect(result.current.content).toBe('Saved draft');
     });
 
+    it('merges a pending voice transcript into the draft on load and clears it', async () => {
+      mockHub.request.mockResolvedValue({
+        session: {
+          metadata: { inputDraft: 'existing', inputDraftVoicePending: 'hello world' },
+        },
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { result } = renderHook(() => useInputDraft('session-1'));
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // The staged voice transcript is appended to the loaded draft...
+      expect(result.current.content).toBe('existing hello world');
+      // ...and the staging field is cleared so it merges only once.
+      expect(mockHub.request).toHaveBeenCalledWith('session.update', {
+        sessionId: 'session-1',
+        metadata: { inputDraftVoicePending: null },
+      });
+    });
+
+    it('uses just the pending transcript when the draft is empty', async () => {
+      mockHub.request.mockResolvedValue({
+        session: { metadata: { inputDraft: null, inputDraftVoicePending: 'hello' } },
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { result } = renderHook(() => useInputDraft('session-1'));
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.content).toBe('hello');
+    });
+
     it('should not load draft when hub is not connected', async () => {
       vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(null);
 

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -241,44 +241,6 @@ describe('useInputDraft', () => {
       expect(result.current.content).toBe('Saved draft');
     });
 
-    it('merges a pending voice transcript into the draft on load and clears it', async () => {
-      mockHub.request.mockResolvedValue({
-        session: {
-          metadata: { inputDraft: 'existing', inputDraftVoicePending: 'hello world' },
-        },
-      });
-      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
-
-      const { result } = renderHook(() => useInputDraft('session-1'));
-
-      await act(async () => {
-        await vi.runAllTimersAsync();
-      });
-
-      // The staged voice transcript is appended to the loaded draft...
-      expect(result.current.content).toBe('existing hello world');
-      // ...and the staging field is cleared so it merges only once.
-      expect(mockHub.request).toHaveBeenCalledWith('session.update', {
-        sessionId: 'session-1',
-        metadata: { inputDraftVoicePending: null },
-      });
-    });
-
-    it('uses just the pending transcript when the draft is empty', async () => {
-      mockHub.request.mockResolvedValue({
-        session: { metadata: { inputDraft: null, inputDraftVoicePending: 'hello' } },
-      });
-      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
-
-      const { result } = renderHook(() => useInputDraft('session-1'));
-
-      await act(async () => {
-        await vi.runAllTimersAsync();
-      });
-
-      expect(result.current.content).toBe('hello');
-    });
-
     it('should not load draft when hub is not connected', async () => {
       vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(null);
 
@@ -290,6 +252,37 @@ describe('useInputDraft', () => {
 
       expect(mockHub.request).not.toHaveBeenCalled();
       expect(result.current.content).toBe('');
+    });
+
+    it('does not apply a draft whose session.get resolved after the session changed', async () => {
+      // Each session.get gets its own deferred promise so we can resolve
+      // session-1's slow get only after the hook has moved on to session-2.
+      const gets: Array<{ resolve: (value: unknown) => void }> = [];
+      mockHub.request.mockImplementation(() => {
+        let resolve!: (value: unknown) => void;
+        const promise = new Promise((r) => {
+          resolve = r;
+        });
+        gets.push({ resolve });
+        return promise;
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { result, rerender } = renderHook(({ sessionId }) => useInputDraft(sessionId), {
+        initialProps: { sessionId: 'session-1' },
+      });
+
+      // Switch to session-2 BEFORE session-1's get resolves.
+      rerender({ sessionId: 'session-2' });
+
+      await act(async () => {
+        // session-1's get finally resolves with its (now stale) draft.
+        gets[0]?.resolve({ session: { metadata: { inputDraft: 'session-1 draft' } } });
+        await vi.runAllTimersAsync();
+      });
+
+      // The stale session-1 draft must not bleed into the session-2 composer.
+      expect(result.current.content).not.toBe('session-1 draft');
     });
 
     it('should handle load error gracefully', async () => {

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -629,6 +629,40 @@ describe('useInputDraft', () => {
       expect(clearCalls).toEqual([]);
     });
 
+    it('retries an explicit draft deletion via the switch flush', async () => {
+      mockHub.request.mockResolvedValue({
+        session: { metadata: { inputDraft: 'loaded draft' } },
+      });
+      vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+
+      const { result, rerender } = renderHook(({ sessionId }) => useInputDraft(sessionId), {
+        initialProps: { sessionId: 'session-A' },
+      });
+
+      // Load settles with content, then the user explicitly deletes the draft.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      expect(result.current.content).toBe('loaded draft');
+      act(() => {
+        result.current.setContent('');
+      });
+      mockHub.request.mockClear();
+
+      // Switch away — the flush must retry inputDraft: null for session-A even
+      // though its last-known content is empty (it was an explicit deletion,
+      // not the transient pre-load '').
+      rerender({ sessionId: 'session-B' });
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(mockHub.request).toHaveBeenCalledWith('session.update', {
+        sessionId: 'session-A',
+        metadata: { inputDraft: null },
+      });
+    });
+
     it('should handle clear error gracefully', async () => {
       mockHub.request.mockResolvedValue({});
       mockHub.request.mockRejectedValue(new Error('Clear error'));

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -53,6 +53,12 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
   const contentSignal = useSignal('');
   const draftSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevSessionIdRef = useRef<string | null>(null);
+  // The sessionId whose initial draft load has settled. While a session's
+  // initial load is still in flight, the signal is transiently '' — letting the
+  // save effect issue its immediate "empty → clear" write in that window can
+  // wipe the server-side draft (including a voice transcript the daemon merged
+  // while serving the load) before the loaded value is re-persisted.
+  const initialLoadSettledRef = useRef<string | null>(null);
 
   // Load draft on session change
   useEffect(() => {
@@ -71,7 +77,10 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     let cancelled = false;
     const loadDraft = async () => {
       const hub = connectionManager.getHubIfConnected();
-      if (!hub) return;
+      if (!hub) {
+        initialLoadSettledRef.current = sessionId;
+        return;
+      }
 
       try {
         const response = await hub.request<{
@@ -87,6 +96,8 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
         }
       } catch {
         // Ignore errors loading draft
+      } finally {
+        if (!cancelled) initialLoadSettledRef.current = sessionId;
       }
     };
 
@@ -131,8 +142,13 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
 
     const trimmedContent = content.trim();
 
-    // Empty content: save immediately to clear draft
+    // Empty content: save immediately to clear draft — EXCEPT while this
+    // session's initial load is still in flight, when the empty signal is the
+    // transient pre-load state, not a user deletion. Clearing then can wipe a
+    // server-side draft (including a just-merged voice transcript) before the
+    // loaded value lands.
     if (trimmedContent === '') {
+      if (initialLoadSettledRef.current !== sessionId) return;
       const hub = connectionManager.getHubIfConnected();
       if (hub) {
         hub

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -180,6 +180,14 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
               inputDraft: null,
             },
           })
+          .then(() => {
+            // Deletion CONFIRMED server-side: drop the retry marker so a later
+            // switch flush cannot null a NEWER draft another client saved in
+            // the meantime. A rejected clear keeps the marker and retries.
+            if (lastSeenContentRef.current.sessionId === sessionId) {
+              lastSeenContentRef.current = { sessionId, content: '' };
+            }
+          })
           .catch(() => {
             /* ignore clear errors */
           });

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -114,14 +114,17 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
   }, [sessionId, contentSignal]);
 
   // Save draft with debouncing - uses useSignalEffect to react to signal changes
-  // Last content observed for each session while it was active. The flush below
+  // Last state observed for each session while it was active. The flush below
   // must NOT read the live signal: by the time it runs, the session-change
   // effect has already cleared the signal to '', and flushing that transient
-  // value would wipe the previous session's draft on every switch.
-  const lastSeenContentRef = useRef<{ sessionId: string | null; content: string }>({
-    sessionId: null,
-    content: '',
-  });
+  // value would wipe the previous session's draft on every switch. `cleared`
+  // marks an EXPLICIT post-load deletion, which the switch flush retries (the
+  // immediate clear may have failed before reaching SQLite).
+  const lastSeenContentRef = useRef<{
+    sessionId: string | null;
+    content: string;
+    cleared?: boolean;
+  }>({ sessionId: null, content: '' });
   useSignalEffect(() => {
     const content = contentSignal.value;
 
@@ -134,22 +137,21 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     }
 
     // If sessionId changed, flush the previous session's draft immediately —
-    // its LAST KNOWN content. Skip when there is nothing to flush: real
-    // in-session deletions were already cleared immediately (post-settle), and
-    // an empty flush here would wipe the previous draft based only on the
-    // transient pre-load ''.
+    // its LAST KNOWN state. Skip only when nothing is known to flush: content,
+    // or an explicit deletion whose clear should be retried. The transient
+    // pre-load '' is never recorded, so it cannot wipe the previous draft.
     if (prevSessionIdRef.current && prevSessionIdRef.current !== sessionId) {
       const prevSessionId = prevSessionIdRef.current;
       const last = lastSeenContentRef.current;
       const trimmedContent = last.sessionId === prevSessionId ? last.content.trim() : '';
 
       const hub = connectionManager.getHubIfConnected();
-      if (hub && trimmedContent) {
+      if (hub && (trimmedContent || (last.sessionId === prevSessionId && last.cleared))) {
         hub
           .request('session.update', {
             sessionId: prevSessionId,
             metadata: {
-              inputDraft: trimmedContent,
+              inputDraft: trimmedContent || null,
             },
           })
           .catch(() => {
@@ -160,7 +162,6 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     prevSessionIdRef.current = sessionId;
 
     const trimmedContent = content.trim();
-    lastSeenContentRef.current = { sessionId, content };
 
     // Empty content: save immediately to clear draft — EXCEPT while this
     // session's initial load is still in flight, when the empty signal is the
@@ -169,6 +170,7 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     // loaded value lands.
     if (trimmedContent === '') {
       if (initialLoadSettledRef.current !== sessionId) return;
+      lastSeenContentRef.current = { sessionId, content: '', cleared: true };
       const hub = connectionManager.getHubIfConnected();
       if (hub) {
         hub
@@ -186,6 +188,7 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     }
 
     // Non-empty content: debounce save
+    lastSeenContentRef.current = { sessionId, content };
     draftSaveTimeoutRef.current = setTimeout(async () => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return;

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -68,6 +68,12 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
       return;
     }
 
+    // A new load begins: invalidate the settled marker BEFORE clearing the
+    // signal, so the transient '' cannot pass the empty-clear guard. Without
+    // this, loading A -> B -> back to A would see the stale marker for A and
+    // clear A's durable draft while A's fresh get is still in flight.
+    initialLoadSettledRef.current = null;
+
     // Clear content immediately to prevent showing stale draft
     contentSignal.value = '';
 
@@ -108,6 +114,14 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
   }, [sessionId, contentSignal]);
 
   // Save draft with debouncing - uses useSignalEffect to react to signal changes
+  // Last content observed for each session while it was active. The flush below
+  // must NOT read the live signal: by the time it runs, the session-change
+  // effect has already cleared the signal to '', and flushing that transient
+  // value would wipe the previous session's draft on every switch.
+  const lastSeenContentRef = useRef<{ sessionId: string | null; content: string }>({
+    sessionId: null,
+    content: '',
+  });
   useSignalEffect(() => {
     const content = contentSignal.value;
 
@@ -119,18 +133,23 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
       draftSaveTimeoutRef.current = null;
     }
 
-    // If sessionId changed, flush the previous session's draft immediately
+    // If sessionId changed, flush the previous session's draft immediately —
+    // its LAST KNOWN content. Skip when there is nothing to flush: real
+    // in-session deletions were already cleared immediately (post-settle), and
+    // an empty flush here would wipe the previous draft based only on the
+    // transient pre-load ''.
     if (prevSessionIdRef.current && prevSessionIdRef.current !== sessionId) {
       const prevSessionId = prevSessionIdRef.current;
-      const trimmedContent = content.trim();
+      const last = lastSeenContentRef.current;
+      const trimmedContent = last.sessionId === prevSessionId ? last.content.trim() : '';
 
       const hub = connectionManager.getHubIfConnected();
-      if (hub) {
+      if (hub && trimmedContent) {
         hub
           .request('session.update', {
             sessionId: prevSessionId,
             metadata: {
-              inputDraft: trimmedContent || null,
+              inputDraft: trimmedContent,
             },
           })
           .catch(() => {
@@ -141,6 +160,7 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     prevSessionIdRef.current = sessionId;
 
     const trimmedContent = content.trim();
+    lastSeenContentRef.current = { sessionId, content };
 
     // Empty content: save immediately to clear draft — EXCEPT while this
     // session's initial load is still in flight, when the empty signal is the

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -28,7 +28,6 @@
 
 import { useEffect, useRef, useCallback, useMemo } from 'preact/hooks';
 import { useSignal, useSignalEffect } from '@preact/signals';
-import { appendDraftText } from '@hyperneo/shared';
 import { connectionManager } from '../lib/connection-manager';
 
 export interface UseInputDraftResult {
@@ -66,33 +65,24 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     // Clear content immediately to prevent showing stale draft
     contentSignal.value = '';
 
+    // Stale-load guard: if the session changes (or the hook unmounts) while this
+    // get is in flight, the cleanup flips `cancelled` so the resolved draft is
+    // not written into a signal now backing a different session.
+    let cancelled = false;
     const loadDraft = async () => {
       const hub = connectionManager.getHubIfConnected();
       if (!hub) return;
 
       try {
         const response = await hub.request<{
-          session: {
-            metadata?: { inputDraft?: string | null; inputDraftVoicePending?: string | null };
-          };
+          session: { metadata?: { inputDraft?: string } };
         }>('session.get', { sessionId });
-        const draft = response.session?.metadata?.inputDraft ?? '';
-        const voicePending = response.session?.metadata?.inputDraftVoicePending;
-        if (voicePending && voicePending.trim()) {
-          // A voice transcript completed after its composer unmounted and was
-          // staged in a separate field so the debounced inputDraft saves could
-          // not clobber it. Merge it into the draft now (single-threaded on
-          // load, so no race) and clear the staging field so it merges once.
-          contentSignal.value = appendDraftText(draft, voicePending);
-          hub
-            .request('session.update', {
-              sessionId,
-              metadata: { inputDraftVoicePending: null },
-            })
-            .catch(() => {
-              /* ignore clear errors — will retry on next load */
-            });
-        } else if (draft) {
+        if (cancelled) return;
+        // The daemon merges any staged voice transcript (inputDraftVoicePending)
+        // into inputDraft atomically while serving this request, so the draft
+        // here already includes it — no client-side merge needed.
+        const draft = response.session?.metadata?.inputDraft;
+        if (draft) {
           contentSignal.value = draft;
         }
       } catch {
@@ -101,6 +91,9 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
     };
 
     loadDraft();
+    return () => {
+      cancelled = true;
+    };
   }, [sessionId, contentSignal]);
 
   // Save draft with debouncing - uses useSignalEffect to react to signal changes

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -28,6 +28,7 @@
 
 import { useEffect, useRef, useCallback, useMemo } from 'preact/hooks';
 import { useSignal, useSignalEffect } from '@preact/signals';
+import { appendDraftText } from '@hyperneo/shared';
 import { connectionManager } from '../lib/connection-manager';
 
 export interface UseInputDraftResult {
@@ -71,10 +72,27 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
 
       try {
         const response = await hub.request<{
-          session: { metadata?: { inputDraft?: string } };
+          session: {
+            metadata?: { inputDraft?: string | null; inputDraftVoicePending?: string | null };
+          };
         }>('session.get', { sessionId });
-        const draft = response.session?.metadata?.inputDraft;
-        if (draft) {
+        const draft = response.session?.metadata?.inputDraft ?? '';
+        const voicePending = response.session?.metadata?.inputDraftVoicePending;
+        if (voicePending && voicePending.trim()) {
+          // A voice transcript completed after its composer unmounted and was
+          // staged in a separate field so the debounced inputDraft saves could
+          // not clobber it. Merge it into the draft now (single-threaded on
+          // load, so no race) and clear the staging field so it merges once.
+          contentSignal.value = appendDraftText(draft, voicePending);
+          hub
+            .request('session.update', {
+              sessionId,
+              metadata: { inputDraftVoicePending: null },
+            })
+            .catch(() => {
+              /* ignore clear errors — will retry on next load */
+            });
+        } else if (draft) {
           contentSignal.value = draft;
         }
       } catch {


### PR DESCRIPTION
## Problem
Voice transcription can take up to 125s. If you click Send/Stop then switch sessions before it resolves, the keyed `<ChatContainer>` unmounts and the transcript is **silently dropped** — `stopAndTranscribe` only writes through the live draft signal/textarea (now gone), and the auto-send effect cannot fire on an unmounted composer. Coming back to the session shows an empty composer.

## Fix
When the composer has unmounted by the time transcription completes, persist the transcript straight to the target session's server-side draft (`session.metadata.inputDraft`), appending to any existing draft with the same spacing/CJK rules as the live insert. The draft survives navigation and is reloaded on return.

Surgical: only the unmounted branch is new; mounted behavior is unchanged.

## Test
Adds navigate-away-during-transcription coverage (previously uncovered). Verified the new test fails without the fix.

## Follow-ups (separate PRs)
- Deliver Send/Queue in the background when navigated away, not just as a draft.
- Keep the recording itself alive across session switches (lift recorder ownership out of the keyed subtree).