### PR TITLE
feat(daemon): add LLM classification tier for unparseable limit errors

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -123,6 +123,7 @@ import { isSDKResultSuccess } from '@hyperneo/shared/sdk/type-guards';
 import { AcpQueryRunner } from '../acp/acp-query-runner';
 import { resolveModelAlias } from '../model-service';
 import { getProviderRegistry } from '../providers/factory.js';
+import { getProviderService } from '../provider-service';
 import {
   AskUserQuestionHandler,
   type AskUserQuestionHandlerContext,
@@ -136,6 +137,7 @@ import {
 import { resolveFallbackChain } from './fallback-recovery';
 import { InterruptHandler, type InterruptHandlerContext } from './interrupt-handler';
 import type { LimitRetryHint } from './limit-error-classifier';
+import { LimitErrorLlmClassifier } from './limit-error-llm-classifier';
 import {
   BATCH_DELIVERY_MAX_CHARS,
   buildBatchedDeliveryContent,
@@ -216,6 +218,7 @@ export class AgentSession
   readonly optionsBuilder: QueryOptionsBuilder;
 
   private queryRunner: QueryRunner | AcpQueryRunner;
+  private limitErrorLlmClassifier: LimitErrorLlmClassifier | null = null;
   readonly interruptHandler: InterruptHandler;
   private sdkRuntimeConfig: SDKRuntimeConfig;
   private eventSubscriptionSetup: EventSubscriptionSetup;
@@ -414,6 +417,13 @@ export class AgentSession
         this.internalEventBus.publish('session.rate_limit_resume', {
           sessionId: this.session.id,
         });
+      },
+      classifyUnknownLimit: (rawText: string) => {
+        this.limitErrorLlmClassifier ??= new LimitErrorLlmClassifier(this.session.id, {
+          providerService: getProviderService(),
+          excludeProvider: (this.session.config.provider as string | undefined) ?? undefined,
+        });
+        return this.limitErrorLlmClassifier.classifyWithTimeout(rawText);
       },
     });
     this.rateLimitWatchdog.setRetryCallback(

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -218,7 +218,6 @@ export class AgentSession
   readonly optionsBuilder: QueryOptionsBuilder;
 
   private queryRunner: QueryRunner | AcpQueryRunner;
-  private limitErrorLlmClassifier: LimitErrorLlmClassifier | null = null;
   readonly interruptHandler: InterruptHandler;
   private sdkRuntimeConfig: SDKRuntimeConfig;
   private eventSubscriptionSetup: EventSubscriptionSetup;
@@ -418,13 +417,11 @@ export class AgentSession
           sessionId: this.session.id,
         });
       },
-      classifyUnknownLimit: (rawText: string) => {
-        this.limitErrorLlmClassifier ??= new LimitErrorLlmClassifier(this.session.id, {
+      classifyUnknownLimit: (rawText: string) =>
+        new LimitErrorLlmClassifier(this.session.id, {
           providerService: getProviderService(),
-          excludeProvider: (this.session.config.provider as string | undefined) ?? undefined,
-        });
-        return this.limitErrorLlmClassifier.classifyWithTimeout(rawText);
-      },
+          excludeProvider: (this.session.config.provider as string | undefined) ?? 'anthropic',
+        }).classifyWithTimeout(rawText),
     });
     this.rateLimitWatchdog.setRetryCallback(
       async (lastUserMessage, switchTo, episodeGeneration) => {

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -129,8 +129,8 @@ export class LimitErrorLlmClassifier {
     this.logger = new Logger(`LimitErrorLlmClassifier ${sessionId}`);
   }
 
-  async classify(rawText: string): Promise<LlmLimitAssessment | null> {
-    if (!rawText) return null;
+  async classify(rawText: string, signal?: AbortSignal): Promise<LlmLimitAssessment | null> {
+    if (!rawText || signal?.aborted) return null;
     const key = normalizeErrorText(rawText);
     const now = Date.now();
     const cached = assessmentCache.get(key);
@@ -138,12 +138,17 @@ export class LimitErrorLlmClassifier {
       return cached.assessment;
     }
     const pending = inflightClassifications.get(key);
-    if (pending) return pending;
-    const task = runSerialized(() => this.classifyUncached(rawText, now)).finally(() => {
+    if (pending) {
+      return signal ? this.raceWithAbort(pending, signal) : pending;
+    }
+    const task = runSerialized(() => {
+      if (signal?.aborted) return Promise.resolve(null);
+      return this.classifyUncached(rawText, now, signal);
+    }).finally(() => {
       inflightClassifications.delete(key);
     });
     inflightClassifications.set(key, task);
-    const assessment = await task;
+    const assessment = await (signal ? this.raceWithAbort(task, signal) : task);
     evictExpiredAssessments(Date.now());
     if (assessment && !assessment.relative) {
       assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
@@ -151,8 +156,37 @@ export class LimitErrorLlmClassifier {
     return assessment;
   }
 
-  private async classifyUncached(rawText: string, now: number): Promise<LlmLimitAssessment | null> {
+  private raceWithAbort(
+    task: Promise<LlmLimitAssessment | null>,
+    signal: AbortSignal
+  ): Promise<LlmLimitAssessment | null> {
+    return new Promise((resolve) => {
+      if (signal.aborted) {
+        resolve(null);
+        return;
+      }
+      const onAbort = () => resolve(null);
+      signal.addEventListener('abort', onAbort, { once: true });
+      task.then(
+        (value) => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(value);
+        },
+        () => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(null);
+        }
+      );
+    });
+  }
+
+  private async classifyUncached(
+    rawText: string,
+    now: number,
+    signal?: AbortSignal
+  ): Promise<LlmLimitAssessment | null> {
     try {
+      if (signal?.aborted) return null;
       const providerId = await this.resolveClassifierProvider();
       if (!providerId) return null;
 
@@ -166,6 +200,10 @@ export class LimitErrorLlmClassifier {
         models.providerModelId
       );
       const abortController = new AbortController();
+      const onOuterAbort = () => abortController.abort();
+      if (signal) {
+        signal.addEventListener('abort', onOuterAbort, { once: true });
+      }
       const abortTimer = setTimeout(
         () => abortController.abort(),
         this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -222,6 +260,9 @@ export class LimitErrorLlmClassifier {
         return parseAssessment(payload);
       } finally {
         clearTimeout(abortTimer);
+        if (signal) {
+          signal.removeEventListener('abort', onOuterAbort);
+        }
         providerService.restoreEnvVars(originalEnv);
       }
     } catch (error) {
@@ -245,14 +286,11 @@ export class LimitErrorLlmClassifier {
 
   classifyWithTimeout(rawText: string): Promise<LlmLimitAssessment | null> {
     const timeoutMs = this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    return Promise.race([
-      this.classify(rawText),
-      new Promise<null>((resolve) => {
-        const timer = setTimeout(() => resolve(null), timeoutMs);
-        if (typeof timer === 'object' && 'unref' in timer) {
-          timer.unref();
-        }
-      }),
-    ]);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref();
+    }
+    return this.classify(rawText, controller.signal).finally(() => clearTimeout(timer));
   }
 }

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -277,9 +277,10 @@ export class LimitErrorLlmClassifier {
   private async resolveClassifierProvider(): Promise<string | null> {
     const providerService = this.deps.providerService;
     const available = await providerService.getAvailableProviders();
+    const usable = available.filter((p) => p.id !== 'acp');
     const ordered = [
-      ...available.filter((p) => p.id !== this.deps.excludeProvider),
-      ...available.filter((p) => p.id === this.deps.excludeProvider),
+      ...usable.filter((p) => p.id !== this.deps.excludeProvider),
+      ...usable.filter((p) => p.id === this.deps.excludeProvider),
     ];
     for (const candidate of ordered) {
       if (await providerService.isProviderAvailable(candidate.id)) return candidate.id;

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -11,6 +11,7 @@ type ClassifierProviderService = Pick<
   ReturnType<typeof getProviderService>,
   | 'getAvailableProviders'
   | 'isProviderAvailable'
+  | 'getCheapTierModel'
   | 'getTitleGenerationModels'
   | 'applyEnvVarsToProcessForProvider'
   | 'getEnvVarsForModel'
@@ -146,7 +147,7 @@ export class LimitErrorLlmClassifier {
     if (pending) {
       return signal ? this.raceWithAbort(pending, signal) : pending;
     }
-    const task = runSerialized(() => this.classifyUncached(rawText, now))
+    const task = runSerialized(() => this.classifyUncached(rawText, Date.now()))
       .then((assessment) => {
         evictExpiredAssessments(Date.now());
         if (assessment && !assessment.relative) {
@@ -205,8 +206,13 @@ export class LimitErrorLlmClassifier {
       const providerId = await raceWithDeadline(this.resolveClassifierProvider(), deadline);
       if (!providerId) return null;
 
+      const cheapFallback = await raceWithDeadline(
+        this.deps.providerService.getCheapTierModel(providerId),
+        deadline
+      );
+      if (!cheapFallback) return null;
       const models = await raceWithDeadline(
-        this.deps.providerService.getTitleGenerationModels(providerId, 'haiku'),
+        this.deps.providerService.getTitleGenerationModels(providerId, cheapFallback),
         deadline
       );
       if (!models) return null;
@@ -286,7 +292,9 @@ export class LimitErrorLlmClassifier {
       ...usable.filter((p) => p.id === this.deps.excludeProvider),
     ];
     for (const candidate of ordered) {
-      if (await providerService.isProviderAvailable(candidate.id)) return candidate.id;
+      if (!(await providerService.isProviderAvailable(candidate.id))) continue;
+      if (!(await providerService.getCheapTierModel(candidate.id))) continue;
+      return candidate.id;
     }
     return null;
   }

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -139,19 +139,20 @@ export class LimitErrorLlmClassifier {
   async classify(rawText: string, signal?: AbortSignal): Promise<LlmLimitAssessment | null> {
     if (!rawText || signal?.aborted) return null;
     const key = normalizeErrorText(rawText);
+    const taskKey = `${key}|${this.deps.excludeProvider ?? ''}`;
     const now = Date.now();
     const cached = assessmentCache.get(key);
     if (cached && cached.expiresAt > now) {
       return cached.assessment;
     }
-    activeWaiters.set(key, (activeWaiters.get(key) ?? 0) + 1);
+    activeWaiters.set(taskKey, (activeWaiters.get(taskKey) ?? 0) + 1);
     try {
-      const pending = inflightClassifications.get(key);
+      const pending = inflightClassifications.get(taskKey);
       const task =
         pending ??
         runSerialized(() => {
-          if ((activeWaiters.get(key) ?? 0) <= 0) {
-            inflightClassifications.delete(key);
+          if ((activeWaiters.get(taskKey) ?? 0) <= 0) {
+            inflightClassifications.delete(taskKey);
             return Promise.resolve(null);
           }
           return this.classifyUncached(rawText, Date.now());
@@ -164,18 +165,18 @@ export class LimitErrorLlmClassifier {
             return assessment;
           })
           .finally(() => {
-            inflightClassifications.delete(key);
+            inflightClassifications.delete(taskKey);
           });
       if (!pending) {
-        inflightClassifications.set(key, task);
+        inflightClassifications.set(taskKey, task);
       }
       return await (signal ? this.raceWithAbort(task, signal) : task);
     } finally {
-      const remaining = (activeWaiters.get(key) ?? 1) - 1;
+      const remaining = (activeWaiters.get(taskKey) ?? 1) - 1;
       if (remaining <= 0) {
-        activeWaiters.delete(key);
+        activeWaiters.delete(taskKey);
       } else {
-        activeWaiters.set(key, remaining);
+        activeWaiters.set(taskKey, remaining);
       }
     }
   }
@@ -311,6 +312,7 @@ export class LimitErrorLlmClassifier {
     ];
     for (const candidate of ordered) {
       try {
+        if (candidate.models.length === 0) continue;
         if (!(await providerService.isProviderAvailable(candidate.id))) continue;
         if (!(await providerService.getCheapTierModel(candidate.id))) continue;
         return candidate.id;

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -236,10 +236,18 @@ export class LimitErrorLlmClassifier {
       );
       if (!models) return null;
       const providerService = this.deps.providerService;
-      const originalEnv = await providerService.applyEnvVarsToProcessForProvider(
+      const applyTask = providerService.applyEnvVarsToProcessForProvider(
         providerId,
         models.providerModelId
       );
+      const originalEnv = await raceWithDeadline(applyTask, deadline);
+      if (!originalEnv) {
+        applyTask.then(
+          (lateEnv) => providerService.restoreEnvVars(lateEnv),
+          () => {}
+        );
+        return null;
+      }
       try {
         const providerEnvVars = await raceWithDeadline(
           providerService.getEnvVarsForModel(models.providerModelId, providerId),

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -58,6 +58,10 @@ function runSerialized<T>(task: () => Promise<T>): Promise<T> {
   return result;
 }
 
+function raceWithDeadline<T>(task: Promise<T>, deadline: Promise<null>): Promise<T | null> {
+  return Promise.race([task.catch(() => null), deadline]);
+}
+
 function normalizeErrorText(rawText: string): string {
   return rawText
     .trim()
@@ -182,30 +186,41 @@ export class LimitErrorLlmClassifier {
   }
 
   private async classifyUncached(rawText: string, now: number): Promise<LlmLimitAssessment | null> {
+    const abortController = new AbortController();
+    const abortTimer = setTimeout(
+      () => abortController.abort(),
+      this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    );
+    if (typeof abortTimer === 'object' && 'unref' in abortTimer) {
+      abortTimer.unref();
+    }
+    const deadline = new Promise<null>((resolve) => {
+      if (abortController.signal.aborted) {
+        resolve(null);
+        return;
+      }
+      abortController.signal.addEventListener('abort', () => resolve(null), { once: true });
+    });
     try {
-      const providerId = await this.resolveClassifierProvider();
+      const providerId = await raceWithDeadline(this.resolveClassifierProvider(), deadline);
       if (!providerId) return null;
 
-      const models = await this.deps.providerService.getTitleGenerationModels(providerId, 'haiku');
+      const models = await raceWithDeadline(
+        this.deps.providerService.getTitleGenerationModels(providerId, 'haiku'),
+        deadline
+      );
+      if (!models) return null;
       const providerService = this.deps.providerService;
       const originalEnv = await providerService.applyEnvVarsToProcessForProvider(
         providerId,
         models.providerModelId
       );
-      const abortController = new AbortController();
-      const abortTimer = setTimeout(
-        () => abortController.abort(),
-        this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
-      );
-      if (typeof abortTimer === 'object' && 'unref' in abortTimer) {
-        abortTimer.unref();
-      }
       try {
-        if (abortController.signal.aborted) return null;
-        const providerEnvVars = await providerService.getEnvVarsForModel(
-          models.providerModelId,
-          providerId
+        const providerEnvVars = await raceWithDeadline(
+          providerService.getEnvVarsForModel(models.providerModelId, providerId),
+          deadline
         );
+        if (!providerEnvVars) return null;
         const query =
           this.deps.queryForTesting ?? (await import('@anthropic-ai/claude-agent-sdk')).query;
         const agentQuery = query({
@@ -252,12 +267,13 @@ export class LimitErrorLlmClassifier {
         if (!payload) return null;
         return parseAssessment(payload);
       } finally {
-        clearTimeout(abortTimer);
         providerService.restoreEnvVars(originalEnv);
       }
     } catch (error) {
       this.logger.warn('LLM limit classification failed:', error);
       return null;
+    } finally {
+      clearTimeout(abortTimer);
     }
   }
 

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -1,0 +1,223 @@
+import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+import { Logger } from '../logger';
+import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver';
+import { withSdkTranscriptRetention } from './sdk-transcript-retention';
+import { normalizeEpochMs } from './limit-error-classifier';
+
+type SdkQueryFunction = typeof import('@anthropic-ai/claude-agent-sdk').query;
+
+type ClassifierProviderService = Pick<
+  ReturnType<typeof getProviderService>,
+  | 'getAvailableProviders'
+  | 'isProviderAvailable'
+  | 'getTitleGenerationModels'
+  | 'applyEnvVarsToProcessForProvider'
+  | 'getEnvVarsForModel'
+  | 'restoreEnvVars'
+>;
+
+export interface LlmLimitAssessment {
+  resetAtMs: number | null;
+  kind: 'rate_limit' | 'usage_limit' | null;
+  notALimit: boolean;
+}
+
+export interface LimitErrorLlmClassifierDeps {
+  providerService: ClassifierProviderService;
+  queryForTesting?: SdkQueryFunction;
+  excludeProvider?: string;
+  timeoutMs?: number;
+}
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 12 * 1000;
+
+interface CacheEntry {
+  assessment: LlmLimitAssessment | null;
+  expiresAt: number;
+}
+
+const assessmentCache = new Map<string, CacheEntry>();
+
+let serializedQueue: Promise<unknown> = Promise.resolve();
+
+function runSerialized<T>(task: () => Promise<T>): Promise<T> {
+  const result = serializedQueue.then(task, task);
+  serializedQueue = result.catch(() => undefined);
+  return result;
+}
+
+function normalizeErrorText(rawText: string): string {
+  return rawText
+    .trim()
+    .replace(/[0-9a-f]{12,}/gi, '[id]')
+    .replace(/\d{10,}/g, '[ts]')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function extractJsonObject(text: string): Record<string, unknown> | null {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  try {
+    const parsed: unknown = JSON.parse(text.slice(start, end + 1));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function parseAssessment(payload: Record<string, unknown>): LlmLimitAssessment {
+  const isLimit = payload.is_limit === true;
+  const kindRaw = payload.kind;
+  const kind =
+    kindRaw === 'usage_limit' || kindRaw === 'rate_limit'
+      ? (kindRaw as 'usage_limit' | 'rate_limit')
+      : null;
+  const resetRaw = payload.reset_at;
+  const resetAtMs =
+    typeof resetRaw === 'number' && Number.isFinite(resetRaw) ? normalizeEpochMs(resetRaw) : null;
+  return {
+    resetAtMs: isLimit ? resetAtMs : null,
+    kind: isLimit ? kind : null,
+    notALimit: !isLimit,
+  };
+}
+
+function buildPrompt(rawText: string, now: number): string {
+  return `You classify LLM provider API errors so a scheduler can decide when to retry.
+
+Current time: ${new Date(now).toISOString()}
+
+Error text:
+"""
+${rawText.slice(0, 1500)}
+"""
+
+Rules:
+1. is_limit is true only for rate limits, usage caps, quota windows, or throttling — not for auth, payment, server, or network errors.
+2. reset_at is the epoch-milliseconds instant when the limit lifts. Use an absolute timestamp in the text (assume timezone UTC+8 for Chinese text unless an explicit zone is given), or compute current time + relative delay for phrases like "retry in 2 hours". Use null when no reset time can be determined.
+
+Reply with ONLY minified JSON, no markdown fences:
+{"is_limit":true,"kind":"usage_limit","reset_at":1755800000000}
+Kind is "usage_limit" for windowed caps (5-hour, daily, weekly) and "rate_limit" for transient request throttling. If it is not a limit error, reply {"is_limit":false,"kind":null,"reset_at":null}.`;
+}
+
+export class LimitErrorLlmClassifier {
+  private logger: Logger;
+
+  constructor(
+    sessionId: string,
+    private deps: LimitErrorLlmClassifierDeps
+  ) {
+    this.logger = new Logger(`LimitErrorLlmClassifier ${sessionId}`);
+  }
+
+  async classify(rawText: string): Promise<LlmLimitAssessment | null> {
+    if (!rawText) return null;
+    const key = normalizeErrorText(rawText);
+    const now = Date.now();
+    const cached = assessmentCache.get(key);
+    if (cached && cached.expiresAt > now) {
+      return cached.assessment;
+    }
+    const assessment = await runSerialized(() => this.classifyUncached(rawText, now));
+    assessmentCache.set(key, { assessment, expiresAt: now + CACHE_TTL_MS });
+    return assessment;
+  }
+
+  private async classifyUncached(rawText: string, now: number): Promise<LlmLimitAssessment | null> {
+    try {
+      const providerId = await this.resolveClassifierProvider();
+      if (!providerId) return null;
+
+      const models = await this.deps.providerService.getTitleGenerationModels(
+        providerId,
+        'default'
+      );
+      const providerService = this.deps.providerService;
+      const originalEnv = await providerService.applyEnvVarsToProcessForProvider(
+        providerId,
+        models.providerModelId
+      );
+      try {
+        const providerEnvVars = await providerService.getEnvVarsForModel(
+          models.providerModelId,
+          providerId
+        );
+        const query =
+          this.deps.queryForTesting ?? (await import('@anthropic-ai/claude-agent-sdk')).query;
+        const agentQuery = query({
+          prompt: buildPrompt(rawText, now),
+          options: {
+            model: models.sdkModelId,
+            maxTurns: 1,
+            permissionMode: 'acceptEdits',
+            allowDangerouslySkipPermissions: false,
+            mcpServers: {},
+            settingSources: [],
+            tools: [],
+            pathToClaudeCodeExecutable: resolveSDKCliPath(),
+            executable: isRunningUnderBun() ? 'bun' : undefined,
+            settings: withSdkTranscriptRetention(),
+            env: mergeProviderEnvVars(providerEnvVars as Record<string, string>),
+            thinking: { type: 'disabled' },
+          },
+        });
+
+        let reply = '';
+        for await (const message of agentQuery) {
+          const assistant = message as {
+            type: string;
+            message?: { content?: Array<{ type: string; text?: string }> };
+          };
+          if (assistant.type !== 'assistant' || !assistant.message) continue;
+          const text = (assistant.message.content ?? [])
+            .filter((block) => block.type === 'text')
+            .map((block) => block.text ?? '')
+            .join(' ')
+            .trim();
+          if (text) {
+            reply = text;
+            break;
+          }
+        }
+        if (!reply) return null;
+        const payload = extractJsonObject(reply);
+        if (!payload) return null;
+        return parseAssessment(payload);
+      } finally {
+        providerService.restoreEnvVars(originalEnv);
+      }
+    } catch (error) {
+      this.logger.warn('LLM limit classification failed:', error);
+      return null;
+    }
+  }
+
+  private async resolveClassifierProvider(): Promise<string | null> {
+    const providerService = this.deps.providerService;
+    const available = await providerService.getAvailableProviders();
+    const candidate = available.find((p) => p.id !== this.deps.excludeProvider) ?? available[0];
+    if (!candidate) return null;
+    if (!(await providerService.isProviderAvailable(candidate.id))) return null;
+    return candidate.id;
+  }
+
+  classifyWithTimeout(rawText: string): Promise<LlmLimitAssessment | null> {
+    const timeoutMs = this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    return Promise.race([
+      this.classify(rawText),
+      new Promise<null>((resolve) => {
+        const timer = setTimeout(() => resolve(null), timeoutMs);
+        if (typeof timer === 'object' && 'unref' in timer) {
+          timer.unref();
+        }
+      }),
+    ]);
+  }
+}

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -142,19 +142,19 @@ export class LimitErrorLlmClassifier {
     if (pending) {
       return signal ? this.raceWithAbort(pending, signal) : pending;
     }
-    const task = runSerialized(() => {
-      if (signal?.aborted) return Promise.resolve(null);
-      return this.classifyUncached(rawText, now, signal);
-    }).finally(() => {
-      inflightClassifications.delete(key);
-    });
+    const task = runSerialized(() => this.classifyUncached(rawText, now))
+      .then((assessment) => {
+        evictExpiredAssessments(Date.now());
+        if (assessment && !assessment.relative) {
+          assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
+        }
+        return assessment;
+      })
+      .finally(() => {
+        inflightClassifications.delete(key);
+      });
     inflightClassifications.set(key, task);
-    const assessment = await (signal ? this.raceWithAbort(task, signal) : task);
-    evictExpiredAssessments(Date.now());
-    if (assessment && !assessment.relative) {
-      assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
-    }
-    return assessment;
+    return signal ? this.raceWithAbort(task, signal) : task;
   }
 
   private raceWithAbort(
@@ -181,13 +181,8 @@ export class LimitErrorLlmClassifier {
     });
   }
 
-  private async classifyUncached(
-    rawText: string,
-    now: number,
-    signal?: AbortSignal
-  ): Promise<LlmLimitAssessment | null> {
+  private async classifyUncached(rawText: string, now: number): Promise<LlmLimitAssessment | null> {
     try {
-      if (signal?.aborted) return null;
       const providerId = await this.resolveClassifierProvider();
       if (!providerId) return null;
 
@@ -198,11 +193,6 @@ export class LimitErrorLlmClassifier {
         models.providerModelId
       );
       const abortController = new AbortController();
-      const onOuterAbort = () => abortController.abort();
-      if (signal) {
-        signal.addEventListener('abort', onOuterAbort, { once: true });
-        if (signal.aborted) onOuterAbort();
-      }
       const abortTimer = setTimeout(
         () => abortController.abort(),
         this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -263,9 +253,6 @@ export class LimitErrorLlmClassifier {
         return parseAssessment(payload);
       } finally {
         clearTimeout(abortTimer);
-        if (signal) {
-          signal.removeEventListener('abort', onOuterAbort);
-        }
         providerService.restoreEnvVars(originalEnv);
       }
     } catch (error) {

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -42,6 +42,7 @@ interface CacheEntry {
 
 const assessmentCache = new Map<string, CacheEntry>();
 const inflightClassifications = new Map<string, Promise<LlmLimitAssessment | null>>();
+const activeWaiters = new Map<string, number>();
 
 function evictExpiredAssessments(now: number): void {
   for (const [key, entry] of assessmentCache) {
@@ -143,23 +144,40 @@ export class LimitErrorLlmClassifier {
     if (cached && cached.expiresAt > now) {
       return cached.assessment;
     }
-    const pending = inflightClassifications.get(key);
-    if (pending) {
-      return signal ? this.raceWithAbort(pending, signal) : pending;
+    activeWaiters.set(key, (activeWaiters.get(key) ?? 0) + 1);
+    try {
+      const pending = inflightClassifications.get(key);
+      const task =
+        pending ??
+        runSerialized(() => {
+          if ((activeWaiters.get(key) ?? 0) <= 0) {
+            inflightClassifications.delete(key);
+            return Promise.resolve(null);
+          }
+          return this.classifyUncached(rawText, Date.now());
+        })
+          .then((assessment) => {
+            evictExpiredAssessments(Date.now());
+            if (assessment && !assessment.relative) {
+              assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
+            }
+            return assessment;
+          })
+          .finally(() => {
+            inflightClassifications.delete(key);
+          });
+      if (!pending) {
+        inflightClassifications.set(key, task);
+      }
+      return await (signal ? this.raceWithAbort(task, signal) : task);
+    } finally {
+      const remaining = (activeWaiters.get(key) ?? 1) - 1;
+      if (remaining <= 0) {
+        activeWaiters.delete(key);
+      } else {
+        activeWaiters.set(key, remaining);
+      }
     }
-    const task = runSerialized(() => this.classifyUncached(rawText, Date.now()))
-      .then((assessment) => {
-        evictExpiredAssessments(Date.now());
-        if (assessment && !assessment.relative) {
-          assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
-        }
-        return assessment;
-      })
-      .finally(() => {
-        inflightClassifications.delete(key);
-      });
-    inflightClassifications.set(key, task);
-    return signal ? this.raceWithAbort(task, signal) : task;
   }
 
   private raceWithAbort(
@@ -292,9 +310,13 @@ export class LimitErrorLlmClassifier {
       ...usable.filter((p) => p.id === this.deps.excludeProvider),
     ];
     for (const candidate of ordered) {
-      if (!(await providerService.isProviderAvailable(candidate.id))) continue;
-      if (!(await providerService.getCheapTierModel(candidate.id))) continue;
-      return candidate.id;
+      try {
+        if (!(await providerService.isProviderAvailable(candidate.id))) continue;
+        if (!(await providerService.getCheapTierModel(candidate.id))) continue;
+        return candidate.id;
+      } catch {
+        continue;
+      }
     }
     return null;
   }

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -20,6 +20,7 @@ export interface LlmLimitAssessment {
   resetAtMs: number | null;
   kind: 'rate_limit' | 'usage_limit' | null;
   notALimit: boolean;
+  relative?: boolean;
 }
 
 export interface LimitErrorLlmClassifierDeps {
@@ -38,6 +39,15 @@ interface CacheEntry {
 }
 
 const assessmentCache = new Map<string, CacheEntry>();
+const inflightClassifications = new Map<string, Promise<LlmLimitAssessment | null>>();
+
+function evictExpiredAssessments(now: number): void {
+  for (const [key, entry] of assessmentCache) {
+    if (entry.expiresAt <= now) {
+      assessmentCache.delete(key);
+    }
+  }
+}
 
 let serializedQueue: Promise<unknown> = Promise.resolve();
 
@@ -85,6 +95,7 @@ function parseAssessment(payload: Record<string, unknown>): LlmLimitAssessment {
     resetAtMs: isLimit ? resetAtMs : null,
     kind: isLimit ? kind : null,
     notALimit: !isLimit,
+    relative: isLimit && payload.relative === true,
   };
 }
 
@@ -101,6 +112,7 @@ ${rawText.slice(0, 1500)}
 Rules:
 1. is_limit is true only for rate limits, usage caps, quota windows, or throttling — not for auth, payment, server, or network errors.
 2. reset_at is the epoch-milliseconds instant when the limit lifts. Use an absolute timestamp in the text (assume timezone UTC+8 for Chinese text unless an explicit zone is given), or compute current time + relative delay for phrases like "retry in 2 hours". Use null when no reset time can be determined.
+3. Set "relative":true when reset_at was computed from a relative delay rather than an absolute timestamp in the text; otherwise omit the field.
 
 Reply with ONLY minified JSON, no markdown fences:
 {"is_limit":true,"kind":"usage_limit","reset_at":1755800000000}
@@ -125,8 +137,17 @@ export class LimitErrorLlmClassifier {
     if (cached && cached.expiresAt > now) {
       return cached.assessment;
     }
-    const assessment = await runSerialized(() => this.classifyUncached(rawText, now));
-    assessmentCache.set(key, { assessment, expiresAt: now + CACHE_TTL_MS });
+    const pending = inflightClassifications.get(key);
+    if (pending) return pending;
+    const task = runSerialized(() => this.classifyUncached(rawText, now)).finally(() => {
+      inflightClassifications.delete(key);
+    });
+    inflightClassifications.set(key, task);
+    const assessment = await task;
+    evictExpiredAssessments(Date.now());
+    if (assessment && !assessment.relative) {
+      assessmentCache.set(key, { assessment, expiresAt: Date.now() + CACHE_TTL_MS });
+    }
     return assessment;
   }
 
@@ -144,6 +165,14 @@ export class LimitErrorLlmClassifier {
         providerId,
         models.providerModelId
       );
+      const abortController = new AbortController();
+      const abortTimer = setTimeout(
+        () => abortController.abort(),
+        this.deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
+      );
+      if (typeof abortTimer === 'object' && 'unref' in abortTimer) {
+        abortTimer.unref();
+      }
       try {
         const providerEnvVars = await providerService.getEnvVarsForModel(
           models.providerModelId,
@@ -166,6 +195,7 @@ export class LimitErrorLlmClassifier {
             settings: withSdkTranscriptRetention(),
             env: mergeProviderEnvVars(providerEnvVars as Record<string, string>),
             thinking: { type: 'disabled' },
+            abortController,
           },
         });
 
@@ -191,6 +221,7 @@ export class LimitErrorLlmClassifier {
         if (!payload) return null;
         return parseAssessment(payload);
       } finally {
+        clearTimeout(abortTimer);
         providerService.restoreEnvVars(originalEnv);
       }
     } catch (error) {
@@ -202,10 +233,14 @@ export class LimitErrorLlmClassifier {
   private async resolveClassifierProvider(): Promise<string | null> {
     const providerService = this.deps.providerService;
     const available = await providerService.getAvailableProviders();
-    const candidate = available.find((p) => p.id !== this.deps.excludeProvider) ?? available[0];
-    if (!candidate) return null;
-    if (!(await providerService.isProviderAvailable(candidate.id))) return null;
-    return candidate.id;
+    const ordered = [
+      ...available.filter((p) => p.id !== this.deps.excludeProvider),
+      ...available.filter((p) => p.id === this.deps.excludeProvider),
+    ];
+    for (const candidate of ordered) {
+      if (await providerService.isProviderAvailable(candidate.id)) return candidate.id;
+    }
+    return null;
   }
 
   classifyWithTimeout(rawText: string): Promise<LlmLimitAssessment | null> {

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -201,6 +201,7 @@ export class LimitErrorLlmClassifier {
       const onOuterAbort = () => abortController.abort();
       if (signal) {
         signal.addEventListener('abort', onOuterAbort, { once: true });
+        if (signal.aborted) onOuterAbort();
       }
       const abortTimer = setTimeout(
         () => abortController.abort(),
@@ -210,6 +211,7 @@ export class LimitErrorLlmClassifier {
         abortTimer.unref();
       }
       try {
+        if (abortController.signal.aborted) return null;
         const providerEnvVars = await providerService.getEnvVarsForModel(
           models.providerModelId,
           providerId

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -106,6 +106,14 @@ function parseAssessment(payload: Record<string, unknown>): LlmLimitAssessment {
   };
 }
 
+function redactErrorText(rawText: string): string {
+  return rawText
+    .replace(/(https?:\/\/)[^\s/@]+:[^\s/@]+@/gi, '$1[credentials]@')
+    .replace(/\b(sk|rk|pk|ghp|gho|xox)[-_][A-Za-z0-9_-]{12,}\b/g, '[key]')
+    .replace(/\bBearer\s+[A-Za-z0-9._+/=-]{12,}/gi, 'Bearer [token]')
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, '[jwt]');
+}
+
 function buildPrompt(rawText: string, now: number): string {
   return `You classify LLM provider API errors so a scheduler can decide when to retry.
 
@@ -113,7 +121,7 @@ Current time: ${new Date(now).toISOString()}
 
 Error text:
 """
-${rawText.slice(0, 1500)}
+${redactErrorText(rawText).slice(0, 1500)}
 """
 
 Rules:

--- a/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
+++ b/packages/daemon/src/lib/agent/limit-error-llm-classifier.ts
@@ -1,4 +1,5 @@
 import { getProviderService, mergeProviderEnvVars } from '../provider-service';
+import { KimiProvider } from '../providers/kimi-provider.js';
 import { Logger } from '../logger';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver';
 import { withSdkTranscriptRetention } from './sdk-transcript-retention';
@@ -190,10 +191,7 @@ export class LimitErrorLlmClassifier {
       const providerId = await this.resolveClassifierProvider();
       if (!providerId) return null;
 
-      const models = await this.deps.providerService.getTitleGenerationModels(
-        providerId,
-        'default'
-      );
+      const models = await this.deps.providerService.getTitleGenerationModels(providerId, 'haiku');
       const providerService = this.deps.providerService;
       const originalEnv = await providerService.applyEnvVarsToProcessForProvider(
         providerId,
@@ -232,7 +230,10 @@ export class LimitErrorLlmClassifier {
             executable: isRunningUnderBun() ? 'bun' : undefined,
             settings: withSdkTranscriptRetention(),
             env: mergeProviderEnvVars(providerEnvVars as Record<string, string>),
-            thinking: { type: 'disabled' },
+            thinking:
+              providerId === 'kimi'
+                ? KimiProvider.resolveKimiTitleThinkingConfig(models.providerModelId)
+                : { type: 'disabled' },
             abortController,
           },
         });

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -278,13 +278,25 @@ export class RateLimitWatchdog {
           `LLM limit refinement: retry at ${new Date(resetMs).toISOString()} ` +
             `(was backoff ladder) for error: ${errorMessage}`
         );
+        const previousHint = this.lastHint;
         if (result.kind) {
           this.lastHint = { ...this.lastHint, kind: result.kind };
         }
-        if (chargedLadder && this.retryCount > 0) {
+        const refunded = chargedLadder && this.retryCount > 0;
+        if (refunded) {
           this.retryCount--;
         }
-        await this.scheduleCooldown(errorMessage, cooldownFromReset(resetMs, now), entryGeneration);
+        const armed = await this.scheduleCooldown(
+          errorMessage,
+          cooldownFromReset(resetMs, now),
+          entryGeneration
+        );
+        if (!armed) {
+          this.lastHint = previousHint;
+          if (refunded) {
+            this.retryCount++;
+          }
+        }
       })
       .catch(() => {})
       .finally(() => {
@@ -296,7 +308,7 @@ export class RateLimitWatchdog {
     errorMessage: string,
     decision: CooldownDecision,
     episodeGeneration: number
-  ): Promise<void> {
+  ): Promise<boolean> {
     const kind = this.lastHint?.kind ?? classifyLimitKind(errorMessage, decision);
     this.limitKind = kind;
 
@@ -318,7 +330,7 @@ export class RateLimitWatchdog {
         'Cooldown state write completed but a newer action owns the cooldown; ' +
           'not publishing pause or arming.'
       );
-      return;
+      return false;
     }
 
     this.notifyPause({
@@ -343,6 +355,7 @@ export class RateLimitWatchdog {
     ) {
       this.cooldownTimer.unref();
     }
+    return true;
   }
 
   private async fireCooldownRetry(errorMessage: string): Promise<void> {

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -282,20 +282,17 @@ export class RateLimitWatchdog {
         if (result.kind) {
           this.lastHint = { ...this.lastHint, kind: result.kind };
         }
-        const refunded = chargedLadder && this.retryCount > 0;
-        if (refunded) {
-          this.retryCount--;
-        }
+        const refund = chargedLadder && this.retryCount > 0;
         const armed = await this.scheduleCooldown(
           errorMessage,
           cooldownFromReset(resetMs, now),
-          entryGeneration
+          entryGeneration,
+          refund ? this.retryCount - 1 : this.retryCount
         );
         if (!armed) {
           this.lastHint = previousHint;
-          if (refunded) {
-            this.retryCount++;
-          }
+        } else if (refund) {
+          this.retryCount--;
         }
       })
       .catch(() => {})
@@ -307,7 +304,8 @@ export class RateLimitWatchdog {
   private async scheduleCooldown(
     errorMessage: string,
     decision: CooldownDecision,
-    episodeGeneration: number
+    episodeGeneration: number,
+    displayRetryCount?: number
   ): Promise<boolean> {
     const kind = this.lastHint?.kind ?? classifyLimitKind(errorMessage, decision);
     this.limitKind = kind;
@@ -320,7 +318,7 @@ export class RateLimitWatchdog {
 
     const timerAtEntry = this.cooldownTimer;
     await this.stateManager.setRateLimitCooldown({
-      retryCount: this.retryCount,
+      retryCount: displayRetryCount ?? this.retryCount,
       maxRetries: this.config.maxAutoRetries,
       retryAt,
     });

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -243,9 +243,10 @@ export class RateLimitWatchdog {
       return true;
     }
 
-    await this.scheduleCooldown(errorMessage, decision, entryGeneration);
+    const armed = await this.scheduleCooldown(errorMessage, decision, entryGeneration);
 
     if (
+      armed &&
       decision.reason === 'backoff-ladder' &&
       this.deps.classifyUnknownLimit &&
       !this.llmRefinementInFlight &&
@@ -329,7 +330,7 @@ export class RateLimitWatchdog {
         'Cooldown state write completed but a newer action owns the cooldown; ' +
           'not publishing pause or arming.'
       );
-      await this.restoreCooldownStateForCurrentOwner(decision.retryAtMs);
+      await this.restoreCooldownStateForCurrentOwner(decision.retryAtMs, episodeGeneration);
       return false;
     }
 
@@ -573,19 +574,26 @@ export class RateLimitWatchdog {
     }
   }
 
-  private async restoreCooldownStateForCurrentOwner(staleRetryAtMs: number): Promise<void> {
-    if (
-      this.cooldownTimer === null ||
-      this.currentRetryAt === null ||
-      this.currentRetryAt === staleRetryAtMs
-    ) {
+  private async restoreCooldownStateForCurrentOwner(
+    staleRetryAtMs: number,
+    episodeGeneration: number
+  ): Promise<void> {
+    if (this.cooldownTimer !== null && this.currentRetryAt !== null) {
+      if (this.currentRetryAt === staleRetryAtMs) return;
+      await this.stateManager.setRateLimitCooldown({
+        retryCount: this.retryCount,
+        maxRetries: this.config.maxAutoRetries,
+        retryAt: this.currentRetryAt,
+      });
       return;
     }
-    await this.stateManager.setRateLimitCooldown({
-      retryCount: this.retryCount,
-      maxRetries: this.config.maxAutoRetries,
-      retryAt: this.currentRetryAt,
-    });
+    if (episodeGeneration === this.generation) {
+      await this.stateManager.setRateLimitCooldown({
+        retryCount: this.retryCount,
+        maxRetries: this.config.maxAutoRetries,
+        retryAt: Date.now(),
+      });
+    }
   }
 
   retryNow(): boolean {

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -281,6 +281,15 @@ export class RateLimitWatchdog {
         if (result.kind) {
           this.lastHint = { ...this.lastHint, kind: result.kind };
         }
+        const refinedHint = this.lastHint;
+        const rollbackHintAndKind = () => {
+          if (this.lastHint === refinedHint) {
+            this.lastHint = previousHint;
+          }
+          if (this.limitKind === result.kind) {
+            this.limitKind = previousLimitKind;
+          }
+        };
         const refund = chargedLadder && this.retryCount > 0;
         try {
           const armed = await this.scheduleCooldown(
@@ -290,15 +299,13 @@ export class RateLimitWatchdog {
             refund ? this.retryCount - 1 : this.retryCount
           );
           if (!armed) {
-            this.lastHint = previousHint;
-            this.limitKind = previousLimitKind;
+            rollbackHintAndKind();
           } else if (refund) {
             this.retryCount--;
           }
         } catch (err) {
           this.logger.warn('LLM refinement cooldown scheduling threw; reconciling state:', err);
-          this.lastHint = previousHint;
-          this.limitKind = previousLimitKind;
+          rollbackHintAndKind();
           if (this.cooldownTimer === timerAtFire && this.currentRetryAt !== null) {
             await this.stateManager
               .setRateLimitCooldown({

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -9,11 +9,7 @@ import {
   MAX_RESET_HORIZON_MS,
   selectNextFallback,
 } from './fallback-recovery';
-import {
-  cooldownFromReset,
-  normalizeEpochMs,
-  type LimitRetryHint,
-} from './limit-error-classifier';
+import { cooldownFromReset, normalizeEpochMs, type LimitRetryHint } from './limit-error-classifier';
 import type { LlmLimitAssessment } from './limit-error-llm-classifier';
 import type { ProcessingStateManager } from './processing-state-manager';
 
@@ -254,18 +250,23 @@ export class RateLimitWatchdog {
       !this.llmRefinementInFlight &&
       entryGeneration === this.generation
     ) {
-      this.fireLlmRefinement(errorMessage, entryGeneration);
+      this.fireLlmRefinement(errorMessage, entryGeneration, !decision.freeWait);
     }
     return true;
   }
 
-  private fireLlmRefinement(errorMessage: string, entryGeneration: number): void {
+  private fireLlmRefinement(
+    errorMessage: string,
+    entryGeneration: number,
+    chargedLadder: boolean
+  ): void {
     const classify = this.deps.classifyUnknownLimit;
     if (!classify) return;
     this.llmRefinementInFlight = true;
+    const timerAtFire = this.cooldownTimer;
     void classify(errorMessage)
       .then(async (result) => {
-        if (entryGeneration !== this.generation || this.cooldownTimer === null) return;
+        if (entryGeneration !== this.generation || this.cooldownTimer !== timerAtFire) return;
         if (!result || result.notALimit) return;
         const resetMs =
           typeof result.resetAtMs === 'number' && Number.isFinite(result.resetAtMs)
@@ -279,6 +280,9 @@ export class RateLimitWatchdog {
         );
         if (result.kind) {
           this.lastHint = { ...this.lastHint, kind: result.kind };
+        }
+        if (chargedLadder && this.retryCount > 0) {
+          this.retryCount--;
         }
         await this.scheduleCooldown(errorMessage, cooldownFromReset(resetMs, now), entryGeneration);
       })
@@ -321,6 +325,7 @@ export class RateLimitWatchdog {
       reason: decision.reason,
     });
 
+    this.cancelCooldownTimer();
     this.cooldownTimer = setTimeout(() => {
       this.cooldownTimer = null;
       this.logger.info(

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -306,15 +306,17 @@ export class RateLimitWatchdog {
         `Error: ${errorMessage}`
     );
 
+    const timerAtEntry = this.cooldownTimer;
     await this.stateManager.setRateLimitCooldown({
       retryCount: this.retryCount,
       maxRetries: this.config.maxAutoRetries,
       retryAt,
     });
 
-    if (episodeGeneration !== this.generation) {
+    if (episodeGeneration !== this.generation || this.cooldownTimer !== timerAtEntry) {
       this.logger.info(
-        'Episode superseded during cooldown state write; not publishing pause or arming.'
+        'Cooldown state write completed but a newer action owns the cooldown; ' +
+          'not publishing pause or arming.'
       );
       return;
     }

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -73,6 +73,7 @@ export class RateLimitWatchdog {
   private deps: RateLimitWatchdogDeps;
   private retryCount = 0;
   private cooldownTimer: ReturnType<typeof setTimeout> | null = null;
+  private currentRetryAt: number | null = null;
   private lastUserMessage: { uuid: string; content: string | MessageContent[] } | null = null;
   private lastErrorMessage = '';
   private retryCallback: RateLimitRetryCallback | null = null;
@@ -328,6 +329,7 @@ export class RateLimitWatchdog {
         'Cooldown state write completed but a newer action owns the cooldown; ' +
           'not publishing pause or arming.'
       );
+      await this.restoreCooldownStateForCurrentOwner(decision.retryAtMs);
       return false;
     }
 
@@ -340,11 +342,13 @@ export class RateLimitWatchdog {
     this.cancelCooldownTimer();
     this.cooldownTimer = setTimeout(() => {
       this.cooldownTimer = null;
+      this.currentRetryAt = null;
       this.logger.info(
         `Cooldown elapsed; firing retry (step ${this.retryCount}/${this.config.maxAutoRetries}).`
       );
       void this.fireCooldownRetry(errorMessage);
     }, decision.delayMs);
+    this.currentRetryAt = decision.retryAtMs;
 
     if (
       this.cooldownTimer &&
@@ -418,8 +422,10 @@ export class RateLimitWatchdog {
     }
     this.cooldownTimer = setTimeout(() => {
       this.cooldownTimer = null;
+      this.currentRetryAt = null;
       void this.fireCooldownRetry(errorMessage);
     }, STARTUP_RETRY_DELAY_MS);
+    this.currentRetryAt = Date.now() + STARTUP_RETRY_DELAY_MS;
     if (
       this.cooldownTimer &&
       typeof this.cooldownTimer === 'object' &&
@@ -562,8 +568,24 @@ export class RateLimitWatchdog {
     if (this.cooldownTimer !== null) {
       clearTimeout(this.cooldownTimer);
       this.cooldownTimer = null;
+      this.currentRetryAt = null;
       this.logger.info('Cancelled pending rate limit cooldown.');
     }
+  }
+
+  private async restoreCooldownStateForCurrentOwner(staleRetryAtMs: number): Promise<void> {
+    if (
+      this.cooldownTimer === null ||
+      this.currentRetryAt === null ||
+      this.currentRetryAt === staleRetryAtMs
+    ) {
+      return;
+    }
+    await this.stateManager.setRateLimitCooldown({
+      retryCount: this.retryCount,
+      maxRetries: this.config.maxAutoRetries,
+      retryAt: this.currentRetryAt,
+    });
   }
 
   retryNow(): boolean {
@@ -577,6 +599,7 @@ export class RateLimitWatchdog {
     if (this.cooldownTimer !== null) {
       clearTimeout(this.cooldownTimer);
       this.cooldownTimer = null;
+      this.currentRetryAt = null;
     }
     if (this.startupExhausted) {
       this.startupExhausted = false;

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -9,7 +9,12 @@ import {
   MAX_RESET_HORIZON_MS,
   selectNextFallback,
 } from './fallback-recovery';
-import { cooldownFromReset, type LimitRetryHint } from './limit-error-classifier';
+import {
+  cooldownFromReset,
+  normalizeEpochMs,
+  type LimitRetryHint,
+} from './limit-error-classifier';
+import type { LlmLimitAssessment } from './limit-error-llm-classifier';
 import type { ProcessingStateManager } from './processing-state-manager';
 
 export interface RateLimitWatchdogConfig {
@@ -57,6 +62,7 @@ export interface RateLimitWatchdogDeps {
   resolveModelId?(provider: string, model: string): Promise<string>;
   notifyPause?(payload: RateLimitPausePayload): void;
   notifyResume?(): void;
+  classifyUnknownLimit?(rawText: string): Promise<LlmLimitAssessment | null>;
 }
 
 export type RateLimitRetryCallback = (
@@ -89,6 +95,7 @@ export class RateLimitWatchdog {
   private lastHint: LimitRetryHint | null = null;
   private billingPauseSurfaced = false;
   private retryCallbackInFlight = false;
+  private llmRefinementInFlight = false;
 
   constructor(
     sessionId: string,
@@ -153,6 +160,7 @@ export class RateLimitWatchdog {
       this.bannerCancelled = false;
       this.billingPauseSurfaced = false;
       this.lastHint = hint ?? null;
+      this.llmRefinementInFlight = false;
     }
 
     const { provider, model } = this.deps.getCurrentModel();
@@ -239,7 +247,45 @@ export class RateLimitWatchdog {
     }
 
     await this.scheduleCooldown(errorMessage, decision, entryGeneration);
+
+    if (
+      decision.reason === 'backoff-ladder' &&
+      this.deps.classifyUnknownLimit &&
+      !this.llmRefinementInFlight &&
+      entryGeneration === this.generation
+    ) {
+      this.fireLlmRefinement(errorMessage, entryGeneration);
+    }
     return true;
+  }
+
+  private fireLlmRefinement(errorMessage: string, entryGeneration: number): void {
+    const classify = this.deps.classifyUnknownLimit;
+    if (!classify) return;
+    this.llmRefinementInFlight = true;
+    void classify(errorMessage)
+      .then(async (result) => {
+        if (entryGeneration !== this.generation || this.cooldownTimer === null) return;
+        if (!result || result.notALimit) return;
+        const resetMs =
+          typeof result.resetAtMs === 'number' && Number.isFinite(result.resetAtMs)
+            ? normalizeEpochMs(result.resetAtMs)
+            : null;
+        const now = Date.now();
+        if (resetMs === null || resetMs <= now || resetMs > now + MAX_RESET_HORIZON_MS) return;
+        this.logger.info(
+          `LLM limit refinement: retry at ${new Date(resetMs).toISOString()} ` +
+            `(was backoff ladder) for error: ${errorMessage}`
+        );
+        if (result.kind) {
+          this.lastHint = { ...this.lastHint, kind: result.kind };
+        }
+        await this.scheduleCooldown(errorMessage, cooldownFromReset(resetMs, now), entryGeneration);
+      })
+      .catch(() => {})
+      .finally(() => {
+        this.llmRefinementInFlight = false;
+      });
   }
 
   private async scheduleCooldown(
@@ -540,6 +586,7 @@ export class RateLimitWatchdog {
     this.chain = null;
     this.limitKind = null;
     this.lastHint = null;
+    this.llmRefinementInFlight = false;
   }
 
   private getRemainingMs(): number {

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -291,6 +291,7 @@ export class RateLimitWatchdog {
           );
           if (!armed) {
             this.lastHint = previousHint;
+            this.limitKind = previousLimitKind;
           } else if (refund) {
             this.retryCount--;
           }

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -92,7 +92,6 @@ export class RateLimitWatchdog {
   private lastHint: LimitRetryHint | null = null;
   private billingPauseSurfaced = false;
   private retryCallbackInFlight = false;
-  private llmRefinementInFlight = false;
 
   constructor(
     sessionId: string,
@@ -157,7 +156,6 @@ export class RateLimitWatchdog {
       this.bannerCancelled = false;
       this.billingPauseSurfaced = false;
       this.lastHint = hint ?? null;
-      this.llmRefinementInFlight = false;
     }
 
     const { provider, model } = this.deps.getCurrentModel();
@@ -249,7 +247,6 @@ export class RateLimitWatchdog {
       armed &&
       decision.reason === 'backoff-ladder' &&
       this.deps.classifyUnknownLimit &&
-      !this.llmRefinementInFlight &&
       entryGeneration === this.generation
     ) {
       this.fireLlmRefinement(errorMessage, entryGeneration, !decision.freeWait);
@@ -264,7 +261,6 @@ export class RateLimitWatchdog {
   ): void {
     const classify = this.deps.classifyUnknownLimit;
     if (!classify) return;
-    this.llmRefinementInFlight = true;
     const timerAtFire = this.cooldownTimer;
     void classify(errorMessage)
       .then(async (result) => {
@@ -297,10 +293,7 @@ export class RateLimitWatchdog {
           this.retryCount--;
         }
       })
-      .catch(() => {})
-      .finally(() => {
-        this.llmRefinementInFlight = false;
-      });
+      .catch(() => {});
   }
 
   private async scheduleCooldown(
@@ -635,7 +628,6 @@ export class RateLimitWatchdog {
     this.chain = null;
     this.limitKind = null;
     this.lastHint = null;
-    this.llmRefinementInFlight = false;
   }
 
   private getRemainingMs(): number {

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -277,20 +277,36 @@ export class RateLimitWatchdog {
             `(was backoff ladder) for error: ${errorMessage}`
         );
         const previousHint = this.lastHint;
+        const previousLimitKind = this.limitKind;
         if (result.kind) {
           this.lastHint = { ...this.lastHint, kind: result.kind };
         }
         const refund = chargedLadder && this.retryCount > 0;
-        const armed = await this.scheduleCooldown(
-          errorMessage,
-          cooldownFromReset(resetMs, now),
-          entryGeneration,
-          refund ? this.retryCount - 1 : this.retryCount
-        );
-        if (!armed) {
+        try {
+          const armed = await this.scheduleCooldown(
+            errorMessage,
+            cooldownFromReset(resetMs, now),
+            entryGeneration,
+            refund ? this.retryCount - 1 : this.retryCount
+          );
+          if (!armed) {
+            this.lastHint = previousHint;
+          } else if (refund) {
+            this.retryCount--;
+          }
+        } catch (err) {
+          this.logger.warn('LLM refinement cooldown scheduling threw; reconciling state:', err);
           this.lastHint = previousHint;
-        } else if (refund) {
-          this.retryCount--;
+          this.limitKind = previousLimitKind;
+          if (this.cooldownTimer === timerAtFire && this.currentRetryAt !== null) {
+            await this.stateManager
+              .setRateLimitCooldown({
+                retryCount: this.retryCount,
+                maxRetries: this.config.maxAutoRetries,
+                retryAt: this.currentRetryAt,
+              })
+              .catch(() => {});
+          }
         }
       })
       .catch(() => {});

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -219,7 +219,10 @@ export class ProviderService {
   ): Promise<{ providerModelId: string; sdkModelId: string }> {
     const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
-    const providerModelId = provider?.getTitleGenerationModel?.() ?? sessionModelId;
+    const providerModelId =
+      provider?.getTitleGenerationModel?.() ??
+      provider?.getModelForTier?.('haiku') ??
+      sessionModelId;
     let sdkModelId = provider?.translateModelIdForSdk?.(providerModelId) ?? providerModelId;
     try {
       const sdkConfig = provider?.buildSdkConfig(providerModelId);

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -219,10 +219,7 @@ export class ProviderService {
   ): Promise<{ providerModelId: string; sdkModelId: string }> {
     const registry = await this.getReadyRegistry();
     const provider = registry.get(providerId);
-    const providerModelId =
-      provider?.getTitleGenerationModel?.() ??
-      provider?.getModelForTier?.('haiku') ??
-      sessionModelId;
+    const providerModelId = provider?.getTitleGenerationModel?.() ?? sessionModelId;
     let sdkModelId = provider?.translateModelIdForSdk?.(providerModelId) ?? providerModelId;
     try {
       const sdkConfig = provider?.buildSdkConfig(providerModelId);
@@ -232,6 +229,13 @@ export class ProviderService {
       providerModelId,
       sdkModelId,
     };
+  }
+
+  async getCheapTierModel(providerId: string): Promise<string | null> {
+    const registry = await this.getReadyRegistry();
+    const provider = registry.get(providerId);
+    if (!provider) return null;
+    return provider.getTitleGenerationModel?.() ?? provider.getModelForTier?.('haiku') ?? null;
   }
 
   async getTitleGenerationModel(providerId: string, sessionModelId: string): Promise<string> {

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -63,8 +63,8 @@ export class ProviderRegistry {
 
     const results = await Promise.all(
       providers.map(async (provider) => {
-        const available = await provider.isAvailable();
-        const models = await provider.getModels();
+        const available = await Promise.resolve(provider.isAvailable()).catch(() => false);
+        const models = await Promise.resolve(provider.getModels()).catch(() => []);
 
         return {
           id: provider.id,

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -31,6 +31,7 @@ function createDeps(replyText: string | Error): {
         { id: 'deepseek', name: 'DeepSeek', models: [], available: true },
       ],
       isProviderAvailable: async () => true,
+      getCheapTierModel: async () => 'cheap-model',
       getTitleGenerationModels: async () => ({
         providerModelId: 'cheap-model',
         sdkModelId: 'sdk-cheap-model',
@@ -311,6 +312,27 @@ describe('LimitErrorLlmClassifier', () => {
     };
     const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'anthropic' });
     await classifier.classify('acp never classifies this wall');
+    expect(seenProviders).toEqual(['glm']);
+  });
+
+  it('skips available providers that expose no cheap-tier model', async () => {
+    const seenProviders: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'openrouter', name: 'OpenRouter', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: [], available: true },
+      ],
+      getCheapTierModel: async (id: string) => (id === 'glm' ? 'cheap-model' : null),
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'anthropic' });
+    await classifier.classify('no cheap tier on the first candidate');
     expect(seenProviders).toEqual(['glm']);
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -177,6 +177,37 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('preserves the Kimi title thinking config when Kimi classifies', async () => {
+    const seenThinking: unknown[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'kimi', name: 'Kimi', models: [], available: true },
+      ],
+      getTitleGenerationModels: async () => ({
+        providerModelId: 'kimi-for-coding',
+        sdkModelId: 'kimi-for-coding',
+      }),
+    };
+    deps.queryForTesting = ((params: { prompt: string; options: { thinking?: unknown } }) => {
+      seenThinking.push(params.options.thinking);
+      return (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: '{"is_limit":true,"kind":"rate_limit","reset_at":null}' },
+            ],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'glm' });
+    await classifier.classify('kimi thinking wall');
+    expect(seenThinking).toEqual([{ type: 'enabled', budgetTokens: 16000 }]);
+  });
+
   it('skips registry-unavailable providers and classifies via the next available one', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -143,7 +143,7 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
-  it('skips the query when the caller aborts during provider setup', async () => {
+  it('unblocks the caller immediately when it aborts during provider setup', async () => {
     let releaseSetup: () => void = () => {};
     const setupGate = new Promise<void>((resolve) => {
       releaseSetup = resolve;
@@ -176,13 +176,18 @@ describe('LimitErrorLlmClassifier', () => {
     const pending = classifier.classify('setup abort wall', controller.signal);
     await new Promise((resolve) => setTimeout(resolve, 5));
     controller.abort();
-    releaseSetup();
 
     expect(await pending).toBeNull();
-    expect(prompts).toHaveLength(0);
+    releaseSetup();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(prompts).toHaveLength(1);
+    const cached = await classifier.classify('setup abort wall');
+    expect(cached?.kind).toBe('rate_limit');
+    expect(prompts).toHaveLength(1);
   });
 
-  it('unblocks the caller and skips the query when a queued lookup is aborted mid-queue', async () => {
+  it('keeps a shared lookup alive for later callers when one waiter aborts mid-queue', async () => {
     let releaseFirst: () => void = () => {};
     const firstGate = new Promise<void>((resolve) => {
       releaseFirst = resolve;
@@ -214,6 +219,9 @@ describe('LimitErrorLlmClassifier', () => {
     releaseFirst();
     expect(await first).not.toBeNull();
     expect(prompts).toHaveLength(1);
+    const retried = await classifier.classify('second distinct queued waf block');
+    expect(retried?.notALimit).toBe(true);
+    expect(prompts).toHaveLength(2);
   });
 
   it('preserves the Kimi title thinking config when Kimi classifies', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -247,6 +247,26 @@ describe('LimitErrorLlmClassifier', () => {
     expect(seenThinking).toEqual([{ type: 'enabled', budgetTokens: 16000 }]);
   });
 
+  it('never selects the acp provider for the SDK classification query', async () => {
+    const seenProviders: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'acp', name: 'ACP', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: [], available: true },
+      ],
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'anthropic' });
+    await classifier.classify('acp never classifies this wall');
+    expect(seenProviders).toEqual(['glm']);
+  });
+
   it('skips registry-unavailable providers and classifies via the next available one', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -143,6 +143,40 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('unblocks the caller and skips the query when a queued lookup is aborted mid-queue', async () => {
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const prompts: string[] = [];
+    const queryForTesting = ((params: { prompt: string }) => {
+      prompts.push(params.prompt);
+      return (async function* () {
+        await firstGate;
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: '{"is_limit":false,"kind":null,"reset_at":null}' }],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const { deps } = createDeps('{"is_limit":false,"kind":null,"reset_at":null}');
+    deps.queryForTesting = queryForTesting;
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+
+    const first = classifier.classify('first distinct queued waf block');
+    const controller = new AbortController();
+    const second = classifier.classify('second distinct queued waf block', controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    controller.abort();
+
+    expect(await second).toBeNull();
+    releaseFirst();
+    expect(await first).not.toBeNull();
+    expect(prompts).toHaveLength(1);
+  });
+
   it('skips registry-unavailable providers and classifies via the next available one', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -143,6 +143,45 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('skips the query when the caller aborts during provider setup', async () => {
+    let releaseSetup: () => void = () => {};
+    const setupGate = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    const prompts: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    deps.providerService = {
+      ...deps.providerService,
+      applyEnvVarsToProcessForProvider: async () => {
+        await setupGate;
+        return {};
+      },
+    };
+    deps.queryForTesting = ((params: { prompt: string }) => {
+      prompts.push(params.prompt);
+      return (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: '{"is_limit":true,"kind":"rate_limit","reset_at":null}' },
+            ],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+
+    const controller = new AbortController();
+    const pending = classifier.classify('setup abort wall', controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    controller.abort();
+    releaseSetup();
+
+    expect(await pending).toBeNull();
+    expect(prompts).toHaveLength(0);
+  });
+
   it('unblocks the caller and skips the query when a queued lookup is aborted mid-queue', async () => {
     let releaseFirst: () => void = () => {};
     const firstGate = new Promise<void>((resolve) => {

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -415,6 +415,21 @@ describe('LimitErrorLlmClassifier', () => {
     expect((await queued)?.kind).toBe('rate_limit');
   });
 
+  it('redacts secrets from the prompt before it crosses providers', async () => {
+    const { deps, prompts } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    await classifier.classify(
+      'quota exceeded for org_123: https://user:secretpass@api.example.com/v1 sk-abc123def456ghi789jkl012 Bearer abcdef1234567890abcdef retry later'
+    );
+    const prompt = prompts[0];
+    expect(prompt).not.toContain('secretpass');
+    expect(prompt).not.toContain('sk-abc123def456ghi789jkl012');
+    expect(prompt).not.toContain('abcdef1234567890abcdef');
+    expect(prompt).toContain('[credentials]@api.example.com');
+    expect(prompt).toContain('[key]');
+    expect(prompt).toContain('Bearer [token]');
+  });
+
   it('skips providers whose model probe returned an empty list', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -144,6 +144,80 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('skips an unstarted queued task once every caller has timed out', async () => {
+    let releaseFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const prompts: string[] = [];
+    const queryForTesting = ((params: { prompt: string }) => {
+      prompts.push(params.prompt);
+      return (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: '{"is_limit":true,"kind":"rate_limit","reset_at":null}' },
+            ],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    deps.queryForTesting = queryForTesting;
+    let discoveryCalls = 0;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => {
+        discoveryCalls += 1;
+        if (discoveryCalls === 1) {
+          await firstGate;
+        }
+        return [{ id: 'glm', name: 'GLM', models: [], available: true }];
+      },
+    };
+    const slowClassifier = new LimitErrorLlmClassifier('s1', { ...deps, timeoutMs: 5000 });
+    const fastClassifier = new LimitErrorLlmClassifier('s2', { ...deps, timeoutMs: 60 });
+
+    const first = slowClassifier.classify('first abandoned queue wall');
+    const second = fastClassifier.classifyWithTimeout('second abandoned queue wall');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(await second).toBeNull();
+
+    releaseFirst();
+    const [firstResult] = await Promise.all([first]);
+    expect(firstResult?.kind).toBe('rate_limit');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('continues past candidates whose availability probe rejects', async () => {
+    const seenProviders: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'broken', name: 'Broken', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: [], available: true },
+      ],
+      isProviderAvailable: async (id: string) => {
+        if (id === 'broken') throw new Error('probe failed');
+        return true;
+      },
+      getCheapTierModel: async () => 'cheap-model',
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'anthropic' });
+    const assessment = await classifier.classify('probe rejection wall');
+    expect(seenProviders).toEqual(['glm']);
+    expect(assessment?.kind).toBe('rate_limit');
+  });
+
   it('enforces its own deadline when provider discovery stalls, freeing the queue', async () => {
     const hangGate = new Promise<never>(() => {});
     const prompts: string[] = [];

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -389,6 +389,32 @@ describe('LimitErrorLlmClassifier', () => {
     expect(seenProviders).toEqual(['glm']);
   });
 
+  it('frees the queue when provider env application stalls past the deadline', async () => {
+    const seenRestores: unknown[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    let applyCalls = 0;
+    deps.providerService = {
+      ...deps.providerService,
+      applyEnvVarsToProcessForProvider: (() => {
+        applyCalls += 1;
+        if (applyCalls === 1) {
+          return new Promise(() => {});
+        }
+        return Promise.resolve({});
+      }) as typeof deps.providerService.applyEnvVarsToProcessForProvider,
+      restoreEnvVars: (env: unknown) => {
+        seenRestores.push(env);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, timeoutMs: 40 });
+
+    const stalled = classifier.classify('env apply stall wall');
+    const queued = classifier.classify('proceeds after the stalled task clears');
+
+    expect(await stalled).toBeNull();
+    expect((await queued)?.kind).toBe('rate_limit');
+  });
+
   it('skips providers whose model probe returned an empty list', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  LimitErrorLlmClassifier,
+  type LimitErrorLlmClassifierDeps,
+} from '../../../../src/lib/agent/limit-error-llm-classifier';
+
+type QueryOptions = {
+  prompt: string;
+  options: { model?: string };
+};
+
+function createDeps(replyText: string | Error): {
+  deps: LimitErrorLlmClassifierDeps;
+  prompts: string[];
+} {
+  const prompts: string[] = [];
+  const queryForTesting = ((params: QueryOptions) => {
+    prompts.push(params.prompt);
+    if (replyText instanceof Error) throw replyText;
+    return (async function* () {
+      yield {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: replyText }] },
+      };
+    })();
+  }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+  const deps: LimitErrorLlmClassifierDeps = {
+    providerService: {
+      getAvailableProviders: async () => [
+        { id: 'glm', name: 'GLM', models: [], available: true },
+        { id: 'deepseek', name: 'DeepSeek', models: [], available: true },
+      ],
+      isProviderAvailable: async () => true,
+      getTitleGenerationModels: async () => ({
+        providerModelId: 'cheap-model',
+        sdkModelId: 'sdk-cheap-model',
+      }),
+      applyEnvVarsToProcessForProvider: async () => ({}),
+      getEnvVarsForModel: async () => ({}),
+      restoreEnvVars: () => {},
+    },
+    queryForTesting,
+  };
+  return { deps, prompts };
+}
+
+describe('LimitErrorLlmClassifier', () => {
+  it('parses a JSON reply with an absolute reset instant', async () => {
+    const resetAt = Date.now() + 3 * 60 * 60 * 1000;
+    const { deps } = createDeps(
+      `{"is_limit":true,"kind":"usage_limit","reset_at":${Math.floor(resetAt / 1000)}}`
+    );
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    const assessment = await classifier.classify('firewall blocked the request');
+    expect(assessment).not.toBeNull();
+    expect(assessment?.notALimit).toBe(false);
+    expect(assessment?.kind).toBe('usage_limit');
+    expect(assessment?.resetAtMs).toBe(Math.floor(resetAt / 1000) * 1000);
+  });
+
+  it('strips markdown fences around the JSON reply', async () => {
+    const { deps } = createDeps(
+      '```json\n{"is_limit":true,"kind":"rate_limit","reset_at":null}\n```'
+    );
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    const assessment = await classifier.classify('throttled, try again later');
+    expect(assessment?.kind).toBe('rate_limit');
+    expect(assessment?.resetAtMs).toBeNull();
+  });
+
+  it('treats is_limit=false as notALimit with no reset', async () => {
+    const { deps } = createDeps('{"is_limit":false,"kind":null,"reset_at":123}');
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    const assessment = await classifier.classify('Error: 401 unauthorized');
+    expect(assessment?.notALimit).toBe(true);
+    expect(assessment?.resetAtMs).toBeNull();
+  });
+
+  it('returns null when the reply has no JSON object', async () => {
+    const { deps } = createDeps('I cannot classify this.');
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    expect(await classifier.classify('weird error')).toBeNull();
+  });
+
+  it('returns null when the query throws', async () => {
+    const { deps } = createDeps(new Error('sdk spawn failed'));
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    expect(await classifier.classify('weird error')).toBeNull();
+  });
+
+  it('prefers a provider that is not the excluded (errored) provider', async () => {
+    const seenModels: string[] = [];
+    const deps = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}').deps;
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenModels.push(`${providerId}/${modelId}`);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'glm' });
+    await classifier.classify('429 from glm');
+    expect(seenModels).toEqual(['deepseek/cheap-model']);
+  });
+
+  it('caches by normalized text so repeated fleet errors hit the cache', async () => {
+    const resetAt = Date.now() + 60 * 60 * 1000;
+    const { deps, prompts } = createDeps(
+      `{"is_limit":true,"kind":"usage_limit","reset_at":${resetAt}}`
+    );
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    await classifier.classify('request [2026082114402920abcdef0123] rejected');
+    await classifier.classify('request [2026082114403188abcdef9876] rejected');
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('returns null when no provider is available', async () => {
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":1}');
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [],
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    expect(await classifier.classify('429')).toBeNull();
+  });
+});

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -27,8 +27,8 @@ function createDeps(replyText: string | Error): {
   const deps: LimitErrorLlmClassifierDeps = {
     providerService: {
       getAvailableProviders: async () => [
-        { id: 'glm', name: 'GLM', models: [], available: true },
-        { id: 'deepseek', name: 'DeepSeek', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: ['some-model'], available: true },
+        { id: 'deepseek', name: 'DeepSeek', models: ['some-model'], available: true },
       ],
       isProviderAvailable: async () => true,
       getCheapTierModel: async () => 'cheap-model',
@@ -173,7 +173,7 @@ describe('LimitErrorLlmClassifier', () => {
         if (discoveryCalls === 1) {
           await firstGate;
         }
-        return [{ id: 'glm', name: 'GLM', models: [], available: true }];
+        return [{ id: 'glm', name: 'GLM', models: ['some-model'], available: true }];
       },
     };
     const slowClassifier = new LimitErrorLlmClassifier('s1', { ...deps, timeoutMs: 5000 });
@@ -199,8 +199,8 @@ describe('LimitErrorLlmClassifier', () => {
     deps.providerService = {
       ...deps.providerService,
       getAvailableProviders: async () => [
-        { id: 'broken', name: 'Broken', models: [], available: true },
-        { id: 'glm', name: 'GLM', models: [], available: true },
+        { id: 'broken', name: 'Broken', models: ['some-model'], available: true },
+        { id: 'glm', name: 'GLM', models: ['some-model'], available: true },
       ],
       isProviderAvailable: async (id: string) => {
         if (id === 'broken') throw new Error('probe failed');
@@ -230,7 +230,7 @@ describe('LimitErrorLlmClassifier', () => {
         if (discoveryCalls === 1) {
           await hangGate;
         }
-        return [{ id: 'glm', name: 'GLM', models: [], available: true }];
+        return [{ id: 'glm', name: 'GLM', models: ['some-model'], available: true }];
       },
     };
     deps.queryForTesting = ((params: { prompt: string }) => {
@@ -344,7 +344,7 @@ describe('LimitErrorLlmClassifier', () => {
     deps.providerService = {
       ...deps.providerService,
       getAvailableProviders: async () => [
-        { id: 'kimi', name: 'Kimi', models: [], available: true },
+        { id: 'kimi', name: 'Kimi', models: ['some-model'], available: true },
       ],
       getTitleGenerationModels: async () => ({
         providerModelId: 'kimi-for-coding',
@@ -376,8 +376,8 @@ describe('LimitErrorLlmClassifier', () => {
     deps.providerService = {
       ...deps.providerService,
       getAvailableProviders: async () => [
-        { id: 'acp', name: 'ACP', models: [], available: true },
-        { id: 'glm', name: 'GLM', models: [], available: true },
+        { id: 'acp', name: 'ACP', models: ['some-model'], available: true },
+        { id: 'glm', name: 'GLM', models: ['some-model'], available: true },
       ],
       applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
         seenProviders.push(providerId);
@@ -389,7 +389,7 @@ describe('LimitErrorLlmClassifier', () => {
     expect(seenProviders).toEqual(['glm']);
   });
 
-  it('skips available providers that expose no cheap-tier model', async () => {
+  it('skips providers whose model probe returned an empty list', async () => {
     const seenProviders: string[] = [];
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
     const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
@@ -397,7 +397,74 @@ describe('LimitErrorLlmClassifier', () => {
       ...deps.providerService,
       getAvailableProviders: async () => [
         { id: 'openrouter', name: 'OpenRouter', models: [], available: true },
-        { id: 'glm', name: 'GLM', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: ['glm-4.6'], available: true },
+      ],
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'anthropic' });
+    const assessment = await classifier.classify('revoked key wall');
+    expect(seenProviders).toEqual(['glm']);
+    expect(assessment?.kind).toBe('rate_limit');
+  });
+
+  it('runs separate lookups for callers excluding different providers', async () => {
+    const seenProviders: string[] = [];
+    let queries = 0;
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'glm', name: 'GLM', models: ['glm-4.6'], available: true },
+        { id: 'deepseek', name: 'DeepSeek', models: ['deepseek-chat'], available: true },
+      ],
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    deps.queryForTesting = (() => {
+      queries += 1;
+      return (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: '{"is_limit":true,"kind":"rate_limit","reset_at":null}' },
+            ],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const glmSession = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'glm' });
+    const anthropicSession = new LimitErrorLlmClassifier('s2', {
+      ...deps,
+      excludeProvider: 'anthropic',
+    });
+
+    const [glmResult, anthropicResult] = await Promise.all([
+      glmSession.classify('shared wall text'),
+      anthropicSession.classify('shared wall text'),
+    ]);
+
+    expect(glmResult?.kind).toBe('rate_limit');
+    expect(anthropicResult?.kind).toBe('rate_limit');
+    expect(queries).toBe(2);
+    expect(seenProviders).toEqual(['deepseek', 'glm']);
+  });
+
+  it('skips available providers that expose no cheap-tier model', async () => {
+    const seenProviders: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'openrouter', name: 'OpenRouter', models: ['some-model'], available: true },
+        { id: 'glm', name: 'GLM', models: ['some-model'], available: true },
       ],
       getCheapTierModel: async (id: string) => (id === 'glm' ? 'cheap-model' : null),
       applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
@@ -417,9 +484,9 @@ describe('LimitErrorLlmClassifier', () => {
     deps.providerService = {
       ...deps.providerService,
       getAvailableProviders: async () => [
-        { id: 'glm', name: 'GLM', models: [], available: true },
-        { id: 'kimi', name: 'Kimi', models: [], available: true },
-        { id: 'deepseek', name: 'DeepSeek', models: [], available: true },
+        { id: 'glm', name: 'GLM', models: ['some-model'], available: true },
+        { id: 'kimi', name: 'Kimi', models: ['some-model'], available: true },
+        { id: 'deepseek', name: 'DeepSeek', models: ['some-model'], available: true },
       ],
       isProviderAvailable: async (id: string) => id === 'deepseek',
       applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -143,6 +143,45 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('enforces its own deadline when provider discovery stalls, freeing the queue', async () => {
+    const hangGate = new Promise<never>(() => {});
+    const prompts: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    let discoveryCalls = 0;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => {
+        discoveryCalls += 1;
+        if (discoveryCalls === 1) {
+          await hangGate;
+        }
+        return [{ id: 'glm', name: 'GLM', models: [], available: true }];
+      },
+    };
+    deps.queryForTesting = ((params: { prompt: string }) => {
+      prompts.push(params.prompt);
+      return (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: '{"is_limit":true,"kind":"rate_limit","reset_at":null}' },
+            ],
+          },
+        };
+      })();
+    }) as LimitErrorLlmClassifierDeps['queryForTesting'];
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, timeoutMs: 40 });
+
+    const stalled = classifier.classify('discovery stall wall');
+    const queued = classifier.classify('proceeds once the stalled task clears');
+
+    const [stalledResult, queuedResult] = await Promise.all([stalled, queued]);
+    expect(stalledResult).toBeNull();
+    expect(queuedResult?.kind).toBe('rate_limit');
+    expect(prompts).toHaveLength(1);
+  });
+
   it('unblocks the caller immediately when it aborts during provider setup', async () => {
     let releaseSetup: () => void = () => {};
     const setupGate = new Promise<void>((resolve) => {

--- a/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/limit-error-llm-classifier.test.ts
@@ -115,6 +115,56 @@ describe('LimitErrorLlmClassifier', () => {
     expect(prompts).toHaveLength(1);
   });
 
+  it('re-classifies relative-delay errors instead of reusing a cached reset', async () => {
+    const { deps, prompts } = createDeps(
+      '{"is_limit":true,"kind":"rate_limit","reset_at":1755800000000,"relative":true}'
+    );
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    await classifier.classify('quota wall, retry soon');
+    await classifier.classify('quota wall, retry soon');
+    expect(prompts).toHaveLength(2);
+  });
+
+  it('does not cache failed classifications', async () => {
+    const { deps, prompts } = createDeps('no json here');
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    await classifier.classify('waf block page');
+    await classifier.classify('waf block page');
+    expect(prompts).toHaveLength(2);
+  });
+
+  it('deduplicates concurrent classifications of the same error text', async () => {
+    const { deps, prompts } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const classifier = new LimitErrorLlmClassifier('s1', deps);
+    await Promise.all([
+      classifier.classify('concurrent waf block'),
+      classifier.classify('concurrent waf block'),
+    ]);
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('skips registry-unavailable providers and classifies via the next available one', async () => {
+    const seenProviders: string[] = [];
+    const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":null}');
+    const originalApply = deps.providerService.applyEnvVarsToProcessForProvider;
+    deps.providerService = {
+      ...deps.providerService,
+      getAvailableProviders: async () => [
+        { id: 'glm', name: 'GLM', models: [], available: true },
+        { id: 'kimi', name: 'Kimi', models: [], available: true },
+        { id: 'deepseek', name: 'DeepSeek', models: [], available: true },
+      ],
+      isProviderAvailable: async (id: string) => id === 'deepseek',
+      applyEnvVarsToProcessForProvider: async (providerId: string, modelId: string) => {
+        seenProviders.push(providerId);
+        return originalApply(providerId, modelId);
+      },
+    };
+    const classifier = new LimitErrorLlmClassifier('s1', { ...deps, excludeProvider: 'glm' });
+    await classifier.classify('429 from glm via unavailable relay');
+    expect(seenProviders).toEqual(['deepseek']);
+  });
+
   it('returns null when no provider is available', async () => {
     const { deps } = createDeps('{"is_limit":true,"kind":"rate_limit","reset_at":1}');
     deps.providerService = {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -659,6 +659,44 @@ describe('RateLimitWatchdog', () => {
       ).toHaveLength(1);
     });
 
+    it('keeps a newer hint supplied while the refinement write was pending', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseStateWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseStateWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      const newerHint = {
+        kind: 'usage_limit' as const,
+        resetAtMs: Date.now() + 3 * 60 * 60 * 1000,
+      };
+      (watchdog as unknown as { lastHint: unknown }).lastHint = newerHint;
+      releaseStateWrite();
+      await flush();
+      await flush();
+
+      expect((watchdog as unknown as { lastHint: unknown }).lastHint).toBe(newerHint);
+      watchdog.cancel();
+    });
+
     it('does not clobber a newer cooldown taken during the refinement state write', async () => {
       const classify = mock(async () => ({
         resetAtMs: Date.now() + 2 * 60 * 60 * 1000,

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -620,6 +620,40 @@ describe('RateLimitWatchdog', () => {
         (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
       ).toHaveLength(1);
     });
+
+    it('does not clobber a newer cooldown taken during the refinement state write', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseStateWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseStateWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      watchdog.retryNow();
+      releaseStateWrite();
+      await flush();
+      await flush();
+
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).toBeNull();
+    });
   });
 
   describe('Phase A — immediate fallback switch', () => {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -520,6 +520,106 @@ describe('RateLimitWatchdog', () => {
         (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
       ).toHaveLength(1);
     });
+
+    it('clears the ladder timer when the refined reset re-arms the cooldown', async () => {
+      let resolveClassify: (value: {
+        resetAtMs: number;
+        kind: 'usage_limit';
+        notALimit: false;
+      }) => void = () => {};
+      const classify = mock(
+        () =>
+          new Promise((resolve) => {
+            resolveClassify = resolve;
+          })
+      );
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify as unknown as ReturnType<typeof mock>;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const realClearTimeout = globalThis.clearTimeout;
+      const clearedHandles: unknown[] = [];
+      globalThis.clearTimeout = ((handle: unknown) => {
+        clearedHandles.push(handle);
+        return realClearTimeout(handle as Parameters<typeof clearTimeout>[0]);
+      }) as typeof clearTimeout;
+
+      try {
+        await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+        const ladderTimer = (watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer;
+        expect(ladderTimer).not.toBeNull();
+
+        resolveClassify({
+          resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+          kind: 'usage_limit',
+          notALimit: false,
+        });
+        await flush();
+        await flush();
+
+        const refinedTimer = (watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer;
+        expect(refinedTimer).not.toBeNull();
+        expect(refinedTimer).not.toBe(ladderTimer);
+        expect(clearedHandles).toContain(ladderTimer);
+      } finally {
+        globalThis.clearTimeout = realClearTimeout;
+        watchdog.cancel();
+      }
+    });
+
+    it('refunds the ladder charge when refinement converts to a free wait', async () => {
+      const resetAt = Date.now() + 2 * 60 * 60 * 1000;
+      const classify = mock(async () => ({
+        resetAtMs: resetAt,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('firewall throttled, no timestamps in body', {
+        uuid: 'm1',
+        content: 'x',
+      });
+      await flush();
+      await flush();
+
+      expect(watchdog.getState().retryCount).toBe(0);
+      watchdog.cancel();
+    });
+
+    it('does not overwrite a newer cooldown armed while classification is in flight', async () => {
+      let resolveClassify: (value: {
+        resetAtMs: number;
+        kind: 'usage_limit';
+        notALimit: false;
+      }) => void = () => {};
+      const classify = mock(
+        () =>
+          new Promise((resolve) => {
+            resolveClassify = resolve;
+          })
+      );
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify as unknown as ReturnType<typeof mock>;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      expect(watchdog.retryNow()).toBe(true);
+      await flush();
+
+      resolveClassify({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit',
+        notALimit: false,
+      });
+      await flush();
+      await flush();
+
+      expect(
+        (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
+      ).toHaveLength(1);
+    });
   });
 
   describe('Phase A — immediate fallback switch', () => {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -736,6 +736,80 @@ describe('RateLimitWatchdog', () => {
       expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).not.toBeNull();
       watchdog.cancel();
     });
+
+    it('persists an expired cooldown when ownership was lost to a retry with no live timer', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseStateWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseStateWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+      watchdog.retryNow();
+      releaseStateWrite();
+      await flush();
+      await flush();
+
+      const lastPayload = originalSet.mock.calls[originalSet.mock.calls.length - 1][0] as {
+        retryAt: number;
+      };
+      expect(lastPayload.retryAt).toBeLessThanOrEqual(Date.now());
+      watchdog.cancel();
+    });
+
+    it('does not start refinement when the scheduling call lost ownership', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseFirstWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseFirstWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 1) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      const first = watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await watchdog.scheduleRetry('throttled by proxy again', { uuid: 'm1', content: 'x' });
+      await flush();
+      releaseFirstWrite();
+      await first;
+      await flush();
+      await flush();
+
+      expect(classify.mock.calls.map((c) => c[0])).toEqual(['throttled by proxy again']);
+      watchdog.cancel();
+    });
   });
 
   describe('Phase A — immediate fallback switch', () => {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -653,6 +653,7 @@ describe('RateLimitWatchdog', () => {
 
       expect(notifyPause).toHaveBeenCalledTimes(1);
       expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).toBeNull();
+      expect(watchdog.getState().retryCount).toBe(1);
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -736,6 +736,7 @@ describe('RateLimitWatchdog', () => {
       expect(lastPayload.retryAt).toBe(ownerRetryAt);
       expect(lastPayload.retryAt).not.toBe(stalePayload.retryAt);
       expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).not.toBeNull();
+      expect(watchdog.getState().limitKind).not.toBe('usage_limit');
       watchdog.cancel();
     });
 

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -423,6 +423,105 @@ describe('RateLimitWatchdog', () => {
     });
   });
 
+  describe('LLM refinement of unparseable limits', () => {
+    it('re-arms the cooldown at the LLM-provided reset when the ladder was armed', async () => {
+      const resetAt = Date.now() + 2 * 60 * 60 * 1000;
+      const classify = mock(async () => ({
+        resetAtMs: resetAt,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('firewall throttled, no timestamps in body', {
+        uuid: 'm1',
+        content: 'x',
+      });
+      await flush();
+      await flush();
+
+      expect(classify).toHaveBeenCalledTimes(1);
+      const calls = (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[1][0].retryAt).toBe(resetAt + RESET_BUFFER_MS);
+      expect(notifyPause.mock.calls[1][0]).toMatchObject({
+        kind: 'usage_limit',
+        resetAt: resetAt + RESET_BUFFER_MS,
+      });
+      watchdog.cancel();
+    });
+
+    it('does not re-arm when the LLM says the error is not a limit', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: null,
+        kind: null,
+        notALimit: true,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('upstream hiccup', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+
+      expect(classify).toHaveBeenCalledTimes(1);
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      watchdog.cancel();
+    });
+
+    it('skips refinement when a parsed reset already scheduled the cooldown', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      const resetIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      await watchdog.scheduleRetry(`resets ${resetIso}`, { uuid: 'm1', content: 'x' });
+      await flush();
+
+      expect(classify).not.toHaveBeenCalled();
+      watchdog.cancel();
+    });
+
+    it('does not re-arm after the episode is cancelled mid-lookup', async () => {
+      let resolveClassify: (value: {
+        resetAtMs: number;
+        kind: 'usage_limit';
+        notALimit: false;
+      }) => void = () => {};
+      const classify = mock(
+        () =>
+          new Promise((resolve) => {
+            resolveClassify = resolve;
+          })
+      );
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify as unknown as ReturnType<typeof mock>;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      watchdog.cancel();
+      resolveClassify({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit',
+        notALimit: false,
+      });
+      await flush();
+      await flush();
+
+      expect(
+        (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
+      ).toHaveLength(1);
+    });
+  });
+
   describe('Phase A — immediate fallback switch', () => {
     const A: FallbackModelEntry = { provider: 'glm', model: 'glm-4.6' };
     const B: FallbackModelEntry = { provider: 'minimax', model: 'abab6.5' };

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -588,6 +588,44 @@ describe('RateLimitWatchdog', () => {
       watchdog.cancel();
     });
 
+    it('keeps the ladder charge visible until the refined cooldown owns, but persists the refund', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseStateWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseStateWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      expect(watchdog.getState().retryCount).toBe(1);
+
+      releaseStateWrite();
+      await flush();
+      await flush();
+
+      expect(
+        (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls[1][0]
+      ).toMatchObject({ retryCount: 0 });
+      expect(watchdog.getState().retryCount).toBe(0);
+      watchdog.cancel();
+    });
+
     it('does not overwrite a newer cooldown armed while classification is in flight', async () => {
       let resolveClassify: (value: {
         resetAtMs: number;

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -777,6 +777,42 @@ describe('RateLimitWatchdog', () => {
       watchdog.cancel();
     });
 
+    it('reconciles persisted state and hint when the refined write throws', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) {
+            throw new Error('publish rejected after persist');
+          }
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+      await flush();
+
+      const writes = originalSet.mock.calls;
+      const lastPayload = writes[writes.length - 1][0] as { retryAt: number };
+      const ownerRetryAt = (watchdog as unknown as { currentRetryAt: number | null })
+        .currentRetryAt;
+      expect(ownerRetryAt).not.toBeNull();
+      expect(lastPayload.retryAt).toBe(ownerRetryAt);
+      expect(watchdog.getState().retryCount).toBe(1);
+      watchdog.cancel();
+    });
+
     it('refines a newer cooldown even while an older refinement is in flight', async () => {
       const classifyCalls: string[] = [];
       let releaseAll: (() => void) | undefined;

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -693,6 +693,49 @@ describe('RateLimitWatchdog', () => {
       expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).toBeNull();
       expect(watchdog.getState().retryCount).toBe(1);
     });
+
+    it('restores the persisted state of a newer cooldown after a stale refinement write', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const originalSet = stateManager.setRateLimitCooldown as ReturnType<typeof mock>;
+      let releaseStateWrite: () => void = () => {};
+      const writeGate = new Promise<void>((resolve) => {
+        releaseStateWrite = resolve;
+      });
+      let stateWrites = 0;
+      (stateManager as unknown as { setRateLimitCooldown: unknown }).setRateLimitCooldown = mock(
+        async (payload: unknown) => {
+          stateWrites += 1;
+          if (stateWrites === 2) await writeGate;
+          return originalSet(payload);
+        }
+      );
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+      await watchdog.scheduleRetry('throttled by proxy again', { uuid: 'm1', content: 'x' });
+      await flush();
+      releaseStateWrite();
+      await flush();
+      await flush();
+
+      const writes = originalSet.mock.calls;
+      expect(notifyPause).toHaveBeenCalledTimes(2);
+      const newerOwnerPayload = writes[1][0] as { retryAt: number };
+      const staleRefinedPayload = writes[2][0] as { retryAt: number };
+      const lastPayload = writes[writes.length - 1][0] as { retryAt: number };
+      expect(lastPayload.retryAt).toBe(newerOwnerPayload.retryAt);
+      expect(lastPayload.retryAt).not.toBe(staleRefinedPayload.retryAt);
+      expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).not.toBeNull();
+      watchdog.cancel();
+    });
   });
 
   describe('Phase A — immediate fallback switch', () => {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -727,12 +727,14 @@ describe('RateLimitWatchdog', () => {
       await flush();
 
       const writes = originalSet.mock.calls;
-      expect(notifyPause).toHaveBeenCalledTimes(2);
-      const newerOwnerPayload = writes[1][0] as { retryAt: number };
-      const staleRefinedPayload = writes[2][0] as { retryAt: number };
+      expect(notifyPause.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const stalePayload = writes[0][0] as { retryAt: number };
       const lastPayload = writes[writes.length - 1][0] as { retryAt: number };
-      expect(lastPayload.retryAt).toBe(newerOwnerPayload.retryAt);
-      expect(lastPayload.retryAt).not.toBe(staleRefinedPayload.retryAt);
+      const ownerRetryAt = (watchdog as unknown as { currentRetryAt: number | null })
+        .currentRetryAt;
+      expect(ownerRetryAt).not.toBeNull();
+      expect(lastPayload.retryAt).toBe(ownerRetryAt);
+      expect(lastPayload.retryAt).not.toBe(stalePayload.retryAt);
       expect((watchdog as unknown as { cooldownTimer: unknown }).cooldownTimer).not.toBeNull();
       watchdog.cancel();
     });
@@ -772,6 +774,54 @@ describe('RateLimitWatchdog', () => {
         retryAt: number;
       };
       expect(lastPayload.retryAt).toBeLessThanOrEqual(Date.now());
+      watchdog.cancel();
+    });
+
+    it('refines a newer cooldown even while an older refinement is in flight', async () => {
+      const classifyCalls: string[] = [];
+      let releaseAll: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        releaseAll = resolve;
+      });
+      const classify = mock(() => {
+        return new Promise<{ resetAtMs: number; kind: 'usage_limit'; notALimit: boolean }>(
+          (resolve) => {
+            void gate.then(() =>
+              resolve({
+                resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+                kind: 'usage_limit',
+                notALimit: false,
+              })
+            );
+          }
+        ).then((value) => {
+          return value;
+        });
+      });
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = async (rawText: string) => {
+        classifyCalls.push(rawText);
+        return classify() as Promise<{
+          resetAtMs: number;
+          kind: 'usage_limit';
+          notALimit: boolean;
+        }>;
+      };
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await watchdog.scheduleRetry('throttled by proxy again', { uuid: 'm1', content: 'x' });
+      await flush();
+
+      expect(classifyCalls).toEqual(['throttled by waf', 'throttled by proxy again']);
+
+      releaseAll?.();
+      await flush();
+      await flush();
+      await flush();
+
+      expect(notifyPause.mock.calls.length).toBeGreaterThanOrEqual(3);
       watchdog.cancel();
     });
 

--- a/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
@@ -172,6 +172,26 @@ describe('ProviderRegistry', () => {
     });
   });
 
+  describe('getProviderInfo', () => {
+    it('isolates per-provider probe failures instead of aborting discovery', async () => {
+      const healthy = makeAnthropicProvider();
+      const broken = new (class extends MockProvider {
+        readonly id = 'broken' as const;
+        override async getModels(): Promise<ModelInfo[]> {
+          throw new Error('probe failed');
+        }
+      })();
+      registry.register(healthy);
+      registry.register(broken);
+
+      const infos = await registry.getProviderInfo();
+
+      expect(infos.map((i) => i.id)).toEqual(['anthropic', 'broken']);
+      expect(infos.find((i) => i.id === 'broken')?.models).toEqual([]);
+      expect(infos.find((i) => i.id === 'anthropic')?.models).toContain('mock-1');
+    });
+  });
+
   describe('getAll', () => {
     it('should return all registered providers', () => {
       const mock1 = new MockProvider();


### PR DESCRIPTION
Stacks on #2661. When the deterministic tier classifies an error as a limit but cannot extract a reset time — WAF/firewall pages, changed provider formats, weekly-limit phrasing with no timestamp — the watchdog currently falls straight to the blind backoff ladder (10m→4h capped at 8h), so a session with a known-in-principle reset gets nagged either far too early or far too late.

This adds a second classification tier. `LimitErrorLlmClassifier` sends the error text as a one-shot `maxTurns: 1`, tool-less SDK query to the cheap title-generation model of a provider that is not the one that errored, and gets back strict JSON `{is_limit, kind, reset_at}` — able to interpret relative delays ("retry in 2 hours") and unusual timestamp formats the regex strategies miss. Results are cached by normalized text (request-ids and epoch runs masked) for 10 minutes, so a fleet hitting the same wall dedupes to a single call; calls are serialized to avoid concurrent provider-env mutation, and race a 12s timeout. The watchdog consults it only when the ladder was armed, fire-and-forget: the ladder schedules immediately, and when a valid reset comes back the cooldown is re-armed at reset+buffer (a free wait, episode- and cancellation-aware) with the refined kind flowing into the pause event and task restrictions. Parsed or structured resets from tier one never trigger a call.

Verified: 1-core (4652), classifier suite (JSON parsing, fence stripping, not-a-limit, provider exclusion, cache dedupe, no-provider), four new watchdog refinement tests including the cancelled-episode race, typecheck, lint, knip, no-comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->