### PR TITLE
feat(daemon): wire Devin callbacks into the ACP query runtime

### DIFF
--- a/packages/daemon/src/lib/acp/acp-client.ts
+++ b/packages/daemon/src/lib/acp/acp-client.ts
@@ -39,6 +39,7 @@ import type {
 } from '@hyperneo/shared';
 import { AcpTransport } from './acp-transport';
 import type { AcpTransportCallbacks } from './acp-transport';
+import type { AcpProcessTreeOwner } from './acp-process-tree';
 
 export interface AcpClientCallbacks {
   onFsRead?(params: AcpFsReadParams): Promise<AcpFsReadResult>;
@@ -62,6 +63,7 @@ export interface AcpClientOptions
   replaceEnv?: boolean;
   cwd?: string;
   requestTimeoutMs?: number;
+  processTreeOwner?: AcpProcessTreeOwner;
 }
 
 export class AcpClient {

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -23,7 +23,22 @@ function isHeaderArgName(name: string): boolean {
   return /^(?:H|header)$/i.test(stripped);
 }
 
-export function redactSecretArgs(args: string[]): string[] {
+function isShellCommandArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^c$/i.test(stripped);
+}
+
+function redactShellCommand(script: string, depth: number): string {
+  if (depth <= 0) return script;
+  try {
+    const { command, args } = parseAcpCommand(script);
+    return [command, ...redactSecretArgs(args, depth - 1)].join(' ');
+  } catch {
+    return script;
+  }
+}
+
+export function redactSecretArgs(args: string[], depth = 3): string[] {
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
@@ -45,13 +60,18 @@ export function redactSecretArgs(args: string[]): string[] {
       continue;
     }
     const next = args[index + 1];
-    if (isSecretArgName(arg) && next !== undefined) {
+    if (isSecretArgName(arg) && next !== undefined && !next.startsWith('--')) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;
     }
     if (isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
       redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (isShellCommandArgName(arg) && next !== undefined) {
+      redacted.push(arg, redactShellCommand(next, depth));
       index++;
       continue;
     }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -4,7 +4,7 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
 const SECRET_ARG_NAME_PATTERN =
-  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)$/i;
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|user|u)$/i;
 
 const SECRET_HEADER_NAME_PATTERN =
   /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
@@ -32,11 +32,17 @@ export function shellQuote(value: string): string {
   return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+function displayQuote(token: string): string {
+  if (!/\s/.test(token)) return token;
+  if (/[$`&|;<>()*?]/.test(token)) return token;
+  return shellQuote(token);
+}
+
 function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
     const { command, args } = parseAcpCommand(script);
-    return [command, ...redactSecretArgs(args, depth - 1)].map(shellQuote).join(' ');
+    return [command, ...redactSecretArgs(args, depth - 1)].map(displayQuote).join(' ');
   } catch {
     return script;
   }
@@ -52,6 +58,10 @@ export function redactSecretArgs(args: string[], depth = 3): string[] {
     }
     if (/^-H./.test(arg)) {
       redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
+      continue;
+    }
+    if (/^-u./.test(arg)) {
+      redacted.push('-u[redacted]');
       continue;
     }
     if (/^-c./.test(arg)) {

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -69,10 +69,27 @@ function redactShellCommand(script: string, depth: number): string {
   try {
     const { command, args } = parseAcpCommand(script);
     const redactedArgs = redactCommandSecrets(command, args, depth - 1);
-    if (redactedArgs.length === args.length && redactedArgs.every((arg, i) => arg === args[i])) {
-      return script;
+    let result = script;
+    let cursor = 0;
+    let changed = false;
+    let missed = false;
+    for (let index = 0; index < redactedArgs.length; index++) {
+      if (redactedArgs[index] === args[index]) continue;
+      const span = result.indexOf(args[index], cursor);
+      if (span === -1) {
+        missed = true;
+        break;
+      }
+      result =
+        result.slice(0, span) + redactedArgs[index] + result.slice(span + args[index].length);
+      cursor = span + redactedArgs[index].length;
+      changed = true;
     }
-    return [command, ...redactedArgs].map(displayQuote).join(' ');
+    if (changed && !missed) return result;
+    if (changed) {
+      return [command, ...redactedArgs].map(displayQuote).join(' ');
+    }
+    return script;
   } catch {
     return script;
   }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -116,12 +116,27 @@ export function redactCommandSecrets(
   let inLeadingAssignments =
     options.shellScript === true ? command.indexOf('=') > 0 || isEnv : true;
   let currentCommand = command;
+  let awaitingCommandWord = options.shellScript === true;
+  let endOfOptions = false;
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
-    if (options.shellScript === true && SHELL_OPERATORS.has(arg)) {
+    if (options.shellScript === true && (SHELL_OPERATORS.has(arg) || /[;&|]$/.test(arg))) {
       inLeadingAssignments = true;
+      endOfOptions = false;
+      awaitingCommandWord = true;
+      const word = arg.replace(/[;&|]+$/, '');
+      if (word && !SHELL_OPERATORS.has(word)) currentCommand = word;
       redacted.push(arg);
+      continue;
+    }
+    if (arg === '--') {
+      endOfOptions = true;
+      redacted.push(arg);
+      continue;
+    }
+    if (endOfOptions) {
+      redacted.push(redactUrlUserinfo(arg));
       continue;
     }
     if (!arg.startsWith('-')) {
@@ -131,7 +146,10 @@ export function redactCommandSecrets(
       } else {
         if (!isAssignmentShaped) {
           inLeadingAssignments = false;
-          currentCommand = arg;
+          if (awaitingCommandWord) {
+            currentCommand = arg;
+            awaitingCommandWord = false;
+          }
         }
         redacted.push(redactUrlUserinfo(arg));
       }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -12,6 +12,7 @@ const SECRET_HEADER_NAME_PATTERN =
 const SHELL_COMMAND_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 const CURL_COMMAND_NAMES = new Set(['curl']);
 const ENV_COMMAND_NAMES = new Set(['env', 'export']);
+const SHELL_OPERATORS = new Set(['&&', '||', ';', '|', '&', '(', ')']);
 
 function commandBaseName(command: string): string {
   return (command.split('/').pop() ?? command).toLowerCase();
@@ -110,17 +111,19 @@ export function redactCommandSecrets(
   depth = 3,
   options: { shellScript?: boolean } = {}
 ): string[] {
-  const commandName = commandBaseName(command);
-  const isShell = SHELL_COMMAND_NAMES.has(commandName);
-  const isCurl = CURL_COMMAND_NAMES.has(commandName);
-  const isEnv = ENV_COMMAND_NAMES.has(commandName);
-  const isHeaderContext = isCurl || options.shellScript === true;
+  const isEnv = ENV_COMMAND_NAMES.has(commandBaseName(command));
   const assignmentsAllowed = isEnv || options.shellScript === true;
-  const commandIsAssignment = command.indexOf('=') > 0;
-  let inLeadingAssignments = options.shellScript === true ? commandIsAssignment || isEnv : true;
+  let inLeadingAssignments =
+    options.shellScript === true ? command.indexOf('=') > 0 || isEnv : true;
+  let currentCommand = command;
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
+    if (options.shellScript === true && SHELL_OPERATORS.has(arg)) {
+      inLeadingAssignments = true;
+      redacted.push(arg);
+      continue;
+    }
     if (!arg.startsWith('-')) {
       const isAssignmentShaped = arg.indexOf('=') > 0;
       if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
@@ -128,20 +131,24 @@ export function redactCommandSecrets(
       } else {
         if (!isAssignmentShaped) {
           inLeadingAssignments = false;
+          currentCommand = arg;
         }
         redacted.push(redactUrlUserinfo(arg));
       }
       continue;
     }
-    if (isHeaderContext && /^-H./.test(arg)) {
+    const tokenCommandName = commandBaseName(currentCommand);
+    const tokenCurl = CURL_COMMAND_NAMES.has(tokenCommandName);
+    const tokenShell = SHELL_COMMAND_NAMES.has(tokenCommandName);
+    if (tokenCurl && /^-H./.test(arg)) {
       redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
       continue;
     }
-    if (isCurl && /^-u./.test(arg)) {
+    if (tokenCurl && /^-u./.test(arg)) {
       redacted.push('-u[redacted]');
       continue;
     }
-    if (isShell && /^-[a-z]*c[a-z]*$/i.test(arg)) {
+    if (tokenShell && /^-[a-z]*c[a-z]*$/i.test(arg)) {
       const next = args[index + 1];
       if (next !== undefined) {
         redacted.push(arg, redactShellCommand(next, depth));
@@ -149,7 +156,7 @@ export function redactCommandSecrets(
         continue;
       }
     }
-    if (isShell && /^-[a-z]*c/i.test(arg)) {
+    if (tokenShell && /^-[a-z]*c/i.test(arg)) {
       const cIndex = arg.toLowerCase().lastIndexOf('c');
       const attachedScript = arg.slice(cIndex + 1);
       if (attachedScript && !/[a-zA-Z]/.test(attachedScript)) {
@@ -163,9 +170,9 @@ export function redactCommandSecrets(
       const value = arg.slice(equalsIndex + 1);
       if (isSecretArgName(name)) {
         redacted.push(`${name}=[redacted]`);
-      } else if (isHeaderArgName(name) && isSecretHeaderValue(value)) {
+      } else if (tokenCurl && isHeaderArgName(name) && isSecretHeaderValue(value)) {
         redacted.push(`${name}=[redacted]`);
-      } else if (isCurl && isUserArgName(name)) {
+      } else if (tokenCurl && isUserArgName(name)) {
         redacted.push(`${name}=[redacted]`);
       } else {
         redacted.push(arg);
@@ -178,17 +185,12 @@ export function redactCommandSecrets(
       index++;
       continue;
     }
-    if (
-      isHeaderContext &&
-      isHeaderArgName(arg) &&
-      next !== undefined &&
-      isSecretHeaderValue(next)
-    ) {
+    if (tokenCurl && isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;
     }
-    if (isCurl && isUserArgName(arg) && next !== undefined && !next.startsWith('--')) {
+    if (tokenCurl && isUserArgName(arg) && next !== undefined && !next.startsWith('--')) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -3,7 +3,6 @@ import { getAcpCommandIdentity } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
-/* @public - consumed by ACP provider sync in a later stack PR */
 export function getAcpCommandIdentityDigest(commandLine: string): string {
   return createHash('sha256').update(getAcpCommandIdentity(commandLine)).digest('hex');
 }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -4,14 +4,14 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
 const SECRET_ARG_NAME_PATTERN =
-  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|user)$/i;
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)$/i;
 
 const SECRET_HEADER_NAME_PATTERN =
   /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
 
 const SHELL_COMMAND_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 const CURL_COMMAND_NAMES = new Set(['curl']);
-const ENV_COMMAND_NAMES = new Set(['env']);
+const ENV_COMMAND_NAMES = new Set(['env', 'export']);
 
 function commandBaseName(command: string): string {
   return (command.split('/').pop() ?? command).toLowerCase();
@@ -69,25 +69,30 @@ function redactShellCommand(script: string, depth: number): string {
   try {
     const { command, args } = parseAcpCommand(script);
     const redactedArgs = redactCommandSecrets(command, args, depth - 1);
+    const redactedCommand = isSecretEnvAssignment(command)
+      ? `${command.slice(0, command.indexOf('='))}=[redacted]`
+      : command;
+    const replacements: Array<[string, string]> = [];
+    if (redactedCommand !== command) replacements.push([command, redactedCommand]);
+    for (let index = 0; index < redactedArgs.length; index++) {
+      if (redactedArgs[index] !== args[index])
+        replacements.push([args[index], redactedArgs[index]]);
+    }
     let result = script;
     let cursor = 0;
-    let changed = false;
     let missed = false;
-    for (let index = 0; index < redactedArgs.length; index++) {
-      if (redactedArgs[index] === args[index]) continue;
-      const span = result.indexOf(args[index], cursor);
+    for (const [from, to] of replacements) {
+      const span = result.indexOf(from, cursor);
       if (span === -1) {
         missed = true;
         break;
       }
-      result =
-        result.slice(0, span) + redactedArgs[index] + result.slice(span + args[index].length);
-      cursor = span + redactedArgs[index].length;
-      changed = true;
+      result = result.slice(0, span) + to + result.slice(span + from.length);
+      cursor = span + to.length;
     }
-    if (changed && !missed) return result;
-    if (changed) {
-      return [command, ...redactedArgs].map(displayQuote).join(' ');
+    if (replacements.length > 0 && !missed) return result;
+    if (replacements.length > 0) {
+      return [redactedCommand, ...redactedArgs].map(displayQuote).join(' ');
     }
     return script;
   } catch {
@@ -130,6 +135,8 @@ export function redactCommandSecrets(command: string, args: string[], depth = 3)
       if (isSecretArgName(name)) {
         redacted.push(`${name}=[redacted]`);
       } else if (isHeaderArgName(name) && isSecretHeaderValue(value)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (isCurl && isUserArgName(name)) {
         redacted.push(`${name}=[redacted]`);
       } else {
         redacted.push(arg);

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -4,10 +4,23 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
 const SECRET_ARG_NAME_PATTERN =
-  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|header)$|^H$/i;
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)$/i;
+
+const SECRET_HEADER_NAME_PATTERN =
+  /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
 
 function isSecretArgName(name: string): boolean {
   return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
+}
+
+function isSecretHeaderValue(value: string): boolean {
+  const headerName = value.split(':', 1)[0]?.trim() ?? '';
+  return SECRET_HEADER_NAME_PATTERN.test(headerName);
+}
+
+function isHeaderArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^(?:H|header)$/i.test(stripped);
 }
 
 export function redactSecretArgs(args: string[]): string[] {
@@ -21,11 +34,23 @@ export function redactSecretArgs(args: string[]): string[] {
     const equalsIndex = arg.indexOf('=');
     if (equalsIndex >= 0) {
       const name = arg.slice(0, equalsIndex);
-      redacted.push(isSecretArgName(name) ? `${name}=[redacted]` : arg);
+      const value = arg.slice(equalsIndex + 1);
+      if (isSecretArgName(name)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (isHeaderArgName(name) && isSecretHeaderValue(value)) {
+        redacted.push(`${name}=[redacted]`);
+      } else {
+        redacted.push(arg);
+      }
       continue;
     }
     const next = args[index + 1];
     if (isSecretArgName(arg) && next !== undefined) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -1,10 +1,39 @@
 import { createHash } from 'node:crypto';
-import { getAcpCommandIdentity } from '@hyperneo/shared/acp';
+import { parseAcpCommand } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
+const SECRET_ARG_NAME_PATTERN = /(token|secret|password|passphrase|credential|api[-_]?key)/i;
+
+function redactSecretArgs(args: string[]): string[] {
+  const redacted: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg.startsWith('-')) {
+      redacted.push(arg);
+      continue;
+    }
+    const equalsIndex = arg.indexOf('=');
+    if (equalsIndex >= 0) {
+      const name = arg.slice(0, equalsIndex);
+      redacted.push(SECRET_ARG_NAME_PATTERN.test(name) ? `${name}=[redacted]` : arg);
+      continue;
+    }
+    const next = args[index + 1];
+    if (SECRET_ARG_NAME_PATTERN.test(arg) && next !== undefined && !next.startsWith('-')) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}
+
 export function getAcpCommandIdentityDigest(commandLine: string): string {
-  return createHash('sha256').update(getAcpCommandIdentity(commandLine)).digest('hex');
+  const { command, args } = parseAcpCommand(commandLine);
+  const identity = JSON.stringify([command, ...redactSecretArgs(args)]);
+  return createHash('sha256').update(identity).digest('hex');
 }
 
 const ACP_SAFE_ENV_KEYS = [

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -4,10 +4,18 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
 const SECRET_ARG_NAME_PATTERN =
-  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|user|u)$/i;
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|user)$/i;
 
 const SECRET_HEADER_NAME_PATTERN =
   /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
+
+const SHELL_COMMAND_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
+const CURL_COMMAND_NAMES = new Set(['curl']);
+const ENV_COMMAND_NAMES = new Set(['env']);
+
+function commandBaseName(command: string): string {
+  return (command.split('/').pop() ?? command).toLowerCase();
+}
 
 function isSecretArgName(name: string): boolean {
   return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
@@ -20,12 +28,23 @@ function isSecretHeaderValue(value: string): boolean {
 
 function isHeaderArgName(name: string): boolean {
   const stripped = name.replace(/^-+/, '');
-  return /^(?:H|header)$/i.test(stripped);
+  return /^H$/i.test(stripped) || /^header$/i.test(stripped);
+}
+
+function isUserArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^u$/i.test(stripped) || /^user$/i.test(stripped);
 }
 
 function isShellCommandArgName(name: string): boolean {
   const stripped = name.replace(/^-+/, '');
   return /^c$/i.test(stripped);
+}
+
+function isSecretEnvAssignment(arg: string): boolean {
+  const equalsIndex = arg.indexOf('=');
+  if (equalsIndex <= 0) return false;
+  return isSecretArgName(arg.slice(0, equalsIndex));
 }
 
 export function shellQuote(value: string): string {
@@ -42,29 +61,38 @@ function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
     const { command, args } = parseAcpCommand(script);
-    return [command, ...redactSecretArgs(args, depth - 1)].map(displayQuote).join(' ');
+    const redactedArgs = redactCommandSecrets(command, args, depth - 1);
+    return [command, ...redactedArgs].map(displayQuote).join(' ');
   } catch {
     return script;
   }
 }
 
-export function redactSecretArgs(args: string[], depth = 3): string[] {
+export function redactCommandSecrets(command: string, args: string[], depth = 3): string[] {
+  const commandName = commandBaseName(command);
+  const isShell = SHELL_COMMAND_NAMES.has(commandName);
+  const isCurl = CURL_COMMAND_NAMES.has(commandName);
+  const isEnv = ENV_COMMAND_NAMES.has(commandName);
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (!arg.startsWith('-')) {
-      redacted.push(arg);
+      if (isEnv && isSecretEnvAssignment(arg)) {
+        redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
+      } else {
+        redacted.push(arg);
+      }
       continue;
     }
-    if (/^-H./.test(arg)) {
+    if (isCurl && /^-H./.test(arg)) {
       redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
       continue;
     }
-    if (/^-u./.test(arg)) {
+    if (isCurl && /^-u./.test(arg)) {
       redacted.push('-u[redacted]');
       continue;
     }
-    if (/^-c./.test(arg)) {
+    if (isShell && /^-c./.test(arg)) {
       redacted.push(`-c${redactShellCommand(arg.slice(2), depth)}`);
       continue;
     }
@@ -87,12 +115,17 @@ export function redactSecretArgs(args: string[], depth = 3): string[] {
       index++;
       continue;
     }
-    if (isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
+    if (isCurl && isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;
     }
-    if (isShellCommandArgName(arg) && next !== undefined) {
+    if (isCurl && isUserArgName(arg) && next !== undefined && !next.startsWith('--')) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (isShell && isShellCommandArgName(arg) && next !== undefined) {
       redacted.push(arg, redactShellCommand(next, depth));
       index++;
       continue;
@@ -104,7 +137,7 @@ export function redactSecretArgs(args: string[], depth = 3): string[] {
 
 export function getAcpCommandIdentityDigest(commandLine: string): string {
   const { command, args } = parseAcpCommand(commandLine);
-  const identity = JSON.stringify([command, ...redactSecretArgs(args)]);
+  const identity = JSON.stringify([command, ...redactCommandSecrets(command, args)]);
   return createHash('sha256').update(identity).digest('hex');
 }
 

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -57,11 +57,21 @@ function displayQuote(token: string): string {
   return shellQuote(token);
 }
 
+const URL_USERINFO_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*:\/\/[^:/@\s]+:)([^@/\s]+)(@.+)$/;
+
+function redactUrlUserinfo(value: string): string {
+  const match = URL_USERINFO_PATTERN.exec(value);
+  return match ? `${match[1]}[redacted]${match[3]}` : value;
+}
+
 function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
     const { command, args } = parseAcpCommand(script);
     const redactedArgs = redactCommandSecrets(command, args, depth - 1);
+    if (redactedArgs.length === args.length && redactedArgs.every((arg, i) => arg === args[i])) {
+      return script;
+    }
     return [command, ...redactedArgs].map(displayQuote).join(' ');
   } catch {
     return script;
@@ -80,7 +90,7 @@ export function redactCommandSecrets(command: string, args: string[], depth = 3)
       if (isEnv && isSecretEnvAssignment(arg)) {
         redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
       } else {
-        redacted.push(arg);
+        redacted.push(redactUrlUserinfo(arg));
       }
       continue;
     }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -121,7 +121,7 @@ export function redactCommandSecrets(
   let inLeadingAssignments =
     options.shellScript === true ? command.indexOf('=') > 0 || isEnv : true;
   let currentCommand = command;
-  let awaitingCommandWord = options.shellScript === true;
+  let awaitingCommandWord = options.shellScript === true || isEnv;
   let endOfOptions = false;
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
@@ -145,6 +145,18 @@ export function redactCommandSecrets(
       continue;
     }
     if (!arg.startsWith('-')) {
+      const looksLikeUrl = /^[a-z][a-z0-9+.-]*:/i.test(arg);
+      if (options.shellScript === true && !looksLikeUrl && /[;&|]/.test(arg)) {
+        inLeadingAssignments = true;
+        endOfOptions = false;
+        awaitingCommandWord = true;
+        redacted.push(
+          arg.replace(/(^|[;&|])([A-Za-z_][\w-]*)=([^;&|\s]*)/g, (whole, pre, name) =>
+            isSecretEnvAssignment(`${name}=`) ? `${pre}${name}=[redacted]` : whole
+          )
+        );
+        continue;
+      }
       const isAssignmentShaped = arg.indexOf('=') > 0;
       if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
         redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
@@ -163,13 +175,43 @@ export function redactCommandSecrets(
     const tokenCommandName = commandBaseName(currentCommand);
     const tokenCurl = CURL_COMMAND_NAMES.has(tokenCommandName);
     const tokenShell = SHELL_COMMAND_NAMES.has(tokenCommandName);
-    if (tokenCurl && /^-H./.test(arg)) {
-      redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
+    if (tokenCurl && /^-[a-z]*$/i.test(arg)) {
+      const letters = arg.slice(1).toLowerCase();
+      const valueFlag = letters.charAt(letters.length - 1);
+      const next = args[index + 1];
+      if (
+        (valueFlag === 'h' || valueFlag === 'u') &&
+        next !== undefined &&
+        !next.startsWith('--')
+      ) {
+        if (valueFlag === 'u' || isSecretHeaderValue(next)) {
+          redacted.push(arg, '[redacted]');
+          index++;
+          continue;
+        }
+      }
+      redacted.push(arg);
       continue;
     }
-    if (tokenCurl && /^-u./.test(arg)) {
-      redacted.push('-u[redacted]');
-      continue;
+    if (tokenCurl && /^-[a-z]*[hu]/i.test(arg)) {
+      const lowered = arg.toLowerCase();
+      let carrierIndex = -1;
+      for (let scan = 1; scan < lowered.length; scan++) {
+        const ch = lowered[scan];
+        if (ch === 'h' || ch === 'u') {
+          carrierIndex = scan;
+          break;
+        }
+        if (!/[a-z]/i.test(ch)) break;
+      }
+      if (carrierIndex > 0) {
+        const value = arg.slice(carrierIndex + 1);
+        const secret = lowered[carrierIndex] === 'u' || isSecretHeaderValue(value);
+        if (secret && value) {
+          redacted.push(`${arg.slice(0, carrierIndex + 1)}[redacted]`);
+          continue;
+        }
+      }
     }
     if (tokenShell && /^-[a-z]*c[a-z]*$/i.test(arg)) {
       const next = args[index + 1];
@@ -198,7 +240,8 @@ export function redactCommandSecrets(
       } else if (tokenCurl && isUserArgName(name)) {
         redacted.push(`${name}=[redacted]`);
       } else {
-        redacted.push(arg);
+        const redactedValue = redactUrlUserinfo(value);
+        redacted.push(redactedValue === value ? arg : `${name}=${redactedValue}`);
       }
       continue;
     }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -28,11 +28,15 @@ function isShellCommandArgName(name: string): boolean {
   return /^c$/i.test(stripped);
 }
 
+export function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
     const { command, args } = parseAcpCommand(script);
-    return [command, ...redactSecretArgs(args, depth - 1)].join(' ');
+    return [command, ...redactSecretArgs(args, depth - 1)].map(shellQuote).join(' ');
   } catch {
     return script;
   }
@@ -44,6 +48,14 @@ export function redactSecretArgs(args: string[], depth = 3): string[] {
     const arg = args[index];
     if (!arg.startsWith('-')) {
       redacted.push(arg);
+      continue;
+    }
+    if (/^-H./.test(arg)) {
+      redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
+      continue;
+    }
+    if (/^-c./.test(arg)) {
+      redacted.push(`-c${redactShellCommand(arg.slice(2), depth)}`);
       continue;
     }
     const equalsIndex = arg.indexOf('=');

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -10,7 +10,7 @@ function isSecretArgName(name: string): boolean {
   return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
 }
 
-function redactSecretArgs(args: string[]): string[] {
+export function redactSecretArgs(args: string[]): string[] {
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -36,10 +36,6 @@ function isUserArgName(name: string): boolean {
   return /^u$/i.test(stripped) || /^user$/i.test(stripped);
 }
 
-function isShellCommandArgName(name: string): boolean {
-  return /^-[a-z]*c$/i.test(name);
-}
-
 function isSecretEnvAssignment(arg: string): boolean {
   const equalsIndex = arg.indexOf('=');
   if (equalsIndex <= 0) return false;
@@ -84,7 +80,18 @@ function redactShellCommand(script: string, depth: number): string {
         changed = false;
         break;
       }
-      result = result.slice(0, span.start) + redactedTokens[index] + result.slice(span.end);
+      const rawText = result.slice(span.start, span.end);
+      const at = rawText.indexOf(tokens[index]);
+      if (at >= 0) {
+        result =
+          result.slice(0, span.start) +
+          rawText.slice(0, at) +
+          redactedTokens[index] +
+          rawText.slice(at + tokens[index].length) +
+          result.slice(span.end);
+      } else {
+        result = result.slice(0, span.start) + redactedTokens[index] + result.slice(span.end);
+      }
       changed = true;
     }
     if (changed) return result;
@@ -115,10 +122,11 @@ export function redactCommandSecrets(
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (!arg.startsWith('-')) {
+      const isAssignmentShaped = arg.indexOf('=') > 0;
       if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
         redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
       } else {
-        if (!isSecretEnvAssignment(arg)) {
+        if (!isAssignmentShaped) {
           inLeadingAssignments = false;
         }
         redacted.push(redactUrlUserinfo(arg));
@@ -133,12 +141,21 @@ export function redactCommandSecrets(
       redacted.push('-u[redacted]');
       continue;
     }
-    if (isShell && /^-[a-z]*c./i.test(arg)) {
-      const attachedScript = arg.slice(arg.toLowerCase().lastIndexOf('c') + 1);
-      redacted.push(
-        `${arg.slice(0, arg.length - attachedScript.length)}${redactShellCommand(attachedScript, depth)}`
-      );
-      continue;
+    if (isShell && /^-[a-z]*c[a-z]*$/i.test(arg)) {
+      const next = args[index + 1];
+      if (next !== undefined) {
+        redacted.push(arg, redactShellCommand(next, depth));
+        index++;
+        continue;
+      }
+    }
+    if (isShell && /^-[a-z]*c/i.test(arg)) {
+      const cIndex = arg.toLowerCase().lastIndexOf('c');
+      const attachedScript = arg.slice(cIndex + 1);
+      if (attachedScript && !/[a-zA-Z]/.test(attachedScript)) {
+        redacted.push(`${arg.slice(0, cIndex + 1)}${redactShellCommand(attachedScript, depth)}`);
+        continue;
+      }
     }
     const equalsIndex = arg.indexOf('=');
     if (equalsIndex >= 0) {
@@ -173,16 +190,6 @@ export function redactCommandSecrets(
     }
     if (isCurl && isUserArgName(arg) && next !== undefined && !next.startsWith('--')) {
       redacted.push(arg, '[redacted]');
-      index++;
-      continue;
-    }
-    if (isShell && isShellCommandArgName(arg) && next !== undefined) {
-      redacted.push(arg, redactShellCommand(next, depth));
-      index++;
-      continue;
-    }
-    if (isShell && /^-[a-z]*c$/i.test(arg) && next !== undefined) {
-      redacted.push(arg, redactShellCommand(next, depth));
       index++;
       continue;
     }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { parseAcpCommand } from '@hyperneo/shared/acp';
+import { parseAcpCommandWithSpans } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
@@ -63,57 +63,33 @@ function redactUrlUserinfo(value: string): string {
   return match ? `${match[1]}[redacted]${match[3]}` : value;
 }
 
-function findValueSpanAfter(text: string, anchor: string, value: string, from: number): number {
-  let anchorSpan = text.indexOf(anchor, from);
-  while (anchorSpan !== -1) {
-    let index = anchorSpan + anchor.length;
-    while (index < text.length && /\s/.test(text[index])) index++;
-    if (text[index] === "'" || text[index] === '"') index++;
-    if (text.startsWith(value, index)) return index;
-    anchorSpan = text.indexOf(anchor, anchorSpan + 1);
-  }
-  return -1;
-}
-
 function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
-    const { command, args } = parseAcpCommand(script);
-    const redactedArgs = redactCommandSecrets(command, args, depth - 1, { shellScript: true });
-    const redactedCommand = isSecretEnvAssignment(command)
-      ? `${command.slice(0, command.indexOf('='))}=[redacted]`
-      : command;
-    const replacements: Array<{ from: string; to: string; anchor?: string }> = [];
-    if (redactedCommand !== command) replacements.push({ from: command, to: redactedCommand });
-    for (let index = 0; index < redactedArgs.length; index++) {
-      if (redactedArgs[index] === args[index]) continue;
-      const anchored =
-        redactedArgs[index] === '[redacted]' &&
-        index > 0 &&
-        args[index - 1] === redactedArgs[index - 1];
-      replacements.push({
-        from: args[index],
-        to: redactedArgs[index],
-        anchor: anchored ? args[index - 1] : undefined,
-      });
-    }
+    const parsed = parseAcpCommandWithSpans(script);
+    const tokens = [parsed.command, ...parsed.args];
+    const redactedArgs = redactCommandSecrets(parsed.command, parsed.args, depth - 1, {
+      shellScript: true,
+    });
+    const redactedCommand = isSecretEnvAssignment(parsed.command)
+      ? `${parsed.command.slice(0, parsed.command.indexOf('='))}=[redacted]`
+      : parsed.command;
+    const redactedTokens = [redactedCommand, ...redactedArgs];
     let result = script;
-    let cursor = 0;
-    let missed = false;
-    for (const { from, to, anchor } of replacements) {
-      const span = anchor
-        ? findValueSpanAfter(result, anchor, from, cursor)
-        : result.indexOf(from, cursor);
-      if (span === -1) {
-        missed = true;
+    let changed = false;
+    for (let index = redactedTokens.length - 1; index >= 0; index--) {
+      if (redactedTokens[index] === tokens[index]) continue;
+      const span = parsed.rawSpans[index];
+      if (!span) {
+        changed = false;
         break;
       }
-      result = result.slice(0, span) + to + result.slice(span + from.length);
-      cursor = span + to.length;
+      result = result.slice(0, span.start) + redactedTokens[index] + result.slice(span.end);
+      changed = true;
     }
-    if (replacements.length > 0 && !missed) return result;
-    if (replacements.length > 0) {
-      return [redactedCommand, ...redactedArgs].map(displayQuote).join(' ');
+    if (changed) return result;
+    if (redactedTokens.some((token, index) => token !== tokens[index])) {
+      return redactedTokens.map(displayQuote).join(' ');
     }
     return script;
   } catch {
@@ -132,13 +108,19 @@ export function redactCommandSecrets(
   const isCurl = CURL_COMMAND_NAMES.has(commandName);
   const isEnv = ENV_COMMAND_NAMES.has(commandName);
   const isHeaderContext = isCurl || options.shellScript === true;
+  const assignmentsAllowed = isEnv || options.shellScript === true;
+  const commandIsAssignment = command.indexOf('=') > 0;
+  let inLeadingAssignments = options.shellScript === true ? commandIsAssignment || isEnv : true;
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (!arg.startsWith('-')) {
-      if ((isEnv || options.shellScript === true) && isSecretEnvAssignment(arg)) {
+      if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
         redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
       } else {
+        if (!isSecretEnvAssignment(arg)) {
+          inLeadingAssignments = false;
+        }
         redacted.push(redactUrlUserinfo(arg));
       }
       continue;
@@ -210,7 +192,7 @@ export function redactCommandSecrets(
 }
 
 export function getAcpCommandIdentityDigest(commandLine: string): string {
-  const { command, args } = parseAcpCommand(commandLine);
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
   const identity = JSON.stringify([command, ...redactCommandSecrets(command, args)]);
   return createHash('sha256').update(identity).digest('hex');
 }

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -37,8 +37,7 @@ function isUserArgName(name: string): boolean {
 }
 
 function isShellCommandArgName(name: string): boolean {
-  const stripped = name.replace(/^-+/, '');
-  return /^c$/i.test(stripped);
+  return /^-[a-z]*c$/i.test(name);
 }
 
 function isSecretEnvAssignment(arg: string): boolean {
@@ -64,25 +63,47 @@ function redactUrlUserinfo(value: string): string {
   return match ? `${match[1]}[redacted]${match[3]}` : value;
 }
 
+function findValueSpanAfter(text: string, anchor: string, value: string, from: number): number {
+  let anchorSpan = text.indexOf(anchor, from);
+  while (anchorSpan !== -1) {
+    let index = anchorSpan + anchor.length;
+    while (index < text.length && /\s/.test(text[index])) index++;
+    if (text[index] === "'" || text[index] === '"') index++;
+    if (text.startsWith(value, index)) return index;
+    anchorSpan = text.indexOf(anchor, anchorSpan + 1);
+  }
+  return -1;
+}
+
 function redactShellCommand(script: string, depth: number): string {
   if (depth <= 0) return script;
   try {
     const { command, args } = parseAcpCommand(script);
-    const redactedArgs = redactCommandSecrets(command, args, depth - 1);
+    const redactedArgs = redactCommandSecrets(command, args, depth - 1, { shellScript: true });
     const redactedCommand = isSecretEnvAssignment(command)
       ? `${command.slice(0, command.indexOf('='))}=[redacted]`
       : command;
-    const replacements: Array<[string, string]> = [];
-    if (redactedCommand !== command) replacements.push([command, redactedCommand]);
+    const replacements: Array<{ from: string; to: string; anchor?: string }> = [];
+    if (redactedCommand !== command) replacements.push({ from: command, to: redactedCommand });
     for (let index = 0; index < redactedArgs.length; index++) {
-      if (redactedArgs[index] !== args[index])
-        replacements.push([args[index], redactedArgs[index]]);
+      if (redactedArgs[index] === args[index]) continue;
+      const anchored =
+        redactedArgs[index] === '[redacted]' &&
+        index > 0 &&
+        args[index - 1] === redactedArgs[index - 1];
+      replacements.push({
+        from: args[index],
+        to: redactedArgs[index],
+        anchor: anchored ? args[index - 1] : undefined,
+      });
     }
     let result = script;
     let cursor = 0;
     let missed = false;
-    for (const [from, to] of replacements) {
-      const span = result.indexOf(from, cursor);
+    for (const { from, to, anchor } of replacements) {
+      const span = anchor
+        ? findValueSpanAfter(result, anchor, from, cursor)
+        : result.indexOf(from, cursor);
       if (span === -1) {
         missed = true;
         break;
@@ -100,23 +121,29 @@ function redactShellCommand(script: string, depth: number): string {
   }
 }
 
-export function redactCommandSecrets(command: string, args: string[], depth = 3): string[] {
+export function redactCommandSecrets(
+  command: string,
+  args: string[],
+  depth = 3,
+  options: { shellScript?: boolean } = {}
+): string[] {
   const commandName = commandBaseName(command);
   const isShell = SHELL_COMMAND_NAMES.has(commandName);
   const isCurl = CURL_COMMAND_NAMES.has(commandName);
   const isEnv = ENV_COMMAND_NAMES.has(commandName);
+  const isHeaderContext = isCurl || options.shellScript === true;
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (!arg.startsWith('-')) {
-      if (isEnv && isSecretEnvAssignment(arg)) {
+      if ((isEnv || options.shellScript === true) && isSecretEnvAssignment(arg)) {
         redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
       } else {
         redacted.push(redactUrlUserinfo(arg));
       }
       continue;
     }
-    if (isCurl && /^-H./.test(arg)) {
+    if (isHeaderContext && /^-H./.test(arg)) {
       redacted.push(isSecretHeaderValue(arg.slice(2)) ? '-H[redacted]' : arg);
       continue;
     }
@@ -124,8 +151,11 @@ export function redactCommandSecrets(command: string, args: string[], depth = 3)
       redacted.push('-u[redacted]');
       continue;
     }
-    if (isShell && /^-c./.test(arg)) {
-      redacted.push(`-c${redactShellCommand(arg.slice(2), depth)}`);
+    if (isShell && /^-[a-z]*c./i.test(arg)) {
+      const attachedScript = arg.slice(arg.toLowerCase().lastIndexOf('c') + 1);
+      redacted.push(
+        `${arg.slice(0, arg.length - attachedScript.length)}${redactShellCommand(attachedScript, depth)}`
+      );
       continue;
     }
     const equalsIndex = arg.indexOf('=');
@@ -149,7 +179,12 @@ export function redactCommandSecrets(command: string, args: string[], depth = 3)
       index++;
       continue;
     }
-    if (isCurl && isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
+    if (
+      isHeaderContext &&
+      isHeaderArgName(arg) &&
+      next !== undefined &&
+      isSecretHeaderValue(next)
+    ) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;
@@ -160,6 +195,11 @@ export function redactCommandSecrets(command: string, args: string[], depth = 3)
       continue;
     }
     if (isShell && isShellCommandArgName(arg) && next !== undefined) {
+      redacted.push(arg, redactShellCommand(next, depth));
+      index++;
+      continue;
+    }
+    if (isShell && /^-[a-z]*c$/i.test(arg) && next !== undefined) {
       redacted.push(arg, redactShellCommand(next, depth));
       index++;
       continue;

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -60,8 +60,13 @@ function redactUrlUserinfo(value: string): string {
   return match ? `${match[1]}[redacted]${match[3]}` : value;
 }
 
+const SCRIPT_SENSITIVITY_PATTERN =
+  /(^|\s)--?[^\s'"]*(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)|(^|\s)-[hu]\b/i;
+
 function redactShellCommand(script: string, depth: number): string {
-  if (depth <= 0) return script;
+  if (depth <= 0) {
+    return SCRIPT_SENSITIVITY_PATTERN.test(script) ? '[redacted script]' : script;
+  }
   try {
     const parsed = parseAcpCommandWithSpans(script);
     const tokens = [parsed.command, ...parsed.args];

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -3,7 +3,12 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
-const SECRET_ARG_NAME_PATTERN = /(token|secret|password|passphrase|credential|api[-_]?key)/i;
+const SECRET_ARG_NAME_PATTERN =
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key)$/i;
+
+function isSecretArgName(name: string): boolean {
+  return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
+}
 
 function redactSecretArgs(args: string[]): string[] {
   const redacted: string[] = [];
@@ -16,11 +21,11 @@ function redactSecretArgs(args: string[]): string[] {
     const equalsIndex = arg.indexOf('=');
     if (equalsIndex >= 0) {
       const name = arg.slice(0, equalsIndex);
-      redacted.push(SECRET_ARG_NAME_PATTERN.test(name) ? `${name}=[redacted]` : arg);
+      redacted.push(isSecretArgName(name) ? `${name}=[redacted]` : arg);
       continue;
     }
     const next = args[index + 1];
-    if (SECRET_ARG_NAME_PATTERN.test(arg) && next !== undefined && !next.startsWith('-')) {
+    if (isSecretArgName(arg) && next !== undefined && !next.startsWith('-')) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -4,7 +4,7 @@ import { parseAcpCommand } from '@hyperneo/shared/acp';
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
 const SECRET_ARG_NAME_PATTERN =
-  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key)$/i;
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer|header)$|^H$/i;
 
 function isSecretArgName(name: string): boolean {
   return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
@@ -25,7 +25,7 @@ export function redactSecretArgs(args: string[]): string[] {
       continue;
     }
     const next = args[index + 1];
-    if (isSecretArgName(arg) && next !== undefined && !next.startsWith('-')) {
+    if (isSecretArgName(arg) && next !== undefined) {
       redacted.push(arg, '[redacted]');
       index++;
       continue;

--- a/packages/daemon/src/lib/acp/acp-process-tree.ts
+++ b/packages/daemon/src/lib/acp/acp-process-tree.ts
@@ -18,6 +18,18 @@ export const basicAcpProcessTreeOwner: AcpProcessTreeOwner = (child) => ({
   },
 });
 
+export function acpProcessGroupAlive(
+  pid: number,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  try {
+    process.kill(platform === 'win32' ? pid : -pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
 export function getAcpProcessTreeOwner(): Promise<AcpProcessTreeOwner> {
   return Promise.resolve(basicAcpProcessTreeOwner);
 }

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -26,6 +26,7 @@ import type {
 import type { McpServerConfig, SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { UUID } from 'crypto';
 import { drainDeliveryWaitersOnTerminalSDKMessage } from '../agent/message-delivery';
+import { MAX_QUESTION_STRING_LENGTH } from '../agent/ask-user-question-handler';
 import type { AgentSession } from '../agent/agent-session';
 import {
   type QueryRunnerContext,
@@ -396,6 +397,9 @@ async function handleAcpPermissionRequest(
     return { outcome: { outcome: 'cancelled' } };
   }
   const question = acpPermissionQuestion(params);
+  if (question.length > MAX_QUESTION_STRING_LENGTH) {
+    throw new Error('ACP permission request is too long to display for approval');
+  }
   const permission = canUseTool('AskUserQuestion', acpPermissionQuestionInput(params), {
     signal: permissionSignal,
     toolUseID: params.toolCall.toolCallId,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -316,7 +316,7 @@ async function authorizeAcpFsWrite(
       sessionId: params.sessionId,
       toolCall: {
         toolCallId: generateUUID(),
-        title: `write ${params.path}`,
+        title: `write ${params.path} (${params.content.length} chars)`,
         kind: 'edit',
         rawInput: { file_path: params.path, content: params.content },
       },

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -711,7 +711,11 @@ export class AcpQueryRunner {
       const processTreeOwner = await getAcpProcessTreeOwner();
       const hostCallbacks = workspace
         ? (() => {
-            const manager = new AcpTerminalManager(buildAcpSafeEnv(), workspace, processTreeOwner);
+            const manager = new AcpTerminalManager(
+              buildAcpSafeEnv(acpEnv),
+              workspace,
+              processTreeOwner
+            );
             terminalManager = manager;
             return {
               onTerminalCreate: async (params: AcpTerminalCreateParams) =>

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -44,7 +44,12 @@ import {
   resolveSpaceMcpSessionPolicy,
 } from '../space/runtime/space-mcp-session-policy';
 import { AcpClient, type AcpClientOptions } from './acp-client';
-import { buildAcpSafeEnv, getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
+import {
+  buildAcpSafeEnv,
+  getAcpCommandIdentityDigest,
+  parseAcpCommand,
+  redactSecretArgs,
+} from './acp-command';
 import { getAcpProcessTreeOwner } from './acp-process-tree';
 import { AcpQueryAdapter } from './acp-query-adapter';
 import { AcpTerminalManager } from './acp-terminal-manager';
@@ -348,13 +353,15 @@ async function authorizeAcpTerminalCreate(
     params.args === undefined
       ? parseAcpCommand(params.command)
       : { command: params.command, args: params.args };
-  const command = [parsed.command, ...parsed.args].map(shellQuote).join(' ');
+  const displayCommand = [parsed.command, ...redactSecretArgs(parsed.args)]
+    .map(shellQuote)
+    .join(' ');
   const permission = await handleAcpPermissionRequest(
     {
       sessionId: params.sessionId,
       toolCall: {
         toolCallId: generateUUID(),
-        title: `terminal command ${command}`,
+        title: `terminal command ${displayCommand}`,
         kind: 'execute',
       },
       options: [
@@ -1465,9 +1472,6 @@ export class AcpQueryRunner {
     } finally {
       signal.removeEventListener('abort', onAbort);
       if (signal.aborted && messageDelivered) {
-        for (const msg of queryObj.flushPendingMessages()) {
-          yield msg;
-        }
         if (pendingNext) {
           try {
             const result = await pendingNext;
@@ -1476,6 +1480,9 @@ export class AcpQueryRunner {
             }
           } catch {}
           pendingNext = null;
+        }
+        for (const msg of queryObj.flushPendingMessages()) {
+          yield msg;
         }
         const drainDeadline = { expired: true } as const;
         let clearDrainTimer: (() => void) | undefined;

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1,43 +1,61 @@
-import type { UUID } from 'crypto';
+import { isAbsolute, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { CanUseTool, Options } from '@anthropic-ai/claude-agent-sdk';
 import {
   generateUUID,
-  THINKING_LEVEL_TOKENS,
   type MessageContent,
   type Session,
+  THINKING_LEVEL_TOKENS,
 } from '@hyperneo/shared';
 import type {
   AcpConfigOption,
   AcpContentBlock,
+  AcpFsReadParams,
+  AcpFsReadResult,
+  AcpFsWriteParams,
+  AcpFsWriteResult,
   AcpMcpServerConfig,
   AcpPermissionRequest,
   AcpPermissionResponseResult,
+  AcpTerminalCreateParams,
+  AcpTerminalKillParams,
+  AcpTerminalOutputParams,
+  AcpTerminalReleaseParams,
+  AcpTerminalWaitForExitParams,
 } from '@hyperneo/shared/acp';
 import type { McpServerConfig, SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
-import { ErrorCategory } from '../error-manager';
-import { getModelsCache, setModelsCache } from '../model-service';
-import { getProviderRegistry } from '../providers/factory';
-import { getProviderService, getUserConfiguredAnthropicEnv } from '../provider-service';
-import { AcpProvider } from '../providers/acp-provider';
-import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from '../agent/transient-error-patterns';
+import type { UUID } from 'crypto';
 import { drainDeliveryWaitersOnTerminalSDKMessage } from '../agent/message-delivery';
 import {
-  refreshQueryEnvFromProcess,
   type QueryRunnerContext,
+  refreshQueryEnvFromProcess,
   type TrackedAgentProcess,
 } from '../agent/query-runner';
+import { TRANSIENT_CONNECTION_ERROR_SUBSTRINGS } from '../agent/transient-error-patterns';
+import { ErrorCategory } from '../error-manager';
+import { getModelsCache, setModelsCache } from '../model-service';
+import { getProviderService, getUserConfiguredAnthropicEnv } from '../provider-service';
+import { AcpProvider } from '../providers/acp-provider';
+import { getProviderRegistry } from '../providers/factory';
 import {
   missingMcpServers,
   resolveSpaceMcpSessionPolicy,
 } from '../space/runtime/space-mcp-session-policy';
 import { AcpClient, type AcpClientOptions } from './acp-client';
-import { parseAcpCommand } from './acp-command';
+import { buildAcpSafeEnv, getAcpCommandIdentityDigest, parseAcpCommand } from './acp-command';
+import { getAcpProcessTreeOwner } from './acp-process-tree';
 import { AcpQueryAdapter } from './acp-query-adapter';
+import { AcpTerminalManager } from './acp-terminal-manager';
+import {
+  isSafeFsSupported,
+  readFileWithinWorkspace,
+  writeFileWithinWorkspace,
+} from './acp-safe-fs';
 import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 const RETRY_EXIT_TIMEOUT_MS = 5000;
+const MAX_FS_READ_BYTES = 4 * 1024 * 1024;
 
 function getStartupTimeoutMs(): number {
   const raw = process.env.HYPERNEO_SDK_STARTUP_TIMEOUT_MS;
@@ -249,10 +267,8 @@ export function convertMcpServersForAcp(
   });
 }
 
-function getAcpWorkspacePath(session: Session, queryOptions: Options): string {
-  return (
-    queryOptions.cwd ?? session.worktree?.worktreePath ?? session.workspacePath ?? process.cwd()
-  );
+function getAcpWorkspacePath(session: Session, queryOptions: Options): string | undefined {
+  return queryOptions.cwd ?? session.worktree?.worktreePath ?? session.workspacePath ?? undefined;
 }
 
 function acpPermissionQuestion(params: AcpPermissionRequest): string {
@@ -278,24 +294,118 @@ function acpPermissionQuestionInput(params: AcpPermissionRequest): Record<string
   };
 }
 
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function authorizeAcpFsWrite(
+  params: AcpFsWriteParams,
+  canUseTool: CanUseTool,
+  signal: AbortSignal
+): Promise<AcpFsWriteParams> {
+  const permission = await handleAcpPermissionRequest(
+    {
+      sessionId: params.sessionId,
+      toolCall: {
+        toolCallId: generateUUID(),
+        title: `write ${params.path}`,
+        kind: 'edit',
+        rawInput: { file_path: params.path, content: params.content },
+      },
+      options: [
+        { optionId: 'allow-write', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'deny-write', name: 'Deny', kind: 'reject_once' },
+      ],
+    },
+    canUseTool,
+    signal
+  );
+  if (signal.aborted) {
+    throw new Error('ACP filesystem write cancelled');
+  }
+  if (permission.outcome.outcome !== 'selected' || permission.outcome.optionId !== 'allow-write') {
+    throw new Error('ACP filesystem write denied');
+  }
+  return params;
+}
+
+async function authorizeAcpTerminalCreate(
+  params: AcpTerminalCreateParams,
+  canUseTool: CanUseTool,
+  signal: AbortSignal
+): Promise<AcpTerminalCreateParams> {
+  if (params.cwd != null || (params.env?.length ?? 0) > 0) {
+    throw new Error('ACP terminal cwd and environment overrides are not supported');
+  }
+  const parsed =
+    params.args === undefined
+      ? parseAcpCommand(params.command)
+      : { command: params.command, args: params.args };
+  const command = [parsed.command, ...parsed.args].map(shellQuote).join(' ');
+  const permission = await handleAcpPermissionRequest(
+    {
+      sessionId: params.sessionId,
+      toolCall: {
+        toolCallId: generateUUID(),
+        title: `terminal command ${command}`,
+        kind: 'execute',
+      },
+      options: [
+        { optionId: 'allow-terminal', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'deny-terminal', name: 'Deny', kind: 'reject_once' },
+      ],
+    },
+    canUseTool,
+    signal
+  );
+  if (signal.aborted) throw new Error('ACP terminal command cancelled');
+  if (
+    permission.outcome.outcome !== 'selected' ||
+    permission.outcome.optionId !== 'allow-terminal'
+  ) {
+    throw new Error('ACP terminal command denied');
+  }
+  return {
+    ...params,
+    command: parsed.command,
+    args: parsed.args,
+    cwd: undefined,
+    env: undefined,
+  };
+}
+
 async function handleAcpPermissionRequest(
   params: AcpPermissionRequest,
-  canUseTool: CanUseTool
+  canUseTool: CanUseTool,
+  signal?: AbortSignal
 ): Promise<AcpPermissionResponseResult> {
   if (params.options.length === 0) {
     return { outcome: { outcome: 'cancelled' } };
   }
 
-  const controller = new AbortController();
+  const permissionSignal = signal ?? new AbortController().signal;
   const question = acpPermissionQuestion(params);
-  const result = await canUseTool('AskUserQuestion', acpPermissionQuestionInput(params), {
-    signal: controller.signal,
+  const permission = canUseTool('AskUserQuestion', acpPermissionQuestionInput(params), {
+    signal: permissionSignal,
     toolUseID: params.toolCall.toolCallId,
     title: question,
     displayName: params.toolCall.title ?? params.toolCall.kind ?? 'ACP tool',
     description: params.toolCall.kind,
     requestId: generateUUID(),
   });
+  let resolveAbort: (() => void) | undefined;
+  const aborted = new Promise<undefined>((resolve) => {
+    resolveAbort = () => resolve(undefined);
+    permissionSignal.addEventListener('abort', resolveAbort, { once: true });
+    if (permissionSignal.aborted) resolveAbort();
+  });
+  const result = await Promise.race([permission, aborted]).finally(() => {
+    if (resolveAbort) permissionSignal.removeEventListener('abort', resolveAbort);
+  });
+
+  if (permissionSignal.aborted) {
+    return { outcome: { outcome: 'cancelled' } };
+  }
 
   if (!result || result.behavior === 'deny') {
     return { outcome: { outcome: 'cancelled' } };
@@ -393,6 +503,17 @@ export class AcpQueryRunner {
     recoveryState = { rateLimitCooldownScheduled: false }
   ): Promise<void> {
     const { session, messageQueue, stateManager, errorManager, logger, optionsBuilder } = this.ctx;
+    const assertActiveAcpStartup = () => {
+      if (
+        this.ctx.isCleaningUp() ||
+        this.ctx.getQueryGeneration() !== queryGeneration ||
+        stateManager.getState().status === 'interrupted'
+      ) {
+        const error = new Error('ACP query aborted during startup');
+        error.name = 'AbortError';
+        throw error;
+      }
+    };
     let client: AcpClient | null = null;
     let queryStartTime = Date.now();
     let startupTimeoutReached = false;
@@ -400,6 +521,7 @@ export class AcpQueryRunner {
     let receivedAcpMessageDuringRun = false;
     let restoreMessageEnqueuedHandler: (() => void) | undefined;
     let proxyBridge: AcpMcpProxyBridge | null = null;
+    let terminalManager: AcpTerminalManager | null = null;
     let turnCompletedNormally = false;
     let runAbortController: AbortController | null = this.ctx.queryAbortController;
 
@@ -448,6 +570,32 @@ export class AcpQueryRunner {
         throw new Error('Set HYPERNEO_ACP_COMMAND to enable ACP agents.');
       }
       const { command, args } = parseAcpCommand(acpCommand);
+      const commandIdentity = getAcpCommandIdentityDigest(acpCommand);
+      const storedIdentity = session.metadata?.acpCommandIdentity;
+      if (
+        session.acpSessionId &&
+        storedIdentity !== undefined &&
+        storedIdentity !== commandIdentity
+      ) {
+        session.acpSessionId = undefined;
+        session.metadata = {
+          ...session.metadata,
+          acpCommandIdentity: commandIdentity,
+          acpInstructionsSent: undefined,
+          acpContextUsageEstimate: undefined,
+          acpSessionCommand: undefined,
+        };
+        this.ctx.db.updateSession(session.id, {
+          acpSessionId: undefined,
+          metadata: session.metadata,
+        });
+      } else if (storedIdentity !== commandIdentity) {
+        session.metadata = {
+          ...session.metadata,
+          acpCommandIdentity: commandIdentity,
+        };
+        this.ctx.db.updateSession(session.id, { metadata: session.metadata });
+      }
       const preCleanupAuth = {
         ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
         CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
@@ -469,8 +617,10 @@ export class AcpQueryRunner {
         (message) => logger.warn(message),
         proxyBridge
       );
-      const cwd = getAcpWorkspacePath(session, queryOptions);
+      const workspace = getAcpWorkspacePath(session, queryOptions);
+      const cwd = workspace ?? process.cwd();
       const startupTimeoutMs = getStartupTimeoutMs();
+      assertActiveAcpStartup();
       const abortController = new AbortController();
       this.ctx.queryAbortController = abortController;
       runAbortController = abortController;
@@ -498,6 +648,12 @@ export class AcpQueryRunner {
                 `(Hint: set HYPERNEO_SDK_STARTUP_TIMEOUT_MS to increase timeout, currently ${startupTimeoutMs}ms)`
             );
             abortController.abort();
+            try {
+              client?.cancel();
+              if (client?.canCloseSession()) {
+                client.closeSession().catch(() => {});
+              }
+            } catch {}
             this.ctx.queryObject?.close();
             client?.close();
           }
@@ -536,15 +692,48 @@ export class AcpQueryRunner {
         acpEnv.CLAUDE_CODE_OAUTH_TOKEN = preCleanupAuth.CLAUDE_CODE_OAUTH_TOKEN;
       }
 
+      const processTreeOwner = await getAcpProcessTreeOwner();
+      const hostCallbacks = workspace
+        ? (() => {
+            const manager = new AcpTerminalManager(buildAcpSafeEnv(), workspace, processTreeOwner);
+            terminalManager = manager;
+            return {
+              onTerminalCreate: async (params: AcpTerminalCreateParams) =>
+                manager.create(
+                  await authorizeAcpTerminalCreate(params, canUseTool, abortController.signal)
+                ),
+              onTerminalOutput: (params: AcpTerminalOutputParams) => manager.output(params),
+              onTerminalWaitForExit: (params: AcpTerminalWaitForExitParams) =>
+                manager.waitForExit(params),
+              onTerminalKill: (params: AcpTerminalKillParams) => manager.kill(params),
+              onTerminalRelease: (params: AcpTerminalReleaseParams) => manager.release(params),
+              ...(isSafeFsSupported()
+                ? {
+                    onFsRead: (params: AcpFsReadParams) => this.handleFsRead(params, workspace),
+                    onFsWrite: async (params: AcpFsWriteParams) =>
+                      this.handleFsWrite(
+                        await authorizeAcpFsWrite(params, canUseTool, abortController.signal),
+                        workspace,
+                        abortController.signal
+                      ),
+                  }
+                : {}),
+            };
+          })()
+        : {};
+      assertActiveAcpStartup();
       client = this.createAcpClient({
         command,
         args,
         cwd,
         env: acpEnv as Record<string, string> | undefined,
+        processTreeOwner,
         onProcessSpawn: (proc) =>
           this.ctx.trackAgentProcess(proc as unknown as TrackedAgentProcess),
         onStderr: (data) => logger.warn(`ACP agent stderr: ${data.trimEnd()}`),
-        onPermissionRequest: (params) => handleAcpPermissionRequest(params, canUseTool),
+        onPermissionRequest: (params) =>
+          handleAcpPermissionRequest(params, canUseTool, abortController.signal),
+        ...hostCallbacks,
       });
 
       if (messageQueue.size() > 0) {
@@ -565,12 +754,12 @@ export class AcpQueryRunner {
 
         try {
           const result = await client.loadSession(existingAcpSessionId, cwd, acpMcpServers);
-          this.persistAcpSessionId(result.sessionId);
+          this.persistAcpSessionId(result.sessionId, acpCommand);
           this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
         } catch (loadError) {
           try {
             const result = await client.resumeSession(existingAcpSessionId, cwd, acpMcpServers);
-            this.persistAcpSessionId(result.sessionId);
+            this.persistAcpSessionId(result.sessionId, acpCommand);
             this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
           } catch (resumeError) {
             const loadMessage = loadError instanceof Error ? loadError.message : String(loadError);
@@ -586,7 +775,7 @@ export class AcpQueryRunner {
         }
       } else {
         const result = await client.createSession(cwd, acpMcpServers);
-        this.persistAcpSessionId(result.sessionId);
+        this.persistAcpSessionId(result.sessionId, acpCommand);
         this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
         createdAcpSessionDuringRun = true;
       }
@@ -724,6 +913,8 @@ export class AcpQueryRunner {
         createdAcpSessionDuringRun,
         receivedAcpMessageDuringRun,
         async () => {
+          terminalManager?.dispose();
+          terminalManager = null;
           await proxyBridge?.close();
           proxyBridge = null;
         },
@@ -731,6 +922,7 @@ export class AcpQueryRunner {
       );
     } finally {
       restoreMessageEnqueuedHandler?.();
+      terminalManager?.dispose();
       await proxyBridge?.close();
       proxyBridge = null;
       const isStaleQuery = this.ctx.getQueryGeneration() !== queryGeneration;
@@ -777,6 +969,7 @@ export class AcpQueryRunner {
           });
         }
 
+        this._lastConsumedUserMessage = null;
         this.ctx.queryPromise = null;
       }
     }
@@ -827,7 +1020,7 @@ export class AcpQueryRunner {
       await stateManager.setIdle({ suppressDeliveryWaiters: true });
 
       if (isStartupTimeout && createdAcpSessionDuringRun && !receivedAcpMessageDuringRun) {
-        this.persistAcpSessionId(undefined);
+        this.clearAcpSessionState();
       }
 
       const lastMsg = this._lastConsumedUserMessage;
@@ -928,6 +1121,55 @@ export class AcpQueryRunner {
     await this.ctx.onMarkApiSuccess(message);
   }
 
+  private async handleFsRead(params: AcpFsReadParams, workspace: string): Promise<AcpFsReadResult> {
+    const { workspacePath, segments } = await this.resolveWorkspaceSegments(params.path, workspace);
+    return {
+      content: await readFileWithinWorkspace(workspacePath, segments, {
+        startLine: Math.max(0, (params.line ?? 1) - 1),
+        lineLimit: params.limit ?? undefined,
+        maxBytes: MAX_FS_READ_BYTES,
+      }),
+    };
+  }
+
+  private async handleFsWrite(
+    params: AcpFsWriteParams,
+    workspace: string,
+    signal: AbortSignal
+  ): Promise<AcpFsWriteResult> {
+    if (signal.aborted) throw new Error('ACP filesystem write cancelled');
+    const { workspacePath, segments } = await this.resolveWorkspaceSegments(params.path, workspace);
+    await writeFileWithinWorkspace(workspacePath, segments, params.content, signal);
+    return {};
+  }
+
+  private async resolveWorkspaceSegments(
+    path: string,
+    workspace: string
+  ): Promise<{ workspacePath: string; segments: string[] }> {
+    const { realpath } = await import('node:fs/promises');
+    const { resolve } = await import('node:path');
+    const workspacePath = await realpath(workspace);
+    const lexicalWorkspace = resolve(workspace);
+    const requestedPath = isAbsolute(path) ? resolve(path) : resolve(lexicalWorkspace, path);
+    let relativePath = relative(lexicalWorkspace, requestedPath);
+    try {
+      this.assertWorkspacePath(requestedPath, lexicalWorkspace, path);
+    } catch {
+      this.assertWorkspacePath(requestedPath, workspacePath, path);
+      relativePath = relative(workspacePath, requestedPath);
+    }
+    if (!relativePath) throw new Error(`ACP filesystem path must identify a file: ${path}`);
+    return { workspacePath, segments: relativePath.split(sep) };
+  }
+
+  private assertWorkspacePath(path: string, workspace: string, requestedPath: string): void {
+    const relativePath = relative(workspace, path);
+    if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+      throw new Error(`ACP filesystem path escapes workspace: ${requestedPath}`);
+    }
+  }
+
   private async ensureRequiredMcpServersForAcp(queryOptions: Options): Promise<Options> {
     const { session, logger } = this.ctx;
     const policy = resolveSpaceMcpSessionPolicy(session, {
@@ -1011,11 +1253,29 @@ export class AcpQueryRunner {
     }
   }
 
-  private persistAcpSessionId(acpSessionId: string | undefined): void {
+  private persistAcpSessionId(acpSessionId: string, acpCommand: string): void {
     const { session, db } = this.ctx;
     if (session.acpSessionId === acpSessionId) return;
     session.acpSessionId = acpSessionId;
-    db.updateSession(session.id, { acpSessionId });
+    session.metadata = {
+      ...session.metadata,
+      acpSessionCommand: acpCommand,
+    };
+    db.updateSession(session.id, { acpSessionId, metadata: session.metadata });
+  }
+
+  private clearAcpSessionState(): void {
+    const { session, db } = this.ctx;
+    session.acpSessionId = undefined;
+    session.metadata = {
+      ...session.metadata,
+      acpContextUsageEstimate: undefined,
+      acpSessionCommand: undefined,
+    };
+    db.updateSession(session.id, {
+      acpSessionId: undefined,
+      metadata: session.metadata,
+    });
   }
 
   private persistAcpInstructionsSent(): void {
@@ -1139,6 +1399,8 @@ export class AcpQueryRunner {
       resolveAbort = resolve;
     });
     const onAbort = () => resolveAbort(abortResult);
+    let messageDelivered = false;
+    let pendingNext: Promise<IteratorResult<SDKMessage>> | null = null;
 
     try {
       if (signal.aborted) {
@@ -1148,20 +1410,47 @@ export class AcpQueryRunner {
       signal.addEventListener('abort', onAbort, { once: true });
 
       while (!signal.aborted) {
-        const result = await Promise.race([iterator.next(), abortPromise]);
+        pendingNext = iterator.next();
+        const result = await Promise.race([pendingNext, abortPromise]);
 
-        if ('aborted' in result || signal.aborted) {
+        if ('aborted' in result) {
           break;
         }
+
+        pendingNext = null;
 
         if (result.done) {
           break;
         }
 
+        messageDelivered = true;
         yield result.value;
       }
     } finally {
       signal.removeEventListener('abort', onAbort);
+      if (signal.aborted && messageDelivered) {
+        for (const msg of queryObj.flushPendingMessages()) {
+          yield msg;
+        }
+        if (pendingNext) {
+          try {
+            const result = await pendingNext;
+            if (!result.done) {
+              yield result.value;
+            }
+          } catch {}
+          pendingNext = null;
+        }
+        while (true) {
+          try {
+            const result = await iterator.next();
+            if (result.done) break;
+            yield result.value;
+          } catch {
+            break;
+          }
+        }
+      }
       try {
         await iterator.return?.();
       } catch {}

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1511,7 +1511,11 @@ export class AcpQueryRunner {
           } catch {
             result = drainDeadline;
           }
-          if (!('expired' in result) && !result.done) {
+          if (
+            !('expired' in result) &&
+            !result.done &&
+            isAcpPostAbortRelevantMessage(result.value)
+          ) {
             yield result.value;
           }
           pendingNext = null;

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -451,6 +451,19 @@ function isAcpToolResultMessage(message: SDKMessage): boolean {
   return message.type === 'user' && (message as SDKUserMessage).parent_tool_use_id != null;
 }
 
+function isAcpToolUseMessage(message: SDKMessage): boolean {
+  if (message.type !== 'assistant') return false;
+  const content = (message as { message?: { content?: unknown } }).message?.content;
+  return (
+    Array.isArray(content) &&
+    content.some((block) => (block as { type?: string } | null)?.type === 'tool_use')
+  );
+}
+
+function isAcpPostAbortRelevantMessage(message: SDKMessage): boolean {
+  return isAcpToolResultMessage(message) || isAcpToolUseMessage(message);
+}
+
 function systemPromptText(systemPrompt: Options['systemPrompt']): string[] {
   if (!systemPrompt) return [];
   if (typeof systemPrompt === 'string') return [systemPrompt];
@@ -772,6 +785,7 @@ export class AcpQueryRunner {
           ),
         ...hostCallbacks,
       });
+      assertActiveAcpStartup();
 
       if (messageQueue.size() > 0) {
         startStartupTimer(() => false);
@@ -826,6 +840,7 @@ export class AcpQueryRunner {
       await this.ctx.onModelsFetched().catch((error) => {
         logger.warn('Background fetch of models failed:', error);
       });
+      assertActiveAcpStartup();
 
       for await (const { message, onSent } of messageQueue.messageGenerator(session.id, {
         suppressPreYieldCallback: true,
@@ -969,6 +984,11 @@ export class AcpQueryRunner {
       proxyBridge = null;
       const isStaleQuery = this.ctx.getQueryGeneration() !== queryGeneration;
 
+      if (isStaleQuery && client) {
+        try {
+          client.close();
+        } catch {}
+      }
       if (!isStaleQuery) {
         this.clearStartupTimer();
 
@@ -1491,7 +1511,7 @@ export class AcpQueryRunner {
           } catch {
             result = drainDeadline;
           }
-          if (!('expired' in result) && !result.done && isAcpToolResultMessage(result.value)) {
+          if (!('expired' in result) && !result.done) {
             yield result.value;
           }
           pendingNext = null;
@@ -1512,7 +1532,7 @@ export class AcpQueryRunner {
           if ('expired' in result) break;
           if (result.done) break;
           drained++;
-          if (isAcpToolResultMessage(result.value)) {
+          if (isAcpPostAbortRelevantMessage(result.value)) {
             yield result.value;
           }
         }

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1488,6 +1488,7 @@ export class AcpQueryRunner {
       }
     } finally {
       signal.removeEventListener('abort', onAbort);
+      pendingNext?.catch(() => {});
       if (signal.aborted && messageDelivered) {
         const drainDeadline = { expired: true } as const;
         let clearDrainTimer: (() => void) | undefined;

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -49,6 +49,7 @@ import {
   getAcpCommandIdentityDigest,
   parseAcpCommand,
   redactSecretArgs,
+  shellQuote,
 } from './acp-command';
 import { getAcpProcessTreeOwner } from './acp-process-tree';
 import { AcpQueryAdapter } from './acp-query-adapter';
@@ -301,10 +302,6 @@ function acpPermissionQuestionInput(params: AcpPermissionRequest): Record<string
       },
     ],
   };
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 async function authorizeAcpFsWrite(

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -56,6 +56,8 @@ import { AcpMcpProxyBridge, shouldProxy } from './mcp-proxy-bridge';
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 const RETRY_EXIT_TIMEOUT_MS = 5000;
 const MAX_FS_READ_BYTES = 4 * 1024 * 1024;
+const MAX_POST_ABORT_DRAIN_MESSAGES = 256;
+const POST_ABORT_DRAIN_TIMEOUT_MS = 1000;
 
 function getStartupTimeoutMs(): number {
   const raw = process.env.HYPERNEO_SDK_STARTUP_TIMEOUT_MS;
@@ -384,6 +386,9 @@ async function handleAcpPermissionRequest(
   }
 
   const permissionSignal = signal ?? new AbortController().signal;
+  if (permissionSignal.aborted) {
+    return { outcome: { outcome: 'cancelled' } };
+  }
   const question = acpPermissionQuestion(params);
   const permission = canUseTool('AskUserQuestion', acpPermissionQuestionInput(params), {
     signal: permissionSignal,
@@ -1435,15 +1440,32 @@ export class AcpQueryRunner {
           } catch {}
           pendingNext = null;
         }
-        while (true) {
+        const drainDeadline = { expired: true } as const;
+        let clearDrainTimer: (() => void) | undefined;
+        const drainTimeout = new Promise<typeof drainDeadline>((resolve) => {
+          const timer = setTimeout(() => resolve(drainDeadline), POST_ABORT_DRAIN_TIMEOUT_MS);
+          timer.unref?.();
+          clearDrainTimer = () => {
+            clearTimeout(timer);
+            resolve(drainDeadline);
+          };
+        });
+        let drained = 0;
+        while (drained < MAX_POST_ABORT_DRAIN_MESSAGES) {
+          const next = iterator.next();
+          next.catch(() => {});
+          let result: IteratorResult<SDKMessage> | typeof drainDeadline;
           try {
-            const result = await iterator.next();
-            if (result.done) break;
-            yield result.value;
+            result = await Promise.race([next, drainTimeout]);
           } catch {
             break;
           }
+          if ('expired' in result) break;
+          if (result.done) break;
+          drained++;
+          yield result.value;
         }
+        clearDrainTimer?.();
       }
       try {
         await iterator.return?.();

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -48,7 +48,7 @@ import {
   buildAcpSafeEnv,
   getAcpCommandIdentityDigest,
   parseAcpCommand,
-  redactSecretArgs,
+  redactCommandSecrets,
   shellQuote,
 } from './acp-command';
 import { getAcpProcessTreeOwner } from './acp-process-tree';
@@ -350,7 +350,7 @@ async function authorizeAcpTerminalCreate(
     params.args === undefined
       ? parseAcpCommand(params.command)
       : { command: params.command, args: params.args };
-  const displayCommand = [parsed.command, ...redactSecretArgs(parsed.args)]
+  const displayCommand = [parsed.command, ...redactCommandSecrets(parsed.command, parsed.args)]
     .map(shellQuote)
     .join(' ');
   const permission = await handleAcpPermissionRequest(

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1472,18 +1472,6 @@ export class AcpQueryRunner {
     } finally {
       signal.removeEventListener('abort', onAbort);
       if (signal.aborted && messageDelivered) {
-        if (pendingNext) {
-          try {
-            const result = await pendingNext;
-            if (!result.done && isAcpToolResultMessage(result.value)) {
-              yield result.value;
-            }
-          } catch {}
-          pendingNext = null;
-        }
-        for (const msg of queryObj.flushPendingMessages()) {
-          yield msg;
-        }
         const drainDeadline = { expired: true } as const;
         let clearDrainTimer: (() => void) | undefined;
         const drainTimeout = new Promise<typeof drainDeadline>((resolve) => {
@@ -1494,6 +1482,23 @@ export class AcpQueryRunner {
             resolve(drainDeadline);
           };
         });
+        if (pendingNext) {
+          const inFlight = pendingNext;
+          inFlight.catch(() => {});
+          let result: IteratorResult<SDKMessage> | typeof drainDeadline;
+          try {
+            result = await Promise.race([inFlight, drainTimeout]);
+          } catch {
+            result = drainDeadline;
+          }
+          if (!('expired' in result) && !result.done && isAcpToolResultMessage(result.value)) {
+            yield result.value;
+          }
+          pendingNext = null;
+        }
+        for (const msg of queryObj.flushPendingMessages()) {
+          yield msg;
+        }
         let drained = 0;
         while (drained < MAX_POST_ABORT_DRAIN_MESSAGES) {
           const next = iterator.next();
@@ -1512,10 +1517,18 @@ export class AcpQueryRunner {
           }
         }
         clearDrainTimer?.();
+        try {
+          const settled = new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, POST_ABORT_DRAIN_TIMEOUT_MS);
+            timer.unref?.();
+          });
+          await Promise.race([Promise.resolve(iterator.return?.()), settled]);
+        } catch {}
+      } else {
+        try {
+          await iterator.return?.();
+        } catch {}
       }
-      try {
-        await iterator.return?.();
-      } catch {}
     }
   }
 

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -304,7 +304,8 @@ function shellQuote(value: string): string {
 async function authorizeAcpFsWrite(
   params: AcpFsWriteParams,
   canUseTool: CanUseTool,
-  signal: AbortSignal
+  signal: AbortSignal,
+  onAbandoned?: () => Promise<void>
 ): Promise<AcpFsWriteParams> {
   const permission = await handleAcpPermissionRequest(
     {
@@ -321,7 +322,8 @@ async function authorizeAcpFsWrite(
       ],
     },
     canUseTool,
-    signal
+    signal,
+    onAbandoned
   );
   if (signal.aborted) {
     throw new Error('ACP filesystem write cancelled');
@@ -335,7 +337,8 @@ async function authorizeAcpFsWrite(
 async function authorizeAcpTerminalCreate(
   params: AcpTerminalCreateParams,
   canUseTool: CanUseTool,
-  signal: AbortSignal
+  signal: AbortSignal,
+  onAbandoned?: () => Promise<void>
 ): Promise<AcpTerminalCreateParams> {
   if (params.cwd != null || (params.env?.length ?? 0) > 0) {
     throw new Error('ACP terminal cwd and environment overrides are not supported');
@@ -359,7 +362,8 @@ async function authorizeAcpTerminalCreate(
       ],
     },
     canUseTool,
-    signal
+    signal,
+    onAbandoned
   );
   if (signal.aborted) throw new Error('ACP terminal command cancelled');
   if (
@@ -380,7 +384,8 @@ async function authorizeAcpTerminalCreate(
 async function handleAcpPermissionRequest(
   params: AcpPermissionRequest,
   canUseTool: CanUseTool,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onAbandoned?: () => Promise<void>
 ): Promise<AcpPermissionResponseResult> {
   if (params.options.length === 0) {
     return { outcome: { outcome: 'cancelled' } };
@@ -399,6 +404,7 @@ async function handleAcpPermissionRequest(
     description: params.toolCall.kind,
     requestId: generateUUID(),
   });
+  permission.catch(() => {});
   let resolveAbort: (() => void) | undefined;
   const aborted = new Promise<undefined>((resolve) => {
     resolveAbort = () => resolve(undefined);
@@ -410,6 +416,7 @@ async function handleAcpPermissionRequest(
   });
 
   if (permissionSignal.aborted) {
+    await onAbandoned?.();
     return { outcome: { outcome: 'cancelled' } };
   }
 
@@ -427,6 +434,10 @@ async function handleAcpPermissionRequest(
   }
 
   return { outcome: { outcome: 'cancelled' } };
+}
+
+function isAcpToolResultMessage(message: SDKMessage): boolean {
+  return message.type === 'user' && (message as SDKUserMessage).parent_tool_use_id != null;
 }
 
 function systemPromptText(systemPrompt: Options['systemPrompt']): string[] {
@@ -705,7 +716,9 @@ export class AcpQueryRunner {
             return {
               onTerminalCreate: async (params: AcpTerminalCreateParams) =>
                 manager.create(
-                  await authorizeAcpTerminalCreate(params, canUseTool, abortController.signal)
+                  await authorizeAcpTerminalCreate(params, canUseTool, abortController.signal, () =>
+                    this.orphanPendingAcpPermission()
+                  )
                 ),
               onTerminalOutput: (params: AcpTerminalOutputParams) => manager.output(params),
               onTerminalWaitForExit: (params: AcpTerminalWaitForExitParams) =>
@@ -717,7 +730,9 @@ export class AcpQueryRunner {
                     onFsRead: (params: AcpFsReadParams) => this.handleFsRead(params, workspace),
                     onFsWrite: async (params: AcpFsWriteParams) =>
                       this.handleFsWrite(
-                        await authorizeAcpFsWrite(params, canUseTool, abortController.signal),
+                        await authorizeAcpFsWrite(params, canUseTool, abortController.signal, () =>
+                          this.orphanPendingAcpPermission()
+                        ),
                         workspace,
                         abortController.signal
                       ),
@@ -737,7 +752,9 @@ export class AcpQueryRunner {
           this.ctx.trackAgentProcess(proc as unknown as TrackedAgentProcess),
         onStderr: (data) => logger.warn(`ACP agent stderr: ${data.trimEnd()}`),
         onPermissionRequest: (params) =>
-          handleAcpPermissionRequest(params, canUseTool, abortController.signal),
+          handleAcpPermissionRequest(params, canUseTool, abortController.signal, () =>
+            this.orphanPendingAcpPermission()
+          ),
         ...hostCallbacks,
       });
 
@@ -1131,6 +1148,12 @@ export class AcpQueryRunner {
     await this.ctx.onMarkApiSuccess(message);
   }
 
+  private async orphanPendingAcpPermission(): Promise<void> {
+    try {
+      await this.ctx.askUserQuestionHandler.markQuestionOrphaned();
+    } catch {}
+  }
+
   private async handleFsRead(params: AcpFsReadParams, workspace: string): Promise<AcpFsReadResult> {
     const { workspacePath, segments } = await this.resolveWorkspaceSegments(params.path, workspace);
     return {
@@ -1440,7 +1463,7 @@ export class AcpQueryRunner {
         if (pendingNext) {
           try {
             const result = await pendingNext;
-            if (!result.done) {
+            if (!result.done && isAcpToolResultMessage(result.value)) {
               yield result.value;
             }
           } catch {}
@@ -1469,7 +1492,9 @@ export class AcpQueryRunner {
           if ('expired' in result) break;
           if (result.done) break;
           drained++;
-          yield result.value;
+          if (isAcpToolResultMessage(result.value)) {
+            yield result.value;
+          }
         }
         clearDrainTimer?.();
       }

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -797,6 +797,7 @@ export class AcpQueryRunner {
 
       await client.initialize();
       await client.authenticate();
+      assertActiveAcpStartup();
       const existingAcpSessionId = session.acpSessionId;
       if (existingAcpSessionId) {
         if (!client.canLoadSession()) {
@@ -1356,6 +1357,7 @@ export class AcpQueryRunner {
     session.acpSessionId = undefined;
     session.metadata = {
       ...session.metadata,
+      acpInstructionsSent: undefined,
       acpContextUsageEstimate: undefined,
     };
     db.updateSession(session.id, {

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -583,7 +583,6 @@ export class AcpQueryRunner {
           acpCommandIdentity: commandIdentity,
           acpInstructionsSent: undefined,
           acpContextUsageEstimate: undefined,
-          acpSessionCommand: undefined,
         };
         this.ctx.db.updateSession(session.id, {
           acpSessionId: undefined,
@@ -754,12 +753,12 @@ export class AcpQueryRunner {
 
         try {
           const result = await client.loadSession(existingAcpSessionId, cwd, acpMcpServers);
-          this.persistAcpSessionId(result.sessionId, acpCommand);
+          this.persistAcpSessionId(result.sessionId);
           this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
         } catch (loadError) {
           try {
             const result = await client.resumeSession(existingAcpSessionId, cwd, acpMcpServers);
-            this.persistAcpSessionId(result.sessionId, acpCommand);
+            this.persistAcpSessionId(result.sessionId);
             this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
           } catch (resumeError) {
             const loadMessage = loadError instanceof Error ? loadError.message : String(loadError);
@@ -775,7 +774,7 @@ export class AcpQueryRunner {
         }
       } else {
         const result = await client.createSession(cwd, acpMcpServers);
-        this.persistAcpSessionId(result.sessionId, acpCommand);
+        this.persistAcpSessionId(result.sessionId);
         this.updateAcpModelCache(result.configOptions, { syncSessionModel: false });
         createdAcpSessionDuringRun = true;
       }
@@ -1253,15 +1252,11 @@ export class AcpQueryRunner {
     }
   }
 
-  private persistAcpSessionId(acpSessionId: string, acpCommand: string): void {
+  private persistAcpSessionId(acpSessionId: string): void {
     const { session, db } = this.ctx;
     if (session.acpSessionId === acpSessionId) return;
     session.acpSessionId = acpSessionId;
-    session.metadata = {
-      ...session.metadata,
-      acpSessionCommand: acpCommand,
-    };
-    db.updateSession(session.id, { acpSessionId, metadata: session.metadata });
+    db.updateSession(session.id, { acpSessionId });
   }
 
   private clearAcpSessionState(): void {
@@ -1270,7 +1265,6 @@ export class AcpQueryRunner {
     session.metadata = {
       ...session.metadata,
       acpContextUsageEstimate: undefined,
-      acpSessionCommand: undefined,
     };
     db.updateSession(session.id, {
       acpSessionId: undefined,

--- a/packages/daemon/src/lib/acp/acp-query-runner.ts
+++ b/packages/daemon/src/lib/acp/acp-query-runner.ts
@@ -1517,6 +1517,8 @@ export class AcpQueryRunner {
           }
         }
         clearDrainTimer?.();
+      }
+      if (signal.aborted) {
         try {
           const settled = new Promise<void>((resolve) => {
             const timer = setTimeout(resolve, POST_ABORT_DRAIN_TIMEOUT_MS);

--- a/packages/daemon/src/lib/acp/acp-terminal-manager.ts
+++ b/packages/daemon/src/lib/acp/acp-terminal-manager.ts
@@ -50,7 +50,6 @@ interface TerminalSession {
   processGroupGone: boolean;
 }
 
-/* @public - wired into the ACP query runner in a later stack PR */
 export class AcpTerminalManager {
   private sessions = new Map<string, TerminalSession>();
   private disposed = false;

--- a/packages/daemon/src/lib/acp/acp-terminal-manager.ts
+++ b/packages/daemon/src/lib/acp/acp-terminal-manager.ts
@@ -14,6 +14,7 @@ import type {
 import { Logger } from '../logger';
 import { parseAcpCommand } from './acp-command';
 import {
+  acpProcessGroupAlive,
   type AcpProcessTree,
   type AcpProcessTreeOwner,
   getAcpProcessTreeOwner,
@@ -23,15 +24,6 @@ const logger = new Logger('AcpTerminalManager');
 const DEFAULT_OUTPUT_BYTE_LIMIT = 1024 * 1024;
 const MAX_OUTPUT_BYTE_LIMIT = 4 * 1024 * 1024;
 const DEFAULT_KILL_ESCALATION_MS = 5000;
-
-const defaultProcessGroupProbe = (pid: number): boolean => {
-  try {
-    process.kill(-pid, 0);
-    return true;
-  } catch (err) {
-    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
-  }
-};
 
 interface TerminalSession {
   process: ChildProcess;
@@ -239,7 +231,7 @@ export class AcpTerminalManager {
   private recordGroupGone(session: TerminalSession): void {
     if (session.processGroupGone) return;
     const pid = session.process.pid;
-    const groupExists = pid != null && (this.processGroupProbe ?? defaultProcessGroupProbe)(pid);
+    const groupExists = pid != null && (this.processGroupProbe ?? acpProcessGroupAlive)(pid);
     if (!groupExists) session.processGroupGone = true;
   }
 

--- a/packages/daemon/src/lib/acp/acp-transport.ts
+++ b/packages/daemon/src/lib/acp/acp-transport.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { kill as processKill } from 'node:process';
 import type {
   AcpJsonRpcError,
   AcpJsonRpcNotification,
@@ -8,9 +7,23 @@ import type {
   AcpJsonRpcResponse,
 } from '@hyperneo/shared';
 import { Logger } from '../logger';
+import {
+  type AcpProcessTree,
+  type AcpProcessTreeOwner,
+  basicAcpProcessTreeOwner,
+} from './acp-process-tree';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const CLOSE_SIGTERM_TIMEOUT_MS = 5_000;
+
+const defaultProcessGroupProbe = (pid: number): boolean => {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+};
 
 const logger = new Logger('AcpTransport');
 
@@ -44,6 +57,9 @@ export interface AcpTransportOptions extends AcpTransportCallbacks {
   replaceEnv?: boolean;
   cwd?: string;
   requestTimeoutMs?: number;
+  closeSIGKILLTimeoutMs?: number;
+  processGroupProbe?: (pid: number) => boolean;
+  processTreeOwner?: AcpProcessTreeOwner;
 }
 
 interface PendingRequest {
@@ -54,11 +70,15 @@ interface PendingRequest {
 
 export class AcpTransport {
   private process: ChildProcess | null = null;
+  private processTree: AcpProcessTree | null = null;
   private nextId = 1;
   private pendingRequests = new Map<number | string, PendingRequest>();
   private buffer = '';
   private closed = false;
   private processExited = false;
+  private processPid: number | undefined;
+  private processGroupGone = false;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
   private closePromise: Promise<void> | null = null;
   private closeResolve: (() => void) | null = null;
 
@@ -82,6 +102,23 @@ export class AcpTransport {
     });
 
     this.process = proc;
+    this.processPid = proc.pid ?? undefined;
+
+    proc.on('error', (err) => {
+      logger.error('ACP agent process error:', err.message);
+      this.recordProcessGroupGone();
+      this.process = null;
+      this.processExited = true;
+      this.rejectAllPending(new Error(`ACP agent process error: ${err.message}`));
+      if (this.options.onExit) {
+        this.options.onExit(null, null);
+      }
+      if (this.closeResolve) {
+        this.closeResolve();
+      }
+    });
+
+    this.processTree = (this.options.processTreeOwner ?? basicAcpProcessTreeOwner)(proc);
     this.options.onProcessSpawn?.(proc);
 
     proc.stdout?.on('data', (chunk: Buffer) => {
@@ -99,6 +136,7 @@ export class AcpTransport {
 
     proc.on('exit', (code, signal) => {
       logger.info(`ACP agent exited (code=${code}, signal=${signal})`);
+      this.recordProcessGroupGone();
       this.process = null;
       this.processExited = true;
       if (this.options.onExit) {
@@ -108,19 +146,6 @@ export class AcpTransport {
 
     proc.on('close', () => {
       this.rejectAllPending(new Error('ACP agent process exited'));
-      if (this.closeResolve) {
-        this.closeResolve();
-      }
-    });
-
-    proc.on('error', (err) => {
-      logger.error('ACP agent process error:', err.message);
-      this.process = null;
-      this.processExited = true;
-      this.rejectAllPending(new Error(`ACP agent process error: ${err.message}`));
-      if (this.options.onExit) {
-        this.options.onExit(null, null);
-      }
       if (this.closeResolve) {
         this.closeResolve();
       }
@@ -327,16 +352,20 @@ export class AcpTransport {
   }
 
   private killProcess(signal: NodeJS.Signals): void {
-    const proc = this.process;
-    if (!proc) return;
+    this.processTree?.terminate(signal);
+  }
 
-    if (process.platform !== 'win32' && proc.pid != null) {
-      try {
-        processKill(-proc.pid, signal);
-        return;
-      } catch {}
+  private recordProcessGroupGone(): void {
+    if (!this.processGroupGone) {
+      const pid = this.processPid;
+      if (pid != null && !(this.options.processGroupProbe ?? defaultProcessGroupProbe)(pid)) {
+        this.processGroupGone = true;
+      }
     }
-    proc.kill(signal);
+    if (this.processGroupGone && this.killTimer) {
+      clearTimeout(this.killTimer);
+      this.killTimer = null;
+    }
   }
 
   close(): Promise<void> {
@@ -350,23 +379,31 @@ export class AcpTransport {
     this.closePromise = new Promise((resolve) => {
       this.closeResolve = resolve;
 
-      if (!this.process || this.processExited) {
+      if (!this.processTree) {
+        resolve();
+        return;
+      }
+
+      this.recordProcessGroupGone();
+      if (this.processGroupGone) {
         resolve();
         return;
       }
 
       this.killProcess('SIGTERM');
 
-      const killTimer = setTimeout(() => {
-        if (!this.processExited) {
-          logger.warn('ACP agent did not exit after SIGTERM, sending SIGKILL');
-          this.killProcess('SIGKILL');
-        }
-      }, CLOSE_SIGTERM_TIMEOUT_MS);
+      this.killTimer = setTimeout(() => {
+        this.killTimer = null;
+        this.recordProcessGroupGone();
+        if (this.processGroupGone) return;
+        logger.warn('ACP agent cleanup escalation after SIGTERM');
+        this.killProcess('SIGKILL');
+      }, this.options.closeSIGKILLTimeoutMs ?? CLOSE_SIGTERM_TIMEOUT_MS);
+      this.killTimer.unref();
 
-      const cleanup = () => clearTimeout(killTimer);
-      this.process.once('exit', cleanup);
-      this.process.once('error', cleanup);
+      if (this.processExited) {
+        resolve();
+      }
     });
 
     return this.closePromise;

--- a/packages/daemon/src/lib/acp/acp-transport.ts
+++ b/packages/daemon/src/lib/acp/acp-transport.ts
@@ -110,7 +110,14 @@ export class AcpTransport {
       }
     });
 
-    this.processTree = (this.options.processTreeOwner ?? basicAcpProcessTreeOwner)(proc);
+    try {
+      this.processTree = (this.options.processTreeOwner ?? basicAcpProcessTreeOwner)(proc);
+    } catch (err) {
+      try {
+        basicAcpProcessTreeOwner(proc).terminate('SIGKILL');
+      } catch {}
+      throw err;
+    }
     this.options.onProcessSpawn?.(proc);
 
     proc.stdout?.on('data', (chunk: Buffer) => {

--- a/packages/daemon/src/lib/acp/acp-transport.ts
+++ b/packages/daemon/src/lib/acp/acp-transport.ts
@@ -378,6 +378,16 @@ export class AcpTransport {
 
       this.recordProcessGroupGone();
       if (this.processGroupGone) {
+        if (!this.processExited) {
+          this.killProcess('SIGTERM');
+          this.killTimer = setTimeout(() => {
+            this.killTimer = null;
+            if (this.processExited) return;
+            logger.warn('ACP agent cleanup escalation after SIGTERM');
+            this.killProcess('SIGKILL');
+          }, this.options.closeSIGKILLTimeoutMs ?? CLOSE_SIGTERM_TIMEOUT_MS);
+          this.killTimer.unref();
+        }
         resolve();
         return;
       }

--- a/packages/daemon/src/lib/acp/acp-transport.ts
+++ b/packages/daemon/src/lib/acp/acp-transport.ts
@@ -8,6 +8,7 @@ import type {
 } from '@hyperneo/shared';
 import { Logger } from '../logger';
 import {
+  acpProcessGroupAlive,
   type AcpProcessTree,
   type AcpProcessTreeOwner,
   basicAcpProcessTreeOwner,
@@ -15,15 +16,6 @@ import {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const CLOSE_SIGTERM_TIMEOUT_MS = 5_000;
-
-const defaultProcessGroupProbe = (pid: number): boolean => {
-  try {
-    process.kill(-pid, 0);
-    return true;
-  } catch (err) {
-    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
-  }
-};
 
 const logger = new Logger('AcpTransport');
 
@@ -358,7 +350,7 @@ export class AcpTransport {
   private recordProcessGroupGone(): void {
     if (!this.processGroupGone) {
       const pid = this.processPid;
-      if (pid != null && !(this.options.processGroupProbe ?? defaultProcessGroupProbe)(pid)) {
+      if (pid != null && !(this.options.processGroupProbe ?? acpProcessGroupAlive)(pid)) {
         this.processGroupGone = true;
       }
     }

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -50,7 +50,7 @@ interface PendingQuestionResolver {
 export const QUESTION_CANCEL_MESSAGE =
   'User cancelled: The user chose not to answer this question. Please proceed accordingly or ask a different question if needed.';
 
-const MAX_QUESTION_STRING_LENGTH = 2000;
+export const MAX_QUESTION_STRING_LENGTH = 2000;
 
 const MAX_QUESTIONS = 4;
 const MAX_OPTIONS = 4;

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -192,11 +192,11 @@ export class QueryLifecycleManager {
     const noPidProcessSnapshot = this.ctx.snapshotNoPidTrackedProcesses?.() ?? [];
     const queryAbortController = this.ctx.queryAbortController;
     const queryPromise = this.ctx.queryPromise;
+    const queryObject = this.ctx.queryObject;
 
     messageQueue.stop();
     queryAbortController?.abort();
 
-    const queryObject = this.ctx.queryObject;
     if (queryObject && typeof queryObject.interrupt === 'function') {
       if (this.ctx.firstMessageReceived) {
         try {
@@ -249,12 +249,13 @@ export class QueryLifecycleManager {
     ) {
       staleAbort.abort();
     }
-    if (staleAbort) {
+    if (this.ctx.queryPromise === queryPromise) {
       this.ctx.queryAbortController = null;
+      this.ctx.queryPromise = null;
     }
-
-    this.ctx.queryObject = null;
-    this.ctx.queryPromise = null;
+    if (this.ctx.queryObject === queryObject) {
+      this.ctx.queryObject = null;
+    }
   }
 
   async restart(): Promise<void> {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -223,15 +223,17 @@ export class QueryLifecycleManager {
       noPidProcesses: noPidProcessSnapshot,
     });
 
-    const lateProcesses = this.ctx
-      .snapshotTrackedAgentProcesses()
-      .filter((process) => !trackedProcessSnapshot.some((entry) => entry[1] === process[1]));
-    if (lateProcesses.length > 0) {
-      this.ctx.terminateTrackedAgentProcesses({
-        forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS,
-        processes: lateProcesses,
-        noPidProcesses: [],
-      });
+    if (this.ctx.queryPromise === queryPromise) {
+      const lateProcesses = this.ctx
+        .snapshotTrackedAgentProcesses()
+        .filter((process) => !trackedProcessSnapshot.some((entry) => entry[1] === process[1]));
+      if (lateProcesses.length > 0) {
+        this.ctx.terminateTrackedAgentProcesses({
+          forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS,
+          processes: lateProcesses,
+          noPidProcesses: [],
+        });
+      }
     }
 
     if (queryObject && this.ctx.queryObject === queryObject) {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -193,6 +193,7 @@ export class QueryLifecycleManager {
     const queryAbortController = this.ctx.queryAbortController;
     const queryPromise = this.ctx.queryPromise;
     const queryObject = this.ctx.queryObject;
+    const startupTimeoutTimer = this.ctx.startupTimeoutTimer;
 
     messageQueue.stop();
     queryAbortController?.abort();
@@ -237,7 +238,7 @@ export class QueryLifecycleManager {
     }
 
     const staleTimer = this.ctx.startupTimeoutTimer;
-    if (staleTimer) {
+    if (staleTimer && staleTimer === startupTimeoutTimer) {
       clearTimeout(staleTimer);
       this.ctx.startupTimeoutTimer = null;
     }

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -191,6 +191,7 @@ export class QueryLifecycleManager {
     const trackedProcessSnapshot = this.ctx.snapshotTrackedAgentProcesses();
     const noPidProcessSnapshot = this.ctx.snapshotNoPidTrackedProcesses?.() ?? [];
     const queryAbortController = this.ctx.queryAbortController;
+    const queryPromise = this.ctx.queryPromise;
 
     messageQueue.stop();
     queryAbortController?.abort();
@@ -204,7 +205,6 @@ export class QueryLifecycleManager {
       }
     }
 
-    const queryPromise = this.ctx.queryPromise;
     if (queryPromise) {
       try {
         const promiseToAwait = catchQueryErrors ? queryPromise.catch(() => {}) : queryPromise;
@@ -242,6 +242,13 @@ export class QueryLifecycleManager {
       this.ctx.startupTimeoutTimer = null;
     }
     const staleAbort = this.ctx.queryAbortController;
+    if (
+      staleAbort &&
+      staleAbort !== queryAbortController &&
+      this.ctx.queryPromise === queryPromise
+    ) {
+      staleAbort.abort();
+    }
     if (staleAbort) {
       this.ctx.queryAbortController = null;
     }

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -188,9 +188,10 @@ export class QueryLifecycleManager {
     const processExitedPromise = this.ctx.processExitedPromise;
     const trackedProcessSnapshot = this.ctx.snapshotTrackedAgentProcesses();
     const noPidProcessSnapshot = this.ctx.snapshotNoPidTrackedProcesses?.() ?? [];
+    const queryAbortController = this.ctx.queryAbortController;
 
     messageQueue.stop();
-    this.ctx.queryAbortController?.abort();
+    queryAbortController?.abort();
 
     const queryObject = this.ctx.queryObject;
     if (queryObject && typeof queryObject.interrupt === 'function') {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -81,10 +81,14 @@ export class QueryLifecycleManager {
       session.acpSessionId = undefined;
       updates.acpSessionId = undefined;
     }
-    if (session.metadata?.acpInstructionsSent) {
+    if (
+      session.metadata?.acpInstructionsSent ||
+      session.metadata?.acpContextUsageEstimate !== undefined
+    ) {
       session.metadata = {
         ...session.metadata,
         acpInstructionsSent: undefined,
+        acpContextUsageEstimate: undefined,
       };
       updates.metadata = session.metadata;
     }
@@ -186,6 +190,7 @@ export class QueryLifecycleManager {
     const noPidProcessSnapshot = this.ctx.snapshotNoPidTrackedProcesses?.() ?? [];
 
     messageQueue.stop();
+    this.ctx.queryAbortController?.abort();
 
     const queryObject = this.ctx.queryObject;
     if (queryObject && typeof queryObject.interrupt === 'function') {

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -223,6 +223,17 @@ export class QueryLifecycleManager {
       noPidProcesses: noPidProcessSnapshot,
     });
 
+    const lateProcesses = this.ctx
+      .snapshotTrackedAgentProcesses()
+      .filter((process) => !trackedProcessSnapshot.some((entry) => entry[1] === process[1]));
+    if (lateProcesses.length > 0) {
+      this.ctx.terminateTrackedAgentProcesses({
+        forceDelayMs: FORCE_PROCESS_KILL_DELAY_MS,
+        processes: lateProcesses,
+        noPidProcesses: [],
+      });
+    }
+
     if (queryObject && this.ctx.queryObject === queryObject) {
       try {
         queryObject.close();

--- a/packages/daemon/tests/unit/1-core/acp-transport.test.ts
+++ b/packages/daemon/tests/unit/1-core/acp-transport.test.ts
@@ -201,6 +201,7 @@ describe('AcpTransport', () => {
     expect(() => new AcpTransport({ command: 'missing', processTreeOwner })).toThrow(
       'missing process id'
     );
+    expect(lastMockProcess?.killed).toBe(true);
     expect(() => lastMockProcess?.emit('error', new Error('spawn ENOENT'))).not.toThrow();
   });
 

--- a/packages/daemon/tests/unit/1-core/acp-transport.test.ts
+++ b/packages/daemon/tests/unit/1-core/acp-transport.test.ts
@@ -192,6 +192,18 @@ describe('AcpTransport', () => {
     await expect(promise).rejects.toThrow('ACP agent process exited');
   });
 
+  test('observes spawn errors when process-tree ownership fails', () => {
+    const processTreeOwner = vi.fn((proc: MockChildProcess) => {
+      expect(proc.listenerCount('error')).toBeGreaterThan(0);
+      throw new Error('missing process id');
+    });
+
+    expect(() => new AcpTransport({ command: 'missing', processTreeOwner })).toThrow(
+      'missing process id'
+    );
+    expect(() => lastMockProcess?.emit('error', new Error('spawn ENOENT'))).not.toThrow();
+  });
+
   test('rejects pending requests on process error', async () => {
     const transport = new AcpTransport({ command: 'acp-agent' });
     const proc = lastMockProcess!;
@@ -282,7 +294,7 @@ describe('AcpTransport', () => {
   });
 
   test('close sends SIGTERM then SIGKILL after timeout', async () => {
-    const transport = new AcpTransport({ command: 'acp-agent' });
+    const transport = new AcpTransport({ command: 'acp-agent', processGroupProbe: () => true });
     const proc = lastMockProcess!;
 
     const closePromise = transport.close();
@@ -294,14 +306,76 @@ describe('AcpTransport', () => {
     expect(proc.killed).toBe(true);
   });
 
-  test('close resolves immediately if process already exited', async () => {
-    const transport = new AcpTransport({ command: 'acp-agent' });
+  test('retains tree ownership after the leader exits', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => true,
+    });
     const proc = lastMockProcess!;
 
     proc.emit('exit', 0, null);
 
     await expect(transport.close()).resolves.toBeUndefined();
+    expect(processTreeOwner).toHaveBeenCalledWith(proc);
+    expect(terminate).toHaveBeenCalledWith('SIGTERM');
   });
+
+  test('does not escalate SIGKILL after the process group is gone', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => false,
+      closeSIGKILLTimeoutMs: 50,
+    });
+    const proc = lastMockProcess!;
+
+    proc.emit('exit', 0, null);
+    await transport.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(terminate).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('escalates SIGKILL while the process group remains', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => true,
+      closeSIGKILLTimeoutMs: 50,
+    });
+
+    transport.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(terminate).toHaveBeenCalledWith('SIGTERM');
+    expect(terminate).toHaveBeenCalledWith('SIGKILL');
+  }, 1000);
+
+  test('skips SIGKILL when the group exits during the escalation delay', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    let groupExists = true;
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => groupExists,
+      closeSIGKILLTimeoutMs: 50,
+    });
+
+    transport.close();
+    groupExists = false;
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(terminate).toHaveBeenCalledWith('SIGTERM');
+    expect(terminate).not.toHaveBeenCalledWith('SIGKILL');
+  }, 1000);
 
   test('onExit callback fires when process exits', () => {
     const exits: Array<{ code: number | null; signal: string | null }> = [];
@@ -504,7 +578,7 @@ describe('AcpTransport', () => {
   });
 
   test('close falls back to direct kill when group kill fails', async () => {
-    const transport = new AcpTransport({ command: 'acp-agent' });
+    const transport = new AcpTransport({ command: 'acp-agent', processGroupProbe: () => true });
     const proc = lastMockProcess!;
     proc.pid = 12345;
 

--- a/packages/daemon/tests/unit/1-core/acp-transport.test.ts
+++ b/packages/daemon/tests/unit/1-core/acp-transport.test.ts
@@ -341,6 +341,56 @@ describe('AcpTransport', () => {
     expect(terminate).not.toHaveBeenCalled();
   }, 1000);
 
+  test('signals and escalates against the leader when the group is gone but it lives', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => false,
+      closeSIGKILLTimeoutMs: 50,
+    });
+
+    await transport.close();
+
+    expect(terminate).toHaveBeenCalledWith('SIGTERM');
+
+    await new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 5000;
+      const check = () => {
+        if (terminate.mock.calls.some(([signal]) => signal === 'SIGKILL')) {
+          resolve();
+          return;
+        }
+        if (Date.now() > deadline) {
+          reject(new Error('SIGKILL escalation did not run'));
+          return;
+        }
+        setTimeout(check, 10);
+      };
+      check();
+    });
+  }, 10000);
+
+  test('cancels leader escalation when the leader exits after the group is gone', async () => {
+    const terminate = vi.fn();
+    const processTreeOwner = vi.fn(() => ({ terminate }));
+    const transport = new AcpTransport({
+      command: 'acp-agent',
+      processTreeOwner,
+      processGroupProbe: () => false,
+      closeSIGKILLTimeoutMs: 50,
+    });
+    const proc = lastMockProcess!;
+
+    await transport.close();
+    proc.emit('exit', 0, null);
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(terminate).toHaveBeenCalledWith('SIGTERM');
+    expect(terminate).not.toHaveBeenCalledWith('SIGKILL');
+  }, 1000);
+
   test('escalates SIGKILL while the process group remains', async () => {
     const terminate = vi.fn();
     const processTreeOwner = vi.fn(() => ({ terminate }));
@@ -353,10 +403,23 @@ describe('AcpTransport', () => {
 
     transport.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 5000;
+      const check = () => {
+        if (terminate.mock.calls.some(([signal]) => signal === 'SIGKILL')) {
+          resolve();
+          return;
+        }
+        if (Date.now() > deadline) {
+          reject(new Error('SIGKILL escalation did not run'));
+          return;
+        }
+        setTimeout(check, 10);
+      };
+      check();
+    });
     expect(terminate).toHaveBeenCalledWith('SIGTERM');
-    expect(terminate).toHaveBeenCalledWith('SIGKILL');
-  }, 1000);
+  }, 10000);
 
   test('skips SIGKILL when the group exits during the escalation delay', async () => {
     const terminate = vi.fn();

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -185,6 +185,24 @@ describe('QueryLifecycleManager', () => {
       expect(abortController.signal.aborted).toBe(true);
     });
 
+    test('aborts only the query controller captured when stop begins', async () => {
+      const entryController = new AbortController();
+      const newerController = new AbortController();
+      mockContext.queryAbortController = entryController;
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      const stopSpy = spyOn(messageQueue, 'stop');
+      stopSpy.mockImplementation(() => {
+        mockContext.queryAbortController = newerController;
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(entryController.signal.aborted).toBe(true);
+      expect(newerController.signal.aborted).toBe(false);
+    });
+
     test('interrupts query when transport is ready', async () => {
       let interruptCalled = false;
       mockContext.queryObject = {

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -247,6 +247,25 @@ describe('QueryLifecycleManager', () => {
       clearTimeout(newerTimer);
     });
 
+    test('terminates agent processes discovered during the stop window', async () => {
+      const lateProcess = { pid: 4242, kill: mock(() => {}) } as never;
+      let call = 0;
+      snapshotTrackedAgentProcessesSpy.mockImplementation(() => {
+        call++;
+        return call === 1 ? [] : ([[4242, lateProcess]] as never);
+      });
+
+      manager = new QueryLifecycleManager(mockContext);
+      await manager.stop();
+
+      expect(terminateTrackedAgentProcessesSpy).toHaveBeenCalledTimes(2);
+      expect(terminateTrackedAgentProcessesSpy.mock.calls[1][0]).toEqual({
+        forceDelayMs: expect.any(Number),
+        processes: [[4242, lateProcess]],
+        noPidProcesses: [],
+      });
+    });
+
     test('aborts a controller installed by the stopped query during the stop window', async () => {
       const lateController = new AbortController();
       mockContext.queryPromise = new Promise(() => {});

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -221,7 +221,7 @@ describe('QueryLifecycleManager', () => {
       });
       manager = new QueryLifecycleManager(mockContext);
 
-      await manager.stop();
+      await manager.stop({ timeoutMs: 50 });
 
       expect(newerController.signal.aborted).toBe(false);
       expect(mockContext.queryAbortController).toBe(newerController);

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -205,6 +205,30 @@ describe('QueryLifecycleManager', () => {
       expect(newerController.signal.aborted).toBe(false);
     });
 
+    test('preserves replacement query references installed during stop', async () => {
+      const entryController = new AbortController();
+      const newerController = new AbortController();
+      const newerQueryObject = { interrupt: mock(async () => {}) };
+      const newerPromise = Promise.resolve();
+      mockContext.queryAbortController = entryController;
+      mockContext.queryPromise = new Promise(() => {});
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      spyOn(messageQueue, 'stop').mockImplementation(() => {
+        mockContext.queryAbortController = newerController;
+        mockContext.queryObject = newerQueryObject as never;
+        mockContext.queryPromise = newerPromise;
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(newerController.signal.aborted).toBe(false);
+      expect(mockContext.queryAbortController).toBe(newerController);
+      expect(mockContext.queryObject).toBe(newerQueryObject);
+      expect(mockContext.queryPromise).toBe(newerPromise);
+    });
+
     test('aborts a controller installed by the stopped query during the stop window', async () => {
       const lateController = new AbortController();
       mockContext.queryPromise = new Promise(() => {});

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -194,6 +194,7 @@ describe('QueryLifecycleManager', () => {
       const stopSpy = spyOn(messageQueue, 'stop');
       stopSpy.mockImplementation(() => {
         mockContext.queryAbortController = newerController;
+        mockContext.queryPromise = Promise.resolve();
         originalStop();
       });
       manager = new QueryLifecycleManager(mockContext);
@@ -201,6 +202,34 @@ describe('QueryLifecycleManager', () => {
       await manager.stop();
 
       expect(entryController.signal.aborted).toBe(true);
+      expect(newerController.signal.aborted).toBe(false);
+    });
+
+    test('aborts a controller installed by the stopped query during the stop window', async () => {
+      const lateController = new AbortController();
+      mockContext.queryPromise = new Promise(() => {});
+      manager = new QueryLifecycleManager(mockContext);
+
+      const stopping = manager.stop({ timeoutMs: 50 });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockContext.queryAbortController = lateController;
+      await stopping;
+
+      expect(lateController.signal.aborted).toBe(true);
+      expect(mockContext.queryAbortController).toBeNull();
+    });
+
+    test('does not abort a newer query controller installed during the stop window', async () => {
+      const newerController = new AbortController();
+      mockContext.queryPromise = new Promise(() => {});
+      manager = new QueryLifecycleManager(mockContext);
+
+      const stopping = manager.stop({ timeoutMs: 50 });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockContext.queryAbortController = newerController;
+      mockContext.queryPromise = Promise.resolve();
+      await stopping;
+
       expect(newerController.signal.aborted).toBe(false);
     });
 

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -229,6 +229,24 @@ describe('QueryLifecycleManager', () => {
       expect(mockContext.queryPromise).toBe(newerPromise);
     });
 
+    test('preserves a replacement startup timer installed during stop', async () => {
+      const entryTimer = setTimeout(() => {}, 10_000);
+      const newerTimer = setTimeout(() => {}, 10_000);
+      mockContext.startupTimeoutTimer = entryTimer;
+      const originalStop = messageQueue.stop.bind(messageQueue);
+      spyOn(messageQueue, 'stop').mockImplementation(() => {
+        mockContext.startupTimeoutTimer = newerTimer;
+        mockContext.queryPromise = Promise.resolve();
+        originalStop();
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(mockContext.startupTimeoutTimer).toBe(newerTimer);
+      clearTimeout(newerTimer);
+    });
+
     test('aborts a controller installed by the stopped query during the stop window', async () => {
       const lateController = new AbortController();
       mockContext.queryPromise = new Promise(() => {});

--- a/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-lifecycle-manager.test.ts
@@ -167,6 +167,24 @@ describe('QueryLifecycleManager', () => {
       expect(stopSpy).toHaveBeenCalled();
     });
 
+    test('aborts the active query before waiting for it to stop', async () => {
+      const abortController = new AbortController();
+      let observedAbort = false;
+      mockContext.queryAbortController = abortController;
+      mockContext.queryPromise = new Promise((resolve) => {
+        abortController.signal.addEventListener('abort', () => {
+          observedAbort = true;
+          resolve();
+        });
+      });
+      manager = new QueryLifecycleManager(mockContext);
+
+      await manager.stop();
+
+      expect(observedAbort).toBe(true);
+      expect(abortController.signal.aborted).toBe(true);
+    });
+
     test('interrupts query when transport is ready', async () => {
       let interruptCalled = false;
       mockContext.queryObject = {
@@ -594,7 +612,10 @@ describe('QueryLifecycleManager', () => {
     test('clears ACP resume state on reset when no query is running', async () => {
       mockContext.session.config.provider = 'acp';
       mockContext.session.acpSessionId = 'stale-acp-session';
-      mockContext.session.metadata = { acpInstructionsSent: true } as Session['metadata'];
+      mockContext.session.metadata = {
+        acpInstructionsSent: true,
+        acpContextUsageEstimate: 12000,
+      } as Session['metadata'];
       manager = new QueryLifecycleManager(mockContext);
 
       const result = await manager.reset();
@@ -602,11 +623,15 @@ describe('QueryLifecycleManager', () => {
       expect(result.success).toBe(true);
       expect(mockContext.session.acpSessionId).toBeUndefined();
       expect(mockContext.session.metadata.acpInstructionsSent).toBeUndefined();
+      expect(mockContext.session.metadata.acpContextUsageEstimate).toBeUndefined();
       expect(updateSessionSpy).toHaveBeenCalledWith(
         'test-session',
         expect.objectContaining({
           acpSessionId: undefined,
-          metadata: expect.objectContaining({ acpInstructionsSent: undefined }),
+          metadata: expect.objectContaining({
+            acpInstructionsSent: undefined,
+            acpContextUsageEstimate: undefined,
+          }),
         })
       );
     });
@@ -618,7 +643,10 @@ describe('QueryLifecycleManager', () => {
       mockContext.queryPromise = Promise.resolve();
       mockContext.session.config.provider = 'acp';
       mockContext.session.acpSessionId = 'stale-acp-session';
-      mockContext.session.metadata = { acpInstructionsSent: true } as Session['metadata'];
+      mockContext.session.metadata = {
+        acpInstructionsSent: true,
+        acpContextUsageEstimate: 12000,
+      } as Session['metadata'];
       manager = new QueryLifecycleManager(mockContext);
 
       const result = await manager.reset({ restartAfter: true });
@@ -626,11 +654,15 @@ describe('QueryLifecycleManager', () => {
       expect(result.success).toBe(true);
       expect(mockContext.session.acpSessionId).toBeUndefined();
       expect(mockContext.session.metadata.acpInstructionsSent).toBeUndefined();
+      expect(mockContext.session.metadata.acpContextUsageEstimate).toBeUndefined();
       expect(updateSessionSpy).toHaveBeenCalledWith(
         'test-session',
         expect.objectContaining({
           acpSessionId: undefined,
-          metadata: expect.objectContaining({ acpInstructionsSent: undefined }),
+          metadata: expect.objectContaining({
+            acpInstructionsSent: undefined,
+            acpContextUsageEstimate: undefined,
+          }),
         })
       );
       expect(startStreamingCalled).toBe(true);

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -325,6 +325,21 @@ describe('redactCommandSecrets', () => {
     ]);
   });
 
+  test('conservatively redacts scripts past the recursion cutoff', () => {
+    let nested = 'curl --token topsecret';
+    for (let i = 0; i < 4; i++) {
+      nested = `sh -c ${JSON.stringify(nested)}`;
+    }
+    const display = redactCommandSecrets('sh', ['-c', nested]);
+    expect(display.join(' ')).toContain('[redacted script]');
+    const sensitive = `sh -c ${JSON.stringify(`sh -c ${JSON.stringify('curl --token topsecret')}`)}`;
+    expect(getAcpCommandIdentityDigest(sensitive)).toBe(
+      getAcpCommandIdentityDigest(sensitive.replace('topsecret', 'othersafe'))
+    );
+    const benign = redactCommandSecrets('sh', ['-c', `sh -c 'echo plain'`]);
+    expect(benign.join(' ')).not.toContain('[redacted');
+  });
+
   test('redacts leading assignments inside shell scripts', () => {
     expect(
       getAcpCommandIdentityDigest("sh -c 'MODE=prod API_TOKEN=topsecret curl https://a'")

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -265,6 +265,20 @@ describe('redactCommandSecrets', () => {
     expect(getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=topsecret'")).toBe(
       getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=othersafe'")
     );
+    expect(
+      getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=topsecret curl https://b'`)
+    ).toBe(
+      getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=othersafe curl https://b'`)
+    );
+  });
+
+  test('limits nested header redaction to header-taking commands', () => {
+    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
+      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
+    );
+    expect(
+      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
+    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
   });
 
   test('keeps the quote wrapper around redacted url tokens', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -186,11 +186,14 @@ describe('redactCommandSecrets', () => {
   test('preserves token boundaries when redisplaying shell command arguments', () => {
     expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
       '-c',
-      `rm -- 'important file' --token [redacted]`,
+      `rm -- "important file" --token [redacted]`,
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
-    ).toEqual(['-c', `curl -H [redacted] https://a`]);
+    ).toEqual(['-c', `curl -H '[redacted]' https://a`]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo "safe; rm -rf /" && curl --token topsecret`])
+    ).toEqual(['-c', `echo "safe; rm -rf /" && curl --token [redacted]`]);
   });
 
   test('redisplays shell scripts verbatim when nothing was redacted', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -228,6 +228,27 @@ describe('getAcpCommandIdentityDigest', () => {
       getAcpCommandIdentityDigest('curl https://example.test -u alice:othersafe')
     );
   });
+
+  test('follows the command launched by env wrappers', () => {
+    expect(getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token topsecret'")).toBe(
+      getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token othersafe'")
+    );
+  });
+
+  test('redacts credentials behind clustered curl flags', () => {
+    expect(getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer topsecret' /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer othersafe' /a`)
+    );
+    expect(getAcpCommandIdentityDigest(`curl -sU alice:topsecret /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sU alice:othersafe /a`)
+    );
+  });
+
+  test('redacts userinfo inside option values', () => {
+    expect(getAcpCommandIdentityDigest('curl --url=https://alice:topsecret@h/a')).toBe(
+      getAcpCommandIdentityDigest('curl --url=https://alice:othersafe@h/a')
+    );
+  });
 });
 
 describe('redactCommandSecrets', () => {
@@ -300,30 +321,12 @@ describe('redactCommandSecrets', () => {
     );
   });
 
-  test('follows the command launched by env wrappers', () => {
-    expect(getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token topsecret'")).toBe(
-      getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token othersafe'")
-    );
-  });
-
   test('redacts credentials behind clustered and attached curl flags', () => {
-    expect(getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer topsecret' /a`)).toBe(
-      getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer othersafe' /a`)
-    );
-    expect(getAcpCommandIdentityDigest(`curl -sU alice:topsecret /a`)).toBe(
-      getAcpCommandIdentityDigest(`curl -sU alice:othersafe /a`)
-    );
     expect(redactCommandSecrets('curl', ['-sH', 'Authorization: Bearer topsecret', '/a'])).toEqual([
       '-sH',
       '[redacted]',
       '/a',
     ]);
-  });
-
-  test('redacts userinfo inside option values', () => {
-    expect(getAcpCommandIdentityDigest('curl --url=https://alice:topsecret@h/a')).toBe(
-      getAcpCommandIdentityDigest('curl --url=https://alice:othersafe@h/a')
-    );
   });
 
   test('treats tokens after -- as positional data', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -295,6 +295,35 @@ describe('redactCommandSecrets', () => {
     expect(getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=topsecret curl /a'")).toBe(
       getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=othersafe curl /a'")
     );
+    expect(getAcpCommandIdentityDigest("sh -c 'echo ok;API_TOKEN=topsecret curl /a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'echo ok;API_TOKEN=othersafe curl /a'")
+    );
+  });
+
+  test('follows the command launched by env wrappers', () => {
+    expect(getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token topsecret'")).toBe(
+      getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token othersafe'")
+    );
+  });
+
+  test('redacts credentials behind clustered and attached curl flags', () => {
+    expect(getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer topsecret' /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer othersafe' /a`)
+    );
+    expect(getAcpCommandIdentityDigest(`curl -sU alice:topsecret /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sU alice:othersafe /a`)
+    );
+    expect(redactCommandSecrets('curl', ['-sH', 'Authorization: Bearer topsecret', '/a'])).toEqual([
+      '-sH',
+      '[redacted]',
+      '/a',
+    ]);
+  });
+
+  test('redacts userinfo inside option values', () => {
+    expect(getAcpCommandIdentityDigest('curl --url=https://alice:topsecret@h/a')).toBe(
+      getAcpCommandIdentityDigest('curl --url=https://alice:othersafe@h/a')
+    );
   });
 
   test('treats tokens after -- as positional data', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -4,6 +4,7 @@ import {
   getAcpCommandIdentity,
   getAcpCommandIdentityDigest,
   parseAcpCommand,
+  redactSecretArgs,
 } from '../../../../src/lib/acp/acp-command';
 
 describe('buildAcpSafeEnv', () => {
@@ -112,6 +113,9 @@ describe('getAcpCommandIdentityDigest', () => {
     ).toBe(
       getAcpCommandIdentityDigest('sh -c "curl -H \'Authorization: Bearer othersafe\' https://a"')
     );
+    expect(getAcpCommandIdentityDigest("curl -H'Authorization: Bearer topsecret' https://a")).toBe(
+      getAcpCommandIdentityDigest("curl -H'Authorization: Bearer othersafe' https://a")
+    );
   });
 
   test('keeps non-credential header values visible in the digest', () => {
@@ -123,6 +127,19 @@ describe('getAcpCommandIdentityDigest', () => {
     );
     expect(getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: DELETE\' /a"')).not.toBe(
       getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: PUT\' /a"')
+    );
+    expect(getAcpCommandIdentityDigest("curl -H'X-Method: DELETE' /a")).not.toBe(
+      getAcpCommandIdentityDigest("curl -H'X-Method: PUT' /a")
+    );
+  });
+
+  test('preserves token boundaries when redisplaying shell command arguments', () => {
+    expect(redactSecretArgs(['-c', 'rm -- "important file"'])).toEqual([
+      '-c',
+      `rm -- 'important file'`,
+    ]);
+    expect(redactSecretArgs(['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])).toEqual(
+      ['-c', `curl -H '[redacted]' https://a`]
     );
   });
 

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -142,31 +142,6 @@ describe('getAcpCommandIdentityDigest', () => {
     );
   });
 
-  test('preserves token boundaries when redisplaying shell command arguments', () => {
-    expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
-      '-c',
-      `rm -- 'important file' --token [redacted]`,
-    ]);
-    expect(
-      redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
-    ).toEqual(['-c', `curl -H [redacted] https://a`]);
-  });
-
-  test('gates tool-specific short options on their executables', () => {
-    expect(getAcpCommandIdentityDigest('python3 -u agent-a.py')).not.toBe(
-      getAcpCommandIdentityDigest('python3 -u agent-b.py')
-    );
-    expect(getAcpCommandIdentityDigest('python3 -c \'print("one")\'')).not.toBe(
-      getAcpCommandIdentityDigest('python3 -c \'print("two")\'')
-    );
-    expect(getAcpCommandIdentityDigest('env API_TOKEN=topsecret agent')).toBe(
-      getAcpCommandIdentityDigest('env API_TOKEN=othersafe agent')
-    );
-    expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
-      getAcpCommandIdentityDigest('env MODE=slow agent')
-    );
-  });
-
   test('redacts userinfo credentials embedded in positional URLs', () => {
     expect(getAcpCommandIdentityDigest('psql postgresql://alice:topsecret@db/app')).toBe(
       getAcpCommandIdentityDigest('psql postgresql://alice:othersafe@db/app')
@@ -177,17 +152,6 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-a/app')).not.toBe(
       getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-b/app')
     );
-  });
-
-  test('redisplays shell scripts verbatim when nothing was redacted', () => {
-    expect(redactCommandSecrets('sh', ['-c', 'echo "safe; rm -rf /"'])).toEqual([
-      '-c',
-      'echo "safe; rm -rf /"',
-    ]);
-    expect(redactCommandSecrets('sh', ['-c', "echo 'a b' && echo c"])).toEqual([
-      '-c',
-      "echo 'a b' && echo c",
-    ]);
   });
 
   test('does not swallow the next flag after a valueless secret flag', () => {
@@ -215,5 +179,28 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('devin acp --password-policy strict')).not.toBe(
       getAcpCommandIdentityDigest('devin acp --password-policy relaxed')
     );
+  });
+});
+
+describe('redactCommandSecrets', () => {
+  test('preserves token boundaries when redisplaying shell command arguments', () => {
+    expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
+      '-c',
+      `rm -- 'important file' --token [redacted]`,
+    ]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
+    ).toEqual(['-c', `curl -H [redacted] https://a`]);
+  });
+
+  test('redisplays shell scripts verbatim when nothing was redacted', () => {
+    expect(redactCommandSecrets('sh', ['-c', 'echo "safe; rm -rf /"'])).toEqual([
+      '-c',
+      'echo "safe; rm -rf /"',
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', "echo 'a b' && echo c"])).toEqual([
+      '-c',
+      "echo 'a b' && echo c",
+    ]);
   });
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -104,6 +104,18 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(
       getAcpCommandIdentityDigest('curl -H "Authorization: Bearer topsecret" https://api')
     ).toBe(getAcpCommandIdentityDigest('curl -H "Authorization: Bearer othersafe" https://api'));
+    expect(getAcpCommandIdentityDigest('curl -H "Cookie: session=topsecret" https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -H "Cookie: session=other" https://a')
+    );
+  });
+
+  test('keeps non-credential header values visible in the digest', () => {
+    expect(getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: DELETE" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: PUT" /a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -H "Accept: application/json" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "Accept: text/plain" /a')
+    );
   });
 
   test('still distinguishes commands that differ outside secret arguments', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   buildAcpSafeEnv,
   getAcpCommandIdentity,
+  getAcpCommandIdentityDigest,
   parseAcpCommand,
 } from '../../../../src/lib/acp/acp-command';
 
@@ -79,6 +80,32 @@ describe('getAcpCommandIdentity', () => {
   test('normalizes equivalent command identities', () => {
     expect(getAcpCommandIdentity('devin   acp "model one"')).toBe(
       getAcpCommandIdentity("devin acp 'model one'")
+    );
+  });
+});
+
+describe('getAcpCommandIdentityDigest', () => {
+  test('excludes secret-shaped argument values from the digest', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --token topsecret')).toBe(
+      getAcpCommandIdentityDigest('devin acp --token othersecret')
+    );
+    expect(getAcpCommandIdentityDigest('agent --api-key=k1 --stdio')).toBe(
+      getAcpCommandIdentityDigest('agent --api-key=k2 --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('agent --password p1 run')).toBe(
+      getAcpCommandIdentityDigest('agent --password p2 run')
+    );
+  });
+
+  test('still distinguishes commands that differ outside secret arguments', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('other-acp --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --model one')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --model two')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --token a --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --token a --verbose')
     );
   });
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -210,13 +210,35 @@ describe('getAcpCommandIdentityDigest', () => {
       getAcpCommandIdentityDigest('devin acp --password-policy relaxed')
     );
   });
+
+  test('limits nested header redaction to header-taking commands', () => {
+    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
+      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
+    );
+    expect(
+      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
+    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
+  });
+
+  test('keeps curl ownership across positional arguments', () => {
+    expect(
+      getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer a"')
+    ).toBe(getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer b"'));
+    expect(getAcpCommandIdentityDigest('curl https://example.test -u alice:topsecret')).toBe(
+      getAcpCommandIdentityDigest('curl https://example.test -u alice:othersafe')
+    );
+  });
 });
 
 describe('redactCommandSecrets', () => {
   test('preserves token boundaries when redisplaying shell command arguments', () => {
     expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
       '-c',
-      `rm -- "important file" --token [redacted]`,
+      `rm -- "important file" --token topsecret`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `rm "important file" --token topsecret`])).toEqual([
+      '-c',
+      `rm "important file" --token [redacted]`,
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
@@ -242,15 +264,6 @@ describe('redactCommandSecrets', () => {
     expect(
       redactCommandSecrets('sh', ['-c', `echo "--token topsecret" && curl --token topsecret`])
     ).toEqual(['-c', `echo "--token topsecret" && curl --token [redacted]`]);
-  });
-
-  test('limits nested header redaction to header-taking commands', () => {
-    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
-      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
-    );
-    expect(
-      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
-    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
   });
 
   test('stops treating assignments as environment after the command word', () => {
@@ -279,6 +292,20 @@ describe('redactCommandSecrets', () => {
     ).toBe(
       getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=othersafe curl https://b'`)
     );
+    expect(getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=topsecret curl /a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=othersafe curl /a'")
+    );
+  });
+
+  test('treats tokens after -- as positional data', () => {
+    expect(getAcpCommandIdentityDigest(`rm -- --password file-a`)).not.toBe(
+      getAcpCommandIdentityDigest(`rm -- --password file-b`)
+    );
+    expect(redactCommandSecrets('rm', ['--', '--password', 'file-a'])).toEqual([
+      '--',
+      '--password',
+      'file-a',
+    ]);
   });
 
   test('keeps the quote wrapper around redacted url tokens', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -116,6 +116,15 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest("curl -H'Authorization: Bearer topsecret' https://a")).toBe(
       getAcpCommandIdentityDigest("curl -H'Authorization: Bearer othersafe' https://a")
     );
+    expect(getAcpCommandIdentityDigest('curl -u admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -u admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -uadmin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -uadmin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
   });
 
   test('keeps non-credential header values visible in the digest', () => {
@@ -139,8 +148,13 @@ describe('getAcpCommandIdentityDigest', () => {
       `rm -- 'important file'`,
     ]);
     expect(redactSecretArgs(['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])).toEqual(
-      ['-c', `curl -H '[redacted]' https://a`]
+      ['-c', `curl -H [redacted] https://a`]
     );
+    expect(redactSecretArgs(['-c', 'echo safe && rm -- "important file"'])).toEqual([
+      '-c',
+      `echo safe && rm -- 'important file'`,
+    ]);
+    expect(redactSecretArgs(['-c', 'echo $HOME | wc -l'])).toEqual(['-c', 'echo $HOME | wc -l']);
   });
 
   test('does not swallow the next flag after a valueless secret flag', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -4,7 +4,7 @@ import {
   getAcpCommandIdentity,
   getAcpCommandIdentityDigest,
   parseAcpCommand,
-  redactSecretArgs,
+  redactCommandSecrets,
 } from '../../../../src/lib/acp/acp-command';
 
 describe('buildAcpSafeEnv', () => {
@@ -143,18 +143,36 @@ describe('getAcpCommandIdentityDigest', () => {
   });
 
   test('preserves token boundaries when redisplaying shell command arguments', () => {
-    expect(redactSecretArgs(['-c', 'rm -- "important file"'])).toEqual([
+    expect(redactCommandSecrets('sh', ['-c', 'rm -- "important file"'])).toEqual([
       '-c',
       `rm -- 'important file'`,
     ]);
-    expect(redactSecretArgs(['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])).toEqual(
-      ['-c', `curl -H [redacted] https://a`]
-    );
-    expect(redactSecretArgs(['-c', 'echo safe && rm -- "important file"'])).toEqual([
+    expect(
+      redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
+    ).toEqual(['-c', `curl -H [redacted] https://a`]);
+    expect(redactCommandSecrets('sh', ['-c', 'echo safe && rm -- "important file"'])).toEqual([
       '-c',
       `echo safe && rm -- 'important file'`,
     ]);
-    expect(redactSecretArgs(['-c', 'echo $HOME | wc -l'])).toEqual(['-c', 'echo $HOME | wc -l']);
+    expect(redactCommandSecrets('sh', ['-c', 'echo $HOME | wc -l'])).toEqual([
+      '-c',
+      'echo $HOME | wc -l',
+    ]);
+  });
+
+  test('gates tool-specific short options on their executables', () => {
+    expect(getAcpCommandIdentityDigest('python3 -u agent-a.py')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -u agent-b.py')
+    );
+    expect(getAcpCommandIdentityDigest('python3 -c \'print("one")\'')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -c \'print("two")\'')
+    );
+    expect(getAcpCommandIdentityDigest('env API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
+      getAcpCommandIdentityDigest('env MODE=slow agent')
+    );
   });
 
   test('does not swallow the next flag after a valueless secret flag', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -244,6 +244,15 @@ describe('redactCommandSecrets', () => {
     ).toEqual(['-c', `echo "--token topsecret" && curl --token [redacted]`]);
   });
 
+  test('limits nested header redaction to header-taking commands', () => {
+    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
+      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
+    );
+    expect(
+      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
+    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
+  });
+
   test('stops treating assignments as environment after the command word', () => {
     expect(getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=one'"`)).not.toBe(
       getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=two'"`)
@@ -270,15 +279,6 @@ describe('redactCommandSecrets', () => {
     ).toBe(
       getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=othersafe curl https://b'`)
     );
-  });
-
-  test('limits nested header redaction to header-taking commands', () => {
-    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
-      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
-    );
-    expect(
-      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
-    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
   });
 
   test('keeps the quote wrapper around redacted url tokens', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -220,7 +220,7 @@ describe('redactCommandSecrets', () => {
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
-    ).toEqual(['-c', `curl -H [redacted] https://a`]);
+    ).toEqual(['-c', `curl -H '[redacted]' https://a`]);
     expect(
       redactCommandSecrets('sh', ['-c', `echo "safe; rm -rf /" && curl --token topsecret`])
     ).toEqual(['-c', `echo "safe; rm -rf /" && curl --token [redacted]`]);
@@ -238,7 +238,7 @@ describe('redactCommandSecrets', () => {
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `echo 'Bearer x' && curl -H 'Authorization: Bearer x'`])
-    ).toEqual(['-c', `echo 'Bearer x' && curl -H [redacted]`]);
+    ).toEqual(['-c', `echo 'Bearer x' && curl -H '[redacted]'`]);
     expect(
       redactCommandSecrets('sh', ['-c', `echo "--token topsecret" && curl --token topsecret`])
     ).toEqual(['-c', `echo "--token topsecret" && curl --token [redacted]`]);
@@ -259,6 +259,29 @@ describe('redactCommandSecrets', () => {
     expect(getAcpCommandIdentityDigest('env FOO=1 cmd data=one')).not.toBe(
       getAcpCommandIdentityDigest('env FOO=1 cmd data=two')
     );
+    expect(getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=topsecret'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=othersafe'")
+    );
+  });
+
+  test('keeps the quote wrapper around redacted url tokens', () => {
+    expect(redactCommandSecrets('sh', ['-c', `curl 'https://u:p@h/a?x=1&y=2'`])).toEqual([
+      '-c',
+      `curl 'https://u:[redacted]@h/a?x=1&y=2'`,
+    ]);
+  });
+
+  test('recurses combined shell flags with c before other letters', () => {
+    expect(getAcpCommandIdentityDigest(`bash -cl 'curl --token topsecret'`)).toBe(
+      getAcpCommandIdentityDigest(`bash -cl 'curl --token othersafe'`)
+    );
+    expect(redactCommandSecrets('bash', ['-cl', `curl --token topsecret`])).toEqual([
+      '-cl',
+      `curl --token [redacted]`,
+    ]);
   });
 
   test('redacts leading assignments inside shell scripts', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -107,6 +107,11 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('curl -H "Cookie: session=topsecret" https://a')).toBe(
       getAcpCommandIdentityDigest('curl -H "Cookie: session=other" https://a')
     );
+    expect(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'Authorization: Bearer topsecret\' https://a"')
+    ).toBe(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'Authorization: Bearer othersafe\' https://a"')
+    );
   });
 
   test('keeps non-credential header values visible in the digest', () => {
@@ -115,6 +120,18 @@ describe('getAcpCommandIdentityDigest', () => {
     );
     expect(getAcpCommandIdentityDigest('curl -H "Accept: application/json" /a')).not.toBe(
       getAcpCommandIdentityDigest('curl -H "Accept: text/plain" /a')
+    );
+    expect(getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: DELETE\' /a"')).not.toBe(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: PUT\' /a"')
+    );
+  });
+
+  test('does not swallow the next flag after a valueless secret flag', () => {
+    expect(getAcpCommandIdentityDigest('agent --token --verbose one')).not.toBe(
+      getAcpCommandIdentityDigest('agent --token --verbose two')
+    );
+    expect(getAcpCommandIdentityDigest('agent --token --verbose')).not.toBe(
+      getAcpCommandIdentityDigest('agent --verbose --token')
     );
   });
 

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -95,6 +95,9 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('agent --password p1 run')).toBe(
       getAcpCommandIdentityDigest('agent --password p2 run')
     );
+    expect(getAcpCommandIdentityDigest('devin acp --auth-token=a')).toBe(
+      getAcpCommandIdentityDigest('devin acp --auth-token=b')
+    );
   });
 
   test('still distinguishes commands that differ outside secret arguments', () => {
@@ -106,6 +109,12 @@ describe('getAcpCommandIdentityDigest', () => {
     );
     expect(getAcpCommandIdentityDigest('devin acp --token a --stdio')).not.toBe(
       getAcpCommandIdentityDigest('devin acp --token a --verbose')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --max-tokens 4096')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --max-tokens 8192')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --password-policy strict')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --password-policy relaxed')
     );
   });
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -98,6 +98,12 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('devin acp --auth-token=a')).toBe(
       getAcpCommandIdentityDigest('devin acp --auth-token=b')
     );
+    expect(getAcpCommandIdentityDigest('agent --token -abc')).toBe(
+      getAcpCommandIdentityDigest('agent --token -xyz')
+    );
+    expect(
+      getAcpCommandIdentityDigest('curl -H "Authorization: Bearer topsecret" https://api')
+    ).toBe(getAcpCommandIdentityDigest('curl -H "Authorization: Bearer othersafe" https://api'));
   });
 
   test('still distinguishes commands that differ outside secret arguments', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -232,6 +232,33 @@ describe('redactCommandSecrets', () => {
       '-c',
       `pip install --user package-a`,
     ]);
+    expect(redactCommandSecrets('sh', ['-c', `echo topsecret && curl --token topsecret`])).toEqual([
+      '-c',
+      `echo topsecret && curl --token [redacted]`,
+    ]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo 'Bearer x' && curl -H 'Authorization: Bearer x'`])
+    ).toEqual(['-c', `echo 'Bearer x' && curl -H '[redacted]'`]);
+  });
+
+  test('redacts leading assignments inside shell scripts', () => {
+    expect(
+      getAcpCommandIdentityDigest("sh -c 'MODE=prod API_TOKEN=topsecret curl https://a'")
+    ).toBe(getAcpCommandIdentityDigest("sh -c 'MODE=prod API_TOKEN=othersafe curl https://a'"));
+    expect(
+      redactCommandSecrets('sh', ['-lc', `MODE=prod API_TOKEN=topsecret curl https://a`])
+    ).toEqual(['-lc', `MODE=prod API_TOKEN=[redacted] curl https://a`]);
+    expect(getAcpCommandIdentityDigest('bash -xc "curl --token topsecret"')).toBe(
+      getAcpCommandIdentityDigest('bash -xc "curl --token othersafe"')
+    );
+    expect(redactCommandSecrets('bash', ['-lc', `curl --token topsecret`])).toEqual([
+      '-lc',
+      `curl --token [redacted]`,
+    ]);
+    expect(redactCommandSecrets('bash', ['-xc', `curl --token topsecret`])).toEqual([
+      '-xc',
+      `curl --token [redacted]`,
+    ]);
   });
 
   test('redisplays shell scripts verbatim when nothing was redacted', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -154,6 +154,36 @@ describe('getAcpCommandIdentityDigest', () => {
     );
   });
 
+  test('gates tool-specific user options on their executables', () => {
+    expect(getAcpCommandIdentityDigest('python3 -u agent-a.py')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -u agent-b.py')
+    );
+    expect(getAcpCommandIdentityDigest('pip install --user package-a')).not.toBe(
+      getAcpCommandIdentityDigest('pip install --user package-b')
+    );
+    expect(getAcpCommandIdentityDigest('python3 -c \'print("one")\'')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -c \'print("two")\'')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user=admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user=admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('env API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
+      getAcpCommandIdentityDigest('env MODE=slow agent')
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'API_TOKEN=topsecret curl https://a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'API_TOKEN=othersafe curl https://a'")
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'export API_TOKEN=topsecret'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'export API_TOKEN=othersafe'")
+    );
+  });
+
   test('does not swallow the next flag after a valueless secret flag', () => {
     expect(getAcpCommandIdentityDigest('agent --token --verbose one')).not.toBe(
       getAcpCommandIdentityDigest('agent --token --verbose two')
@@ -194,6 +224,14 @@ describe('redactCommandSecrets', () => {
     expect(
       redactCommandSecrets('sh', ['-c', `echo "safe; rm -rf /" && curl --token topsecret`])
     ).toEqual(['-c', `echo "safe; rm -rf /" && curl --token [redacted]`]);
+    expect(redactCommandSecrets('sh', ['-c', `API_TOKEN=topsecret curl https://a`])).toEqual([
+      '-c',
+      `API_TOKEN=[redacted] curl https://a`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `pip install --user package-a`])).toEqual([
+      '-c',
+      `pip install --user package-a`,
+    ]);
   });
 
   test('redisplays shell scripts verbatim when nothing was redacted', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -143,21 +143,13 @@ describe('getAcpCommandIdentityDigest', () => {
   });
 
   test('preserves token boundaries when redisplaying shell command arguments', () => {
-    expect(redactCommandSecrets('sh', ['-c', 'rm -- "important file"'])).toEqual([
+    expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
       '-c',
-      `rm -- 'important file'`,
+      `rm -- 'important file' --token [redacted]`,
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
     ).toEqual(['-c', `curl -H [redacted] https://a`]);
-    expect(redactCommandSecrets('sh', ['-c', 'echo safe && rm -- "important file"'])).toEqual([
-      '-c',
-      `echo safe && rm -- 'important file'`,
-    ]);
-    expect(redactCommandSecrets('sh', ['-c', 'echo $HOME | wc -l'])).toEqual([
-      '-c',
-      'echo $HOME | wc -l',
-    ]);
   });
 
   test('gates tool-specific short options on their executables', () => {
@@ -173,6 +165,29 @@ describe('getAcpCommandIdentityDigest', () => {
     expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
       getAcpCommandIdentityDigest('env MODE=slow agent')
     );
+  });
+
+  test('redacts userinfo credentials embedded in positional URLs', () => {
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:topsecret@db/app')).toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:othersafe@db/app')
+    );
+    expect(getAcpCommandIdentityDigest('curl https://alice:topsecret@example.test/a')).toBe(
+      getAcpCommandIdentityDigest('curl https://alice:othersafe@example.test/a')
+    );
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-a/app')).not.toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-b/app')
+    );
+  });
+
+  test('redisplays shell scripts verbatim when nothing was redacted', () => {
+    expect(redactCommandSecrets('sh', ['-c', 'echo "safe; rm -rf /"'])).toEqual([
+      '-c',
+      'echo "safe; rm -rf /"',
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', "echo 'a b' && echo c"])).toEqual([
+      '-c',
+      "echo 'a b' && echo c",
+    ]);
   });
 
   test('does not swallow the next flag after a valueless secret flag', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -220,7 +220,7 @@ describe('redactCommandSecrets', () => {
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
-    ).toEqual(['-c', `curl -H '[redacted]' https://a`]);
+    ).toEqual(['-c', `curl -H [redacted] https://a`]);
     expect(
       redactCommandSecrets('sh', ['-c', `echo "safe; rm -rf /" && curl --token topsecret`])
     ).toEqual(['-c', `echo "safe; rm -rf /" && curl --token [redacted]`]);
@@ -238,7 +238,27 @@ describe('redactCommandSecrets', () => {
     ]);
     expect(
       redactCommandSecrets('sh', ['-c', `echo 'Bearer x' && curl -H 'Authorization: Bearer x'`])
-    ).toEqual(['-c', `echo 'Bearer x' && curl -H '[redacted]'`]);
+    ).toEqual(['-c', `echo 'Bearer x' && curl -H [redacted]`]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo "--token topsecret" && curl --token topsecret`])
+    ).toEqual(['-c', `echo "--token topsecret" && curl --token [redacted]`]);
+  });
+
+  test('stops treating assignments as environment after the command word', () => {
+    expect(getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=one'"`)).not.toBe(
+      getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=two'"`)
+    );
+    expect(redactCommandSecrets('sh', ['-c', `rm -- 'API_TOKEN=one'`])).toEqual([
+      '-c',
+      `rm -- 'API_TOKEN=one'`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `MODE=prod rm -- 'API_TOKEN=one'`])).toEqual([
+      '-c',
+      `MODE=prod rm -- 'API_TOKEN=one'`,
+    ]);
+    expect(getAcpCommandIdentityDigest('env FOO=1 cmd data=one')).not.toBe(
+      getAcpCommandIdentityDigest('env FOO=1 cmd data=two')
+    );
   });
 
   test('redacts leading assignments inside shell scripts', () => {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1383,14 +1383,8 @@ describe('AcpQueryRunner', () => {
 
       const created = await constructorOptions[0].onTerminalCreate?.({
         sessionId: 'acp-session-1',
-        command: process.execPath,
-        args: [
-          '-e',
-          'process.stdout.write(process.argv.slice(1).join(" "))',
-          '--',
-          '--token',
-          'topsecret',
-        ],
+        command: '/bin/sh',
+        args: ['-c', 'printf "[%s]" "$1"', '--token', 'topsecret'],
       });
       if (!created) throw new Error('ACP terminal was not created');
       await constructorOptions[0].onTerminalWaitForExit?.({
@@ -1413,7 +1407,7 @@ describe('AcpQueryRunner', () => {
           throw new Error('ACP terminal produced no output');
         if (!output) await new Promise((resolve) => setTimeout(resolve, 10));
       }
-      expect(output).toContain('--token topsecret');
+      expect(output).toBe('[topsecret]');
       releasePrompt();
       await ctx.queryPromise;
     } finally {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1274,6 +1274,62 @@ describe('AcpQueryRunner', () => {
     }
   });
 
+  test('redacts secret arguments in terminal approval prompts', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    let approvalQuestion = '';
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      canUseTool: async (_toolName, input) => {
+        approvalQuestion = (input.questions as Array<{ question: string }>)[0].question;
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      const created = await constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: [
+          '-e',
+          'process.stdout.write(process.argv.slice(1).join(" "))',
+          '--',
+          '--token',
+          'topsecret',
+        ],
+      });
+      if (!created) throw new Error('ACP terminal was not created');
+      await constructorOptions[0].onTerminalWaitForExit?.({
+        sessionId: 'acp-session-1',
+        terminalId: created.terminalId,
+      });
+
+      expect(approvalQuestion).toContain("--token '[redacted]'");
+      expect(approvalQuestion).not.toContain('topsecret');
+
+      let output = '';
+      const outputDeadline = Date.now() + 5000;
+      while (!output) {
+        const result = await constructorOptions[0].onTerminalOutput?.({
+          sessionId: 'acp-session-1',
+          terminalId: created.terminalId,
+        });
+        output = result?.output.trim() ?? '';
+        if (!output && Date.now() > outputDeadline)
+          throw new Error('ACP terminal produced no output');
+        if (!output) await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(output).toContain('--token topsecret');
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+    }
+  }, 10000);
+
   test('rejects terminal cwd and environment overrides before permission checks', async () => {
     const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture();
 
@@ -2036,6 +2092,53 @@ describe('AcpQueryRunner', () => {
           (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
       )
     ).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('does not duplicate tool results completed during abort', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tc-interrupted',
+          status: 'completed',
+        },
+      };
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    const toolResults = onSDKMessage.mock.calls.filter(
+      ([message]) =>
+        message.type === 'user' &&
+        (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+    );
+    expect(toolResults.length).toBe(1);
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
 

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -133,6 +133,7 @@ function createRunnerFixture(overrides: RunnerFixtureOverrides = {}) {
     overrides.canUseTool ??
       (async (_toolName, input) => ({ behavior: 'allow' as const, updatedInput: input }))
   );
+  const markQuestionOrphaned = mock(async () => true);
   const mockClient = overrides.client ?? createMockClient();
   const constructorOptions: AcpClientOptions[] = [];
   const queryOptions = overrides.queryOptions ?? { cwd: '/tmp/acp-session', mcpServers: {} };
@@ -216,6 +217,7 @@ function createRunnerFixture(overrides: RunnerFixtureOverrides = {}) {
     } as unknown as QueryOptionsBuilder,
     askUserQuestionHandler: {
       createCanUseToolCallback: mock(() => canUseTool),
+      markQuestionOrphaned: markQuestionOrphaned,
     } as unknown as AskUserQuestionHandler,
     messageHandler: {
       markMessageSubmitted: mock(() => true),
@@ -258,6 +260,7 @@ function createRunnerFixture(overrides: RunnerFixtureOverrides = {}) {
     onSDKMessage,
     onMarkApiSuccess,
     canUseTool,
+    markQuestionOrphaned,
     messageQueue,
   };
 }
@@ -820,7 +823,7 @@ describe('AcpQueryRunner', () => {
       updatedInput: { answers: Record<string, string> };
     }>();
     const { client, promptStarted, releasePrompt } = createHeldPromptClient();
-    const { runner, ctx, constructorOptions } = createRunnerFixture({
+    const { runner, ctx, constructorOptions, markQuestionOrphaned } = createRunnerFixture({
       client,
       canUseTool: async () => {
         permissionStarted.resolve();
@@ -843,6 +846,11 @@ describe('AcpQueryRunner', () => {
     ctx.queryAbortController?.abort();
 
     await expect(pending).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
+    expect(markQuestionOrphaned).toHaveBeenCalledTimes(1);
+    permission.resolve({
+      behavior: 'allow',
+      updatedInput: { answers: {} },
+    });
     releasePrompt();
     await ctx.queryPromise;
   });
@@ -1136,24 +1144,33 @@ describe('AcpQueryRunner', () => {
   });
 
   test('cancels ACP permission requests denied by the approval callback', async () => {
-    const { runner, ctx, constructorOptions } = createRunnerFixture({
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      client,
       canUseTool: async () => ({ behavior: 'deny', message: 'Denied' }),
     });
 
-    await runner.start();
-    await ctx.queryPromise;
+    try {
+      await runner.start();
+      await promptStarted;
 
-    const result = await constructorOptions[0].onPermissionRequest?.({
-      sessionId: 'acp-session-1',
-      toolCall: {
-        toolCallId: 'tool-1',
-        title: 'Edit file',
-        kind: 'edit',
-      },
-      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
-    });
+      const result = await constructorOptions[0].onPermissionRequest?.({
+        sessionId: 'acp-session-1',
+        toolCall: {
+          toolCallId: 'tool-1',
+          title: 'Edit file',
+          kind: 'edit',
+        },
+        options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+      });
 
-    expect(result).toEqual({ outcome: { outcome: 'cancelled' } });
+      expect(canUseTool).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ outcome: { outcome: 'cancelled' } });
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+    }
   });
 
   test('uses an allowlisted environment for ACP terminal commands', async () => {
@@ -1210,37 +1227,45 @@ describe('AcpQueryRunner', () => {
   }, 10000);
 
   test('prompts before terminal creation', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
     const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      client,
       canUseTool: async (_toolName, input) => {
         const question = (input.questions as Array<{ question: string }>)[0].question;
         return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
       },
     });
 
-    await runner.start();
-    await ctx.queryPromise;
+    try {
+      await runner.start();
+      await promptStarted;
 
-    await expect(
-      constructorOptions[0].onTerminalCreate?.({
+      const created = await constructorOptions[0].onTerminalCreate?.({
         sessionId: 'acp-session-1',
         command: process.execPath,
         args: ['-e', 'process.exit(0)'],
-      })
-    ).rejects.toThrow('ACP terminal command cancelled');
-    expect(canUseTool).toHaveBeenCalledWith(
-      'AskUserQuestion',
-      expect.objectContaining({
-        questions: [
-          expect.objectContaining({
-            question: `Allow terminal command ${process.execPath} -e 'process.exit(0)'?`,
-            header: 'ACP approval',
-          }),
-        ],
-      }),
-      expect.objectContaining({
-        displayName: `terminal command ${process.execPath} -e 'process.exit(0)'`,
-      })
-    );
+      });
+
+      expect(created?.terminalId).toEqual(expect.any(String));
+      expect(canUseTool).toHaveBeenCalledWith(
+        'AskUserQuestion',
+        expect.objectContaining({
+          questions: [
+            expect.objectContaining({
+              question: `Allow terminal command ${process.execPath} -e 'process.exit(0)'?`,
+              header: 'ACP approval',
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          displayName: `terminal command ${process.execPath} -e 'process.exit(0)'`,
+        })
+      );
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+    }
   });
 
   test('rejects terminal cwd and environment overrides before permission checks', async () => {
@@ -2028,7 +2053,10 @@ describe('AcpQueryRunner', () => {
           (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
       )
     ).toBe(true);
-    expect(onSDKMessage.mock.calls.length).toBeLessThanOrEqual(600);
+    expect(
+      onSDKMessage.mock.calls.filter(([message]) => message.type === 'assistant').length
+    ).toBeLessThanOrEqual(2);
+    expect(onSDKMessage.mock.calls.length).toBeLessThanOrEqual(10);
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -855,6 +855,84 @@ describe('AcpQueryRunner', () => {
     await ctx.queryPromise;
   });
 
+  test('closes the ACP client when the query becomes stale during startup', async () => {
+    const client = createMockClient();
+    let releaseInitialize: (() => void) | undefined;
+    let markInitializeStarted: (() => void) | undefined;
+    const initializeStarted = new Promise<void>((resolve) => {
+      markInitializeStarted = resolve;
+    });
+    const initializeGate = new Promise<void>((resolve) => {
+      releaseInitialize = resolve;
+    });
+    client.initialize.mockImplementation(async () => {
+      markInitializeStarted?.();
+      await initializeGate;
+      return { protocolVersion: 1, agentCapabilities: {}, agentInfo: {} };
+    });
+    const { runner, ctx } = createRunnerFixture({ client });
+
+    await runner.start();
+    await initializeStarted;
+    ctx.incrementQueryGeneration();
+    releaseInitialize?.();
+    await ctx.queryPromise;
+
+    expect(client.sendPrompt).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalled();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  });
+
+  test('delivers an interrupted tool call with its synthesized result', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: { sessionUpdate: 'plan', entries: [] },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-late',
+          title: 'Late tool',
+          rawInput: {},
+        },
+      };
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    const hasToolUse = onSDKMessage.mock.calls.some(
+      ([message]) =>
+        message.type === 'assistant' &&
+        (
+          (message as { message?: { content?: Array<{ type?: string }> } }).message?.content ?? []
+        ).some((block) => block?.type === 'tool_use')
+    );
+    const hasToolResult = onSDKMessage.mock.calls.some(
+      ([message]) =>
+        message.type === 'user' && (message as SDKUserMessage).parent_tool_use_id === 'tc-late'
+    );
+    expect(hasToolUse).toBe(true);
+    expect(hasToolResult).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
   test('aborts stale ACP startup after cleanup begins', async () => {
     let markBuildStarted: () => void;
     const buildStarted = new Promise<void>((resolve) => {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1299,6 +1299,29 @@ describe('AcpQueryRunner', () => {
     expect(canUseTool).not.toHaveBeenCalled();
   });
 
+  test('rejects terminal commands too long to display for approval', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({ client });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      await expect(
+        constructorOptions[0].onTerminalCreate?.({
+          sessionId: 'acp-session-1',
+          command: process.execPath,
+          args: ['a'.repeat(2100)],
+        })
+      ).rejects.toThrow('ACP permission request is too long to display for approval');
+      expect(canUseTool).not.toHaveBeenCalled();
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+    }
+  });
+
   test('does not create terminals denied by the permission callback', async () => {
     const { client, promptStarted, releasePrompt } = createHeldPromptClient();
     const { runner, ctx, constructorOptions } = createRunnerFixture({

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1,25 +1,29 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 import type { MessageContent, MessageHub, Session } from '@hyperneo/shared';
 import type { SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
-import type { Database } from '../../../../src/storage/database';
-import type { ErrorManager } from '../../../../src/lib/error-manager';
-import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
-import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
-import type { Logger } from '../../../../src/lib/logger';
-import type { QueryOptionsBuilder } from '../../../../src/lib/agent/query-options-builder';
-import type { AskUserQuestionHandler } from '../../../../src/lib/agent/ask-user-question-handler';
-import type { QueryRunnerContext } from '../../../../src/lib/agent/query-runner';
 import type { AcpClient, AcpClientOptions } from '../../../../src/lib/acp/acp-client';
+import { getAcpCommandIdentityDigest } from '../../../../src/lib/acp/acp-command';
 import {
   AcpQueryRunner,
   convertMcpServersForAcp,
   parseAcpCommand,
 } from '../../../../src/lib/acp/acp-query-runner';
 import { AcpMcpProxyBridge } from '../../../../src/lib/acp/mcp-proxy-bridge';
+import type { AskUserQuestionHandler } from '../../../../src/lib/agent/ask-user-question-handler';
+import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
+import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
+import type { QueryOptionsBuilder } from '../../../../src/lib/agent/query-options-builder';
+import type { QueryRunnerContext } from '../../../../src/lib/agent/query-runner';
+import type { ErrorManager } from '../../../../src/lib/error-manager';
+import type { Logger } from '../../../../src/lib/logger';
 import { resetProviderFactory } from '../../../../src/lib/providers/factory';
 import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
 import { AcpProvider } from '../../../../src/lib/providers/acp-provider';
+import type { Database } from '../../../../src/storage/database';
 
 function createMockClient() {
   return {
@@ -29,6 +33,8 @@ function createMockClient() {
     loadSession: mock(async (sessionId: string) => ({ sessionId, configOptions: [] })),
     resumeSession: mock(async (sessionId: string) => ({ sessionId, configOptions: [] })),
     canLoadSession: mock(() => false),
+    canCloseSession: mock(() => false),
+    closeSession: mock(async () => {}),
     sendPrompt: mock(async function* (
       _prompt: unknown,
       callbacks?: { onSubmitted?: () => void; onAccepted?: () => void }
@@ -51,6 +57,27 @@ function createMockClient() {
     close: mock(() => {}),
     cancel: mock(() => {}),
   };
+}
+
+function createHeldPromptClient() {
+  let markPromptStarted: (() => void) | undefined;
+  let releasePrompt: (() => void) | undefined;
+  const promptStarted = new Promise<void>((resolve) => {
+    markPromptStarted = resolve;
+  });
+  const client = createMockClient();
+  client.sendPrompt = mock(async function* (
+    _prompt: unknown,
+    callbacks?: { onSubmitted?: () => void; onAccepted?: () => void }
+  ) {
+    callbacks?.onSubmitted?.();
+    callbacks?.onAccepted?.();
+    markPromptStarted?.();
+    await new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+  });
+  return { client, promptStarted, releasePrompt: () => releasePrompt?.() };
 }
 
 function makeUserMessage(content: string | MessageContent[]): SDKUserMessage {
@@ -582,6 +609,251 @@ describe('AcpQueryRunner', () => {
     expect(onSDKMessage.mock.calls.some(([message]) => message.type === 'result')).toBe(true);
     expect(onMarkApiSuccess).toHaveBeenCalled();
     expect(stopSpy).toHaveBeenCalled();
+    expect(runner.lastConsumedUserMessage).toBeNull();
+  });
+
+  const bunRuntimeTest = process.versions.bun ? test : test.skip;
+
+  bunRuntimeTest(
+    'confines filesystem callbacks to the workspace and honors read ranges',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-fs-'));
+      const workspace = join(root, 'workspace');
+      const outside = join(root, 'outside.txt');
+      await mkdir(workspace);
+      await writeFile(join(workspace, 'inside.txt'), 'one\ntwo\nthree\nfour');
+      await writeFile(outside, 'secret');
+      const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+      const { runner, ctx, constructorOptions } = createRunnerFixture({
+        client,
+        session: { workspacePath: workspace },
+        queryOptions: { cwd: workspace, mcpServers: {} },
+        canUseTool: async (_toolName, input) => {
+          const question = (input.questions as Array<{ question: string }>)[0].question;
+          return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+        },
+      });
+
+      try {
+        await runner.start();
+        await promptStarted;
+
+        await expect(
+          constructorOptions[0].onFsRead?.({
+            sessionId: 'acp-session-1',
+            path: join(workspace, 'inside.txt'),
+            line: 2,
+            limit: 2,
+          })
+        ).resolves.toEqual({ content: 'two\nthree\n' });
+        await expect(
+          constructorOptions[0].onFsRead?.({
+            sessionId: 'acp-session-1',
+            path: join(await realpath(workspace), 'inside.txt'),
+          })
+        ).resolves.toEqual({ content: 'one\ntwo\nthree\nfour' });
+        await expect(
+          constructorOptions[0].onFsRead?.({
+            sessionId: 'acp-session-1',
+            path: outside,
+          })
+        ).rejects.toThrow('escapes workspace');
+        await expect(
+          constructorOptions[0].onFsWrite?.({
+            sessionId: 'acp-session-1',
+            path: '../escaped.txt',
+            content: 'blocked',
+          })
+        ).rejects.toThrow('escapes workspace');
+        await constructorOptions[0].onFsWrite?.({
+          sessionId: 'acp-session-1',
+          path: join(workspace, 'nested', 'written.txt'),
+          content: 'written',
+        });
+        expect(await readFile(join(workspace, 'nested', 'written.txt'), 'utf-8')).toBe('written');
+        await constructorOptions[0].onFsWrite?.({
+          sessionId: 'acp-session-1',
+          path: '..hidden/written.txt',
+          content: 'hidden',
+        });
+        expect(await readFile(join(workspace, '..hidden', 'written.txt'), 'utf-8')).toBe('hidden');
+        releasePrompt();
+        await ctx.queryPromise;
+      } finally {
+        releasePrompt();
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  test('denies ACP filesystem writes before mutating the workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-write-'));
+    const workspace = join(root, 'workspace');
+    const target = join(workspace, 'denied.txt');
+    await mkdir(workspace);
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      client,
+      session: { workspacePath: workspace },
+      queryOptions: { cwd: workspace, mcpServers: {} },
+      canUseTool: async () => ({ behavior: 'deny', message: 'Denied' }),
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      await expect(
+        constructorOptions[0].onFsWrite?.({
+          sessionId: 'acp-session-1',
+          path: target,
+          content: 'blocked',
+        })
+      ).rejects.toThrow('ACP filesystem write denied');
+      await expect(readFile(target, 'utf-8')).rejects.toThrow();
+      expect(canUseTool).toHaveBeenCalledWith(
+        'AskUserQuestion',
+        expect.objectContaining({
+          questions: [
+            expect.objectContaining({
+              question: `Allow write ${target}?`,
+              header: 'ACP approval',
+            }),
+          ],
+        }),
+        expect.objectContaining({ displayName: `write ${target}` })
+      );
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('cancels a pending ACP filesystem write when the query ends', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-write-'));
+    const workspace = join(root, 'workspace');
+    const target = join(workspace, 'cancelled.txt');
+    await mkdir(workspace);
+    let approveWrite: (() => void) | undefined;
+    const writeApproved = new Promise<void>((resolve) => {
+      approveWrite = resolve;
+    });
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      session: { workspacePath: workspace },
+      queryOptions: { cwd: workspace, mcpServers: {} },
+      canUseTool: async (_toolName, input) => {
+        await writeApproved;
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+      const write = constructorOptions[0].onFsWrite?.({
+        sessionId: 'acp-session-1',
+        path: target,
+        content: 'blocked',
+      });
+      ctx.queryAbortController?.abort();
+      approveWrite?.();
+
+      await expect(write).rejects.toThrow('ACP filesystem write cancelled');
+      await expect(readFile(target, 'utf-8')).rejects.toThrow();
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('cancels pending native permission requests when the query ends', async () => {
+    const permissionStarted = Promise.withResolvers<void>();
+    const permission = Promise.withResolvers<{
+      behavior: 'allow';
+      updatedInput: { answers: Record<string, string> };
+    }>();
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      canUseTool: async () => {
+        permissionStarted.resolve();
+        return permission.promise;
+      },
+    });
+
+    await runner.start();
+    await promptStarted;
+    const pending = constructorOptions[0].onPermissionRequest?.({
+      sessionId: 'acp-session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+      },
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+    });
+    await permissionStarted.promise;
+    ctx.queryAbortController?.abort();
+
+    await expect(pending).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
+    releasePrompt();
+    await ctx.queryPromise;
+  });
+
+  test('aborts stale ACP startup after cleanup begins', async () => {
+    let markBuildStarted: () => void;
+    const buildStarted = new Promise<void>((resolve) => {
+      markBuildStarted = resolve;
+    });
+    let releaseBuild: () => void;
+    const buildGate = new Promise<void>((resolve) => {
+      releaseBuild = resolve;
+    });
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      queryOptions: { cwd: '/tmp/acp-session', mcpServers: {} },
+    });
+    ctx.optionsBuilder.build = mock(async () => {
+      markBuildStarted();
+      await buildGate;
+      return { cwd: '/tmp/acp-session', mcpServers: {} };
+    });
+
+    await runner.start();
+    await buildStarted;
+    ctx.isCleaningUp = () => true;
+    releaseBuild!();
+    await ctx.queryPromise;
+
+    expect(constructorOptions).toHaveLength(0);
+    expect(ctx.queryAbortController).toBeNull();
+  });
+
+  test('starts workspace-less ACP sessions without host filesystem or terminal callbacks', async () => {
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      session: { workspacePath: undefined },
+      queryOptions: { mcpServers: {} },
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(constructorOptions).toHaveLength(1);
+    expect(constructorOptions[0]).toMatchObject({ cwd: process.cwd() });
+    expect(constructorOptions[0].onFsRead).toBeUndefined();
+    expect(constructorOptions[0].onFsWrite).toBeUndefined();
+    expect(constructorOptions[0].onTerminalCreate).toBeUndefined();
+    expect(constructorOptions[0].onTerminalOutput).toBeUndefined();
+    expect(constructorOptions[0].onTerminalWaitForExit).toBeUndefined();
+    expect(constructorOptions[0].onTerminalKill).toBeUndefined();
+    expect(constructorOptions[0].onTerminalRelease).toBeUndefined();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   });
 
   test('publishes query.trigger on normal turn completion to replay deferred rows', async () => {
@@ -767,7 +1039,9 @@ describe('AcpQueryRunner', () => {
   });
 
   test('maps ACP permission requests through AskUserQuestion approval callback', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
     const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      client,
       canUseTool: async (_toolName, _input, _options) => ({
         behavior: 'allow',
         updatedInput: { answers: { 'Allow Edit file?': 'Allow once' } },
@@ -775,7 +1049,7 @@ describe('AcpQueryRunner', () => {
     });
 
     await runner.start();
-    await ctx.queryPromise;
+    await promptStarted;
 
     const result = await constructorOptions[0].onPermissionRequest?.({
       sessionId: 'acp-session-1',
@@ -786,6 +1060,7 @@ describe('AcpQueryRunner', () => {
       },
       options: [
         { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'allow-session', name: 'Allow for session', kind: 'allow_always' },
         { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' },
       ],
     });
@@ -803,6 +1078,153 @@ describe('AcpQueryRunner', () => {
       expect.objectContaining({ toolUseID: 'tool-1' })
     );
     expect(result).toEqual({ outcome: { outcome: 'selected', optionId: 'allow-once' } });
+    releasePrompt();
+    await ctx.queryPromise;
+  });
+
+  test('cancels ACP permission requests denied by the approval callback', async () => {
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      canUseTool: async () => ({ behavior: 'deny', message: 'Denied' }),
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    const result = await constructorOptions[0].onPermissionRequest?.({
+      sessionId: 'acp-session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+      },
+      options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }],
+    });
+
+    expect(result).toEqual({ outcome: { outcome: 'cancelled' } });
+  });
+
+  test('uses an allowlisted environment for ACP terminal commands', async () => {
+    const previousGithubToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'github-secret';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'sk-ant-oat-acp-token';
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      canUseTool: async (_toolName, input) => {
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+      const created = await constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'console.log(JSON.stringify(process.env))'],
+      });
+      if (!created) throw new Error('ACP terminal was not created');
+      await constructorOptions[0].onTerminalWaitForExit?.({
+        sessionId: 'acp-session-1',
+        terminalId: created.terminalId,
+      });
+      const output = await constructorOptions[0].onTerminalOutput?.({
+        sessionId: 'acp-session-1',
+        terminalId: created.terminalId,
+      });
+      if (!output) throw new Error('ACP terminal output was not returned');
+      const terminalEnv = JSON.parse(output.output.trim()) as Record<string, string>;
+
+      expect(terminalEnv.PATH).toBe(process.env.PATH);
+      expect(terminalEnv.GITHUB_TOKEN).toBeUndefined();
+      expect(terminalEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    } finally {
+      releasePrompt();
+      await ctx.queryPromise;
+      if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = previousGithubToken;
+    }
+  });
+
+  test('prompts before terminal creation', async () => {
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      canUseTool: async (_toolName, input) => {
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'process.exit(0)'],
+      })
+    ).rejects.toThrow('ACP terminal command cancelled');
+    expect(canUseTool).toHaveBeenCalledWith(
+      'AskUserQuestion',
+      expect.objectContaining({
+        questions: [
+          expect.objectContaining({
+            question: `Allow terminal command ${process.execPath} -e 'process.exit(0)'?`,
+            header: 'ACP approval',
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        displayName: `terminal command ${process.execPath} -e 'process.exit(0)'`,
+      })
+    );
+  });
+
+  test('rejects terminal cwd and environment overrides before permission checks', async () => {
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture();
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: 'git',
+        args: ['status'],
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow('ACP terminal cwd and environment overrides are not supported');
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: 'git',
+        args: ['status'],
+        env: [{ name: 'PATH', value: '/tmp/bin' }],
+      })
+    ).rejects.toThrow('ACP terminal cwd and environment overrides are not supported');
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+  test('does not create terminals denied by the permission callback', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      canUseTool: async () => ({ behavior: 'deny', message: 'Denied' }),
+    });
+
+    await runner.start();
+    await promptStarted;
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'process.exit(0)'],
+      })
+    ).rejects.toThrow('ACP terminal command denied');
+    releasePrompt();
+    await ctx.queryPromise;
   });
 
   test('persists new ACP session ids', async () => {
@@ -815,6 +1237,7 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('acp-session-1');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'acp-session-1',
+      metadata: expect.objectContaining({ acpSessionCommand: 'mock-acp --stdio' }),
     });
   });
 
@@ -854,6 +1277,86 @@ describe('AcpQueryRunner', () => {
     expect(client.sendPrompt.mock.calls[0][0]).toEqual([{ type: 'text', text: 'hello' }]);
   });
 
+  test('creates a new ACP session when the persisted command identity changes', async () => {
+    const client = createMockClient();
+    client.canLoadSession.mockImplementation(() => true);
+    const { runner, ctx } = createRunnerFixture({
+      client,
+      session: {
+        acpSessionId: 'persisted-acp-session',
+        metadata: {
+          acpCommandIdentity: getAcpCommandIdentityDigest('other-acp --stdio'),
+          acpInstructionsSent: true,
+          acpContextUsageEstimate: 12000,
+        },
+      } as Partial<Session>,
+      queryOptions: {
+        cwd: '/tmp/acp-session',
+        mcpServers: {},
+        systemPrompt: { type: 'preset', preset: 'none', append: 'Follow current rules.' },
+      },
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(client.loadSession).not.toHaveBeenCalled();
+    expect(client.resumeSession).not.toHaveBeenCalled();
+    expect(client.createSession).toHaveBeenCalledWith('/tmp/acp-session', []);
+    expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
+      acpSessionId: undefined,
+      metadata: expect.objectContaining({
+        acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+        acpContextUsageEstimate: undefined,
+      }),
+    });
+    expect(ctx.session.metadata.acpInstructionsSent).toBe(true);
+    expect(client.sendPrompt.mock.calls[0][0]).toEqual([
+      {
+        type: 'text',
+        text: 'HyperNeo session instructions:\n\nFollow current rules.',
+      },
+      { type: 'text', text: 'hello' },
+    ]);
+  });
+
+  test('preserves an existing session whose command identity matches', async () => {
+    const client = createMockClient();
+    client.canLoadSession.mockImplementation(() => true);
+    const { runner, ctx } = createRunnerFixture({
+      client,
+      session: {
+        acpSessionId: 'persisted-acp-session',
+        metadata: {
+          messageCount: 2,
+          acpCommandIdentity: getAcpCommandIdentityDigest('mock-acp --stdio'),
+        },
+      } as Partial<Session>,
+    });
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    expect(client.loadSession).toHaveBeenCalledWith(
+      'persisted-acp-session',
+      '/tmp/acp-session',
+      []
+    );
+    expect(client.createSession).not.toHaveBeenCalled();
+  });
+
+  test('persists only a digest of the ACP command identity', async () => {
+    process.env.HYPERNEO_ACP_COMMAND = 'devin acp --token topsecret';
+    const { runner, ctx } = createRunnerFixture();
+
+    await runner.start();
+    await ctx.queryPromise;
+
+    const identity = ctx.session.metadata.acpCommandIdentity as string;
+    expect(identity).toBe(getAcpCommandIdentityDigest('devin acp --token topsecret'));
+    expect(identity).not.toContain('topsecret');
+  });
+
   test('falls back to resume when ACP session load fails', async () => {
     const client = createMockClient();
     client.canLoadSession.mockImplementation(() => true);
@@ -886,6 +1389,7 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('resumed-acp-session');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'resumed-acp-session',
+      metadata: expect.objectContaining({ acpSessionCommand: 'mock-acp --stdio' }),
     });
   });
 
@@ -1126,6 +1630,7 @@ describe('AcpQueryRunner', () => {
   test('retries ACP startup timeout even after timeout aborts controller', async () => {
     const firstClient = createMockClient();
     let releasePrompt: (() => void) | undefined;
+    firstClient.canCloseSession.mockImplementation(() => true);
     firstClient.close.mockImplementation(() => releasePrompt?.());
     firstClient.sendPrompt.mockImplementation(async function* () {
       await new Promise<void>((resolve) => {
@@ -1150,6 +1655,8 @@ describe('AcpQueryRunner', () => {
       await ctx.queryPromise;
 
       expect(createClient).toHaveBeenCalledTimes(2);
+      expect(firstClient.cancel).toHaveBeenCalled();
+      expect(firstClient.closeSession).toHaveBeenCalled();
       expect(firstClient.close).toHaveBeenCalled();
       expect(messageQueue.enqueueWithId).toHaveBeenCalledWith('user-message-1', [
         { type: 'text', text: 'hello' },
@@ -1348,6 +1855,46 @@ describe('AcpQueryRunner', () => {
     await ctx.queryPromise;
 
     expect(client.sendPrompt).toHaveBeenCalled();
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('delivers pending ACP tool results when abort drops the iterator output', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -614,15 +614,68 @@ describe('AcpQueryRunner', () => {
 
   const bunRuntimeTest = process.versions.bun ? test : test.skip;
 
+  test('rejects filesystem callbacks that escape the workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-escape-'));
+    const workspace = join(root, 'workspace');
+    const outside = join(root, 'outside.txt');
+    await mkdir(workspace);
+    await writeFile(outside, 'secret');
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions } = createRunnerFixture({
+      client,
+      session: { workspacePath: workspace },
+      queryOptions: { cwd: workspace, mcpServers: {} },
+      canUseTool: async (_toolName, input) => {
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    try {
+      await runner.start();
+      await promptStarted;
+
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: outside,
+        })
+      ).rejects.toThrow('escapes workspace');
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: '../outside.txt',
+        })
+      ).rejects.toThrow('escapes workspace');
+      await expect(
+        constructorOptions[0].onFsRead?.({
+          sessionId: 'acp-session-1',
+          path: workspace,
+        })
+      ).rejects.toThrow('must identify a file');
+      await expect(
+        constructorOptions[0].onFsWrite?.({
+          sessionId: 'acp-session-1',
+          path: '../escaped.txt',
+          content: 'blocked',
+        })
+      ).rejects.toThrow('escapes workspace');
+      expect(await readFile(outside, 'utf-8')).toBe('secret');
+      releasePrompt();
+      await ctx.queryPromise;
+    } finally {
+      releasePrompt();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   bunRuntimeTest(
     'confines filesystem callbacks to the workspace and honors read ranges',
     async () => {
       const root = await mkdtemp(join(tmpdir(), 'hyperneo-acp-fs-'));
       const workspace = join(root, 'workspace');
-      const outside = join(root, 'outside.txt');
       await mkdir(workspace);
       await writeFile(join(workspace, 'inside.txt'), 'one\ntwo\nthree\nfour');
-      await writeFile(outside, 'secret');
       const { client, promptStarted, releasePrompt } = createHeldPromptClient();
       const { runner, ctx, constructorOptions } = createRunnerFixture({
         client,
@@ -652,19 +705,6 @@ describe('AcpQueryRunner', () => {
             path: join(await realpath(workspace), 'inside.txt'),
           })
         ).resolves.toEqual({ content: 'one\ntwo\nthree\nfour' });
-        await expect(
-          constructorOptions[0].onFsRead?.({
-            sessionId: 'acp-session-1',
-            path: outside,
-          })
-        ).rejects.toThrow('escapes workspace');
-        await expect(
-          constructorOptions[0].onFsWrite?.({
-            sessionId: 'acp-session-1',
-            path: '../escaped.txt',
-            content: 'blocked',
-          })
-        ).rejects.toThrow('escapes workspace');
         await constructorOptions[0].onFsWrite?.({
           sessionId: 'acp-session-1',
           path: join(workspace, 'nested', 'written.txt'),
@@ -1129,12 +1169,21 @@ describe('AcpQueryRunner', () => {
         sessionId: 'acp-session-1',
         terminalId: created.terminalId,
       });
-      const output = await constructorOptions[0].onTerminalOutput?.({
-        sessionId: 'acp-session-1',
-        terminalId: created.terminalId,
-      });
-      if (!output) throw new Error('ACP terminal output was not returned');
-      const terminalEnv = JSON.parse(output.output.trim()) as Record<string, string>;
+      let terminalEnv: Record<string, string> | undefined;
+      const outputDeadline = Date.now() + 5000;
+      while (terminalEnv === undefined) {
+        const output = await constructorOptions[0].onTerminalOutput?.({
+          sessionId: 'acp-session-1',
+          terminalId: created.terminalId,
+        });
+        const text = output?.output.trim() ?? '';
+        if (text) {
+          terminalEnv = JSON.parse(text) as Record<string, string>;
+        } else {
+          if (Date.now() > outputDeadline) throw new Error('ACP terminal produced no output');
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
 
       expect(terminalEnv.PATH).toBe(process.env.PATH);
       expect(terminalEnv.GITHUB_TOKEN).toBeUndefined();
@@ -1145,7 +1194,7 @@ describe('AcpQueryRunner', () => {
       if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN;
       else process.env.GITHUB_TOKEN = previousGithubToken;
     }
-  });
+  }, 10000);
 
   test('prompts before terminal creation', async () => {
     const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
@@ -1223,6 +1272,32 @@ describe('AcpQueryRunner', () => {
         args: ['-e', 'process.exit(0)'],
       })
     ).rejects.toThrow('ACP terminal command denied');
+    releasePrompt();
+    await ctx.queryPromise;
+  });
+
+  test('does not prompt for terminal commands after the query has aborted', async () => {
+    const { client, promptStarted, releasePrompt } = createHeldPromptClient();
+    const { runner, ctx, constructorOptions, canUseTool } = createRunnerFixture({
+      client,
+      canUseTool: async (_toolName, input) => {
+        const question = (input.questions as Array<{ question: string }>)[0].question;
+        return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
+      },
+    });
+
+    await runner.start();
+    await promptStarted;
+    ctx.queryAbortController?.abort();
+
+    await expect(
+      constructorOptions[0].onTerminalCreate?.({
+        sessionId: 'acp-session-1',
+        command: process.execPath,
+        args: ['-e', 'process.exit(0)'],
+      })
+    ).rejects.toThrow('ACP terminal command cancelled');
+    expect(canUseTool).not.toHaveBeenCalled();
     releasePrompt();
     await ctx.queryPromise;
   });
@@ -1353,6 +1428,7 @@ describe('AcpQueryRunner', () => {
 
     const identity = ctx.session.metadata.acpCommandIdentity as string;
     expect(identity).toBe(getAcpCommandIdentityDigest('devin acp --token topsecret'));
+    expect(identity).toBe(getAcpCommandIdentityDigest('devin acp --token anothertoken'));
     expect(identity).not.toContain('topsecret');
   });
 
@@ -1893,6 +1969,53 @@ describe('AcpQueryRunner', () => {
           (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
       )
     ).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 1000);
+
+  test('stops draining a continuing producer after abort', async () => {
+    const client = createMockClient();
+    let releasePrompt: (() => void) | undefined;
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      await new Promise<void>((resolve) => {
+        releasePrompt = resolve;
+        promptBlockedResolve?.();
+      });
+      while (true) {
+        yield {
+          sessionId: 'acp-session-1',
+          update: { sessionUpdate: 'plan', entries: [] },
+        };
+      }
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    releasePrompt?.();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
+    expect(onSDKMessage.mock.calls.length).toBeLessThanOrEqual(600);
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -2142,6 +2142,42 @@ describe('AcpQueryRunner', () => {
     expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
   }, 1000);
 
+  test('settles the query when the agent stops responding after abort', async () => {
+    const client = createMockClient();
+    let promptBlockedResolve: (() => void) | undefined;
+    const promptBlocked = new Promise<void>((resolve) => {
+      promptBlockedResolve = resolve;
+    });
+    client.sendPrompt.mockImplementation(async function* () {
+      yield {
+        sessionId: 'acp-session-1',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-interrupted',
+          title: 'Long tool',
+          rawInput: {},
+        },
+      };
+      promptBlockedResolve?.();
+      await new Promise<void>(() => {});
+    });
+    const { runner, ctx, onSDKMessage } = createRunnerFixture({ client });
+
+    await runner.start();
+    await promptBlocked;
+    ctx.queryAbortController?.abort();
+    await ctx.queryPromise;
+
+    expect(
+      onSDKMessage.mock.calls.some(
+        ([message]) =>
+          message.type === 'user' &&
+          (message as SDKUserMessage).parent_tool_use_id === 'tc-interrupted'
+      )
+    ).toBe(true);
+    expect(ctx.errorManager.handleError).not.toHaveBeenCalled();
+  }, 5000);
+
   test('stops draining a continuing producer after abort', async () => {
     const client = createMockClient();
     let releasePrompt: (() => void) | undefined;

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -742,6 +742,8 @@ describe('AcpQueryRunner', () => {
       canUseTool: async () => ({ behavior: 'deny', message: 'Denied' }),
     });
 
+    const content = 'blocked';
+
     try {
       await runner.start();
       await promptStarted;
@@ -750,7 +752,7 @@ describe('AcpQueryRunner', () => {
         constructorOptions[0].onFsWrite?.({
           sessionId: 'acp-session-1',
           path: target,
-          content: 'blocked',
+          content,
         })
       ).rejects.toThrow('ACP filesystem write denied');
       await expect(readFile(target, 'utf-8')).rejects.toThrow();
@@ -759,12 +761,12 @@ describe('AcpQueryRunner', () => {
         expect.objectContaining({
           questions: [
             expect.objectContaining({
-              question: `Allow write ${target}?`,
+              question: `Allow write ${target} (${content.length} chars)?`,
               header: 'ACP approval',
             }),
           ],
         }),
-        expect.objectContaining({ displayName: `write ${target}` })
+        expect.objectContaining({ displayName: `write ${target} (${content.length} chars)` })
       );
       releasePrompt();
       await ctx.queryPromise;

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1180,6 +1180,11 @@ describe('AcpQueryRunner', () => {
     const { client, promptStarted, releasePrompt } = createHeldPromptClient();
     const { runner, ctx, constructorOptions } = createRunnerFixture({
       client,
+      queryOptions: {
+        cwd: '/tmp/acp-session',
+        mcpServers: {},
+        env: { HTTPS_PROXY: 'http://session-proxy.example:8080' },
+      },
       canUseTool: async (_toolName, input) => {
         const question = (input.questions as Array<{ question: string }>)[0].question;
         return { behavior: 'allow', updatedInput: { answers: { [question]: 'Allow once' } } };
@@ -1216,6 +1221,7 @@ describe('AcpQueryRunner', () => {
       }
 
       expect(terminalEnv.PATH).toBe(process.env.PATH);
+      expect(terminalEnv.HTTPS_PROXY).toBe('http://session-proxy.example:8080');
       expect(terminalEnv.GITHUB_TOKEN).toBeUndefined();
       expect(terminalEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     } finally {

--- a/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-query-runner.test.ts
@@ -1237,7 +1237,6 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('acp-session-1');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'acp-session-1',
-      metadata: expect.objectContaining({ acpSessionCommand: 'mock-acp --stdio' }),
     });
   });
 
@@ -1389,7 +1388,6 @@ describe('AcpQueryRunner', () => {
     expect(ctx.session.acpSessionId).toBe('resumed-acp-session');
     expect(ctx.db.updateSession).toHaveBeenCalledWith('session-1', {
       acpSessionId: 'resumed-acp-session',
-      metadata: expect.objectContaining({ acpSessionCommand: 'mock-acp --stdio' }),
     });
   });
 

--- a/packages/daemon/tests/unit/lib/acp/acp-transport.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-transport.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { acpProcessGroupAlive } from '../../../../src/lib/acp/acp-process-tree';
 import { AcpTransport, buildAcpProcessEnv } from '../../../../src/lib/acp/acp-transport';
 
 describe('buildAcpProcessEnv', () => {
@@ -48,6 +50,16 @@ describe('AcpTransport replaceEnv spawn', () => {
       delete process.env.ACP_PROBE_TEST_SECRET;
       await transport?.close();
     }
+  });
+});
+
+describe('acpProcessGroupAlive', () => {
+  it('probes the direct pid on win32 instead of a POSIX process group', async () => {
+    expect(acpProcessGroupAlive(process.pid, 'win32')).toBe(true);
+
+    const child = spawn('true', [], { stdio: 'ignore' });
+    await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+    expect(acpProcessGroupAlive(child.pid!, 'win32')).toBe(false);
   });
 });
 

--- a/packages/shared/src/acp/acp-command.ts
+++ b/packages/shared/src/acp/acp-command.ts
@@ -1,62 +1,110 @@
+export interface AcpCommandTokenSpan {
+  start: number;
+  end: number;
+}
+
+export interface ParsedAcpCommandWithSpans {
+  command: string;
+  args: string[];
+  rawSpans: AcpCommandTokenSpan[];
+}
+
 export function getAcpCommandIdentity(commandLine: string): string {
   const { command, args } = parseAcpCommand(commandLine);
   return JSON.stringify([command, ...args]);
 }
 
 export function parseAcpCommand(commandLine: string): { command: string; args: string[] } {
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
+  return { command, args };
+}
+
+export function parseAcpCommandWithSpans(commandLine: string): ParsedAcpCommandWithSpans {
   const tokens: string[] = [];
+  const rawSpans: AcpCommandTokenSpan[] = [];
   let current = '';
   let quote: 'single' | 'double' | null = null;
   let escaping = false;
   let tokenStarted = false;
+  let rawStart = 0;
+  let rawEnd = 0;
 
   const trimmedCommand = commandLine.trim();
+  const base = commandLine.length - commandLine.trimStart().length;
+
+  const pushToken = () => {
+    tokens.push(current);
+    rawSpans.push({ start: rawStart, end: rawEnd });
+    current = '';
+    tokenStarted = false;
+  };
+
   for (let index = 0; index < trimmedCommand.length; index++) {
-    const char = trimmedCommand[index];
     if (escaping) {
-      current += char;
+      current += trimmedCommand[index];
+      rawEnd = base + index + 1;
       escaping = false;
       tokenStarted = true;
       continue;
     }
 
+    const char = trimmedCommand[index];
     if (char === '\\') {
       const next = trimmedCommand[index + 1];
       if (
         next !== undefined &&
         (/\s/.test(next) || next === "'" || next === '"' || next === '\\')
       ) {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
+        rawEnd = base + index + 1;
         escaping = true;
       } else {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
         current += char;
-        tokenStarted = true;
+        rawEnd = base + index + 1;
       }
       continue;
     }
 
     if (char === "'" && quote !== 'double') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'single' ? null : 'single';
-      tokenStarted = true;
       continue;
     }
 
     if (char === '"' && quote !== 'single') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'double' ? null : 'double';
-      tokenStarted = true;
       continue;
     }
 
     if (/\s/.test(char) && !quote) {
       if (tokenStarted) {
-        tokens.push(current);
-        current = '';
-        tokenStarted = false;
+        pushToken();
       }
       continue;
     }
 
+    if (!tokenStarted) {
+      tokenStarted = true;
+      rawStart = base + index;
+    }
     current += char;
-    tokenStarted = true;
+    rawEnd = base + index + 1;
   }
 
   if (escaping) {
@@ -66,10 +114,10 @@ export function parseAcpCommand(commandLine: string): { command: string; args: s
   if (quote) {
     throw new Error('Invalid ACP command: unmatched quote');
   }
-  if (tokenStarted) tokens.push(current);
+  if (tokenStarted) pushToken();
   if (!tokens[0]) {
     throw new Error('Invalid ACP command: command is empty');
   }
 
-  return { command: tokens[0], args: tokens.slice(1) };
+  return { command: tokens[0], args: tokens.slice(1), rawSpans };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -318,7 +318,6 @@ export interface SessionMetadata {
   refusalRewindTargetUuid?: string | null;
   acpInstructionsSent?: boolean;
   acpCommandIdentity?: string;
-  acpSessionCommand?: string;
   pastSdkSessionIds?: string[];
   acpContextUsageEstimate?: number;
   worktreeChoice?: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -317,6 +317,8 @@ export interface SessionMetadata {
   costBaseline?: number;
   refusalRewindTargetUuid?: string | null;
   acpInstructionsSent?: boolean;
+  acpCommandIdentity?: string;
+  acpSessionCommand?: string;
   pastSdkSessionIds?: string[];
   acpContextUsageEstimate?: number;
   worktreeChoice?: {


### PR DESCRIPTION
ACP split 8/10 (from #2599). The query runner now registers workspace-scoped safe-fs read/write and terminal host callbacks (each gated by AskUserQuestion approval), stamps a command-identity digest on the session so changing the ACP command starts a fresh conversation, and passes process-tree ownership into the transport/client for group-wide termination. Transport close runs a SIGTERM → group-probe → SIGKILL ladder that cancels escalation once the process group is gone (probing the direct pid on win32, where process groups don't exist), and QueryLifecycleManager aborts the active query before waiting on stop plus clears cached ACP context usage on reset.

Retained race fixes: stale startup aborts, timed-out sessions are cancelled/closed before the retry re-spawns, interrupting a run preserves the in-flight iterator result and flushes pending tool results, and pending approvals cancel promptly when the query ends.

Intentionally dropped (follow-ups):
- win32 case-insensitive env-key normalization in `buildAcpProcessEnv` (speculative portability; cleanup is POSIX-only today)
- legacy pre-digest `acpCommandIdentity` comparison fallback in the query runner
- persisting the raw ACP command (`acpSessionCommand` metadata) — dropped per review; it would store inline credentials in the DB and session-metadata APIs, and the identity digest already covers change detection
- the redundant third `recordProcessGroupGone()` re-probe after arming the close timer
- tests: 4MB maxBytes / limit-0 / symlink / dangling-link probes in the fs wiring test (already pinned in acp-safe-fs.test.ts); "cancels pending terminal approval promptly" (abort race pinned by the fs-write cancel and permission cancel tests); "cancels empty permission requests without prompting" (pre-existing early return); "does not create terminals when the explicit deny option is selected" (duplicate of the deny-path test); legacy-identity preservation tests