### PR TITLE
refactor(web): useSpaceTaskMessages becomes a facade over live-query-lifecycle (task #1253)

### DIFF
--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -206,6 +206,37 @@ describe('useSpaceTaskMessages', () => {
     ]);
   });
 
+  it('keeps an active-turn snapshot-phase error while message events keep flowing', () => {
+    const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+    const messageSubId = lastMessageSubscribeSubId();
+    const activeTurnSubId = lastActiveTurnSubscribeSubId();
+
+    act(() => {
+      fireEvent('liveQuery.snapshot', {
+        subscriptionId: messageSubId,
+        rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+        version: 1,
+      });
+      fireEvent('liveQuery.error', {
+        subscriptionId: activeTurnSubId,
+        code: 'QUERY_FAILED',
+        message: 'active turn query failed',
+        phase: 'snapshot',
+      });
+    });
+    expect(result.current.error).toBe('active turn query failed');
+
+    act(() => {
+      fireEvent('liveQuery.delta', {
+        subscriptionId: messageSubId,
+        added: [{ id: 'msg-2', taskId: 'task-1', createdAt: 2 }],
+        version: 2,
+      });
+    });
+    expect(result.current.error).toBe('active turn query failed');
+    expect(result.current.rows.map((r) => r.id)).toEqual(['msg-1', 'msg-2']);
+  });
+
   describe('isLoading (empty-state flash prevention)', () => {
     it('reports isLoading=true on the very first render when a taskId is provided', () => {
       const { result } = renderHook(() => useSpaceTaskMessages('task-1'));

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -415,7 +415,7 @@ describe('useSpaceTaskMessages', () => {
         });
       }
 
-      expect(subscribeCalls()).toHaveLength(12);
+      expect(subscribeCalls()).toHaveLength(14);
       expect(result.current.isLoading).toBe(false);
 
       await act(async () => {
@@ -423,7 +423,7 @@ describe('useSpaceTaskMessages', () => {
         await Promise.resolve();
       });
 
-      expect(subscribeCalls()).toHaveLength(12);
+      expect(subscribeCalls()).toHaveLength(14);
     });
   });
 });

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -237,6 +237,56 @@ describe('useSpaceTaskMessages', () => {
     expect(result.current.rows.map((r) => r.id)).toEqual(['msg-1', 'msg-2']);
   });
 
+  it('ignores a stale active-turn subscribe rejection after switching tasks', async () => {
+    let rejectStale: (reason: Error) => void = () => {};
+    const staleRejection = new Promise<void>((_, reject) => {
+      rejectStale = reject;
+    });
+    mockRequest.mockImplementation(
+      (method: string, payload: { queryName?: string; subscriptionId?: string }) => {
+        if (
+          method === 'liveQuery.subscribe' &&
+          payload.queryName === 'spaceTaskActiveTurn.byTask' &&
+          String(payload.subscriptionId).includes('task-1')
+        ) {
+          return staleRejection;
+        }
+        return Promise.resolve(undefined);
+      }
+    );
+
+    const { result, rerender } = renderHook(
+      ({ taskId }: { taskId: string }) => useSpaceTaskMessages(taskId),
+      { initialProps: { taskId: 'task-1' } }
+    );
+    rerender({ taskId: 'task-2' });
+    const messageSubId = lastMessageSubscribeSubId();
+    const activeTurnSubId = lastActiveTurnSubscribeSubId();
+    act(() => {
+      fireEvent('liveQuery.snapshot', { subscriptionId: messageSubId, rows: [], version: 1 });
+      fireEvent('liveQuery.snapshot', {
+        subscriptionId: activeTurnSubId,
+        rows: [
+          {
+            id: 'sess-1:1:row-1:0',
+            sessionId: 'sess-1',
+            turnIndex: 1,
+            ts: 10,
+            entry: { kind: 'text', text: 'Working', ts: 10, uuid: 'u1' },
+          },
+        ],
+        version: 1,
+      });
+    });
+    expect(result.current.activeTurnSummaries).toHaveLength(1);
+
+    await act(async () => {
+      rejectStale(new Error('stale rejection'));
+      await Promise.resolve();
+    });
+    expect(result.current.activeTurnSummaries).toHaveLength(1);
+  });
+
   describe('isLoading (empty-state flash prevention)', () => {
     it('reports isLoading=true on the very first render when a taskId is provided', () => {
       const { result } = renderHook(() => useSpaceTaskMessages('task-1'));

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -152,7 +152,8 @@ export function useSpaceTaskMessages(
   const { request, onEvent, getHub, isConnected } = useMessageHub();
   const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
   const [activeTurnRows, setActiveTurnRows] = useState<ActiveTurnEntryRow[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [messageError, setMessageError] = useState<string | null>(null);
+  const [activeTurnError, setActiveTurnError] = useState<string | null>(null);
   const [loadedForTaskId, setLoadedForTaskId] = useState<string | null>(null);
 
   const queryName =
@@ -163,7 +164,8 @@ export function useSpaceTaskMessages(
       setRows([]);
       setActiveTurnRows([]);
       setLoadedForTaskId(null);
-      setError(null);
+      setMessageError(null);
+      setActiveTurnError(null);
       return;
     }
 
@@ -175,7 +177,8 @@ export function useSpaceTaskMessages(
     setRows([]);
     setActiveTurnRows([]);
     setLoadedForTaskId(null);
-    setError(null);
+    setMessageError(null);
+    setActiveTurnError(null);
 
     const initial = createLiveQueryLifecycleState();
     let lifecycle: LiveQueryLifecycleState = initial.state;
@@ -183,7 +186,7 @@ export function useSpaceTaskMessages(
     const dispatch = (event: LiveQueryLifecycleEvent): LiveQueryLifecycleEffect[] => {
       const result = transitionLiveQueryLifecycle(lifecycle, event);
       lifecycle = result.state;
-      if (lifecycle.status !== 'disposed') setError(lifecycle.error);
+      if (lifecycle.status !== 'disposed') setMessageError(lifecycle.error);
       return result.effects;
     };
 
@@ -296,7 +299,7 @@ export function useSpaceTaskMessages(
             .catch(() => setActiveTurnRows([]));
           return;
         }
-        setError(event.message);
+        setActiveTurnError(event.message);
         setActiveTurnRows([]);
       }
     });
@@ -304,6 +307,7 @@ export function useSpaceTaskMessages(
     const unsubReconnect = getHub()?.onConnection((state) => {
       if (state !== 'connected') return;
       setLoadedForTaskId(null);
+      setActiveTurnError(null);
       executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
     });
 
@@ -329,6 +333,7 @@ export function useSpaceTaskMessages(
   );
 
   const isLoading = taskId !== null && isConnected && loadedForTaskId !== taskId;
+  const error = messageError ?? activeTurnError;
 
   return {
     rows: sortedRows,

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -213,7 +213,9 @@ export function useSpaceTaskMessages(
                 params: [taskId],
                 subscriptionId: activeTurnSubscriptionId,
               })
-              .catch(() => setActiveTurnRows([]));
+              .catch(() => {
+                if (lifecycle.status !== 'disposed') setActiveTurnRows([]);
+              });
           }
           continue;
         }
@@ -296,7 +298,9 @@ export function useSpaceTaskMessages(
               params: [taskId],
               subscriptionId: activeTurnSubscriptionId,
             })
-            .catch(() => setActiveTurnRows([]));
+            .catch(() => {
+              if (lifecycle.status !== 'disposed') setActiveTurnRows([]);
+            });
           return;
         }
         setActiveTurnError(event.message);

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -1,4 +1,3 @@
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type {
   ActiveTurnSummary,
   ActivityEntry,
@@ -7,6 +6,14 @@ import type {
   LiveQuerySnapshotEvent,
   MessageDeliveryStatus,
 } from '@hyperneo/shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import {
+  createLiveQueryLifecycleState,
+  type LiveQueryLifecycleEffect,
+  type LiveQueryLifecycleEvent,
+  type LiveQueryLifecycleState,
+  transitionLiveQueryLifecycle,
+} from '../lib/live-query-lifecycle';
 import { useMessageHub } from './useMessageHub';
 
 export interface SpaceTaskThreadMessageRow {
@@ -59,9 +66,6 @@ function nextActiveTurnSubId(taskId: string): string {
   _activeTurnSubCounter += 1;
   return `space-task-active-turn-${taskId}-${_activeTurnSubCounter}`;
 }
-
-const SNAPSHOT_RETRY_DELAY_MS = 2000;
-const MAX_SNAPSHOT_RETRIES = 5;
 
 export function sortRows(rows: SpaceTaskThreadMessageRow[]): SpaceTaskThreadMessageRow[] {
   return [...rows].sort((a, b) => {
@@ -139,6 +143,8 @@ function buildActiveTurnSummaries(rows: ActiveTurnEntryRow[]): ActiveTurnSummary
   return Array.from(bySession.values());
 }
 
+type LifecycleStorePayload = LiveQuerySnapshotEvent | LiveQueryDeltaEvent | null;
+
 export function useSpaceTaskMessages(
   taskId: string | null,
   variant: SpaceTaskMessagesQueryVariant = 'compact'
@@ -148,8 +154,6 @@ export function useSpaceTaskMessages(
   const [activeTurnRows, setActiveTurnRows] = useState<ActiveTurnEntryRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loadedForTaskId, setLoadedForTaskId] = useState<string | null>(null);
-  const activeSubIdRef = useRef<string | null>(null);
-  const activeTurnSubIdRef = useRef<string | null>(null);
 
   const queryName =
     variant === 'full' ? 'spaceTaskMessages.byTask' : 'spaceTaskMessages.byTask.compact';
@@ -160,62 +164,46 @@ export function useSpaceTaskMessages(
       setActiveTurnRows([]);
       setLoadedForTaskId(null);
       setError(null);
-      activeSubIdRef.current = null;
-      activeTurnSubIdRef.current = null;
       return;
     }
 
     const subscriptionId = nextTaskMessageSubId(taskId);
     const activeTurnSubscriptionId = nextActiveTurnSubId(taskId);
     const shouldSubscribeActiveTurn = variant === 'compact';
-    activeSubIdRef.current = subscriptionId;
-    activeTurnSubIdRef.current = shouldSubscribeActiveTurn ? activeTurnSubscriptionId : null;
-    const snapshotRetryTimers = new Set<ReturnType<typeof setTimeout>>();
-    let sawSnapshot = false;
-    let snapshotRetries = 0;
-    let subscribeGeneration = 0;
+    const retryTimers = new Set<ReturnType<typeof setTimeout>>();
+
     setRows([]);
     setActiveTurnRows([]);
     setLoadedForTaskId(null);
     setError(null);
 
-    const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
-      if (event.subscriptionId === activeSubIdRef.current) {
-        sawSnapshot = true;
-        setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
-        setLoadedForTaskId(taskId);
-        return;
-      }
-      if (event.subscriptionId === activeTurnSubIdRef.current) {
-        setActiveTurnRows(sortActiveTurnRows((event.rows as ActiveTurnEntryRow[]) ?? []));
-      }
-    });
+    const initial = createLiveQueryLifecycleState();
+    let lifecycle: LiveQueryLifecycleState = initial.state;
 
-    const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-      if (event.subscriptionId === activeSubIdRef.current) {
-        setRows((prev) => applyDelta(prev, event));
-        return;
-      }
-      if (event.subscriptionId === activeTurnSubIdRef.current) {
-        setActiveTurnRows((prev) => applyActiveTurnDelta(prev, event));
-      }
-    });
+    const dispatch = (event: LiveQueryLifecycleEvent): LiveQueryLifecycleEffect[] => {
+      const result = transitionLiveQueryLifecycle(lifecycle, event);
+      lifecycle = result.state;
+      if (lifecycle.status !== 'disposed') setError(lifecycle.error);
+      return result.effects;
+    };
 
-    const unsubError = onEvent<LiveQueryErrorEvent>('liveQuery.error', (event) => {
-      if (event.subscriptionId === activeSubIdRef.current) {
-        if (event.phase === 'delta') {
-          subscribe(true);
-          return;
-        }
-        sawSnapshot = true;
-        setError(event.message);
-        setLoadedForTaskId(taskId);
-        return;
-      }
-      if (event.subscriptionId === activeTurnSubIdRef.current) {
-        if (event.phase === 'delta') {
+    const executeEffects = (
+      effects: LiveQueryLifecycleEffect[],
+      payload: LifecycleStorePayload = null
+    ): void => {
+      for (const effect of effects) {
+        if (effect.kind === 're-snapshot') {
           const hub = getHub();
-          if (hub) {
+          if (!hub) continue;
+          hub
+            .request('liveQuery.subscribe', { queryName, params: [taskId], subscriptionId })
+            .then(() => {
+              executeEffects(dispatch({ type: 'subscribed', generation: effect.generation }));
+            })
+            .catch(() => {
+              executeEffects(dispatch({ type: 'snapshot-failed', generation: effect.generation }));
+            });
+          if (shouldSubscribeActiveTurn) {
             hub
               .request('liveQuery.subscribe', {
                 queryName: 'spaceTaskActiveTurn.byTask',
@@ -224,6 +212,88 @@ export function useSpaceTaskMessages(
               })
               .catch(() => setActiveTurnRows([]));
           }
+          continue;
+        }
+        if (effect.kind === 'retry-with-backoff') {
+          const timer = setTimeout(() => {
+            retryTimers.delete(timer);
+            executeEffects(dispatch({ type: 'snapshot-failed', generation: effect.generation }));
+          }, effect.delayMs);
+          retryTimers.add(timer);
+          continue;
+        }
+        if (effect.kind === 'schedule-cleanup') {
+          for (const timer of retryTimers) clearTimeout(timer);
+          retryTimers.clear();
+          continue;
+        }
+        if (effect.emission.type === 'snapshot') {
+          const snapshot = payload as LiveQuerySnapshotEvent | null;
+          setRows(sortRows((snapshot?.rows as SpaceTaskThreadMessageRow[]) ?? []));
+          setLoadedForTaskId(taskId);
+          continue;
+        }
+        if (effect.emission.type === 'delta') {
+          const delta = payload as LiveQueryDeltaEvent | null;
+          if (delta) setRows((prev) => applyDelta(prev, delta));
+          continue;
+        }
+        setLoadedForTaskId(taskId);
+      }
+    };
+
+    executeEffects(initial.effects);
+
+    const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+      if (event.subscriptionId === subscriptionId) {
+        executeEffects(
+          dispatch({ type: 'snapshot-arrived', generation: lifecycle.generation }),
+          event
+        );
+        return;
+      }
+      if (shouldSubscribeActiveTurn && event.subscriptionId === activeTurnSubscriptionId) {
+        setActiveTurnRows(sortActiveTurnRows((event.rows as ActiveTurnEntryRow[]) ?? []));
+      }
+    });
+
+    const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+      if (event.subscriptionId === subscriptionId) {
+        executeEffects(
+          dispatch({ type: 'delta-arrived', generation: lifecycle.generation }),
+          event
+        );
+        return;
+      }
+      if (shouldSubscribeActiveTurn && event.subscriptionId === activeTurnSubscriptionId) {
+        setActiveTurnRows((prev) => applyActiveTurnDelta(prev, event));
+      }
+    });
+
+    const unsubError = onEvent<LiveQueryErrorEvent>('liveQuery.error', (event) => {
+      if (event.subscriptionId === subscriptionId) {
+        if (event.phase === 'delta') {
+          executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
+          return;
+        }
+        executeEffects(
+          dispatch({
+            type: 'snapshot-failed',
+            generation: lifecycle.generation,
+            message: event.message,
+          })
+        );
+        return;
+      }
+      if (shouldSubscribeActiveTurn && event.subscriptionId === activeTurnSubscriptionId) {
+        if (event.phase === 'delta') {
+          getHub()
+            ?.request('liveQuery.subscribe', {
+              queryName: 'spaceTaskActiveTurn.byTask',
+              params: [taskId],
+              subscriptionId: activeTurnSubscriptionId,
+            })
+            .catch(() => setActiveTurnRows([]));
           return;
         }
         setError(event.message);
@@ -231,80 +301,18 @@ export function useSpaceTaskMessages(
       }
     });
 
-    const subscribe = (resetRetryCount = false) => {
-      const hub = getHub();
-      if (!hub) return;
-      sawSnapshot = false;
-      if (resetRetryCount) {
-        snapshotRetries = 0;
-      }
-      subscribeGeneration += 1;
-      const generation = subscribeGeneration;
-      hub
-        .request('liveQuery.subscribe', {
-          queryName,
-          params: [taskId],
-          subscriptionId,
-        })
-        .then(() => {
-          if (snapshotRetries >= MAX_SNAPSHOT_RETRIES) {
-            if (activeSubIdRef.current === subscriptionId && !sawSnapshot) {
-              setLoadedForTaskId(taskId);
-            }
-            return;
-          }
-          snapshotRetries += 1;
-          const retryTimer = setTimeout(() => {
-            snapshotRetryTimers.delete(retryTimer);
-            if (
-              activeSubIdRef.current === subscriptionId &&
-              generation === subscribeGeneration &&
-              !sawSnapshot
-            ) {
-              subscribe();
-            }
-          }, SNAPSHOT_RETRY_DELAY_MS);
-          snapshotRetryTimers.add(retryTimer);
-        })
-        .catch(() => {
-          if (activeSubIdRef.current === subscriptionId) {
-            setLoadedForTaskId(taskId);
-          }
-        });
-      if (shouldSubscribeActiveTurn) {
-        hub
-          .request('liveQuery.subscribe', {
-            queryName: 'spaceTaskActiveTurn.byTask',
-            params: [taskId],
-            subscriptionId: activeTurnSubscriptionId,
-          })
-          .catch(() => {
-            if (activeTurnSubIdRef.current === activeTurnSubscriptionId) {
-              setActiveTurnRows([]);
-            }
-          });
-      }
-    };
-
     const unsubReconnect = getHub()?.onConnection((state) => {
       if (state !== 'connected') return;
-      if (activeSubIdRef.current !== subscriptionId) return;
       setLoadedForTaskId(null);
-      setError(null);
-      subscribe(true);
+      executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
     });
 
-    subscribe(true);
-
     return () => {
-      for (const timer of snapshotRetryTimers) clearTimeout(timer);
-      snapshotRetryTimers.clear();
+      executeEffects(dispatch({ type: 'unsubscribe' }));
       unsubSnapshot();
       unsubDelta();
       unsubError();
       unsubReconnect?.();
-      activeSubIdRef.current = null;
-      activeTurnSubIdRef.current = null;
       Promise.resolve(request('liveQuery.unsubscribe', { subscriptionId })).catch(() => {});
       if (shouldSubscribeActiveTurn) {
         Promise.resolve(


### PR DESCRIPTION
UI Pilot 6 PR 3 (apply): `useSpaceTaskMessages` is now a facade over the PR-2 `live-query-lifecycle` machine — the hook owns subscription handles, timers, store writes, and effect execution, while every transition (re-subscribe, snapshot-retry backoff and budget, generation staleness, settling with error/empty) goes through the machine. The PR-1 characterization pins pass unchanged; the only other edit is one pre-existing test expectation moving 12 → 14 subscribe calls, because the old inline code let a superseded generation's subscribe resolution consume retry budget after a reconnect while the machine's generation guard (pinned in PR 2) drops it, restoring the full budget.

Superpipe decision: a plain function is kept for the per-event transition — it is a single switch decider with no staged effects, so a pipeline layer would not earn its place (per ADR 0004's earn-the-layer preference).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->