### PR TITLE
refactor(daemon): extract spawn admission gates and slot resolution (task #1238)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/spawn-admission-gates.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-admission-gates.ts
@@ -1,12 +1,13 @@
 import type { SpaceTaskStatus } from '@hyperneo/shared';
 import { isRateOrUsageLimited } from '@hyperneo/shared';
 
-export type SpawnExecutionAdmissionRejectReason =
+export type SpawnExecutionPermanentRejectReason =
   | 'task_archived'
   | 'task_cancelled'
-  | 'task_rate_or_usage_limited'
   | 'workflow_invalid'
   | 'slot_unresolvable';
+
+export type SpawnExecutionTransientRejectReason = 'task_rate_or_usage_limited';
 
 export interface SpawnExecutionAdmissionInput {
   hasLiveIndexedSession: boolean;
@@ -20,8 +21,8 @@ export type SpawnExecutionAdmissionDecision =
   | { action: 'reuse_live' }
   | { action: 'wait_concurrent' }
   | { action: 'proceed_fresh' }
-  | { action: 'reject_permanent'; reason: SpawnExecutionAdmissionRejectReason }
-  | { action: 'reject_transient'; reason: 'task_rate_or_usage_limited' };
+  | { action: 'reject_permanent'; reason: SpawnExecutionPermanentRejectReason }
+  | { action: 'reject_transient'; reason: SpawnExecutionTransientRejectReason };
 
 export function decideSpawnExecutionAdmission(
   input: SpawnExecutionAdmissionInput

--- a/packages/daemon/src/lib/space/runtime/spawn-admission-gates.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-admission-gates.ts
@@ -1,0 +1,47 @@
+import type { SpaceTaskStatus } from '@hyperneo/shared';
+import { isRateOrUsageLimited } from '@hyperneo/shared';
+
+export type SpawnExecutionAdmissionRejectReason =
+  | 'task_archived'
+  | 'task_cancelled'
+  | 'task_rate_or_usage_limited'
+  | 'workflow_invalid'
+  | 'slot_unresolvable';
+
+export interface SpawnExecutionAdmissionInput {
+  hasLiveIndexedSession: boolean;
+  isSpawningExecution: boolean;
+  taskStatus: SpaceTaskStatus;
+  executionWorkflowValid: boolean;
+  slotResolvable: boolean;
+}
+
+export type SpawnExecutionAdmissionDecision =
+  | { action: 'reuse_live' }
+  | { action: 'wait_concurrent' }
+  | { action: 'proceed_fresh' }
+  | { action: 'reject_permanent'; reason: SpawnExecutionAdmissionRejectReason }
+  | { action: 'reject_transient'; reason: 'task_rate_or_usage_limited' };
+
+export function decideSpawnExecutionAdmission(
+  input: SpawnExecutionAdmissionInput
+): SpawnExecutionAdmissionDecision {
+  if (input.hasLiveIndexedSession) return { action: 'reuse_live' };
+  if (input.isSpawningExecution) return { action: 'wait_concurrent' };
+  if (input.taskStatus === 'archived') {
+    return { action: 'reject_permanent', reason: 'task_archived' };
+  }
+  if (input.taskStatus === 'cancelled') {
+    return { action: 'reject_permanent', reason: 'task_cancelled' };
+  }
+  if (isRateOrUsageLimited(input.taskStatus)) {
+    return { action: 'reject_transient', reason: 'task_rate_or_usage_limited' };
+  }
+  if (!input.executionWorkflowValid) {
+    return { action: 'reject_permanent', reason: 'workflow_invalid' };
+  }
+  if (!input.slotResolvable) {
+    return { action: 'reject_permanent', reason: 'slot_unresolvable' };
+  }
+  return { action: 'proceed_fresh' };
+}

--- a/packages/daemon/src/lib/space/runtime/spawn-slot-resolution.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-slot-resolution.ts
@@ -1,0 +1,143 @@
+import { resolveNodeAgents } from '@hyperneo/shared';
+import type {
+  McpServerConfig,
+  SpaceTask,
+  SpaceWorkflow,
+  WorkflowNode,
+  WorkflowNodeAgent,
+} from '@hyperneo/shared';
+import type { AgentSessionInit } from '../../agent/agent-session';
+import type { SlotOverrides } from '../agents/custom-agent';
+
+export interface WorkflowNodeSlotResolution {
+  node: WorkflowNode;
+  slot: WorkflowNodeAgent;
+}
+
+export function resolveWorkflowNodeSlot(
+  workflow: SpaceWorkflow | null | undefined,
+  workflowNodeId: string,
+  agentName: string
+): WorkflowNodeSlotResolution | null {
+  const node = workflow?.nodes.find((candidate) => candidate.id === workflowNodeId);
+  if (!node) return null;
+
+  let nodeAgents: ReturnType<typeof resolveNodeAgents>;
+  try {
+    nodeAgents = resolveNodeAgents(node);
+  } catch {
+    return null;
+  }
+
+  const slot =
+    nodeAgents.length === 1
+      ? nodeAgents[0]
+      : nodeAgents.find((agentSlot) => agentSlot.name === agentName);
+  return slot?.agentId ? { node, slot } : null;
+}
+
+export interface BuildSlotOverridesContext {
+  task?: Pick<SpaceTask, 'workflowModelOverrides'>;
+  node?: { id: string; name: string };
+  workflow?: { id: string };
+  workflowRun?: { id: string };
+}
+
+export function buildSlotOverrides(
+  slot: WorkflowNodeAgent,
+  context?: BuildSlotOverridesContext
+): SlotOverrides {
+  let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
+  if (!slotCustomPrompt && slot.replaceAgentPrompt !== true) {
+    const legacySlot = slot as {
+      systemPrompt?: { value: string };
+      instructions?: { value: string };
+    };
+    const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
+    const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
+    if (legacySp && legacyInstr) {
+      slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
+    } else {
+      slotCustomPrompt = legacySp || legacyInstr || undefined;
+    }
+  }
+  const modelOverrideKey = context?.node ? `${context.node.id}:${slot.name}` : null;
+  const taskModelOverride = modelOverrideKey
+    ? context?.task?.workflowModelOverrides?.[modelOverrideKey]
+    : undefined;
+  const effectiveGuards = slot.toolGuards;
+  return {
+    model: taskModelOverride ?? slot.model,
+    thinkingLevel: slot.thinkingLevel,
+    customPrompt: slotCustomPrompt,
+    replaceAgentPrompt: slot.replaceAgentPrompt,
+    disabledSkillIds: slot.disabledSkillIds,
+    extraMcpServers: slot.extraMcpServers,
+    toolGuards: effectiveGuards,
+    resolutionContext: {
+      agentId: slot.agentId,
+      agentName: slot.name,
+      workflowRunId: context?.workflowRun?.id,
+      workflowId: context?.workflow?.id,
+      nodeId: context?.node?.id,
+      nodeName: context?.node?.name,
+    },
+  };
+}
+
+export function buildExecutionBaseSessionId(
+  spaceId: string,
+  taskId: string,
+  executionId: string
+): string {
+  return `space:${spaceId}:task:${taskId}:exec:${executionId}`;
+}
+
+export function findAvailableSessionId(
+  baseId: string,
+  isTaken: (sessionId: string) => boolean
+): string {
+  if (!isTaken(baseId)) return baseId;
+
+  const MAX_ATTEMPTS = 100;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const candidateId = `${baseId}:${attempt}`;
+    if (!isTaken(candidateId)) return candidateId;
+  }
+  throw new Error(
+    `Could not find available session ID for base "${baseId}" after ${MAX_ATTEMPTS} attempts`
+  );
+}
+
+export interface SpawnWorkspaceResolution {
+  workspacePath: string;
+  createWorktree: boolean;
+}
+
+export function resolveSpawnWorkspace(input: {
+  cachedTaskWorktreePath: string | undefined;
+  hasWorktreeManager: boolean;
+  spaceWorkspacePath: string;
+}): SpawnWorkspaceResolution {
+  return {
+    workspacePath: input.cachedTaskWorktreePath ?? input.spaceWorkspacePath,
+    createWorktree: input.cachedTaskWorktreePath === undefined && input.hasWorktreeManager,
+  };
+}
+
+export function assembleNodeAgentSessionInit(input: {
+  baseInit: AgentSessionInit;
+  title: string;
+  nodeAgentMcpServer: McpServerConfig;
+  agentMemoryMcpServers: Record<string, McpServerConfig>;
+}): AgentSessionInit {
+  return {
+    ...input.baseInit,
+    title: input.title,
+    mcpServers: {
+      ...input.baseInit.mcpServers,
+      'node-agent': input.nodeAgentMcpServer,
+      ...input.agentMemoryMcpServers,
+    },
+  };
+}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -72,8 +72,18 @@ import { jsonResult } from '../tools/tool-result';
 import {
   assertExecutionValidAgainstWorkflow,
   PermanentSpawnError,
+  validateExecutionAgainstWorkflow,
   validateTaskAllowsSpawn,
 } from './workflow-node-execution-validation';
+import { decideSpawnExecutionAdmission } from './spawn-admission-gates';
+import {
+  assembleNodeAgentSessionInit,
+  buildExecutionBaseSessionId,
+  buildSlotOverrides,
+  findAvailableSessionId,
+  resolveSpawnWorkspace,
+  resolveWorkflowNodeSlot,
+} from './spawn-slot-resolution';
 import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-manager';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
@@ -93,11 +103,7 @@ import {
   WorkflowHookEngine,
 } from './workflow-hook-engine';
 import { WorkflowHookStateRepository } from '../../../storage/repositories/workflow-hook-state-repository';
-import {
-  buildCustomAgentTaskMessage,
-  resolveAgentInit,
-  type SlotOverrides,
-} from '../agents/custom-agent';
+import { buildCustomAgentTaskMessage, resolveAgentInit } from '../agents/custom-agent';
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import { Logger } from '../../logger';
 import {
@@ -268,55 +274,6 @@ const VERIFIED_STOP_ESCALATION_FORCE_KILL_MS = 2000;
 
 interface SpawnTaskAgentOptions {
   kickoff?: boolean;
-}
-
-export interface BuildSlotOverridesContext {
-  task?: Pick<SpaceTask, 'workflowModelOverrides'>;
-  node?: { id: string; name: string };
-  workflow?: { id: string };
-  workflowRun?: { id: string };
-}
-
-export function buildSlotOverrides(
-  slot: WorkflowNodeAgent,
-  context?: BuildSlotOverridesContext
-): SlotOverrides {
-  let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
-  if (!slotCustomPrompt && slot.replaceAgentPrompt !== true) {
-    const legacySlot = slot as {
-      systemPrompt?: { value: string };
-      instructions?: { value: string };
-    };
-    const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
-    const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
-    if (legacySp && legacyInstr) {
-      slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
-    } else {
-      slotCustomPrompt = legacySp || legacyInstr || undefined;
-    }
-  }
-  const modelOverrideKey = context?.node ? `${context.node.id}:${slot.name}` : null;
-  const taskModelOverride = modelOverrideKey
-    ? context?.task?.workflowModelOverrides?.[modelOverrideKey]
-    : undefined;
-  const effectiveGuards = slot.toolGuards;
-  return {
-    model: taskModelOverride ?? slot.model,
-    thinkingLevel: slot.thinkingLevel,
-    customPrompt: slotCustomPrompt,
-    replaceAgentPrompt: slot.replaceAgentPrompt,
-    disabledSkillIds: slot.disabledSkillIds,
-    extraMcpServers: slot.extraMcpServers,
-    toolGuards: effectiveGuards,
-    resolutionContext: {
-      agentId: slot.agentId,
-      agentName: slot.name,
-      workflowRunId: context?.workflowRun?.id,
-      workflowId: context?.workflow?.id,
-      nodeId: context?.node?.id,
-      nodeName: context?.node?.name,
-    },
-  };
 }
 
 export function resolvePostApprovalTargetAgentName(
@@ -655,21 +612,43 @@ export class TaskAgentManager {
     execution: NodeExecution,
     options: SpawnTaskAgentOptions = {}
   ): Promise<string> {
-    if (execution.agentSessionId && this.agentSessionIndex.has(execution.agentSessionId)) {
-      if (this.isSessionAlive(execution.agentSessionId)) {
-        const startedAt = execution.startedAt ?? Date.now();
-        this.config.nodeExecutionRepo.update(execution.id, {
-          status: 'in_progress',
-          agentSessionId: execution.agentSessionId,
-          startedAt,
-          completedAt: null,
-        });
-        return execution.agentSessionId;
+    const indexedSessionId = execution.agentSessionId;
+    let hasLiveIndexedSession = false;
+    if (indexedSessionId && this.agentSessionIndex.has(indexedSessionId)) {
+      if (this.isSessionAlive(indexedSessionId)) {
+        hasLiveIndexedSession = true;
+      } else {
+        this.agentSessionIndex.delete(indexedSessionId);
       }
-      this.agentSessionIndex.delete(execution.agentSessionId);
     }
 
-    if (this.spawningExecutionIds.has(execution.id)) {
+    const freshTask = this.config.taskRepo.getTask(task.id) ?? task;
+    const slotResolution = resolveWorkflowNodeSlot(
+      workflow,
+      execution.workflowNodeId,
+      execution.agentName
+    );
+    const admission = decideSpawnExecutionAdmission({
+      hasLiveIndexedSession,
+      isSpawningExecution: this.spawningExecutionIds.has(execution.id),
+      taskStatus: freshTask.status,
+      executionWorkflowValid: validateExecutionAgainstWorkflow(execution, workflow).valid,
+      slotResolvable: slotResolution !== null,
+    });
+
+    if (admission.action === 'reuse_live') {
+      const sessionId = indexedSessionId!;
+      const startedAt = execution.startedAt ?? Date.now();
+      this.config.nodeExecutionRepo.update(execution.id, {
+        status: 'in_progress',
+        agentSessionId: sessionId,
+        startedAt,
+        completedAt: null,
+      });
+      return sessionId;
+    }
+
+    if (admission.action === 'wait_concurrent') {
       const CONCURRENT_SPAWN_TIMEOUT_MS = 30_000;
       const deadline = Date.now() + CONCURRENT_SPAWN_TIMEOUT_MS;
       return new Promise((resolve, reject) => {
@@ -701,32 +680,32 @@ export class TaskAgentManager {
       });
     }
 
+    if (admission.action === 'reject_permanent' || admission.action === 'reject_transient') {
+      validateTaskAllowsSpawn(freshTask);
+      assertExecutionValidAgainstWorkflow(execution, workflow);
+      throw new Error(
+        `No agent slot found for agent name "${execution.agentName}" in node "${execution.workflowNodeId}"`
+      );
+    }
+
+    const { node, slot } = slotResolution!;
+
     this.spawningExecutionIds.add(execution.id);
     let spawnedSessionId: string | null = null;
 
     try {
-      const freshTask = this.config.taskRepo.getTask(task.id) ?? task;
-      validateTaskAllowsSpawn(freshTask);
-      assertExecutionValidAgainstWorkflow(execution, workflow);
-
-      const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId)!;
-      const nodeAgents = resolveNodeAgents(node);
-      const slot =
-        nodeAgents.length === 1
-          ? nodeAgents[0]
-          : nodeAgents.find((agentSlot) => agentSlot.name === execution.agentName);
-      if (!slot?.agentId) {
-        throw new Error(
-          `No agent slot found for agent name "${execution.agentName}" in node "${execution.workflowNodeId}"`
-        );
-      }
-
       const taskId = task.id;
-      const baseSessionId = `space:${space.id}:task:${taskId}:exec:${execution.id}`;
-      const sessionId = this.resolveSessionId(baseSessionId);
+      const sessionId = this.resolveSessionId(
+        buildExecutionBaseSessionId(space.id, taskId, execution.id)
+      );
 
-      let workspacePath = this.taskWorktreePaths.get(taskId) ?? space.workspacePath;
-      if (!this.taskWorktreePaths.has(taskId) && this.config.worktreeManager) {
+      const workspace = resolveSpawnWorkspace({
+        cachedTaskWorktreePath: this.taskWorktreePaths.get(taskId),
+        hasWorktreeManager: Boolean(this.config.worktreeManager),
+        spaceWorkspacePath: space.workspacePath,
+      });
+      let workspacePath = workspace.workspacePath;
+      if (workspace.createWorktree && this.config.worktreeManager) {
         try {
           const result = await this.config.worktreeManager.createTaskWorktree(
             space.id,
@@ -780,15 +759,12 @@ export class TaskAgentManager {
         execution.workflowNodeId
       );
 
-      init = {
-        ...init,
+      init = assembleNodeAgentSessionInit({
+        baseInit: init,
         title: formatWorkflowNodeSessionTitle(task, execution.agentName),
-        mcpServers: {
-          ...init.mcpServers,
-          'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
-          ...this.buildAgentMemoryMcpServers(space.id, sessionId),
-        },
-      };
+        nodeAgentMcpServer: nodeAgentMcpServer as unknown as McpServerConfig,
+        agentMemoryMcpServers: this.buildAgentMemoryMcpServers(space.id, sessionId),
+      });
 
       const actualSessionId = await this.createSubSession(taskId, sessionId, init, {
         agentId: slot.agentId,
@@ -2780,19 +2756,8 @@ export class TaskAgentManager {
   }
 
   private resolveSessionId(baseId: string): string {
-    if (!this.config.db.getSession(baseId)) {
-      return baseId;
-    }
-
-    const MAX_ATTEMPTS = 100;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      const candidateId = `${baseId}:${attempt}`;
-      if (!this.config.db.getSession(candidateId)) {
-        return candidateId;
-      }
-    }
-    throw new Error(
-      `Could not find available session ID for base "${baseId}" after ${MAX_ATTEMPTS} attempts`
+    return findAvailableSessionId(baseId, (candidateId) =>
+      Boolean(this.config.db.getSession(candidateId))
     );
   }
 

--- a/packages/daemon/tests/unit/5-space/agent/slot-overrides.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/slot-overrides.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import type { WorkflowNodeAgent } from '@hyperneo/shared';
-import { buildSlotOverrides } from '../../../../src/lib/space/runtime/task-agent-manager';
+import { buildSlotOverrides } from '../../../../src/lib/space/runtime/spawn-slot-resolution';
 import { resolveCustomAgentPrompt } from '../../../../src/lib/space/agents/custom-agent';
 import type { SpaceWorkerAgent } from '@hyperneo/shared';
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -448,6 +448,20 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     expect(h.order).toEqual([]);
   });
 
+  test('single-agent node with a renamed sole slot is a permanent rejection even though slot lookup resolves the sole slot', async () => {
+    const h = makeSpawnHarness({
+      workflow: makeWorkflow([
+        { id: NODE_ID, agents: [{ agentId: AGENT_ID, name: 'renamed-slot' }] },
+      ]),
+    });
+
+    await expect(h.spawn()).rejects.toBeInstanceOf(PermanentSpawnError);
+    await expect(h.spawn()).rejects.toThrow(
+      `Agent slot ${AGENT_NAME} no longer exists on workflow node ${NODE_ID}`
+    );
+    expect(h.order).toEqual([]);
+  });
+
   test('task-status validation precedes workflow validation', async () => {
     const h = makeSpawnHarness({
       taskStatus: 'cancelled',

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-admission-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-admission-gates.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+import type { SpaceTaskStatus } from '@hyperneo/shared';
+import {
+  decideSpawnExecutionAdmission,
+  type SpawnExecutionAdmissionDecision,
+} from '../../../../src/lib/space/runtime/spawn-admission-gates';
+
+const ALL_STATUSES: SpaceTaskStatus[] = [
+  'draft',
+  'open',
+  'in_progress',
+  'review',
+  'approved',
+  'done',
+  'blocked',
+  'cancelled',
+  'archived',
+  'rate_limited',
+  'usage_limited',
+  'stopped',
+];
+
+const STATUS_DECISIONS: Partial<Record<SpaceTaskStatus, SpawnExecutionAdmissionDecision>> = {
+  archived: { action: 'reject_permanent', reason: 'task_archived' },
+  cancelled: { action: 'reject_permanent', reason: 'task_cancelled' },
+  rate_limited: { action: 'reject_transient', reason: 'task_rate_or_usage_limited' },
+  usage_limited: { action: 'reject_transient', reason: 'task_rate_or_usage_limited' },
+};
+
+function statusDecision(status: SpaceTaskStatus): SpawnExecutionAdmissionDecision {
+  return STATUS_DECISIONS[status] ?? { action: 'proceed_fresh' };
+}
+
+function decide(
+  overrides: Partial<Parameters<typeof decideSpawnExecutionAdmission>[0]>
+): SpawnExecutionAdmissionDecision {
+  return decideSpawnExecutionAdmission({
+    hasLiveIndexedSession: false,
+    isSpawningExecution: false,
+    taskStatus: 'in_progress',
+    executionWorkflowValid: true,
+    slotResolvable: true,
+    ...overrides,
+  });
+}
+
+describe('decideSpawnExecutionAdmission — decision table over task status and workflow/slot inputs', () => {
+  for (const status of ALL_STATUSES) {
+    const statusOutcome = statusDecision(status);
+
+    test(`valid workflow + resolvable slot + ${status} → ${statusOutcome.action}`, () => {
+      expect(decide({ taskStatus: status })).toEqual(statusOutcome);
+    });
+
+    const workflowOutcome: SpawnExecutionAdmissionDecision =
+      statusOutcome.action === 'proceed_fresh'
+        ? { action: 'reject_permanent', reason: 'workflow_invalid' }
+        : statusOutcome;
+    test(`invalid workflow + resolvable slot + ${status} → ${workflowOutcome.action}`, () => {
+      expect(decide({ taskStatus: status, executionWorkflowValid: false })).toEqual(
+        workflowOutcome
+      );
+    });
+
+    const slotOutcome: SpawnExecutionAdmissionDecision =
+      statusOutcome.action === 'proceed_fresh'
+        ? { action: 'reject_permanent', reason: 'slot_unresolvable' }
+        : statusOutcome;
+    test(`valid workflow + unresolvable slot + ${status} → ${slotOutcome.action}`, () => {
+      expect(decide({ taskStatus: status, slotResolvable: false })).toEqual(slotOutcome);
+    });
+
+    test(`invalid workflow + unresolvable slot + ${status} → ${workflowOutcome.action}`, () => {
+      expect(
+        decide({ taskStatus: status, executionWorkflowValid: false, slotResolvable: false })
+      ).toEqual(workflowOutcome);
+    });
+  }
+
+  test('archived and cancelled mirror the validateTaskAllowsSpawn permanent arm', () => {
+    expect(decide({ taskStatus: 'archived' })).toEqual({
+      action: 'reject_permanent',
+      reason: 'task_archived',
+    });
+    expect(decide({ taskStatus: 'cancelled' })).toEqual({
+      action: 'reject_permanent',
+      reason: 'task_cancelled',
+    });
+  });
+
+  test('rate_limited and usage_limited mirror the validateTaskAllowsSpawn transient arm', () => {
+    expect(decide({ taskStatus: 'rate_limited' })).toEqual({
+      action: 'reject_transient',
+      reason: 'task_rate_or_usage_limited',
+    });
+    expect(decide({ taskStatus: 'usage_limited' })).toEqual({
+      action: 'reject_transient',
+      reason: 'task_rate_or_usage_limited',
+    });
+  });
+
+  test('statuses validateTaskAllowsSpawn lets through pass through to proceed_fresh unchanged', () => {
+    for (const status of ALL_STATUSES.filter((candidate) => !STATUS_DECISIONS[candidate])) {
+      expect(decide({ taskStatus: status })).toEqual({ action: 'proceed_fresh' });
+    }
+  });
+});
+
+describe('decideSpawnExecutionAdmission — precedence', () => {
+  test('reuse_live beats wait_concurrent, both rejects, and proceed', () => {
+    expect(
+      decide({
+        hasLiveIndexedSession: true,
+        isSpawningExecution: true,
+        taskStatus: 'archived',
+        executionWorkflowValid: false,
+        slotResolvable: false,
+      })
+    ).toEqual({ action: 'reuse_live' });
+  });
+
+  test('reuse_live beats a permanent task rejection (live-session reuse precedes task validation)', () => {
+    expect(
+      decide({
+        hasLiveIndexedSession: true,
+        taskStatus: 'archived',
+        executionWorkflowValid: false,
+        slotResolvable: false,
+      })
+    ).toEqual({ action: 'reuse_live' });
+  });
+
+  test('wait_concurrent beats both rejects and proceed', () => {
+    expect(
+      decide({
+        isSpawningExecution: true,
+        taskStatus: 'cancelled',
+        executionWorkflowValid: false,
+        slotResolvable: false,
+      })
+    ).toEqual({ action: 'wait_concurrent' });
+  });
+
+  test('wait_concurrent beats proceed for an otherwise clean spawn', () => {
+    expect(decide({ isSpawningExecution: true })).toEqual({ action: 'wait_concurrent' });
+  });
+
+  test('task-status rejection beats workflow rejection (task-status validation precedes workflow validation)', () => {
+    expect(
+      decide({ taskStatus: 'cancelled', executionWorkflowValid: false, slotResolvable: false })
+    ).toEqual({ action: 'reject_permanent', reason: 'task_cancelled' });
+  });
+
+  test('a transient task-status rejection still beats the permanent workflow rejection', () => {
+    expect(decide({ taskStatus: 'rate_limited', executionWorkflowValid: false })).toEqual({
+      action: 'reject_transient',
+      reason: 'task_rate_or_usage_limited',
+    });
+  });
+
+  test('workflow rejection beats slot rejection', () => {
+    expect(decide({ executionWorkflowValid: false, slotResolvable: false })).toEqual({
+      action: 'reject_permanent',
+      reason: 'workflow_invalid',
+    });
+  });
+
+  test('slot rejection alone rejects permanent after a valid workflow', () => {
+    expect(decide({ slotResolvable: false })).toEqual({
+      action: 'reject_permanent',
+      reason: 'slot_unresolvable',
+    });
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-slot-resolution.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-slot-resolution.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'bun:test';
+import type { McpServerConfig, SpaceWorkflow, WorkflowNode } from '@hyperneo/shared';
+import {
+  assembleNodeAgentSessionInit,
+  buildExecutionBaseSessionId,
+  findAvailableSessionId,
+  resolveSpawnWorkspace,
+  resolveWorkflowNodeSlot,
+} from '../../../../src/lib/space/runtime/spawn-slot-resolution';
+import type { AgentSessionInit } from '../../../../src/lib/agent/agent-session';
+
+function makeNode(overrides: Partial<WorkflowNode> = {}): WorkflowNode {
+  return {
+    id: 'node-coder',
+    name: 'coder',
+    agents: [{ agentId: 'agent-coder', name: 'coder' }],
+    ...overrides,
+  } as unknown as WorkflowNode;
+}
+
+function makeWorkflow(nodes: WorkflowNode[]): SpaceWorkflow {
+  return { nodes } as unknown as SpaceWorkflow;
+}
+
+describe('resolveWorkflowNodeSlot', () => {
+  test('resolves the sole slot of a single-agent node regardless of the execution agent name', () => {
+    const resolution = resolveWorkflowNodeSlot(makeWorkflow([makeNode()]), 'node-coder', 'other');
+    expect(resolution?.slot).toEqual({ agentId: 'agent-coder', name: 'coder' });
+    expect(resolution?.node.id).toBe('node-coder');
+  });
+
+  test('resolves a multi-agent node slot by name', () => {
+    const node = makeNode({
+      agents: [
+        { agentId: 'agent-a', name: 'alice' },
+        { agentId: 'agent-b', name: 'bob' },
+      ],
+    });
+    const resolution = resolveWorkflowNodeSlot(makeWorkflow([node]), 'node-coder', 'bob');
+    expect(resolution?.slot).toEqual({ agentId: 'agent-b', name: 'bob' });
+  });
+
+  test('returns null for a multi-agent node when the execution agent name is absent', () => {
+    const node = makeNode({
+      agents: [
+        { agentId: 'agent-a', name: 'alice' },
+        { agentId: 'agent-b', name: 'bob' },
+      ],
+    });
+    expect(resolveWorkflowNodeSlot(makeWorkflow([node]), 'node-coder', 'carol')).toBeNull();
+  });
+
+  test('returns null when the resolved slot has no agent id', () => {
+    const node = makeNode({ agents: [{ agentId: null, name: 'coder' }] });
+    expect(resolveWorkflowNodeSlot(makeWorkflow([node]), 'node-coder', 'coder')).toBeNull();
+  });
+
+  test('returns null when the node is absent from the workflow', () => {
+    expect(resolveWorkflowNodeSlot(makeWorkflow([makeNode()]), 'node-gone', 'coder')).toBeNull();
+  });
+
+  test('returns null for a null or undefined workflow', () => {
+    expect(resolveWorkflowNodeSlot(null, 'node-coder', 'coder')).toBeNull();
+    expect(resolveWorkflowNodeSlot(undefined, 'node-coder', 'coder')).toBeNull();
+  });
+
+  test('returns null when the node has no agents and no legacy agent id', () => {
+    const node = makeNode({ agents: [] });
+    expect(resolveWorkflowNodeSlot(makeWorkflow([node]), 'node-coder', 'coder')).toBeNull();
+  });
+
+  test('resolves the legacy single-agent shape through the node-level agent id', () => {
+    const node = {
+      id: 'node-legacy',
+      name: 'legacy',
+      agents: [],
+      agentId: 'agent-legacy',
+    } as unknown as WorkflowNode;
+    const resolution = resolveWorkflowNodeSlot(makeWorkflow([node]), 'node-legacy', 'anyone');
+    expect(resolution?.slot).toEqual({ agentId: 'agent-legacy', name: 'legacy' });
+  });
+});
+
+describe('buildExecutionBaseSessionId', () => {
+  test('assembles the execution-scoped session id', () => {
+    expect(buildExecutionBaseSessionId('space-1', 'task-9', 'exec-7')).toBe(
+      'space:space-1:task:task-9:exec:exec-7'
+    );
+  });
+});
+
+describe('findAvailableSessionId', () => {
+  test('returns the base id when it is not taken', () => {
+    expect(findAvailableSessionId('base', () => false)).toBe('base');
+  });
+
+  test('suffixes with the first free attempt number', () => {
+    expect(findAvailableSessionId('base', (candidate) => candidate === 'base')).toBe('base:1');
+    expect(findAvailableSessionId('base', (candidate) => candidate !== 'base:2')).toBe('base:2');
+  });
+
+  test('throws after exhausting 100 attempts', () => {
+    expect(() => findAvailableSessionId('base', () => true)).toThrow(
+      'Could not find available session ID for base "base" after 100 attempts'
+    );
+  });
+});
+
+describe('resolveSpawnWorkspace', () => {
+  test('reuses the cached task worktree without creating one', () => {
+    expect(
+      resolveSpawnWorkspace({
+        cachedTaskWorktreePath: '/wt/task-9',
+        hasWorktreeManager: true,
+        spaceWorkspacePath: '/space',
+      })
+    ).toEqual({ workspacePath: '/wt/task-9', createWorktree: false });
+  });
+
+  test('falls back to the space workspace and creates a worktree when uncached with a manager', () => {
+    expect(
+      resolveSpawnWorkspace({
+        cachedTaskWorktreePath: undefined,
+        hasWorktreeManager: true,
+        spaceWorkspacePath: '/space',
+      })
+    ).toEqual({ workspacePath: '/space', createWorktree: true });
+  });
+
+  test('falls back to the space workspace without creating a worktree when no manager exists', () => {
+    expect(
+      resolveSpawnWorkspace({
+        cachedTaskWorktreePath: undefined,
+        hasWorktreeManager: false,
+        spaceWorkspacePath: '/space',
+      })
+    ).toEqual({ workspacePath: '/space', createWorktree: false });
+  });
+});
+
+describe('assembleNodeAgentSessionInit', () => {
+  const baseInit: AgentSessionInit = {
+    sessionId: 'session-1',
+    workspacePath: '/wt/task-9',
+    model: 'm1',
+    mcpServers: { existing: { type: 'stdio', command: 'x' } as McpServerConfig },
+  };
+  const nodeAgentServer = { type: 'stdio', command: 'node-agent' } as unknown as McpServerConfig;
+  const memoryServers = {
+    'agent-memory': { type: 'stdio', command: 'memory' } as McpServerConfig,
+  };
+
+  test('passes base init fields through unchanged and applies the title', () => {
+    const init = assembleNodeAgentSessionInit({
+      baseInit: baseInit,
+      title: 'Task #9: Pin',
+      nodeAgentMcpServer: nodeAgentServer,
+      agentMemoryMcpServers: memoryServers,
+    });
+    expect(init.sessionId).toBe('session-1');
+    expect(init.workspacePath).toBe('/wt/task-9');
+    expect(init.model).toBe('m1');
+    expect(init.title).toBe('Task #9: Pin');
+  });
+
+  test('merges the node-agent server and memory servers over the base mcp servers', () => {
+    const init = assembleNodeAgentSessionInit({
+      baseInit: baseInit,
+      title: 't',
+      nodeAgentMcpServer: nodeAgentServer,
+      agentMemoryMcpServers: memoryServers,
+    });
+    expect(init.mcpServers).toEqual({
+      existing: baseInit.mcpServers?.existing,
+      'node-agent': nodeAgentServer,
+      'agent-memory': memoryServers['agent-memory'],
+    });
+  });
+
+  test('spreads memory servers after the node-agent server (memory wins a key collision)', () => {
+    const init = assembleNodeAgentSessionInit({
+      baseInit: baseInit,
+      title: 't',
+      nodeAgentMcpServer: nodeAgentServer,
+      agentMemoryMcpServers: { 'node-agent': memoryServers['agent-memory'] },
+    });
+    expect(init.mcpServers?.['node-agent']).toBe(memoryServers['agent-memory']);
+  });
+
+  test('builds the mcp server map from nothing when the base init has none', () => {
+    const init = assembleNodeAgentSessionInit({
+      baseInit: { sessionId: 'session-1', workspacePath: '/wt' },
+      title: 't',
+      nodeAgentMcpServer: nodeAgentServer,
+      agentMemoryMcpServers: memoryServers,
+    });
+    expect(init.mcpServers).toEqual({
+      'node-agent': nodeAgentServer,
+      'agent-memory': memoryServers['agent-memory'],
+    });
+  });
+});


### PR DESCRIPTION
Superpipe sub-pilot 7 Chain P, PR 2/6. Extracts the `spawnWorkflowNodeAgentForExecution` admission seam into two pure modules — `spawn-admission-gates.ts` (decision union `reuse_live | wait_concurrent | proceed_fresh | reject_permanent | reject_transient` over plain inputs, mirroring `validateTaskAllowsSpawn` semantics via inputs) and `spawn-slot-resolution.ts` (slot lookup, `buildSlotOverrides`, session-id/worktree/init assembly as plain transforms). The manager interprets the gates inline this PR; composition lands in P4. No behavior change — the P1 (#2712) decision-table pins pass unmodified.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->