### PR TITLE
feat(shared): add getSdkResultOriginKind guard for SDK result origin

### DIFF
--- a/packages/shared/src/sdk/index.ts
+++ b/packages/shared/src/sdk/index.ts
@@ -9,6 +9,7 @@ export {
   isSDKResultMessage,
   isSDKResultSuccess,
   isSDKResultError,
+  getSdkResultOriginKind,
   isSDKSystemMessage,
   isSDKSystemInit,
   isSDKCompactBoundary,

--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -87,6 +87,11 @@ export function isSDKResultError(msg: SDKMessage): msg is Extract<
   return msg.type === "result" && (msg as SDKResultMessage).subtype !== "success";
 }
 
+export function getSdkResultOriginKind(msg: SDKMessage): string | null {
+  if (!isSDKResultMessage(msg)) return null;
+  return msg.origin?.kind ?? null;
+}
+
 export function isSDKSystemMessage(
   msg: SDKMessage,
 ): msg is Extract<SDKMessage, { type: "system" }> {

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -7,6 +7,7 @@ import {
   isSDKResultMessage,
   isSDKResultSuccess,
   isSDKResultError,
+  getSdkResultOriginKind,
   isSDKSystemMessage,
   isSDKSystemInit,
   isSDKCompactBoundary,
@@ -216,6 +217,41 @@ describe('isSDKResultError', () => {
       num_turns: 1,
     };
     expect(isSDKResultError(msg as unknown as SDKMessage)).toBe(false);
+  });
+});
+
+describe('getSdkResultOriginKind', () => {
+  test('should return the origin kind for result message with origin', () => {
+    const msg = {
+      ...baseProps,
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      num_turns: 2,
+      origin: { kind: 'task-notification' },
+    };
+    expect(getSdkResultOriginKind(msg as unknown as SDKMessage)).toBe('task-notification');
+  });
+
+  test('should return null for result message without origin', () => {
+    const msg = {
+      ...baseProps,
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      num_turns: 1,
+    };
+    expect(getSdkResultOriginKind(msg as unknown as SDKMessage)).toBeNull();
+  });
+
+  test('should return null for non-result message', () => {
+    const msg = {
+      ...baseProps,
+      type: 'user',
+      parent_tool_use_id: null,
+      message: { role: 'user', content: 'Hello' },
+    };
+    expect(getSdkResultOriginKind(msg as unknown as SDKMessage)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Part 1 of #2726. The vendored `sdk.d.ts` already models `origin?: SDKMessageOrigin` on `SDKResultSuccess`/`SDKResultError` (including `{ kind: 'task-notification' }`), so the missing piece for daemon code to branch on is a type-guard helper: `getSdkResultOriginKind(message)` returns the origin kind for result messages carrying an origin, and `null` for absent origin or non-result messages. Type-only, zero behavior changes; consumers land in Parts 2-5. Covered by unit tests colocated with the existing sdk type-guard tests.

Note: `cd packages/shared && bun test` has 3 pre-existing failures in `websocket-client-transport.test.ts` (network-failure timing tests) that also fail on a clean `origin/dev` checkout; the type-guard suite passes 83/83.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->