### PR TITLE
fix(daemon): clear at the front of the flush batch and never clear over pending work (Pilot 4 PR 8, incident #1085)

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -152,6 +152,7 @@ import {
   throwIfDeliveryAborted,
   waitForDeliveryAbort,
   withSessionLock,
+  withSessionResetCoordination,
 } from './message-delivery';
 import {
   classifyTurnCompletion,
@@ -1256,6 +1257,7 @@ export class AgentSession
     excludeMessageUuid?: string;
     skipContextReset?: boolean;
     skipResetCoordination?: boolean;
+    pendingTaskInput?: boolean;
   }): Promise<{ success: boolean; messageCount: number; error?: string }> {
     return this.queryModeHandler.handleQueryTrigger(options);
   }
@@ -2027,21 +2029,23 @@ export class AgentSession
       return 0;
     }
 
-    const reEnqueued = await withSessionLock(this.session.id, async () => {
-      const active = jobQueue.activeDeliveryMessageUuids(this.session.id);
-      const stranded = selectStrandedDeliveries(
-        this.db.getUserMessageIdsByStatus(this.session.id, 'enqueued'),
-        active,
-        (uuid) => this.messageQueue.hasPendingOrInFlight(uuid)
-      );
-      for (const uuid of stranded) {
-        const role = deliverMessage(jobQueue, this.session.id, uuid, { origin: 'recovery' });
-        if (role === 'turn') {
-          await this.stateManager.setQueuedIfIdle(uuid).catch(() => {});
+    const reEnqueued = await withSessionResetCoordination(this.session.id, async () =>
+      withSessionLock(this.session.id, async () => {
+        const active = jobQueue.activeDeliveryMessageUuids(this.session.id);
+        const stranded = selectStrandedDeliveries(
+          this.db.getUserMessageIdsByStatus(this.session.id, 'enqueued'),
+          active,
+          (uuid) => this.messageQueue.hasPendingOrInFlight(uuid)
+        );
+        for (const uuid of stranded) {
+          const role = deliverMessage(jobQueue, this.session.id, uuid, { origin: 'recovery' });
+          if (role === 'turn') {
+            await this.stateManager.setQueuedIfIdle(uuid).catch(() => {});
+          }
         }
-      }
-      return stranded.length;
-    });
+        return stranded.length;
+      })
+    );
     let settled = 0;
     const sdkRepo = this.db.getSDKMessageRepo();
     await withSessionLock(this.session.id, async () => {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -272,6 +272,8 @@ export class AgentSession
 
   onMissingMemberSpaceMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
+  slotResetsContext?: () => boolean;
+
   get mcpEnablementRepo(): import('../../storage/repositories/mcp-enablement-repository').McpEnablementRepository {
     return this.db.mcpEnablement;
   }

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -680,6 +680,13 @@ export class AgentSession
     await this.queryModeHandler.replayPendingMessagesForImmediateMode();
   }
 
+  async sendEnqueuedMessagesOnTurnEnd(options?: {
+    pendingTaskInput?: boolean;
+    skipResetCoordination?: boolean;
+  }): Promise<{ replayedWork: boolean; clearedContext: boolean }> {
+    return this.queryModeHandler.sendEnqueuedMessagesOnTurnEnd(options);
+  }
+
   async ensureQueryStarted(): Promise<void> {
     await this.lifecycleManager.ensureQueryStarted();
   }

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -680,6 +680,11 @@ export class AgentSession
     await this.queryModeHandler.replayPendingMessagesForImmediateMode();
   }
 
+  async replayAllPendingMessages(): Promise<void> {
+    this.reconcilerProvisioned = true;
+    await this.queryModeHandler.replayPendingMessagesForImmediateMode();
+  }
+
   async sendEnqueuedMessagesOnTurnEnd(options?: {
     pendingTaskInput?: boolean;
     skipResetCoordination?: boolean;

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -1254,6 +1254,8 @@ export class AgentSession
   async handleQueryTrigger(options?: {
     deliverIndividually?: boolean;
     excludeMessageUuid?: string;
+    skipContextReset?: boolean;
+    skipResetCoordination?: boolean;
   }): Promise<{ success: boolean; messageCount: number; error?: string }> {
     return this.queryModeHandler.handleQueryTrigger(options);
   }

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -683,7 +683,7 @@ export class AgentSession
   async sendEnqueuedMessagesOnTurnEnd(options?: {
     pendingTaskInput?: boolean;
     skipResetCoordination?: boolean;
-  }): Promise<{ replayedWork: boolean; clearedContext: boolean }> {
+  }): Promise<{ replayedWork: boolean; clearedContext: boolean; replayFailed: boolean }> {
     return this.queryModeHandler.sendEnqueuedMessagesOnTurnEnd(options);
   }
 

--- a/packages/daemon/src/lib/agent/context-reset-planner.ts
+++ b/packages/daemon/src/lib/agent/context-reset-planner.ts
@@ -45,9 +45,10 @@ export function planInjectContextReset(args: {
 
 export function planTurnEndFlushContextReset(args: {
   slotResetsContext: boolean;
-  deliverableCount: number;
+  hasPriorContext: boolean;
+  taskDeliverableCount: number;
 }): TurnEndFlushContextResetPlan {
-  if (args.slotResetsContext && args.deliverableCount > 0) {
+  if (args.slotResetsContext && args.hasPriorContext && args.taskDeliverableCount > 0) {
     return { action: 'clear_then_flush' };
   }
   return { action: 'flush_without_clear' };

--- a/packages/daemon/src/lib/agent/context-reset-planner.ts
+++ b/packages/daemon/src/lib/agent/context-reset-planner.ts
@@ -12,7 +12,7 @@ export type InjectContextResetPlan =
 
 export type TurnEndFlushContextResetPlan =
   | { action: 'clear_then_flush' }
-  | { action: 'flush_without_clear' };
+  | { action: 'flush_without_clear'; reason?: 'active_delivery_job' };
 
 export function planInjectContextReset(args: {
   inputKind: string;
@@ -56,6 +56,9 @@ export function planTurnEndFlushContextReset(args: {
     args.taskDeliverableCount > 0
   ) {
     return { action: 'clear_then_flush' };
+  }
+  if (args.slotResetsContext && args.hasPriorContext && args.hasActiveDeliveryJob) {
+    return { action: 'flush_without_clear', reason: 'active_delivery_job' };
   }
   return { action: 'flush_without_clear' };
 }

--- a/packages/daemon/src/lib/agent/context-reset-planner.ts
+++ b/packages/daemon/src/lib/agent/context-reset-planner.ts
@@ -46,9 +46,15 @@ export function planInjectContextReset(args: {
 export function planTurnEndFlushContextReset(args: {
   slotResetsContext: boolean;
   hasPriorContext: boolean;
+  hasActiveDeliveryJob: boolean;
   taskDeliverableCount: number;
 }): TurnEndFlushContextResetPlan {
-  if (args.slotResetsContext && args.hasPriorContext && args.taskDeliverableCount > 0) {
+  if (
+    args.slotResetsContext &&
+    args.hasPriorContext &&
+    !args.hasActiveDeliveryJob &&
+    args.taskDeliverableCount > 0
+  ) {
     return { action: 'clear_then_flush' };
   }
   return { action: 'flush_without_clear' };

--- a/packages/daemon/src/lib/agent/context-reset-planner.ts
+++ b/packages/daemon/src/lib/agent/context-reset-planner.ts
@@ -3,13 +3,16 @@ export type InjectContextResetReason =
   | 'session_busy'
   | 'no_prior_context'
   | 'slot_not_reset'
-  | 'delivery_job_active';
+  | 'delivery_job_active'
+  | 'unconsumed_work_pending';
 
 export type InjectContextResetPlan =
   | { action: 'clear_before_deliver' }
   | { action: 'deliver_without_clear'; reason: InjectContextResetReason };
 
-export type TurnEndFlushContextResetPlan = { action: 'flush_without_clear' };
+export type TurnEndFlushContextResetPlan =
+  | { action: 'clear_then_flush' }
+  | { action: 'flush_without_clear' };
 
 export function planInjectContextReset(args: {
   inputKind: string;
@@ -17,6 +20,7 @@ export function planInjectContextReset(args: {
   hasPriorContext: boolean;
   slotResetsContext: boolean;
   hasActiveDeliveryJob: boolean;
+  hasUnconsumedDeliveredWork: boolean;
 }): InjectContextResetPlan {
   if (args.inputKind !== 'task') {
     return { action: 'deliver_without_clear', reason: 'not_task_input' };
@@ -33,12 +37,18 @@ export function planInjectContextReset(args: {
   if (args.hasActiveDeliveryJob) {
     return { action: 'deliver_without_clear', reason: 'delivery_job_active' };
   }
+  if (args.hasUnconsumedDeliveredWork) {
+    return { action: 'deliver_without_clear', reason: 'unconsumed_work_pending' };
+  }
   return { action: 'clear_before_deliver' };
 }
 
-export function planTurnEndFlushContextReset(_args: {
+export function planTurnEndFlushContextReset(args: {
   slotResetsContext: boolean;
   deliverableCount: number;
 }): TurnEndFlushContextResetPlan {
+  if (args.slotResetsContext && args.deliverableCount > 0) {
+    return { action: 'clear_then_flush' };
+  }
   return { action: 'flush_without_clear' };
 }

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -103,7 +103,7 @@ export class EventSubscriptionSetup {
     const unsubQueryTrigger = internalEventBus.subscribe(
       'query.trigger',
       async () => {
-        await queryModeHandler.handleQueryTrigger();
+        await queryModeHandler.replayPendingMessagesForImmediateMode();
       },
       { sessionId, subscriberName: 'EventSubscriptionSetup.queryTrigger' }
     );

--- a/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
+++ b/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
@@ -109,6 +109,7 @@ export interface TurnEndFlushCtx {
   activeTurnInJobQueue: boolean;
   slotResetsContext: boolean;
   hasPriorContext: boolean;
+  pendingTaskInput: boolean;
   flushPlan: FlushDeliveryPlan | null;
   contextReset: TurnEndFlushContextResetPlan | null;
   decision: TurnEndFlushPlan | null;
@@ -141,14 +142,15 @@ export function applyFlushContextResetGate(ctx: TurnEndFlushCtx): TurnEndFlushCt
         ? flushPlan.deliver
         : [];
   const deliverableSet = new Set(deliverables);
-  const taskDeliverableCount = ctx.messages.filter(
-    (message) => deliverableSet.has(message.uuid) && message.isTaskInput
-  ).length;
+  const taskDeliverableCount =
+    ctx.messages.filter((message) => deliverableSet.has(message.uuid) && message.isTaskInput)
+      .length + (ctx.pendingTaskInput ? 1 : 0);
   return {
     ...ctx,
     contextReset: planTurnEndFlushContextReset({
       slotResetsContext: ctx.slotResetsContext,
       hasPriorContext: ctx.hasPriorContext,
+      hasActiveDeliveryJob: ctx.activeInJobQueue.size > 0,
       taskDeliverableCount,
     }),
   };

--- a/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
+++ b/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
@@ -108,6 +108,7 @@ export interface TurnEndFlushCtx {
   pendingInMemoryUuids: ReadonlySet<string>;
   activeTurnInJobQueue: boolean;
   slotResetsContext: boolean;
+  hasPriorContext: boolean;
   flushPlan: FlushDeliveryPlan | null;
   contextReset: TurnEndFlushContextResetPlan | null;
   decision: TurnEndFlushPlan | null;
@@ -133,17 +134,22 @@ export function applyFlushOwnershipGate(ctx: TurnEndFlushCtx): TurnEndFlushCtx {
 
 export function applyFlushContextResetGate(ctx: TurnEndFlushCtx): TurnEndFlushCtx {
   const flushPlan: FlushDeliveryPlan = ctx.flushPlan ?? { action: 'noop' };
-  const deliverableCount =
+  const deliverables =
     flushPlan.action === 'batch'
-      ? flushPlan.uuids.length
+      ? flushPlan.uuids
       : flushPlan.action === 'each'
-        ? flushPlan.deliver.length
-        : 0;
+        ? flushPlan.deliver
+        : [];
+  const deliverableSet = new Set(deliverables);
+  const taskDeliverableCount = ctx.messages.filter(
+    (message) => deliverableSet.has(message.uuid) && message.isTaskInput
+  ).length;
   return {
     ...ctx,
     contextReset: planTurnEndFlushContextReset({
       slotResetsContext: ctx.slotResetsContext,
-      deliverableCount,
+      hasPriorContext: ctx.hasPriorContext,
+      taskDeliverableCount,
     }),
   };
 }

--- a/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
+++ b/packages/daemon/src/lib/agent/message-delivery-pipeline.ts
@@ -28,6 +28,7 @@ export interface InjectDeliveryCtx {
   hasPriorContext: boolean;
   slotResetsContext: boolean;
   hasActiveDeliveryJob: boolean;
+  hasUnconsumedDeliveredWork: boolean;
   reopenFailedDelivery: boolean;
   decision: InjectDeliveryDecision | null;
 }
@@ -66,6 +67,7 @@ export function applyInjectContextResetGate(ctx: InjectDeliveryCtx): InjectDeliv
       hasPriorContext: ctx.hasPriorContext,
       slotResetsContext: ctx.slotResetsContext,
       hasActiveDeliveryJob: ctx.hasActiveDeliveryJob,
+      hasUnconsumedDeliveredWork: ctx.hasUnconsumedDeliveredWork,
     })
   );
 }

--- a/packages/daemon/src/lib/agent/message-delivery.ts
+++ b/packages/daemon/src/lib/agent/message-delivery.ts
@@ -414,6 +414,30 @@ export async function awaitDeliveryConsumption(args: {
 
 const sessionLocks = new Map<string, Promise<unknown>>();
 
+export const sessionResetCoordinationLocks = new Map<string, Promise<unknown>>();
+
+export async function withSessionResetCoordination<T>(
+  sessionId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = sessionResetCoordinationLocks.get(sessionId) ?? Promise.resolve();
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = prev.then(() => held);
+  sessionResetCoordinationLocks.set(sessionId, tail);
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (sessionResetCoordinationLocks.get(sessionId) === tail) {
+      sessionResetCoordinationLocks.delete(sessionId);
+    }
+  }
+}
+
 export function throwIfDeliveryAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw signal.reason ?? new DOMException('Aborted', 'AbortError');
 }

--- a/packages/daemon/src/lib/agent/message-ownership-gates.ts
+++ b/packages/daemon/src/lib/agent/message-ownership-gates.ts
@@ -18,6 +18,11 @@ export interface FlushMessage {
   flattenedText: string | null;
 }
 
+export function isTaskFlushInput(message: { isSynthetic?: boolean; inputKind?: string }): boolean {
+  if (message.inputKind !== undefined) return message.inputKind === 'task';
+  return message.isSynthetic === true;
+}
+
 export type FlushSkipOwnership = 'job_queue' | 'memory_queue' | 'not_user_message';
 
 export interface FlushSkipEntry {

--- a/packages/daemon/src/lib/agent/message-ownership-gates.ts
+++ b/packages/daemon/src/lib/agent/message-ownership-gates.ts
@@ -14,6 +14,7 @@ export function resolveMessageOwnership(args: {
 export interface FlushMessage {
   uuid: string;
   isUserMessage: boolean;
+  isTaskInput: boolean;
   flattenedText: string | null;
 }
 

--- a/packages/daemon/src/lib/agent/message-ownership-gates.ts
+++ b/packages/daemon/src/lib/agent/message-ownership-gates.ts
@@ -13,6 +13,7 @@ export function resolveMessageOwnership(args: {
 
 export interface FlushMessage {
   uuid: string;
+  dbId: string;
   isUserMessage: boolean;
   isTaskInput: boolean;
   flattenedText: string | null;

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -11,6 +11,7 @@ import {
   flattenDeliveryText,
   isMessageDeliveryV2Enabled,
   type MessageDeliveryOrigin,
+  withSessionResetCoordination,
 } from './message-delivery';
 import { decideTurnEndFlush, type TurnEndFlushPlan } from './message-delivery-pipeline';
 import type { FlushMessage } from './message-ownership-gates';
@@ -38,6 +39,8 @@ export class QueryModeHandler {
   async handleQueryTrigger(options?: {
     deliverIndividually?: boolean;
     excludeMessageUuid?: string;
+    skipContextReset?: boolean;
+    skipResetCoordination?: boolean;
   }): Promise<{
     success: boolean;
     messageCount: number;
@@ -45,14 +48,14 @@ export class QueryModeHandler {
   }> {
     const { session, db, internalEventBus, messageQueue, logger } = this.ctx;
 
-    try {
+    const runFlush = async (): Promise<number> => {
       const { messages: allDeferred } = db.getUserMessagesByStatus(session.id, 'deferred');
       const deferredMessages = options?.excludeMessageUuid
         ? allDeferred.filter((m) => m.uuid !== options.excludeMessageUuid)
         : allDeferred;
 
       if (deferredMessages.length === 0) {
-        return { success: true, messageCount: 0 };
+        return 0;
       }
 
       const dbIds = deferredMessages.map((m) => m.dbId);
@@ -79,7 +82,7 @@ export class QueryModeHandler {
       });
 
       if (!isMessageDeliveryV2Enabled()) {
-        await this.clearContextAheadOfFlush(flushMessages);
+        await this.clearContextAheadOfFlush(flushMessages, options);
         const v2Owned =
           db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
         await this.ctx.ensureQueryStarted();
@@ -93,7 +96,14 @@ export class QueryModeHandler {
         }
       }
 
-      return { success: true, messageCount: deferredMessages.length };
+      return deferredMessages.length;
+    };
+
+    try {
+      const messageCount = options?.skipResetCoordination
+        ? await runFlush()
+        : await withSessionResetCoordination(session.id, runFlush);
+      return { success: true, messageCount };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Failed to trigger query:', error);
@@ -111,6 +121,7 @@ export class QueryModeHandler {
         return {
           uuid: msg.uuid as string,
           isUserMessage,
+          isTaskInput: (msg as { isSynthetic?: boolean }).isSynthetic === true,
           flattenedText: isUserMessage ? flattenDeliveryText(msg.message.content ?? '') : null,
         };
       });
@@ -124,10 +135,15 @@ export class QueryModeHandler {
       pendingInMemoryUuids: new Set<string>(),
       activeTurnInJobQueue: jobQueue.hasActiveTurnDeliveryJob(this.ctx.session.id),
       slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
+      hasPriorContext: !!this.ctx.session.sdkSessionId,
     });
   }
 
-  private async clearContextAheadOfFlush(flushMessages: FlushMessage[]): Promise<void> {
+  private async clearContextAheadOfFlush(
+    flushMessages: FlushMessage[],
+    options?: { skipContextReset?: boolean }
+  ): Promise<void> {
+    if (options?.skipContextReset) return;
     if (!this.ctx.clearConversationContext) return;
     const plan = this.planFlush(flushMessages);
     if (plan.action === 'noop') return;
@@ -146,13 +162,13 @@ export class QueryModeHandler {
   private async deliverFlushUnderV2(
     flushMessages: FlushMessage[],
     origin: MessageDeliveryOrigin,
-    options?: { deliverIndividually?: boolean }
+    options?: { deliverIndividually?: boolean; skipContextReset?: boolean }
   ): Promise<void> {
     const jobQueue = this.ctx.db.getJobQueueRepo();
     const plan = this.planFlush(flushMessages);
     if (plan.action === 'noop') return;
     if (plan.contextReset.action === 'clear_then_flush') {
-      await this.clearContextAheadOfFlush(flushMessages);
+      await this.clearContextAheadOfFlush(flushMessages, options);
     }
     const deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.action === 'batch' && !options?.deliverIndividually) {
@@ -176,10 +192,11 @@ export class QueryModeHandler {
     }
   }
 
-  async sendEnqueuedMessagesOnTurnEnd(): Promise<void> {
+  async sendEnqueuedMessagesOnTurnEnd(): Promise<boolean> {
     const { session, db, messageQueue, logger } = this.ctx;
+    let replayedWork = false;
 
-    try {
+    const runReplay = async (): Promise<void> => {
       const { messages: queuedMessages } = db.getUserMessagesByStatus(session.id, 'enqueued');
       const pendingMessages = queuedMessages.filter(
         (msg) => typeof msg.uuid === 'string' && !messageQueue.hasPendingOrInFlight(msg.uuid)
@@ -188,6 +205,7 @@ export class QueryModeHandler {
       if (pendingMessages.length === 0) {
         return;
       }
+      replayedWork = true;
 
       if (isMessageDeliveryV2Enabled()) {
         await this.deliverFlushUnderV2(this.toFlushMessages(pendingMessages), 'recovery');
@@ -204,14 +222,19 @@ export class QueryModeHandler {
           }
         }
       }
+    };
+
+    try {
+      await withSessionResetCoordination(session.id, runReplay);
     } catch (error) {
       logger.error('Failed to send enqueued messages on turn end:', error);
     }
+    return replayedWork;
   }
 
   async replayPendingMessagesForImmediateMode(): Promise<void> {
-    await this.sendEnqueuedMessagesOnTurnEnd();
-    await this.handleQueryTrigger();
+    const replayedWork = await this.sendEnqueuedMessagesOnTurnEnd();
+    await this.handleQueryTrigger({ skipContextReset: replayedWork });
   }
 
   private toReplayContent(

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -63,24 +63,29 @@ export class QueryModeHandler {
       db.updateMessageStatus(dbIds, 'enqueued');
       const flushMessages = this.toFlushMessages(deferredMessages);
 
+      let reDeferredDbIds: string[] = [];
       if (isMessageDeliveryV2Enabled()) {
         try {
-          await this.deliverFlushUnderV2(flushMessages, 'recovery', options);
+          const v2 = await this.deliverFlushUnderV2(flushMessages, 'recovery', options);
+          reDeferredDbIds = v2.reDeferredDbIds;
         } catch (error) {
           await internalEventBus.publish('messages.statusChanged', {
             sessionId: session.id,
-            messageIds: dbIds,
+            messageIds: dbIds.filter((id) => !reDeferredDbIds.includes(id)),
             status: 'enqueued',
           });
           throw error;
         }
       }
 
-      await internalEventBus.publish('messages.statusChanged', {
-        sessionId: session.id,
-        messageIds: dbIds,
-        status: 'enqueued',
-      });
+      const admittedDbIds = dbIds.filter((id) => !reDeferredDbIds.includes(id));
+      if (admittedDbIds.length > 0) {
+        await internalEventBus.publish('messages.statusChanged', {
+          sessionId: session.id,
+          messageIds: admittedDbIds,
+          status: 'enqueued',
+        });
+      }
 
       if (!isMessageDeliveryV2Enabled()) {
         await this.deliverRowsViaMemoryQueue(deferredMessages, flushMessages, options);
@@ -238,17 +243,18 @@ export class QueryModeHandler {
   private async deferTaskDeliverables(
     flushMessages: FlushMessage[],
     deliverables: ReadonlySet<string>
-  ): Promise<void> {
+  ): Promise<string[]> {
     const dbIds = flushMessages
       .filter((message) => message.isTaskInput && deliverables.has(message.uuid))
       .map((message) => message.dbId);
-    if (dbIds.length === 0) return;
+    if (dbIds.length === 0) return [];
     this.ctx.db.updateMessageStatus(dbIds, 'deferred');
     await this.ctx.internalEventBus.publish('messages.statusChanged', {
       sessionId: this.ctx.session.id,
       messageIds: dbIds,
       status: 'deferred',
     });
+    return dbIds;
   }
 
   private async deliverFlushUnderV2(
@@ -259,22 +265,23 @@ export class QueryModeHandler {
       skipContextReset?: boolean;
       pendingTaskInput?: boolean;
     }
-  ): Promise<boolean> {
+  ): Promise<{ clearedContext: boolean; reDeferredDbIds: string[] }> {
     const jobQueue = this.ctx.db.getJobQueueRepo();
     const plan = this.planFlush(flushMessages, options);
-    if (plan.action === 'noop') return false;
+    if (plan.action === 'noop') return { clearedContext: false, reDeferredDbIds: [] };
     let clearedContext = false;
+    let reDeferredDbIds: string[] = [];
     let deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.contextReset.action === 'clear_then_flush') {
       clearedContext = await this.clearContextAheadOfFlush(flushMessages, options);
     } else if (plan.contextReset.reason === 'active_delivery_job') {
       const deliverableSet = new Set(deliverables);
-      await this.deferTaskDeliverables(flushMessages, deliverableSet);
+      reDeferredDbIds = await this.deferTaskDeliverables(flushMessages, deliverableSet);
       deliverables = deliverables.filter((uuid) => {
         const message = flushMessages.find((entry) => entry.uuid === uuid);
         return message !== undefined && !message.isTaskInput;
       });
-      if (deliverables.length === 0) return clearedContext;
+      if (deliverables.length === 0) return { clearedContext, reDeferredDbIds };
     }
     if (plan.action === 'batch' && !options?.deliverIndividually) {
       const batched = await deliverBatchAndMarkQueued({
@@ -284,7 +291,7 @@ export class QueryModeHandler {
         messageUuids: deliverables,
         origin,
       });
-      if (batched) return clearedContext;
+      if (batched) return { clearedContext, reDeferredDbIds };
     }
     for (const uuid of deliverables) {
       await deliverAndMarkQueued({
@@ -295,7 +302,7 @@ export class QueryModeHandler {
         origin,
       });
     }
-    return clearedContext;
+    return { clearedContext, reDeferredDbIds };
   }
 
   async sendEnqueuedMessagesOnTurnEnd(options?: {
@@ -323,11 +330,12 @@ export class QueryModeHandler {
       replayedWork = true;
 
       if (isMessageDeliveryV2Enabled()) {
-        clearedContext = await this.deliverFlushUnderV2(
+        const v2 = await this.deliverFlushUnderV2(
           this.toFlushMessages(pendingMessages),
           'recovery',
           { pendingTaskInput: options?.pendingTaskInput }
         );
+        clearedContext = v2.clearedContext;
       } else {
         clearedContext = await this.deliverRowsViaMemoryQueue(
           pendingMessages,
@@ -357,10 +365,35 @@ export class QueryModeHandler {
     if (!clearedContext) {
       const jobQueue = this.ctx.db.getJobQueueRepo?.();
       if (jobQueue?.activeDeliveryMessageUuids?.(this.ctx.session.id).size) {
+        this.schedulePostSettlementFlush();
         return;
       }
     }
     await this.handleQueryTrigger({ skipContextReset: clearedContext });
+  }
+
+  private postSettlementFlushScheduled = false;
+
+  private schedulePostSettlementFlush(): void {
+    if (this.postSettlementFlushScheduled) return;
+    this.postSettlementFlushScheduled = true;
+    void (async () => {
+      try {
+        const jobQueue = this.ctx.db.getJobQueueRepo?.();
+        for (let i = 0; i < 240; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          if (!jobQueue?.activeDeliveryMessageUuids?.(this.ctx.session.id).size) break;
+        }
+        await this.handleQueryTrigger();
+      } catch (error) {
+        this.ctx.logger.warn(
+          `post-settlement deferred flush failed for session ${this.ctx.session.id}:`,
+          error
+        );
+      } finally {
+        this.postSettlementFlushScheduled = false;
+      }
+    })();
   }
 
   private toReplayContent(

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -274,10 +274,12 @@ export class QueryModeHandler {
   }): Promise<{
     replayedWork: boolean;
     clearedContext: boolean;
+    replayFailed: boolean;
   }> {
     const { session, db, messageQueue, logger } = this.ctx;
     let replayedWork = false;
     let clearedContext = false;
+    let replayFailed = false;
 
     const runReplay = async (): Promise<void> => {
       const { messages: queuedMessages } = db.getUserMessagesByStatus(session.id, 'enqueued');
@@ -313,9 +315,10 @@ export class QueryModeHandler {
       }
     } catch (error) {
       if (error instanceof ClearConversationCancelledError) throw error;
+      replayFailed = true;
       logger.error('Failed to send enqueued messages on turn end:', error);
     }
-    return { replayedWork, clearedContext };
+    return { replayedWork, clearedContext, replayFailed };
   }
 
   async replayPendingMessagesForImmediateMode(): Promise<void> {

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -4,6 +4,7 @@ import { isSDKUserMessage } from '@hyperneo/shared/sdk/type-guards';
 import type { Database } from '../../storage/database';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import type { Logger } from '../logger';
+import { ClearConversationCancelledError } from './agent-session';
 import {
   deliverAndMarkQueued,
   deliverBatchAndMarkQueued,
@@ -131,7 +132,15 @@ export class QueryModeHandler {
     const plan = this.planFlush(flushMessages);
     if (plan.action === 'noop') return;
     if (plan.contextReset.action !== 'clear_then_flush') return;
-    await this.ctx.clearConversationContext();
+    try {
+      await this.ctx.clearConversationContext();
+    } catch (error) {
+      if (error instanceof ClearConversationCancelledError) throw error;
+      this.ctx.logger.warn(
+        `turn-end flush clear failed for session ${this.ctx.session.id}: ` +
+          `${error instanceof Error ? error.message : String(error)} — flushing without clear`
+      );
+    }
   }
 
   private async deliverFlushUnderV2(

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -127,7 +127,7 @@ export class QueryModeHandler {
       const replayContent = this.toReplayContent(msg.message.content);
       if (!replayContent) continue;
       if (!clearAttempted && taskUuids.has(msg.uuid)) {
-        if (this.ctx.messageQueue.isRunning()) {
+        if (this.ctx.messageQueue.size() > 0) {
           await this.deferRemainingRows(messages, v2Owned, msg.uuid);
           return clearedContext;
         }
@@ -135,10 +135,12 @@ export class QueryModeHandler {
       }
       await this.ctx.messageQueue.enqueueWithId(msg.uuid, replayContent);
     }
-    if (!clearAttempted && options?.pendingTaskInput === true) {
-      if (!this.ctx.messageQueue.isRunning()) {
-        await clearAheadOfTask();
-      }
+    if (
+      !clearAttempted &&
+      options?.pendingTaskInput === true &&
+      this.ctx.messageQueue.size() === 0
+    ) {
+      await clearAheadOfTask();
     }
     return clearedContext;
   }
@@ -260,7 +262,10 @@ export class QueryModeHandler {
     return clearedContext;
   }
 
-  async sendEnqueuedMessagesOnTurnEnd(): Promise<{
+  async sendEnqueuedMessagesOnTurnEnd(options?: {
+    pendingTaskInput?: boolean;
+    skipResetCoordination?: boolean;
+  }): Promise<{
     replayedWork: boolean;
     clearedContext: boolean;
   }> {
@@ -282,18 +287,24 @@ export class QueryModeHandler {
       if (isMessageDeliveryV2Enabled()) {
         clearedContext = await this.deliverFlushUnderV2(
           this.toFlushMessages(pendingMessages),
-          'recovery'
+          'recovery',
+          { pendingTaskInput: options?.pendingTaskInput }
         );
       } else {
         clearedContext = await this.deliverRowsViaMemoryQueue(
           pendingMessages,
-          this.toFlushMessages(pendingMessages)
+          this.toFlushMessages(pendingMessages),
+          { pendingTaskInput: options?.pendingTaskInput }
         );
       }
     };
 
     try {
-      await withSessionResetCoordination(session.id, runReplay);
+      if (options?.skipResetCoordination) {
+        await runReplay();
+      } else {
+        await withSessionResetCoordination(session.id, runReplay);
+      }
     } catch (error) {
       if (error instanceof ClearConversationCancelledError) throw error;
       logger.error('Failed to send enqueued messages on turn end:', error);

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -105,6 +105,7 @@ export class QueryModeHandler {
         : await withSessionResetCoordination(session.id, runFlush);
       return { success: true, messageCount };
     } catch (error) {
+      if (error instanceof ClearConversationCancelledError) throw error;
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Failed to trigger query:', error);
       return { success: false, messageCount: 0, error: errorMessage };
@@ -142,12 +143,12 @@ export class QueryModeHandler {
   private async clearContextAheadOfFlush(
     flushMessages: FlushMessage[],
     options?: { skipContextReset?: boolean }
-  ): Promise<void> {
-    if (options?.skipContextReset) return;
-    if (!this.ctx.clearConversationContext) return;
+  ): Promise<boolean> {
+    if (options?.skipContextReset) return false;
+    if (!this.ctx.clearConversationContext) return false;
     const plan = this.planFlush(flushMessages);
-    if (plan.action === 'noop') return;
-    if (plan.contextReset.action !== 'clear_then_flush') return;
+    if (plan.action === 'noop') return false;
+    if (plan.contextReset.action !== 'clear_then_flush') return false;
     try {
       await this.ctx.clearConversationContext();
     } catch (error) {
@@ -156,19 +157,22 @@ export class QueryModeHandler {
         `turn-end flush clear failed for session ${this.ctx.session.id}: ` +
           `${error instanceof Error ? error.message : String(error)} — flushing without clear`
       );
+      return false;
     }
+    return true;
   }
 
   private async deliverFlushUnderV2(
     flushMessages: FlushMessage[],
     origin: MessageDeliveryOrigin,
     options?: { deliverIndividually?: boolean; skipContextReset?: boolean }
-  ): Promise<void> {
+  ): Promise<boolean> {
     const jobQueue = this.ctx.db.getJobQueueRepo();
     const plan = this.planFlush(flushMessages);
-    if (plan.action === 'noop') return;
+    if (plan.action === 'noop') return false;
+    let clearedContext = false;
     if (plan.contextReset.action === 'clear_then_flush') {
-      await this.clearContextAheadOfFlush(flushMessages, options);
+      clearedContext = await this.clearContextAheadOfFlush(flushMessages, options);
     }
     const deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.action === 'batch' && !options?.deliverIndividually) {
@@ -179,7 +183,7 @@ export class QueryModeHandler {
         messageUuids: deliverables,
         origin,
       });
-      if (batched) return;
+      if (batched) return clearedContext;
     }
     for (const uuid of deliverables) {
       await deliverAndMarkQueued({
@@ -190,11 +194,16 @@ export class QueryModeHandler {
         origin,
       });
     }
+    return clearedContext;
   }
 
-  async sendEnqueuedMessagesOnTurnEnd(): Promise<boolean> {
+  async sendEnqueuedMessagesOnTurnEnd(): Promise<{
+    replayedWork: boolean;
+    clearedContext: boolean;
+  }> {
     const { session, db, messageQueue, logger } = this.ctx;
     let replayedWork = false;
+    let clearedContext = false;
 
     const runReplay = async (): Promise<void> => {
       const { messages: queuedMessages } = db.getUserMessagesByStatus(session.id, 'enqueued');
@@ -208,9 +217,12 @@ export class QueryModeHandler {
       replayedWork = true;
 
       if (isMessageDeliveryV2Enabled()) {
-        await this.deliverFlushUnderV2(this.toFlushMessages(pendingMessages), 'recovery');
+        clearedContext = await this.deliverFlushUnderV2(
+          this.toFlushMessages(pendingMessages),
+          'recovery'
+        );
       } else {
-        await this.clearContextAheadOfFlush(this.toFlushMessages(pendingMessages));
+        clearedContext = await this.clearContextAheadOfFlush(this.toFlushMessages(pendingMessages));
         const v2Owned =
           db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
         await this.ctx.ensureQueryStarted();
@@ -227,14 +239,15 @@ export class QueryModeHandler {
     try {
       await withSessionResetCoordination(session.id, runReplay);
     } catch (error) {
+      if (error instanceof ClearConversationCancelledError) throw error;
       logger.error('Failed to send enqueued messages on turn end:', error);
     }
-    return replayedWork;
+    return { replayedWork, clearedContext };
   }
 
   async replayPendingMessagesForImmediateMode(): Promise<void> {
-    const replayedWork = await this.sendEnqueuedMessagesOnTurnEnd();
-    await this.handleQueryTrigger({ skipContextReset: replayedWork });
+    const { clearedContext } = await this.sendEnqueuedMessagesOnTurnEnd();
+    await this.handleQueryTrigger({ skipContextReset: clearedContext });
   }
 
   private toReplayContent(

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -120,6 +120,11 @@ export class QueryModeHandler {
     const taskUuids = new Set(
       flushMessages.filter((message) => message.isTaskInput).map((message) => message.uuid)
     );
+    const plan = this.planFlush(flushMessages, options);
+    const deferForActiveJob =
+      plan.action !== 'noop' &&
+      plan.contextReset.action === 'flush_without_clear' &&
+      plan.contextReset.reason === 'active_delivery_job';
     await this.ctx.ensureQueryStarted();
     let clearAttempted = false;
     let clearedContext = false;
@@ -133,7 +138,7 @@ export class QueryModeHandler {
       const replayContent = this.toReplayContent(msg.message.content);
       if (!replayContent) continue;
       if (!clearAttempted && taskUuids.has(msg.uuid)) {
-        if (this.flushClearBlockedByLiveWork()) {
+        if (this.flushClearBlockedByLiveWork() || deferForActiveJob) {
           await this.deferRemainingRows(messages, v2Owned, msg.uuid);
           return clearedContext;
         }
@@ -183,6 +188,7 @@ export class QueryModeHandler {
         const isUserMessage = isSDKUserMessage(msg);
         return {
           uuid: msg.uuid as string,
+          dbId: msg.dbId,
           isUserMessage,
           isTaskInput: isTaskFlushInput(msg as { isSynthetic?: boolean; inputKind?: string }),
           flattenedText: isUserMessage ? flattenDeliveryText(msg.message.content ?? '') : null,
@@ -198,9 +204,9 @@ export class QueryModeHandler {
     return decideTurnEndFlush({
       messages: flushMessages,
       activeInJobQueue:
-        jobQueue?.activeDeliveryMessageUuids(this.ctx.session.id) ?? new Set<string>(),
+        jobQueue?.activeDeliveryMessageUuids?.(this.ctx.session.id) ?? new Set<string>(),
       pendingInMemoryUuids: new Set<string>(),
-      activeTurnInJobQueue: jobQueue?.hasActiveTurnDeliveryJob(this.ctx.session.id) ?? false,
+      activeTurnInJobQueue: jobQueue?.hasActiveTurnDeliveryJob?.(this.ctx.session.id) ?? false,
       slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
       hasPriorContext: !!this.ctx.session.sdkSessionId,
       pendingTaskInput: options?.pendingTaskInput === true,
@@ -229,6 +235,22 @@ export class QueryModeHandler {
     return true;
   }
 
+  private async deferTaskDeliverables(
+    flushMessages: FlushMessage[],
+    deliverables: ReadonlySet<string>
+  ): Promise<void> {
+    const dbIds = flushMessages
+      .filter((message) => message.isTaskInput && deliverables.has(message.uuid))
+      .map((message) => message.dbId);
+    if (dbIds.length === 0) return;
+    this.ctx.db.updateMessageStatus(dbIds, 'deferred');
+    await this.ctx.internalEventBus.publish('messages.statusChanged', {
+      sessionId: this.ctx.session.id,
+      messageIds: dbIds,
+      status: 'deferred',
+    });
+  }
+
   private async deliverFlushUnderV2(
     flushMessages: FlushMessage[],
     origin: MessageDeliveryOrigin,
@@ -242,10 +264,18 @@ export class QueryModeHandler {
     const plan = this.planFlush(flushMessages, options);
     if (plan.action === 'noop') return false;
     let clearedContext = false;
+    let deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.contextReset.action === 'clear_then_flush') {
       clearedContext = await this.clearContextAheadOfFlush(flushMessages, options);
+    } else if (plan.contextReset.reason === 'active_delivery_job') {
+      const deliverableSet = new Set(deliverables);
+      await this.deferTaskDeliverables(flushMessages, deliverableSet);
+      deliverables = deliverables.filter((uuid) => {
+        const message = flushMessages.find((entry) => entry.uuid === uuid);
+        return message !== undefined && !message.isTaskInput;
+      });
+      if (deliverables.length === 0) return clearedContext;
     }
-    const deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.action === 'batch' && !options?.deliverIndividually) {
       const batched = await deliverBatchAndMarkQueued({
         jobQueue,
@@ -325,7 +355,7 @@ export class QueryModeHandler {
     const { clearedContext } = await this.sendEnqueuedMessagesOnTurnEnd();
     if (!clearedContext) {
       const jobQueue = this.ctx.db.getJobQueueRepo?.();
-      if (jobQueue?.activeDeliveryMessageUuids(this.ctx.session.id).size) {
+      if (jobQueue?.activeDeliveryMessageUuids?.(this.ctx.session.id).size) {
         return;
       }
     }

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -1,5 +1,5 @@
 import type { MessageContent, Session } from '@hyperneo/shared';
-import type { SDKMessage } from '@hyperneo/shared/sdk';
+import type { SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
 import { isSDKUserMessage } from '@hyperneo/shared/sdk/type-guards';
 import type { Database } from '../../storage/database';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
@@ -47,7 +47,7 @@ export class QueryModeHandler {
     messageCount: number;
     error?: string;
   }> {
-    const { session, db, internalEventBus, messageQueue, logger } = this.ctx;
+    const { session, db, internalEventBus, logger } = this.ctx;
 
     const runFlush = async (): Promise<number> => {
       const { messages: allDeferred } = db.getUserMessagesByStatus(session.id, 'deferred');
@@ -83,18 +83,7 @@ export class QueryModeHandler {
       });
 
       if (!isMessageDeliveryV2Enabled()) {
-        await this.clearContextAheadOfFlush(flushMessages, options);
-        const v2Owned =
-          db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
-        await this.ctx.ensureQueryStarted();
-        for (const msg of deferredMessages) {
-          if (typeof msg.uuid !== 'string' || msg.uuid.length === 0) continue;
-          if (v2Owned.has(msg.uuid)) continue;
-          const replayContent = this.toReplayContent(msg.message.content);
-          if (replayContent) {
-            await messageQueue.enqueueWithId(msg.uuid, replayContent);
-          }
-        }
+        await this.deliverRowsViaMemoryQueue(deferredMessages, flushMessages, options);
       }
 
       return deferredMessages.length;
@@ -111,6 +100,41 @@ export class QueryModeHandler {
       logger.error('Failed to trigger query:', error);
       return { success: false, messageCount: 0, error: errorMessage };
     }
+  }
+
+  private async deliverRowsViaMemoryQueue(
+    messages: Array<SDKUserMessage & { dbId: string; timestamp: number }>,
+    flushMessages: FlushMessage[],
+    options?: { skipContextReset?: boolean; pendingTaskInput?: boolean }
+  ): Promise<boolean> {
+    const session = this.ctx.session;
+    const v2Owned =
+      this.ctx.db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ??
+      new Set<string>();
+    const taskUuids = new Set(
+      flushMessages.filter((message) => message.isTaskInput).map((message) => message.uuid)
+    );
+    await this.ctx.ensureQueryStarted();
+    let clearAttempted = false;
+    let clearedContext = false;
+    const clearAheadOfTask = async (): Promise<void> => {
+      clearAttempted = true;
+      clearedContext = await this.clearContextAheadOfFlush(flushMessages, options);
+    };
+    for (const msg of messages) {
+      if (typeof msg.uuid !== 'string' || msg.uuid.length === 0) continue;
+      if (v2Owned.has(msg.uuid)) continue;
+      const replayContent = this.toReplayContent(msg.message.content);
+      if (!replayContent) continue;
+      if (!clearAttempted && taskUuids.has(msg.uuid)) {
+        await clearAheadOfTask();
+      }
+      await this.ctx.messageQueue.enqueueWithId(msg.uuid, replayContent);
+    }
+    if (!clearAttempted && options?.pendingTaskInput === true) {
+      await clearAheadOfTask();
+    }
+    return clearedContext;
   }
 
   private toFlushMessages(
@@ -232,17 +256,10 @@ export class QueryModeHandler {
           'recovery'
         );
       } else {
-        clearedContext = await this.clearContextAheadOfFlush(this.toFlushMessages(pendingMessages));
-        const v2Owned =
-          db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
-        await this.ctx.ensureQueryStarted();
-        for (const msg of pendingMessages) {
-          if (v2Owned.has((msg.uuid ?? '') as string)) continue;
-          const replayContent = this.toReplayContent(msg.message.content);
-          if (replayContent) {
-            await messageQueue.enqueueWithId(msg.uuid as string, replayContent);
-          }
-        }
+        clearedContext = await this.deliverRowsViaMemoryQueue(
+          pendingMessages,
+          this.toFlushMessages(pendingMessages)
+        );
       }
     };
 

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -41,6 +41,7 @@ export class QueryModeHandler {
     excludeMessageUuid?: string;
     skipContextReset?: boolean;
     skipResetCoordination?: boolean;
+    pendingTaskInput?: boolean;
   }): Promise<{
     success: boolean;
     messageCount: number;
@@ -128,25 +129,30 @@ export class QueryModeHandler {
       });
   }
 
-  private planFlush(flushMessages: FlushMessage[]): TurnEndFlushPlan {
+  private planFlush(
+    flushMessages: FlushMessage[],
+    options?: { pendingTaskInput?: boolean }
+  ): TurnEndFlushPlan {
     const jobQueue = this.ctx.db.getJobQueueRepo();
+    const activeInJobQueue = jobQueue.activeDeliveryMessageUuids(this.ctx.session.id);
     return decideTurnEndFlush({
       messages: flushMessages,
-      activeInJobQueue: jobQueue.activeDeliveryMessageUuids(this.ctx.session.id),
+      activeInJobQueue,
       pendingInMemoryUuids: new Set<string>(),
       activeTurnInJobQueue: jobQueue.hasActiveTurnDeliveryJob(this.ctx.session.id),
       slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
       hasPriorContext: !!this.ctx.session.sdkSessionId,
+      pendingTaskInput: options?.pendingTaskInput === true,
     });
   }
 
   private async clearContextAheadOfFlush(
     flushMessages: FlushMessage[],
-    options?: { skipContextReset?: boolean }
+    options?: { skipContextReset?: boolean; pendingTaskInput?: boolean }
   ): Promise<boolean> {
     if (options?.skipContextReset) return false;
     if (!this.ctx.clearConversationContext) return false;
-    const plan = this.planFlush(flushMessages);
+    const plan = this.planFlush(flushMessages, options);
     if (plan.action === 'noop') return false;
     if (plan.contextReset.action !== 'clear_then_flush') return false;
     try {
@@ -165,10 +171,14 @@ export class QueryModeHandler {
   private async deliverFlushUnderV2(
     flushMessages: FlushMessage[],
     origin: MessageDeliveryOrigin,
-    options?: { deliverIndividually?: boolean; skipContextReset?: boolean }
+    options?: {
+      deliverIndividually?: boolean;
+      skipContextReset?: boolean;
+      pendingTaskInput?: boolean;
+    }
   ): Promise<boolean> {
     const jobQueue = this.ctx.db.getJobQueueRepo();
-    const plan = this.planFlush(flushMessages);
+    const plan = this.planFlush(flushMessages, options);
     if (plan.action === 'noop') return false;
     let clearedContext = false;
     if (plan.contextReset.action === 'clear_then_flush') {

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -127,14 +127,43 @@ export class QueryModeHandler {
       const replayContent = this.toReplayContent(msg.message.content);
       if (!replayContent) continue;
       if (!clearAttempted && taskUuids.has(msg.uuid)) {
+        if (this.ctx.messageQueue.isRunning()) {
+          await this.deferRemainingRows(messages, v2Owned, msg.uuid);
+          return clearedContext;
+        }
         await clearAheadOfTask();
       }
       await this.ctx.messageQueue.enqueueWithId(msg.uuid, replayContent);
     }
     if (!clearAttempted && options?.pendingTaskInput === true) {
-      await clearAheadOfTask();
+      if (!this.ctx.messageQueue.isRunning()) {
+        await clearAheadOfTask();
+      }
     }
     return clearedContext;
+  }
+
+  private async deferRemainingRows(
+    messages: Array<SDKUserMessage & { dbId: string; timestamp: number }>,
+    v2Owned: ReadonlySet<string>,
+    fromUuid: string
+  ): Promise<void> {
+    const dbIds: string[] = [];
+    let delaying = false;
+    for (const msg of messages) {
+      if (!delaying && msg.uuid !== fromUuid) continue;
+      delaying = true;
+      if (typeof msg.uuid !== 'string' || msg.uuid.length === 0) continue;
+      if (v2Owned.has(msg.uuid)) continue;
+      dbIds.push(msg.dbId);
+    }
+    if (dbIds.length === 0) return;
+    this.ctx.db.updateMessageStatus(dbIds, 'deferred');
+    await this.ctx.internalEventBus.publish('messages.statusChanged', {
+      sessionId: this.ctx.session.id,
+      messageIds: dbIds,
+      status: 'deferred',
+    });
   }
 
   private toFlushMessages(
@@ -157,13 +186,13 @@ export class QueryModeHandler {
     flushMessages: FlushMessage[],
     options?: { pendingTaskInput?: boolean }
   ): TurnEndFlushPlan {
-    const jobQueue = this.ctx.db.getJobQueueRepo();
-    const activeInJobQueue = jobQueue.activeDeliveryMessageUuids(this.ctx.session.id);
+    const jobQueue = this.ctx.db.getJobQueueRepo?.();
     return decideTurnEndFlush({
       messages: flushMessages,
-      activeInJobQueue,
+      activeInJobQueue:
+        jobQueue?.activeDeliveryMessageUuids(this.ctx.session.id) ?? new Set<string>(),
       pendingInMemoryUuids: new Set<string>(),
-      activeTurnInJobQueue: jobQueue.hasActiveTurnDeliveryJob(this.ctx.session.id),
+      activeTurnInJobQueue: jobQueue?.hasActiveTurnDeliveryJob(this.ctx.session.id) ?? false,
       slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
       hasPriorContext: !!this.ctx.session.sdkSessionId,
       pendingTaskInput: options?.pendingTaskInput === true,
@@ -274,6 +303,12 @@ export class QueryModeHandler {
 
   async replayPendingMessagesForImmediateMode(): Promise<void> {
     const { clearedContext } = await this.sendEnqueuedMessagesOnTurnEnd();
+    if (!clearedContext) {
+      const jobQueue = this.ctx.db.getJobQueueRepo?.();
+      if (jobQueue?.activeDeliveryMessageUuids(this.ctx.session.id).size) {
+        return;
+      }
+    }
     await this.handleQueryTrigger({ skipContextReset: clearedContext });
   }
 

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -11,7 +11,8 @@ import {
   isMessageDeliveryV2Enabled,
   type MessageDeliveryOrigin,
 } from './message-delivery';
-import { decideTurnEndFlush } from './message-delivery-pipeline';
+import { decideTurnEndFlush, type TurnEndFlushPlan } from './message-delivery-pipeline';
+import type { FlushMessage } from './message-ownership-gates';
 import type { MessageQueue } from './message-queue';
 
 export interface QueryModeHandlerContext {
@@ -24,6 +25,8 @@ export interface QueryModeHandlerContext {
     setQueuedIfIdle(messageId: string): Promise<boolean>;
     getState(): { status: string };
   };
+  slotResetsContext?(): boolean;
+  clearConversationContext?(): Promise<void>;
 
   ensureQueryStarted(): Promise<void>;
 }
@@ -53,10 +56,11 @@ export class QueryModeHandler {
 
       const dbIds = deferredMessages.map((m) => m.dbId);
       db.updateMessageStatus(dbIds, 'enqueued');
+      const flushMessages = this.toFlushMessages(deferredMessages);
 
       if (isMessageDeliveryV2Enabled()) {
         try {
-          await this.deliverFlushUnderV2(deferredMessages, 'recovery', options);
+          await this.deliverFlushUnderV2(flushMessages, 'recovery', options);
         } catch (error) {
           await internalEventBus.publish('messages.statusChanged', {
             sessionId: session.id,
@@ -74,6 +78,7 @@ export class QueryModeHandler {
       });
 
       if (!isMessageDeliveryV2Enabled()) {
+        await this.clearContextAheadOfFlush(flushMessages);
         const v2Owned =
           db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
         await this.ctx.ensureQueryStarted();
@@ -95,13 +100,10 @@ export class QueryModeHandler {
     }
   }
 
-  private async deliverFlushUnderV2(
-    messages: Array<SDKMessage & { dbId: string; timestamp: number }>,
-    origin: MessageDeliveryOrigin,
-    options?: { deliverIndividually?: boolean }
-  ): Promise<void> {
-    const jobQueue = this.ctx.db.getJobQueueRepo();
-    const flushMessages = messages
+  private toFlushMessages(
+    messages: Array<SDKMessage & { dbId: string; timestamp: number }>
+  ): FlushMessage[] {
+    return messages
       .filter((msg) => typeof msg.uuid === 'string' && msg.uuid.length > 0)
       .map((msg) => {
         const isUserMessage = isSDKUserMessage(msg);
@@ -111,14 +113,38 @@ export class QueryModeHandler {
           flattenedText: isUserMessage ? flattenDeliveryText(msg.message.content ?? '') : null,
         };
       });
-    const plan = decideTurnEndFlush({
+  }
+
+  private planFlush(flushMessages: FlushMessage[]): TurnEndFlushPlan {
+    const jobQueue = this.ctx.db.getJobQueueRepo();
+    return decideTurnEndFlush({
       messages: flushMessages,
       activeInJobQueue: jobQueue.activeDeliveryMessageUuids(this.ctx.session.id),
       pendingInMemoryUuids: new Set<string>(),
       activeTurnInJobQueue: jobQueue.hasActiveTurnDeliveryJob(this.ctx.session.id),
-      slotResetsContext: false,
+      slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
     });
+  }
+
+  private async clearContextAheadOfFlush(flushMessages: FlushMessage[]): Promise<void> {
+    if (!this.ctx.clearConversationContext) return;
+    const plan = this.planFlush(flushMessages);
     if (plan.action === 'noop') return;
+    if (plan.contextReset.action !== 'clear_then_flush') return;
+    await this.ctx.clearConversationContext();
+  }
+
+  private async deliverFlushUnderV2(
+    flushMessages: FlushMessage[],
+    origin: MessageDeliveryOrigin,
+    options?: { deliverIndividually?: boolean }
+  ): Promise<void> {
+    const jobQueue = this.ctx.db.getJobQueueRepo();
+    const plan = this.planFlush(flushMessages);
+    if (plan.action === 'noop') return;
+    if (plan.contextReset.action === 'clear_then_flush') {
+      await this.clearContextAheadOfFlush(flushMessages);
+    }
     const deliverables = plan.action === 'batch' ? plan.uuids : plan.deliver;
     if (plan.action === 'batch' && !options?.deliverIndividually) {
       const batched = await deliverBatchAndMarkQueued({
@@ -155,8 +181,9 @@ export class QueryModeHandler {
       }
 
       if (isMessageDeliveryV2Enabled()) {
-        await this.deliverFlushUnderV2(pendingMessages, 'recovery');
+        await this.deliverFlushUnderV2(this.toFlushMessages(pendingMessages), 'recovery');
       } else {
+        await this.clearContextAheadOfFlush(this.toFlushMessages(pendingMessages));
         const v2Owned =
           db.getJobQueueRepo?.()?.activeDeliveryMessageUuids?.(session.id) ?? new Set<string>();
         await this.ctx.ensureQueryStarted();

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -208,7 +208,7 @@ export class QueryModeHandler {
       pendingInMemoryUuids: new Set<string>(),
       activeTurnInJobQueue: jobQueue?.hasActiveTurnDeliveryJob?.(this.ctx.session.id) ?? false,
       slotResetsContext: this.ctx.slotResetsContext?.() ?? false,
-      hasPriorContext: !!this.ctx.session.sdkSessionId,
+      hasPriorContext: !!(this.ctx.session.sdkSessionId || this.ctx.session.acpSessionId),
       pendingTaskInput: options?.pendingTaskInput === true,
     });
   }
@@ -352,7 +352,8 @@ export class QueryModeHandler {
   }
 
   async replayPendingMessagesForImmediateMode(): Promise<void> {
-    const { clearedContext } = await this.sendEnqueuedMessagesOnTurnEnd();
+    const { clearedContext, replayFailed } = await this.sendEnqueuedMessagesOnTurnEnd();
+    if (replayFailed) return;
     if (!clearedContext) {
       const jobQueue = this.ctx.db.getJobQueueRepo?.();
       if (jobQueue?.activeDeliveryMessageUuids?.(this.ctx.session.id).size) {

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -102,6 +102,12 @@ export class QueryModeHandler {
     }
   }
 
+  private flushClearBlockedByLiveWork(): boolean {
+    if (this.ctx.messageQueue.size() > 0) return true;
+    const status = this.ctx.stateManager?.getState().status;
+    return status !== undefined && status !== 'idle';
+  }
+
   private async deliverRowsViaMemoryQueue(
     messages: Array<SDKUserMessage & { dbId: string; timestamp: number }>,
     flushMessages: FlushMessage[],
@@ -127,7 +133,7 @@ export class QueryModeHandler {
       const replayContent = this.toReplayContent(msg.message.content);
       if (!replayContent) continue;
       if (!clearAttempted && taskUuids.has(msg.uuid)) {
-        if (this.ctx.messageQueue.size() > 0) {
+        if (this.flushClearBlockedByLiveWork()) {
           await this.deferRemainingRows(messages, v2Owned, msg.uuid);
           return clearedContext;
         }
@@ -138,7 +144,7 @@ export class QueryModeHandler {
     if (
       !clearAttempted &&
       options?.pendingTaskInput === true &&
-      this.ctx.messageQueue.size() === 0
+      !this.flushClearBlockedByLiveWork()
     ) {
       await clearAheadOfTask();
     }

--- a/packages/daemon/src/lib/agent/query-mode-handler.ts
+++ b/packages/daemon/src/lib/agent/query-mode-handler.ts
@@ -14,7 +14,7 @@ import {
   withSessionResetCoordination,
 } from './message-delivery';
 import { decideTurnEndFlush, type TurnEndFlushPlan } from './message-delivery-pipeline';
-import type { FlushMessage } from './message-ownership-gates';
+import { type FlushMessage, isTaskFlushInput } from './message-ownership-gates';
 import type { MessageQueue } from './message-queue';
 
 export interface QueryModeHandlerContext {
@@ -121,7 +121,7 @@ export class QueryModeHandler {
         return {
           uuid: msg.uuid as string,
           isUserMessage,
-          isTaskInput: (msg as { isSynthetic?: boolean }).isSynthetic === true,
+          isTaskInput: isTaskFlushInput(msg as { isSynthetic?: boolean; inputKind?: string }),
           flattenedText: isUserMessage ? flattenDeliveryText(msg.message.content ?? '') : null,
         };
       });

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -839,16 +839,18 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
           : {}),
       });
     } else {
-      await session.ensureQueryStarted();
-      const dbId = deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
-      await deps.internalEventBus
-        .publish('messages.statusChanged', {
-          sessionId,
-          messageIds: [dbId],
-          status: 'enqueued',
-        })
-        .catch(() => {});
-      await session.messageQueue.enqueueWithId(messageId, message);
+      await withSessionResetCoordination(sessionId, async () => {
+        await session.ensureQueryStarted();
+        const dbId = deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+        await deps.internalEventBus
+          .publish('messages.statusChanged', {
+            sessionId,
+            messageIds: [dbId],
+            status: 'enqueued',
+          })
+          .catch(() => {});
+        await session.messageQueue.enqueueWithId(messageId, message);
+      });
     }
   };
 

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -86,6 +86,7 @@ import {
   deliverAndMarkQueued,
   deliveryConsumptionTimeoutMs,
   isMessageDeliveryV2Enabled,
+  withSessionResetCoordination,
 } from '../agent/message-delivery';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
@@ -799,25 +800,27 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         messageUuid: messageId,
         timeoutMs: deliveryConsumptionTimeoutMs(session.getSessionData?.().config?.provider),
         deliver: () =>
-          deliverAndMarkQueued({
-            jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
-            stateManager: session.stateManager,
-            sessionId,
-            messageUuid: messageId,
-            origin: 'space_agent',
-            onEnqueueFailure: () => {
-              const failedDbId = sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId);
-              if (failedDbId) {
-                void deps.internalEventBus
-                  .publish('messages.statusChanged', {
-                    sessionId,
-                    messageIds: [failedDbId],
-                    status: 'failed',
-                  })
-                  .catch(() => {});
-              }
-            },
-          }),
+          withSessionResetCoordination(sessionId, async () =>
+            deliverAndMarkQueued({
+              jobQueue: deps.reactiveDb.db.getJobQueueRepo(),
+              stateManager: session.stateManager,
+              sessionId,
+              messageUuid: messageId,
+              origin: 'space_agent',
+              onEnqueueFailure: () => {
+                const failedDbId = sdkMessageRepo.markDeliveryFailedByUuid(sessionId, messageId);
+                if (failedDbId) {
+                  void deps.internalEventBus
+                    .publish('messages.statusChanged', {
+                      sessionId,
+                      messageIds: [failedDbId],
+                      status: 'failed',
+                    })
+                    .catch(() => {});
+                }
+              },
+            })
+          ),
         ...(fresh
           ? {
               terminalizeOnTimeout: () => {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -995,7 +995,7 @@ export function setupSessionHandlers(
       throw new Error('Session not found');
     }
 
-    await agentSession.replayPendingMessagesForImmediateMode();
+    await agentSession.replayAllPendingMessages();
 
     return { success: true };
   });

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -1169,7 +1169,9 @@ export function setupSessionHandlers(
         })
       );
     } else {
-      await agentSession.startQueryAndEnqueue(message.uuid, replayContent);
+      await withSessionResetCoordination(targetSessionId, async () => {
+        await agentSession.startQueryAndEnqueue(messageUuid, replayContent);
+      });
     }
 
     return {
@@ -1245,7 +1247,9 @@ export function setupSessionHandlers(
       } else {
         const replayContent = toReplayContent(message.message.content);
         if (replayContent) {
-          await agentSession.startQueryAndEnqueue(message.uuid, replayContent);
+          await withSessionResetCoordination(targetSessionId, async () => {
+            await agentSession.startQueryAndEnqueue(messageUuid, replayContent);
+          });
         }
       }
     } catch (err) {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -995,9 +995,9 @@ export function setupSessionHandlers(
       throw new Error('Session not found');
     }
 
-    const result = await agentSession.handleQueryTrigger();
+    await agentSession.replayPendingMessagesForImmediateMode();
 
-    return result;
+    return { success: true };
   });
 
   messageHub.onRequest('session.messages.countByStatus', async (data) => {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -24,7 +24,11 @@ import {
   markRefreshAttemptedFor,
 } from '../model-service.js';
 import { getProviderRegistry } from '../providers/registry.js';
-import { deliverAndMarkQueued, isMessageDeliveryV2Enabled } from '../agent/message-delivery';
+import {
+  deliverAndMarkQueued,
+  isMessageDeliveryV2Enabled,
+  withSessionResetCoordination,
+} from '../agent/message-delivery';
 import {
   archiveSDKSessionFiles,
   deleteSDKSessionFiles,
@@ -1145,6 +1149,7 @@ export function setupSessionHandlers(
     if (!replayContent) {
       return { promoted: false };
     }
+    const messageUuid = message.uuid;
 
     db.updateMessageStatus([message.dbId], 'enqueued');
     await internalEventBus.publish('messages.statusChanged', {
@@ -1154,13 +1159,15 @@ export function setupSessionHandlers(
     });
 
     if (isMessageDeliveryV2Enabled()) {
-      await deliverAndMarkQueued({
-        jobQueue: db.getJobQueueRepo(),
-        stateManager: agentSession.stateManager,
-        sessionId: targetSessionId,
-        messageUuid: message.uuid,
-        origin: 'chat',
-      });
+      await withSessionResetCoordination(targetSessionId, async () =>
+        deliverAndMarkQueued({
+          jobQueue: db.getJobQueueRepo(),
+          stateManager: agentSession.stateManager,
+          sessionId: targetSessionId,
+          messageUuid,
+          origin: 'chat',
+        })
+      );
     } else {
       await agentSession.startQueryAndEnqueue(message.uuid, replayContent);
     }
@@ -1203,6 +1210,7 @@ export function setupSessionHandlers(
     if (!reopenedId) {
       return { retried: false };
     }
+    const messageUuid = message.uuid;
 
     const rollbackToFailed = async () => {
       const rolledBack = db
@@ -1225,13 +1233,15 @@ export function setupSessionHandlers(
       });
 
       if (isMessageDeliveryV2Enabled()) {
-        await deliverAndMarkQueued({
-          jobQueue: db.getJobQueueRepo(),
-          stateManager: agentSession.stateManager,
-          sessionId: targetSessionId,
-          messageUuid: message.uuid,
-          origin: 'chat',
-        });
+        await withSessionResetCoordination(targetSessionId, async () =>
+          deliverAndMarkQueued({
+            jobQueue: db.getJobQueueRepo(),
+            stateManager: agentSession.stateManager,
+            sessionId: targetSessionId,
+            messageUuid,
+            origin: 'chat',
+          })
+        );
       } else {
         const replayContent = toReplayContent(message.message.content);
         if (replayContent) {

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -14,7 +14,10 @@ import type { UUID } from 'crypto';
 import type { Database } from '../../storage/database';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { buildReferenceContext, prependContextToMessage } from '../agent/reference-context-builder';
-import { isMessageDeliveryV2Enabled } from '../agent/message-delivery';
+import {
+  isMessageDeliveryV2Enabled,
+  withSessionResetCoordination,
+} from '../agent/message-delivery';
 import { persistAndEnqueueDelivery } from '../agent/message-delivery-outbox';
 import { expandBuiltInCommand } from '../built-in-commands';
 import { Logger } from '../logger';
@@ -205,16 +208,18 @@ export class MessagePersistence {
             .catch(() => {});
           throw new Error(`Session ${sessionId} is archived`);
         }
-        const outbox = persistAndEnqueueDelivery({
-          db: this.db.getDatabase(),
-          sdkMessageRepo: this.db.getSDKMessageRepo(),
-          jobQueue: jobQueueRepo,
-          sessionId,
-          message: sdkUserMessage,
-          sendStatus,
-          origin,
-          delivery: { origin: 'chat' },
-        });
+        const outbox = await withSessionResetCoordination(sessionId, async () =>
+          persistAndEnqueueDelivery({
+            db: this.db.getDatabase(),
+            sdkMessageRepo: this.db.getSDKMessageRepo(),
+            jobQueue: jobQueueRepo,
+            sessionId,
+            message: sdkUserMessage,
+            sendStatus,
+            origin,
+            delivery: { origin: 'chat' },
+          })
+        );
         dbMessageId = outbox.dbMessageId;
         outboxRole = outbox.role;
         if (outboxRole === 'turn') {

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -269,7 +269,9 @@ export class MessagePersistence {
         );
 
       if (shouldDispatchToQuery && !useV2Delivery) {
-        await agentSession.startQueryAndEnqueue(messageId, messageContent);
+        await withSessionResetCoordination(sessionId, async () => {
+          await agentSession.startQueryAndEnqueue(messageId, messageContent);
+        });
       }
       if (shouldDispatchToQuery) {
         await this.internalEventBus

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1446,6 +1446,8 @@ export class SpaceRuntimeService {
 
     if (this.sessionBelongsToLongHorizonAgent(spaceId, session.id)) return;
 
+    this.taskAgentManager?.reattachSlotContextReset(agentSession);
+
     const mcpServer = this.buildMemberSpaceToolsMcpServer(space, session.id);
 
     const additional: Record<string, McpServerConfig> = {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -42,6 +42,7 @@ import {
   deliverAndMarkQueued,
   deliveryConsumptionTimeoutMs,
   isMessageDeliveryV2Enabled,
+  withSessionResetCoordination,
 } from '../../agent/message-delivery';
 import type { DaemonInternalEventMap, InternalEventBus } from '../../internal-event-bus';
 import { SpaceRuntime } from './space-runtime';
@@ -459,19 +460,21 @@ export class SpaceRuntimeService {
         messageUuid: id,
         timeoutMs: deliveryConsumptionTimeoutMs(session.getSessionData?.().config?.provider),
         deliver: () =>
-          deliverAndMarkQueued({
-            jobQueue: reactiveDb.getJobQueueRepo(),
-            stateManager: session.stateManager,
-            sessionId,
-            messageUuid: id,
-            origin: 'long_term_agent',
-            onEnqueueFailure: () => {
-              const failedDbId = sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id);
-              if (failedDbId) {
-                void this.publishMessageStatusChanged(sessionId, failedDbId, 'failed');
-              }
-            },
-          }),
+          withSessionResetCoordination(sessionId, async () =>
+            deliverAndMarkQueued({
+              jobQueue: reactiveDb.getJobQueueRepo(),
+              stateManager: session.stateManager,
+              sessionId,
+              messageUuid: id,
+              origin: 'long_term_agent',
+              onEnqueueFailure: () => {
+                const failedDbId = sdkMessageRepo.markDeliveryFailedByUuid(sessionId, id);
+                if (failedDbId) {
+                  void this.publishMessageStatusChanged(sessionId, failedDbId, 'failed');
+                }
+              },
+            })
+          ),
         ...(fresh
           ? {
               terminalizeOnTimeout: () => {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3243,12 +3243,13 @@ export class TaskAgentManager {
         ]
       : [{ type: 'text' as const, text: message }];
 
-    const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
+    const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean; inputKind: MessageInputKind } = {
       type: 'user' as const,
       uuid: messageId as UUID,
       session_id: sessionId,
       parent_tool_use_id: null,
       isSynthetic: isSyntheticMessage,
+      inputKind,
       message: {
         role: 'user' as const,
         content: sdkContent,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3198,6 +3198,20 @@ export class TaskAgentManager {
     );
   }
 
+  private clearStillBlocked(session: AgentSession): boolean {
+    const state = session.getProcessingState();
+    if (
+      state.status === 'processing' ||
+      state.status === 'queued' ||
+      state.status === 'waiting_for_input' ||
+      state.status === 'interrupted' ||
+      state.status === 'rate_limit_cooldown'
+    ) {
+      return true;
+    }
+    return this.hasActiveDeliveryJob(session.session.id);
+  }
+
   private async injectMessageIntoSession(
     session: AgentSession,
     message: string,
@@ -3349,6 +3363,13 @@ export class TaskAgentManager {
           `TaskAgentManager: deferred backlog replay for session ${sessionId} failed: ` +
             `${replay.error ?? 'unknown error'} — delivering current message only`
         );
+      }
+      if (clearSuppressedByPendingWork && !clearedUpstream && this.clearStillBlocked(session)) {
+        const deferredDbId = existing
+          ? messageId
+          : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
+        await this.publishMessageStatusChanged(sessionId, deferredDbId, 'deferred');
+        return deferredDbId;
       }
     }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1384,8 +1384,10 @@ export class TaskAgentManager {
         this.agentSessionIndex.get(subSessionId) ??
         Array.from(this.subSessions.values())
           .map((nodeMap) => nodeMap.get(subSessionId))
-          .find((session) => session !== undefined) ??
-        target;
+          .find((session) => session !== undefined);
+      if (!currentTarget) {
+        throw new Error(`Sub-session not found: ${subSessionId}`);
+      }
 
       return await this.injectMessageIntoSession(
         currentTarget,
@@ -3336,12 +3338,13 @@ export class TaskAgentManager {
         outcome.decision.action === 'deliver_without_clear' &&
         outcome.decision.reason === 'unconsumed_work_pending';
       let clearedUpstream = false;
+      let backlogReplayFailed = false;
       const sendEnqueued = (
         session as AgentSession & {
           sendEnqueuedMessagesOnTurnEnd?: (options?: {
             pendingTaskInput?: boolean;
             skipResetCoordination?: boolean;
-          }) => Promise<{ replayedWork: boolean; clearedContext: boolean }>;
+          }) => Promise<{ replayedWork: boolean; clearedContext: boolean; replayFailed: boolean }>;
         }
       ).sendEnqueuedMessagesOnTurnEnd;
       if (clearSuppressedByPendingWork && typeof sendEnqueued === 'function') {
@@ -3350,6 +3353,7 @@ export class TaskAgentManager {
           skipResetCoordination: true,
         });
         clearedUpstream = replayed.clearedContext;
+        backlogReplayFailed = replayed.replayFailed;
       }
       const replay = await session.handleQueryTrigger({
         deliverIndividually: true,
@@ -3364,7 +3368,11 @@ export class TaskAgentManager {
             `${replay.error ?? 'unknown error'} — delivering current message only`
         );
       }
-      if (clearSuppressedByPendingWork && !clearedUpstream && this.clearStillBlocked(session)) {
+      if (
+        clearSuppressedByPendingWork &&
+        !clearedUpstream &&
+        (backlogReplayFailed || this.clearStillBlocked(session))
+      ) {
         const deferredDbId = existing
           ? messageId
           : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1057,6 +1057,8 @@ export class TaskAgentManager {
       subSession.mergeRuntimeMcpServers(subSessionInit.mcpServers);
     }
 
+    this.attachSlotContextReset(subSession);
+
     if (!this.subSessions.has(taskId)) {
       this.subSessions.set(taskId, new Map());
     }
@@ -1848,6 +1850,7 @@ export class TaskAgentManager {
     agentSession.onMissingWorkflowMcpServers = async (target: AgentSession, missing: string[]) => {
       await this.mcpSelfHeal(target, missing);
     };
+    this.attachSlotContextReset(agentSession);
 
     if (!this.subSessions.has(taskId)) {
       this.subSessions.set(taskId, new Map());
@@ -2738,6 +2741,11 @@ export class TaskAgentManager {
     return slot?.resetContextPerTurn === true;
   }
 
+  private attachSlotContextReset(agentSession: AgentSession): void {
+    const sessionId = agentSession.session.id;
+    agentSession.slotResetsContext = () => this.slotResetsContextForSession(sessionId);
+  }
+
   private buildAgentNameAliasesForExecution(
     workflow: SpaceWorkflow | null,
     execution: NodeExecution
@@ -3042,6 +3050,7 @@ export class TaskAgentManager {
     agentSession.onMissingWorkflowMcpServers = async (target: AgentSession, missing: string[]) => {
       await this.mcpSelfHeal(target, missing);
     };
+    this.attachSlotContextReset(agentSession);
 
     const pendingToolContinuations =
       this.config.toolContinuationRepo?.listPendingInboxForSession(subSessionId) ?? [];
@@ -3204,6 +3213,13 @@ export class TaskAgentManager {
     return this.config.db.getJobQueueRepo().activeDeliveryMessageUuids(sessionId).size > 0;
   }
 
+  private hasUnconsumedDeliveredWork(sessionId: string): boolean {
+    return (
+      this.config.db.getMessageCountByStatus(sessionId, 'enqueued') > 0 ||
+      this.config.db.getMessageCountByStatus(sessionId, 'deferred') > 0
+    );
+  }
+
   private async injectMessageIntoSession(
     session: AgentSession,
     message: string,
@@ -3272,6 +3288,7 @@ export class TaskAgentManager {
       hasPriorContext: !!session.session.sdkSessionId,
       slotResetsContext: this.slotResetsContextForSession(sessionId),
       hasActiveDeliveryJob: this.hasActiveDeliveryJob(sessionId),
+      hasUnconsumedDeliveredWork: this.hasUnconsumedDeliveredWork(sessionId),
     });
 
     if (outcome.decision.action === 'noop') {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3201,7 +3201,10 @@ export class TaskAgentManager {
     return (['enqueued', 'deferred'] as const).some((status) =>
       this.config.db
         .getUserMessageIdsByStatus(sessionId, status)
-        .some((row) => row.uuid !== excludeMessageId)
+        .some(
+          (row) =>
+            typeof row.uuid === 'string' && row.uuid.length > 0 && row.uuid !== excludeMessageId
+        )
     );
   }
 
@@ -3329,6 +3332,9 @@ export class TaskAgentManager {
         deliverIndividually: true,
         excludeMessageUuid: messageId,
         skipResetCoordination: true,
+        pendingTaskInput:
+          outcome.decision.action === 'deliver_without_clear' &&
+          outcome.decision.reason === 'unconsumed_work_pending',
       });
       if (!replay.success) {
         log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1349,6 +1349,23 @@ export class TaskAgentManager {
       }
     }
 
+    const resolveSessionTarget = async (): Promise<AgentSession | null> => {
+      const indexed = this.agentSessionIndex.get(subSessionId);
+      if (indexed) return indexed;
+
+      for (const [, nodeMap] of this.subSessions) {
+        const session = nodeMap.get(subSessionId);
+        if (session) return session;
+      }
+
+      return await this.rehydrateSubSession(subSessionId);
+    };
+
+    const target = await resolveSessionTarget();
+    if (!target) {
+      throw new Error(`Sub-session not found: ${subSessionId}`);
+    }
+
     return this.withSessionInjectLock(subSessionId, async () => {
       const lockedExecution = this.resolveNodeExecutionForSubSession(subSessionId);
       if (lockedExecution) {
@@ -1363,50 +1380,23 @@ export class TaskAgentManager {
         }
       }
 
-      const indexed = this.agentSessionIndex.get(subSessionId);
-      if (indexed) {
-        return await this.injectMessageIntoSession(
-          indexed,
-          message,
-          deliveryMode,
-          origin,
-          isSyntheticMessage,
-          images,
-          inputKind,
-          messageId
-        );
-      }
+      const currentTarget =
+        this.agentSessionIndex.get(subSessionId) ??
+        Array.from(this.subSessions.values())
+          .map((nodeMap) => nodeMap.get(subSessionId))
+          .find((session) => session !== undefined) ??
+        target;
 
-      for (const [, nodeMap] of this.subSessions) {
-        const session = nodeMap.get(subSessionId);
-        if (session) {
-          return await this.injectMessageIntoSession(
-            session,
-            message,
-            deliveryMode,
-            origin,
-            isSyntheticMessage,
-            images,
-            inputKind,
-            messageId
-          );
-        }
-      }
-
-      const rehydrated = await this.rehydrateSubSession(subSessionId);
-      if (rehydrated) {
-        return await this.injectMessageIntoSession(
-          rehydrated,
-          message,
-          deliveryMode,
-          origin,
-          isSyntheticMessage,
-          images,
-          inputKind,
-          messageId
-        );
-      }
-      throw new Error(`Sub-session not found: ${subSessionId}`);
+      return await this.injectMessageIntoSession(
+        currentTarget,
+        message,
+        deliveryMode,
+        origin,
+        isSyntheticMessage,
+        images,
+        inputKind,
+        messageId
+      );
     });
   }
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3371,11 +3371,24 @@ export class TaskAgentManager {
       if (
         clearSuppressedByPendingWork &&
         !clearedUpstream &&
-        (backlogReplayFailed || this.clearStillBlocked(session))
+        (backlogReplayFailed || !replay.success || this.clearStillBlocked(session))
       ) {
-        const deferredDbId = existing
-          ? messageId
-          : this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'deferred', origin);
+        if (existing) {
+          const flippedDbId = this.config.db
+            .getSDKMessageRepo()
+            .markDeliveryDeferredByUuid(sessionId, messageId);
+          if (flippedDbId) {
+            await this.publishMessageStatusChanged(sessionId, flippedDbId, 'deferred');
+            return flippedDbId;
+          }
+          return messageId;
+        }
+        const deferredDbId = this.config.db.saveUserMessage(
+          sessionId,
+          sdkUserMessage,
+          'deferred',
+          origin
+        );
         await this.publishMessageStatusChanged(sessionId, deferredDbId, 'deferred');
         return deferredDbId;
       }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -26,6 +26,7 @@ import {
   deliverAndMarkQueued,
   deliveryConsumptionTimeoutMs,
   isMessageDeliveryV2Enabled,
+  withSessionResetCoordination,
 } from '../../../lib/agent/message-delivery';
 import { decideInjectDelivery } from '../../../lib/agent/message-delivery-pipeline';
 import { validateImageSizes } from '../../session/message-persistence';
@@ -350,8 +351,6 @@ export class TaskAgentManager {
   private agentSessionIndex = new Map<string, AgentSession>();
 
   private cancellingSessions = new Set<string>();
-
-  private readonly sessionInjectLocks = new Map<string, Promise<void>>();
 
   private readonly sessionRestoreLocks = new Map<string, Promise<void>>();
 
@@ -1057,7 +1056,7 @@ export class TaskAgentManager {
       subSession.mergeRuntimeMcpServers(subSessionInit.mcpServers);
     }
 
-    this.attachSlotContextReset(subSession);
+    this.reattachSlotContextReset(subSession);
 
     if (!this.subSessions.has(taskId)) {
       this.subSessions.set(taskId, new Map());
@@ -1425,23 +1424,8 @@ export class TaskAgentManager {
     return null;
   }
 
-  private async withSessionInjectLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
-    const prev = this.sessionInjectLocks.get(sessionId) ?? Promise.resolve();
-    let release!: () => void;
-    const held = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = prev.then(() => held);
-    this.sessionInjectLocks.set(sessionId, tail);
-    await prev;
-    try {
-      return await fn();
-    } finally {
-      release();
-      if (this.sessionInjectLocks.get(sessionId) === tail) {
-        this.sessionInjectLocks.delete(sessionId);
-      }
-    }
+  private withSessionInjectLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    return withSessionResetCoordination(sessionId, fn);
   }
 
   private async withSessionRestoreLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
@@ -1850,7 +1834,7 @@ export class TaskAgentManager {
     agentSession.onMissingWorkflowMcpServers = async (target: AgentSession, missing: string[]) => {
       await this.mcpSelfHeal(target, missing);
     };
-    this.attachSlotContextReset(agentSession);
+    this.reattachSlotContextReset(agentSession);
 
     if (!this.subSessions.has(taskId)) {
       this.subSessions.set(taskId, new Map());
@@ -2741,7 +2725,7 @@ export class TaskAgentManager {
     return slot?.resetContextPerTurn === true;
   }
 
-  private attachSlotContextReset(agentSession: AgentSession): void {
+  reattachSlotContextReset(agentSession: AgentSession): void {
     const sessionId = agentSession.session.id;
     agentSession.slotResetsContext = () => this.slotResetsContextForSession(sessionId);
   }
@@ -3050,7 +3034,7 @@ export class TaskAgentManager {
     agentSession.onMissingWorkflowMcpServers = async (target: AgentSession, missing: string[]) => {
       await this.mcpSelfHeal(target, missing);
     };
-    this.attachSlotContextReset(agentSession);
+    this.reattachSlotContextReset(agentSession);
 
     const pendingToolContinuations =
       this.config.toolContinuationRepo?.listPendingInboxForSession(subSessionId) ?? [];
@@ -3213,10 +3197,11 @@ export class TaskAgentManager {
     return this.config.db.getJobQueueRepo().activeDeliveryMessageUuids(sessionId).size > 0;
   }
 
-  private hasUnconsumedDeliveredWork(sessionId: string): boolean {
-    return (
-      this.config.db.getMessageCountByStatus(sessionId, 'enqueued') > 0 ||
-      this.config.db.getMessageCountByStatus(sessionId, 'deferred') > 0
+  private hasUnconsumedDeliveredWork(sessionId: string, excludeMessageId?: string): boolean {
+    return (['enqueued', 'deferred'] as const).some((status) =>
+      this.config.db
+        .getUserMessageIdsByStatus(sessionId, status)
+        .some((row) => row.uuid !== excludeMessageId)
     );
   }
 
@@ -3288,7 +3273,7 @@ export class TaskAgentManager {
       hasPriorContext: !!session.session.sdkSessionId,
       slotResetsContext: this.slotResetsContextForSession(sessionId),
       hasActiveDeliveryJob: this.hasActiveDeliveryJob(sessionId),
-      hasUnconsumedDeliveredWork: this.hasUnconsumedDeliveredWork(sessionId),
+      hasUnconsumedDeliveredWork: this.hasUnconsumedDeliveredWork(sessionId, messageId),
     });
 
     if (outcome.decision.action === 'noop') {
@@ -3342,6 +3327,7 @@ export class TaskAgentManager {
       const replay = await session.handleQueryTrigger({
         deliverIndividually: true,
         excludeMessageUuid: messageId,
+        skipResetCoordination: true,
       });
       if (!replay.success) {
         log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3318,13 +3318,31 @@ export class TaskAgentManager {
     }
 
     if (!isBusy) {
+      const clearSuppressedByPendingWork =
+        outcome.decision.action === 'deliver_without_clear' &&
+        outcome.decision.reason === 'unconsumed_work_pending';
+      let clearedUpstream = false;
+      const sendEnqueued = (
+        session as AgentSession & {
+          sendEnqueuedMessagesOnTurnEnd?: (options?: {
+            pendingTaskInput?: boolean;
+            skipResetCoordination?: boolean;
+          }) => Promise<{ replayedWork: boolean; clearedContext: boolean }>;
+        }
+      ).sendEnqueuedMessagesOnTurnEnd;
+      if (clearSuppressedByPendingWork && typeof sendEnqueued === 'function') {
+        const replayed = await sendEnqueued.call(session, {
+          pendingTaskInput: true,
+          skipResetCoordination: true,
+        });
+        clearedUpstream = replayed.clearedContext;
+      }
       const replay = await session.handleQueryTrigger({
         deliverIndividually: true,
         excludeMessageUuid: messageId,
         skipResetCoordination: true,
-        pendingTaskInput:
-          outcome.decision.action === 'deliver_without_clear' &&
-          outcome.decision.reason === 'unconsumed_work_pending',
+        skipContextReset: clearedUpstream,
+        pendingTaskInput: clearSuppressedByPendingWork && !clearedUpstream,
       });
       if (!replay.success) {
         log.warn(

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -1925,6 +1925,22 @@ describe('AgentSession', () => {
       }
     });
 
+    it('replayAllPendingMessages bypasses the manual-mode guard that stops immediate-mode replay', async () => {
+      agentSession.session.config.queryMode = 'manual';
+      const inner = agentSession.queryModeHandler as unknown as {
+        replayPendingMessagesForImmediateMode: ReturnType<typeof mock>;
+      };
+      const innerSpy = spyOn(inner, 'replayPendingMessagesForImmediateMode').mockResolvedValue(
+        undefined
+      );
+
+      await agentSession.replayPendingMessagesForImmediateMode();
+      expect(innerSpy).not.toHaveBeenCalled();
+
+      await agentSession.replayAllPendingMessages();
+      expect(innerSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('handleModelSwitch should delegate to modelSwitchHandler', async () => {
       const mockResult = { success: true, model: 'claude-opus-4-20250514' };
       const switchModelSpy = mock(() => mockResult);

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -14,6 +14,7 @@ import {
   MessageDeliveryRecoverableTurnError,
   MessageDeliveryTerminalTurnError,
   waitForDeliveryConsumption,
+  withSessionResetCoordination,
 } from '../../../../src/lib/agent/message-delivery';
 import type { Database } from '../../../../src/storage/database';
 import {
@@ -1876,6 +1877,48 @@ describe('AgentSession', () => {
         expect(await agentSession.reconcileStrandedDeliveries()).toBe(0);
 
         expect(activeDeliveryMessageUuids).not.toHaveBeenCalled();
+      } finally {
+        if (previous === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+        else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previous;
+      }
+    });
+
+    it('reconcileStrandedDeliveries waits for the reset-coordination lock before re-enqueueing', async () => {
+      const previous = process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
+      process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = '1';
+      try {
+        const enqueue = mock(() => ({}));
+        mockDb.getJobQueueRepo = mock(() => ({
+          activeDeliveryMessageUuids: mock(() => new Set<string>()),
+          getActiveDeliveryRole: mock(() => null),
+          enqueue,
+        }));
+        mockDb.getUserMessageIdsByStatus = mock((_sessionId: string, status: string) =>
+          status === 'enqueued' ? [{ dbId: 'db-1', uuid: 'uuid-1', timestamp: 1 }] : []
+        );
+        mockDb.getSDKMessageRepo = mock(() => ({
+          markDeliveryFailedByUuid: mock(() => null),
+        }));
+
+        let release!: () => void;
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const holder = withSessionResetCoordination('test-session-id', async () => {
+          await gate;
+        });
+        const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+        const reconcilePromise = agentSession.reconcileStrandedDeliveries();
+        await settle();
+        await settle();
+
+        expect(enqueue).not.toHaveBeenCalled();
+
+        release();
+        await holder;
+        await reconcilePromise;
+
+        expect(enqueue).toHaveBeenCalledTimes(1);
       } finally {
         if (previous === undefined) delete process.env.HYPERNEO_MESSAGE_DELIVERY_V2;
         else process.env.HYPERNEO_MESSAGE_DELIVERY_V2 = previous;

--- a/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
@@ -152,7 +152,7 @@ describe('planTurnEndFlushContextReset', () => {
     ).toEqual({ action: 'flush_without_clear' });
   });
 
-  test('an active delivery job suppresses the flush clear', () => {
+  test('an active delivery job suppresses the flush clear and defers the reset', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: true,
@@ -160,6 +160,6 @@ describe('planTurnEndFlushContextReset', () => {
         hasActiveDeliveryJob: true,
         taskDeliverableCount: 3,
       })
-    ).toEqual({ action: 'flush_without_clear' });
+    ).toEqual({ action: 'flush_without_clear', reason: 'active_delivery_job' });
   });
 });

--- a/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
@@ -10,6 +10,7 @@ const baseArgs = {
   hasPriorContext: true,
   slotResetsContext: true,
   hasActiveDeliveryJob: false,
+  hasUnconsumedDeliveredWork: false,
 };
 
 describe('planInjectContextReset', () => {
@@ -48,6 +49,26 @@ describe('planInjectContextReset', () => {
     });
   });
 
+  test('unconsumed delivered work blocks the clear step (#1085)', () => {
+    expect(planInjectContextReset({ ...baseArgs, hasUnconsumedDeliveredWork: true })).toEqual({
+      action: 'deliver_without_clear',
+      reason: 'unconsumed_work_pending',
+    });
+  });
+
+  test('an active delivery job outranks unconsumed delivered work', () => {
+    expect(
+      planInjectContextReset({
+        ...baseArgs,
+        hasActiveDeliveryJob: true,
+        hasUnconsumedDeliveredWork: true,
+      })
+    ).toEqual({
+      action: 'deliver_without_clear',
+      reason: 'delivery_job_active',
+    });
+  });
+
   test('all conjuncts true clears before delivery', () => {
     expect(planInjectContextReset(baseArgs)).toEqual({
       action: 'clear_before_deliver',
@@ -62,6 +83,7 @@ describe('planInjectContextReset', () => {
         hasPriorContext: false,
         slotResetsContext: false,
         hasActiveDeliveryJob: true,
+        hasUnconsumedDeliveredWork: true,
       })
     ).toEqual({
       action: 'deliver_without_clear',
@@ -70,17 +92,25 @@ describe('planInjectContextReset', () => {
   });
 });
 
-describe('planTurnEndFlushContextReset [KNOWN-BUG #1085]', () => {
-  test('turn-end flush never clears even when a reset slot has deliverables', () => {
+describe('planTurnEndFlushContextReset', () => {
+  test('a reset slot with deliverables clears once before the first message (#1085)', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: true,
         deliverableCount: 3,
       })
-    ).toEqual({ action: 'flush_without_clear' });
+    ).toEqual({ action: 'clear_then_flush' });
   });
 
-  test('turn-end flush keeps no-clear behavior for non-reset slots', () => {
+  test('a batch of any size gets exactly one clear plan, never per message', () => {
+    for (const deliverableCount of [1, 2, 8, 64]) {
+      expect(planTurnEndFlushContextReset({ slotResetsContext: true, deliverableCount })).toEqual({
+        action: 'clear_then_flush',
+      });
+    }
+  });
+
+  test('a non-reset slot flushes without a clear even with deliverables', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: false,
@@ -89,7 +119,7 @@ describe('planTurnEndFlushContextReset [KNOWN-BUG #1085]', () => {
     ).toEqual({ action: 'flush_without_clear' });
   });
 
-  test('turn-end flush keeps no-clear behavior when the queue is empty', () => {
+  test('a reset slot with an empty queue flushes without a clear', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: true,

--- a/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
@@ -93,28 +93,36 @@ describe('planInjectContextReset', () => {
 });
 
 describe('planTurnEndFlushContextReset', () => {
-  test('a reset slot with deliverables clears once before the first message (#1085)', () => {
+  test('a reset slot with task deliverables clears once before the first message (#1085)', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: true,
-        deliverableCount: 3,
+        hasPriorContext: true,
+        taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'clear_then_flush' });
   });
 
   test('a batch of any size gets exactly one clear plan, never per message', () => {
-    for (const deliverableCount of [1, 2, 8, 64]) {
-      expect(planTurnEndFlushContextReset({ slotResetsContext: true, deliverableCount })).toEqual({
+    for (const taskDeliverableCount of [1, 2, 8, 64]) {
+      expect(
+        planTurnEndFlushContextReset({
+          slotResetsContext: true,
+          hasPriorContext: true,
+          taskDeliverableCount,
+        })
+      ).toEqual({
         action: 'clear_then_flush',
       });
     }
   });
 
-  test('a non-reset slot flushes without a clear even with deliverables', () => {
+  test('a non-reset slot flushes without a clear even with task deliverables', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: false,
-        deliverableCount: 3,
+        hasPriorContext: true,
+        taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'flush_without_clear' });
   });
@@ -123,7 +131,18 @@ describe('planTurnEndFlushContextReset', () => {
     expect(
       planTurnEndFlushContextReset({
         slotResetsContext: true,
-        deliverableCount: 0,
+        hasPriorContext: true,
+        taskDeliverableCount: 0,
+      })
+    ).toEqual({ action: 'flush_without_clear' });
+  });
+
+  test('a session without prior context flushes without a clear on the first turn', () => {
+    expect(
+      planTurnEndFlushContextReset({
+        slotResetsContext: true,
+        hasPriorContext: false,
+        taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'flush_without_clear' });
   });

--- a/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-reset-planner.test.ts
@@ -98,6 +98,7 @@ describe('planTurnEndFlushContextReset', () => {
       planTurnEndFlushContextReset({
         slotResetsContext: true,
         hasPriorContext: true,
+        hasActiveDeliveryJob: false,
         taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'clear_then_flush' });
@@ -109,6 +110,7 @@ describe('planTurnEndFlushContextReset', () => {
         planTurnEndFlushContextReset({
           slotResetsContext: true,
           hasPriorContext: true,
+          hasActiveDeliveryJob: false,
           taskDeliverableCount,
         })
       ).toEqual({
@@ -122,6 +124,7 @@ describe('planTurnEndFlushContextReset', () => {
       planTurnEndFlushContextReset({
         slotResetsContext: false,
         hasPriorContext: true,
+        hasActiveDeliveryJob: false,
         taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'flush_without_clear' });
@@ -132,6 +135,7 @@ describe('planTurnEndFlushContextReset', () => {
       planTurnEndFlushContextReset({
         slotResetsContext: true,
         hasPriorContext: true,
+        hasActiveDeliveryJob: false,
         taskDeliverableCount: 0,
       })
     ).toEqual({ action: 'flush_without_clear' });
@@ -142,6 +146,18 @@ describe('planTurnEndFlushContextReset', () => {
       planTurnEndFlushContextReset({
         slotResetsContext: true,
         hasPriorContext: false,
+        hasActiveDeliveryJob: false,
+        taskDeliverableCount: 3,
+      })
+    ).toEqual({ action: 'flush_without_clear' });
+  });
+
+  test('an active delivery job suppresses the flush clear', () => {
+    expect(
+      planTurnEndFlushContextReset({
+        slotResetsContext: true,
+        hasPriorContext: true,
+        hasActiveDeliveryJob: true,
         taskDeliverableCount: 3,
       })
     ).toEqual({ action: 'flush_without_clear' });

--- a/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
@@ -62,6 +62,7 @@ describe('EventSubscriptionSetup', () => {
 
     mockQueryModeHandler = {
       handleQueryTrigger: mock(async () => ({ success: true, messageCount: 1 })),
+      replayPendingMessagesForImmediateMode: mock(async () => {}),
       sendEnqueuedMessagesOnTurnEnd: mock(async () => {}),
     } as unknown as QueryModeHandler;
 
@@ -401,13 +402,13 @@ describe('EventSubscriptionSetup', () => {
     });
 
     describe('query.trigger handler', () => {
-      it('should call queryModeHandler.handleQueryTrigger', async () => {
+      it('should call queryModeHandler.replayPendingMessagesForImmediateMode', async () => {
         setup.setup();
 
         const callback = registeredCallbacks.get('query.trigger')!;
         await callback({ sessionId: 'test-session-id' });
 
-        expect(mockQueryModeHandler.handleQueryTrigger).toHaveBeenCalled();
+        expect(mockQueryModeHandler.replayPendingMessagesForImmediateMode).toHaveBeenCalled();
       });
     });
   });

--- a/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
@@ -79,6 +79,7 @@ function makeFlushInput(overrides: Partial<TurnEndFlushInput> = {}): TurnEndFlus
     activeTurnInJobQueue: false,
     slotResetsContext: true,
     hasPriorContext: true,
+    pendingTaskInput: false,
     ...overrides,
   };
 }
@@ -432,6 +433,26 @@ describe('message turn-end flush decision pipeline', () => {
       { hasPriorContext: false },
       { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
     ],
+    [
+      'an active delivery job suppresses the flush clear',
+      { activeInJobQueue: new Set(['uuid-active']) },
+      { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
+    ],
+    [
+      'a pending task input behind a human-only backlog plans one clear ahead of the batch',
+      {
+        messages: [
+          makeFlushMessage({ uuid: 'human-1', isTaskInput: false }),
+          makeFlushMessage({ uuid: 'human-2', isTaskInput: false, flattenedText: 'follow-up' }),
+        ],
+        pendingTaskInput: true,
+      },
+      {
+        action: 'batch',
+        uuids: ['human-1', 'human-2'],
+        contextReset: { action: 'clear_then_flush' },
+      },
+    ],
   ];
 
   for (const [label, overrides, expected] of cases) {
@@ -485,6 +506,7 @@ describe('message turn-end flush decision pipeline', () => {
         planTurnEndFlushContextReset({
           slotResetsContext: true,
           hasPriorContext: true,
+          hasActiveDeliveryJob: false,
           taskDeliverableCount: 2,
         })
       );
@@ -540,7 +562,8 @@ describe('message turn-end flush decision pipeline', () => {
                 contextReset: planTurnEndFlushContextReset({
                   slotResetsContext: input.slotResetsContext,
                   hasPriorContext: input.hasPriorContext,
-                  taskDeliverableCount,
+                  hasActiveDeliveryJob: input.activeInJobQueue.size > 0,
+                  taskDeliverableCount: taskDeliverableCount + (input.pendingTaskInput ? 1 : 0),
                 }),
               };
         expect(decideTurnEndFlush(input)).toEqual(expected);

--- a/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
@@ -434,9 +434,13 @@ describe('message turn-end flush decision pipeline', () => {
       { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
     ],
     [
-      'an active delivery job suppresses the flush clear',
+      'an active delivery job suppresses the flush clear and defers the reset',
       { activeInJobQueue: new Set(['uuid-active']) },
-      { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
+      {
+        action: 'batch',
+        uuids: ['a', 'b'],
+        contextReset: { action: 'flush_without_clear', reason: 'active_delivery_job' },
+      },
     ],
     [
       'a pending task input behind a human-only backlog plans one clear ahead of the batch',

--- a/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
@@ -49,6 +49,7 @@ function makeInjectInput(overrides: Partial<InjectDeliveryInput> = {}): InjectDe
     hasPriorContext: true,
     slotResetsContext: true,
     hasActiveDeliveryJob: false,
+    hasUnconsumedDeliveredWork: false,
     ...overrides,
   };
 }
@@ -118,6 +119,11 @@ describe('message inject delivery decision pipeline', () => {
       'an active delivery job delivers without clear',
       { hasActiveDeliveryJob: true },
       { action: 'deliver_without_clear', reason: 'delivery_job_active' },
+    ],
+    [
+      'unconsumed delivered work delivers without clear (#1085)',
+      { hasUnconsumedDeliveredWork: true },
+      { action: 'deliver_without_clear', reason: 'unconsumed_work_pending' },
     ],
     [
       'a fresh task input on a reset slot clears before delivery',
@@ -249,6 +255,7 @@ describe('message inject delivery decision pipeline', () => {
           hasPriorContext: input.hasPriorContext,
           slotResetsContext: input.slotResetsContext,
           hasActiveDeliveryJob: input.hasActiveDeliveryJob,
+          hasUnconsumedDeliveredWork: input.hasUnconsumedDeliveredWork,
         });
         const coreExpected =
           input.existingSendStatus === 'consumed'
@@ -266,6 +273,7 @@ describe('message inject delivery decision pipeline', () => {
         { inputKind: 'steer' },
         { isBusy: true },
         { hasActiveDeliveryJob: true },
+        { hasUnconsumedDeliveredWork: true },
       ] as Partial<InjectDeliveryInput>[]) {
         const input = makeInjectInput(overrides);
         expect(applyInjectContextResetGate(makeInjectCtx(overrides)).decision).toEqual(
@@ -275,6 +283,7 @@ describe('message inject delivery decision pipeline', () => {
             hasPriorContext: input.hasPriorContext,
             slotResetsContext: input.slotResetsContext,
             hasActiveDeliveryJob: input.hasActiveDeliveryJob,
+            hasUnconsumedDeliveredWork: input.hasUnconsumedDeliveredWork,
           })
         );
       }
@@ -298,13 +307,19 @@ describe('message turn-end flush decision pipeline', () => {
       { action: 'noop' },
     ],
     [
-      'two batchable messages batch without a context clear',
-      {},
+      'two batchable messages on a non-reset slot batch without a context clear',
+      { slotResetsContext: false },
       { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
+    ],
+    [
+      'a batch of deliverables on a reset slot plans exactly one clear ahead of the batch (#1085)',
+      {},
+      { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'clear_then_flush' } },
     ],
     [
       'owned and non-user messages are skipped alongside per-message delivery',
       {
+        slotResetsContext: false,
         messages: [
           makeFlushMessage({ uuid: 'job-owned' }),
           makeFlushMessage({ uuid: 'assistant', isUserMessage: false, flattenedText: null }),
@@ -325,7 +340,10 @@ describe('message turn-end flush decision pipeline', () => {
     ],
     [
       'a single deliverable message is delivered per message',
-      { messages: [makeFlushMessage({ uuid: 'solo' })] },
+      {
+        slotResetsContext: false,
+        messages: [makeFlushMessage({ uuid: 'solo' })],
+      },
       {
         action: 'each',
         deliver: ['solo'],
@@ -335,7 +353,7 @@ describe('message turn-end flush decision pipeline', () => {
     ],
     [
       'an active turn in the job queue forces per-message delivery',
-      { activeTurnInJobQueue: true },
+      { slotResetsContext: false, activeTurnInJobQueue: true },
       {
         action: 'each',
         deliver: ['a', 'b'],
@@ -346,6 +364,7 @@ describe('message turn-end flush decision pipeline', () => {
     [
       'a slash command forces per-message delivery',
       {
+        slotResetsContext: false,
         messages: [
           makeFlushMessage({ uuid: 'slash', flattenedText: '/compact' }),
           makeFlushMessage({ uuid: 'plain', flattenedText: 'hello' }),
@@ -356,6 +375,21 @@ describe('message turn-end flush decision pipeline', () => {
         deliver: ['slash', 'plain'],
         skip: [],
         contextReset: { action: 'flush_without_clear' },
+      },
+    ],
+    [
+      'a slash-command flush on a reset slot still plans one clear ahead of per-message delivery',
+      {
+        messages: [
+          makeFlushMessage({ uuid: 'slash', flattenedText: '/compact' }),
+          makeFlushMessage({ uuid: 'plain', flattenedText: 'hello' }),
+        ],
+      },
+      {
+        action: 'each',
+        deliver: ['slash', 'plain'],
+        skip: [],
+        contextReset: { action: 'clear_then_flush' },
       },
     ],
   ];
@@ -421,7 +455,7 @@ describe('message turn-end flush decision pipeline', () => {
       ).toEqual({
         action: 'batch',
         uuids: ['a', 'b'],
-        contextReset: { action: 'flush_without_clear' },
+        contextReset: { action: 'clear_then_flush' },
       });
       expect(
         applyFlushFinalGate(
@@ -433,7 +467,7 @@ describe('message turn-end flush decision pipeline', () => {
         action: 'each',
         deliver: ['a', 'b'],
         skip: [],
-        contextReset: { action: 'flush_without_clear' },
+        contextReset: { action: 'clear_then_flush' },
       });
     });
   });

--- a/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-delivery-pipeline.test.ts
@@ -59,7 +59,13 @@ function makeInjectCtx(overrides: Partial<InjectDeliveryInput> = {}): InjectDeli
 }
 
 function makeFlushMessage(overrides: Partial<FlushMessage> = {}): FlushMessage {
-  return { uuid: 'uuid-1', isUserMessage: true, flattenedText: 'hello', ...overrides };
+  return {
+    uuid: 'uuid-1',
+    isUserMessage: true,
+    isTaskInput: true,
+    flattenedText: 'hello',
+    ...overrides,
+  };
 }
 
 function makeFlushInput(overrides: Partial<TurnEndFlushInput> = {}): TurnEndFlushInput {
@@ -72,6 +78,7 @@ function makeFlushInput(overrides: Partial<TurnEndFlushInput> = {}): TurnEndFlus
     pendingInMemoryUuids: new Set<string>(),
     activeTurnInJobQueue: false,
     slotResetsContext: true,
+    hasPriorContext: true,
     ...overrides,
   };
 }
@@ -392,6 +399,39 @@ describe('message turn-end flush decision pipeline', () => {
         contextReset: { action: 'clear_then_flush' },
       },
     ],
+    [
+      'human-only deliverables on a reset slot flush without a clear',
+      {
+        messages: [
+          makeFlushMessage({ uuid: 'human-1', isTaskInput: false }),
+          makeFlushMessage({ uuid: 'human-2', isTaskInput: false, flattenedText: 'follow-up' }),
+        ],
+      },
+      {
+        action: 'batch',
+        uuids: ['human-1', 'human-2'],
+        contextReset: { action: 'flush_without_clear' },
+      },
+    ],
+    [
+      'a mixed human and task batch plans one clear ahead of the batch',
+      {
+        messages: [
+          makeFlushMessage({ uuid: 'human-1', isTaskInput: false }),
+          makeFlushMessage({ uuid: 'task-1', flattenedText: 'handoff' }),
+        ],
+      },
+      {
+        action: 'batch',
+        uuids: ['human-1', 'task-1'],
+        contextReset: { action: 'clear_then_flush' },
+      },
+    ],
+    [
+      'a session without prior context flushes without a clear on the first turn',
+      { hasPriorContext: false },
+      { action: 'batch', uuids: ['a', 'b'], contextReset: { action: 'flush_without_clear' } },
+    ],
   ];
 
   for (const [label, overrides, expected] of cases) {
@@ -442,7 +482,11 @@ describe('message turn-end flush decision pipeline', () => {
       const ownershipCtx = applyFlushOwnershipGate(makeFlushCtx({}));
       const ctx = applyFlushContextResetGate(ownershipCtx);
       expect(ctx.contextReset).toEqual(
-        planTurnEndFlushContextReset({ slotResetsContext: true, deliverableCount: 2 })
+        planTurnEndFlushContextReset({
+          slotResetsContext: true,
+          hasPriorContext: true,
+          taskDeliverableCount: 2,
+        })
       );
       expect(ctx.decision).toBeNull();
     });
@@ -482,12 +526,12 @@ describe('message turn-end flush decision pipeline', () => {
           pendingInMemoryUuids: input.pendingInMemoryUuids,
           activeTurnInJobQueue: input.activeTurnInJobQueue,
         });
-        const deliverableCount =
-          core.action === 'batch'
-            ? core.uuids.length
-            : core.action === 'each'
-              ? core.deliver.length
-              : 0;
+        const deliverables =
+          core.action === 'batch' ? core.uuids : core.action === 'each' ? core.deliver : [];
+        const deliverableSet = new Set(deliverables);
+        const taskDeliverableCount = input.messages.filter(
+          (message) => deliverableSet.has(message.uuid) && message.isTaskInput
+        ).length;
         const expected =
           core.action === 'noop'
             ? ({ action: 'noop' } as TurnEndFlushPlan)
@@ -495,7 +539,8 @@ describe('message turn-end flush decision pipeline', () => {
                 ...core,
                 contextReset: planTurnEndFlushContextReset({
                   slotResetsContext: input.slotResetsContext,
-                  deliverableCount,
+                  hasPriorContext: input.hasPriorContext,
+                  taskDeliverableCount,
                 }),
               };
         expect(decideTurnEndFlush(input)).toEqual(expected);

--- a/packages/daemon/tests/unit/1-core/agent/message-ownership-gates.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-ownership-gates.test.ts
@@ -15,6 +15,7 @@ function makeFlushMessage(overrides: Partial<FlushMessage> = {}): FlushMessage {
   return {
     uuid: 'uuid-1',
     isUserMessage: true,
+    isTaskInput: true,
     flattenedText: 'hello',
     ...overrides,
   };

--- a/packages/daemon/tests/unit/1-core/agent/message-ownership-gates.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/message-ownership-gates.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   decideDeferAdmission,
   type FlushMessage,
+  isTaskFlushInput,
   planFlushDelivery,
   resolveDeliveryRole,
   resolveMessageOwnership,
@@ -20,6 +21,26 @@ function makeFlushMessage(overrides: Partial<FlushMessage> = {}): FlushMessage {
     ...overrides,
   };
 }
+
+describe('isTaskFlushInput', () => {
+  test('a persisted task input kind classifies as a task', () => {
+    expect(isTaskFlushInput({ isSynthetic: true, inputKind: 'task' })).toBe(true);
+  });
+
+  test('a persisted system input kind never classifies as a task, even when synthetic', () => {
+    expect(isTaskFlushInput({ isSynthetic: true, inputKind: 'system' })).toBe(false);
+  });
+
+  test('a persisted human input kind never classifies as a task', () => {
+    expect(isTaskFlushInput({ isSynthetic: false, inputKind: 'human' })).toBe(false);
+  });
+
+  test('a legacy row without an input kind falls back to the synthetic flag', () => {
+    expect(isTaskFlushInput({ isSynthetic: true })).toBe(true);
+    expect(isTaskFlushInput({ isSynthetic: false })).toBe(false);
+    expect(isTaskFlushInput({})).toBe(false);
+  });
+});
 
 describe('resolveMessageOwnership', () => {
   test('job_queue wins when both queues hold the message', () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -639,7 +639,7 @@ describe('QueryModeHandler', () => {
       expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
     });
 
-    it('clears ahead of a human-only backlog when a task input is pending behind it', async () => {
+    it('delivers a human-only backlog first and clears for the task input pending behind it', async () => {
       const order: string[] = [];
       const clearSpy = mock(async () => {
         order.push('clear');
@@ -665,7 +665,38 @@ describe('QueryModeHandler', () => {
       const result = await handler.handleQueryTrigger({ pendingTaskInput: true });
 
       expect(result).toEqual({ success: true, messageCount: 1 });
-      expect(order).toEqual(['clear', 'uuid-human']);
+      expect(order).toEqual(['uuid-human', 'clear']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('delivers leading human rows before the clear that fronts the task rows', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            inputKind: 'human',
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+          ...deferredBatch(2),
+        ] as unknown as SDKMessage[])
+      );
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(order).toEqual(['uuid-human', 'clear', 'uuid-1', 'uuid-2']);
       expect(clearSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -700,6 +700,40 @@ describe('QueryModeHandler', () => {
       expect(updateMessageStatusSpy).toHaveBeenLastCalledWith(['db-1', 'db-2'], 'deferred');
     });
 
+    it('defers task rows while the leading human row turn is still processing', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            inputKind: 'human',
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+          ...deferredBatch(2),
+        ] as unknown as SDKMessage[])
+      );
+      resetSlotDb();
+      sizeSpy.mockImplementation(() => 0);
+
+      handler = new QueryModeHandler({
+        ...resetSlotContext(clearSpy),
+        stateManager: {
+          setQueuedIfIdle: async () => false,
+          getState: () => ({ status: 'processing' }),
+        },
+      });
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueWithIdSpy).toHaveBeenCalledWith('uuid-human', 'a human follow-up');
+      expect(updateMessageStatusSpy).toHaveBeenLastCalledWith(['db-1', 'db-2'], 'deferred');
+    });
+
     it('delivers leading human rows before the clear that fronts the task rows', async () => {
       const order: string[] = [];
       const clearSpy = mock(async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -618,6 +618,57 @@ describe('QueryModeHandler', () => {
       expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
     });
 
+    it('never clears while another delivery job is active for the session', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      resetSlotDb();
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(['uuid-active']),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('clears ahead of a human-only backlog when a task input is pending behind it', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            inputKind: 'human',
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+        ] as unknown as SDKMessage[])
+      );
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger({ pendingTaskInput: true });
+
+      expect(result).toEqual({ success: true, messageCount: 1 });
+      expect(order).toEqual(['clear', 'uuid-human']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('never clears for human-only deliverables on a reset slot', async () => {
       const clearSpy = mock(async () => {});
       getUserMessagesByStatusSpy.mockReturnValue(

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -31,6 +31,7 @@ describe('QueryModeHandler', () => {
   let updateMessageStatusSpy: ReturnType<typeof mock>;
   let emitSpy: ReturnType<typeof mock>;
   let enqueueWithIdSpy: ReturnType<typeof mock>;
+  let isRunningSpy: ReturnType<typeof mock>;
   let hasPendingOrInFlightSpy: ReturnType<typeof mock>;
   let ensureQueryStartedSpy: ReturnType<typeof mock>;
   let v2Previous: string | undefined;
@@ -79,10 +80,12 @@ describe('QueryModeHandler', () => {
     } as unknown as DaemonHub;
 
     enqueueWithIdSpy = mock(async () => {});
+    isRunningSpy = mock(() => false);
     hasPendingOrInFlightSpy = mock(() => false);
     mockMessageQueue = {
       enqueueWithId: enqueueWithIdSpy,
       hasPendingOrInFlight: hasPendingOrInFlightSpy,
+      isRunning: isRunningSpy,
     } as unknown as MessageQueue;
 
     mockLogger = {
@@ -669,6 +672,34 @@ describe('QueryModeHandler', () => {
       expect(clearSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('defers task rows without clearing while the memory queue is mid-turn', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            inputKind: 'human',
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+          ...deferredBatch(2),
+        ] as unknown as SDKMessage[])
+      );
+      resetSlotDb();
+      isRunningSpy.mockImplementation(() => true);
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueWithIdSpy).toHaveBeenCalledWith('uuid-human', 'a human follow-up');
+      expect(updateMessageStatusSpy).toHaveBeenLastCalledWith(['db-1', 'db-2'], 'deferred');
+    });
+
     it('delivers leading human rows before the clear that fronts the task rows', async () => {
       const order: string[] = [];
       const clearSpy = mock(async () => {
@@ -1252,6 +1283,48 @@ describe('QueryModeHandler', () => {
       expect(deliveryUuids()).toEqual([]);
       expect(enqueueWithIdSpy).not.toHaveBeenCalled();
       expect(ensureQueryStartedSpy).not.toHaveBeenCalled();
+    });
+
+    it('replay defers the deferred-task pass while the replayed human job is active', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockImplementation((_: string, status: string) =>
+        byStatusResult(
+          status === 'enqueued'
+            ? [
+                {
+                  dbId: 'db-human',
+                  uuid: 'uuid-human',
+                  type: 'user',
+                  isSynthetic: false,
+                  inputKind: 'human',
+                  message: { role: 'user', content: 'a human follow-up' },
+                },
+              ]
+            : [
+                {
+                  dbId: 'db-task',
+                  uuid: 'uuid-task',
+                  type: 'user',
+                  isSynthetic: true,
+                  inputKind: 'task',
+                  message: { role: 'user', content: 'the deferred task' },
+                },
+              ]
+        )
+      );
+
+      handler = new QueryModeHandler({
+        ...createContext(),
+        session: { ...mockSession, sdkSessionId: 'prior-sdk-session' },
+        slotResetsContext: () => true,
+        clearConversationContext: clearSpy,
+      });
+      await handler.replayPendingMessagesForImmediateMode();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      const jobs = deliveryUuids();
+      expect(jobs).toEqual([{ uuid: 'uuid-human', role: 'turn' }]);
+      expect(updateMessageStatusSpy).not.toHaveBeenCalled();
     });
 
     it('handleQueryTrigger clears exactly once before the durable batch job is created (#1085)', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -736,11 +736,68 @@ describe('QueryModeHandler', () => {
       resetSlotDb();
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
-      const result = await handler.handleQueryTrigger();
+      await expect(handler.handleQueryTrigger()).rejects.toThrow('cancelled by query teardown');
 
-      expect(result.success).toBe(false);
       expect(clearSpy).toHaveBeenCalledTimes(1);
       expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('propagates a cancelled clear out of the enqueued-row turn-end replay', async () => {
+      const clearSpy = mock(async () => {
+        throw new ClearConversationCancelledError();
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(2)));
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await expect(handler.sendEnqueuedMessagesOnTurnEnd()).rejects.toThrow(
+        'cancelled by query teardown'
+      );
+
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('clears before the deferred task when the enqueued replay carried only human rows', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockImplementation((_: string, status: string) =>
+        byStatusResult(
+          status === 'enqueued'
+            ? [
+                {
+                  dbId: 'db-human',
+                  uuid: 'uuid-human',
+                  type: 'user',
+                  isSynthetic: false,
+                  inputKind: 'human',
+                  message: { role: 'user', content: 'a human follow-up' },
+                },
+              ]
+            : [
+                {
+                  dbId: 'db-task',
+                  uuid: 'uuid-task',
+                  type: 'user',
+                  isSynthetic: true,
+                  inputKind: 'task',
+                  message: { role: 'user', content: 'the deferred task' },
+                },
+              ]
+        )
+      );
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await handler.replayPendingMessagesForImmediateMode();
+
+      expect(order).toEqual(['uuid-human', 'clear', 'uuid-task']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -31,7 +31,7 @@ describe('QueryModeHandler', () => {
   let updateMessageStatusSpy: ReturnType<typeof mock>;
   let emitSpy: ReturnType<typeof mock>;
   let enqueueWithIdSpy: ReturnType<typeof mock>;
-  let isRunningSpy: ReturnType<typeof mock>;
+  let sizeSpy: ReturnType<typeof mock>;
   let hasPendingOrInFlightSpy: ReturnType<typeof mock>;
   let ensureQueryStartedSpy: ReturnType<typeof mock>;
   let v2Previous: string | undefined;
@@ -80,12 +80,12 @@ describe('QueryModeHandler', () => {
     } as unknown as DaemonHub;
 
     enqueueWithIdSpy = mock(async () => {});
-    isRunningSpy = mock(() => false);
+    sizeSpy = mock(() => 0);
     hasPendingOrInFlightSpy = mock(() => false);
     mockMessageQueue = {
       enqueueWithId: enqueueWithIdSpy,
       hasPendingOrInFlight: hasPendingOrInFlightSpy,
-      isRunning: isRunningSpy,
+      size: sizeSpy,
     } as unknown as MessageQueue;
 
     mockLogger = {
@@ -688,7 +688,7 @@ describe('QueryModeHandler', () => {
         ] as unknown as SDKMessage[])
       );
       resetSlotDb();
-      isRunningSpy.mockImplementation(() => true);
+      sizeSpy.mockImplementation(() => 1);
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
       const result = await handler.handleQueryTrigger();

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -524,6 +524,7 @@ describe('QueryModeHandler', () => {
         dbId: `db-${i + 1}`,
         uuid: `uuid-${i + 1}`,
         type: 'user',
+        isSynthetic: true,
         message: { role: 'user', content: `message ${i + 1}` },
       })) as unknown as SDKMessage[];
     }
@@ -531,9 +532,21 @@ describe('QueryModeHandler', () => {
     function resetSlotContext(clearSpy: ReturnType<typeof mock>): QueryModeHandlerContext {
       return {
         ...createContext(),
+        session: { ...mockSession, sdkSessionId: 'prior-sdk-session' },
         slotResetsContext: () => true,
         clearConversationContext: clearSpy,
       };
+    }
+
+    function resetSlotDb(): void {
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
     }
 
     it('clears exactly once before the first message of a deferred batch (v1)', async () => {
@@ -545,14 +558,7 @@ describe('QueryModeHandler', () => {
         order.push(uuid);
       });
       getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
-      mockDb = {
-        getUserMessagesByStatus: getUserMessagesByStatusSpy,
-        updateMessageStatus: updateMessageStatusSpy,
-        getJobQueueRepo: () => ({
-          activeDeliveryMessageUuids: () => new Set<string>(),
-          hasActiveTurnDeliveryJob: () => false,
-        }),
-      } as unknown as Database;
+      resetSlotDb();
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
       await handler.handleQueryTrigger();
@@ -570,14 +576,7 @@ describe('QueryModeHandler', () => {
         order.push(uuid);
       });
       getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(2)));
-      mockDb = {
-        getUserMessagesByStatus: getUserMessagesByStatusSpy,
-        updateMessageStatus: updateMessageStatusSpy,
-        getJobQueueRepo: () => ({
-          activeDeliveryMessageUuids: () => new Set<string>(),
-          hasActiveTurnDeliveryJob: () => false,
-        }),
-      } as unknown as Database;
+      resetSlotDb();
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
       await handler.sendEnqueuedMessagesOnTurnEnd();
@@ -589,14 +588,7 @@ describe('QueryModeHandler', () => {
     it('never clears for a slot that does not reset context', async () => {
       const clearSpy = mock(async () => {});
       getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
-      mockDb = {
-        getUserMessagesByStatus: getUserMessagesByStatusSpy,
-        updateMessageStatus: updateMessageStatusSpy,
-        getJobQueueRepo: () => ({
-          activeDeliveryMessageUuids: () => new Set<string>(),
-          hasActiveTurnDeliveryJob: () => false,
-        }),
-      } as unknown as Database;
+      resetSlotDb();
 
       handler = new QueryModeHandler({
         ...createContext(),
@@ -609,6 +601,86 @@ describe('QueryModeHandler', () => {
       expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
     });
 
+    it('never clears on the first turn before prior context exists', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      resetSlotDb();
+
+      handler = new QueryModeHandler({
+        ...createContext(),
+        slotResetsContext: () => true,
+        clearConversationContext: clearSpy,
+      });
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('never clears for human-only deliverables on a reset slot', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+        ] as unknown as SDKMessage[])
+      );
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 1 });
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledWith('uuid-human', 'a human follow-up');
+    });
+
+    it('replays mixed pending states behind exactly one clear at the front (v1)', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockImplementation((_: string, status: string) =>
+        byStatusResult(
+          status === 'enqueued'
+            ? [
+                {
+                  dbId: 'db-enq',
+                  uuid: 'uuid-enq',
+                  type: 'user',
+                  isSynthetic: true,
+                  message: { role: 'user', content: 'queued task' },
+                },
+              ]
+            : [
+                {
+                  dbId: 'db-def',
+                  uuid: 'uuid-def',
+                  type: 'user',
+                  isSynthetic: true,
+                  message: { role: 'user', content: 'deferred task' },
+                },
+              ]
+        )
+      );
+      resetSlotDb();
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await handler.replayPendingMessagesForImmediateMode();
+
+      expect(order).toEqual(['clear', 'uuid-enq', 'uuid-def']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('skips the clear when no message is deliverable', async () => {
       const clearSpy = mock(async () => {});
       getUserMessagesByStatusSpy.mockReturnValue(
@@ -617,10 +689,12 @@ describe('QueryModeHandler', () => {
             dbId: 'db-owned',
             uuid: 'uuid-owned',
             type: 'user',
+            isSynthetic: true,
             message: { role: 'user', content: 'owned by the durable queue' },
           },
         ] as unknown as SDKMessage[])
       );
+      resetSlotDb();
       mockDb = {
         getUserMessagesByStatus: getUserMessagesByStatusSpy,
         updateMessageStatus: updateMessageStatusSpy,
@@ -642,14 +716,7 @@ describe('QueryModeHandler', () => {
         throw new Error('MessageQueueTimeoutError: /clear delivery timed out');
       });
       getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
-      mockDb = {
-        getUserMessagesByStatus: getUserMessagesByStatusSpy,
-        updateMessageStatus: updateMessageStatusSpy,
-        getJobQueueRepo: () => ({
-          activeDeliveryMessageUuids: () => new Set<string>(),
-          hasActiveTurnDeliveryJob: () => false,
-        }),
-      } as unknown as Database;
+      resetSlotDb();
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
       const result = await handler.handleQueryTrigger();
@@ -666,14 +733,7 @@ describe('QueryModeHandler', () => {
         throw new ClearConversationCancelledError();
       });
       getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
-      mockDb = {
-        getUserMessagesByStatus: getUserMessagesByStatusSpy,
-        updateMessageStatus: updateMessageStatusSpy,
-        getJobQueueRepo: () => ({
-          activeDeliveryMessageUuids: () => new Set<string>(),
-          hasActiveTurnDeliveryJob: () => false,
-        }),
-      } as unknown as Database;
+      resetSlotDb();
 
       handler = new QueryModeHandler(resetSlotContext(clearSpy));
       const result = await handler.handleQueryTrigger();
@@ -1067,12 +1127,25 @@ describe('QueryModeHandler', () => {
       });
       getUserMessagesByStatusSpy.mockReturnValue(
         byStatusResult([
-          { dbId: 'db-1', uuid: 'uuid-1', type: 'user', message: { role: 'user', content: 'one' } },
-          { dbId: 'db-2', uuid: 'uuid-2', type: 'user', message: { role: 'user', content: 'two' } },
+          {
+            dbId: 'db-1',
+            uuid: 'uuid-1',
+            type: 'user',
+            isSynthetic: true,
+            message: { role: 'user', content: 'one' },
+          },
+          {
+            dbId: 'db-2',
+            uuid: 'uuid-2',
+            type: 'user',
+            isSynthetic: true,
+            message: { role: 'user', content: 'two' },
+          },
           {
             dbId: 'db-3',
             uuid: 'uuid-3',
             type: 'user',
+            isSynthetic: true,
             message: { role: 'user', content: 'three' },
           },
         ] as unknown as SDKMessage[])
@@ -1080,6 +1153,7 @@ describe('QueryModeHandler', () => {
 
       handler = new QueryModeHandler({
         ...createContext(),
+        session: { ...mockSession, sdkSessionId: 'prior-sdk-session' },
         slotResetsContext: () => true,
         clearConversationContext: clearSpy,
       });

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -735,6 +735,39 @@ describe('QueryModeHandler', () => {
       expect(updateMessageStatusSpy).toHaveBeenLastCalledWith(['db-1', 'db-2'], 'deferred');
     });
 
+    it('re-triggers the deferred flush after the blocking delivery job settles', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(1)));
+      resetSlotDb();
+      let jobActive = true;
+      setTimeout(() => {
+        jobActive = false;
+      }, 50);
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => (jobActive ? new Set(['uuid-active']) : new Set()),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await handler.replayPendingMessagesForImmediateMode();
+
+      expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+      await new Promise((resolve) => setTimeout(resolve, 700));
+
+      expect(order).toEqual(['clear', 'uuid-1']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('delivers leading human rows before the clear that fronts the task rows', async () => {
       const order: string[] = [];
       const clearSpy = mock(async () => {
@@ -1318,6 +1351,60 @@ describe('QueryModeHandler', () => {
       expect(deliveryUuids()).toEqual([]);
       expect(enqueueWithIdSpy).not.toHaveBeenCalled();
       expect(ensureQueryStartedSpy).not.toHaveBeenCalled();
+    });
+
+    it('excludes re-deferred task rows from the trailing enqueued announce', async () => {
+      jobQueue.enqueue({
+        queue: 'message_delivery',
+        payload: {
+          sessionId: 'test-session-id',
+          messageUuid: 'uuid-active',
+          role: 'turn',
+          origin: 'chat',
+          parentToolUseId: null,
+        },
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-human',
+            uuid: 'uuid-human',
+            type: 'user',
+            isSynthetic: false,
+            inputKind: 'human',
+            message: { role: 'user', content: 'a human follow-up' },
+          },
+          {
+            dbId: 'db-task',
+            uuid: 'uuid-task',
+            type: 'user',
+            isSynthetic: true,
+            inputKind: 'task',
+            message: { role: 'user', content: 'handoff' },
+          },
+        ] as unknown as SDKMessage[])
+      );
+
+      handler = new QueryModeHandler({
+        ...createContext(),
+        session: { ...mockSession, sdkSessionId: 'prior-sdk-session' },
+        slotResetsContext: () => true,
+        clearConversationContext: async () => {},
+      });
+      await handler.handleQueryTrigger();
+
+      const events = emitSpy.mock.calls
+        .filter(([event]) => event === 'messages.statusChanged')
+        .map(([, payload]) => payload as { status: string; messageIds: string[] });
+      const enqueuedIds = events
+        .filter((p) => p.status === 'enqueued')
+        .flatMap((p) => p.messageIds);
+      const deferredIds = events
+        .filter((p) => p.status === 'deferred')
+        .flatMap((p) => p.messageIds);
+      expect(deferredIds).toEqual(['db-task']);
+      expect(enqueuedIds).toContain('db-human');
+      expect(enqueuedIds).not.toContain('db-task');
     });
 
     it('replay defers the deferred-task pass while the replayed human job is active', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -517,6 +517,126 @@ describe('QueryModeHandler', () => {
     });
   });
 
+  describe('turn-end flush context reset (resetContextPerTurn slots)', () => {
+    function deferredBatch(count: number): SDKMessage[] {
+      return Array.from({ length: count }, (_, i) => ({
+        dbId: `db-${i + 1}`,
+        uuid: `uuid-${i + 1}`,
+        type: 'user',
+        message: { role: 'user', content: `message ${i + 1}` },
+      })) as unknown as SDKMessage[];
+    }
+
+    function resetSlotContext(clearSpy: ReturnType<typeof mock>): QueryModeHandlerContext {
+      return {
+        ...createContext(),
+        slotResetsContext: () => true,
+        clearConversationContext: clearSpy,
+      };
+    }
+
+    it('clears exactly once before the first message of a deferred batch (v1)', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await handler.handleQueryTrigger();
+
+      expect(order).toEqual(['clear', 'uuid-1', 'uuid-2', 'uuid-3']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears exactly once before replaying enqueued messages on turn end (v1)', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      enqueueWithIdSpy.mockImplementation(async (uuid: string) => {
+        order.push(uuid);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(2)));
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      await handler.sendEnqueuedMessagesOnTurnEnd();
+
+      expect(order).toEqual(['clear', 'uuid-1', 'uuid-2']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('never clears for a slot that does not reset context', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler({
+        ...createContext(),
+        slotResetsContext: () => false,
+        clearConversationContext: clearSpy,
+      });
+      await handler.handleQueryTrigger();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('skips the clear when no message is deliverable', async () => {
+      const clearSpy = mock(async () => {});
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          {
+            dbId: 'db-owned',
+            uuid: 'uuid-owned',
+            type: 'user',
+            message: { role: 'user', content: 'owned by the durable queue' },
+          },
+        ] as unknown as SDKMessage[])
+      );
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(['uuid-owned']),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 1 });
+      expect(clearSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('durable delivery (v2 default) — task #861 item 3', () => {
     let jobQueue: JobQueueRepository;
     let jobsDb: Database;
@@ -886,6 +1006,43 @@ describe('QueryModeHandler', () => {
       expect(deliveryUuids()).toEqual([]);
       expect(enqueueWithIdSpy).not.toHaveBeenCalled();
       expect(ensureQueryStartedSpy).not.toHaveBeenCalled();
+    });
+
+    it('handleQueryTrigger clears exactly once before the durable batch job is created (#1085)', async () => {
+      const order: string[] = [];
+      const clearSpy = mock(async () => {
+        order.push('clear');
+      });
+      const enqueue = jobQueue.enqueue.bind(jobQueue);
+      jobQueue.enqueue = mock((...args: Parameters<typeof enqueue>) => {
+        order.push('job');
+        return enqueue(...args);
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(
+        byStatusResult([
+          { dbId: 'db-1', uuid: 'uuid-1', type: 'user', message: { role: 'user', content: 'one' } },
+          { dbId: 'db-2', uuid: 'uuid-2', type: 'user', message: { role: 'user', content: 'two' } },
+          {
+            dbId: 'db-3',
+            uuid: 'uuid-3',
+            type: 'user',
+            message: { role: 'user', content: 'three' },
+          },
+        ] as unknown as SDKMessage[])
+      );
+
+      handler = new QueryModeHandler({
+        ...createContext(),
+        slotResetsContext: () => true,
+        clearConversationContext: clearSpy,
+      });
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(order).toEqual(['clear', 'job']);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(deliveryUuids()).toHaveLength(1);
+      jobQueue.enqueue = enqueue;
     });
   });
 });

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { Session } from '@hyperneo/shared';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
+import { ClearConversationCancelledError } from '../../../../src/lib/agent/agent-session';
 import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
 import {
   QueryModeHandler,
@@ -634,6 +635,52 @@ describe('QueryModeHandler', () => {
 
       expect(result).toEqual({ success: true, messageCount: 1 });
       expect(clearSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps flushing when the pre-flush clear fails (non-cancellation)', async () => {
+      const clearSpy = mock(async () => {
+        throw new Error('MessageQueueTimeoutError: /clear delivery timed out');
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result).toEqual({ success: true, messageCount: 3 });
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(String(mockLogger.warn.mock.calls[0][0])).toContain('flushing without clear');
+    });
+
+    it('aborts the flush when the pre-flush clear is cancelled by teardown', async () => {
+      const clearSpy = mock(async () => {
+        throw new ClearConversationCancelledError();
+      });
+      getUserMessagesByStatusSpy.mockReturnValue(byStatusResult(deferredBatch(3)));
+      mockDb = {
+        getUserMessagesByStatus: getUserMessagesByStatusSpy,
+        updateMessageStatus: updateMessageStatusSpy,
+        getJobQueueRepo: () => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        }),
+      } as unknown as Database;
+
+      handler = new QueryModeHandler(resetSlotContext(clearSpy));
+      const result = await handler.handleQueryTrigger();
+
+      expect(result.success).toBe(false);
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(enqueueWithIdSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-mode-handler.test.ts
@@ -639,7 +639,8 @@ describe('QueryModeHandler', () => {
 
       expect(result).toEqual({ success: true, messageCount: 3 });
       expect(clearSpy).not.toHaveBeenCalled();
-      expect(enqueueWithIdSpy).toHaveBeenCalledTimes(3);
+      expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+      expect(updateMessageStatusSpy).toHaveBeenLastCalledWith(['db-1', 'db-2', 'db-3'], 'deferred');
     });
 
     it('delivers a human-only backlog first and clears for the task input pending behind it', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -799,6 +799,31 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.enqueueMock).toHaveBeenCalledWith(expect.any(String), '/compact');
   });
 
+  it('aborts the injection when the backlog replay clear is cancelled by teardown (#1085)', async () => {
+    const { manager, session } = makeManager({
+      slotResets: true,
+      unconsumedCounts: { enqueued: 1 },
+    });
+    session.replayMock.mockRejectedValue(new ClearConversationCancelledError());
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await expect(
+      manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true)
+    ).rejects.toThrow('cancelled by query teardown');
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.saveUserMessage).toHaveBeenCalledTimes(0);
+    expect(session.enqueueMock).not.toHaveBeenCalled();
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -960,6 +960,34 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.clearMock).toHaveBeenCalledTimes(1);
   });
 
+  it('defers the injected task when the backlog replay leaves a live turn and its clear is still due (#1085)', async () => {
+    const { manager, session } = makeManager({
+      slotResets: true,
+      unconsumedCounts: { deferred: 1 },
+    });
+    let status = 'idle';
+    session.replayMock.mockImplementation(async () => {
+      status = 'processing';
+      return { success: true, messageCount: 1 };
+    });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.saveUserMessage).toHaveBeenCalledTimes(1);
+    expect(session.saveUserMessage.mock.calls[0][2]).toBe('deferred');
+    expect(session.enqueueMock).not.toHaveBeenCalled();
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -824,6 +824,75 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.enqueueMock).not.toHaveBeenCalled();
   });
 
+  it('clears at the front when an injected task follows a human-only backlog (#1085)', async () => {
+    const { manager, session } = makeManager({ slotResets: true });
+    let status = 'processing';
+    const order: string[] = [];
+    session.enqueueMock.mockImplementation(async (_uuid: string, content: string) => {
+      order.push(content);
+    });
+    session.clearMock.mockImplementation(async () => {
+      order.push('/clear');
+    });
+    const humanDeferredRow = {
+      dbId: 'db-human',
+      uuid: 'uuid-human',
+      timestamp: 1,
+      type: 'user',
+      isSynthetic: false,
+      inputKind: 'human',
+      message: { role: 'user', content: 'a human follow-up' },
+    };
+    const backlogFlush = new QueryModeHandler({
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      db: {
+        getUserMessagesByStatus: mock(() => ({
+          messages: [humanDeferredRow],
+          total: 1,
+        })),
+        updateMessageStatus: mock(() => {}),
+        getJobQueueRepo: mock(() => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        })),
+      },
+      internalEventBus: { publish: mock(async () => {}) },
+      messageQueue: { enqueueWithId: session.enqueueMock },
+      logger: { error: mock(() => {}) },
+      ensureQueryStarted: session.ensureStartedMock,
+      slotResetsContext: () => true,
+      clearConversationContext: session.clearMock,
+    } as unknown as QueryModeHandlerContext);
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: (opts?: Parameters<QueryModeHandler['handleQueryTrigger']>[0]) =>
+        backlogFlush.handleQueryTrigger(opts),
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(
+      SESSION_ID,
+      'a human follow-up',
+      false,
+      undefined,
+      'defer'
+    );
+    session.getUserMessageIdsByStatus.mockImplementation(
+      (_sessionId: string, sendStatus: string) =>
+        sendStatus === 'deferred' ? [{ dbId: 'db-human', uuid: 'uuid-human', timestamp: 1 }] : []
+    );
+
+    status = 'idle';
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(order).toEqual(['/clear', 'a human follow-up', '─── Message from coder ───']);
+    expect(session.clearMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,
@@ -865,6 +934,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       deliverIndividually: true,
       excludeMessageUuid: expect.any(String),
       skipResetCoordination: true,
+      pendingTaskInput: false,
     });
     expect(session.saveUserMessage).toHaveBeenCalled();
     expect(session.enqueueMock).toHaveBeenCalled();

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -988,6 +988,34 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.enqueueMock).not.toHaveBeenCalled();
   });
 
+  it('defers the injected task when the backlog replay fails (#1085)', async () => {
+    const { manager, session } = makeManager({
+      slotResets: true,
+      unconsumedCounts: { deferred: 1 },
+    });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      sendEnqueuedMessagesOnTurnEnd: async () => ({
+        replayedWork: true,
+        clearedContext: false,
+        replayFailed: true,
+      }),
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.saveUserMessage).toHaveBeenCalledTimes(1);
+    expect(session.saveUserMessage.mock.calls[0][2]).toBe('deferred');
+    expect(session.enqueueMock).not.toHaveBeenCalled();
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -749,6 +749,56 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(context).toEqual(['urgent task']);
   });
 
+  it('does NOT clear when replaying a stranded system recovery row on a reset slot', async () => {
+    const { manager, session } = makeManager({ slotResets: true });
+    let status = 'processing';
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(
+      SESSION_ID,
+      '/compact',
+      true,
+      undefined,
+      'defer',
+      'system'
+    );
+    const stranded = session.saveUserMessage.mock.calls[0][1] as SDKMessage;
+    status = 'idle';
+    const flush = new QueryModeHandler({
+      session: live.session,
+      db: {
+        getUserMessagesByStatus: mock(() => ({
+          messages: [{ ...stranded, dbId: 'db-compact', timestamp: 1 }],
+          total: 1,
+        })),
+        updateMessageStatus: mock(() => {}),
+        getJobQueueRepo: mock(() => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        })),
+      },
+      internalEventBus: { publish: mock(async () => {}) },
+      messageQueue: live.messageQueue,
+      logger: { error: mock(() => {}) },
+      ensureQueryStarted: session.ensureStartedMock,
+      slotResetsContext: () => true,
+      clearConversationContext: session.clearMock,
+    } as unknown as QueryModeHandlerContext);
+
+    await flush.handleQueryTrigger();
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.enqueueMock).toHaveBeenCalledWith(expect.any(String), '/compact');
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -31,6 +31,7 @@ function makeManager(opts: {
   reopenDbId?: string;
   failedDbId?: string;
   enqueueThrows?: boolean;
+  unconsumedCounts?: Record<string, number>;
 }): {
   manager: TaskAgentManager;
   session: Record<string, ReturnType<typeof mock>>;
@@ -52,6 +53,9 @@ function makeManager(opts: {
   const reopenDeliveryByUuid = mock(() => opts.reopenDbId ?? null);
   const markDeliveryDeferredByUuid = mock(() => null);
   const markDeliveryFailedByUuid = mock(() => opts.failedDbId ?? null);
+  const getMessageCountByStatus = mock(
+    (_sessionId: string, status: string) => opts.unconsumedCounts?.[status] ?? 0
+  );
   const publishStatusChanged = mock(async () => {});
 
   function makeSession(o: MockSessionOptions) {
@@ -80,6 +84,7 @@ function makeManager(opts: {
     db: {
       getDatabase: () => ({}),
       saveUserMessage,
+      getMessageCountByStatus,
       getSDKMessageRepo: () => ({
         getDeliveryContent: () => opts.deliveryContent ?? null,
         reopenDeliveryByUuid,
@@ -137,6 +142,7 @@ function makeManager(opts: {
       reopenDeliveryByUuid,
       markDeliveryDeferredByUuid,
       markDeliveryFailedByUuid,
+      getMessageCountByStatus,
       publishStatusChanged,
     },
   };
@@ -600,7 +606,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(locks.size).toBe(0);
   });
 
-  it('KNOWN-BUG turn-end delivers handoff then later idle clear wipes that handoff', async () => {
+  it('turn-end flush clears before the deferred handoff and a later inject never clears over it (#1085)', async () => {
     const { manager, session } = makeManager({ slotResets: true });
     let status = 'processing';
     const context: string[] = [];
@@ -633,24 +639,55 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
           total: 1,
         })),
         updateMessageStatus: mock(() => {}),
-        getJobQueueRepo: mock(() => ({ activeDeliveryMessageUuids: () => new Set<string>() })),
+        getJobQueueRepo: mock(() => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        })),
       },
       internalEventBus: { publish: mock(async () => {}) },
       messageQueue: live.messageQueue,
       logger: { error: mock(() => {}) },
       ensureQueryStarted: session.ensureStartedMock,
+      slotResetsContext: () => true,
+      clearConversationContext: session.clearMock,
     } as unknown as QueryModeHandlerContext);
 
     await flush.handleQueryTrigger();
 
-    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.clearMock).toHaveBeenCalledTimes(1);
     expect(context).toEqual(['handoff']);
 
     status = 'idle';
+    session.getMessageCountByStatus.mockImplementation((_sessionId: string, sendStatus: string) =>
+      sendStatus === 'enqueued' ? 1 : 0
+    );
     await manager.injectSubSessionMessage(SESSION_ID, 'later task', true);
 
-    expect(order).toEqual(['handoff', '/clear', 'later task']);
-    expect(context).toEqual(['later task']);
+    expect(order).toEqual(['/clear', 'handoff', 'later task']);
+    expect(context).toEqual(['handoff', 'later task']);
+    expect(session.clearMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
+    const { manager, session } = makeManager({
+      slotResets: true,
+      unconsumedCounts: { enqueued: 2 },
+    });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(session.clearMock).not.toHaveBeenCalled();
+    expect(session.saveUserMessage).toHaveBeenCalled();
+    expect(session.enqueueMock).toHaveBeenCalled();
   });
 
   it('replays the deferred backlog as individual messages when injecting into an idle session', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -2,7 +2,10 @@ import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import { ClearConversationCancelledError } from '../../../../src/lib/agent/agent-session.ts';
-import { signalDeliveryConsumed } from '../../../../src/lib/agent/message-delivery';
+import {
+  sessionResetCoordinationLocks,
+  signalDeliveryConsumed,
+} from '../../../../src/lib/agent/message-delivery';
 import {
   QueryModeHandler,
   type QueryModeHandlerContext,
@@ -53,8 +56,12 @@ function makeManager(opts: {
   const reopenDeliveryByUuid = mock(() => opts.reopenDbId ?? null);
   const markDeliveryDeferredByUuid = mock(() => null);
   const markDeliveryFailedByUuid = mock(() => opts.failedDbId ?? null);
-  const getMessageCountByStatus = mock(
-    (_sessionId: string, status: string) => opts.unconsumedCounts?.[status] ?? 0
+  const getUserMessageIdsByStatus = mock((_sessionId: string, status: string) =>
+    Array.from({ length: opts.unconsumedCounts?.[status] ?? 0 }, (_, i) => ({
+      dbId: `db-${status}-${i}`,
+      uuid: `uuid-${status}-${i}`,
+      timestamp: 0,
+    }))
   );
   const publishStatusChanged = mock(async () => {});
 
@@ -84,7 +91,7 @@ function makeManager(opts: {
     db: {
       getDatabase: () => ({}),
       saveUserMessage,
-      getMessageCountByStatus,
+      getUserMessageIdsByStatus,
       getSDKMessageRepo: () => ({
         getDeliveryContent: () => opts.deliveryContent ?? null,
         reopenDeliveryByUuid,
@@ -142,7 +149,7 @@ function makeManager(opts: {
       reopenDeliveryByUuid,
       markDeliveryDeferredByUuid,
       markDeliveryFailedByUuid,
-      getMessageCountByStatus,
+      getUserMessageIdsByStatus,
       publishStatusChanged,
     },
   };
@@ -601,9 +608,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
 
     await manager.injectSubSessionMessage(SESSION_ID, 'msg', true);
 
-    const locks = (manager as unknown as { sessionInjectLocks: Map<string, unknown> })
-      .sessionInjectLocks;
-    expect(locks.size).toBe(0);
+    expect(sessionResetCoordinationLocks.size).toBe(0);
   });
 
   it('turn-end flush clears before the deferred handoff and a later inject never clears over it (#1085)', async () => {
@@ -658,14 +663,90 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(context).toEqual(['handoff']);
 
     status = 'idle';
-    session.getMessageCountByStatus.mockImplementation((_sessionId: string, sendStatus: string) =>
-      sendStatus === 'enqueued' ? 1 : 0
+    session.getUserMessageIdsByStatus.mockImplementation(
+      (_sessionId: string, sendStatus: string) =>
+        sendStatus === 'enqueued'
+          ? [{ dbId: 'db-handoff', uuid: 'uuid-handoff', timestamp: 1 }]
+          : []
     );
     await manager.injectSubSessionMessage(SESSION_ID, 'later task', true);
 
     expect(order).toEqual(['/clear', 'handoff', 'later task']);
     expect(context).toEqual(['handoff', 'later task']);
     expect(session.clearMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes the flush clear against concurrent injections so the clear never wipes a delivered task (#1085)', async () => {
+    const { manager, session } = makeManager({ slotResets: true });
+    let status = 'processing';
+    const context: string[] = [];
+    const order: string[] = [];
+    let clearReleased = false;
+    let releaseClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
+    });
+    session.enqueueMock.mockImplementation(async (_uuid: string, content: string) => {
+      order.push(content);
+      context.push(content);
+    });
+    session.clearMock.mockImplementation(async () => {
+      order.push('/clear');
+      context.length = 0;
+      if (!clearReleased) await clearGate;
+    });
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, 'handoff', true, undefined, 'defer');
+    const deferred = session.saveUserMessage.mock.calls[0][1] as SDKMessage;
+    const flush = new QueryModeHandler({
+      session: live.session,
+      db: {
+        getUserMessagesByStatus: mock(() => ({
+          messages: [{ ...deferred, dbId: 'db-handoff', timestamp: 1 }],
+          total: 1,
+        })),
+        updateMessageStatus: mock(() => {}),
+        getJobQueueRepo: mock(() => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        })),
+      },
+      internalEventBus: { publish: mock(async () => {}) },
+      messageQueue: live.messageQueue,
+      logger: { error: mock(() => {}) },
+      ensureQueryStarted: session.ensureStartedMock,
+      slotResetsContext: () => true,
+      clearConversationContext: session.clearMock,
+    } as unknown as QueryModeHandlerContext);
+
+    status = 'idle';
+    const settle = () => new Promise((r) => setTimeout(r, 0));
+    const flushPromise = flush.handleQueryTrigger();
+    await settle();
+    await settle();
+
+    const injectPromise = manager.injectSubSessionMessage(SESSION_ID, 'urgent task', true);
+    await settle();
+    await settle();
+
+    expect(order).toEqual(['/clear']);
+    expect(session.saveUserMessage).toHaveBeenCalledTimes(1);
+
+    clearReleased = true;
+    releaseClear();
+    await Promise.all([flushPromise, injectPromise]);
+
+    expect(order).toEqual(['/clear', 'handoff', '/clear', 'urgent task']);
+    expect(context).toEqual(['urgent task']);
   });
 
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
@@ -708,6 +789,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.replayMock).toHaveBeenCalledWith({
       deliverIndividually: true,
       excludeMessageUuid: expect.any(String),
+      skipResetCoordination: true,
     });
     expect(session.saveUserMessage).toHaveBeenCalled();
     expect(session.enqueueMock).toHaveBeenCalled();

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -72,7 +72,7 @@ function makeManager(opts: {
       handleQueryTrigger: replayMock,
       ensureQueryStarted: ensureStartedMock,
       clearConversationContext: clearMock,
-      messageQueue: { enqueueWithId: enqueueMock },
+      messageQueue: { enqueueWithId: enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
   }
 
@@ -186,7 +186,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -206,7 +206,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -225,7 +225,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -244,7 +244,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -261,7 +261,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -278,7 +278,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -295,7 +295,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -312,7 +312,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -328,7 +328,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -353,7 +353,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -371,7 +371,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -402,7 +402,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -430,7 +430,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         throw new ClearConversationCancelledError();
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -465,7 +465,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -537,7 +537,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -583,7 +583,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -602,7 +602,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -630,7 +630,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -701,7 +701,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -758,7 +758,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -811,7 +811,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -857,7 +857,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
         })),
       },
       internalEventBus: { publish: mock(async () => {}) },
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
       logger: { error: mock(() => {}) },
       ensureQueryStarted: session.ensureStartedMock,
       slotResetsContext: () => true,
@@ -870,7 +870,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       handleQueryTrigger: (opts?: Parameters<QueryModeHandler['handleQueryTrigger']>[0]) =>
         backlogFlush.handleQueryTrigger(opts),
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -904,7 +904,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -923,7 +923,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -948,7 +948,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -974,7 +974,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1008,7 +1008,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
   }
 
@@ -1072,7 +1072,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1090,7 +1090,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1108,7 +1108,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'idle' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -1127,7 +1127,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1154,7 +1154,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1196,7 +1196,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'rate_limit_cooldown' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock },
+      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
     } as unknown as AgentSession;
     indexSession(manager, live);
 

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -889,7 +889,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     status = 'idle';
     await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
 
-    expect(order).toEqual(['/clear', 'a human follow-up', '─── Message from coder ───']);
+    expect(order).toEqual(['a human follow-up', '/clear', '─── Message from coder ───']);
     expect(session.clearMock).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/reset-context-per-turn.test.ts
@@ -72,7 +72,7 @@ function makeManager(opts: {
       handleQueryTrigger: replayMock,
       ensureQueryStarted: ensureStartedMock,
       clearConversationContext: clearMock,
-      messageQueue: { enqueueWithId: enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
   }
 
@@ -186,7 +186,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -206,7 +206,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -225,7 +225,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -244,7 +244,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -261,7 +261,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -278,7 +278,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -295,7 +295,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -312,7 +312,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -328,7 +328,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -353,7 +353,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -371,7 +371,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -402,7 +402,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -430,7 +430,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         throw new ClearConversationCancelledError();
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -465,7 +465,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -537,7 +537,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       clearConversationContext: mock(async () => {
         await clearGate;
       }),
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -583,7 +583,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -602,7 +602,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -630,7 +630,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -701,7 +701,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -758,7 +758,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -811,7 +811,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -857,7 +857,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
         })),
       },
       internalEventBus: { publish: mock(async () => {}) },
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
       logger: { error: mock(() => {}) },
       ensureQueryStarted: session.ensureStartedMock,
       slotResetsContext: () => true,
@@ -870,7 +870,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       handleQueryTrigger: (opts?: Parameters<QueryModeHandler['handleQueryTrigger']>[0]) =>
         backlogFlush.handleQueryTrigger(opts),
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -893,6 +893,73 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
     expect(session.clearMock).toHaveBeenCalledTimes(1);
   });
 
+  it('clears for an injected task behind a stranded enqueued row with no delivery job (#1085)', async () => {
+    const { manager, session } = makeManager({ slotResets: true });
+    const order: string[] = [];
+    session.enqueueMock.mockImplementation(async (_uuid: string, content: string) => {
+      order.push(content);
+    });
+    session.clearMock.mockImplementation(async () => {
+      order.push('/clear');
+    });
+    session.getUserMessageIdsByStatus.mockImplementation(
+      (_sessionId: string, sendStatus: string) =>
+        sendStatus === 'enqueued'
+          ? [{ dbId: 'db-stranded', uuid: 'uuid-stranded', timestamp: 1 }]
+          : []
+    );
+    const strandedRow = {
+      dbId: 'db-stranded',
+      uuid: 'uuid-stranded',
+      timestamp: 1,
+      type: 'user',
+      isSynthetic: true,
+      inputKind: 'task',
+      message: { role: 'user', content: 'stranded task' },
+    };
+    const enqueuedFlush = new QueryModeHandler({
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      db: {
+        getUserMessagesByStatus: mock(() => ({
+          messages: [strandedRow],
+          total: 1,
+        })),
+        updateMessageStatus: mock(() => {}),
+        getJobQueueRepo: mock(() => ({
+          activeDeliveryMessageUuids: () => new Set<string>(),
+          hasActiveTurnDeliveryJob: () => false,
+        })),
+      },
+      internalEventBus: { publish: mock(async () => {}) },
+      messageQueue: {
+        enqueueWithId: session.enqueueMock,
+        size: () => 0,
+        hasPendingOrInFlight: () => false,
+      },
+      logger: { error: mock(() => {}) },
+      ensureQueryStarted: session.ensureStartedMock,
+      slotResetsContext: () => true,
+      clearConversationContext: session.clearMock,
+    } as unknown as QueryModeHandlerContext);
+    const live = {
+      session: { id: SESSION_ID, sdkSessionId: 'prior-sdk-session' },
+      getProcessingState: () => ({ status: 'idle' }),
+      ensureQueryStarted: session.ensureStartedMock,
+      handleQueryTrigger: session.replayMock,
+      sendEnqueuedMessagesOnTurnEnd: (
+        opts?: Parameters<QueryModeHandler['sendEnqueuedMessagesOnTurnEnd']>[0]
+      ) => enqueuedFlush.sendEnqueuedMessagesOnTurnEnd(opts),
+      clearConversationContext: session.clearMock,
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
+    } as unknown as AgentSession;
+    indexSession(manager, live);
+
+    await manager.injectSubSessionMessage(SESSION_ID, '─── Message from coder ───', true);
+
+    expect(order).toEqual(['/clear', 'stranded task', '─── Message from coder ───']);
+    expect(session.clearMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does NOT clear on inject while unconsumed delivered work is pending (#1085)', async () => {
     const { manager, session } = makeManager({
       slotResets: true,
@@ -904,7 +971,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -923,7 +990,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -934,6 +1001,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       deliverIndividually: true,
       excludeMessageUuid: expect.any(String),
       skipResetCoordination: true,
+      skipContextReset: false,
       pendingTaskInput: false,
     });
     expect(session.saveUserMessage).toHaveBeenCalled();
@@ -948,7 +1016,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -974,7 +1042,7 @@ describe('resetContextPerTurn — TaskAgentManager injection gating', () => {
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1008,7 +1076,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
   }
 
@@ -1072,7 +1140,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1090,7 +1158,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1108,7 +1176,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'idle' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
     attachSessionToTask(manager, live);
@@ -1127,7 +1195,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       ensureQueryStarted: session.ensureStartedMock,
       handleQueryTrigger: session.replayMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1154,7 +1222,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'processing' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 
@@ -1196,7 +1264,7 @@ describe('injectMessageIntoSession — v2 idempotent persist (Codex P1)', () => 
       getProcessingState: () => ({ status: 'rate_limit_cooldown' }),
       ensureQueryStarted: session.ensureStartedMock,
       clearConversationContext: session.clearMock,
-      messageQueue: { enqueueWithId: session.enqueueMock, isRunning: () => false },
+      messageQueue: { enqueueWithId: session.enqueueMock, size: () => 0 },
     } as unknown as AgentSession;
     indexSession(manager, live);
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -1976,6 +1976,21 @@ describe('SpaceRuntimeService', () => {
       expect(agent.setRuntimeSystemPrompt).not.toHaveBeenCalled();
     });
 
+    test('re-attaches the slot context reset policy onto the fresh session instance', async () => {
+      const agent = makeMemberAgentSession();
+      const sessionManager = makeSessionManager(agent);
+      const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+      const reattachSlotContextReset = mock(() => {});
+      svc.setTaskAgentManager({
+        reattachSlotContextReset,
+      } as unknown as TaskAgentManager);
+
+      await svc.attachSpaceToolsToMemberSession(makeMemberSession());
+
+      expect(reattachSlotContextReset).toHaveBeenCalledTimes(1);
+      expect(reattachSlotContextReset).toHaveBeenCalledWith(agent);
+    });
+
     test('also attaches db-query when dbPath is configured', async () => {
       const agent = makeMemberAgentSession();
       const sessionManager = makeSessionManager(agent);

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-rehydration-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-rehydration-mcp.test.ts
@@ -300,6 +300,58 @@ describe('TaskAgentManager — ghost rehydration MCP invariant', () => {
     expect(fake.state.session.config.mcpServers?.['node-agent']).toBeDefined();
   });
 
+  test('rejects the injection when the resolved session disappears before the lock', async () => {
+    const { tam } = makeManager();
+    const fake = makeFakeAgentSession(SUB_SESSION_ID);
+    const config = (
+      tam as unknown as {
+        config: {
+          db: Record<string, unknown>;
+          nodeExecutionRepo: Record<string, unknown>;
+        };
+      }
+    ).config;
+    config.nodeExecutionRepo.getByAgentSessionId = () => makeExecution();
+    config.db.getSDKMessageRepo = () => ({
+      getDeliveryContent: () => null,
+      reopenDeliveryByUuid: () => null,
+      markDeliveryFailedByUuid: () => null,
+      markDeliveryDeferredByUuid: () => null,
+    });
+    config.db.getJobQueueRepo = () => ({
+      activeDeliveryMessageUuids: () => new Set<string>(),
+      hasActiveTurnDeliveryJob: () => false,
+      getActiveDeliveryRole: () => null,
+      enqueue: () => ({ id: 'job-1' }),
+    });
+    config.db.saveUserMessage = () => 'db-id';
+    config.db.getUserMessageIdsByStatus = () => [];
+    const session = fake.agentSession as unknown as Record<string, unknown>;
+    session.handleQueryTrigger = async () => ({ success: true, messageCount: 0 });
+    session.ensureQueryStarted = async () => {};
+    session.messageQueue = { enqueueWithId: async () => {}, size: () => 0 };
+    const index = (tam as unknown as { agentSessionIndex: Map<string, AgentSessionType> })
+      .agentSessionIndex;
+    index.set(SUB_SESSION_ID, fake.agentSession);
+
+    let releaseLock!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const holder = withSessionResetCoordination(SUB_SESSION_ID, async () => {
+      await gate;
+    });
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+    const injectPromise = tam.injectSubSessionMessage(SUB_SESSION_ID, 'handoff', true);
+    await settle();
+    await settle();
+
+    index.delete(SUB_SESSION_ID);
+    releaseLock();
+    await holder;
+    await expect(injectPromise).rejects.toThrow(`Sub-session not found: ${SUB_SESSION_ID}`);
+  });
+
   test('injecting into an uncached sub-session never deadlocks against the reset-coordination lock', async () => {
     const { tam } = makeManager();
     const fake = makeFakeAgentSession(SUB_SESSION_ID);

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-rehydration-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-rehydration-mcp.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, afterEach, spyOn } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
+import {
+  signalDeliveryConsumed,
+  withSessionResetCoordination,
+} from '../../../../src/lib/agent/message-delivery';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
@@ -294,5 +298,55 @@ describe('TaskAgentManager — ghost rehydration MCP invariant', () => {
     await callback!(fake.agentSession, ['node-agent']);
 
     expect(fake.state.session.config.mcpServers?.['node-agent']).toBeDefined();
+  });
+
+  test('injecting into an uncached sub-session never deadlocks against the reset-coordination lock', async () => {
+    const { tam } = makeManager();
+    const fake = makeFakeAgentSession(SUB_SESSION_ID);
+    const config = (
+      tam as unknown as {
+        config: {
+          db: Record<string, unknown>;
+          nodeExecutionRepo: Record<string, unknown>;
+        };
+      }
+    ).config;
+    config.nodeExecutionRepo.getByAgentSessionId = () => makeExecution();
+    config.db.getSDKMessageRepo = () => ({
+      getDeliveryContent: () => null,
+      reopenDeliveryByUuid: () => null,
+      markDeliveryFailedByUuid: () => null,
+      markDeliveryDeferredByUuid: () => null,
+    });
+    config.db.getJobQueueRepo = () => ({
+      activeDeliveryMessageUuids: () => new Set<string>(),
+      hasActiveTurnDeliveryJob: () => false,
+      getActiveDeliveryRole: () => null,
+      enqueue: (args: { payload?: { sessionId?: string; messageUuid?: string } }) => {
+        const uuid = args?.payload?.messageUuid;
+        if (uuid) signalDeliveryConsumed(args!.payload!.sessionId!, uuid);
+        return { id: 'job-1' };
+      },
+    });
+    config.db.saveUserMessage = () => 'db-id';
+    config.db.getUserMessageIdsByStatus = () => [];
+    const session = fake.agentSession as unknown as Record<string, unknown>;
+    session.replayPendingMessagesForImmediateMode = async () => {
+      await withSessionResetCoordination(SUB_SESSION_ID, async () => {});
+    };
+    session.handleQueryTrigger = async () => ({ success: true, messageCount: 0 });
+    session.ensureQueryStarted = async () => {};
+    session.messageQueue = { enqueueWithId: async () => {}, isRunning: () => false };
+    restoreSpy = spyOn(AgentSession, 'restore').mockImplementation(
+      (() => fake.agentSession) as unknown as typeof AgentSession.restore
+    );
+
+    const dbId = await tam.injectSubSessionMessage(
+      SUB_SESSION_ID,
+      '─── Message from coder ───',
+      true
+    );
+
+    expect(dbId).toBe('db-id');
   });
 });


### PR DESCRIPTION
Fixes the two root causes of live incident #1085 (resetContextPerTurn lineage #784→#785, absorbed from cancelled task #1098): the turn-end flush now emits one confirmed `clear_then_flush` before the first message of a batch instead of never clearing, and the inject clear gate gains `hasUnconsumedDeliveredWork` (`unconsumed_work_pending`) so a clear can never fire over enqueued/deferred work — together the message-then-later-clear inversion becomes clear-before-handoff, and the reviewer keeps its instructions. Non-reset slots and V1 behavior are unchanged; PR-1 KNOWN-BUG pins flipped to the regression pins.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->