### PR TITLE
refactor(space): extract stop-verification-gates pure core (superpipe S3 PR 3/6)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/stop-verification-gates.ts
+++ b/packages/daemon/src/lib/space/runtime/stop-verification-gates.ts
@@ -21,7 +21,20 @@ export type StopVerificationDecision =
   | { action: 'report_leak'; reason: string };
 
 export function isStopDownProcessingStatus(status: AgentProcessingState['status']): boolean {
-  return status === 'idle' || status === 'interrupted';
+  switch (status) {
+    case 'idle':
+    case 'interrupted':
+      return true;
+    case 'queued':
+    case 'processing':
+    case 'waiting_for_input':
+    case 'rate_limit_cooldown':
+      return false;
+    default: {
+      const _exhaustive: never = status;
+      return Boolean(_exhaustive);
+    }
+  }
 }
 
 export interface SessionLivenessSnapshot {

--- a/packages/daemon/src/lib/space/runtime/stop-verification-gates.ts
+++ b/packages/daemon/src/lib/space/runtime/stop-verification-gates.ts
@@ -1,0 +1,79 @@
+import type { AgentProcessingState } from '@hyperneo/shared';
+import type { VerifiedSessionStop } from './task-agent-manager';
+
+export const VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS = 2;
+
+export interface StopVerificationSnapshot {
+  sessionPresent: boolean;
+  processingStatus: AgentProcessingState['status'];
+  interruptInProgress: boolean;
+  livePids: readonly number[];
+  interruptAttemptsSoFar: number;
+  escalationDone: boolean;
+}
+
+export type SessionLiveness = { down: true } | { down: false; reason: string };
+
+export type StopVerificationDecision =
+  | { action: 'down' }
+  | { action: 'retry_interrupt'; reason: string }
+  | { action: 'escalate_terminate'; reason: string }
+  | { action: 'report_leak'; reason: string };
+
+export function isStopDownProcessingStatus(status: AgentProcessingState['status']): boolean {
+  return status === 'idle' || status === 'interrupted';
+}
+
+export interface SessionLivenessSnapshot {
+  processingStatus: StopVerificationSnapshot['processingStatus'];
+  interruptInProgress: boolean;
+  livePids: readonly number[];
+}
+
+export function inspectSessionLiveness(snapshot: SessionLivenessSnapshot): SessionLiveness {
+  if (!isStopDownProcessingStatus(snapshot.processingStatus)) {
+    return { down: false, reason: `processing state '${snapshot.processingStatus}'` };
+  }
+  if (snapshot.interruptInProgress) {
+    return { down: false, reason: 'interrupt still in progress' };
+  }
+  if (snapshot.livePids.length > 0) {
+    return { down: false, reason: `live SDK process pid(s) ${snapshot.livePids.join(', ')}` };
+  }
+  return { down: true };
+}
+
+export function decideStopVerification(
+  snapshot: StopVerificationSnapshot
+): StopVerificationDecision {
+  if (!snapshot.sessionPresent) return { action: 'down' };
+  const liveness = inspectSessionLiveness(snapshot);
+  if (liveness.down) return { action: 'down' };
+  if (snapshot.interruptAttemptsSoFar < VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS) {
+    return { action: 'retry_interrupt', reason: liveness.reason };
+  }
+  if (!snapshot.escalationDone) {
+    return { action: 'escalate_terminate', reason: liveness.reason };
+  }
+  return { action: 'report_leak', reason: liveness.reason };
+}
+
+export interface VerifiedStopAssembly {
+  sessionId: string;
+  notes: readonly string[];
+  decision: StopVerificationDecision;
+}
+
+export function assembleVerifiedStopResult(assembly: VerifiedStopAssembly): VerifiedSessionStop {
+  if (assembly.decision.action === 'down') {
+    if (assembly.notes.length === 0) {
+      return { sessionId: assembly.sessionId, stopped: true };
+    }
+    return { sessionId: assembly.sessionId, stopped: true, detail: assembly.notes.join('; ') };
+  }
+  return {
+    sessionId: assembly.sessionId,
+    stopped: false,
+    detail: [...assembly.notes, `still alive: ${assembly.decision.reason}`].join('; '),
+  };
+}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -84,6 +84,13 @@ import {
   resolveSpawnWorkspace,
   resolveWorkflowNodeSlot,
 } from './spawn-slot-resolution';
+import {
+  assembleVerifiedStopResult,
+  decideStopVerification,
+  isStopDownProcessingStatus,
+  type StopVerificationDecision,
+  type StopVerificationSnapshot,
+} from './stop-verification-gates';
 import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-manager';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
@@ -2227,32 +2234,42 @@ export class TaskAgentManager {
       }
 
       const notes: string[] = [];
+      let interruptAttemptsSoFar = 0;
+      let escalationDone = false;
 
-      try {
-        await this.stopSessionPreserveDb(sessionId, session, { strict: true });
-      } catch (err) {
-        notes.push(`interrupt failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-
-      let verdict = await this.inspectSessionDown(session);
-      if (!verdict.down) {
-        log.warn(
-          `TaskAgentManager.stopSessionsVerified: session ${sessionId} still alive after interrupt (${verdict.reason}); retrying once`
-        );
+      const attemptInterrupt = async (failureNote: string): Promise<void> => {
         try {
           await this.stopSessionPreserveDb(sessionId, session, { strict: true });
         } catch (err) {
-          notes.push(`retry interrupt failed: ${err instanceof Error ? err.message : String(err)}`);
+          notes.push(`${failureNote}: ${err instanceof Error ? err.message : String(err)}`);
         }
-        verdict = await this.inspectSessionDown(session);
-        if (verdict.down) notes.push('first interrupt did not land; stopped on retry');
-      }
+        interruptAttemptsSoFar += 1;
+      };
 
-      if (!verdict.down) {
-        log.warn(
-          `TaskAgentManager.stopSessionsVerified: session ${sessionId} survived interrupt retry (${verdict.reason}); escalating to tracked process termination`
+      const decideNextStopAction = async (): Promise<StopVerificationDecision> =>
+        decideStopVerification(
+          await this.gatherStopVerificationSnapshot(session, interruptAttemptsSoFar, escalationDone)
         );
-        notes.push(`escalated after verification failure (${verdict.reason})`);
+
+      await attemptInterrupt('interrupt failed');
+
+      let decision = await decideNextStopAction();
+      while (decision.action === 'retry_interrupt' || decision.action === 'escalate_terminate') {
+        if (decision.action === 'retry_interrupt') {
+          log.warn(
+            `TaskAgentManager.stopSessionsVerified: session ${sessionId} still alive after interrupt (${decision.reason}); retrying once`
+          );
+          await attemptInterrupt('retry interrupt failed');
+          decision = await decideNextStopAction();
+          if (decision.action === 'down') {
+            notes.push('first interrupt did not land; stopped on retry');
+          }
+          continue;
+        }
+        log.warn(
+          `TaskAgentManager.stopSessionsVerified: session ${sessionId} survived interrupt retry (${decision.reason}); escalating to tracked process termination`
+        );
+        notes.push(`escalated after verification failure (${decision.reason})`);
         try {
           session.terminateTrackedAgentProcesses({
             forceDelayMs: VERIFIED_STOP_ESCALATION_FORCE_KILL_MS,
@@ -2260,7 +2277,8 @@ export class TaskAgentManager {
         } catch (err) {
           notes.push(`escalation failed: ${err instanceof Error ? err.message : String(err)}`);
         }
-        verdict = await this.inspectSessionDown(session);
+        escalationDone = true;
+        decision = await decideNextStopAction();
       }
 
       this.detachSessionBookkeeping(sessionId);
@@ -2271,37 +2289,37 @@ export class TaskAgentManager {
         notes.push(`unregister failed: ${err instanceof Error ? err.message : String(err)}`);
       }
 
-      if (verdict.down) {
-        return notes.length > 0
-          ? { sessionId, stopped: true, detail: notes.join('; ') }
-          : { sessionId, stopped: true };
-      }
-      return {
-        sessionId,
-        stopped: false,
-        detail: [...notes, `still alive: ${verdict.reason}`].join('; '),
-      };
+      return assembleVerifiedStopResult({ sessionId, notes, decision });
     } finally {
       this.cancellingSessions.delete(sessionId);
     }
   }
 
-  private async inspectSessionDown(
-    session: AgentSession
-  ): Promise<{ down: boolean; reason?: string }> {
-    const status = session.getProcessingState().status;
-    if (status !== 'idle' && status !== 'interrupted') {
-      return { down: false, reason: `processing state '${status}'` };
-    }
-    if (session.isInterruptInProgress()) {
-      return { down: false, reason: 'interrupt still in progress' };
-    }
+  private async gatherStopVerificationSnapshot(
+    session: AgentSession,
+    interruptAttemptsSoFar: number,
+    escalationDone: boolean
+  ): Promise<StopVerificationSnapshot> {
+    const processingStatus = session.getProcessingState().status;
+    const interruptInProgress =
+      isStopDownProcessingStatus(processingStatus) && session.isInterruptInProgress();
+    const livePids =
+      isStopDownProcessingStatus(processingStatus) && !interruptInProgress
+        ? await this.readLivePidsAfterSettle(session)
+        : [];
+    return {
+      sessionPresent: true,
+      processingStatus,
+      interruptInProgress,
+      livePids,
+      interruptAttemptsSoFar,
+      escalationDone,
+    };
+  }
+
+  private async readLivePidsAfterSettle(session: AgentSession): Promise<number[]> {
     await this.awaitSessionProcessExit(session, VERIFIED_STOP_PROCESS_EXIT_SETTLE_MS);
-    const livePids = session.getTrackedAgentRootPidsSplit().live;
-    if (livePids.length > 0) {
-      return { down: false, reason: `live SDK process pid(s) ${livePids.join(', ')}` };
-    }
-    return { down: true };
+    return session.getTrackedAgentRootPidsSplit().live;
   }
 
   private async awaitSessionProcessExit(session: AgentSession, timeoutMs: number): Promise<void> {

--- a/packages/daemon/tests/unit/5-space/runtime/stop-verification-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/stop-verification-gates.test.ts
@@ -10,21 +10,22 @@ import {
   VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS,
 } from '../../../../src/lib/space/runtime/stop-verification-gates';
 
-const ALL_PROCESSING_STATUSES: AgentProcessingState['status'][] = [
-  'idle',
-  'queued',
-  'processing',
-  'waiting_for_input',
-  'rate_limit_cooldown',
-  'interrupted',
-];
+const STATUS_DOWN_ELIGIBILITY: Record<AgentProcessingState['status'], boolean> = {
+  idle: true,
+  interrupted: true,
+  queued: false,
+  processing: false,
+  waiting_for_input: false,
+  rate_limit_cooldown: false,
+};
 
-const NOT_DOWN_PROCESSING_STATUSES: AgentProcessingState['status'][] = [
-  'queued',
-  'processing',
-  'waiting_for_input',
-  'rate_limit_cooldown',
-];
+const ALL_PROCESSING_STATUSES = Object.keys(
+  STATUS_DOWN_ELIGIBILITY
+) as AgentProcessingState['status'][];
+
+const NOT_DOWN_PROCESSING_STATUSES = ALL_PROCESSING_STATUSES.filter(
+  (status) => !STATUS_DOWN_ELIGIBILITY[status]
+);
 
 function makeSnapshot(overrides: Partial<StopVerificationSnapshot> = {}): StopVerificationSnapshot {
   return {
@@ -47,6 +48,12 @@ describe('isStopDownProcessingStatus', () => {
   test('rejects every other processing status', () => {
     for (const status of NOT_DOWN_PROCESSING_STATUSES) {
       expect(isStopDownProcessingStatus(status)).toBe(false);
+    }
+  });
+
+  test('agrees with the exhaustive eligibility table for every status', () => {
+    for (const status of ALL_PROCESSING_STATUSES) {
+      expect(isStopDownProcessingStatus(status)).toBe(STATUS_DOWN_ELIGIBILITY[status]);
     }
   });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/stop-verification-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/stop-verification-gates.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentProcessingState } from '@hyperneo/shared';
+import {
+  assembleVerifiedStopResult,
+  decideStopVerification,
+  inspectSessionLiveness,
+  isStopDownProcessingStatus,
+  type StopVerificationDecision,
+  type StopVerificationSnapshot,
+  VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS,
+} from '../../../../src/lib/space/runtime/stop-verification-gates';
+
+const ALL_PROCESSING_STATUSES: AgentProcessingState['status'][] = [
+  'idle',
+  'queued',
+  'processing',
+  'waiting_for_input',
+  'rate_limit_cooldown',
+  'interrupted',
+];
+
+const NOT_DOWN_PROCESSING_STATUSES: AgentProcessingState['status'][] = [
+  'queued',
+  'processing',
+  'waiting_for_input',
+  'rate_limit_cooldown',
+];
+
+function makeSnapshot(overrides: Partial<StopVerificationSnapshot> = {}): StopVerificationSnapshot {
+  return {
+    sessionPresent: true,
+    processingStatus: 'processing',
+    interruptInProgress: false,
+    livePids: [],
+    interruptAttemptsSoFar: 1,
+    escalationDone: false,
+    ...overrides,
+  };
+}
+
+describe('isStopDownProcessingStatus', () => {
+  test('accepts idle and interrupted as down-eligible statuses', () => {
+    expect(isStopDownProcessingStatus('idle')).toBe(true);
+    expect(isStopDownProcessingStatus('interrupted')).toBe(true);
+  });
+
+  test('rejects every other processing status', () => {
+    for (const status of NOT_DOWN_PROCESSING_STATUSES) {
+      expect(isStopDownProcessingStatus(status)).toBe(false);
+    }
+  });
+});
+
+describe('inspectSessionLiveness', () => {
+  test('reports down for a settled session with no live pids', () => {
+    expect(
+      inspectSessionLiveness({ processingStatus: 'idle', interruptInProgress: false, livePids: [] })
+    ).toEqual({ down: true });
+    expect(
+      inspectSessionLiveness({
+        processingStatus: 'interrupted',
+        interruptInProgress: false,
+        livePids: [],
+      })
+    ).toEqual({ down: true });
+  });
+
+  test('reports the processing state reason first', () => {
+    for (const status of NOT_DOWN_PROCESSING_STATUSES) {
+      expect(
+        inspectSessionLiveness({
+          processingStatus: status,
+          interruptInProgress: true,
+          livePids: [7],
+        })
+      ).toEqual({ down: false, reason: `processing state '${status}'` });
+    }
+  });
+
+  test('reports the interrupt-in-progress reason before live pids', () => {
+    expect(
+      inspectSessionLiveness({ processingStatus: 'idle', interruptInProgress: true, livePids: [7] })
+    ).toEqual({ down: false, reason: 'interrupt still in progress' });
+  });
+
+  test('reports live pids in order as the last not-down reason', () => {
+    expect(
+      inspectSessionLiveness({
+        processingStatus: 'idle',
+        interruptInProgress: false,
+        livePids: [11],
+      })
+    ).toEqual({ down: false, reason: 'live SDK process pid(s) 11' });
+    expect(
+      inspectSessionLiveness({
+        processingStatus: 'interrupted',
+        interruptInProgress: false,
+        livePids: [11, 22],
+      })
+    ).toEqual({ down: false, reason: 'live SDK process pid(s) 11, 22' });
+  });
+});
+
+describe('decideStopVerification pinned decision table', () => {
+  const cases: Array<{
+    name: string;
+    input: Partial<StopVerificationSnapshot>;
+    expected: StopVerificationDecision;
+  }> = [
+    {
+      name: 'missing session decides down regardless of every other gate',
+      input: {
+        sessionPresent: false,
+        processingStatus: 'processing',
+        interruptInProgress: true,
+        livePids: [7],
+        interruptAttemptsSoFar: 5,
+        escalationDone: true,
+      },
+      expected: { action: 'down' },
+    },
+    {
+      name: 'settled idle session decides down',
+      input: { processingStatus: 'idle', interruptAttemptsSoFar: 1 },
+      expected: { action: 'down' },
+    },
+    {
+      name: 'settled interrupted session decides down',
+      input: { processingStatus: 'interrupted', interruptAttemptsSoFar: 1 },
+      expected: { action: 'down' },
+    },
+    {
+      name: 'busy session with retry budget decides retry_interrupt',
+      input: { processingStatus: 'processing', interruptAttemptsSoFar: 1 },
+      expected: { action: 'retry_interrupt', reason: "processing state 'processing'" },
+    },
+    {
+      name: 'interrupt in progress with retry budget decides retry_interrupt',
+      input: { processingStatus: 'idle', interruptInProgress: true, interruptAttemptsSoFar: 1 },
+      expected: { action: 'retry_interrupt', reason: 'interrupt still in progress' },
+    },
+    {
+      name: 'live pids with retry budget decides retry_interrupt',
+      input: { processingStatus: 'idle', livePids: [4242], interruptAttemptsSoFar: 1 },
+      expected: { action: 'retry_interrupt', reason: 'live SDK process pid(s) 4242' },
+    },
+    {
+      name: 'spent retry budget decides escalate_terminate',
+      input: { processingStatus: 'processing', interruptAttemptsSoFar: 2, escalationDone: false },
+      expected: { action: 'escalate_terminate', reason: "processing state 'processing'" },
+    },
+    {
+      name: 'spent retry budget with a live pid decides escalate_terminate',
+      input: { processingStatus: 'idle', livePids: [4242], interruptAttemptsSoFar: 2 },
+      expected: { action: 'escalate_terminate', reason: 'live SDK process pid(s) 4242' },
+    },
+    {
+      name: 'escalated session that is still busy decides report_leak',
+      input: { processingStatus: 'processing', interruptAttemptsSoFar: 2, escalationDone: true },
+      expected: { action: 'report_leak', reason: "processing state 'processing'" },
+    },
+    {
+      name: 'escalated session with an interrupt in progress decides report_leak',
+      input: {
+        processingStatus: 'idle',
+        interruptInProgress: true,
+        interruptAttemptsSoFar: 2,
+        escalationDone: true,
+      },
+      expected: { action: 'report_leak', reason: 'interrupt still in progress' },
+    },
+    {
+      name: 'escalation marker alone does not outrank a remaining retry',
+      input: { processingStatus: 'processing', interruptAttemptsSoFar: 1, escalationDone: true },
+      expected: { action: 'retry_interrupt', reason: "processing state 'processing'" },
+    },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    test(name, () => {
+      expect(decideStopVerification(makeSnapshot(input))).toStrictEqual(expected);
+    });
+  }
+
+  test('pins the retry budget at one initial interrupt plus one retry', () => {
+    expect(VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS).toBe(2);
+  });
+
+  test('covers the full decision table across every input combination', () => {
+    for (const sessionPresent of [false, true]) {
+      for (const processingStatus of ALL_PROCESSING_STATUSES) {
+        for (const interruptInProgress of [false, true]) {
+          for (const livePids of [[], [11], [11, 22]]) {
+            for (const interruptAttemptsSoFar of [0, 1, 2, 5]) {
+              for (const escalationDone of [false, true]) {
+                const snapshot = makeSnapshot({
+                  sessionPresent,
+                  processingStatus,
+                  interruptInProgress,
+                  livePids,
+                  interruptAttemptsSoFar,
+                  escalationDone,
+                });
+                const decision = decideStopVerification(snapshot);
+                const statusDownEligible =
+                  processingStatus === 'idle' || processingStatus === 'interrupted';
+                const livenessDown =
+                  statusDownEligible && !interruptInProgress && livePids.length === 0;
+                if (!sessionPresent || livenessDown) {
+                  expect(decision).toStrictEqual({ action: 'down' });
+                  continue;
+                }
+                const expectedReason = !statusDownEligible
+                  ? `processing state '${processingStatus}'`
+                  : interruptInProgress
+                    ? 'interrupt still in progress'
+                    : `live SDK process pid(s) ${livePids.join(', ')}`;
+                const expectedAction =
+                  interruptAttemptsSoFar < VERIFIED_STOP_MAX_INTERRUPT_ATTEMPTS
+                    ? 'retry_interrupt'
+                    : escalationDone
+                      ? 'report_leak'
+                      : 'escalate_terminate';
+                expect(decision).toStrictEqual({ action: expectedAction, reason: expectedReason });
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+});
+
+describe('decideStopVerification precedence', () => {
+  test('down beats every downstream gate at any attempt count or escalation state', () => {
+    for (const interruptAttemptsSoFar of [0, 1, 2, 5]) {
+      for (const escalationDone of [false, true]) {
+        for (const processingStatus of ['idle', 'interrupted'] as const) {
+          expect(
+            decideStopVerification(
+              makeSnapshot({
+                processingStatus,
+                interruptInProgress: false,
+                livePids: [],
+                interruptAttemptsSoFar,
+                escalationDone,
+              })
+            )
+          ).toStrictEqual({ action: 'down' });
+        }
+      }
+    }
+  });
+
+  test('the processing-state gate outranks the interrupt-in-progress gate', () => {
+    const decision = decideStopVerification(
+      makeSnapshot({ processingStatus: 'processing', interruptInProgress: true, livePids: [7] })
+    );
+    expect(decision).toStrictEqual({
+      action: 'retry_interrupt',
+      reason: "processing state 'processing'",
+    });
+  });
+
+  test('the interrupt-in-progress gate outranks the live-pids gate', () => {
+    const decision = decideStopVerification(
+      makeSnapshot({ processingStatus: 'idle', interruptInProgress: true, livePids: [7] })
+    );
+    expect(decision).toStrictEqual({
+      action: 'retry_interrupt',
+      reason: 'interrupt still in progress',
+    });
+  });
+});
+
+describe('decideStopVerification pass-through identity', () => {
+  test('repeated calls with the same snapshot return the identical decision', () => {
+    const snapshot = makeSnapshot({
+      processingStatus: 'idle',
+      livePids: [],
+      interruptAttemptsSoFar: 5,
+    });
+    expect(decideStopVerification(snapshot)).toStrictEqual(decideStopVerification(snapshot));
+    const busy = makeSnapshot({
+      processingStatus: 'processing',
+      interruptAttemptsSoFar: 2,
+      escalationDone: true,
+    });
+    expect(decideStopVerification(busy)).toStrictEqual(decideStopVerification(busy));
+  });
+
+  test('does not mutate the input snapshot', () => {
+    const snapshot = makeSnapshot({ processingStatus: 'idle', livePids: [3, 4] });
+    const before = JSON.stringify(snapshot);
+    decideStopVerification(snapshot);
+    expect(JSON.stringify(snapshot)).toBe(before);
+  });
+});
+
+describe('assembleVerifiedStopResult', () => {
+  test('omits the detail key for a clean down verdict', () => {
+    const result = assembleVerifiedStopResult({
+      sessionId: 'sess-1',
+      notes: [],
+      decision: { action: 'down' },
+    });
+    expect(result).toStrictEqual({ sessionId: 'sess-1', stopped: true });
+    expect(Object.hasOwn(result, 'detail')).toBe(false);
+  });
+
+  test('passes the notes through verbatim and in order for a down verdict', () => {
+    expect(
+      assembleVerifiedStopResult({
+        sessionId: 'sess-1',
+        notes: ['interrupt failed: boom', 'first interrupt did not land; stopped on retry'],
+        decision: { action: 'down' },
+      })
+    ).toStrictEqual({
+      sessionId: 'sess-1',
+      stopped: true,
+      detail: 'interrupt failed: boom; first interrupt did not land; stopped on retry',
+    });
+  });
+
+  test('appends the still-alive leak reason after the notes', () => {
+    expect(
+      assembleVerifiedStopResult({
+        sessionId: 'sess-1',
+        notes: ['escalated after verification failure (interrupt still in progress)'],
+        decision: { action: 'report_leak', reason: 'interrupt still in progress' },
+      })
+    ).toStrictEqual({
+      sessionId: 'sess-1',
+      stopped: false,
+      detail:
+        'escalated after verification failure (interrupt still in progress); ' +
+        'still alive: interrupt still in progress',
+    });
+  });
+
+  test('reports a bare leak when no notes accumulated', () => {
+    expect(
+      assembleVerifiedStopResult({
+        sessionId: 'sess-1',
+        notes: [],
+        decision: { action: 'report_leak', reason: "processing state 'processing'" },
+      })
+    ).toStrictEqual({
+      sessionId: 'sess-1',
+      stopped: false,
+      detail: "still alive: processing state 'processing'",
+    });
+  });
+
+  test('does not mutate the notes array', () => {
+    const notes = ['a', 'b'];
+    assembleVerifiedStopResult({ sessionId: 'sess-1', notes, decision: { action: 'down' } });
+    expect(notes).toStrictEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
Superpipe S3 (sub-pilot 6, Chain S) PR 3/6 — additive extraction, no behavior change. The verified-stop ladder's decisions move from task-agent-manager.ts into a pure stop-verification-gates.ts (decideStopVerification → down | retry_interrupt | escalate_terminate | report_leak, preserving inspectSessionDown's processing-state → interrupt-in-progress → live-pids precedence, plus inspectSessionLiveness and assembleVerifiedStopResult). stopSessionVerified keeps all effects and interprets the gates inline; unit tests pin the full decision table, precedence, and pass-through identity. decisionRun composition lands in PR 4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->