### PR TITLE
fix(daemon): order watermark subqueries by consumed_seq, add uuid tie-break

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1541,21 +1541,18 @@ export class SDKMessageRepository {
     sessionId: string,
     uuid: string
   ): { uuid: string; timestamp: number; content: string } | undefined {
-    const rows = this.db
+    const row = this.db
       .prepare(
         `SELECT sdk_message, timestamp FROM sdk_messages
          WHERE session_id = ?
            AND message_type = 'user'
-           AND sdk_uuid = ?`
+           AND sdk_uuid = ?
+         ORDER BY timestamp ASC, rowid ASC
+         LIMIT 1`
       )
-      .all(sessionId, uuid) as Array<{ sdk_message: string; timestamp: string }>;
-    if (rows.length === 0) return undefined;
-
-    let earliest = rows[0];
-    for (let i = 1; i < rows.length; i++) {
-      if (rows[i].timestamp < earliest.timestamp) earliest = rows[i];
-    }
-    return this.parseUserMessageRow(earliest, uuid);
+      .get(sessionId, uuid) as { sdk_message: string; timestamp: string } | undefined;
+    if (!row) return undefined;
+    return this.parseUserMessageRow(row, uuid);
   }
 
   getUserMessageContentByUuid(sessionId: string, uuid: string): string | MessageContent[] | null {
@@ -1615,7 +1612,8 @@ export class SDKMessageRepository {
             AND r.consumed_seq IS NOT NULL
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
-               WHERE m.session_id = ? AND m.sdk_uuid = ? LIMIT 1
+               WHERE m.session_id = ? AND m.sdk_uuid = ?
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
             )
             AND NOT (
               COALESCE(json_extract(r.sdk_message, '$.is_error'), 0) = 1
@@ -1654,7 +1652,8 @@ export class SDKMessageRepository {
             AND r.consumed_seq IS NOT NULL
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
-               WHERE m.session_id = ? AND m.sdk_uuid = ? LIMIT 1
+               WHERE m.session_id = ? AND m.sdk_uuid = ?
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
             )
             AND COALESCE(json_extract(r.sdk_message, '$.recovery_intercepted'), 0) = 1
             AND COALESCE(json_extract(r.sdk_message, '$.recovery_billing_terminal'), 0) = 0
@@ -1678,7 +1677,8 @@ export class SDKMessageRepository {
             AND r.consumed_seq IS NOT NULL
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
-               WHERE m.session_id = ? AND m.sdk_uuid = ? LIMIT 1
+               WHERE m.session_id = ? AND m.sdk_uuid = ?
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
             )
           ORDER BY r.consumed_seq DESC
           LIMIT 1`

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1613,7 +1613,7 @@ export class SDKMessageRepository {
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
                WHERE m.session_id = ? AND m.sdk_uuid = ?
-               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq DESC LIMIT 1
             )
             AND NOT (
               COALESCE(json_extract(r.sdk_message, '$.is_error'), 0) = 1
@@ -1653,7 +1653,7 @@ export class SDKMessageRepository {
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
                WHERE m.session_id = ? AND m.sdk_uuid = ?
-               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq DESC LIMIT 1
             )
             AND COALESCE(json_extract(r.sdk_message, '$.recovery_intercepted'), 0) = 1
             AND COALESCE(json_extract(r.sdk_message, '$.recovery_billing_terminal'), 0) = 0
@@ -1678,7 +1678,7 @@ export class SDKMessageRepository {
             AND r.consumed_seq >= (
               SELECT m.consumed_seq FROM sdk_messages m
                WHERE m.session_id = ? AND m.sdk_uuid = ?
-               ORDER BY m.consumed_seq IS NULL, m.consumed_seq LIMIT 1
+               ORDER BY m.consumed_seq IS NULL, m.consumed_seq DESC LIMIT 1
             )
           ORDER BY r.consumed_seq DESC
           LIMIT 1`

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -2261,6 +2261,83 @@ describe('SDKMessageRepository', () => {
       expect(repository.hasTerminalResultAfter('session-1', 'migrated-msg')).toBe(false);
     });
 
+    it('duplicate-uuid rows leave the watermark pick ambiguous — either pick flips the re-claim outcome (bug-#2 characterization)', () => {
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-msg',
+        timestamp: '2026-08-11T15:20:00.000Z',
+        sendStatus: 'failed',
+      });
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-msg',
+        timestamp: '2026-08-11T15:21:00.000Z',
+      });
+      insertMessage('session-1', 'result', {
+        timestamp: '2026-08-11T15:22:00.000Z',
+        terminal: true,
+        subtype: 'success',
+      });
+
+      const picks = db
+        .prepare(`SELECT consumed_seq FROM sdk_messages WHERE session_id = ? AND sdk_uuid = ?`)
+        .all('session-1', 'dup-msg') as Array<{ consumed_seq: number | null }>;
+      const seqs = picks.map((pick) => pick.consumed_seq);
+      expect(seqs).toContain(null);
+      const consumedSeqs = seqs.filter((seq): seq is number => seq !== null);
+      expect(consumedSeqs).toHaveLength(1);
+
+      const successSeenWithWatermark = (watermark: number | null) =>
+        db
+          .prepare(
+            `SELECT 1 FROM sdk_messages r
+              WHERE r.session_id = 'session-1' AND r.message_type = 'result' AND r.is_terminal = 1
+                AND r.message_subtype = 'success' AND r.parent_tool_use_id IS NULL
+                AND r.consumed_seq IS NOT NULL AND r.consumed_seq >= ? LIMIT 1`
+          )
+          .get(watermark) != null;
+      expect(successSeenWithWatermark(consumedSeqs[0])).toBe(true);
+      expect(successSeenWithWatermark(null)).toBe(false);
+    });
+
+    it('the same duplicate-uuid ambiguity hides the terminal-error subtype from the error probe (bug-#2 characterization)', () => {
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-err',
+        timestamp: '2026-08-11T15:20:00.000Z',
+        sendStatus: 'failed',
+      });
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-err',
+        timestamp: '2026-08-11T15:21:00.000Z',
+      });
+      insertMessage('session-1', 'result', {
+        timestamp: '2026-08-11T15:22:00.000Z',
+        terminal: true,
+        subtype: 'error_max_budget_usd',
+      });
+
+      const errorSubtypeWithWatermark = (watermark: number | null): string | null => {
+        const row = db
+          .prepare(
+            `SELECT r.message_subtype AS subtype FROM sdk_messages r
+              WHERE r.session_id = 'session-1' AND r.message_type = 'result' AND r.is_terminal = 1
+                AND r.message_subtype IS NOT NULL AND r.message_subtype != 'success'
+                AND r.parent_tool_use_id IS NULL AND r.consumed_seq IS NOT NULL
+                AND r.consumed_seq >= ? ORDER BY r.consumed_seq DESC LIMIT 1`
+          )
+          .get(watermark) as { subtype: string | null } | undefined;
+        return row?.subtype ?? null;
+      };
+      const consumedSeq = (
+        db
+          .prepare(
+            `SELECT consumed_seq FROM sdk_messages
+              WHERE session_id = ? AND sdk_uuid = ? AND consumed_seq IS NOT NULL LIMIT 1`
+          )
+          .get('session-1', 'dup-err') as { consumed_seq: number }
+      ).consumed_seq;
+      expect(errorSubtypeWithWatermark(consumedSeq)).toBe('error_max_budget_usd');
+      expect(errorSubtypeWithWatermark(null)).toBeNull();
+    });
+
     it('is true when a terminal result shares the consumption millisecond but inserts after (P2 tiebreak)', () => {
       insertMessage('session-1', 'user', {
         uuid: 'tie-msg',
@@ -3106,6 +3183,41 @@ describe('SDKMessageRepository', () => {
 
       expect(message).toBeDefined();
       expect(message?.content).toBe('Earliest failed copy');
+    });
+
+    it('returns whichever row SQLite picks first for timestamp-tied duplicates (characterized ambiguity)', () => {
+      const sessionId = 'session-tied';
+      const insert = db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status, sdk_uuid)
+         VALUES (?, ?, 'user', ?, ?, ?, 'tied-uuid')`
+      );
+      insert.run(
+        'tied-a',
+        sessionId,
+        JSON.stringify({
+          type: 'user',
+          uuid: 'tied-uuid',
+          message: { role: 'user', content: [{ type: 'text', text: 'First copy' }] },
+        }),
+        '2026-08-11T15:20:00.000Z',
+        'failed'
+      );
+      insert.run(
+        'tied-b',
+        sessionId,
+        JSON.stringify({
+          type: 'user',
+          uuid: 'tied-uuid',
+          message: { role: 'user', content: [{ type: 'text', text: 'Second copy' }] },
+        }),
+        '2026-08-11T15:20:00.000Z',
+        'consumed'
+      );
+
+      const message = repository.getUserMessageByUuid(sessionId, 'tied-uuid');
+
+      expect(message).toBeDefined();
+      expect(['First copy', 'Second copy']).toContain(message?.content);
     });
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -2338,6 +2338,48 @@ describe('SDKMessageRepository', () => {
       expect(errorSubtypeWithWatermark(null)).toBeNull();
     });
 
+    it('prefers the non-NULL watermark across duplicate-uuid rows — all probes deterministic (bug-#2 fix)', () => {
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-msg',
+        timestamp: '2026-08-11T15:20:00.000Z',
+        sendStatus: 'failed',
+      });
+      insertMessage('session-1', 'user', {
+        uuid: 'dup-msg',
+        timestamp: '2026-08-11T15:21:00.000Z',
+      });
+      insertMessage('session-1', 'result', {
+        uuid: 'dup-result',
+        timestamp: '2026-08-11T15:22:00.000Z',
+        terminal: true,
+        subtype: 'success',
+        sdkMessage: JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: true,
+          terminal_reason: 'api_error',
+        }),
+      });
+
+      expect(repository.hasTerminalResultAfter('session-1', 'dup-msg')).toBe(true);
+      expect(repository.hasRecoveryInterceptedResultAfter('session-1', 'dup-msg')).toBe(false);
+
+      repository.markResultRecoveryIntercepted('session-1', 'dup-result');
+
+      expect(repository.hasTerminalResultAfter('session-1', 'dup-msg')).toBe(false);
+      expect(repository.hasRecoveryInterceptedResultAfter('session-1', 'dup-msg')).toBe(true);
+      expect(repository.getErrorTerminalResultSubtypeAfter('session-1', 'dup-msg')).toBeNull();
+
+      insertMessage('session-1', 'result', {
+        timestamp: '2026-08-11T15:23:00.000Z',
+        terminal: true,
+        subtype: 'error_max_budget_usd',
+      });
+      expect(repository.getErrorTerminalResultSubtypeAfter('session-1', 'dup-msg')).toBe(
+        'error_max_budget_usd'
+      );
+    });
+
     it('is true when a terminal result shares the consumption millisecond but inserts after (P2 tiebreak)', () => {
       insertMessage('session-1', 'user', {
         uuid: 'tie-msg',
@@ -3185,7 +3227,7 @@ describe('SDKMessageRepository', () => {
       expect(message?.content).toBe('Earliest failed copy');
     });
 
-    it('returns whichever row SQLite picks first for timestamp-tied duplicates (characterized ambiguity)', () => {
+    it('breaks timestamp ties by earliest rowid across duplicate rows', () => {
       const sessionId = 'session-tied';
       const insert = db.prepare(
         `INSERT INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp, send_status, sdk_uuid)
@@ -3217,7 +3259,7 @@ describe('SDKMessageRepository', () => {
       const message = repository.getUserMessageByUuid(sessionId, 'tied-uuid');
 
       expect(message).toBeDefined();
-      expect(['First copy', 'Second copy']).toContain(message?.content);
+      expect(message?.content).toBe('First copy');
     });
   });
 
@@ -3284,7 +3326,9 @@ describe('SDKMessageRepository', () => {
         `SELECT sdk_message, timestamp FROM sdk_messages
          WHERE session_id = ?
            AND message_type = 'user'
-           AND sdk_uuid = ?`,
+           AND sdk_uuid = ?
+         ORDER BY timestamp ASC, rowid ASC
+         LIMIT 1`,
         ['s1', 'uuid-5']
       );
       expect(plan).toContain('idx_sdk_messages_session_uuid');

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -2380,6 +2380,21 @@ describe('SDKMessageRepository', () => {
       );
     });
 
+    it('follows the EARLIEST non-NULL watermark when duplicate rows carry different consumed_seq values (retry layout)', () => {
+      const insertDuplicate = db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq)
+         VALUES (?, 'session-1', 'user', NULL, '{}', ?, 'consumed', 0, 'dup-seq-msg', ?)`
+      );
+      insertDuplicate.run('dup-seq-first', '2026-08-11T15:20:00.000Z', 10);
+      insertDuplicate.run('dup-seq-second', '2026-08-11T15:21:00.000Z', 5);
+      db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq, parent_tool_use_id)
+         VALUES ('dup-seq-result', 'session-1', 'result', 'success', '{}', '2026-08-11T15:22:00.000Z', NULL, 1, 'dup-seq-result-uuid', 7, NULL)`
+      ).run();
+
+      expect(repository.hasTerminalResultAfter('session-1', 'dup-seq-msg')).toBe(true);
+    });
+
     it('is true when a terminal result shares the consumption millisecond but inserts after (P2 tiebreak)', () => {
       insertMessage('session-1', 'user', {
         uuid: 'tie-msg',

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -2574,7 +2574,7 @@ describe('SDKMessageRepository', () => {
       );
     });
 
-    it('follows the EARLIEST non-NULL watermark when duplicate rows carry different consumed_seq values (retry layout)', () => {
+    it('follows the LATEST non-NULL watermark when duplicate rows carry different consumed_seq values — prior-attempt results stay invisible (retry layout)', () => {
       const insertDuplicate = db.prepare(
         `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq)
          VALUES (?, 'session-1', 'user', NULL, '{}', ?, 'consumed', 0, 'dup-seq-msg', ?)`
@@ -2586,7 +2586,44 @@ describe('SDKMessageRepository', () => {
          VALUES ('dup-seq-result', 'session-1', 'result', 'success', '{}', '2026-08-11T15:22:00.000Z', NULL, 1, 'dup-seq-result-uuid', 7, NULL)`
       ).run();
 
+      expect(repository.hasTerminalResultAfter('session-1', 'dup-seq-msg')).toBe(false);
+
+      db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq, parent_tool_use_id)
+         VALUES ('dup-seq-result-own', 'session-1', 'result', 'success', '{}', '2026-08-11T15:23:00.000Z', NULL, 1, 'dup-seq-result-own-uuid', 12, NULL)`
+      ).run();
+
       expect(repository.hasTerminalResultAfter('session-1', 'dup-seq-msg')).toBe(true);
+    });
+
+    it('a stale prior-attempt recovery-intercepted result does not reopen the latest attempt (Codex P1)', () => {
+      const insertDuplicate = db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq)
+         VALUES (?, 'session-1', 'user', NULL, '{}', ?, 'consumed', 0, 'stale-msg', ?)`
+      );
+      insertDuplicate.run('stale-old', '2026-08-11T15:20:00.000Z', 5);
+      insertDuplicate.run('stale-new', '2026-08-11T15:21:00.000Z', 10);
+      db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq, parent_tool_use_id)
+         VALUES ('stale-intercepted', 'session-1', 'result', 'success', ?, '2026-08-11T15:22:00.000Z', NULL, 1, 'stale-intercepted-uuid', 7, NULL)`
+      ).run(
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: true,
+          terminal_reason: 'api_error',
+          recovery_intercepted: 1,
+          recovery_billing_terminal: 0,
+        })
+      );
+      db.prepare(
+        `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, is_terminal, sdk_uuid, consumed_seq, parent_tool_use_id)
+         VALUES ('stale-success', 'session-1', 'result', 'success', '{}', '2026-08-11T15:23:00.000Z', NULL, 1, 'stale-success-uuid', 12, NULL)`
+      ).run();
+
+      expect(repository.hasTerminalResultAfter('session-1', 'stale-msg')).toBe(true);
+      expect(repository.hasRecoveryInterceptedResultAfter('session-1', 'stale-msg')).toBe(false);
+      expect(repository.getErrorTerminalResultSubtypeAfter('session-1', 'stale-msg')).toBeNull();
     });
 
     it('is true when a terminal result shares the consumption millisecond but inserts after (P2 tiebreak)', () => {


### PR DESCRIPTION
The un-ordered `LIMIT 1` watermark subqueries in `hasTerminalResultAfter`, `hasRecoveryInterceptedResultAfter` (same pattern, added post-survey in #2661), and `getErrorTerminalResultSubtypeAfter` could pick a NULL-`consumed_seq` row when duplicate `sdk_uuid` rows span status buckets, suppressing every result row — a false negative at the delivery re-claim boundary (the #2598 double-delivery class). They now order by `consumed_seq IS NULL, consumed_seq DESC`: non-NULL preferred, and among multiple non-NULL duplicates the latest consumption wins, so prior-attempt results between watermarks can't reopen or complete the current attempt (Codex P1, discussion_r3836699720). `getUserMessageByUuid` gets a `(timestamp, rowid)` tie-break in SQL. Characterization commit pins the either/or ambiguity first (survey §7 bug 2 / A1 guidance); the fix commits assert the deterministic outcomes.