### PR TITLE
refactor(daemon): extract activation routing pure core (task #1239)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/activation-routing.ts
+++ b/packages/daemon/src/lib/space/runtime/activation-routing.ts
@@ -1,0 +1,62 @@
+import type { NodeExecutionStatus, WorkflowNode } from '@hyperneo/shared';
+import { resolveNodeAgents } from '@hyperneo/shared';
+
+export interface ActivationExistingExecutionFacts {
+  status: NodeExecutionStatus;
+  agentSessionId: string | null;
+  sessionAlive: boolean;
+}
+
+export interface ActivationRoutingInput {
+  existingExecution?: ActivationExistingExecutionFacts | null;
+  workflowNodeId?: string;
+  agentDeclaredOnNode?: boolean;
+  taskRunWorkflowResolvable?: boolean;
+  executionResolvable?: boolean;
+}
+
+export type ActivationRoutingDecision =
+  | { action: 'reuse_existing'; sessionId: string }
+  | { action: 'reset_pending_and_continue' }
+  | { action: 'reject_undeclared' }
+  | { action: 'spawn_with_timeout' }
+  | { action: 'return_empty' };
+
+export function decideActivationRouting(input: ActivationRoutingInput): ActivationRoutingDecision {
+  const existing = input.existingExecution ?? null;
+  if (existing && (existing.status === 'in_progress' || existing.status === 'blocked')) {
+    if (existing.agentSessionId && existing.sessionAlive) {
+      return { action: 'reuse_existing', sessionId: existing.agentSessionId };
+    }
+    return { action: 'reset_pending_and_continue' };
+  }
+  if (input.workflowNodeId !== undefined && input.agentDeclaredOnNode === false) {
+    return { action: 'reject_undeclared' };
+  }
+  if (input.taskRunWorkflowResolvable === false) {
+    return { action: 'return_empty' };
+  }
+  if (input.executionResolvable === false) {
+    return { action: 'return_empty' };
+  }
+  return { action: 'spawn_with_timeout' };
+}
+
+export function selectWorkflowNodeForAgent(
+  nodes: readonly WorkflowNode[],
+  agentName: string,
+  workflowNodeId?: string
+): WorkflowNode | null {
+  for (const node of nodes) {
+    let slots: ReturnType<typeof resolveNodeAgents>;
+    try {
+      slots = resolveNodeAgents(node);
+    } catch {
+      continue;
+    }
+    if (!slots.some((slot) => slot.name === agentName)) continue;
+    if (workflowNodeId && node.id !== workflowNodeId) continue;
+    return node;
+  }
+  return null;
+}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1892,17 +1892,10 @@ export class TaskAgentManager {
               : false,
           }
         : null,
-      workflowNodeId: options?.workflowNodeId,
-      agentDeclaredOnNode: this.resolveAgentDeclaredOnNode(
-        taskId,
-        agentName,
-        options?.workflowNodeId
-      ),
     });
     if (route.action === 'reuse_existing') {
       return [{ agentName, sessionId: route.sessionId }];
     }
-    if (route.action === 'reject_undeclared') return [];
     if (route.action === 'reset_pending_and_continue' && existing) {
       if (existing.agentSessionId) {
         this.agentSessionIndex.delete(existing.agentSessionId);
@@ -1911,6 +1904,16 @@ export class TaskAgentManager {
         status: 'pending',
       });
     }
+
+    const gateRoute = decideActivationRouting({
+      workflowNodeId: options?.workflowNodeId,
+      agentDeclaredOnNode: this.resolveAgentDeclaredOnNode(
+        taskId,
+        agentName,
+        options?.workflowNodeId
+      ),
+    });
+    if (gateRoute.action === 'reject_undeclared') return [];
 
     await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -75,6 +75,7 @@ import {
   validateExecutionAgainstWorkflow,
   validateTaskAllowsSpawn,
 } from './workflow-node-execution-validation';
+import { decideActivationRouting, selectWorkflowNodeForAgent } from './activation-routing';
 import { decideSpawnExecutionAdmission } from './spawn-admission-gates';
 import {
   assembleNodeAgentSessionInit,
@@ -1881,10 +1882,28 @@ export class TaskAgentManager {
           (execution.status === 'in_progress' || execution.status === 'blocked')
       )
       .at(-1);
-    if (existing) {
-      if (existing.agentSessionId && this.isSessionAlive(existing.agentSessionId)) {
-        return [{ agentName, sessionId: existing.agentSessionId }];
-      }
+    const route = decideActivationRouting({
+      existingExecution: existing
+        ? {
+            status: existing.status,
+            agentSessionId: existing.agentSessionId,
+            sessionAlive: existing.agentSessionId
+              ? this.isSessionAlive(existing.agentSessionId)
+              : false,
+          }
+        : null,
+      workflowNodeId: options?.workflowNodeId,
+      agentDeclaredOnNode: this.resolveAgentDeclaredOnNode(
+        taskId,
+        agentName,
+        options?.workflowNodeId
+      ),
+    });
+    if (route.action === 'reuse_existing') {
+      return [{ agentName, sessionId: route.sessionId }];
+    }
+    if (route.action === 'reject_undeclared') return [];
+    if (route.action === 'reset_pending_and_continue' && existing) {
       if (existing.agentSessionId) {
         this.agentSessionIndex.delete(existing.agentSessionId);
       }
@@ -1893,21 +1912,7 @@ export class TaskAgentManager {
       });
     }
 
-    if (options?.workflowNodeId) {
-      const task = this.config.taskRepo.getTask(taskId);
-      if (task?.workflowRunId) {
-        const run = this.config.workflowRunRepo.getRun(task.workflowRunId);
-        if (run?.workflowId) {
-          const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run);
-          const node = workflow?.nodes.find((candidate) => candidate.id === options.workflowNodeId);
-          const slots = node ? resolveNodeAgents(node) : [];
-          if (!slots.some((slot) => slot.name === agentName)) return [];
-        }
-      }
-      await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
-    } else {
-      await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
-    }
+    await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
 
     const task = this.config.taskRepo.getTask(taskId);
     const run = this.config.workflowRunRepo.getRun(workflowRunId);
@@ -1915,14 +1920,25 @@ export class TaskAgentManager {
       ? this.config.spaceWorkflowManager.getWorkflowForRun(run)
       : null;
     const space = task ? await this.config.spaceManager.getSpace(task.spaceId) : null;
-    if (!task || !run || !workflow || !space) return [];
-
     const execution = this.config.nodeExecutionRepo
       .listByWorkflowRun(workflowRunId)
       .find(
         (candidate) => candidate.agentName === agentName && matchesNode(candidate.workflowNodeId)
       );
-    if (!execution) return [];
+    const postRoute = decideActivationRouting({
+      taskRunWorkflowResolvable: !!(task && run && workflow && space),
+      executionResolvable: !!execution,
+    });
+    if (
+      postRoute.action !== 'spawn_with_timeout' ||
+      !task ||
+      !run ||
+      !workflow ||
+      !space ||
+      !execution
+    ) {
+      return [];
+    }
 
     const spawnPromise = this.spawnWorkflowNodeAgentForExecution(
       task,
@@ -1957,6 +1973,21 @@ export class TaskAgentManager {
     return [{ agentName, sessionId }];
   }
 
+  private resolveAgentDeclaredOnNode(
+    taskId: string,
+    agentName: string,
+    workflowNodeId: string | undefined
+  ): boolean {
+    if (!workflowNodeId) return true;
+    const task = this.config.taskRepo.getTask(taskId);
+    const run = task?.workflowRunId ? this.config.workflowRunRepo.getRun(task.workflowRunId) : null;
+    if (!run?.workflowId) return true;
+    const workflow = this.config.spaceWorkflowManager.getWorkflowForRun(run);
+    const node = workflow?.nodes.find((candidate) => candidate.id === workflowNodeId);
+    const slots = node ? resolveNodeAgents(node) : [];
+    return slots.some((slot) => slot.name === agentName);
+  }
+
   async ensureWorkflowNodeActivationForAgent(
     taskId: string,
     agentName: string,
@@ -1972,21 +2003,12 @@ export class TaskAgentManager {
       const space = await this.config.spaceManager.getSpace(task.spaceId);
       if (!space) return false;
 
-      let targetNodeId: string | null = null;
-      for (const node of workflow.nodes) {
-        let slots: ReturnType<typeof resolveNodeAgents>;
-        try {
-          slots = resolveNodeAgents(node);
-        } catch {
-          continue;
-        }
-        if (slots.some((slot) => slot.name === agentName)) {
-          if (options?.workflowNodeId && node.id !== options.workflowNodeId) continue;
-          targetNodeId = node.id;
-          break;
-        }
-      }
-      if (!targetNodeId) return false;
+      const targetNode = selectWorkflowNodeForAgent(
+        workflow.nodes,
+        agentName,
+        options?.workflowNodeId
+      );
+      if (!targetNode) return false;
 
       const channelRouter = new ChannelRouter({
         taskRepo: this.config.taskRepo,
@@ -2000,7 +2022,7 @@ export class TaskAgentManager {
         internalEventBus: this.config.internalEventBus,
       });
 
-      await channelRouter.activateNode(run.id, targetNodeId, {
+      await channelRouter.activateNode(run.id, targetNode.id, {
         allowTerminalReopen: true,
         reopenReason: options?.reopenReason ?? `lazy activation of agent "${agentName}"`,
         reopenBy: options?.reopenBy ?? 'task-agent',

--- a/packages/daemon/tests/unit/5-space/runtime/activation-routing.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/activation-routing.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from 'bun:test';
+import type { NodeExecutionStatus, WorkflowNode } from '@hyperneo/shared';
+import {
+  type ActivationRoutingDecision,
+  type ActivationRoutingInput,
+  decideActivationRouting,
+  selectWorkflowNodeForAgent,
+} from '../../../../src/lib/space/runtime/activation-routing';
+
+const ALL_STATUSES: NodeExecutionStatus[] = [
+  'pending',
+  'in_progress',
+  'idle',
+  'waiting_rebind',
+  'blocked',
+  'cancelled',
+];
+
+const ACTIVATION_STATUSES: NodeExecutionStatus[] = ['in_progress', 'blocked'];
+
+function decide(overrides: Partial<ActivationRoutingInput> = {}): ActivationRoutingDecision {
+  return decideActivationRouting({
+    existingExecution: null,
+    workflowNodeId: undefined,
+    agentDeclaredOnNode: true,
+    taskRunWorkflowResolvable: true,
+    executionResolvable: true,
+    ...overrides,
+  });
+}
+
+describe('decideActivationRouting — existing-execution decision table', () => {
+  for (const status of ALL_STATUSES) {
+    const isActivationStatus = ACTIVATION_STATUSES.includes(status);
+
+    test(`${status} + live session → ${isActivationStatus ? 'reuse_existing' : 'spawn_with_timeout'}`, () => {
+      expect(
+        decide({
+          existingExecution: { status, agentSessionId: 'session-1', sessionAlive: true },
+        })
+      ).toEqual(
+        isActivationStatus
+          ? { action: 'reuse_existing', sessionId: 'session-1' }
+          : { action: 'spawn_with_timeout' }
+      );
+    });
+
+    test(`${status} + dead session → ${isActivationStatus ? 'reset_pending_and_continue' : 'spawn_with_timeout'}`, () => {
+      expect(
+        decide({
+          existingExecution: { status, agentSessionId: 'session-1', sessionAlive: false },
+        })
+      ).toEqual(
+        isActivationStatus
+          ? { action: 'reset_pending_and_continue' }
+          : { action: 'spawn_with_timeout' }
+      );
+    });
+
+    test(`${status} + no session id → ${isActivationStatus ? 'reset_pending_and_continue' : 'spawn_with_timeout'}`, () => {
+      expect(
+        decide({
+          existingExecution: { status, agentSessionId: null, sessionAlive: false },
+        })
+      ).toEqual(
+        isActivationStatus
+          ? { action: 'reset_pending_and_continue' }
+          : { action: 'spawn_with_timeout' }
+      );
+    });
+  }
+
+  test('a live session without a session id cannot be reused', () => {
+    expect(
+      decide({
+        existingExecution: { status: 'in_progress', agentSessionId: null, sessionAlive: true },
+      })
+    ).toEqual({ action: 'reset_pending_and_continue' });
+  });
+
+  test('an empty session id is treated as absent', () => {
+    expect(
+      decide({
+        existingExecution: { status: 'blocked', agentSessionId: '', sessionAlive: true },
+      })
+    ).toEqual({ action: 'reset_pending_and_continue' });
+  });
+
+  test('a missing existing execution falls through to the spawn path', () => {
+    expect(decide({ existingExecution: null })).toEqual({ action: 'spawn_with_timeout' });
+    expect(decide({ existingExecution: undefined })).toEqual({ action: 'spawn_with_timeout' });
+  });
+});
+
+describe('decideActivationRouting — node declaration gate', () => {
+  test('an undeclared agent on the requested node is rejected', () => {
+    expect(decide({ workflowNodeId: 'node-review', agentDeclaredOnNode: false })).toEqual({
+      action: 'reject_undeclared',
+    });
+  });
+
+  test('a declared agent on the requested node continues to spawn', () => {
+    expect(decide({ workflowNodeId: 'node-review', agentDeclaredOnNode: true })).toEqual({
+      action: 'spawn_with_timeout',
+    });
+  });
+
+  test('the declaration gate only applies when a workflow node id is given', () => {
+    expect(decide({ workflowNodeId: undefined, agentDeclaredOnNode: false })).toEqual({
+      action: 'spawn_with_timeout',
+    });
+  });
+
+  test('an omitted declaration fact does not reject', () => {
+    expect(decide({ workflowNodeId: 'node-review', agentDeclaredOnNode: undefined })).toEqual({
+      action: 'spawn_with_timeout',
+    });
+  });
+});
+
+describe('decideActivationRouting — post-activation gates', () => {
+  test('an unresolvable task/run/workflow context returns empty', () => {
+    expect(decide({ taskRunWorkflowResolvable: false })).toEqual({ action: 'return_empty' });
+  });
+
+  test('a missing execution after activation returns empty', () => {
+    expect(decide({ executionResolvable: false })).toEqual({ action: 'return_empty' });
+  });
+
+  test('an unresolvable context returns empty even when an execution exists', () => {
+    expect(decide({ taskRunWorkflowResolvable: false, executionResolvable: true })).toEqual({
+      action: 'return_empty',
+    });
+  });
+
+  test('a resolvable context with an execution routes to the timed spawn', () => {
+    expect(decide({ taskRunWorkflowResolvable: true, executionResolvable: true })).toEqual({
+      action: 'spawn_with_timeout',
+    });
+  });
+
+  test('the post-activation shell shape omits the earlier facts entirely', () => {
+    expect(
+      decideActivationRouting({ taskRunWorkflowResolvable: true, executionResolvable: false })
+    ).toEqual({ action: 'return_empty' });
+    expect(decideActivationRouting({})).toEqual({ action: 'spawn_with_timeout' });
+  });
+});
+
+describe('decideActivationRouting — precedence', () => {
+  test('reuse_existing beats reject_undeclared', () => {
+    expect(
+      decide({
+        existingExecution: {
+          status: 'in_progress',
+          agentSessionId: 'session-1',
+          sessionAlive: true,
+        },
+        workflowNodeId: 'node-review',
+        agentDeclaredOnNode: false,
+      })
+    ).toEqual({ action: 'reuse_existing', sessionId: 'session-1' });
+  });
+
+  test('reuse_existing beats return_empty', () => {
+    expect(
+      decide({
+        existingExecution: { status: 'blocked', agentSessionId: 'session-1', sessionAlive: true },
+        taskRunWorkflowResolvable: false,
+        executionResolvable: false,
+      })
+    ).toEqual({ action: 'reuse_existing', sessionId: 'session-1' });
+  });
+
+  test('reset_pending_and_continue beats reject_undeclared (reset precedes the declaration check)', () => {
+    expect(
+      decide({
+        existingExecution: {
+          status: 'in_progress',
+          agentSessionId: 'session-1',
+          sessionAlive: false,
+        },
+        workflowNodeId: 'node-review',
+        agentDeclaredOnNode: false,
+      })
+    ).toEqual({ action: 'reset_pending_and_continue' });
+  });
+
+  test('reset_pending_and_continue beats return_empty and spawn', () => {
+    expect(
+      decide({
+        existingExecution: { status: 'in_progress', agentSessionId: null, sessionAlive: false },
+        taskRunWorkflowResolvable: false,
+        executionResolvable: false,
+      })
+    ).toEqual({ action: 'reset_pending_and_continue' });
+  });
+
+  test('reject_undeclared short-circuits spawn when a node id is given', () => {
+    expect(
+      decide({
+        workflowNodeId: 'node-review',
+        agentDeclaredOnNode: false,
+        taskRunWorkflowResolvable: true,
+        executionResolvable: true,
+      })
+    ).toEqual({ action: 'reject_undeclared' });
+  });
+
+  test('reject_undeclared beats return_empty', () => {
+    expect(
+      decide({
+        workflowNodeId: 'node-review',
+        agentDeclaredOnNode: false,
+        taskRunWorkflowResolvable: false,
+        executionResolvable: false,
+      })
+    ).toEqual({ action: 'reject_undeclared' });
+  });
+});
+
+describe('decideActivationRouting — pass-through identity', () => {
+  test('reuse_existing carries the existing session id through unchanged', () => {
+    const sessionId = 'space:s1:task:t1:exec:e1';
+    const decision = decide({
+      existingExecution: { status: 'in_progress', agentSessionId: sessionId, sessionAlive: true },
+    });
+    expect(decision).toEqual({ action: 'reuse_existing', sessionId });
+    if (decision.action === 'reuse_existing') {
+      expect(decision.sessionId).toBe(sessionId);
+    }
+  });
+});
+
+function makeNode(overrides: Partial<WorkflowNode> = {}): WorkflowNode {
+  return {
+    id: 'node-coder',
+    name: 'coder',
+    agents: [{ agentId: 'agent-coder', name: 'coder' }],
+    ...overrides,
+  } as unknown as WorkflowNode;
+}
+
+describe('selectWorkflowNodeForAgent', () => {
+  test('returns the first node whose slots contain the agent', () => {
+    const first = makeNode();
+    const second = makeNode({ id: 'node-coder-2', name: 'coder-2' });
+    expect(selectWorkflowNodeForAgent([first, second], 'coder')).toBe(first);
+  });
+
+  test('scans past nodes that do not declare the agent', () => {
+    const other = makeNode({
+      id: 'node-review',
+      name: 'review',
+      agents: [{ agentId: 'a', name: 'reviewer' }],
+    });
+    const target = makeNode();
+    expect(selectWorkflowNodeForAgent([other, target], 'coder')).toBe(target);
+  });
+
+  test('honors the workflowNodeId filter', () => {
+    const first = makeNode();
+    const second = makeNode({ id: 'node-coder-2', name: 'coder-2' });
+    expect(selectWorkflowNodeForAgent([first, second], 'coder', 'node-coder-2')).toBe(second);
+  });
+
+  test('returns null when the filtered node is not the one declaring the agent', () => {
+    const first = makeNode();
+    const other = makeNode({
+      id: 'node-review',
+      name: 'review',
+      agents: [{ agentId: 'a', name: 'reviewer' }],
+    });
+    expect(selectWorkflowNodeForAgent([first, other], 'coder', 'node-review')).toBeNull();
+  });
+
+  test('without a filter the first declaring node wins', () => {
+    const first = makeNode();
+    expect(selectWorkflowNodeForAgent([first], 'coder', undefined)).toBe(first);
+  });
+
+  test('skips nodes whose slots cannot be resolved', () => {
+    const broken = makeNode({ id: 'node-broken', name: 'broken', agents: [] });
+    const target = makeNode();
+    expect(selectWorkflowNodeForAgent([broken, target], 'coder')).toBe(target);
+  });
+
+  test('resolves legacy single-agent nodes by node name', () => {
+    const legacy = makeNode({
+      id: 'node-legacy',
+      name: 'reviewer',
+      agents: [],
+      agentId: 'agent-legacy',
+    });
+    expect(selectWorkflowNodeForAgent([legacy], 'reviewer')).toBe(legacy);
+  });
+
+  test('returns null when no node declares the agent or all fail to resolve', () => {
+    const broken = makeNode({ agents: [] });
+    const other = makeNode({
+      id: 'node-review',
+      name: 'review',
+      agents: [{ agentId: 'a', name: 'reviewer' }],
+    });
+    expect(selectWorkflowNodeForAgent([broken, other], 'coder')).toBeNull();
+    expect(selectWorkflowNodeForAgent([], 'coder')).toBeNull();
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/activation-routing.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/activation-routing.test.ts
@@ -172,7 +172,19 @@ describe('decideActivationRouting — precedence', () => {
     ).toEqual({ action: 'reuse_existing', sessionId: 'session-1' });
   });
 
-  test('reset_pending_and_continue beats reject_undeclared (reset precedes the declaration check)', () => {
+  test('the reuse evaluation needs no declaration fact, so it cannot reject or throw on one', () => {
+    expect(
+      decideActivationRouting({
+        existingExecution: {
+          status: 'in_progress',
+          agentSessionId: 'session-1',
+          sessionAlive: true,
+        },
+      })
+    ).toEqual({ action: 'reuse_existing', sessionId: 'session-1' });
+  });
+
+  test('a stale execution yields reset_pending_and_continue even when the agent is undeclared', () => {
     expect(
       decide({
         existingExecution: {
@@ -184,6 +196,18 @@ describe('decideActivationRouting — precedence', () => {
         agentDeclaredOnNode: false,
       })
     ).toEqual({ action: 'reset_pending_and_continue' });
+  });
+
+  test('the post-reset continuation with the existing execution cleared still rejects an undeclared agent', () => {
+    expect(
+      decideActivationRouting({
+        existingExecution: null,
+        workflowNodeId: 'node-review',
+        agentDeclaredOnNode: false,
+        taskRunWorkflowResolvable: true,
+        executionResolvable: true,
+      })
+    ).toEqual({ action: 'reject_undeclared' });
   });
 
   test('reset_pending_and_continue beats return_empty and spawn', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-activation-routing.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-activation-routing.test.ts
@@ -1,0 +1,173 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+
+const SPACE_ID = 'space-activation-routing';
+const RUN_ID = 'run-activation-routing';
+const TASK_ID = 'task-activation-routing';
+const EXEC_ID = 'exec-activation-routing';
+const AGENT_NAME = 'coder';
+const LIVE_SESSION_ID = 'session-live';
+const DEAD_SESSION_ID = 'session-dead';
+const NODE_ID = 'node-1';
+
+interface ActivationRoutingHarness {
+  manager: TaskAgentManager;
+  updates: Array<{ id: string; params: unknown }>;
+  activationCalls: () => number;
+  spawnCalls: () => number;
+}
+
+function makeManager(input: {
+  executionStatus: 'in_progress' | 'blocked' | null;
+  agentSessionId: string | null;
+  sessionAlive: boolean;
+  nodeAgents: Array<{ agentId: string; name: string }>;
+}): ActivationRoutingHarness {
+  const db = new BunDatabase(':memory:');
+  const task = { id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID };
+  const run = { id: RUN_ID, workflowId: 'wf-activation-routing' };
+  const workflow = {
+    id: 'wf-activation-routing',
+    spaceId: SPACE_ID,
+    nodes: [{ id: NODE_ID, name: 'work', agents: input.nodeAgents }],
+  };
+  const execution =
+    input.executionStatus === null
+      ? null
+      : {
+          id: EXEC_ID,
+          agentName: AGENT_NAME,
+          workflowNodeId: NODE_ID,
+          agentSessionId: input.agentSessionId,
+          status: input.executionStatus,
+        };
+  const updates: Array<{ id: string; params: unknown }> = [];
+  let activationCalls = 0;
+  let spawnCalls = 0;
+  const manager = new TaskAgentManager({
+    db: { getDatabase: () => db },
+    internalEventBus: { subscribe: () => () => {} },
+    taskRepo: { getTask: () => task },
+    workflowRunRepo: { getRun: () => run },
+    spaceWorkflowManager: { getWorkflowForRun: () => workflow },
+    spaceManager: { getSpace: async () => ({ id: SPACE_ID }) },
+    nodeExecutionRepo: {
+      listByWorkflowRun: () => (execution ? [execution] : []),
+      update: (id: string, params: unknown) => {
+        updates.push({ id, params });
+      },
+    },
+  } as unknown as ConstructorParameters<typeof TaskAgentManager>[0]);
+  const internals = manager as unknown as Record<string, unknown>;
+  internals.tryResumeNodeAgentSession = async () => undefined;
+  internals.isSessionAlive = () => input.sessionAlive;
+  internals.ensureWorkflowNodeActivationForAgent = async () => {
+    activationCalls += 1;
+    return true;
+  };
+  internals.spawnWorkflowNodeAgentForExecution = async () => {
+    spawnCalls += 1;
+    return LIVE_SESSION_ID;
+  };
+  return {
+    manager,
+    updates,
+    activationCalls: () => activationCalls,
+    spawnCalls: () => spawnCalls,
+  };
+}
+
+describe('TaskAgentManager.activateTargetSessionsForMessage activation routing', () => {
+  test('a dead execution for an agent no longer declared on the node resets and returns [] without activating', async () => {
+    const harness = makeManager({
+      executionStatus: 'in_progress',
+      agentSessionId: DEAD_SESSION_ID,
+      sessionAlive: false,
+      nodeAgents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
+    });
+    const result = await harness.manager.activateTargetSessionsForMessage(
+      TASK_ID,
+      RUN_ID,
+      AGENT_NAME,
+      { workflowNodeId: NODE_ID }
+    );
+    expect(result).toEqual([]);
+    expect(harness.updates).toEqual([{ id: EXEC_ID, params: { status: 'pending' } }]);
+    expect(harness.activationCalls()).toBe(0);
+    expect(harness.spawnCalls()).toBe(0);
+  });
+
+  test('an undeclared agent without an existing execution returns [] before activation', async () => {
+    const harness = makeManager({
+      executionStatus: null,
+      agentSessionId: null,
+      sessionAlive: false,
+      nodeAgents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
+    });
+    const result = await harness.manager.activateTargetSessionsForMessage(
+      TASK_ID,
+      RUN_ID,
+      AGENT_NAME,
+      { workflowNodeId: NODE_ID }
+    );
+    expect(result).toEqual([]);
+    expect(harness.updates).toEqual([]);
+    expect(harness.activationCalls()).toBe(0);
+  });
+
+  test('a dead execution for a declared agent is reset, activated, and spawned', async () => {
+    const harness = makeManager({
+      executionStatus: 'blocked',
+      agentSessionId: DEAD_SESSION_ID,
+      sessionAlive: false,
+      nodeAgents: [{ agentId: 'agent-coder', name: AGENT_NAME }],
+    });
+    const result = await harness.manager.activateTargetSessionsForMessage(
+      TASK_ID,
+      RUN_ID,
+      AGENT_NAME,
+      { workflowNodeId: NODE_ID }
+    );
+    expect(result).toEqual([{ agentName: AGENT_NAME, sessionId: LIVE_SESSION_ID }]);
+    expect(harness.updates).toEqual([{ id: EXEC_ID, params: { status: 'pending' } }]);
+    expect(harness.activationCalls()).toBe(1);
+    expect(harness.spawnCalls()).toBe(1);
+  });
+
+  test('a live session is reused before the node declaration lookup can throw', async () => {
+    const harness = makeManager({
+      executionStatus: 'in_progress',
+      agentSessionId: LIVE_SESSION_ID,
+      sessionAlive: true,
+      nodeAgents: [],
+    });
+    const result = await harness.manager.activateTargetSessionsForMessage(
+      TASK_ID,
+      RUN_ID,
+      AGENT_NAME,
+      { workflowNodeId: NODE_ID }
+    );
+    expect(result).toEqual([{ agentName: AGENT_NAME, sessionId: LIVE_SESSION_ID }]);
+    expect(harness.updates).toEqual([]);
+    expect(harness.activationCalls()).toBe(0);
+    expect(harness.spawnCalls()).toBe(0);
+  });
+
+  test('a live session for an undeclared agent is still reused', async () => {
+    const harness = makeManager({
+      executionStatus: 'in_progress',
+      agentSessionId: LIVE_SESSION_ID,
+      sessionAlive: true,
+      nodeAgents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
+    });
+    const result = await harness.manager.activateTargetSessionsForMessage(
+      TASK_ID,
+      RUN_ID,
+      AGENT_NAME,
+      { workflowNodeId: NODE_ID }
+    );
+    expect(result).toEqual([{ agentName: AGENT_NAME, sessionId: LIVE_SESSION_ID }]);
+    expect(harness.activationCalls()).toBe(0);
+  });
+});


### PR DESCRIPTION
Superpipe sub-pilot 7 Chain P, PR 3 of 6. Extracts `activation-routing.ts` — a pure decision core (`decideActivationRouting`: reuse_existing / reset_pending_and_continue / reject_undeclared / spawn_with_timeout / return_empty) plus the `selectWorkflowNodeForAgent` target-node selector — and has `activateTargetSessionsForMessage` interpret the routing inline across the two fact-gathering stages (pre- and post-activation), keeping the spawn call and 30s timeout race as shell effects. Additive extraction, no behavior change; unit tests pin the decision table, precedence, and pass-through identity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->