### PR TITLE
fix(daemon): admit api-error terminal results into runtime continue recovery

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7370,11 +7370,13 @@ export class SpaceRuntime {
     spaceId: string,
     canonicalTask: SpaceTask,
     execution: NodeExecution,
-    errorResult: { subtype: string; errors?: string[] },
+    errorResult: { subtype: string; errors?: string[]; result?: string },
     tam: TaskAgentManager,
     detail: string
   ): Promise<void> {
-    const errorSnippet = (errorResult.errors ?? []).join('; ').slice(0, 280);
+    const errorDetails = (errorResult.errors ?? []).join('; ');
+    const fallbackText = typeof errorResult.result === 'string' ? errorResult.result : '';
+    const errorSnippet = (errorDetails !== '' ? errorDetails : fallbackText).slice(0, 280);
     const reason =
       `Agent session ended on a terminal error result and exhausted runtime auto-continue recovery ` +
       `(node ${execution.workflowNodeId}, agent ${execution.agentName}, subtype ${errorResult.subtype}): ` +
@@ -7438,7 +7440,10 @@ export class SpaceRuntime {
     return (
       isSDKResultSuccess(message) &&
       message.is_error === true &&
-      (message.terminal_reason === 'api_error' || typeof message.api_error_status === 'number')
+      (message.terminal_reason === 'api_error' ||
+        message.terminal_reason === 'blocking_limit' ||
+        message.terminal_reason === 'rapid_refill_breaker' ||
+        typeof message.api_error_status === 'number')
     );
   }
 
@@ -7454,13 +7459,16 @@ export class SpaceRuntime {
     terminal_reason?: string;
     errors?: string[];
     result?: string;
+    api_error_status?: number | null;
   }): string {
     const terminalReason =
       typeof message.terminal_reason === 'string' ? message.terminal_reason : '';
     const errors = (message.errors ?? []).map((entry) => entry.trim().slice(0, 200));
     const resultText =
       typeof message.result === 'string' ? message.result.trim().slice(0, 200) : '';
-    return `${message.subtype}|${terminalReason}|${errors.join('\n')}${resultText}`;
+    const status =
+      typeof message.api_error_status === 'number' ? String(message.api_error_status) : '';
+    return `${message.subtype}|${terminalReason}|${errors.join('\n')}${resultText}|${status}`;
   }
 
   private isPromptTooLongResultError(message: {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7226,6 +7226,8 @@ export class SpaceRuntime {
       }
       if (this.isPromptTooLongResultError(lastMessage)) continue;
 
+      if (this.isRecoveryInterceptedResult(lastMessage)) continue;
+
       if (this.isApiErrorTerminalResult(lastMessage) && this.isLimitErrorApiResult(lastMessage)) {
         continue;
       }
@@ -7443,6 +7445,13 @@ export class SpaceRuntime {
       message.is_error === true &&
       message.terminal_reason === 'api_error'
     );
+  }
+
+  private isRecoveryInterceptedResult(message: {
+    subtype: string;
+    recovery_intercepted?: boolean | number;
+  }): boolean {
+    return message.recovery_intercepted === true || message.recovery_intercepted === 1;
   }
 
   private isLimitErrorApiResult(message: {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -7474,9 +7474,14 @@ export class SpaceRuntime {
   private isPromptTooLongResultError(message: {
     terminal_reason?: string;
     errors?: string[];
+    result?: string;
   }): boolean {
     if (message.terminal_reason === 'prompt_too_long') return true;
-    return (message.errors ?? []).some((entry) => /prompt is too long/i.test(entry));
+    const text = [
+      ...(message.errors ?? []),
+      typeof message.result === 'string' ? message.result : '',
+    ].join('\n');
+    return /prompt is too long/i.test(text);
   }
 
   private buildTerminalErrorContinueMessage(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -40,7 +40,6 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { Database as BunDatabase } from '../../../storage/sqlite-compat';
-import { assessLimitError } from '../../agent/limit-error-classifier';
 import { formatExternalEventEssence } from '../../external-events/event-essence';
 import type { ExternalEventPublishedPayload } from '../../external-events/external-event-service';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
@@ -7228,10 +7227,6 @@ export class SpaceRuntime {
 
       if (this.isRecoveryInterceptedResult(lastMessage)) continue;
 
-      if (this.isApiErrorTerminalResult(lastMessage) && this.isLimitErrorApiResult(lastMessage)) {
-        continue;
-      }
-
       if (
         sessionExecutions.some(
           (e) =>
@@ -7443,7 +7438,7 @@ export class SpaceRuntime {
     return (
       isSDKResultSuccess(message) &&
       message.is_error === true &&
-      message.terminal_reason === 'api_error'
+      (message.terminal_reason === 'api_error' || typeof message.api_error_status === 'number')
     );
   }
 
@@ -7452,19 +7447,6 @@ export class SpaceRuntime {
     recovery_intercepted?: boolean | number;
   }): boolean {
     return message.recovery_intercepted === true || message.recovery_intercepted === 1;
-  }
-
-  private isLimitErrorApiResult(message: {
-    result?: string;
-    api_error_status?: number | null;
-    terminal_reason?: string;
-  }): boolean {
-    return assessLimitError({
-      rawText: typeof message.result === 'string' ? message.result : '',
-      httpStatus:
-        typeof message.api_error_status === 'number' ? message.api_error_status : undefined,
-      terminalReason: message.terminal_reason,
-    }).isLimit;
   }
 
   private computeTerminalErrorSignature(message: {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -22,7 +22,7 @@ import {
   resolveNodeAgents,
 } from '@hyperneo/shared';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
-import { isSDKResultError } from '@hyperneo/shared/sdk';
+import { isSDKResultError, isSDKResultSuccess } from '@hyperneo/shared/sdk';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import {
   ChannelCycleRepository,
@@ -40,6 +40,7 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { Database as BunDatabase } from '../../../storage/sqlite-compat';
+import { assessLimitError } from '../../agent/limit-error-classifier';
 import { formatExternalEventEssence } from '../../external-events/event-essence';
 import type { ExternalEventPublishedPayload } from '../../external-events/external-event-service';
 import type { ExternalEventStore } from '../../external-events/external-event-store';
@@ -7217,7 +7218,7 @@ export class SpaceRuntime {
       const sessionId = execution.agentSessionId!;
       const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
       const key = `${runId}:${execution.id}`;
-      if (!lastMessage || !isSDKResultError(lastMessage)) continue;
+      if (!lastMessage || !this.isRecoverableTerminalErrorResult(lastMessage)) continue;
       const sessionExecutions = executionsBySession.get(sessionId) ?? [execution];
 
       if (sessionExecutions.some((e) => this.promptTooLongRecovery.has(`${runId}:${e.id}`))) {
@@ -7225,10 +7226,7 @@ export class SpaceRuntime {
       }
       if (this.isPromptTooLongResultError(lastMessage)) continue;
 
-      if (
-        lastMessage.subtype !== 'error_during_execution' &&
-        lastMessage.subtype !== 'error_max_turns'
-      ) {
+      if (this.isApiErrorTerminalResult(lastMessage) && this.isLimitErrorApiResult(lastMessage)) {
         continue;
       }
 
@@ -7305,7 +7303,8 @@ export class SpaceRuntime {
 
       if (
         state.lastRetriedErrorSignature === signature &&
-        lastMessage.subtype === 'error_during_execution'
+        (lastMessage.subtype === 'error_during_execution' ||
+          this.isApiErrorTerminalResult(lastMessage))
       ) {
         await this.escalateTerminalErrorToBlocked(
           runId,
@@ -7427,15 +7426,50 @@ export class SpaceRuntime {
     });
   }
 
+  private isRecoverableTerminalErrorResult(
+    message: SDKMessage
+  ): message is Extract<SDKMessage, { type: 'result' }> {
+    if (isSDKResultError(message)) {
+      return message.subtype === 'error_during_execution' || message.subtype === 'error_max_turns';
+    }
+    return this.isApiErrorTerminalResult(message);
+  }
+
+  private isApiErrorTerminalResult(
+    message: SDKMessage
+  ): message is Extract<SDKMessage, { type: 'result'; subtype: 'success' }> {
+    return (
+      isSDKResultSuccess(message) &&
+      message.is_error === true &&
+      message.terminal_reason === 'api_error'
+    );
+  }
+
+  private isLimitErrorApiResult(message: {
+    result?: string;
+    api_error_status?: number | null;
+    terminal_reason?: string;
+  }): boolean {
+    return assessLimitError({
+      rawText: typeof message.result === 'string' ? message.result : '',
+      httpStatus:
+        typeof message.api_error_status === 'number' ? message.api_error_status : undefined,
+      terminalReason: message.terminal_reason,
+    }).isLimit;
+  }
+
   private computeTerminalErrorSignature(message: {
     subtype: string;
     terminal_reason?: string;
     errors?: string[];
+    result?: string;
   }): string {
     const terminalReason =
       typeof message.terminal_reason === 'string' ? message.terminal_reason : '';
     const errors = (message.errors ?? []).map((entry) => entry.trim().slice(0, 200));
-    return `${message.subtype}|${terminalReason}|${errors.join('\n')}`;
+    const resultText =
+      typeof message.result === 'string' ? message.result.trim().slice(0, 200) : '';
+    return `${message.subtype}|${terminalReason}|${errors.join('\n')}${resultText}`;
   }
 
   private isPromptTooLongResultError(message: {
@@ -7448,9 +7482,11 @@ export class SpaceRuntime {
 
   private buildTerminalErrorContinueMessage(
     execution: NodeExecution,
-    errorResult: { subtype: string; errors?: string[] }
+    errorResult: { subtype: string; errors?: string[]; result?: string }
   ): string {
-    const errorSummary = (errorResult.errors ?? []).join('; ').slice(0, 280);
+    const errorDetails = (errorResult.errors ?? []).join('; ');
+    const fallbackText = typeof errorResult.result === 'string' ? errorResult.result : '';
+    const errorSummary = (errorDetails !== '' ? errorDetails : fallbackText).slice(0, 280);
     return [
       '[Runtime recovery — terminal error]',
       '',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -827,6 +827,23 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
   });
 
+  test('declined rapid-refill-breaker result falls through to runtime continue (limit pipeline did not claim it)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'rapid_refill_breaker',
+      resultText: 'API Error: rapid refill breaker open',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(tam._injected[0].message).toContain('rapid refill breaker');
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
   test('status-only results with different HTTP statuses are distinct signatures', async () => {
     const { executionId } = seedIdleErrorRun({
       subtype: 'success',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -517,6 +517,23 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     ).toHaveLength(0);
   });
 
+  test('prompt-too-long text on an api-error success result is skipped (deferred to the ptl path)', async () => {
+    seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: prompt is too long: 205616 tokens > 200000 maximum',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(
+      tam._injected.filter((m) => m.message.includes('[Runtime recovery — terminal error]'))
+    ).toHaveLength(0);
+  });
+
   test('dead terminal-error session is reset for a FRESH re-spawn (stale session cleared)', async () => {
     const { executionId } = seedIdleErrorRun({
       subtype: 'error_during_execution',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -173,6 +173,8 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       errors?: string[];
       terminalReason?: string;
       minutesAgo?: number;
+      resultText?: string;
+      apiErrorStatus?: number;
     }
   ): void {
     const id = `${sessionId}-result-${Math.random().toString(36).slice(2)}`;
@@ -192,6 +194,10 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       uuid: id,
     };
     if (opts.terminalReason) message.terminal_reason = opts.terminalReason;
+    if (opts.subtype === 'success') {
+      message.result = opts.resultText ?? '';
+      if (typeof opts.apiErrorStatus === 'number') message.api_error_status = opts.apiErrorStatus;
+    }
     const ts = new Date(Date.now() - (opts.minutesAgo ?? 0) * 60_000).toISOString();
     db.prepare(
       `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, is_renderable, is_terminal)
@@ -206,6 +212,8 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     taskStatus?: string;
     sessionAlive?: boolean;
     sessionId?: string;
+    resultText?: string;
+    apiErrorStatus?: number;
   }): { runId: string; taskId: string; executionId: string } {
     const workflow = workflowManager.createWorkflow({
       spaceId: SPACE_ID,
@@ -250,13 +258,21 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       subtype: opts.subtype,
       errors: opts.errors,
       terminalReason: opts.terminalReason,
+      resultText: opts.resultText,
+      apiErrorStatus: opts.apiErrorStatus,
     });
     return { runId: run.id, taskId: task.id, executionId: execution.id };
   }
 
   function resumeToIdle(
     executionId: string,
-    opts: { subtype: string; errors?: string[]; terminalReason?: string }
+    opts: {
+      subtype: string;
+      errors?: string[];
+      terminalReason?: string;
+      resultText?: string;
+      apiErrorStatus?: number;
+    }
   ): void {
     const execution = nodeExecutionRepo.getById(executionId);
     const sessionId = execution?.agentSessionId ?? SESSION;
@@ -332,6 +348,63 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
 
     expect(tam._injected).toHaveLength(1);
+  });
+
+  test('api-error success result (is_error + terminal_reason api_error) injects one continue', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: Connection refused (ConnectionRefused)',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(tam._injected[0].sessionId).toBe(SESSION);
+    expect(tam._injected[0].message).toContain('[Runtime recovery — terminal error]');
+    expect(tam._injected[0].message).toContain('Connection refused');
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
+    expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
+  });
+
+  test('api-error success result with HTTP 429 is carved out (limit machinery owns it)', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: Too many requests',
+      apiErrorStatus: 429,
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
+    expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
+    expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
+  });
+
+  test('api-error success result with usage-limit text is carved out (limit machinery owns it)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: usage limit reached, upgrades available',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
   });
 
   test('error_max_budget_usd (cost guard) is never continued or blocked', async () => {
@@ -644,6 +717,37 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(nodeExecutionRepo.getById(executionId)?.agentSessionId).toBeNull();
     expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+  });
+
+  test('identical api-error signature recurrence escalates to blocked', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: Connection refused (ConnectionRefused)',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    resumeToIdle(executionId, {
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: Connection refused (ConnectionRefused)',
+    });
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(nodeExecutionRepo.getById(executionId)?.agentSessionId).toBeNull();
+    expect(tam._cancelled).toContain(SESSION);
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+    expect(notifications).toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
+    expect(notifications).toContainEqual(expect.objectContaining({ kind: 'workflow_run_blocked' }));
   });
 
   test('grace cooldown suppresses a re-evaluation before the prior continue is consumed', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -806,8 +806,58 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(tam._cancelled).toContain(SESSION);
     expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.result).toContain('Connection refused');
     expect(notifications).toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
     expect(notifications).toContainEqual(expect.objectContaining({ kind: 'workflow_run_blocked' }));
+  });
+
+  test('declined blocking-limit result falls through to runtime continue (limit pipeline did not claim it)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'blocking_limit',
+      resultText: 'API Error: usage limit reached',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('status-only results with different HTTP statuses are distinct signatures', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      apiErrorStatus: 502,
+      resultText: '',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    resumeToIdle(executionId, {
+      subtype: 'success',
+      apiErrorStatus: 503,
+      resultText: '',
+    });
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+
+    resumeToIdle(executionId, {
+      subtype: 'success',
+      apiErrorStatus: 504,
+      resultText: '',
+    });
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(2);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
   });
 
   test('distinct api-error texts are distinct signatures (second continue before budget exhaustion)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -198,6 +198,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       message.result = opts.resultText ?? '';
       if (typeof opts.apiErrorStatus === 'number') message.api_error_status = opts.apiErrorStatus;
     }
+    if (opts.recoveryIntercepted) message.recovery_intercepted = 1;
     const ts = new Date(Date.now() - (opts.minutesAgo ?? 0) * 60_000).toISOString();
     db.prepare(
       `INSERT INTO sdk_messages (id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin, is_renderable, is_terminal)
@@ -214,6 +215,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     sessionId?: string;
     resultText?: string;
     apiErrorStatus?: number;
+    recoveryIntercepted?: boolean;
   }): { runId: string; taskId: string; executionId: string } {
     const workflow = workflowManager.createWorkflow({
       spaceId: SPACE_ID,
@@ -260,6 +262,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       terminalReason: opts.terminalReason,
       resultText: opts.resultText,
       apiErrorStatus: opts.apiErrorStatus,
+      recoveryIntercepted: opts.recoveryIntercepted,
     });
     return { runId: run.id, taskId: task.id, executionId: execution.id };
   }
@@ -272,6 +275,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       terminalReason?: string;
       resultText?: string;
       apiErrorStatus?: number;
+      recoveryIntercepted?: boolean;
     }
   ): void {
     const execution = nodeExecutionRepo.getById(executionId);
@@ -404,6 +408,43 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
 
     expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('recovery_intercepted flag carves out a generic-text api-error result (limit pipeline owns it)', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: 500 Internal Server Error',
+      recoveryIntercepted: true,
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('in_progress');
+    expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
+    expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
+  });
+
+  test('generic-text api-error result without the interception flag is still admitted', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: 500 Internal Server Error',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
+    expect(tam._injected[0].message).toContain('500 Internal Server Error');
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
   });
 
@@ -748,6 +789,41 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
     expect(notifications).toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
     expect(notifications).toContainEqual(expect.objectContaining({ kind: 'workflow_run_blocked' }));
+  });
+
+  test('distinct api-error texts are distinct signatures (second continue before budget exhaustion)', async () => {
+    const { runId, taskId, executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: Connection refused (ConnectionRefused)',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(1);
+
+    resumeToIdle(executionId, {
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: 502 Bad Gateway',
+    });
+    await rt.executeTick();
+    expect(tam._injected).toHaveLength(2);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+
+    resumeToIdle(executionId, {
+      subtype: 'success',
+      terminalReason: 'api_error',
+      resultText: 'API Error: 503 Service Unavailable',
+    });
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(2);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('blocked');
+    expect(workflowRunRepo.getRun(runId)?.status).toBe('blocked');
+    expect(taskRepo.getTask(taskId)?.status).toBe('blocked');
   });
 
   test('grace cooldown suppresses a re-evaluation before the prior continue is consumed', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-terminal-error-recovery.test.ts
@@ -175,6 +175,7 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
       minutesAgo?: number;
       resultText?: string;
       apiErrorStatus?: number;
+      recoveryIntercepted?: boolean;
     }
   ): void {
     const id = `${sessionId}-result-${Math.random().toString(36).slice(2)}`;
@@ -375,12 +376,13 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(taskRepo.getTask(taskId)?.status).toBe('in_progress');
   });
 
-  test('api-error success result with HTTP 429 is carved out (limit machinery owns it)', async () => {
+  test('flagged 429 api-error result is carved out (limit machinery owns it)', async () => {
     const { runId, taskId, executionId } = seedIdleErrorRun({
       subtype: 'success',
       terminalReason: 'api_error',
       resultText: 'API Error: Too many requests',
       apiErrorStatus: 429,
+      recoveryIntercepted: true,
     });
     const tam = makeTam();
     const rt = new SpaceRuntime(buildConfig(tam));
@@ -395,11 +397,12 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     expect(notifications).not.toContainEqual(expect.objectContaining({ kind: 'task_blocked' }));
   });
 
-  test('api-error success result with usage-limit text is carved out (limit machinery owns it)', async () => {
+  test('flagged usage-limit-text api-error result is carved out (limit machinery owns it)', async () => {
     const { executionId } = seedIdleErrorRun({
       subtype: 'success',
       terminalReason: 'api_error',
       resultText: 'API Error: usage limit reached, upgrades available',
+      recoveryIntercepted: true,
     });
     const tam = makeTam();
     const rt = new SpaceRuntime(buildConfig(tam));
@@ -408,6 +411,22 @@ describe('SpaceRuntime — terminal-error idle recovery (#673)', () => {
     await rt.executeTick();
 
     expect(tam._injected).toHaveLength(0);
+    expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
+  });
+
+  test('unflagged status-only 429 result falls through to runtime continue (limit pipeline declined it)', async () => {
+    const { executionId } = seedIdleErrorRun({
+      subtype: 'success',
+      apiErrorStatus: 429,
+      resultText: 'API Error: Too many requests',
+    });
+    const tam = makeTam();
+    const rt = new SpaceRuntime(buildConfig(tam));
+    (rt as unknown as { recoveryDone: boolean }).recoveryDone = true;
+
+    await rt.executeTick();
+
+    expect(tam._injected).toHaveLength(1);
     expect(nodeExecutionRepo.getById(executionId)?.status).toBe('idle');
   });
 


### PR DESCRIPTION
Part 3 of #2726. SDK API errors arrive as `subtype:"success"` + `is_error:true` + `terminal_reason:"api_error"`, which `handleTerminalErrorIdleExecutions` skipped — hung the incident session permanently.

Admission now accepts those results (terminal_reason `api_error` or numeric `api_error_status`) into the existing continue machinery — grace window, retry cap, identical-signature escalation to blocked. Results the limit pipeline actually claimed at turn end (persisted `recovery_intercepted=1`) are skipped, so the limit watchdog/fallback chain keeps sole ownership while declined or unclaimed limit-shaped results still get bounded generic recovery instead of hanging.