### PR TITLE
feat(space): paginate list_goal_tasks with keyset cursor + compact projection

### DIFF
--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -4580,7 +4580,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
       ),
       tool(
         'list_goal_tasks',
-        "List tasks linked to a goal in this space, optionally filtered by status. Returns a bounded page (default 20, max 100) ordered by most-recently-updated; pass the last item's updatedAt as `before` and its id as `before_id` to fetch the next page.",
+        "List tasks linked to a goal in this space, optionally filtered by status. Returns a bounded page (default 20, max 100) ordered by most-recently-created; pass the last item's createdAt as `before` and its id as `before_id` to fetch the next page.",
         {
           goal_id: z.string().describe('Goal ID'),
           status: z
@@ -4608,7 +4608,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
             .number()
             .int()
             .optional()
-            .describe('Return tasks updated before this timestamp (cursor)'),
+            .describe('Return tasks created before this timestamp (cursor)'),
           before_id: z.string().optional().describe('Cursor id for same-timestamp pagination'),
         },
         (args) => handlers.list_goal_tasks(args)

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -3091,7 +3091,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     }): Promise<ToolResult> {
       try {
         requireGoalInSpace(args.goal_id);
-        const page = taskRepo.listByGoal(args.goal_id, {
+        const page = taskRepo.listByGoal(spaceId, args.goal_id, {
           status: args.status,
           limit: args.limit,
           before: args.before,
@@ -4580,7 +4580,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
       ),
       tool(
         'list_goal_tasks',
-        "List tasks linked to a goal in this space, optionally filtered by status. Returns a bounded page (default 20, max 100) ordered by most-recently-created; pass the last item's createdAt as `before` and its id as `before_id` to fetch the next page.",
+        "List tasks linked to a goal in this space, optionally filtered by status. Returns a bounded page (default 20, max 100) of compact task summaries (id, task_number, title, status, priority, createdAt, updatedAt) ordered by most-recently-created; results omit description and result. Pass the last item's createdAt as `before` and its id as `before_id` to fetch the next page. Use `get_task_detail` to retrieve the full record for any task whose outcome you need to inspect.",
         {
           goal_id: z.string().describe('Goal ID'),
           status: z

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -3085,14 +3085,33 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     async list_goal_tasks(args: {
       goal_id: string;
       status?: SpaceTaskStatus;
+      limit?: number;
+      before?: number;
+      before_id?: string;
     }): Promise<ToolResult> {
       try {
         requireGoalInSpace(args.goal_id);
-        const tasks = taskRepo
-          .listBySpace(spaceId, args.status === 'archived')
-          .filter((task) => task.goalId === args.goal_id)
-          .filter((task) => (args.status ? task.status === args.status : true));
-        return jsonResult({ success: true, total: tasks.length, tasks });
+        const page = taskRepo.listByGoal(args.goal_id, {
+          status: args.status,
+          limit: args.limit,
+          before: args.before,
+          beforeId: args.before_id,
+        });
+        const tasks = page.tasks.map((task) => ({
+          id: task.id,
+          taskNumber: task.taskNumber,
+          title: task.title,
+          status: task.status,
+          priority: task.priority,
+          createdAt: task.createdAt,
+          updatedAt: task.updatedAt,
+        }));
+        return jsonResult({
+          success: true,
+          total: page.total,
+          tasks,
+          has_more: page.hasMore,
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ success: false, error: message });
@@ -4561,7 +4580,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
       ),
       tool(
         'list_goal_tasks',
-        'List tasks linked to a goal in this space, optionally filtered by status.',
+        "List tasks linked to a goal in this space, optionally filtered by status. Returns a bounded page (default 20, max 100) ordered by most-recently-updated; pass the last item's updatedAt as `before` and its id as `before_id` to fetch the next page.",
         {
           goal_id: z.string().describe('Goal ID'),
           status: z
@@ -4578,6 +4597,19 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
             ])
             .optional()
             .describe('Filter by linked task status'),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .optional()
+            .describe('Max tasks to return (default 20)'),
+          before: z
+            .number()
+            .int()
+            .optional()
+            .describe('Return tasks updated before this timestamp (cursor)'),
+          before_id: z.string().optional().describe('Cursor id for same-timestamp pagination'),
         },
         (args) => handlers.list_goal_tasks(args)
       ),

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -237,6 +237,50 @@ export class SpaceTaskRepository {
     return rows.map((r) => this.rowToSpaceTask(r));
   }
 
+  listByGoal(
+    goalId: string,
+    params: {
+      status?: SpaceTaskStatus;
+      limit?: number;
+      before?: number;
+      beforeId?: string;
+    } = {}
+  ): { tasks: SpaceTask[]; total: number; hasMore: boolean } {
+    const limit = Math.max(1, Math.min(100, Math.trunc(params.limit ?? 20)));
+    const cursorId =
+      typeof params.beforeId === 'string' && params.beforeId.length > 0 ? params.beforeId : null;
+    const where: string[] = [`goal_id = ?`];
+    const bind: SQLiteValue[] = [goalId];
+    if (params.status) {
+      where.push(`status = ?`);
+      bind.push(params.status);
+    } else {
+      where.push(`status != 'archived'`);
+    }
+    if (params.before !== undefined) {
+      if (cursorId) {
+        where.push(`(updated_at < ? OR (updated_at = ? AND id < ?))`);
+        bind.push(params.before, params.before, cursorId);
+      } else {
+        where.push(`updated_at < ?`);
+        bind.push(params.before);
+      }
+    }
+    const whereSql = where.join(' AND ');
+    const countRow = this.db
+      .prepare(`SELECT COUNT(*) as count FROM space_tasks WHERE ${whereSql}`)
+      .get(...bind) as { count: number } | undefined;
+    const total = countRow?.count ?? 0;
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM space_tasks WHERE ${whereSql} ORDER BY updated_at DESC, id DESC LIMIT ?`
+      )
+      .all(...bind, limit + 1) as Record<string, unknown>[];
+    const hasMore = rows.length > limit;
+    const tasks = rows.slice(0, limit).map((r) => this.rowToSpaceTask(r));
+    return { tasks, total, hasMore };
+  }
+
   hasApprovedTaskForWorkflow(workflowId: string): boolean {
     const row = this.db
       .prepare(

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -249,33 +249,34 @@ export class SpaceTaskRepository {
     const limit = Math.max(1, Math.min(100, Math.trunc(params.limit ?? 20)));
     const cursorId =
       typeof params.beforeId === 'string' && params.beforeId.length > 0 ? params.beforeId : null;
-    const where: string[] = [`goal_id = ?`];
-    const bind: SQLiteValue[] = [goalId];
+    const scopeWhere: string[] = [`goal_id = ?`];
+    const scopeBind: SQLiteValue[] = [goalId];
     if (params.status) {
-      where.push(`status = ?`);
-      bind.push(params.status);
+      scopeWhere.push(`status = ?`);
+      scopeBind.push(params.status);
     } else {
-      where.push(`status != 'archived'`);
+      scopeWhere.push(`status != 'archived'`);
     }
+    const countRow = this.db
+      .prepare(`SELECT COUNT(*) as count FROM space_tasks WHERE ${scopeWhere.join(' AND ')}`)
+      .get(...scopeBind) as { count: number } | undefined;
+    const total = countRow?.count ?? 0;
+    const pageWhere = [...scopeWhere];
+    const pageBind = [...scopeBind];
     if (params.before !== undefined) {
       if (cursorId) {
-        where.push(`(updated_at < ? OR (updated_at = ? AND id < ?))`);
-        bind.push(params.before, params.before, cursorId);
+        pageWhere.push(`(created_at < ? OR (created_at = ? AND id < ?))`);
+        pageBind.push(params.before, params.before, cursorId);
       } else {
-        where.push(`updated_at < ?`);
-        bind.push(params.before);
+        pageWhere.push(`created_at < ?`);
+        pageBind.push(params.before);
       }
     }
-    const whereSql = where.join(' AND ');
-    const countRow = this.db
-      .prepare(`SELECT COUNT(*) as count FROM space_tasks WHERE ${whereSql}`)
-      .get(...bind) as { count: number } | undefined;
-    const total = countRow?.count ?? 0;
     const rows = this.db
       .prepare(
-        `SELECT * FROM space_tasks WHERE ${whereSql} ORDER BY updated_at DESC, id DESC LIMIT ?`
+        `SELECT * FROM space_tasks WHERE ${pageWhere.join(' AND ')} ORDER BY created_at DESC, id DESC LIMIT ?`
       )
-      .all(...bind, limit + 1) as Record<string, unknown>[];
+      .all(...pageBind, limit + 1) as Record<string, unknown>[];
     const hasMore = rows.length > limit;
     const tasks = rows.slice(0, limit).map((r) => this.rowToSpaceTask(r));
     return { tasks, total, hasMore };

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -238,6 +238,7 @@ export class SpaceTaskRepository {
   }
 
   listByGoal(
+    spaceId: string,
     goalId: string,
     params: {
       status?: SpaceTaskStatus;
@@ -249,8 +250,8 @@ export class SpaceTaskRepository {
     const limit = Math.max(1, Math.min(100, Math.trunc(params.limit ?? 20)));
     const cursorId =
       typeof params.beforeId === 'string' && params.beforeId.length > 0 ? params.beforeId : null;
-    const scopeWhere: string[] = [`goal_id = ?`];
-    const scopeBind: SQLiteValue[] = [goalId];
+    const scopeWhere: string[] = [`goal_id = ?`, `space_id = ?`];
+    const scopeBind: SQLiteValue[] = [goalId, spaceId];
     if (params.status) {
       scopeWhere.push(`status = ?`);
       scopeBind.push(params.status);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -441,6 +441,8 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   run(migrationMarkerKey(200), () => runMigration200(db));
 
   run(migrationMarkerKey(201), () => runMigration201(db));
+
+  run(migrationMarkerKey(202), () => runMigration202(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -9519,4 +9521,10 @@ export function runMigration201(db: BunDatabase): void {
   if (!tableHasColumn(db, 'space_tasks', 'spawn_reservation_token')) {
     db.exec(`ALTER TABLE space_tasks ADD COLUMN spawn_reservation_token TEXT`);
   }
+}
+
+export function runMigration202(db: BunDatabase): void {
+  if (!tableExists(db, 'space_tasks')) return;
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_created
+    ON space_tasks(goal_id, created_at DESC, id DESC)`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9525,6 +9525,7 @@ export function runMigration201(db: BunDatabase): void {
 
 export function runMigration202(db: BunDatabase): void {
   if (!tableExists(db, 'space_tasks')) return;
+  if (!tableHasColumn(db, 'space_tasks', 'goal_id')) return;
   db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_created
     ON space_tasks(goal_id, created_at DESC, id DESC)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_status_created

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -9527,4 +9527,6 @@ export function runMigration202(db: BunDatabase): void {
   if (!tableExists(db, 'space_tasks')) return;
   db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_created
     ON space_tasks(goal_id, created_at DESC, id DESC)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_status_created
+    ON space_tasks(goal_id, status, created_at DESC, id DESC)`);
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-202_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-202_test.ts
@@ -1,0 +1,86 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { runMigration202 } from '../../../../../src/storage/schema/migrations.ts';
+
+function indexNames(db: BunDatabase): string[] {
+  const rows = db.prepare(`PRAGMA index_list('space_tasks')`).all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+function seedPreM202Schema(db: BunDatabase): void {
+  db.exec(`
+    CREATE TABLE space_tasks (
+      id TEXT PRIMARY KEY,
+      space_id TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      goal_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+}
+
+describe('Migration 202: goal task keyset indexes', () => {
+  let testDir: string;
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    testDir = join(
+      process.cwd(),
+      'tmp',
+      'test-migration-202',
+      `test-${Date.now()}-${Math.random()}`
+    );
+    mkdirSync(testDir, { recursive: true });
+    db = new BunDatabase(join(testDir, 'test.db'));
+    db.exec('PRAGMA foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {}
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  describe('pre-M202 schema with goal_id', () => {
+    beforeEach(() => {
+      seedPreM202Schema(db);
+    });
+
+    test('creates both goal-task keyset indexes', () => {
+      runMigration202(db);
+      const indexes = indexNames(db);
+      expect(indexes).toContain('idx_space_tasks_goal_created');
+      expect(indexes).toContain('idx_space_tasks_goal_status_created');
+    });
+
+    test('is idempotent — a second run does not throw or duplicate', () => {
+      runMigration202(db);
+      expect(() => runMigration202(db)).not.toThrow();
+      expect(indexNames(db).filter((n) => n === 'idx_space_tasks_goal_created')).toHaveLength(1);
+    });
+  });
+
+  describe('pre-M202 schema without goal_id', () => {
+    test('skips index creation when goal_id is absent', () => {
+      db.exec(`
+        CREATE TABLE space_tasks (
+          id TEXT PRIMARY KEY,
+          space_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'open'
+        );
+      `);
+      expect(() => runMigration202(db)).not.toThrow();
+      expect(indexNames(db)).not.toContain('idx_space_tasks_goal_created');
+    });
+
+    test('is a no-op when space_tasks does not exist', () => {
+      expect(() => runMigration202(db)).not.toThrow();
+    });
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -1366,7 +1366,7 @@ describe('SpaceTaskRepository', () => {
   describe('listByGoal', () => {
     const goalId = 'goal-pagination';
 
-    function seedTask(title: string, updatedAt: number, status: string = 'open'): string {
+    function seedTask(title: string, createdAt: number, status: string = 'open'): string {
       const task = repo.createTask({
         spaceId,
         title,
@@ -1375,12 +1375,12 @@ describe('SpaceTaskRepository', () => {
         status: status as any,
       });
       (db as any)
-        .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
-        .run(updatedAt, task.id);
+        .prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`)
+        .run(createdAt, task.id);
       return task.id;
     }
 
-    it('returns only tasks for the goal, ordered by updated_at DESC, excluding archived by default', () => {
+    it('returns only tasks for the goal, ordered by created_at DESC, excluding archived by default', () => {
       const older = seedTask('older', 1000);
       const newer = seedTask('newer', 3000);
 
@@ -1390,7 +1390,7 @@ describe('SpaceTaskRepository', () => {
         description: '',
         goalId: 'other-goal',
       });
-      (db as any).prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(6000, other.id);
+      (db as any).prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`).run(6000, other.id);
 
       const { tasks, total, hasMore } = repo.listByGoal(goalId);
       expect(tasks.map((t) => t.id)).toEqual([newer, older]);
@@ -1438,11 +1438,53 @@ describe('SpaceTaskRepository', () => {
         collected.push(...page.tasks.map((t) => t.id));
         if (!page.hasMore) break;
         const last = page.tasks[page.tasks.length - 1];
-        before = last.updatedAt;
+        before = last.createdAt;
         beforeId = last.id;
       }
 
       expect(collected).toEqual(expected);
+    });
+
+    it('reports a stable total across pages (independent of the cursor)', () => {
+      for (let i = 0; i < 5; i++) seedTask(`task-${i}`, 1000 + i * 100);
+
+      const first = repo.listByGoal(goalId, { limit: 2 });
+      expect(first.total).toBe(5);
+      expect(first.tasks.length).toBe(2);
+
+      const second = repo.listByGoal(goalId, {
+        limit: 2,
+        before: first.tasks[first.tasks.length - 1].createdAt,
+        beforeId: first.tasks[first.tasks.length - 1].id,
+      });
+      expect(second.total).toBe(5);
+      expect(second.tasks.length).toBe(2);
+    });
+
+    it('keeps an updated-but-unseen task in the traversal (immutable created_at key)', () => {
+      const ids: string[] = [];
+      for (let i = 0; i < 4; i++) ids.push(seedTask(`task-${i}`, 1000 + i * 100));
+
+      const first = repo.listByGoal(goalId, { limit: 2 });
+      const lastUnseen = ids[1];
+      (db as any)
+        .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
+        .run(999999, lastUnseen);
+
+      const collected = [...first.tasks.map((t) => t.id)];
+      let before = first.tasks[first.tasks.length - 1].createdAt;
+      let beforeId = first.tasks[first.tasks.length - 1].id;
+      for (let guard = 0; guard < 10; guard++) {
+        const page = repo.listByGoal(goalId, { limit: 10, before, beforeId });
+        collected.push(...page.tasks.map((t) => t.id));
+        if (!page.hasMore) break;
+        const last = page.tasks[page.tasks.length - 1];
+        before = last.createdAt;
+        beforeId = last.id;
+      }
+
+      expect(new Set(collected).size).toBe(ids.length);
+      expect(collected).toContain(lastUnseen);
     });
 
     it('clamps the page size to the bounded range', () => {
@@ -1467,13 +1509,13 @@ describe('SpaceTaskRepository', () => {
       seedTask('late-insert', 9000);
 
       const collected = [...first.tasks.map((t) => t.id)];
-      let before = first.tasks[0].updatedAt;
+      let before = first.tasks[0].createdAt;
       let beforeId = first.tasks[0].id;
       for (let guard = 0; guard < 10; guard++) {
         const page = repo.listByGoal(goalId, { limit: 1, before, beforeId });
         if (page.tasks.length === 0) break;
         collected.push(page.tasks[0].id);
-        before = page.tasks[0].updatedAt;
+        before = page.tasks[0].createdAt;
         beforeId = page.tasks[0].id;
         if (!page.hasMore) break;
       }

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -1380,6 +1380,28 @@ describe('SpaceTaskRepository', () => {
       return task.id;
     }
 
+    it('excludes tasks from other spaces even when the goal id matches', () => {
+      const inSpace = seedTask('in-space', 1000);
+      const otherSpace = spaceRepo.createSpace({
+        workspacePath: '/workspace/other',
+        slug: 'other',
+        name: 'Other',
+      });
+      const crossSpace = repo.createTask({
+        spaceId: otherSpace.id,
+        title: 'cross-space',
+        description: '',
+        goalId,
+      });
+      (db as any)
+        .prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`)
+        .run(2000, crossSpace.id);
+
+      const { tasks, total } = repo.listByGoal(spaceId, goalId);
+      expect(tasks.map((t) => t.id)).toEqual([inSpace]);
+      expect(total).toBe(1);
+    });
+
     it('returns only tasks for the goal, ordered by created_at DESC, excluding archived by default', () => {
       const older = seedTask('older', 1000);
       const newer = seedTask('newer', 3000);
@@ -1392,7 +1414,7 @@ describe('SpaceTaskRepository', () => {
       });
       (db as any).prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`).run(6000, other.id);
 
-      const { tasks, total, hasMore } = repo.listByGoal(goalId);
+      const { tasks, total, hasMore } = repo.listByGoal(spaceId, goalId);
       expect(tasks.map((t) => t.id)).toEqual([newer, older]);
       expect(total).toBe(2);
       expect(hasMore).toBe(false);
@@ -1403,7 +1425,7 @@ describe('SpaceTaskRepository', () => {
       const done = seedTask('done-b', 2000, 'done');
       seedTask('open-c', 3000, 'open');
 
-      const { tasks, total } = repo.listByGoal(goalId, { status: 'done' });
+      const { tasks, total } = repo.listByGoal(spaceId, goalId, { status: 'done' });
       expect(tasks.map((t) => t.id)).toEqual([done]);
       expect(total).toBe(1);
     });
@@ -1412,10 +1434,10 @@ describe('SpaceTaskRepository', () => {
       const archived = seedTask('archived-a', 1000, 'archived');
       const open = seedTask('open-b', 2000, 'open');
 
-      const defaultPage = repo.listByGoal(goalId);
+      const defaultPage = repo.listByGoal(spaceId, goalId);
       expect(defaultPage.tasks.map((t) => t.id)).toEqual([open]);
 
-      const archivedPage = repo.listByGoal(goalId, { status: 'archived' });
+      const archivedPage = repo.listByGoal(spaceId, goalId, { status: 'archived' });
       expect(archivedPage.tasks.map((t) => t.id)).toEqual([archived]);
     });
 
@@ -1430,7 +1452,7 @@ describe('SpaceTaskRepository', () => {
       let before: number | undefined;
       let beforeId: string | undefined;
       for (let guard = 0; guard < 10; guard++) {
-        const page = repo.listByGoal(goalId, {
+        const page = repo.listByGoal(spaceId, goalId, {
           limit: 2,
           before,
           beforeId,
@@ -1448,11 +1470,11 @@ describe('SpaceTaskRepository', () => {
     it('reports a stable total across pages (independent of the cursor)', () => {
       for (let i = 0; i < 5; i++) seedTask(`task-${i}`, 1000 + i * 100);
 
-      const first = repo.listByGoal(goalId, { limit: 2 });
+      const first = repo.listByGoal(spaceId, goalId, { limit: 2 });
       expect(first.total).toBe(5);
       expect(first.tasks.length).toBe(2);
 
-      const second = repo.listByGoal(goalId, {
+      const second = repo.listByGoal(spaceId, goalId, {
         limit: 2,
         before: first.tasks[first.tasks.length - 1].createdAt,
         beforeId: first.tasks[first.tasks.length - 1].id,
@@ -1465,7 +1487,7 @@ describe('SpaceTaskRepository', () => {
       const ids: string[] = [];
       for (let i = 0; i < 4; i++) ids.push(seedTask(`task-${i}`, 1000 + i * 100));
 
-      const first = repo.listByGoal(goalId, { limit: 2 });
+      const first = repo.listByGoal(spaceId, goalId, { limit: 2 });
       const lastUnseen = ids[1];
       (db as any)
         .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
@@ -1475,7 +1497,7 @@ describe('SpaceTaskRepository', () => {
       let before = first.tasks[first.tasks.length - 1].createdAt;
       let beforeId = first.tasks[first.tasks.length - 1].id;
       for (let guard = 0; guard < 10; guard++) {
-        const page = repo.listByGoal(goalId, { limit: 10, before, beforeId });
+        const page = repo.listByGoal(spaceId, goalId, { limit: 10, before, beforeId });
         collected.push(...page.tasks.map((t) => t.id));
         if (!page.hasMore) break;
         const last = page.tasks[page.tasks.length - 1];
@@ -1490,11 +1512,11 @@ describe('SpaceTaskRepository', () => {
     it('clamps the page size to the bounded range', () => {
       for (let i = 0; i < 5; i++) seedTask(`task-${i}`, 1000 + i * 100);
 
-      const tiny = repo.listByGoal(goalId, { limit: -1 });
+      const tiny = repo.listByGoal(spaceId, goalId, { limit: -1 });
       expect(tiny.tasks.length).toBe(1);
       expect(tiny.hasMore).toBe(true);
 
-      const huge = repo.listByGoal(goalId, { limit: 1000 });
+      const huge = repo.listByGoal(spaceId, goalId, { limit: 1000 });
       expect(huge.tasks.length).toBe(5);
       expect(huge.hasMore).toBe(false);
     });
@@ -1503,7 +1525,7 @@ describe('SpaceTaskRepository', () => {
       const ids: string[] = [];
       for (let i = 0; i < 3; i++) ids.push(seedTask(`task-${i}`, 1000 + i * 100));
 
-      const first = repo.listByGoal(goalId, { limit: 1 });
+      const first = repo.listByGoal(spaceId, goalId, { limit: 1 });
       expect(first.tasks.length).toBe(1);
 
       seedTask('late-insert', 9000);
@@ -1512,7 +1534,7 @@ describe('SpaceTaskRepository', () => {
       let before = first.tasks[0].createdAt;
       let beforeId = first.tasks[0].id;
       for (let guard = 0; guard < 10; guard++) {
-        const page = repo.listByGoal(goalId, { limit: 1, before, beforeId });
+        const page = repo.listByGoal(spaceId, goalId, { limit: 1, before, beforeId });
         if (page.tasks.length === 0) break;
         collected.push(page.tasks[0].id);
         before = page.tasks[0].createdAt;

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -1362,4 +1362,124 @@ describe('SpaceTaskRepository', () => {
       expect(active).toEqual([]);
     });
   });
+
+  describe('listByGoal', () => {
+    const goalId = 'goal-pagination';
+
+    function seedTask(title: string, updatedAt: number, status: string = 'open'): string {
+      const task = repo.createTask({
+        spaceId,
+        title,
+        description: '',
+        goalId,
+        status: status as any,
+      });
+      (db as any)
+        .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
+        .run(updatedAt, task.id);
+      return task.id;
+    }
+
+    it('returns only tasks for the goal, ordered by updated_at DESC, excluding archived by default', () => {
+      const older = seedTask('older', 1000);
+      const newer = seedTask('newer', 3000);
+
+      const other = repo.createTask({
+        spaceId,
+        title: 'other',
+        description: '',
+        goalId: 'other-goal',
+      });
+      (db as any).prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(6000, other.id);
+
+      const { tasks, total, hasMore } = repo.listByGoal(goalId);
+      expect(tasks.map((t) => t.id)).toEqual([newer, older]);
+      expect(total).toBe(2);
+      expect(hasMore).toBe(false);
+    });
+
+    it('filters by status when provided', () => {
+      seedTask('open-a', 1000, 'open');
+      const done = seedTask('done-b', 2000, 'done');
+      seedTask('open-c', 3000, 'open');
+
+      const { tasks, total } = repo.listByGoal(goalId, { status: 'done' });
+      expect(tasks.map((t) => t.id)).toEqual([done]);
+      expect(total).toBe(1);
+    });
+
+    it('includes archived tasks only when status is archived', () => {
+      const archived = seedTask('archived-a', 1000, 'archived');
+      const open = seedTask('open-b', 2000, 'open');
+
+      const defaultPage = repo.listByGoal(goalId);
+      expect(defaultPage.tasks.map((t) => t.id)).toEqual([open]);
+
+      const archivedPage = repo.listByGoal(goalId, { status: 'archived' });
+      expect(archivedPage.tasks.map((t) => t.id)).toEqual([archived]);
+    });
+
+    it('paginates with a keyset cursor and yields every matching task exactly once', () => {
+      const ids: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        ids.push(seedTask(`task-${i}`, 1000 + i * 100));
+      }
+      const expected = [...ids].reverse();
+
+      const collected: string[] = [];
+      let before: number | undefined;
+      let beforeId: string | undefined;
+      for (let guard = 0; guard < 10; guard++) {
+        const page = repo.listByGoal(goalId, {
+          limit: 2,
+          before,
+          beforeId,
+        });
+        collected.push(...page.tasks.map((t) => t.id));
+        if (!page.hasMore) break;
+        const last = page.tasks[page.tasks.length - 1];
+        before = last.updatedAt;
+        beforeId = last.id;
+      }
+
+      expect(collected).toEqual(expected);
+    });
+
+    it('clamps the page size to the bounded range', () => {
+      for (let i = 0; i < 5; i++) seedTask(`task-${i}`, 1000 + i * 100);
+
+      const tiny = repo.listByGoal(goalId, { limit: -1 });
+      expect(tiny.tasks.length).toBe(1);
+      expect(tiny.hasMore).toBe(true);
+
+      const huge = repo.listByGoal(goalId, { limit: 1000 });
+      expect(huge.tasks.length).toBe(5);
+      expect(huge.hasMore).toBe(false);
+    });
+
+    it('does not skip or duplicate tasks when a new task is inserted mid-iteration', () => {
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) ids.push(seedTask(`task-${i}`, 1000 + i * 100));
+
+      const first = repo.listByGoal(goalId, { limit: 1 });
+      expect(first.tasks.length).toBe(1);
+
+      seedTask('late-insert', 9000);
+
+      const collected = [...first.tasks.map((t) => t.id)];
+      let before = first.tasks[0].updatedAt;
+      let beforeId = first.tasks[0].id;
+      for (let guard = 0; guard < 10; guard++) {
+        const page = repo.listByGoal(goalId, { limit: 1, before, beforeId });
+        if (page.tasks.length === 0) break;
+        collected.push(page.tasks[0].id);
+        before = page.tasks[0].updatedAt;
+        beforeId = page.tasks[0].id;
+        if (!page.hasMore) break;
+      }
+
+      expect(collected).toEqual([...ids].reverse());
+      expect(new Set(collected).size).toBe(collected.length);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -2149,7 +2149,7 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
       });
       ids.push(task.id);
       ctx.db
-        .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
+        .prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`)
         .run(1000 + i * 100, task.id);
     }
     const expected = [...ids].reverse();
@@ -2183,7 +2183,7 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
       }
       if (!out.has_more) break;
       const last = out.tasks[out.tasks.length - 1];
-      before = last.updatedAt;
+      before = last.createdAt;
       beforeId = last.id;
     }
 
@@ -2215,9 +2215,9 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
       goalId: goal.id,
     });
 
-    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(3000, openTask.id);
-    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(2000, doneTask.id);
-    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(1000, archived.id);
+    ctx.db.prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`).run(3000, openTask.id);
+    ctx.db.prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`).run(2000, doneTask.id);
+    ctx.db.prepare(`UPDATE space_tasks SET created_at = ? WHERE id = ?`).run(1000, archived.id);
 
     const open = JSON.parse((await handlers.list_goal_tasks({ goal_id: goal.id })).content[0].text);
     expect(open.total).toBe(2);

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -2134,6 +2134,108 @@ describe('createSpaceAgentToolHandlers — goal tools', () => {
     );
   });
 
+  test('paginates list_goal_tasks with a cursor and returns the compact projection', async () => {
+    const handlers = makeHandlers(ctx);
+    const goal = ctx.goalService.createGoal({ spaceId: ctx.spaceId, title: 'Paginated goal' });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const task = ctx.taskRepo.createTask({
+        spaceId: ctx.spaceId,
+        title: `task-${i}`,
+        description: `desc-${i}`,
+        result: `result-${i}`,
+        goalId: goal.id,
+      });
+      ids.push(task.id);
+      ctx.db
+        .prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`)
+        .run(1000 + i * 100, task.id);
+    }
+    const expected = [...ids].reverse();
+
+    const collected: string[] = [];
+    let before: number | undefined;
+    let beforeId: string | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const out = JSON.parse(
+        (
+          await handlers.list_goal_tasks({
+            goal_id: goal.id,
+            limit: 2,
+            before,
+            before_id: beforeId,
+          })
+        ).content[0].text
+      );
+      expect(out.success).toBe(true);
+      collected.push(...out.tasks.map((t: { id: string }) => t.id));
+      for (const t of out.tasks) {
+        expect(t).not.toHaveProperty('description');
+        expect(t).not.toHaveProperty('result');
+        expect(typeof t.id).toBe('string');
+        expect(typeof t.taskNumber).toBe('number');
+        expect(typeof t.title).toBe('string');
+        expect(typeof t.status).toBe('string');
+        expect(typeof t.priority).toBe('string');
+        expect(typeof t.createdAt).toBe('number');
+        expect(typeof t.updatedAt).toBe('number');
+      }
+      if (!out.has_more) break;
+      const last = out.tasks[out.tasks.length - 1];
+      before = last.updatedAt;
+      beforeId = last.id;
+    }
+
+    expect(collected).toEqual(expected);
+  });
+
+  test('list_goal_tasks honors the status filter and archived semantics', async () => {
+    const handlers = makeHandlers(ctx);
+    const goal = ctx.goalService.createGoal({ spaceId: ctx.spaceId, title: 'Filter goal' });
+
+    const openTask = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'open',
+      description: '',
+      goalId: goal.id,
+    });
+    const doneTask = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'done',
+      description: '',
+      status: 'done',
+      goalId: goal.id,
+    });
+    const archived = ctx.taskRepo.createTask({
+      spaceId: ctx.spaceId,
+      title: 'archived',
+      description: '',
+      status: 'archived',
+      goalId: goal.id,
+    });
+
+    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(3000, openTask.id);
+    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(2000, doneTask.id);
+    ctx.db.prepare(`UPDATE space_tasks SET updated_at = ? WHERE id = ?`).run(1000, archived.id);
+
+    const open = JSON.parse((await handlers.list_goal_tasks({ goal_id: goal.id })).content[0].text);
+    expect(open.total).toBe(2);
+    expect(open.tasks.map((t: { id: string }) => t.id)).toEqual([openTask.id, doneTask.id]);
+
+    const done = JSON.parse(
+      (await handlers.list_goal_tasks({ goal_id: goal.id, status: 'done' })).content[0].text
+    );
+    expect(done.total).toBe(1);
+    expect(done.tasks[0].id).toBe(doneTask.id);
+
+    const archivedOut = JSON.parse(
+      (await handlers.list_goal_tasks({ goal_id: goal.id, status: 'archived' })).content[0].text
+    );
+    expect(archivedOut.total).toBe(1);
+    expect(archivedOut.tasks[0].id).toBe(archived.id);
+  });
+
   test('rejects cross-space goal access', async () => {
     const otherGoal = ctx.goalService.createGoal({
       spaceId: ctx.spaceId,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -324,6 +324,9 @@ export function createSpaceTables(db: BunDatabase): void {
     `CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_created ON space_tasks(goal_id, created_at DESC, id DESC)`
   );
   db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_status_created ON space_tasks(goal_id, status, created_at DESC, id DESC)`
+  );
+  db.exec(
     `CREATE INDEX IF NOT EXISTS idx_space_tasks_evolution_scope_id ON space_tasks(evolution_scope_id)`
   );
   db.exec(

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -321,6 +321,9 @@ export function createSpaceTables(db: BunDatabase): void {
   );
   db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_id ON space_tasks(goal_id)`);
   db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_created ON space_tasks(goal_id, created_at DESC, id DESC)`
+  );
+  db.exec(
     `CREATE INDEX IF NOT EXISTS idx_space_tasks_evolution_scope_id ON space_tasks(evolution_scope_id)`
   );
   db.exec(

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -525,6 +525,16 @@ export interface PaginatedSpaceTaskResult {
   total: number;
 }
 
+export interface SpaceTaskCompact {
+  id: string;
+  taskNumber: number;
+  title: string;
+  status: SpaceTaskStatus;
+  priority: SpaceTaskPriority;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface SpaceTaskActivityMember {
   id: string;
   sessionId: string;


### PR DESCRIPTION
Closes #2737

## Summary
- Bound the goal-task retrieval path used by LH agents: `list_goal_tasks` previously loaded every Space task via `listBySpace` and filtered in memory.
- Add `SpaceTaskRepository.listByGoal`: SQL-filtered by `goal_id` (uses the existing `idx_space_tasks_goal_id` index), keyset cursor on `(updated_at, id)`, bounded page (default 20, max 100), archived excluded unless `status='archived'`.
- Return the new compact `SpaceTaskCompact` projection (id, taskNumber, title, status, priority, createdAt, updatedAt) + `has_more`; full records remain available via `get_task_detail`.
- New tool args: `limit`, `before` (updated_at cursor), `before_id` (id cursor), mirroring `list_goal_events` pagination.

## Test plan
- Repo tests: goal filtering, status filter, archived semantics, keyset page iteration yields every task exactly once, mid-iteration insert does not skip/dup, page-size clamping.
- Tool tests: compact projection shape (no description/result), cursor iteration, status/archived behavior.
- `bun run check` green (lint, types, knip, format, guards); daemon unit suites pass (435 tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->