### PR TITLE
feat(space): goal-owner-resolution decision core (ADR 0004)

### DIFF
--- a/packages/daemon/src/lib/space/goals/goal-owner-resolution.ts
+++ b/packages/daemon/src/lib/space/goals/goal-owner-resolution.ts
@@ -21,7 +21,8 @@ export type GoalOwnerResolutionDecision =
       owner: GoalOwnerCandidate;
       conflicts: GoalOwnerCandidate[];
     }
-  | { action: 'coordinator_fallback' };
+  | { action: 'coordinator_fallback'; coordinatorAgentId: string }
+  | { action: 'no_recipient' };
 
 export interface GoalOwnerResolutionCtx {
   candidates: GoalOwnerCandidate[];
@@ -76,7 +77,11 @@ export function applyDegradedOwnerGate(ctx: GoalOwnerResolutionCtx): GoalOwnerRe
 export function applyCoordinatorFallbackGate(ctx: GoalOwnerResolutionCtx): GoalOwnerResolutionCtx {
   const owners = ownerCandidates(ctx.candidates);
   if (owners.length >= 1) return ctx;
-  return decided(ctx, { action: 'coordinator_fallback' });
+  if (ctx.coordinatorAgentId === null) return decided(ctx, { action: 'no_recipient' });
+  return decided(ctx, {
+    action: 'coordinator_fallback',
+    coordinatorAgentId: ctx.coordinatorAgentId,
+  });
 }
 
 const ownerResolutionRun = decisionRun('goal-owner-resolution', [
@@ -89,5 +94,5 @@ export function decideGoalOwnerResolution(
   input: GoalOwnerResolutionInput
 ): GoalOwnerResolutionDecision {
   const ctx = ownerResolutionRun(input);
-  return ctx.decision ?? { action: 'coordinator_fallback' };
+  return ctx.decision ?? { action: 'no_recipient' };
 }

--- a/packages/daemon/src/lib/space/goals/goal-owner-resolution.ts
+++ b/packages/daemon/src/lib/space/goals/goal-owner-resolution.ts
@@ -1,0 +1,93 @@
+import { decisionRun } from '../runtime/decision-pipeline';
+
+export type GoalOwnerAgentState =
+  | { state: 'active' }
+  | { state: 'missing' }
+  | { state: 'paused' }
+  | { state: 'disabled' }
+  | { state: 'archived' };
+
+export interface GoalOwnerCandidate {
+  agentId: string;
+  relationship: 'owner' | 'manager' | 'watcher';
+  createdAt: number;
+}
+
+export type GoalOwnerResolutionDecision =
+  | { action: 'resolved'; owner: GoalOwnerCandidate; conflicts: GoalOwnerCandidate[] }
+  | {
+      action: 'degraded';
+      reason: GoalOwnerAgentState['state'];
+      owner: GoalOwnerCandidate;
+      conflicts: GoalOwnerCandidate[];
+    }
+  | { action: 'coordinator_fallback' };
+
+export interface GoalOwnerResolutionCtx {
+  candidates: GoalOwnerCandidate[];
+  agentStates: Record<string, GoalOwnerAgentState>;
+  coordinatorAgentId: string | null;
+  decision: GoalOwnerResolutionDecision | null;
+}
+
+export type GoalOwnerResolutionInput = Omit<GoalOwnerResolutionCtx, 'decision'>;
+
+function decided(
+  ctx: GoalOwnerResolutionCtx,
+  decision: GoalOwnerResolutionDecision
+): GoalOwnerResolutionCtx {
+  return { ...ctx, decision };
+}
+
+function ownerCandidates(candidates: GoalOwnerCandidate[]): GoalOwnerCandidate[] {
+  return candidates
+    .filter((c) => c.relationship === 'owner')
+    .slice()
+    .sort((a, b) => a.createdAt - b.createdAt || a.agentId.localeCompare(b.agentId));
+}
+
+function agentState(ctx: GoalOwnerResolutionCtx, agentId: string): GoalOwnerAgentState {
+  return ctx.agentStates[agentId] ?? { state: 'missing' };
+}
+
+export function applyResolvedOwnerGate(ctx: GoalOwnerResolutionCtx): GoalOwnerResolutionCtx {
+  const owners = ownerCandidates(ctx.candidates);
+  if (owners.length < 1) return ctx;
+  const primary = owners[0];
+  const agent = agentState(ctx, primary.agentId);
+  if (agent.state !== 'active') return ctx;
+  return decided(ctx, { action: 'resolved', owner: primary, conflicts: owners.slice(1) });
+}
+
+export function applyDegradedOwnerGate(ctx: GoalOwnerResolutionCtx): GoalOwnerResolutionCtx {
+  const owners = ownerCandidates(ctx.candidates);
+  if (owners.length < 1) return ctx;
+  const primary = owners[0];
+  const agent = agentState(ctx, primary.agentId);
+  if (agent.state === 'active') return ctx;
+  return decided(ctx, {
+    action: 'degraded',
+    reason: agent.state,
+    owner: primary,
+    conflicts: owners.slice(1),
+  });
+}
+
+export function applyCoordinatorFallbackGate(ctx: GoalOwnerResolutionCtx): GoalOwnerResolutionCtx {
+  const owners = ownerCandidates(ctx.candidates);
+  if (owners.length >= 1) return ctx;
+  return decided(ctx, { action: 'coordinator_fallback' });
+}
+
+const ownerResolutionRun = decisionRun('goal-owner-resolution', [
+  applyResolvedOwnerGate,
+  applyDegradedOwnerGate,
+  applyCoordinatorFallbackGate,
+]);
+
+export function decideGoalOwnerResolution(
+  input: GoalOwnerResolutionInput
+): GoalOwnerResolutionDecision {
+  const ctx = ownerResolutionRun(input);
+  return ctx.decision ?? { action: 'coordinator_fallback' };
+}

--- a/packages/daemon/tests/unit/1-core/validate-test-matrix.test.ts
+++ b/packages/daemon/tests/unit/1-core/validate-test-matrix.test.ts
@@ -46,7 +46,7 @@ for f in 1-core/c.test.ts helpers/h.test.ts lib/acp/l.test.ts \\
   5-space/workflow/w.test.ts 4-space-storage/s.test.ts 4-space-storage/app/a.test.ts \\
   4-space-storage/storage/st.test.ts 4-space-storage/storage/migrations/m1.test.ts \\
   4-space-storage/storage/migrations/m2.test.ts 5-space/s.test.ts 5-space/agent/a.test.ts \\
-  5-space/other/o.test.ts 5-space/tools/t.test.ts \\
+  5-space/goals/g.test.ts 5-space/other/o.test.ts 5-space/tools/t.test.ts \\
   5-space/runtime/r1.test.ts 5-space/runtime/connectors/c1.test.ts; do
   mk "$U/$f"
 done

--- a/packages/daemon/tests/unit/5-space/goals/goal-owner-resolution.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/goal-owner-resolution.test.ts
@@ -104,7 +104,15 @@ describe('decideGoalOwnerResolution', () => {
 
   test('falls back to the coordinator when there is no owner row', () => {
     const result = decideGoalOwnerResolution(input({ candidates: [] }));
-    expect(result).toEqual({ action: 'coordinator_fallback' });
+    expect(result).toEqual({
+      action: 'coordinator_fallback',
+      coordinatorAgentId: 'coordinator-1',
+    });
+  });
+
+  test('reports no_recipient when there is no owner and no coordinator', () => {
+    const result = decideGoalOwnerResolution(input({ candidates: [], coordinatorAgentId: null }));
+    expect(result).toEqual({ action: 'no_recipient' });
   });
 
   test('falls back to the coordinator when only non-owner relationships exist', () => {
@@ -114,7 +122,10 @@ describe('decideGoalOwnerResolution', () => {
         agentStates: { 'agent-w': active },
       })
     );
-    expect(result).toEqual({ action: 'coordinator_fallback' });
+    expect(result).toEqual({
+      action: 'coordinator_fallback',
+      coordinatorAgentId: 'coordinator-1',
+    });
   });
 
   test('resolves duplicate owners deterministically to the earliest assignment', () => {

--- a/packages/daemon/tests/unit/5-space/goals/goal-owner-resolution.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/goal-owner-resolution.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decideGoalOwnerResolution,
+  type GoalOwnerCandidate,
+  type GoalOwnerResolutionInput,
+} from '../../../../src/lib/space/goals/goal-owner-resolution';
+
+const active = { state: 'active' } as const;
+const missing = { state: 'missing' } as const;
+const paused = { state: 'paused' } as const;
+const disabled = { state: 'disabled' } as const;
+const archived = { state: 'archived' } as const;
+
+function owner(agentId: string, createdAt: number): GoalOwnerCandidate {
+  return { agentId, relationship: 'owner', createdAt };
+}
+
+function input(overrides: Partial<GoalOwnerResolutionInput> = {}): GoalOwnerResolutionInput {
+  return {
+    candidates: [],
+    agentStates: {},
+    coordinatorAgentId: 'coordinator-1',
+    ...overrides,
+  };
+}
+
+describe('decideGoalOwnerResolution', () => {
+  test('resolves a single active primary owner', () => {
+    const result = decideGoalOwnerResolution(
+      input({ candidates: [owner('agent-a', 100)], agentStates: { 'agent-a': active } })
+    );
+    expect(result).toEqual({
+      action: 'resolved',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+
+  test('prefers owner relationship over manager/watcher candidates', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [
+          { agentId: 'agent-w', relationship: 'watcher', createdAt: 50 },
+          { agentId: 'agent-m', relationship: 'manager', createdAt: 75 },
+          { agentId: 'agent-o', relationship: 'owner', createdAt: 100 },
+        ],
+        agentStates: { 'agent-o': active, 'agent-w': active, 'agent-m': active },
+      })
+    );
+    expect(result).toEqual({
+      action: 'resolved',
+      owner: owner('agent-o', 100),
+      conflicts: [],
+    });
+  });
+
+  test('degrades when the owner agent is paused', () => {
+    const result = decideGoalOwnerResolution(
+      input({ candidates: [owner('agent-a', 100)], agentStates: { 'agent-a': paused } })
+    );
+    expect(result).toEqual({
+      action: 'degraded',
+      reason: 'paused',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+
+  test('degrades when the owner agent is disabled', () => {
+    const result = decideGoalOwnerResolution(
+      input({ candidates: [owner('agent-a', 100)], agentStates: { 'agent-a': disabled } })
+    );
+    expect(result).toEqual({
+      action: 'degraded',
+      reason: 'disabled',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+
+  test('degrades when the owner agent is archived', () => {
+    const result = decideGoalOwnerResolution(
+      input({ candidates: [owner('agent-a', 100)], agentStates: { 'agent-a': archived } })
+    );
+    expect(result).toEqual({
+      action: 'degraded',
+      reason: 'archived',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+
+  test('degrades when the owner agent is missing from the snapshot', () => {
+    const result = decideGoalOwnerResolution(
+      input({ candidates: [owner('agent-a', 100)], agentStates: {} })
+    );
+    expect(result).toEqual({
+      action: 'degraded',
+      reason: 'missing',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+
+  test('falls back to the coordinator when there is no owner row', () => {
+    const result = decideGoalOwnerResolution(input({ candidates: [] }));
+    expect(result).toEqual({ action: 'coordinator_fallback' });
+  });
+
+  test('falls back to the coordinator when only non-owner relationships exist', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [{ agentId: 'agent-w', relationship: 'watcher', createdAt: 50 }],
+        agentStates: { 'agent-w': active },
+      })
+    );
+    expect(result).toEqual({ action: 'coordinator_fallback' });
+  });
+
+  test('resolves duplicate owners deterministically to the earliest assignment', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [owner('agent-late', 200), owner('agent-early', 100)],
+        agentStates: { 'agent-late': active, 'agent-early': active },
+      })
+    );
+    expect(result).toEqual({
+      action: 'resolved',
+      owner: owner('agent-early', 100),
+      conflicts: [owner('agent-late', 200)],
+    });
+  });
+
+  test('breaks duplicate-owner ties deterministically by agent id', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [owner('agent-z', 100), owner('agent-a', 100)],
+        agentStates: { 'agent-z': active, 'agent-a': active },
+      })
+    );
+    expect(result).toEqual({
+      action: 'resolved',
+      owner: owner('agent-a', 100),
+      conflicts: [owner('agent-z', 100)],
+    });
+  });
+
+  test('degraded duplicates keep the earliest owner and expose the losers', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [owner('agent-late', 200), owner('agent-early', 100)],
+        agentStates: { 'agent-late': active, 'agent-early': paused },
+      })
+    );
+    expect(result).toEqual({
+      action: 'degraded',
+      reason: 'paused',
+      owner: owner('agent-early', 100),
+      conflicts: [owner('agent-late', 200)],
+    });
+  });
+
+  test('is deterministic given the same snapshot', () => {
+    const snapshot: GoalOwnerResolutionInput = input({
+      candidates: [owner('agent-b', 150), owner('agent-a', 120), owner('agent-c', 120)],
+      agentStates: { 'agent-a': active, 'agent-b': paused, 'agent-c': active },
+    });
+    const first = decideGoalOwnerResolution(snapshot);
+    const second = decideGoalOwnerResolution(snapshot);
+    expect(second).toEqual(first);
+  });
+
+  test('ignores agent state entries for agents with no candidate', () => {
+    const result = decideGoalOwnerResolution(
+      input({
+        candidates: [owner('agent-a', 100)],
+        agentStates: { ghost: active, 'agent-a': active },
+      })
+    );
+    expect(result).toEqual({
+      action: 'resolved',
+      owner: owner('agent-a', 100),
+      conflicts: [],
+    });
+  });
+});

--- a/scripts/test-daemon.sh
+++ b/scripts/test-daemon.sh
@@ -390,7 +390,7 @@ shard_paths() {
 		migration_shard_paths 1
 		;;
 	5-space-agent-other)
-		printf '%s\n' "$TEST_ROOT/5-space"/*.test.ts "$TEST_ROOT/5-space/agent" "$TEST_ROOT/5-space/other" "$TEST_ROOT/5-space/tools" "$TEST_ROOT/5-space/workflow"
+		printf '%s\n' "$TEST_ROOT/5-space"/*.test.ts "$TEST_ROOT/5-space/agent" "$TEST_ROOT/5-space/goals" "$TEST_ROOT/5-space/other" "$TEST_ROOT/5-space/tools" "$TEST_ROOT/5-space/workflow"
 		;;
 	# 5-space-runtime-a/b are resolved by hash_split_resolve above (stable hash
 	# over the full 5-space/runtime tree, so no file is ever hand-listed or dropped).


### PR DESCRIPTION
Closes #2738

## Summary
- Pure `decisionRun` core (`goal-owner-resolution`) for resolving a goal's primary long-horizon agent owner, per ADR 0004 and roadmap MC1.
- Gates in precedence order:
  1. `resolved` — an owner relationship whose agent is `active`
  2. `degraded` — owner exists but agent is `missing`/`paused`/`disabled`/`archived`
  3. `coordinator_fallback` — no owner row (or only manager/watcher links)
- Duplicate owner rows reconcile deterministically: earliest assignment wins, `agentId` breaks ties, losers surfaced as `conflicts` (persistence is MC1-B).
- Input is a plain snapshot (candidates, agent states, coordinator identity); no repository/DB imports. `decideGoalOwnerResolution` wrapper returns the decision union.
- Registered the `5-space/goals` test directory in the `5-space-agent-other` shard.

## Test plan
- 13 pinned decision-table tests: single active owner, manager/watcher exclusion, each degraded reason, missing agent, coordinator fallback, duplicate earliest-winner + tie-break, degraded-duplicates conflicts, determinism, ghost agent-state entries.
- `bun run check` green (lint, types, knip, format, test-matrix).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->