### PR TITLE
feat(space): single-owner migration + ownership admission gate (MC1-B)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -409,6 +409,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
   const spaceGoalRepo = new SpaceGoalRepository(deps.db.getDatabase(), deps.reactiveDb);
   const spaceGoalEventRepo = new SpaceGoalEventRepository(deps.db.getDatabase(), deps.reactiveDb);
+  const longHorizonAgentRepo = new SpaceLongHorizonAgentRepository(deps.db.getDatabase());
   const spaceGoalService = new SpaceGoalService({
     goalRepo: spaceGoalRepo,
     goalEventRepo: spaceGoalEventRepo,
@@ -416,6 +417,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     spaceRepo,
     scheduleService,
     db: deps.db.getDatabase(),
+    longHorizonAgentRepo,
     eventHub: {
       publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
     },
@@ -482,7 +484,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   spaceWorkflowRepo.backfillExistingDefinitionVersions();
   spaceWorkflowRunRepo.backfillDefinitionPins((id) => spaceWorkflowRepo.getWorkflow(id));
   const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
-  const longHorizonAgentRepo = new SpaceLongHorizonAgentRepository(deps.db.getDatabase());
   const agentLookup: SpaceAgentLookup = {
     getAgentById(spaceId: string, id: string) {
       const agent = spaceAgentRepo.getById(id);

--- a/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
+++ b/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
@@ -13,9 +13,7 @@ export function decideGoalOwnershipMutationAdmission(
   input: GoalOwnershipAdmissionInput
 ): GoalOwnershipAdmissionDecision {
   if (input.isCoordinatorAgent) return { action: 'allow' };
-  if (input.callerRole === 'coordinator' || input.callerRole === 'ad_hoc_member') {
-    return { action: 'allow' };
-  }
+  if (input.callerRole === 'coordinator') return { action: 'allow' };
   return {
     action: 'deny',
     reason: 'not_coordinator_or_human',

--- a/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
+++ b/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
@@ -6,13 +6,13 @@ export type GoalOwnershipAdmissionDecision =
 
 export interface GoalOwnershipAdmissionInput {
   callerRole: SpaceMcpSessionRole | undefined;
-  isCoordinatorAgent: boolean;
+  hasSession: boolean;
 }
 
 export function decideGoalOwnershipMutationAdmission(
   input: GoalOwnershipAdmissionInput
 ): GoalOwnershipAdmissionDecision {
-  if (input.isCoordinatorAgent) return { action: 'allow' };
+  if (!input.hasSession) return { action: 'allow' };
   if (input.callerRole === 'coordinator') return { action: 'allow' };
   return {
     action: 'deny',

--- a/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
+++ b/packages/daemon/src/lib/space/goals/goal-ownership-gates.ts
@@ -1,0 +1,25 @@
+import type { SpaceMcpSessionRole } from '../runtime/space-mcp-session-policy';
+
+export type GoalOwnershipAdmissionDecision =
+  | { action: 'allow' }
+  | { action: 'deny'; reason: 'not_coordinator_or_human'; message: string };
+
+export interface GoalOwnershipAdmissionInput {
+  callerRole: SpaceMcpSessionRole | undefined;
+  isCoordinatorAgent: boolean;
+}
+
+export function decideGoalOwnershipMutationAdmission(
+  input: GoalOwnershipAdmissionInput
+): GoalOwnershipAdmissionDecision {
+  if (input.isCoordinatorAgent) return { action: 'allow' };
+  if (input.callerRole === 'coordinator' || input.callerRole === 'ad_hoc_member') {
+    return { action: 'allow' };
+  }
+  return {
+    action: 'deny',
+    reason: 'not_coordinator_or_human',
+    message:
+      'assign_agent_to_goal/unassign_agent_from_goal owner mutations require coordinator or explicit human authorization. Request human approval or use the coordinator agent.',
+  };
+}

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -17,6 +17,7 @@ import type { SpaceRepository } from '../../../storage/repositories/space-reposi
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceGoalEventRepository } from '../../../storage/repositories/space-goal-event-repository';
 import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
+import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { ScheduleService } from '../schedule/schedule-service';
 import type { GoalAutomationService } from './goal-automation-service';
 import { pauseScheduleStrict } from './goal-automation-schedule-sync';
@@ -58,6 +59,7 @@ export interface SpaceGoalServiceDeps {
   };
   goalAutomationService?: Pick<GoalAutomationService, 'onTaskCompleted'>;
   onGoalResumed?: (goalId: string, spaceId: string) => void;
+  longHorizonAgentRepo?: Pick<SpaceLongHorizonAgentRepository, 'assignGoal'>;
 }
 
 export class SpaceGoalService {
@@ -77,6 +79,9 @@ export class SpaceGoalService {
 
     const result = this.runAtomic(() => {
       const goal = this.deps.goalRepo.create(params);
+      if (params.primaryOwnerAgentId && this.deps.longHorizonAgentRepo) {
+        this.deps.longHorizonAgentRepo.assignGoal(params.primaryOwnerAgentId, goal.id);
+      }
       if (params.checkInCronExpression) {
         const schedule = this.deps.scheduleService.createGoalSchedule({
           spaceId: params.spaceId,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -69,6 +69,7 @@ import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { mapPostApprovalDispatchWarning } from '../runtime/post-approval-router';
 import type { SpaceMcpSessionRole } from '../runtime/space-mcp-session-policy';
+import { decideGoalOwnershipMutationAdmission } from '../goals/goal-ownership-gates';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
 import { decideUpdateTask } from './space-tool-pipeline';
@@ -797,6 +798,20 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
     return config.longHorizonAgentRepo;
   }
 
+  function resolveCreateGoalOwnerId(explicitOwnerAgentId?: string | null): string | null {
+    if (typeof explicitOwnerAgentId === 'string' && explicitOwnerAgentId.length > 0) {
+      requireLongHorizonAgentInSpace(explicitOwnerAgentId);
+      return explicitOwnerAgentId;
+    }
+    if (!config.longHorizonAgentRepo) return null;
+    if (typeof myAgentId === 'string' && myAgentId.length > 0) {
+      const self = config.longHorizonAgentRepo.getById(myAgentId);
+      if (self?.spaceId === spaceId) return self.id;
+    }
+    const coordinator = config.longHorizonAgentRepo.getCoordinator(spaceId);
+    return coordinator?.id ?? null;
+  }
+
   function getLongHorizonAgentInSpace(agentId: string) {
     const existing = requireLongHorizonAgentRepo().getById(agentId);
     return existing?.spaceId === spaceId ? existing : null;
@@ -1488,6 +1503,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
     async assign_agent_to_goal(args: { agent_id: string; goal_id: string }): Promise<ToolResult> {
       try {
+        const admission = decideGoalOwnershipMutationAdmission({
+          callerRole,
+          isCoordinatorAgent,
+        });
+        if (admission.action === 'deny') {
+          return jsonResult({ success: false, error: admission.message });
+        }
         requireLongHorizonAgentInSpace(args.agent_id);
         requireGoalInSpace(args.goal_id);
         requireLongHorizonAgentRepo().assignGoal(args.agent_id, args.goal_id);
@@ -1504,9 +1526,20 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       goal_id: string;
     }): Promise<ToolResult> {
       try {
+        const admission = decideGoalOwnershipMutationAdmission({
+          callerRole,
+          isCoordinatorAgent,
+        });
+        if (admission.action === 'deny') {
+          return jsonResult({ success: false, error: admission.message });
+        }
         requireLongHorizonAgentInSpace(args.agent_id);
         requireGoalInSpace(args.goal_id);
-        requireLongHorizonAgentRepo().deleteGoalAssignment(args.agent_id, args.goal_id);
+        requireLongHorizonAgentRepo().deleteGoalAssignmentByRelationship(
+          args.agent_id,
+          args.goal_id,
+          'owner'
+        );
         logAudit('unassign_agent_from_goal', args);
         return jsonResult({ success: true });
       } catch (err) {
@@ -2993,8 +3026,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       check_in_cron_expression?: string;
       check_in_timezone?: string;
       trigger_immediately?: boolean;
+      owner_agent_id?: string | null;
     }): Promise<ToolResult> {
       try {
+        const primaryOwnerAgentId = resolveCreateGoalOwnerId(args.owner_agent_id);
         const goal = requireGoalService().createGoal(
           {
             spaceId,
@@ -3012,6 +3047,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             checkInCronExpression: args.check_in_cron_expression,
             checkInTimezone: args.check_in_timezone,
             triggerImmediately: args.trigger_immediately,
+            primaryOwnerAgentId,
           },
           goalToolContext
         );
@@ -4551,6 +4587,13 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
             .boolean()
             .optional()
             .describe('Create first goal task immediately'),
+          owner_agent_id: z
+            .string()
+            .nullable()
+            .optional()
+            .describe(
+              'Long-horizon agent id to assign as the goal primary owner atomically at creation. Defaults to the calling agent (self-claim) or the coordinator when absent.'
+            ),
         },
         (args) => handlers.create_goal(args)
       ),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -801,6 +801,16 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
   function resolveCreateGoalOwnerId(explicitOwnerAgentId?: string | null): string | null {
     if (typeof explicitOwnerAgentId === 'string' && explicitOwnerAgentId.length > 0) {
       requireLongHorizonAgentInSpace(explicitOwnerAgentId);
+      const isSelf = typeof myAgentId === 'string' && myAgentId === explicitOwnerAgentId;
+      const admission = decideGoalOwnershipMutationAdmission({
+        callerRole,
+        hasSession: typeof mySessionId === 'string',
+      });
+      if (!isSelf && admission.action === 'deny') {
+        throw new Error(
+          'Specifying an owner other than yourself requires coordinator or explicit human authorization.'
+        );
+      }
       return explicitOwnerAgentId;
     }
     if (!config.longHorizonAgentRepo) return null;
@@ -1505,7 +1515,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       try {
         const admission = decideGoalOwnershipMutationAdmission({
           callerRole,
-          isCoordinatorAgent,
+          hasSession: typeof mySessionId === 'string',
         });
         if (admission.action === 'deny') {
           return jsonResult({ success: false, error: admission.message });
@@ -1528,7 +1538,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       try {
         const admission = decideGoalOwnershipMutationAdmission({
           callerRole,
-          isCoordinatorAgent,
+          hasSession: typeof mySessionId === 'string',
         });
         if (admission.action === 'deny') {
           return jsonResult({ success: false, error: admission.message });

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -1,5 +1,10 @@
 import type { Database as BunDatabase } from '../sqlite-compat';
 import { generateUUID } from '@hyperneo/shared';
+import {
+  decideGoalOwnerResolution,
+  type GoalOwnerAgentState,
+  type GoalOwnerResolutionDecision,
+} from '../../lib/space/goals/goal-owner-resolution';
 import type {
   CreateSpaceLongHorizonAgentParams,
   CreateSpaceLongHorizonAgentReminderParams,
@@ -207,10 +212,53 @@ export class SpaceLongHorizonAgentRepository {
     return rows.map(rowToGoalLink);
   }
 
+  listGoalAssignments(goalId: string): SpaceLongHorizonAgentGoal[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM space_long_horizon_agent_goals WHERE goal_id = ?`)
+      .all(goalId) as Record<string, unknown>[];
+    return rows.map(rowToGoalLink);
+  }
+
   deleteGoalAssignment(agentId: string, goalId: string): void {
     this.db
       .prepare(`DELETE FROM space_long_horizon_agent_goals WHERE agent_id = ? AND goal_id = ?`)
       .run(agentId, goalId);
+  }
+
+  deleteGoalAssignmentByRelationship(
+    agentId: string,
+    goalId: string,
+    relationship: SpaceLongHorizonAgentGoal['relationship']
+  ): void {
+    this.db
+      .prepare(
+        `DELETE FROM space_long_horizon_agent_goals WHERE agent_id = ? AND goal_id = ? AND relationship = ?`
+      )
+      .run(agentId, goalId, relationship);
+  }
+
+  getPrimaryGoalOwner(goalId: string, spaceId: string): GoalOwnerResolutionDecision {
+    const assignments = this.listGoalAssignments(goalId);
+    const candidates = assignments
+      .filter((a) => a.relationship === 'owner')
+      .map((a) => ({ agentId: a.agentId, relationship: a.relationship, createdAt: a.createdAt }));
+    const agentStates: Record<string, GoalOwnerAgentState> = {};
+    for (const candidate of candidates) {
+      const agent = this.getById(candidate.agentId);
+      if (!agent) {
+        agentStates[candidate.agentId] = { state: 'missing' };
+      } else if (agent.spaceId !== spaceId) {
+        agentStates[candidate.agentId] = { state: 'missing' };
+      } else {
+        agentStates[candidate.agentId] = { state: agent.status };
+      }
+    }
+    const coordinator = this.getCoordinator(spaceId);
+    return decideGoalOwnerResolution({
+      candidates,
+      agentStates,
+      coordinatorAgentId: coordinator?.id ?? null,
+    });
   }
 
   assignForgeScope(

--- a/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-long-horizon-agent-repository.ts
@@ -194,13 +194,23 @@ export class SpaceLongHorizonAgentRepository {
     const agent = this.requireAgent(agentId);
     this.requireMatchingSpace('space_goals', goalId, agent.spaceId, 'Goal');
     const now = Date.now();
-    this.db
-      .prepare(
-        `INSERT INTO space_long_horizon_agent_goals (agent_id, goal_id, relationship, created_at, updated_at)
-				 VALUES (?, ?, ?, ?, ?)
-				 ON CONFLICT(agent_id, goal_id, relationship) DO UPDATE SET updated_at = excluded.updated_at`
-      )
-      .run(agentId, goalId, relationship, now, now);
+    const replace = this.db.transaction(() => {
+      if (relationship === 'owner') {
+        this.db
+          .prepare(
+            `DELETE FROM space_long_horizon_agent_goals WHERE goal_id = ? AND relationship = 'owner'`
+          )
+          .run(goalId);
+      }
+      this.db
+        .prepare(
+          `INSERT INTO space_long_horizon_agent_goals (agent_id, goal_id, relationship, created_at, updated_at)
+					 VALUES (?, ?, ?, ?, ?)
+					 ON CONFLICT(agent_id, goal_id, relationship) DO UPDATE SET updated_at = excluded.updated_at`
+        )
+        .run(agentId, goalId, relationship, now, now);
+    });
+    replace();
   }
 
   listGoals(agentId: string): SpaceLongHorizonAgentGoal[] {

--- a/packages/daemon/src/storage/schema/long-horizon-agents.ts
+++ b/packages/daemon/src/storage/schema/long-horizon-agents.ts
@@ -49,6 +49,10 @@ export function createLongHorizonAgentTables(db: BunDatabase): void {
     `CREATE INDEX IF NOT EXISTS idx_space_lh_agent_goals_goal ` +
       `ON space_long_horizon_agent_goals(goal_id)`
   );
+  db.exec(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner ` +
+      `ON space_long_horizon_agent_goals(goal_id) WHERE relationship = 'owner'`
+  );
   db.exec(`
 		CREATE TABLE IF NOT EXISTS space_long_horizon_agent_forge_scopes (
 			agent_id TEXT NOT NULL,

--- a/packages/daemon/src/storage/schema/long-horizon-agents.ts
+++ b/packages/daemon/src/storage/schema/long-horizon-agents.ts
@@ -49,10 +49,6 @@ export function createLongHorizonAgentTables(db: BunDatabase): void {
     `CREATE INDEX IF NOT EXISTS idx_space_lh_agent_goals_goal ` +
       `ON space_long_horizon_agent_goals(goal_id)`
   );
-  db.exec(
-    `CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner ` +
-      `ON space_long_horizon_agent_goals(goal_id) WHERE relationship = 'owner'`
-  );
   db.exec(`
 		CREATE TABLE IF NOT EXISTS space_long_horizon_agent_forge_scopes (
 			agent_id TEXT NOT NULL,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -443,6 +443,8 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   run(migrationMarkerKey(201), () => runMigration201(db));
 
   run(migrationMarkerKey(202), () => runMigration202(db));
+
+  run(migrationMarkerKey(203), () => runMigration203(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -9530,4 +9532,20 @@ export function runMigration202(db: BunDatabase): void {
     ON space_tasks(goal_id, created_at DESC, id DESC)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_space_tasks_goal_status_created
     ON space_tasks(goal_id, status, created_at DESC, id DESC)`);
+}
+
+export function runMigration203(db: BunDatabase): void {
+  if (!tableExists(db, 'space_long_horizon_agent_goals')) return;
+  db.exec(`DELETE FROM space_long_horizon_agent_goals AS a
+    WHERE a.relationship = 'owner'
+      AND EXISTS (
+        SELECT 1 FROM space_long_horizon_agent_goals AS o
+        WHERE o.relationship = 'owner'
+          AND o.goal_id = a.goal_id
+          AND (o.created_at < a.created_at
+               OR (o.created_at = a.created_at AND o.agent_id < a.agent_id))
+      )`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner
+    ON space_long_horizon_agent_goals(goal_id)
+    WHERE relationship = 'owner'`);
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-203_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-203_test.ts
@@ -1,0 +1,127 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { runMigration203 } from '../../../../../src/storage/schema/migrations.ts';
+
+interface OwnerRow {
+  agent_id: string;
+  goal_id: string;
+  relationship: string;
+}
+
+function ownerRows(db: BunDatabase): OwnerRow[] {
+  return db
+    .prepare(`SELECT agent_id, goal_id, relationship FROM space_long_horizon_agent_goals`)
+    .all() as OwnerRow[];
+}
+
+function seedPreM203Schema(db: BunDatabase): void {
+  db.exec(`
+    CREATE TABLE space_long_horizon_agent_goals (
+      agent_id TEXT NOT NULL,
+      goal_id TEXT NOT NULL,
+      relationship TEXT NOT NULL DEFAULT 'owner'
+        CHECK(relationship IN ('owner', 'manager', 'watcher')),
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY(agent_id, goal_id, relationship)
+    );
+  `);
+}
+
+function insertOwner(
+  db: BunDatabase,
+  agentId: string,
+  goalId: string,
+  createdAt: number,
+  relationship: string = 'owner'
+): void {
+  db.prepare(
+    `INSERT INTO space_long_horizon_agent_goals (agent_id, goal_id, relationship, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).run(agentId, goalId, relationship, createdAt, createdAt);
+}
+
+describe('Migration 203: single-owner reconciliation + unique index', () => {
+  let testDir: string;
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    testDir = join(
+      process.cwd(),
+      'tmp',
+      'test-migration-203',
+      `test-${Date.now()}-${Math.random()}`
+    );
+    mkdirSync(testDir, { recursive: true });
+    db = new BunDatabase(join(testDir, 'test.db'));
+    db.exec('PRAGMA foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {}
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('keeps the earliest owner and deletes duplicate owners for the same goal', () => {
+    seedPreM203Schema(db);
+    insertOwner(db, 'agent-late', 'goal-1', 200);
+    insertOwner(db, 'agent-early', 'goal-1', 100);
+    insertOwner(db, 'agent-only', 'goal-2', 150);
+
+    runMigration203(db);
+
+    const rows = ownerRows(db);
+    const goal1Owners = rows.filter((r) => r.goal_id === 'goal-1' && r.relationship === 'owner');
+    expect(goal1Owners).toHaveLength(1);
+    expect(goal1Owners[0].agent_id).toBe('agent-early');
+    expect(rows.some((r) => r.goal_id === 'goal-2' && r.agent_id === 'agent-only')).toBe(true);
+  });
+
+  test('ties on created_at break by lexicographically smallest agent id', () => {
+    seedPreM203Schema(db);
+    insertOwner(db, 'agent-z', 'goal-1', 100);
+    insertOwner(db, 'agent-a', 'goal-1', 100);
+
+    runMigration203(db);
+
+    const owners = ownerRows(db).filter(
+      (r) => r.goal_id === 'goal-1' && r.relationship === 'owner'
+    );
+    expect(owners).toHaveLength(1);
+    expect(owners[0].agent_id).toBe('agent-a');
+  });
+
+  test('leaves manager/watcher rows untouched', () => {
+    seedPreM203Schema(db);
+    insertOwner(db, 'agent-owner', 'goal-1', 100);
+    insertOwner(db, 'agent-manager', 'goal-1', 150, 'manager');
+    insertOwner(db, 'agent-watcher', 'goal-1', 160, 'watcher');
+
+    runMigration203(db);
+
+    const rows = ownerRows(db);
+    expect(rows.filter((r) => r.goal_id === 'goal-1')).toHaveLength(3);
+    expect(rows.some((r) => r.relationship === 'manager')).toBe(true);
+    expect(rows.some((r) => r.relationship === 'watcher')).toBe(true);
+  });
+
+  test('adds a partial unique index so a second owner insert is rejected', () => {
+    seedPreM203Schema(db);
+    insertOwner(db, 'agent-a', 'goal-1', 100);
+    runMigration203(db);
+
+    expect(() => insertOwner(db, 'agent-b', 'goal-1', 200)).toThrow(/UNIQUE/i);
+    expect(() => insertOwner(db, 'agent-a', 'goal-2', 100)).not.toThrow();
+    expect(() => insertOwner(db, 'agent-b', 'goal-1', 200, 'manager')).not.toThrow();
+  });
+
+  test('is a no-op when space_long_horizon_agent_goals does not exist', () => {
+    expect(() => runMigration203(db)).not.toThrow();
+  });
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -285,6 +285,33 @@ describe('SpaceLongHorizonAgentRepository', () => {
     });
   });
 
+  test('assigning a new owner replaces the existing owner atomically', () => {
+    const coordinator = repo.ensureCoordinator('space-1');
+    const newOwner = repo.create({
+      spaceId: 'space-1',
+      handle: 'new-owner',
+      displayName: 'New Owner',
+    });
+    db.prepare(
+      `INSERT INTO space_goals (
+				id, space_id, title, description, status, type, priority, labels, metrics,
+				summary, progress, next_steps, auto_trigger_next, pending_next_run, created_at, updated_at
+			) VALUES (?, ?, ?, '', 'active', 'one_shot', 'normal', '[]', '{}', '', 0, '[]', 0, 0, ?, ?)`
+    ).run('goal-1', 'space-1', 'Goal 1', 1, 1);
+
+    repo.assignGoal(coordinator.id, 'goal-1', 'owner');
+    repo.assignGoal(newOwner.id, 'goal-1', 'owner');
+
+    expect(repo.getPrimaryGoalOwner('goal-1', 'space-1')).toEqual({
+      action: 'resolved',
+      owner: expect.objectContaining({ agentId: newOwner.id }),
+      conflicts: [],
+    });
+    expect(
+      repo.listGoalAssignments('goal-1').filter((a) => a.relationship === 'owner')
+    ).toHaveLength(1);
+  });
+
   test('upserts, lists active, and deletes event subscriptions by route', () => {
     const agent = repo.ensureCoordinator('space-1');
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-long-horizon-agent-repository.test.ts
@@ -218,6 +218,73 @@ describe('SpaceLongHorizonAgentRepository', () => {
     });
   });
 
+  test('lists goal assignments by goal and deletes a single relationship', () => {
+    const agent = repo.ensureCoordinator('space-1');
+    db.prepare(
+      `INSERT INTO space_goals (
+				id, space_id, title, description, status, type, priority, labels, metrics,
+				summary, progress, next_steps, auto_trigger_next, pending_next_run, created_at, updated_at
+			) VALUES (?, ?, ?, '', 'active', 'one_shot', 'normal', '[]', '{}', '', 0, '[]', 0, 0, ?, ?)`
+    ).run('goal-1', 'space-1', 'Goal 1', 1, 1);
+
+    repo.assignGoal(agent.id, 'goal-1', 'owner');
+    repo.assignGoal(agent.id, 'goal-1', 'manager');
+    repo.assignGoal(agent.id, 'goal-1', 'watcher');
+
+    expect(repo.listGoalAssignments('goal-1')).toEqual([
+      expect.objectContaining({ agentId: agent.id, goalId: 'goal-1', relationship: 'owner' }),
+      expect.objectContaining({ agentId: agent.id, goalId: 'goal-1', relationship: 'manager' }),
+      expect.objectContaining({ agentId: agent.id, goalId: 'goal-1', relationship: 'watcher' }),
+    ]);
+
+    repo.deleteGoalAssignmentByRelationship(agent.id, 'goal-1', 'owner');
+    expect(repo.listGoalAssignments('goal-1').map((a) => a.relationship)).toEqual([
+      'manager',
+      'watcher',
+    ]);
+  });
+
+  test('resolves the primary goal owner with coordinator fallback', () => {
+    const coordinator = repo.ensureCoordinator('space-1');
+    db.prepare(
+      `INSERT INTO space_goals (
+				id, space_id, title, description, status, type, priority, labels, metrics,
+				summary, progress, next_steps, auto_trigger_next, pending_next_run, created_at, updated_at
+			) VALUES (?, ?, ?, '', 'active', 'one_shot', 'normal', '[]', '{}', '', 0, '[]', 0, 0, ?, ?)`
+    ).run('goal-1', 'space-1', 'Goal 1', 1, 1);
+
+    expect(repo.getPrimaryGoalOwner('goal-1', 'space-1')).toEqual({
+      action: 'coordinator_fallback',
+      coordinatorAgentId: coordinator.id,
+    });
+
+    repo.assignGoal(coordinator.id, 'goal-1', 'owner');
+    expect(repo.getPrimaryGoalOwner('goal-1', 'space-1')).toEqual({
+      action: 'resolved',
+      owner: expect.objectContaining({ agentId: coordinator.id, relationship: 'owner' }),
+      conflicts: [],
+    });
+  });
+
+  test('resolves a degraded owner when the agent is paused', () => {
+    const agent = repo.ensureCoordinator('space-1');
+    db.prepare(
+      `INSERT INTO space_goals (
+				id, space_id, title, description, status, type, priority, labels, metrics,
+				summary, progress, next_steps, auto_trigger_next, pending_next_run, created_at, updated_at
+			) VALUES (?, ?, ?, '', 'active', 'one_shot', 'normal', '[]', '{}', '', 0, '[]', 0, 0, ?, ?)`
+    ).run('goal-1', 'space-1', 'Goal 1', 1, 1);
+    repo.assignGoal(agent.id, 'goal-1', 'owner');
+    repo.update(agent.id, { status: 'paused' });
+
+    expect(repo.getPrimaryGoalOwner('goal-1', 'space-1')).toEqual({
+      action: 'degraded',
+      reason: 'paused',
+      owner: expect.objectContaining({ agentId: agent.id }),
+      conflicts: [],
+    });
+  });
+
   test('upserts, lists active, and deletes event subscriptions by route', () => {
     const agent = repo.ensureCoordinator('space-1');
 

--- a/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
@@ -2,60 +2,45 @@ import { describe, expect, test } from 'bun:test';
 import { decideGoalOwnershipMutationAdmission } from '../../../../src/lib/space/goals/goal-ownership-gates';
 
 describe('decideGoalOwnershipMutationAdmission', () => {
-  test('allows the coordinator agent (no session)', () => {
+  test('allows a coordinator agent invocation without a session', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({ callerRole: undefined, isCoordinatorAgent: true })
+      decideGoalOwnershipMutationAdmission({ callerRole: undefined, hasSession: false })
     ).toEqual({ action: 'allow' });
   });
 
   test('allows a coordinator session', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({ callerRole: 'coordinator', isCoordinatorAgent: true })
+      decideGoalOwnershipMutationAdmission({ callerRole: 'coordinator', hasSession: true })
     ).toEqual({ action: 'allow' });
+  });
+
+  test('denies a long-term agent even with a display name of coordinator', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({ callerRole: 'long_term_agent', hasSession: true })
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 
   test('denies an ad-hoc member session (not proof of human operator)', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({
-        callerRole: 'ad_hoc_member',
-        isCoordinatorAgent: false,
-      })
+      decideGoalOwnershipMutationAdmission({ callerRole: 'ad_hoc_member', hasSession: true })
     ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 
   test('denies a workflow worker', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({
-        callerRole: 'workflow_worker',
-        isCoordinatorAgent: false,
-      })
-    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
-  });
-
-  test('denies a long-term agent', () => {
-    expect(
-      decideGoalOwnershipMutationAdmission({
-        callerRole: 'long_term_agent',
-        isCoordinatorAgent: false,
-      })
+      decideGoalOwnershipMutationAdmission({ callerRole: 'workflow_worker', hasSession: true })
     ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 
   test('denies a legacy task agent', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({
-        callerRole: 'legacy_task_agent',
-        isCoordinatorAgent: false,
-      })
+      decideGoalOwnershipMutationAdmission({ callerRole: 'legacy_task_agent', hasSession: true })
     ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 
   test('denies an outside-space session', () => {
     expect(
-      decideGoalOwnershipMutationAdmission({
-        callerRole: 'outside_space',
-        isCoordinatorAgent: false,
-      })
+      decideGoalOwnershipMutationAdmission({ callerRole: 'outside_space', hasSession: true })
     ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 });

--- a/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { decideGoalOwnershipMutationAdmission } from '../../../../src/lib/space/goals/goal-ownership-gates';
+
+describe('decideGoalOwnershipMutationAdmission', () => {
+  test('allows the coordinator agent (no session)', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({ callerRole: undefined, isCoordinatorAgent: true })
+    ).toEqual({ action: 'allow' });
+  });
+
+  test('allows a coordinator session', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({ callerRole: 'coordinator', isCoordinatorAgent: true })
+    ).toEqual({ action: 'allow' });
+  });
+
+  test('allows an ad-hoc member (explicit human) session', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({
+        callerRole: 'ad_hoc_member',
+        isCoordinatorAgent: false,
+      })
+    ).toEqual({ action: 'allow' });
+  });
+
+  test('denies a workflow worker', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({
+        callerRole: 'workflow_worker',
+        isCoordinatorAgent: false,
+      })
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
+  });
+
+  test('denies a long-term agent', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({
+        callerRole: 'long_term_agent',
+        isCoordinatorAgent: false,
+      })
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
+  });
+
+  test('denies a legacy task agent', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({
+        callerRole: 'legacy_task_agent',
+        isCoordinatorAgent: false,
+      })
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
+  });
+
+  test('denies an outside-space session', () => {
+    expect(
+      decideGoalOwnershipMutationAdmission({
+        callerRole: 'outside_space',
+        isCoordinatorAgent: false,
+      })
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
+  });
+});

--- a/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/goal-ownership-gates.test.ts
@@ -14,13 +14,13 @@ describe('decideGoalOwnershipMutationAdmission', () => {
     ).toEqual({ action: 'allow' });
   });
 
-  test('allows an ad-hoc member (explicit human) session', () => {
+  test('denies an ad-hoc member session (not proof of human operator)', () => {
     expect(
       decideGoalOwnershipMutationAdmission({
         callerRole: 'ad_hoc_member',
         isCoordinatorAgent: false,
       })
-    ).toEqual({ action: 'allow' });
+    ).toMatchObject({ action: 'deny', reason: 'not_coordinator_or_human' });
   });
 
   test('denies a workflow worker', () => {

--- a/packages/daemon/tests/unit/5-space/other/legacy-long-horizon-migration.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/legacy-long-horizon-migration.test.ts
@@ -9,6 +9,7 @@ function makeDb(): BunDatabase {
   const db = new BunDatabase(':memory:');
   db.exec('PRAGMA foreign_keys = ON');
   runMigrations(db, () => {});
+  db.exec(`DROP INDEX IF EXISTS idx_space_lh_agent_goals_one_owner`);
   return db;
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -228,6 +228,7 @@ function makeCtx(): TestCtx {
     spaceRepo,
     scheduleService,
     db,
+    longHorizonAgentRepo,
   });
   const evolutionRepo = new EvolutionRepository(db);
   const evolutionScopeService = new EvolutionScopeService({
@@ -1640,6 +1641,70 @@ describe('createSpaceAgentToolHandlers — long-horizon agent tools', () => {
           .content[0].text
       ).success
     ).toBe(true);
+  });
+
+  test('rejects owner mutations from a workflow worker session', async () => {
+    const handlers = makeHandlers(ctx, {
+      callerRole: 'workflow_worker',
+      mySessionId: 'worker-session',
+      myAgentName: 'worker',
+    });
+    const agent = ctx.longHorizonAgentRepo.ensureCoordinator(ctx.spaceId);
+    const goal = ctx.goalService.createGoal({ spaceId: ctx.spaceId, title: 'Gated goal' });
+
+    const assign = JSON.parse(
+      (await handlers.assign_agent_to_goal({ agent_id: agent.id, goal_id: goal.id })).content[0]
+        .text
+    );
+    expect(assign.success).toBe(false);
+    expect(assign.error).toContain('coordinator or explicit human');
+
+    const unassign = JSON.parse(
+      (await handlers.unassign_agent_from_goal({ agent_id: agent.id, goal_id: goal.id })).content[0]
+        .text
+    );
+    expect(unassign.success).toBe(false);
+    expect(unassign.error).toContain('coordinator or explicit human');
+  });
+
+  test('create_goal atomically assigns the coordinator as owner by default', async () => {
+    const handlers = makeHandlers(ctx);
+    const coordinator = ctx.longHorizonAgentRepo.ensureCoordinator(ctx.spaceId);
+
+    const created = JSON.parse(
+      (await handlers.create_goal({ title: 'Owned goal', type: 'one_shot' })).content[0].text
+    );
+    expect(created.success).toBe(true);
+
+    const owner = ctx.longHorizonAgentRepo.getPrimaryGoalOwner(created.goal.id, ctx.spaceId);
+    expect(owner).toEqual({
+      action: 'resolved',
+      owner: expect.objectContaining({ agentId: coordinator.id }),
+      conflicts: [],
+    });
+  });
+
+  test('create_goal honors an explicit owner_agent_id', async () => {
+    const handlers = makeHandlers(ctx);
+    const agent = ctx.longHorizonAgentRepo.ensureCoordinator(ctx.spaceId);
+
+    const created = JSON.parse(
+      (
+        await handlers.create_goal({
+          title: 'Explicit owner goal',
+          type: 'one_shot',
+          owner_agent_id: agent.id,
+        })
+      ).content[0].text
+    );
+    expect(created.success).toBe(true);
+
+    const owner = ctx.longHorizonAgentRepo.getPrimaryGoalOwner(created.goal.id, ctx.spaceId);
+    expect(owner).toEqual({
+      action: 'resolved',
+      owner: expect.objectContaining({ agentId: agent.id }),
+      conflicts: [],
+    });
   });
 
   test('returns errors for missing and cross-space agents', async () => {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -485,6 +485,10 @@ export function createSpaceTables(db: BunDatabase): void {
 
   createEvolutionTables(db);
   createLongHorizonAgentTables(db);
+  db.exec(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner ` +
+      `ON space_long_horizon_agent_goals(goal_id) WHERE relationship = 'owner'`
+  );
   createWorkflowEventSubscriptionTables(db);
 
   db.exec(`

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -404,6 +404,7 @@ export interface CreateSpaceGoalParams {
   checkInCronExpression?: string | null;
   checkInTimezone?: string;
   triggerImmediately?: boolean;
+  primaryOwnerAgentId?: string | null;
 }
 
 export interface UpdateSpaceGoalParams {


### PR DESCRIPTION
Closes #2739

## Summary
Enforce the single primary-owner invariant and gate ownership mutations per roadmap MC1:

- **Migration 203** reconciles pre-existing duplicate `owner` rows deterministically (earliest `created_at`, `agent_id` tiebreak) and adds a partial unique index `(goal_id) WHERE relationship='owner'`. The index is created **only** in migration 203 — after migration 155 copies legacy `space_agent_goal_assignments` — so the reconciliation sees the copied duplicates rather than silently dropping them. Duplicate-owner DBs no longer fail startup.
- **`goal-ownership-gates`** decision core: owner mutations require the **coordinator session role** (`callerRole === 'coordinator'`) or a genuine no-session coordinator invocation. It deliberately does **not** trust `ad_hoc_member` (a fallback role for any non-workflow session, not proof of a human operator) or display names (a long-term agent could be named "Coordinator"/"Space Agent"). Humans act through the coordinator. This is the minimal core's only authorization gate.
- **`assign_agent_to_goal` / `unassign_agent_from_goal`** run the gate; unassign deletes only the `owner` relationship, preserving the same agent's `manager`/`watcher` rows.
- **`create_goal`** accepts `owner_agent_id`: a non-self owner requires the same coordinator/human gate; self-claim (the calling agent) and the coordinator default are the roadmap's safe self-claim path. Ownership is assigned atomically in the same transaction as goal creation.
- Repo gains `listGoalAssignments`, `deleteGoalAssignmentByRelationship`, and `getPrimaryGoalOwner` wiring the MC1-A resolution core with explicit coordinator fallback. `assignGoal` replaces an existing owner atomically when assigning a different one.

## Non-goals (deferred per roadmap)
- Other member-isolation gates (G9), ownership UI (#2517), automatic template `ownershipPatterns`.

## Test plan
- Migration 203: earliest-owner keep, tie-break, manager/watcher preservation, unique-index rejection, no-op guards; legacy-migration test simulates the pre-203 copy order.
- Gates: coordinator/no-session allow; ad-hoc/worker/long-term/legacy/outside deny (incl. display-name spoof case).
- Repo: `listGoalAssignments`, relationship-specific delete, owner replacement, `getPrimaryGoalOwner` resolved/degraded/coordinator-fallback.
- Tool: gate denial from worker session, create_goal default-coordinator + explicit `owner_agent_id` ownership.
- `bun run check` green (lint, types, knip, format, test-matrix, db-schema parity).