### PR TITLE
refactor(web): pin and migrate useActorMessageProjections/useTaskMilestones onto live-query-lifecycle (task #1254)

### DIFF
--- a/packages/web/src/hooks/__tests__/useActorMessageProjections.lifecycle.test.ts
+++ b/packages/web/src/hooks/__tests__/useActorMessageProjections.lifecycle.test.ts
@@ -1,0 +1,311 @@
+import { act, renderHook } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequest, mockOnEvent, mockGetHub, mockIsConnected } = vi.hoisted(() => ({
+  mockRequest: vi.fn().mockResolvedValue(undefined),
+  mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
+    () => () => {}
+  ),
+  mockGetHub: vi.fn(),
+  mockIsConnected: { value: true },
+}));
+
+vi.mock('../useMessageHub', () => ({
+  useMessageHub: () => ({
+    request: mockRequest,
+    onEvent: mockOnEvent,
+    getHub: mockGetHub,
+    get isConnected() {
+      return mockIsConnected.value;
+    },
+  }),
+}));
+
+type EventHandler = (event: unknown) => void;
+let eventHandlers: Record<string, EventHandler[]> = {};
+
+function fireEvent(method: string, payload: unknown): void {
+  (eventHandlers[method] ?? []).forEach((h) => h(payload));
+}
+
+function subscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+}
+
+function unsubscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.unsubscribe');
+}
+
+function makeRow(id: string, createdAt: number, summary = '') {
+  return {
+    id,
+    scope: 'task_timeline',
+    eventKind: 'answer',
+    from: { kind: 'worker', label: 'Coder' },
+    title: 'Answer',
+    summary,
+    createdAt,
+  } as never;
+}
+
+import { useActorMessageProjections } from '../useActorMessageProjections';
+
+describe('useActorMessageProjections liveQuery lifecycle', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockRequest.mockReset();
+    mockOnEvent.mockReset();
+    mockGetHub.mockReset();
+    mockRequest.mockResolvedValue(undefined);
+    mockGetHub.mockReturnValue({ request: mockRequest, onConnection: vi.fn(() => () => {}) });
+    mockIsConnected.value = true;
+    eventHandlers = {};
+    mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
+      if (!eventHandlers[method]) eventHandlers[method] = [];
+      eventHandlers[method].push(handler);
+      return () => {
+        eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('snapshot retry behavior', () => {
+    it('never retries while a snapshot fails to arrive', async () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(result.current.isLoading).toBe(true);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('releases loading when the subscribe request rejects without retrying and still accepts a late snapshot', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValueOnce(new Error('subscribe failed'));
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.rows).toEqual([]);
+      expect('error' in result.current).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'late')],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('liveQuery.error handling', () => {
+    it('resubscribes with the same subscription id on a delta-phase error keeping rows', async () => {
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'hello')],
+          version: 1,
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+      await act(async () => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(subscribeCalls()[1][1].subscriptionId).toBe(subId);
+      expect(subscribeCalls()[1][1]).toMatchObject({
+        queryName: 'actorMessages.byTask',
+        params: ['task-1'],
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      expect(result.current.isLoading).toBe(false);
+      expect('error' in result.current).toBe(false);
+    });
+
+    it('applies a snapshot racing the delta-phase resubscribe before it resolves', async () => {
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'hello')],
+          version: 1,
+        });
+      });
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r2', 2, 'raced')],
+          version: 2,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r2']);
+    });
+
+    it('releases loading on a snapshot-phase error without surfacing an error and revives on a late snapshot', async () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'QUERY_FAILED',
+          message: 'query failed',
+          phase: 'snapshot',
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.rows).toEqual([]);
+      expect('error' in result.current).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'revived')],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('reconnect and disconnect', () => {
+    it('resubscribes on a hub reconnect keeping rows and reloading', async () => {
+      let connectionHandler: ((state: string) => void) | null = null;
+      mockGetHub.mockReturnValue({
+        request: mockRequest,
+        onConnection: vi.fn((handler: (state: string) => void) => {
+          connectionHandler = handler;
+          return () => {};
+        }),
+      });
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'hello')],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      await act(async () => {
+        connectionHandler?.('disconnected');
+        connectionHandler?.('connected');
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(subscribeCalls()[1][1].subscriptionId).toBe(subId);
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('clears rows while disconnected and reports isReconnecting', async () => {
+      const { result, rerender } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'hello')],
+          version: 1,
+        });
+      });
+      expect(result.current.rows).toHaveLength(1);
+      mockIsConnected.value = false;
+      rerender();
+      expect(result.current.isReconnecting).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.rows).toEqual([]);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('unsubscribes on unmount and stays inert afterwards', async () => {
+      vi.useFakeTimers();
+      const { unmount } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      await act(async () => {
+        await Promise.resolve();
+      });
+      unmount();
+      expect(unsubscribeCalls()).toEqual([['liveQuery.unsubscribe', { subscriptionId: subId }]]);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      fireEvent('liveQuery.snapshot', {
+        subscriptionId: subId,
+        rows: [makeRow('late', 1, 'late')],
+        version: 2,
+      });
+      fireEvent('liveQuery.delta', {
+        subscriptionId: subId,
+        added: [makeRow('late-2', 2, 'late')],
+        version: 3,
+      });
+      fireEvent('liveQuery.error', {
+        subscriptionId: subId,
+        code: 'LATE',
+        message: 'late',
+        phase: 'delta',
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/web/src/hooks/__tests__/useActorMessageProjections.lifecycle.test.ts
+++ b/packages/web/src/hooks/__tests__/useActorMessageProjections.lifecycle.test.ts
@@ -216,6 +216,47 @@ describe('useActorMessageProjections liveQuery lifecycle', () => {
       expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
       expect(result.current.isLoading).toBe(false);
     });
+
+    it('pauses deltas after a snapshot-phase error while live and revives on a fresh snapshot', () => {
+      const { result } = renderHook(() =>
+        useActorMessageProjections({ scope: 'task_timeline', taskId: 'task-1' })
+      );
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r1', 1, 'hello')],
+          version: 1,
+        });
+      });
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'QUERY_FAILED',
+          message: 'query failed',
+          phase: 'snapshot',
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      act(() => {
+        fireEvent('liveQuery.delta', {
+          subscriptionId: subId,
+          added: [makeRow('r2', 2, 'paused')],
+          version: 2,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r1']);
+      expect(result.current.isLoading).toBe(false);
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('r3', 3, 'revived')],
+          version: 3,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['r3']);
+      expect(result.current.isLoading).toBe(false);
+    });
   });
 
   describe('reconnect and disconnect', () => {

--- a/packages/web/src/hooks/__tests__/useTaskMilestones.lifecycle.test.ts
+++ b/packages/web/src/hooks/__tests__/useTaskMilestones.lifecycle.test.ts
@@ -1,0 +1,272 @@
+import { act, renderHook } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequest, mockOnEvent, mockGetHub, mockIsConnected } = vi.hoisted(() => ({
+  mockRequest: vi.fn().mockResolvedValue(undefined),
+  mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
+    () => () => {}
+  ),
+  mockGetHub: vi.fn(),
+  mockIsConnected: { value: true },
+}));
+
+vi.mock('../useMessageHub', () => ({
+  useMessageHub: () => ({
+    request: mockRequest,
+    onEvent: mockOnEvent,
+    getHub: mockGetHub,
+    get isConnected() {
+      return mockIsConnected.value;
+    },
+  }),
+}));
+
+type EventHandler = (event: unknown) => void;
+let eventHandlers: Record<string, EventHandler[]> = {};
+
+function fireEvent(method: string, payload: unknown): void {
+  (eventHandlers[method] ?? []).forEach((h) => h(payload));
+}
+
+function subscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+}
+
+function unsubscribeCalls() {
+  return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.unsubscribe');
+}
+
+function makeRow(id: string, createdAt: number) {
+  return {
+    id,
+    taskId: 'task-1',
+    label: `milestone-${id}`,
+    state: 'done',
+    createdAt,
+  } as never;
+}
+
+import { useTaskMilestones } from '../useTaskMilestones';
+
+describe('useTaskMilestones liveQuery lifecycle', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockRequest.mockReset();
+    mockOnEvent.mockReset();
+    mockGetHub.mockReset();
+    mockRequest.mockResolvedValue(undefined);
+    mockGetHub.mockReturnValue({ request: mockRequest, onConnection: vi.fn(() => () => {}) });
+    mockIsConnected.value = true;
+    eventHandlers = {};
+    mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
+      if (!eventHandlers[method]) eventHandlers[method] = [];
+      eventHandlers[method].push(handler);
+      return () => {
+        eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('snapshot retry behavior', () => {
+    it('never retries while a snapshot fails to arrive', async () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(subscribeCalls()[0][1]).toMatchObject({
+        queryName: 'taskMilestones.byTask',
+        params: ['task-1'],
+      });
+      expect(result.current.isLoading).toBe(true);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('releases loading when the subscribe request rejects without retrying and still accepts a late snapshot', async () => {
+      vi.useFakeTimers();
+      mockRequest.mockRejectedValueOnce(new Error('subscribe failed'));
+      const { result } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.rows).toEqual([]);
+      expect('error' in result.current).toBe(false);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('ms1', 1)],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['ms1']);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('liveQuery.error handling', () => {
+    it('registers no liveQuery.error listener at all', () => {
+      renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const methods = mockOnEvent.mock.calls.map((call) => call[0]);
+      expect(methods).toEqual(['liveQuery.snapshot', 'liveQuery.delta']);
+    });
+
+    it('ignores a delta-phase error without resubscribing and keeps rows', async () => {
+      const { result } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('ms1', 1)],
+          version: 1,
+        });
+      });
+      expect(result.current.isLoading).toBe(false);
+      await act(async () => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'STREAM_LOST',
+          message: 'stream lost',
+          phase: 'delta',
+        });
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      expect(result.current.rows.map((r) => r.id)).toEqual(['ms1']);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('ignores a snapshot-phase error while awaiting so loading stays claimed', async () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.error', {
+          subscriptionId: subId,
+          code: 'QUERY_FAILED',
+          message: 'query failed',
+          phase: 'snapshot',
+        });
+      });
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.rows).toEqual([]);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('ms1', 1)],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['ms1']);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('reconnect and disconnect', () => {
+    it('resubscribes on a hub reconnect keeping rows and reloading', async () => {
+      let connectionHandler: ((state: string) => void) | null = null;
+      mockGetHub.mockReturnValue({
+        request: mockRequest,
+        onConnection: vi.fn((handler: (state: string) => void) => {
+          connectionHandler = handler;
+          return () => {};
+        }),
+      });
+      const { result } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('ms1', 1)],
+          version: 1,
+        });
+      });
+      expect(result.current.rows.map((r) => r.id)).toEqual(['ms1']);
+      await act(async () => {
+        connectionHandler?.('disconnected');
+        connectionHandler?.('connected');
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(2);
+      expect(subscribeCalls()[1][1].subscriptionId).toBe(subId);
+      expect(result.current.rows.map((r) => r.id)).toEqual(['ms1']);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('clears rows while disconnected and reports isReconnecting', () => {
+      const { result, rerender } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      act(() => {
+        fireEvent('liveQuery.snapshot', {
+          subscriptionId: subId,
+          rows: [makeRow('ms1', 1)],
+          version: 1,
+        });
+      });
+      expect(result.current.rows).toHaveLength(1);
+      mockIsConnected.value = false;
+      rerender();
+      expect(result.current.isReconnecting).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.rows).toEqual([]);
+    });
+
+    it('does nothing without a task id', () => {
+      const { result } = renderHook(() => useTaskMilestones({ taskId: null }));
+      expect(subscribeCalls()).toHaveLength(0);
+      expect(result.current.rows).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isReconnecting).toBe(false);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('unsubscribes on unmount and stays inert afterwards', async () => {
+      vi.useFakeTimers();
+      const { unmount } = renderHook(() => useTaskMilestones({ taskId: 'task-1' }));
+      const subId = subscribeCalls()[0][1].subscriptionId;
+      await act(async () => {
+        await Promise.resolve();
+      });
+      unmount();
+      expect(unsubscribeCalls()).toEqual([['liveQuery.unsubscribe', { subscriptionId: subId }]]);
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+      fireEvent('liveQuery.snapshot', {
+        subscriptionId: subId,
+        rows: [makeRow('late', 1)],
+        version: 2,
+      });
+      fireEvent('liveQuery.delta', {
+        subscriptionId: subId,
+        added: [makeRow('late-2', 2)],
+        version: 3,
+      });
+      expect(subscribeCalls()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/web/src/hooks/useActorMessageProjections.ts
+++ b/packages/web/src/hooks/useActorMessageProjections.ts
@@ -5,6 +5,13 @@ import type {
   LiveQuerySnapshotEvent,
 } from '@hyperneo/shared';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import {
+  createLiveQueryLifecycleState,
+  type LiveQueryLifecycleEffect,
+  type LiveQueryLifecycleEvent,
+  type LiveQueryLifecycleState,
+  transitionLiveQueryLifecycle,
+} from '../lib/live-query-lifecycle';
 import { useMessageHub } from './useMessageHub';
 
 type ProjectionScope = 'task_timeline' | 'workflow_log';
@@ -52,6 +59,8 @@ function applyDelta(
   return sortRows(Array.from(next.values()));
 }
 
+type LifecycleStorePayload = LiveQuerySnapshotEvent | LiveQueryDeltaEvent | null;
+
 export function useActorMessageProjections({
   scope,
   taskId,
@@ -92,52 +101,92 @@ export function useActorMessageProjections({
     setRows([]);
     setLoadedForKey(null);
 
+    const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
+    let lifecycle: LiveQueryLifecycleState = initial.state;
+
+    const dispatch = (event: LiveQueryLifecycleEvent): LiveQueryLifecycleEffect[] => {
+      const result = transitionLiveQueryLifecycle(lifecycle, event);
+      lifecycle = result.state;
+      return result.effects;
+    };
+
+    const executeEffects = (
+      effects: LiveQueryLifecycleEffect[],
+      payload: LifecycleStorePayload = null
+    ): void => {
+      for (const effect of effects) {
+        if (effect.kind === 're-snapshot') {
+          const hub = getHub();
+          if (!hub) continue;
+          hub
+            .request('liveQuery.subscribe', {
+              queryName: query.queryName,
+              params: query.params,
+              subscriptionId,
+            })
+            .then(() => {
+              executeEffects(dispatch({ type: 'subscribed', generation: effect.generation }));
+            })
+            .catch(() => {
+              executeEffects(dispatch({ type: 'snapshot-failed', generation: effect.generation }));
+            });
+          continue;
+        }
+        if (effect.kind !== 'emit-to-store') continue;
+        if (effect.emission.type === 'snapshot') {
+          const snapshot = payload as LiveQuerySnapshotEvent | null;
+          setRows(sortRows((snapshot?.rows as ActorMessageProjectionRow[]) ?? []));
+          setLoadedForKey(query.key);
+          continue;
+        }
+        if (effect.emission.type === 'delta') {
+          const delta = payload as LiveQueryDeltaEvent | null;
+          if (delta) setRows((prev) => applyDelta(prev, delta));
+          continue;
+        }
+        setLoadedForKey(query.key);
+      }
+    };
+
+    executeEffects(initial.effects);
+
     const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      setRows(sortRows((event.rows as ActorMessageProjectionRow[]) ?? []));
-      setLoadedForKey(query.key);
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(
+        dispatch({ type: 'snapshot-arrived', generation: lifecycle.generation }),
+        event
+      );
     });
 
     const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      setRows((prev) => applyDelta(prev, event));
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(dispatch({ type: 'delta-arrived', generation: lifecycle.generation }), event);
     });
 
     const unsubError = onEvent<LiveQueryErrorEvent>('liveQuery.error', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
+      if (event.subscriptionId !== subscriptionId) return;
       if (event.phase === 'delta') {
-        subscribe();
+        executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
         return;
       }
-      setLoadedForKey(query.key);
-    });
-
-    const subscribe = () => {
-      const hub = getHub();
-      if (!hub) return;
-      hub
-        .request('liveQuery.subscribe', {
-          queryName: query.queryName,
-          params: query.params,
-          subscriptionId,
+      executeEffects(
+        dispatch({
+          type: 'snapshot-failed',
+          generation: lifecycle.generation,
+          message: event.message,
         })
-        .catch(() => {
-          if (activeSubIdRef.current === subscriptionId) {
-            setLoadedForKey(query.key);
-          }
-        });
-    };
+      );
+    });
 
     const unsubReconnect = getHub()?.onConnection((state) => {
       if (state !== 'connected') return;
       if (activeSubIdRef.current !== subscriptionId) return;
       setLoadedForKey(null);
-      subscribe();
+      executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
     });
 
-    subscribe();
-
     return () => {
+      executeEffects(dispatch({ type: 'unsubscribe' }));
       unsubSnapshot();
       unsubDelta();
       unsubError();

--- a/packages/web/src/hooks/useTaskMilestones.ts
+++ b/packages/web/src/hooks/useTaskMilestones.ts
@@ -4,6 +4,13 @@ import type {
   TaskMilestoneRow,
 } from '@hyperneo/shared';
 import { useEffect, useRef, useState } from 'preact/hooks';
+import {
+  createLiveQueryLifecycleState,
+  type LiveQueryLifecycleEffect,
+  type LiveQueryLifecycleEvent,
+  type LiveQueryLifecycleState,
+  transitionLiveQueryLifecycle,
+} from '../lib/live-query-lifecycle';
 import { useMessageHub } from './useMessageHub';
 
 interface UseTaskMilestonesOptions {
@@ -47,6 +54,8 @@ function applyDelta(
   return sortRows(Array.from(next.values()));
 }
 
+type LifecycleStorePayload = LiveQuerySnapshotEvent | LiveQueryDeltaEvent | null;
+
 export function useTaskMilestones({ taskId }: UseTaskMilestonesOptions): UseTaskMilestonesResult {
   const { request, onEvent, getHub, isConnected } = useMessageHub();
   const [rows, setRows] = useState<TaskMilestoneRow[]>([]);
@@ -66,43 +75,77 @@ export function useTaskMilestones({ taskId }: UseTaskMilestonesOptions): UseTask
     setRows([]);
     setLoadedForTaskId(null);
 
+    const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
+    let lifecycle: LiveQueryLifecycleState = initial.state;
+
+    const dispatch = (event: LiveQueryLifecycleEvent): LiveQueryLifecycleEffect[] => {
+      const result = transitionLiveQueryLifecycle(lifecycle, event);
+      lifecycle = result.state;
+      return result.effects;
+    };
+
+    const executeEffects = (
+      effects: LiveQueryLifecycleEffect[],
+      payload: LifecycleStorePayload = null
+    ): void => {
+      for (const effect of effects) {
+        if (effect.kind === 're-snapshot') {
+          const hub = getHub();
+          if (!hub) continue;
+          hub
+            .request('liveQuery.subscribe', {
+              queryName: 'taskMilestones.byTask',
+              params: [taskId],
+              subscriptionId,
+            })
+            .then(() => {
+              executeEffects(dispatch({ type: 'subscribed', generation: effect.generation }));
+            })
+            .catch(() => {
+              executeEffects(dispatch({ type: 'snapshot-failed', generation: effect.generation }));
+            });
+          continue;
+        }
+        if (effect.kind !== 'emit-to-store') continue;
+        if (effect.emission.type === 'snapshot') {
+          const snapshot = payload as LiveQuerySnapshotEvent | null;
+          setRows(sortRows((snapshot?.rows as TaskMilestoneRow[]) ?? []));
+          setLoadedForTaskId(taskId);
+          continue;
+        }
+        if (effect.emission.type === 'delta') {
+          const delta = payload as LiveQueryDeltaEvent | null;
+          if (delta) setRows((prev) => applyDelta(prev, delta));
+          continue;
+        }
+        setLoadedForTaskId(taskId);
+      }
+    };
+
+    executeEffects(initial.effects);
+
     const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      setRows(sortRows((event.rows as TaskMilestoneRow[]) ?? []));
-      setLoadedForTaskId(taskId);
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(
+        dispatch({ type: 'snapshot-arrived', generation: lifecycle.generation }),
+        event
+      );
     });
 
     const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-      if (event.subscriptionId !== activeSubIdRef.current) return;
-      setRows((prev) => applyDelta(prev, event));
+      if (event.subscriptionId !== subscriptionId) return;
+      executeEffects(dispatch({ type: 'delta-arrived', generation: lifecycle.generation }), event);
     });
-
-    const subscribe = () => {
-      const hub = getHub();
-      if (!hub) return;
-      hub
-        .request('liveQuery.subscribe', {
-          queryName: 'taskMilestones.byTask',
-          params: [taskId],
-          subscriptionId,
-        })
-        .catch(() => {
-          if (activeSubIdRef.current === subscriptionId) {
-            setLoadedForTaskId(taskId);
-          }
-        });
-    };
 
     const unsubReconnect = getHub()?.onConnection((state) => {
       if (state !== 'connected') return;
       if (activeSubIdRef.current !== subscriptionId) return;
       setLoadedForTaskId(null);
-      subscribe();
+      executeEffects(dispatch({ type: 'transport-error', generation: lifecycle.generation }));
     });
 
-    subscribe();
-
     return () => {
+      executeEffects(dispatch({ type: 'unsubscribe' }));
       unsubSnapshot();
       unsubDelta();
       unsubReconnect?.();

--- a/packages/web/src/lib/live-query-lifecycle.test.ts
+++ b/packages/web/src/lib/live-query-lifecycle.test.ts
@@ -434,6 +434,46 @@ describe('live-query-lifecycle', () => {
     });
   });
 
+  describe('snapshot retry disabled', () => {
+    it('moves to awaiting-snapshot without arming a backoff timer', () => {
+      const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
+      expect(initial.state.config).toEqual({
+        snapshotRetryDelayMs: 2000,
+        maxSnapshotRetries: 5,
+        snapshotRetryEnabled: false,
+      });
+      const resolved = transitionLiveQueryLifecycle(initial.state, {
+        type: 'subscribed',
+        generation: 1,
+      });
+      expect(resolved.state).toEqual(
+        fixtureState('awaiting-snapshot', {
+          generation: 1,
+          snapshotRetries: 0,
+          config: { ...FIXTURE_CONFIG, snapshotRetryEnabled: false },
+        })
+      );
+      expect(resolved.effects).toEqual([]);
+    });
+
+    it('never exhausts a retry budget across transport-error resubscribes', () => {
+      const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
+      let state = initial.state;
+      for (let i = 0; i < 10; i += 1) {
+        const generation = state.generation;
+        const resolved = transitionLiveQueryLifecycle(state, {
+          type: 'subscribed',
+          generation,
+        });
+        expect(resolved.state.status).toBe('awaiting-snapshot');
+        expect(resolved.state.snapshotRetries).toBe(0);
+        expect(resolved.effects).toEqual([]);
+        state = resolved.state;
+      }
+      expect(state.status).toBe('awaiting-snapshot');
+    });
+  });
+
   describe('disposed', () => {
     it('stays disposed for every event and never re-declares cleanup', () => {
       const disposed = fixtureState('disposed');

--- a/packages/web/src/lib/live-query-lifecycle.test.ts
+++ b/packages/web/src/lib/live-query-lifecycle.test.ts
@@ -460,10 +460,18 @@ describe('live-query-lifecycle', () => {
       const initial = createLiveQueryLifecycleState({ snapshotRetryEnabled: false });
       let state = initial.state;
       for (let i = 0; i < 10; i += 1) {
-        const generation = state.generation;
-        const resolved = transitionLiveQueryLifecycle(state, {
+        const dropped = transitionLiveQueryLifecycle(state, {
+          type: 'transport-error',
+          generation: state.generation,
+        });
+        expect(dropped.state.status).toBe('subscribing');
+        expect(dropped.state.snapshotRetries).toBe(0);
+        expect(dropped.effects).toEqual([
+          { kind: 're-snapshot', generation: state.generation + 1 },
+        ]);
+        const resolved = transitionLiveQueryLifecycle(dropped.state, {
           type: 'subscribed',
-          generation,
+          generation: dropped.state.generation,
         });
         expect(resolved.state.status).toBe('awaiting-snapshot');
         expect(resolved.state.snapshotRetries).toBe(0);
@@ -471,6 +479,7 @@ describe('live-query-lifecycle', () => {
         state = resolved.state;
       }
       expect(state.status).toBe('awaiting-snapshot');
+      expect(state.snapshotRetries).toBe(0);
     });
   });
 

--- a/packages/web/src/lib/live-query-lifecycle.ts
+++ b/packages/web/src/lib/live-query-lifecycle.ts
@@ -8,6 +8,7 @@ export type LiveQueryLifecycleStatus =
 export interface LiveQueryLifecycleConfig {
   snapshotRetryDelayMs: number;
   maxSnapshotRetries: number;
+  snapshotRetryEnabled?: boolean;
 }
 
 export const DEFAULT_LIVE_QUERY_LIFECYCLE_CONFIG: LiveQueryLifecycleConfig = {
@@ -57,6 +58,9 @@ export function createLiveQueryLifecycleState(
   }
   if (config.maxSnapshotRetries !== undefined) {
     merged.maxSnapshotRetries = config.maxSnapshotRetries;
+  }
+  if (config.snapshotRetryEnabled !== undefined) {
+    merged.snapshotRetryEnabled = config.snapshotRetryEnabled;
   }
   return {
     state: {
@@ -108,6 +112,12 @@ function transitionSubscribing(
   event: LiveQueryLifecycleEvent
 ): LiveQueryLifecycleTransition {
   if (event.type === 'subscribed') {
+    if (state.config.snapshotRetryEnabled === false) {
+      return {
+        state: { ...state, status: 'awaiting-snapshot' },
+        effects: [],
+      };
+    }
     if (state.snapshotRetries >= state.config.maxSnapshotRetries) {
       return {
         state: { ...state, status: 'error-retry' },


### PR DESCRIPTION
Pins the current observable behavior of both drifted hooks with characterization tests (green pre-migration), then migrates each onto the shared live-query-lifecycle machine via config (`snapshotRetryEnabled: false`, an optional flag added to the machine — no fork); pins pass unchanged after the rewrite. Drift is intentionally NOT fixed here; the table below feeds the PR 6 drift report.

## Drift table (copy vs machine/reference)

| # | Copy | Drift point | How preserved |
|---|------|-------------|---------------|
| 1 | both | No await-snapshot watchdog/retry: if the server never answers, isLoading stays claimed forever (reference retries every 2s, gives up after 5) | machine config `snapshotRetryEnabled: false` skips backoff arming and can never exhaust |
| 2 | both | Subscribe-request rejection silently releases loading (no retry, no error state); late snapshot still revives | machine settles messageless `snapshot-failed` → `settled-empty`; facade executes it as a loading release |
| 3 | projections | Snapshot-phase `liveQuery.error`: message swallowed entirely (no `error` field in result, unlike useSpaceTaskMessages); only releases loading; late snapshot revives from error-retry | facade ignores the machine's `error` emission payload, keeps only its loading-release effect |
| 4 | projections | Delta-phase error: plain re-subscribe with the same subscriptionId, rows kept, no error surfaced; snapshots racing the resubscribe are still applied (no generation drop visible) | machine `transport-error` path; events tagged with current generation so the race still applies |
| 5 | milestones | No `liveQuery.error` listener at all: stream-loss does not resubscribe; snapshot-phase errors leave loading claimed indefinitely | preserved by not wiring the error event into the machine |
| 6 | milestones | Otherwise matches reference reconnect/disconnect/cleanup semantics | direct mapping |
| 7 | projections | Snapshot-phase error while live: old copy kept applying subsequent deltas; machine routes live→error-retry which pauses deltas until a fresh snapshot revives (same semantic as reference useSpaceTaskMessages; surfaced by review) | accepted as machine semantic, pinned post-migration (live→error→delta paused→snapshot revives); recorded for PR 6 unification decision |
| 8 | both | Deltas arriving before the first snapshot: old copies applied any delta with a matching subscriptionId unconditionally (rows could render while isLoading stayed true); the machine drops delta-arrived unless live, so pre-snapshot deltas vanish until the snapshot lands. Likely protocol-unreachable (daemon pushes the snapshot at subscribe acceptance, re-pushes after failures) — surfaced by review | machine delta gating accepted; recorded for PR 6 |

Files: `live-query-lifecycle.ts` (+optional config flag + tests), both hooks rewritten as facades, two new `.lifecycle.test.ts` pin files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


