### PR TITLE
feat(space): reportable-terminal-gates decision core (MC2-A)

### DIFF
--- a/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
+++ b/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
@@ -8,10 +8,12 @@ export const TERMINAL_TASK_STATUSES: readonly SpaceTaskStatus[] = [
   'archived',
 ];
 
+export const REPORTABLE_TERMINAL_PREDICATE_VERSION = 1;
+
 export type ReportableTerminalDecision =
   | { action: 'none'; reason: 'not_terminal' | 'administrative' | 'no_outcome_change' }
-  | { action: 'notify' }
-  | { action: 'supersede_notify' };
+  | { action: 'notify'; predicateVersion: number }
+  | { action: 'supersede_notify'; predicateVersion: number };
 
 export interface ReportableTerminalCtx {
   fromStatus: SpaceTaskStatus | null;
@@ -44,6 +46,12 @@ export function applyAdministrativeGate(ctx: ReportableTerminalCtx): ReportableT
   return ctx.hasStartGeneration ? ctx : decided(ctx, { action: 'none', reason: 'administrative' });
 }
 
+export function applyArchiveGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return ctx.toStatus === 'archived'
+    ? decided(ctx, { action: 'none', reason: 'administrative' })
+    : ctx;
+}
+
 export function applySameOutcomeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
   return ctx.fromStatus === ctx.toStatus
     ? decided(ctx, { action: 'none', reason: 'no_outcome_change' })
@@ -51,16 +59,25 @@ export function applySameOutcomeGate(ctx: ReportableTerminalCtx): ReportableTerm
 }
 
 export function applySupersedeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
-  return ctx.hasPriorTerminalGeneration ? decided(ctx, { action: 'supersede_notify' }) : ctx;
+  return ctx.hasPriorTerminalGeneration
+    ? decided(ctx, {
+        action: 'supersede_notify',
+        predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,
+      })
+    : ctx;
 }
 
 export function applyNotifyGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
-  return decided(ctx, { action: 'notify' });
+  return decided(ctx, {
+    action: 'notify',
+    predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,
+  });
 }
 
 const reportableTerminalRun = decisionRun('reportable-terminal', [
   applyNotTerminalGate,
   applyAdministrativeGate,
+  applyArchiveGate,
   applySameOutcomeGate,
   applySupersedeGate,
   applyNotifyGate,

--- a/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
+++ b/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
@@ -59,7 +59,7 @@ export function applySameOutcomeGate(ctx: ReportableTerminalCtx): ReportableTerm
 }
 
 export function applySupersedeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
-  return ctx.hasPriorTerminalGeneration
+  return ctx.hasPriorTerminalGeneration && isTerminalStatus(ctx.fromStatus)
     ? decided(ctx, {
         action: 'supersede_notify',
         predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,

--- a/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
+++ b/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
@@ -1,0 +1,74 @@
+import { decisionRun } from '../runtime/decision-pipeline';
+import type { SpaceTaskStatus } from '@hyperneo/shared';
+
+export const TERMINAL_TASK_STATUSES: readonly SpaceTaskStatus[] = [
+  'done',
+  'blocked',
+  'cancelled',
+  'archived',
+];
+
+export type ReportableTerminalDecision =
+  | { action: 'none'; reason: 'not_terminal' | 'administrative' | 'no_outcome_change' }
+  | { action: 'notify' }
+  | { action: 'supersede_notify' };
+
+export interface ReportableTerminalCtx {
+  fromStatus: SpaceTaskStatus | null;
+  toStatus: SpaceTaskStatus;
+  hasStartGeneration: boolean;
+  hasPriorTerminalGeneration: boolean;
+  decision: ReportableTerminalDecision | null;
+}
+
+export type ReportableTerminalInput = Omit<ReportableTerminalCtx, 'decision'>;
+
+function decided(
+  ctx: ReportableTerminalCtx,
+  decision: ReportableTerminalDecision
+): ReportableTerminalCtx {
+  return { ...ctx, decision };
+}
+
+function isTerminalStatus(status: SpaceTaskStatus | null): boolean {
+  return status !== null && TERMINAL_TASK_STATUSES.includes(status);
+}
+
+export function applyNotTerminalGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return isTerminalStatus(ctx.toStatus)
+    ? ctx
+    : decided(ctx, { action: 'none', reason: 'not_terminal' });
+}
+
+export function applyAdministrativeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return ctx.hasStartGeneration ? ctx : decided(ctx, { action: 'none', reason: 'administrative' });
+}
+
+export function applySameOutcomeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return ctx.fromStatus === ctx.toStatus
+    ? decided(ctx, { action: 'none', reason: 'no_outcome_change' })
+    : ctx;
+}
+
+export function applySupersedeGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return ctx.hasPriorTerminalGeneration ? decided(ctx, { action: 'supersede_notify' }) : ctx;
+}
+
+export function applyNotifyGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
+  return decided(ctx, { action: 'notify' });
+}
+
+const reportableTerminalRun = decisionRun('reportable-terminal', [
+  applyNotTerminalGate,
+  applyAdministrativeGate,
+  applySameOutcomeGate,
+  applySupersedeGate,
+  applyNotifyGate,
+]);
+
+export function decideReportableTerminal(
+  input: ReportableTerminalInput
+): ReportableTerminalDecision {
+  const ctx = reportableTerminalRun(input);
+  return ctx.decision ?? { action: 'none', reason: 'not_terminal' };
+}

--- a/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
+++ b/packages/daemon/src/lib/space/goals/reportable-terminal-gates.ts
@@ -47,7 +47,7 @@ export function applyAdministrativeGate(ctx: ReportableTerminalCtx): ReportableT
 }
 
 export function applyArchiveGate(ctx: ReportableTerminalCtx): ReportableTerminalCtx {
-  return ctx.toStatus === 'archived'
+  return ctx.toStatus === 'archived' && isTerminalStatus(ctx.fromStatus)
     ? decided(ctx, { action: 'none', reason: 'administrative' })
     : ctx;
 }

--- a/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   decideReportableTerminal,
+  REPORTABLE_TERMINAL_PREDICATE_VERSION,
   type ReportableTerminalInput,
 } from '../../../../src/lib/space/goals/reportable-terminal-gates';
 
@@ -41,13 +42,54 @@ describe('decideReportableTerminal', () => {
     });
   });
 
+  describe('archival never produces a worker outcome notification', () => {
+    test('archives an already-done task', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'done',
+            toStatus: 'archived',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+
+    test('archives an already-blocked task', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'blocked',
+            toStatus: 'archived',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+
+    test('archives an already-cancelled task', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'cancelled',
+            toStatus: 'archived',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+  });
+
   describe('active-work completions notify', () => {
     test('notifies for in_progress → open → done (started, completed from open)', () => {
       expect(
         decideReportableTerminal(
           input({ fromStatus: 'open', toStatus: 'done', hasStartGeneration: true })
         )
-      ).toEqual({ action: 'notify' });
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
 
     test('notifies for in_progress → done', () => {
@@ -55,7 +97,7 @@ describe('decideReportableTerminal', () => {
         decideReportableTerminal(
           input({ fromStatus: 'in_progress', toStatus: 'done', hasStartGeneration: true })
         )
-      ).toEqual({ action: 'notify' });
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
 
     test('notifies for in_progress → cancelled after start', () => {
@@ -63,7 +105,7 @@ describe('decideReportableTerminal', () => {
         decideReportableTerminal(
           input({ fromStatus: 'in_progress', toStatus: 'cancelled', hasStartGeneration: true })
         )
-      ).toEqual({ action: 'notify' });
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
 
     test('notifies for review → approved → done', () => {
@@ -71,7 +113,7 @@ describe('decideReportableTerminal', () => {
         decideReportableTerminal(
           input({ fromStatus: 'approved', toStatus: 'done', hasStartGeneration: true })
         )
-      ).toEqual({ action: 'notify' });
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
   });
 
@@ -86,7 +128,10 @@ describe('decideReportableTerminal', () => {
             hasPriorTerminalGeneration: true,
           })
         )
-      ).toEqual({ action: 'supersede_notify' });
+      ).toEqual({
+        action: 'supersede_notify',
+        predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,
+      });
     });
 
     test('cancelled → done produces a new terminal generation superseding the record', () => {
@@ -99,7 +144,10 @@ describe('decideReportableTerminal', () => {
             hasPriorTerminalGeneration: true,
           })
         )
-      ).toEqual({ action: 'supersede_notify' });
+      ).toEqual({
+        action: 'supersede_notify',
+        predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,
+      });
     });
 
     test('in_progress → blocked → done supersedes the blocked record', () => {
@@ -112,7 +160,10 @@ describe('decideReportableTerminal', () => {
             hasPriorTerminalGeneration: true,
           })
         )
-      ).toEqual({ action: 'supersede_notify' });
+      ).toEqual({
+        action: 'supersede_notify',
+        predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION,
+      });
     });
   });
 
@@ -145,7 +196,7 @@ describe('decideReportableTerminal', () => {
         decideReportableTerminal(
           input({ fromStatus: null, toStatus: 'done', hasStartGeneration: true })
         )
-      ).toEqual({ action: 'notify' });
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
   });
 });

--- a/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decideReportableTerminal,
+  type ReportableTerminalInput,
+} from '../../../../src/lib/space/goals/reportable-terminal-gates';
+
+function input(overrides: Partial<ReportableTerminalInput> = {}): ReportableTerminalInput {
+  return {
+    fromStatus: 'open',
+    toStatus: 'done',
+    hasStartGeneration: true,
+    hasPriorTerminalGeneration: false,
+    ...overrides,
+  };
+}
+
+describe('decideReportableTerminal', () => {
+  describe('administrative transitions produce no notification', () => {
+    test('archives a queued/draft task with no start generation', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'draft', toStatus: 'archived', hasStartGeneration: false })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+
+    test('cancels a task before execution', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'open', toStatus: 'cancelled', hasStartGeneration: false })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+
+    test('completes an open task with no prior start (open → done)', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'open', toStatus: 'done', hasStartGeneration: false })
+        )
+      ).toEqual({ action: 'none', reason: 'administrative' });
+    });
+  });
+
+  describe('active-work completions notify', () => {
+    test('notifies for in_progress → open → done (started, completed from open)', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'open', toStatus: 'done', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify' });
+    });
+
+    test('notifies for in_progress → done', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'in_progress', toStatus: 'done', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify' });
+    });
+
+    test('notifies for in_progress → cancelled after start', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'in_progress', toStatus: 'cancelled', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify' });
+    });
+
+    test('notifies for review → approved → done', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'approved', toStatus: 'done', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify' });
+    });
+  });
+
+  describe('outcome-changing terminal-to-terminal transitions supersede + notify', () => {
+    test('blocked → done produces a new terminal generation superseding the record', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'blocked',
+            toStatus: 'done',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'supersede_notify' });
+    });
+
+    test('cancelled → done produces a new terminal generation superseding the record', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'cancelled',
+            toStatus: 'done',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'supersede_notify' });
+    });
+
+    test('in_progress → blocked → done supersedes the blocked record', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'blocked',
+            toStatus: 'done',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'supersede_notify' });
+    });
+  });
+
+  describe('same-terminal rewrites produce no new notification', () => {
+    test('done → done is a no-op', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'done',
+            toStatus: 'done',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'none', reason: 'no_outcome_change' });
+    });
+  });
+
+  describe('non-terminal target statuses', () => {
+    test('open → in_progress is not terminal', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'open', toStatus: 'in_progress', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'none', reason: 'not_terminal' });
+    });
+
+    test('null fromStatus to done with a start is a notify', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: null, toStatus: 'done', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify' });
+    });
+  });
+});

--- a/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
@@ -97,6 +97,19 @@ describe('decideReportableTerminal', () => {
         )
       ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
     });
+
+    test('archiving active work does not supersede a stale prior generation', () => {
+      expect(
+        decideReportableTerminal(
+          input({
+            fromStatus: 'review',
+            toStatus: 'archived',
+            hasStartGeneration: true,
+            hasPriorTerminalGeneration: true,
+          })
+        )
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
+    });
   });
 
   describe('active-work completions notify', () => {

--- a/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
+++ b/packages/daemon/tests/unit/5-space/goals/reportable-terminal-gates.test.ts
@@ -81,6 +81,22 @@ describe('decideReportableTerminal', () => {
         )
       ).toEqual({ action: 'none', reason: 'administrative' });
     });
+
+    test('reports archiving active work from review', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'review', toStatus: 'archived', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
+    });
+
+    test('reports archiving active work from approved', () => {
+      expect(
+        decideReportableTerminal(
+          input({ fromStatus: 'approved', toStatus: 'archived', hasStartGeneration: true })
+        )
+      ).toEqual({ action: 'notify', predicateVersion: REPORTABLE_TERMINAL_PREDICATE_VERSION });
+    });
   });
 
   describe('active-work completions notify', () => {


### PR DESCRIPTION
Closes #2740

## Summary
- Pure `decisionRun` core (`reportable-terminal-gates`) for the reportable-terminal predicate, per roadmap MC2 and ADR 0004.
- Input: `(fromStatus, toStatus, hasStartGeneration, hasPriorTerminalGeneration)`; output is exactly one of:
  - `none` (reason `not_terminal` / `administrative` / `no_outcome_change`) — archives of queued/draft, cancel-before-execution, `open → done` with no start, and same-status rewrites;
  - `notify` — transitions terminating previously active goal work (started tasks completing from `open`/`in_progress`/`approved`), keyed to the durable start generation, not the immediate prior status (covers `in_progress → open → done`);
  - `supersede_notify` — outcome-changing terminal-to-terminal transitions (`blocked → done`, `cancelled → done`) producing a new terminal generation superseding the prior record.
- Gates follow first-deciding-wins discipline; no I/O imports, no persistence.

## Non-goals
- Notification persistence / wake injection / goal revision machinery (MC2-B, MC2-C).
- Workflow-runtime refactors beyond the core.

## Test plan
- 13 pinned decision-table tests: administrative no-notify cases, active-work notifies (incl. the `in_progress → open → done` compound and `review → approved → done`), terminal-to-terminal supersedes, same-status no-op, non-terminal target.
- `bun run check` green (lint, types, knip, format, test-matrix).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->