### PR TITLE
fix(daemon): classify task-notification-origin results non-terminal for idle watch

### DIFF
--- a/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
+++ b/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
@@ -1,4 +1,4 @@
-import type { SDKMessage } from '@hyperneo/shared/sdk';
+import { getSdkResultOriginKind, type SDKMessage } from '@hyperneo/shared/sdk';
 
 export type LastMessageClassification =
   | { terminal: true; reason: string }
@@ -10,6 +10,10 @@ export function classifyLastMessageForIdleAgent(
   if (!message) return { terminal: false, reason: 'no SDK messages were recorded' };
 
   if (message.type === 'result') {
+    const isError = (message as { is_error?: unknown }).is_error === true;
+    if (!isError && getSdkResultOriginKind(message) === 'task-notification') {
+      return { terminal: false, reason: 'task-notification result awaits follow-up turn' };
+    }
     const subtype =
       typeof (message as { subtype?: unknown }).subtype === 'string'
         ? (message as { subtype: string }).subtype

--- a/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
+++ b/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
@@ -10,8 +10,7 @@ export function classifyLastMessageForIdleAgent(
   if (!message) return { terminal: false, reason: 'no SDK messages were recorded' };
 
   if (message.type === 'result') {
-    const isError = (message as { is_error?: unknown }).is_error === true;
-    if (!isError && getSdkResultOriginKind(message) === 'task-notification') {
+    if (isHollowTaskNotificationResult(message)) {
       return { terminal: false, reason: 'task-notification result awaits follow-up turn' };
     }
     const subtype =
@@ -63,6 +62,19 @@ export function classifyLastMessageForIdleAgent(
   }
 
   return { terminal: false, reason: 'assistant message has no terminal end_turn/result signal' };
+}
+
+function isHollowTaskNotificationResult(message: SDKMessage): boolean {
+  if ((message as { is_error?: unknown }).is_error === true) return false;
+  if (getSdkResultOriginKind(message) !== 'task-notification') return false;
+  const result = (message as { result?: unknown }).result;
+  if (typeof result === 'string' && result.trim().length > 0) return false;
+  const usage = (message as { usage?: unknown }).usage;
+  const inputTokens =
+    isRecord(usage) && typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const outputTokens =
+    isRecord(usage) && typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+  return inputTokens === 0 && outputTokens === 0;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/daemon/tests/unit/5-space/runtime/last-message-classifier.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/last-message-classifier.test.ts
@@ -39,6 +39,34 @@ describe('classifyLastMessageForIdleAgent', () => {
     });
   });
 
+  it('classifies a task-notification-origin result with non-empty text as terminal', () => {
+    const message = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: 'Background task output consumed; continuing.',
+      usage: { input_tokens: 0, output_tokens: 0 },
+      origin: { kind: 'task-notification' },
+    } as unknown as SDKMessage;
+    expect(classifyLastMessageForIdleAgent(message)).toEqual(
+      expect.objectContaining({ terminal: true })
+    );
+  });
+
+  it('classifies a task-notification-origin result with nonzero usage as terminal', () => {
+    const message = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: '',
+      usage: { input_tokens: 12, output_tokens: 34 },
+      origin: { kind: 'task-notification' },
+    } as unknown as SDKMessage;
+    expect(classifyLastMessageForIdleAgent(message)).toEqual(
+      expect.objectContaining({ terminal: true })
+    );
+  });
+
   it('classifies an error-flagged task-notification-origin result as terminal (part-3 territory)', () => {
     const message = {
       type: 'result',

--- a/packages/daemon/tests/unit/5-space/runtime/last-message-classifier.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/last-message-classifier.test.ts
@@ -24,6 +24,45 @@ describe('classifyLastMessageForIdleAgent', () => {
     );
   });
 
+  it('classifies a hollow task-notification-origin result as non-terminal', () => {
+    const message = {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: '',
+      usage: { input_tokens: 0, output_tokens: 0 },
+      origin: { kind: 'task-notification' },
+    } as unknown as SDKMessage;
+    expect(classifyLastMessageForIdleAgent(message)).toEqual({
+      terminal: false,
+      reason: 'task-notification result awaits follow-up turn',
+    });
+  });
+
+  it('classifies an error-flagged task-notification-origin result as terminal (part-3 territory)', () => {
+    const message = {
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      origin: { kind: 'task-notification' },
+    } as unknown as SDKMessage;
+    expect(classifyLastMessageForIdleAgent(message)).toEqual(
+      expect.objectContaining({ terminal: true })
+    );
+  });
+
+  it('classifies an api-error result (subtype success, is_error true) as terminal', () => {
+    const message = {
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      result: 'API Error: Connection refused (ConnectionRefused)',
+    } as unknown as SDKMessage;
+    expect(classifyLastMessageForIdleAgent(message)).toEqual(
+      expect.objectContaining({ terminal: true })
+    );
+  });
+
   it('classifies a system task-progress signal as non-terminal (active work)', () => {
     for (const subtype of ['task_started', 'task_progress', 'task_updated']) {
       const message = {


### PR DESCRIPTION
Part 2 of #2726. A hollow task-notification result (0 tokens, empty text) is the CLI handing a completed background task to the host, not a finished model turn — but `classifyLastMessageForIdleAgent` treated every result as terminal, so the 15-min non-terminal-idle nudge stood down and the session parked silently.

A result now classifies non-terminal (reason "task-notification result awaits follow-up turn") only when it matches the hollow handoff shape: `is_error` not true, `origin.kind === "task-notification"` via the part-1 `getSdkResultOriginKind` guard, empty/absent result text, and zero input+output usage tokens. All-zero usage proves no model ran, so legitimately-empty real turns are unaffected; a task-notification-origin result with real content stays terminal. Error-flagged results stay terminal — part 3 owns those via the terminal-error continue path.

Net effect: the existing runtime nudge (`buildNonTerminalIdleNudgeMessage`) fires as the recovery backstop and starts the follow-up turn that consumes the notification.

Tests cover the full boundary: hollow → non-terminal; non-empty text or nonzero usage or `is_error:true` (with or without the origin) → terminal.