### PR TITLE
refactor(agent): extract pure circuit-breaker transition core

### DIFF
--- a/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
+++ b/packages/daemon/src/lib/agent/api-error-circuit-breaker.ts
@@ -1,47 +1,21 @@
 import { Logger } from '../logger';
-import { TRANSIENT_CONNECTION_ERROR_REGEXES } from './transient-error-patterns';
-import { PROMPT_TOO_LONG_RE, matchPromptTooLong } from '@hyperneo/shared/provider/error-taxonomy';
-
-interface ErrorOccurrence {
-  pattern: string;
-  timestamp: number;
-  fullMessage: string;
-}
-
-export interface CircuitBreakerState {
-  isTripped: boolean;
-  tripReason: string | null;
-  tripCount: number;
-  lastTripTime: number | null;
-}
-
-export interface CircuitBreakerConfig {
-  errorThreshold: number;
-  timeWindowMs: number;
-  cooldownMs: number;
-  rapidFireThreshold: number;
-  rapidFireWindowMs: number;
-}
-
-const DEFAULT_CONFIG: CircuitBreakerConfig = {
-  errorThreshold: 3,
-  timeWindowMs: 30000,
-  cooldownMs: 60000,
-  rapidFireThreshold: 30,
-  rapidFireWindowMs: 3000,
-};
-
-const FATAL_ERROR_PATTERNS = [
-  PROMPT_TOO_LONG_RE,
-  /invalid_request_error/i,
-  /Error:\s*Connection\s+error/i,
-  /Connection\s+error/i,
-  /ImageSizeError/i,
-  /Image.*size.*exceeds.*limit/i,
-  /image.*base64.*size.*exceeds/i,
-];
-
-const TRANSIENT_CONNECTION_PATTERNS = TRANSIENT_CONNECTION_ERROR_REGEXES;
+import type {
+  CircuitBreakerConfig,
+  CircuitBreakerState,
+  ErrorOccurrence,
+} from './circuit-breaker-transitions';
+import {
+  advanceRapidFire,
+  applyReset,
+  applyTrip,
+  buildTripMessage,
+  DEFAULT_CIRCUIT_BREAKER_CONFIG,
+  extractErrorPattern,
+  extractMessageText,
+  matchesTransientConnectionPattern,
+  recordError,
+  shouldReleaseCooldown,
+} from './circuit-breaker-transitions';
 
 export class ApiErrorCircuitBreaker {
   private logger: Logger;
@@ -59,58 +33,11 @@ export class ApiErrorCircuitBreaker {
 
   constructor(sessionId: string, config: Partial<CircuitBreakerConfig> = {}) {
     this.logger = new Logger(`CircuitBreaker ${sessionId}`);
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.config = { ...DEFAULT_CIRCUIT_BREAKER_CONFIG, ...config };
   }
 
   setOnTripCallback(callback: (reason: string, errorCount: number) => Promise<void>): void {
     this.onTrip = callback;
-  }
-
-  private extractErrorPattern(messageContent: string): string | null {
-    if (
-      /ImageSizeError/i.test(messageContent) ||
-      /image.*size.*exceeds.*limit/i.test(messageContent)
-    ) {
-      return 'image_size_error';
-    }
-
-    const stderrMatch = messageContent.match(
-      /<local-command-stderr>([\s\S]*?)<\/local-command-stderr>/
-    );
-    if (stderrMatch) {
-      const errorContent = stderrMatch[1];
-
-      for (const pattern of FATAL_ERROR_PATTERNS) {
-        if (pattern.test(errorContent)) {
-          const promptTooLong = matchPromptTooLong(errorContent);
-          if (promptTooLong) {
-            return promptTooLong.maxTokens !== undefined
-              ? `prompt_too_long:${promptTooLong.maxTokens}`
-              : 'prompt_too_long';
-          }
-
-          if (/Connection\s+error/i.test(errorContent)) {
-            return 'connection_error';
-          }
-
-          if (/ImageSizeError/i.test(errorContent) || /image.*size.*exceeds/i.test(errorContent)) {
-            return 'image_size_error';
-          }
-
-          return 'invalid_request_error';
-        }
-      }
-
-      const apiErrorMatch = errorContent.match(/Error:\s*(\d{3})\s*\{/);
-      if (apiErrorMatch) {
-        const statusCode = apiErrorMatch[1];
-        if (statusCode === '400' || statusCode === '429') {
-          return `api_error:${statusCode}`;
-        }
-      }
-    }
-
-    return null;
   }
 
   async checkMessage(message: unknown): Promise<boolean> {
@@ -124,74 +51,50 @@ export class ApiErrorCircuitBreaker {
     }
 
     const now = Date.now();
-
     const agentContext = msg.parent_tool_use_id ?? 'main';
 
-    let agentTimestamps = this.messageTimestampsByAgent.get(agentContext);
-    if (!agentTimestamps) {
-      agentTimestamps = [];
-      this.messageTimestampsByAgent.set(agentContext, agentTimestamps);
-    }
-    agentTimestamps.push(now);
+    const rapidFire = advanceRapidFire({
+      timestamps: this.messageTimestampsByAgent.get(agentContext) ?? [],
+      now,
+      windowMs: this.config.rapidFireWindowMs,
+      threshold: this.config.rapidFireThreshold,
+    });
+    this.messageTimestampsByAgent.set(agentContext, rapidFire.timestamps);
 
-    const rapidFireCutoff = now - this.config.rapidFireWindowMs;
-    const filteredTimestamps = agentTimestamps.filter((t) => t > rapidFireCutoff);
-    this.messageTimestampsByAgent.set(agentContext, filteredTimestamps);
-
-    if (filteredTimestamps.length >= this.config.rapidFireThreshold) {
-      await this.trip('rapid_fire', filteredTimestamps.length);
+    if (rapidFire.shouldTrip) {
+      await this.trip('rapid_fire', rapidFire.timestamps.length);
       return true;
     }
 
-    const content = msg.message?.content;
-    let messageText = '';
-
-    if (typeof content === 'string') {
-      messageText = content;
-    } else if (Array.isArray(content)) {
-      for (const block of content) {
-        if (typeof block === 'object' && block !== null) {
-          const b = block as { type?: string; text?: string; content?: string };
-          if (b.type === 'text' && b.text) {
-            messageText += b.text;
-          } else if (b.type === 'tool_result' && b.content) {
-            messageText += b.content;
-          }
-        }
-      }
-    }
+    const messageText = extractMessageText(msg.message?.content);
 
     if (!messageText) {
       return false;
     }
 
-    const errorPattern = this.extractErrorPattern(messageText);
+    const errorPattern = extractErrorPattern(messageText);
 
     if (!errorPattern) {
-      for (const pattern of TRANSIENT_CONNECTION_PATTERNS) {
-        if (pattern.test(messageText)) {
-          return false;
-        }
+      if (matchesTransientConnectionPattern(messageText)) {
+        return false;
       }
-    }
-
-    if (!errorPattern) {
       return false;
     }
 
-    this.recentErrors.push({
-      pattern: errorPattern,
-      timestamp: now,
-      fullMessage: messageText.substring(0, 200),
+    const evaluation = recordError({
+      errors: this.recentErrors,
+      occurrence: {
+        pattern: errorPattern,
+        timestamp: now,
+        fullMessage: messageText.substring(0, 200),
+      },
+      timeWindowMs: this.config.timeWindowMs,
+      errorThreshold: this.config.errorThreshold,
     });
+    this.recentErrors = evaluation.errors;
 
-    const cutoff = now - this.config.timeWindowMs;
-    this.recentErrors = this.recentErrors.filter((e) => e.timestamp > cutoff);
-
-    const patternCount = this.recentErrors.filter((e) => e.pattern === errorPattern).length;
-
-    if (patternCount >= this.config.errorThreshold) {
-      await this.trip(errorPattern, patternCount);
+    if (evaluation.shouldTrip) {
+      await this.trip(errorPattern, evaluation.patternCount);
       return true;
     }
 
@@ -199,10 +102,7 @@ export class ApiErrorCircuitBreaker {
   }
 
   private async trip(reason: string, errorCount: number): Promise<void> {
-    this.state.isTripped = true;
-    this.state.tripReason = reason;
-    this.state.tripCount++;
-    this.state.lastTripTime = Date.now();
+    this.state = applyTrip(this.state, reason, Date.now());
 
     this.recentErrors = [];
 
@@ -216,8 +116,7 @@ export class ApiErrorCircuitBreaker {
   }
 
   reset(): void {
-    this.state.isTripped = false;
-    this.state.tripReason = null;
+    this.state = applyReset(this.state);
     this.recentErrors = [];
     this.messageTimestampsByAgent.clear();
   }
@@ -231,97 +130,13 @@ export class ApiErrorCircuitBreaker {
   }
 
   isTripped(): boolean {
-    if (this.state.isTripped && this.state.lastTripTime) {
-      const elapsed = Date.now() - this.state.lastTripTime;
-      if (elapsed > this.config.cooldownMs) {
-        this.reset();
-      }
+    if (shouldReleaseCooldown(this.state, Date.now(), this.config.cooldownMs)) {
+      this.reset();
     }
     return this.state.isTripped;
   }
 
   getTripMessage(): string {
-    if (!this.state.tripReason) {
-      return 'Unknown error';
-    }
-
-    if (this.state.tripReason === 'rapid_fire') {
-      return `Rapid message loop detected and stopped.
-
-**What happened:**
-- The system detected an abnormal message pattern (too many messages in a short time)
-- This usually indicates an SDK error loop that was automatically stopped
-
-**What to do:**
-- The session has been paused to prevent resource waste
-- Try your request again - if the issue persists, the underlying error needs to be addressed
-- Consider starting a new session if the problem continues`;
-    }
-
-    if (this.state.tripReason.startsWith('prompt_too_long')) {
-      const maxTokens = this.state.tripReason.split(':')[1];
-      const header = maxTokens
-        ? `Context limit exceeded (${maxTokens} tokens maximum).`
-        : 'Context limit exceeded.';
-      return `${header}
-
-**Possible causes:**
-- A single tool output was extremely large (e.g., huge file, massive diff)
-- The conversation context has grown too large
-
-**What to do:**
-- Output limiting is now **enabled by default** to prevent this
-- If you still see this error, reduce the output limits in HyperNeo's global
-  settings (outputLimiter section):
-  - outputLimiter.bash.headLines (default: 100)
-  - outputLimiter.bash.tailLines (default: 200)
-  - outputLimiter.read.maxLines (default: 1000)
-  - outputLimiter.grep.maxMatches (default: 250)
-- Use filtering in tools (e.g., grep with patterns, head/tail for files)
-- Start a new session if context is too large
-- Use /compact to reduce conversation context`;
-    }
-
-    if (this.state.tripReason === 'invalid_request_error') {
-      return 'The API rejected the request. This usually means the conversation context is too large or malformed.';
-    }
-
-    if (this.state.tripReason === 'image_size_error') {
-      return `Image size exceeds API limit (5 MB for base64-encoded data).
-
-**What happened:**
-- The image you uploaded is too large after base64 encoding
-- Base64 encoding increases file size by ~33%
-
-**What to do:**
-- Resize the image to under 3.75 MB before uploading
-- Use image compression tools to reduce file size
-- Consider using a lower resolution or cropping the image`;
-    }
-
-    if (this.state.tripReason === 'connection_error') {
-      return `Connection error detected repeatedly.
-
-**Possible causes:**
-- Network connectivity issues
-- API service temporarily unavailable
-- Firewall or proxy blocking the connection
-
-**What to do:**
-- Check your internet connection
-- Verify your API key is valid and has not expired
-- Try again in a few moments
-- If the problem persists, check the Anthropic API status page`;
-    }
-
-    if (this.state.tripReason.startsWith('api_error:')) {
-      const statusCode = this.state.tripReason.split(':')[1];
-      if (statusCode === '429') {
-        return 'Rate limit exceeded. Please wait a moment before continuing.';
-      }
-      return `API error (${statusCode}). The request could not be processed.`;
-    }
-
-    return `Error detected: ${this.state.tripReason}`;
+    return buildTripMessage(this.state.tripReason);
   }
 }

--- a/packages/daemon/src/lib/agent/circuit-breaker-transitions.ts
+++ b/packages/daemon/src/lib/agent/circuit-breaker-transitions.ts
@@ -1,0 +1,254 @@
+import { matchPromptTooLong, PROMPT_TOO_LONG_RE } from '@hyperneo/shared/provider/error-taxonomy';
+import { TRANSIENT_CONNECTION_ERROR_REGEXES } from './transient-error-patterns';
+
+export interface ErrorOccurrence {
+  pattern: string;
+  timestamp: number;
+  fullMessage: string;
+}
+
+export interface CircuitBreakerState {
+  isTripped: boolean;
+  tripReason: string | null;
+  tripCount: number;
+  lastTripTime: number | null;
+}
+
+export interface CircuitBreakerConfig {
+  errorThreshold: number;
+  timeWindowMs: number;
+  cooldownMs: number;
+  rapidFireThreshold: number;
+  rapidFireWindowMs: number;
+}
+
+export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
+  errorThreshold: 3,
+  timeWindowMs: 30000,
+  cooldownMs: 60000,
+  rapidFireThreshold: 30,
+  rapidFireWindowMs: 3000,
+};
+
+const FATAL_ERROR_PATTERNS = [
+  PROMPT_TOO_LONG_RE,
+  /invalid_request_error/i,
+  /Error:\s*Connection\s+error/i,
+  /Connection\s+error/i,
+  /ImageSizeError/i,
+  /Image.*size.*exceeds.*limit/i,
+  /image.*base64.*size.*exceeds/i,
+];
+
+const TRANSIENT_CONNECTION_PATTERNS = TRANSIENT_CONNECTION_ERROR_REGEXES;
+
+export function extractMessageText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  let messageText = '';
+  for (const block of content) {
+    if (typeof block === 'object' && block !== null) {
+      const b = block as { type?: string; text?: string; content?: string };
+      if (b.type === 'text' && b.text) {
+        messageText += b.text;
+      } else if (b.type === 'tool_result' && b.content) {
+        messageText += b.content;
+      }
+    }
+  }
+  return messageText;
+}
+
+export function extractErrorPattern(messageContent: string): string | null {
+  if (
+    /ImageSizeError/i.test(messageContent) ||
+    /image.*size.*exceeds.*limit/i.test(messageContent)
+  ) {
+    return 'image_size_error';
+  }
+
+  const stderrMatch = messageContent.match(
+    /<local-command-stderr>([\s\S]*?)<\/local-command-stderr>/
+  );
+  if (stderrMatch) {
+    const errorContent = stderrMatch[1];
+
+    for (const pattern of FATAL_ERROR_PATTERNS) {
+      if (pattern.test(errorContent)) {
+        const promptTooLong = matchPromptTooLong(errorContent);
+        if (promptTooLong) {
+          return promptTooLong.maxTokens !== undefined
+            ? `prompt_too_long:${promptTooLong.maxTokens}`
+            : 'prompt_too_long';
+        }
+
+        if (/Connection\s+error/i.test(errorContent)) {
+          return 'connection_error';
+        }
+
+        if (/ImageSizeError/i.test(errorContent) || /image.*size.*exceeds/i.test(errorContent)) {
+          return 'image_size_error';
+        }
+
+        return 'invalid_request_error';
+      }
+    }
+
+    const apiErrorMatch = errorContent.match(/Error:\s*(\d{3})\s*\{/);
+    if (apiErrorMatch) {
+      const statusCode = apiErrorMatch[1];
+      if (statusCode === '400' || statusCode === '429') {
+        return `api_error:${statusCode}`;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function matchesTransientConnectionPattern(messageText: string): boolean {
+  for (const pattern of TRANSIENT_CONNECTION_PATTERNS) {
+    if (pattern.test(messageText)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function advanceRapidFire(args: {
+  timestamps: number[];
+  now: number;
+  windowMs: number;
+  threshold: number;
+}): { timestamps: number[]; shouldTrip: boolean } {
+  const cutoff = args.now - args.windowMs;
+  const timestamps = [...args.timestamps, args.now].filter((t) => t > cutoff);
+  return { timestamps, shouldTrip: timestamps.length >= args.threshold };
+}
+
+export function recordError(args: {
+  errors: ErrorOccurrence[];
+  occurrence: ErrorOccurrence;
+  timeWindowMs: number;
+  errorThreshold: number;
+}): { errors: ErrorOccurrence[]; shouldTrip: boolean; patternCount: number } {
+  const cutoff = args.occurrence.timestamp - args.timeWindowMs;
+  const errors = [...args.errors, args.occurrence].filter((e) => e.timestamp > cutoff);
+  const patternCount = errors.filter((e) => e.pattern === args.occurrence.pattern).length;
+  return { errors, shouldTrip: patternCount >= args.errorThreshold, patternCount };
+}
+
+export function applyTrip(
+  state: CircuitBreakerState,
+  reason: string,
+  now: number
+): CircuitBreakerState {
+  return {
+    isTripped: true,
+    tripReason: reason,
+    tripCount: state.tripCount + 1,
+    lastTripTime: now,
+  };
+}
+
+export function applyReset(state: CircuitBreakerState): CircuitBreakerState {
+  return { ...state, isTripped: false, tripReason: null };
+}
+
+export function shouldReleaseCooldown(
+  state: CircuitBreakerState,
+  now: number,
+  cooldownMs: number
+): boolean {
+  if (!state.isTripped || !state.lastTripTime) return false;
+  return now - state.lastTripTime > cooldownMs;
+}
+
+export function buildTripMessage(tripReason: string | null): string {
+  if (!tripReason) {
+    return 'Unknown error';
+  }
+
+  if (tripReason === 'rapid_fire') {
+    return `Rapid message loop detected and stopped.
+
+**What happened:**
+- The system detected an abnormal message pattern (too many messages in a short time)
+- This usually indicates an SDK error loop that was automatically stopped
+
+**What to do:**
+- The session has been paused to prevent resource waste
+- Try your request again - if the issue persists, the underlying error needs to be addressed
+- Consider starting a new session if the problem continues`;
+  }
+
+  if (tripReason.startsWith('prompt_too_long')) {
+    const maxTokens = tripReason.split(':')[1];
+    const header = maxTokens
+      ? `Context limit exceeded (${maxTokens} tokens maximum).`
+      : 'Context limit exceeded.';
+    return `${header}
+
+**Possible causes:**
+- A single tool output was extremely large (e.g., huge file, massive diff)
+- The conversation context has grown too large
+
+**What to do:**
+- Output limiting is now **enabled by default** to prevent this
+- If you still see this error, reduce the output limits in HyperNeo's global
+  settings (outputLimiter section):
+  - outputLimiter.bash.headLines (default: 100)
+  - outputLimiter.bash.tailLines (default: 200)
+  - outputLimiter.read.maxLines (default: 1000)
+  - outputLimiter.grep.maxMatches (default: 250)
+- Use filtering in tools (e.g., grep with patterns, head/tail for files)
+- Start a new session if context is too large
+- Use /compact to reduce conversation context`;
+  }
+
+  if (tripReason === 'invalid_request_error') {
+    return 'The API rejected the request. This usually means the conversation context is too large or malformed.';
+  }
+
+  if (tripReason === 'image_size_error') {
+    return `Image size exceeds API limit (5 MB for base64-encoded data).
+
+**What happened:**
+- The image you uploaded is too large after base64 encoding
+- Base64 encoding increases file size by ~33%
+
+**What to do:**
+- Resize the image to under 3.75 MB before uploading
+- Use image compression tools to reduce the size
+- Consider using a lower resolution or cropping the image`;
+  }
+
+  if (tripReason === 'connection_error') {
+    return `Connection error detected repeatedly.
+
+**Possible causes:**
+- Network connectivity issues
+- API service temporarily unavailable
+- Firewall or proxy blocking the connection
+
+**What to do:**
+- Check your internet connection
+- Verify your API key is valid and has not expired
+- Try again in a few moments
+- If the problem persists, check the Anthropic API status page`;
+  }
+
+  if (tripReason.startsWith('api_error:')) {
+    const statusCode = tripReason.split(':')[1];
+    if (statusCode === '429') {
+      return 'Rate limit exceeded. Please wait a moment before continuing.';
+    }
+    return `API error (${statusCode}). The request could not be processed.`;
+  }
+
+  return `Error detected: ${tripReason}`;
+}

--- a/packages/daemon/src/lib/agent/circuit-breaker-transitions.ts
+++ b/packages/daemon/src/lib/agent/circuit-breaker-transitions.ts
@@ -223,7 +223,7 @@ export function buildTripMessage(tripReason: string | null): string {
 
 **What to do:**
 - Resize the image to under 3.75 MB before uploading
-- Use image compression tools to reduce the size
+- Use image compression tools to reduce file size
 - Consider using a lower resolution or cropping the image`;
   }
 

--- a/packages/daemon/tests/unit/1-core/agent/api-error-circuit-breaker.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/api-error-circuit-breaker.test.ts
@@ -897,6 +897,7 @@ describe('ApiErrorCircuitBreaker', () => {
         const cb = new ApiErrorCircuitBreaker('s', { errorThreshold: 1 });
         await cb.checkMessage(userMessage('ImageSizeError: file too large'));
         expect(cb.getTripMessage()).toContain('Image size exceeds API limit');
+        expect(cb.getTripMessage()).toContain('- Use image compression tools to reduce file size');
       });
 
       it('renders the bare prompt_too_long message without a token count', async () => {


### PR DESCRIPTION
Policy-core pilot PR 2 of 2 for `api-error-circuit-breaker.ts` (task #1219, follows #2733): the circuit-breaker state transitions move into a new pure module `circuit-breaker-transitions.ts` (pattern/text extraction, rapid-fire and error-threshold evaluation, trip/reset/cooldown-release state functions, trip-message rendering, default config), and `ApiErrorCircuitBreaker` becomes a snapshot-reader + interpreter that keeps `Date.now()`, the logger, the onTrip callback, and the mutable accumulators, per ADR 0004's resource-ownership rule.

Zero behavior change: all 57 characterization pins from #2733 pass unchanged. Parity details the reviewer flagged are preserved — `FATAL_ERROR_PATTERNS` order is byte-identical (prompt_too_long before connection_error, pinned by the precedence test), the cooldown release keeps `lastTripTime` truthiness (not `!== null`), and counting stays rate-based within windows. Plain pure functions rather than `decisionRun` — the transitions are a fold with recording, not a decide-once gate list, and the task sanctions plain functions when simpler.

Verified: `bunx tsc --noEmit`, `bun test tests/unit/1-core/agent/` (breaker files 0 fail; the 5 query-runner single-process failures are the pre-existing ones reproduced on a clean tree in #2733). CI runs the full shard split.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->