### PR TITLE
feat(space): per-goal revision counter + per-task terminal generation (MC2-B)

### DIFF
--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -289,7 +289,9 @@ export class SpaceGoalService {
     return { goal: updatedGoal, task, queued: false };
   }
 
-  handleTaskTerminal(taskId: string): { goal: SpaceGoal; nextTask: SpaceTask | null } | null {
+  handleTaskTerminal(
+    taskId: string
+  ): { goal: SpaceGoal; nextTask: SpaceTask | null; terminalGeneration: number } | null {
     const task = this.deps.taskRepo.getTask(taskId);
     if (!task?.goalId) return null;
     if (!isTerminalTaskStatus(task.status)) return null;
@@ -303,11 +305,12 @@ export class SpaceGoalService {
       note: `Task reached terminal status: ${task.status}`,
     });
     if (task.status === 'done') this.deps.goalAutomationService?.onTaskCompleted(taskId);
+    const terminalGeneration = task.terminalGeneration;
     if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
-      return { goal: fresh, nextTask: null };
+      return { goal: fresh, nextTask: null, terminalGeneration };
     }
     const created = this.createImmediateTask(fresh.id, { source: 'system' });
-    return { goal: created.goal, nextTask: created.task };
+    return { goal: created.goal, nextTask: created.task, terminalGeneration };
   }
 
   canClaimScheduledTask(task: Pick<SpaceTask, 'spaceId' | 'goalId'>): {

--- a/packages/daemon/src/storage/repositories/space-goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-repository.ts
@@ -35,8 +35,8 @@ export class SpaceGoalRepository {
 					id, space_id, title, description, status, type, priority, labels, metrics,
 					summary, progress, next_steps, preferred_workflow_id, auto_trigger_next,
 					pending_next_run, active_task_id, last_task_id, last_check_in_at,
-					next_check_in_at, created_at, updated_at, completed_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					next_check_in_at, created_at, updated_at, completed_at, revision
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -60,7 +60,8 @@ export class SpaceGoalRepository {
         null,
         now,
         now,
-        null
+        null,
+        1
       );
     this.reactiveDb?.notifyChange('space_goals');
     return this.getById(id) as SpaceGoal;
@@ -143,8 +144,8 @@ export class SpaceGoalRepository {
     }
 
     if (sets.length === 0) return this.getById(id);
-    add('updated_at', Date.now());
-    values.push(id);
+    sets.push(`updated_at = ?`, `revision = revision + 1`);
+    values.push(Date.now(), id);
     this.db.prepare(`UPDATE space_goals SET ${sets.join(', ')} WHERE id = ?`).run(...values);
     this.reactiveDb?.notifyChange('space_goals');
     return this.getById(id);
@@ -152,7 +153,9 @@ export class SpaceGoalRepository {
 
   setTaskScheduleId(id: string, scheduleId: string | null): SpaceGoal | null {
     this.db
-      .prepare(`UPDATE space_goals SET task_schedule_id = ?, updated_at = ? WHERE id = ?`)
+      .prepare(
+        `UPDATE space_goals SET task_schedule_id = ?, updated_at = ?, revision = revision + 1 WHERE id = ?`
+      )
       .run(scheduleId, Date.now(), id);
     this.reactiveDb?.notifyChange('space_goals');
     return this.getById(id);
@@ -163,7 +166,7 @@ export class SpaceGoalRepository {
       .prepare(
         `UPDATE space_goals
 				 SET active_task_id = ?, last_task_id = ?, pending_next_run = 0,
-				     last_check_in_at = ?, updated_at = ?
+				     last_check_in_at = ?, updated_at = ?, revision = revision + 1
 				 WHERE id = ? AND status = 'active' AND active_task_id IS NULL`
       )
       .run(taskId, taskId, Date.now(), Date.now(), goalId);
@@ -179,7 +182,7 @@ export class SpaceGoalRepository {
     const result = this.db
       .prepare(
         `UPDATE space_goals
-				 SET active_task_id = NULL, last_task_id = ?, updated_at = ?
+				 SET active_task_id = NULL, last_task_id = ?, updated_at = ?, revision = revision + 1
 				 WHERE id = ? AND active_task_id = ?`
       )
       .run(taskId, Date.now(), goalId, taskId);
@@ -212,6 +215,7 @@ export class SpaceGoalRepository {
       createdAt: row.created_at as number,
       updatedAt: row.updated_at as number,
       completedAt: (row.completed_at as number | null) ?? null,
+      revision: (row.revision as number) ?? 0,
     };
   }
 }

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -716,7 +716,9 @@ export class SpaceTaskRepository {
   archiveTask(id: string): SpaceTask | null {
     const now = Date.now();
     const stmt = this.db.prepare(
-      `UPDATE space_tasks SET status = 'archived', archived_at = ?, updated_at = ? WHERE id = ?`
+      `UPDATE space_tasks SET status = 'archived', archived_at = ?, updated_at = ?,
+        terminal_generation = terminal_generation + CASE WHEN status = 'archived' THEN 0 ELSE 1 END
+       WHERE id = ?`
     );
     stmt.run(now, now, id);
     this.upsertTaskSearchRow(id);

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -167,10 +167,11 @@ export class SpaceTaskRepository {
           .get(params.spaceId) as { next: number }
       ).next;
 
+      const initialStatus = params.status ?? 'open';
       this.db
         .prepare(
-          `INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, evolution_scope_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          `INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, goal_id, evolution_scope_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at, terminal_generation)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           id,
@@ -178,7 +179,7 @@ export class SpaceTaskRepository {
           nextNumber,
           params.title,
           params.description ?? '',
-          params.status ?? 'open',
+          initialStatus,
           params.priority ?? 'normal',
           JSON.stringify(params.labels ?? []),
           params.workflowRunId ?? null,
@@ -192,7 +193,8 @@ export class SpaceTaskRepository {
           params.createdBySession ?? null,
           params.createdByTaskScheduleId ?? null,
           now,
-          now
+          now,
+          isTerminalStatus(initialStatus) ? 1 : 0
         );
     });
 

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -453,6 +453,9 @@ export class SpaceTaskRepository {
         fields.push('archived_at = ?');
         values.push(Date.now());
       }
+      if (isTerminalStatus(params.status)) {
+        fields.push('terminal_generation = terminal_generation + 1');
+      }
     }
     if (params.priority !== undefined) {
       fields.push('priority = ?');
@@ -842,8 +845,15 @@ export class SpaceTaskRepository {
       startedAt: (row.started_at as number | null) ?? null,
       completedAt: (row.completed_at as number | null) ?? null,
       updatedAt: (row.updated_at as number | null) ?? (row.created_at as number),
+      terminalGeneration: (row.terminal_generation as number) ?? 0,
     };
   }
+}
+
+function isTerminalStatus(status: SpaceTaskStatus): boolean {
+  return (
+    status === 'done' || status === 'blocked' || status === 'cancelled' || status === 'archived'
+  );
 }
 
 function parseRestrictions(raw: unknown): TaskRestriction | null {

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -454,7 +454,10 @@ export class SpaceTaskRepository {
         values.push(Date.now());
       }
       if (isTerminalStatus(params.status)) {
-        fields.push('terminal_generation = terminal_generation + 1');
+        fields.push(
+          `terminal_generation = terminal_generation + CASE WHEN status = ? THEN 0 ELSE 1 END`
+        );
+        values.push(params.status);
       }
     }
     if (params.priority !== undefined) {
@@ -632,9 +635,19 @@ export class SpaceTaskRepository {
     const expectedStatuses = Array.isArray(expected) ? [...expected] : [expected];
     if (expectedStatuses.length === 0) return 'superseded';
     const placeholders = expectedStatuses.map(() => '?').join(', ');
+    const sets = ['status = ?'];
+    const values: SQLiteValue[] = [next];
+    if (isTerminalStatus(next)) {
+      sets.push(
+        `terminal_generation = terminal_generation + CASE WHEN status = ? THEN 0 ELSE 1 END`
+      );
+      values.push(next);
+    }
     const result = this.db
-      .prepare(`UPDATE space_tasks SET status = ? WHERE id = ? AND status IN (${placeholders})`)
-      .run(next, taskId, ...expectedStatuses);
+      .prepare(
+        `UPDATE space_tasks SET ${sets.join(', ')} WHERE id = ? AND status IN (${placeholders})`
+      )
+      .run(...values, taskId, ...expectedStatuses);
     return result.changes > 0 ? 'won' : 'superseded';
   }
 
@@ -657,6 +670,12 @@ export class SpaceTaskRepository {
     if (next === 'in_progress') {
       sets.push('started_at = ?', 'completed_at = ?');
       values.push(now, null);
+    }
+    if (isTerminalStatus(next)) {
+      sets.push(
+        `terminal_generation = terminal_generation + CASE WHEN status = ? THEN 0 ELSE 1 END`
+      );
+      values.push(next);
     }
     const result = this.db
       .prepare(

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -430,6 +430,7 @@ export function createTables(db: BunDatabase): void {
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL,
         completed_at INTEGER,
+        revision INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
       )
     `);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -445,6 +445,8 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   run(migrationMarkerKey(202), () => runMigration202(db));
 
   run(migrationMarkerKey(203), () => runMigration203(db));
+
+  run(migrationMarkerKey(204), () => runMigration204(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -9548,4 +9550,13 @@ export function runMigration203(db: BunDatabase): void {
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner
     ON space_long_horizon_agent_goals(goal_id)
     WHERE relationship = 'owner'`);
+}
+
+export function runMigration204(db: BunDatabase): void {
+  if (tableExists(db, 'space_goals') && !tableHasColumn(db, 'space_goals', 'revision')) {
+    db.exec(`ALTER TABLE space_goals ADD COLUMN revision INTEGER NOT NULL DEFAULT 0`);
+  }
+  if (tableExists(db, 'space_tasks') && !tableHasColumn(db, 'space_tasks', 'terminal_generation')) {
+    db.exec(`ALTER TABLE space_tasks ADD COLUMN terminal_generation INTEGER NOT NULL DEFAULT 0`);
+  }
 }

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1002,5 +1002,23 @@ describe('SpaceGoalService', () => {
     taskRepo.updateTask(task.task!.id, { status: 'cancelled' });
     const reopened = taskRepo.getTask(task.task!.id);
     expect(reopened?.terminalGeneration).toBe(2);
+
+    taskRepo.updateTask(task.task!.id, { status: 'cancelled' });
+    expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(2);
+  });
+
+  it('advances the terminal generation through the CAS writer', () => {
+    const goal = service.createGoal({ spaceId, title: 'CAS generation goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    const won = taskRepo.casStatus(task.task!.id, 'in_progress', 'blocked');
+    expect(won).toBe('won');
+    expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
+
+    const superseded = taskRepo.casStatus(task.task!.id, 'in_progress', 'done');
+    expect(superseded).toBe('superseded');
+    expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -969,4 +969,38 @@ describe('SpaceGoalService', () => {
     expect((last?.diff?.checkInCronExpression as { previous: string }).previous).toBe('0 9 * * 1');
     expect((last?.diff?.checkInCronExpression as { current: string }).current).toBe('0 * * * *');
   });
+
+  it('increments the goal revision monotonically on each mutation', () => {
+    const goal = service.createGoal({ spaceId, title: 'Revision counter' });
+    expect(goal.revision).toBe(1);
+
+    const updated = service.updateGoal(goal.id, { summary: 'v2' });
+    expect(updated.revision).toBe(2);
+
+    const again = service.updateGoal(goal.id, { progress: 50 });
+    expect(again.revision).toBe(3);
+
+    expect(goalRepo.getById(goal.id)?.revision).toBe(3);
+  });
+
+  it('exposes the durable terminal generation from handleTaskTerminal', () => {
+    const goal = service.createGoal({ spaceId, title: 'Generation goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    taskRepo.updateTask(task.task!.id, { status: 'open' });
+    taskRepo.updateTask(task.task!.id, { status: 'done' });
+
+    const done = taskRepo.getTask(task.task!.id);
+    expect(done?.terminalGeneration).toBe(1);
+
+    const terminal = service.handleTaskTerminal(task.task!.id);
+    expect(terminal?.terminalGeneration).toBe(1);
+
+    taskRepo.updateTask(task.task!.id, { status: 'open' });
+    taskRepo.updateTask(task.task!.id, { status: 'cancelled' });
+    const reopened = taskRepo.getTask(task.task!.id);
+    expect(reopened?.terminalGeneration).toBe(2);
+  });
 });

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1021,4 +1021,17 @@ describe('SpaceGoalService', () => {
     expect(superseded).toBe('superseded');
     expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
   });
+
+  it('advances the terminal generation through the archive writer without re-advancing archived rows', () => {
+    const goal = service.createGoal({ spaceId, title: 'Archive generation goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    taskRepo.archiveTask(task.task!.id);
+    expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
+
+    taskRepo.archiveTask(task.task!.id);
+    expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
+  });
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-204_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-204_test.ts
@@ -1,0 +1,87 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { runMigration204 } from '../../../../../src/storage/schema/migrations.ts';
+
+function columnNames(db: BunDatabase, table: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+describe('Migration 204: goal revision + task terminal generation', () => {
+  let testDir: string;
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    testDir = join(
+      process.cwd(),
+      'tmp',
+      'test-migration-204',
+      `test-${Date.now()}-${Math.random()}`
+    );
+    mkdirSync(testDir, { recursive: true });
+    db = new BunDatabase(join(testDir, 'test.db'));
+    db.exec('PRAGMA foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {}
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('adds revision to space_goals and terminal_generation to space_tasks', () => {
+    db.exec(`
+      CREATE TABLE space_goals (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+      CREATE TABLE space_tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+    `);
+    expect(columnNames(db, 'space_goals')).not.toContain('revision');
+    expect(columnNames(db, 'space_tasks')).not.toContain('terminal_generation');
+
+    runMigration204(db);
+
+    expect(columnNames(db, 'space_goals')).toContain('revision');
+    expect(columnNames(db, 'space_tasks')).toContain('terminal_generation');
+  });
+
+  test('existing rows get the default revision 0 (pre-counter sentinel) and generation 0', () => {
+    db.exec(`
+      CREATE TABLE space_goals (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+      CREATE TABLE space_tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+      INSERT INTO space_goals (id, title) VALUES ('g1', 'Goal');
+      INSERT INTO space_tasks (id, title) VALUES ('t1', 'Task');
+    `);
+
+    runMigration204(db);
+
+    expect(
+      (db.prepare(`SELECT revision AS r FROM space_goals WHERE id = ?`).get('g1') as { r: number })
+        .r
+    ).toBe(0);
+    expect(
+      (
+        db.prepare(`SELECT terminal_generation AS g FROM space_tasks WHERE id = ?`).get('t1') as {
+          g: number;
+        }
+      ).g
+    ).toBe(0);
+  });
+
+  test('is idempotent', () => {
+    db.exec(`
+      CREATE TABLE space_goals (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+      CREATE TABLE space_tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL);
+    `);
+    runMigration204(db);
+    expect(() => runMigration204(db)).not.toThrow();
+    expect(columnNames(db, 'space_goals').filter((c) => c === 'revision')).toHaveLength(1);
+  });
+
+  test('is a no-op when the tables do not exist', () => {
+    expect(() => runMigration204(db)).not.toThrow();
+  });
+});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -307,6 +307,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			started_at INTEGER,
 			completed_at INTEGER,
 			updated_at INTEGER NOT NULL,
+			terminal_generation INTEGER NOT NULL DEFAULT 0,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
 			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
 		)
@@ -361,6 +362,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			completed_at INTEGER,
+			revision INTEGER NOT NULL DEFAULT 0,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
 		)
 	`);

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -386,6 +386,7 @@ export interface SpaceGoal {
   createdAt: number;
   updatedAt: number;
   completedAt: number | null;
+  revision: number;
 }
 
 export interface CreateSpaceGoalParams {
@@ -519,6 +520,7 @@ export interface SpaceTask {
   postApprovalSourceNodeId?: string | null;
   restrictions?: TaskRestriction | null;
   updatedAt: number;
+  terminalGeneration: number;
 }
 
 export interface PaginatedSpaceTaskResult {

--- a/packages/web/src/components/space/__tests__/GoalDetailPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/GoalDetailPanel.test.tsx
@@ -94,6 +94,7 @@ function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
     createdAt: now - 120_000,
     updatedAt: now,
     completedAt: null,
+    revision: 3,
     ...overrides,
   };
 }
@@ -124,6 +125,7 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
     reportedSummary: null,
     createdAt: now - 180_000,
     updatedAt: now - 60_000,
+    terminalGeneration: 1,
     ...overrides,
   };
 }

--- a/packages/web/src/components/space/__tests__/ScopeDetailPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/ScopeDetailPanel.test.tsx
@@ -104,6 +104,7 @@ function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
     createdAt: now,
     updatedAt: now,
     completedAt: null,
+    revision: 2,
     ...overrides,
   };
 }

--- a/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceForge.test.tsx
@@ -95,6 +95,7 @@ function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
     createdAt: now,
     updatedAt: now,
     completedAt: null,
+    revision: 2,
     ...overrides,
   };
 }

--- a/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceGoals.test.tsx
@@ -104,6 +104,7 @@ function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
     createdAt: now - 120_000,
     updatedAt: now,
     completedAt: null,
+    revision: 3,
     ...overrides,
   };
 }
@@ -134,6 +135,7 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
     reportedSummary: null,
     createdAt: now - 180_000,
     updatedAt: now - 60_000,
+    terminalGeneration: 1,
     ...overrides,
   };
 }

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -70,6 +70,7 @@ function makeTask(id: string, status = 'open', workflowRunId?: string): SpaceTas
     reportedSummary: null,
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    terminalGeneration: 0,
     ...(workflowRunId ? { workflowRunId } : {}),
   };
 }
@@ -99,6 +100,7 @@ function makeGoal(overrides: Partial<SpaceGoal> = {}): SpaceGoal {
     createdAt: Date.now(),
     updatedAt: Date.now(),
     completedAt: null,
+    revision: 1,
     ...overrides,
   };
 }


### PR DESCRIPTION
Closes #2741

## Summary
Durable revision/generation state for the terminal seam, per roadmap MC2:

- **Migration 204** adds `space_goals.revision INTEGER NOT NULL DEFAULT 0` and `space_tasks.terminal_generation INTEGER NOT NULL DEFAULT 0`. Existing rows backfill to `0` — the documented pre-counter sentinel, treated as always-stale by MC3 so pre-counter notifications terminalize through the disposition path rather than comparing against a missing value.
- **Goal repo**: `create` seeds `revision = 1`; `update` and the direct mutation helpers (`setTaskScheduleId`, `claimActiveTask`, `clearActiveTaskIfMatches`) increment `revision = revision + 1` in the same UPDATE — strictly monotonic, not a timestamp, so no `updatedAt` collisions.
- **Task repo**: `updateTask` advances `terminal_generation` by 1 on every transition into a terminal status, durable and atomic with the transition (exactly-once per transition, survives reopen→recomplete cycles).
- **`SpaceGoalService.handleTaskTerminal`** now returns the durable `terminalGeneration` so MC2-C can bind notifications to it.

## Non-goals
- Notification record + wake injection (MC2-C); revisions surfaced in MCP tools (MC3).

## Test plan
- Migration 204: column addition, pre-counter default backfill, idempotency, no-op guards.
- Goal service: revision increments 1→2→3 monotonically across mutations; terminal generation advances across a reopen/recomplete cycle and is exposed by `handleTaskTerminal`.
- `bun run check` green (lint, types, knip, format, test-matrix, db-schema parity); web fixtures updated for the new fields.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->