### PR TITLE
feat(space): compose spawn flow as decisionRun admission + stagedRun pipeline (superpipe P4 PR 4/6)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/spawn-admission-decision-pipeline.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-admission-decision-pipeline.ts
@@ -1,0 +1,69 @@
+import { isRateOrUsageLimited } from '@hyperneo/shared';
+import { decisionRun } from './decision-pipeline';
+import type {
+  SpawnExecutionAdmissionDecision,
+  SpawnExecutionAdmissionInput,
+} from './spawn-admission-gates';
+
+export interface SpawnAdmissionCtx extends SpawnExecutionAdmissionInput {
+  decision: SpawnExecutionAdmissionDecision | null;
+}
+
+function decided(
+  ctx: SpawnAdmissionCtx,
+  decision: SpawnExecutionAdmissionDecision
+): SpawnAdmissionCtx {
+  return { ...ctx, decision };
+}
+
+export function applyLiveSessionGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  return ctx.hasLiveIndexedSession ? decided(ctx, { action: 'reuse_live' }) : ctx;
+}
+
+export function applyConcurrentSpawnGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  return ctx.isSpawningExecution ? decided(ctx, { action: 'wait_concurrent' }) : ctx;
+}
+
+export function applyTaskStatusGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  if (ctx.taskStatus === 'archived') {
+    return decided(ctx, { action: 'reject_permanent', reason: 'task_archived' });
+  }
+  if (ctx.taskStatus === 'cancelled') {
+    return decided(ctx, { action: 'reject_permanent', reason: 'task_cancelled' });
+  }
+  if (isRateOrUsageLimited(ctx.taskStatus)) {
+    return decided(ctx, { action: 'reject_transient', reason: 'task_rate_or_usage_limited' });
+  }
+  return ctx;
+}
+
+export function applyWorkflowValidityGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  return ctx.executionWorkflowValid
+    ? ctx
+    : decided(ctx, { action: 'reject_permanent', reason: 'workflow_invalid' });
+}
+
+export function applySlotResolutionGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  return ctx.slotResolvable
+    ? ctx
+    : decided(ctx, { action: 'reject_permanent', reason: 'slot_unresolvable' });
+}
+
+export function applyProceedGate(ctx: SpawnAdmissionCtx): SpawnAdmissionCtx {
+  return decided(ctx, { action: 'proceed_fresh' });
+}
+
+const spawnAdmissionDecisionRun = decisionRun('spawn-execution-admission', [
+  applyLiveSessionGate,
+  applyConcurrentSpawnGate,
+  applyTaskStatusGate,
+  applyWorkflowValidityGate,
+  applySlotResolutionGate,
+  applyProceedGate,
+]);
+
+export function decideSpawnExecutionAdmissionViaPipeline(
+  input: SpawnExecutionAdmissionInput
+): SpawnExecutionAdmissionDecision {
+  return spawnAdmissionDecisionRun(input).decision ?? { action: 'proceed_fresh' };
+}

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -105,6 +105,17 @@ export function isSpawnFlowWaitConcurrent(result: unknown): result is {
   );
 }
 
+export function isSpawnFlowReusedSession(result: unknown): result is {
+  kind: 'reused_session';
+  sessionId: string;
+} {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    (result as { kind?: unknown }).kind === 'reused_session'
+  );
+}
+
 interface SpawnAttemptBox {
   sessionId: string | null;
   workspacePath: string | null;
@@ -176,7 +187,10 @@ export function runSpawnExecutionFlow(
       s.halt({
         name: 'return-live-session',
         when: 'reuseLive',
-        run: (view) => (view.reuseLive as { sessionId: string }).sessionId,
+        run: (view) => ({
+          kind: 'reused_session',
+          sessionId: (view.reuseLive as { sessionId: string }).sessionId,
+        }),
       }),
       s.halt({
         name: 'defer-to-concurrent-spawn',

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -1,0 +1,328 @@
+import type {
+  NodeExecution,
+  Space,
+  SpaceTask,
+  SpaceWorkflow,
+  SpaceWorkflowRun,
+  WorkflowNode,
+  WorkflowNodeAgent,
+} from '@hyperneo/shared';
+import { decideSpawnExecutionAdmissionViaPipeline } from './spawn-admission-decision-pipeline';
+import type { WorkflowNodeSlotResolution } from './spawn-slot-resolution';
+import { resolveWorkflowNodeSlot } from './spawn-slot-resolution';
+import { stagedRun, type StagedRunOutcome } from './staged-run';
+import { validateExecutionAgainstWorkflow } from './workflow-node-execution-validation';
+
+export interface IndexedSessionInspection {
+  sessionId: string | null;
+  alive: boolean;
+}
+
+export interface SpawnSessionRequest {
+  task: SpaceTask;
+  space: Space;
+  workflow: SpaceWorkflow;
+  workflowRun: SpaceWorkflowRun;
+  execution: NodeExecution;
+  node: WorkflowNode;
+  slot: WorkflowNodeAgent;
+  sessionId: string;
+  workspacePath: string;
+  kickoff: boolean;
+}
+
+export interface AttachNodeAgentRequest {
+  task: SpaceTask;
+  space: Space;
+  workflowRun: SpaceWorkflowRun;
+  execution: NodeExecution;
+  sessionId: string;
+  workspacePath: string;
+}
+
+export interface KickoffMessageRequest {
+  task: SpaceTask;
+  space: Space;
+  workflow: SpaceWorkflow;
+  workflowRun: SpaceWorkflowRun;
+  execution: NodeExecution;
+  node: WorkflowNode;
+  slot: WorkflowNodeAgent;
+  sessionId: string;
+  workspacePath: string;
+}
+
+export interface SpawnExecutionFlowDeps {
+  getFreshTask(taskId: string): SpaceTask | null;
+  getNodeExecution(executionId: string): NodeExecution | null;
+  isSpawningExecution(executionId: string): boolean;
+  inspectIndexedSession(agentSessionId: string | null): IndexedSessionInspection;
+  reserveExecution(executionId: string): void;
+  releaseExecution(executionId: string): void;
+  cancelSpawnedSession(sessionId: string): void;
+  rebindLiveExecution(execution: NodeExecution, sessionId: string): void;
+  raiseSpawnRejection(
+    freshTask: SpaceTask,
+    execution: NodeExecution,
+    workflow: SpaceWorkflow
+  ): never;
+  resolveSpawnSessionId(space: Space, task: SpaceTask, execution: NodeExecution): string;
+  resolveWorkspacePath(task: SpaceTask, space: Space): Promise<string>;
+  createSpawnedSession(request: SpawnSessionRequest): Promise<string>;
+  bindExecutionToSession(execution: NodeExecution, sessionId: string): void;
+  attachNodeAgent(request: AttachNodeAgentRequest): Promise<void>;
+  registerSpawnCompletionCallback(taskId: string, workflowNodeId: string, sessionId: string): void;
+  buildKickoffMessage(request: KickoffMessageRequest): Promise<string>;
+  injectKickoffMessage(sessionId: string, message: string): Promise<void>;
+}
+
+export interface SpawnExecutionFlowInput {
+  task: SpaceTask;
+  space: Space;
+  workflow: SpaceWorkflow;
+  workflowRun: SpaceWorkflowRun;
+  execution: NodeExecution;
+  kickoff: boolean;
+}
+
+interface SpawnExecutionFlowState extends SpawnExecutionFlowInput {
+  freshTask: SpaceTask;
+  slotResolution: WorkflowNodeSlotResolution | null;
+  workflowValid: boolean;
+  isSpawning: boolean;
+  indexedSession: IndexedSessionInspection;
+  spawnedSessionId: string;
+  workspacePath: string;
+}
+
+export function isSpawnFlowWaitConcurrent(result: unknown): result is {
+  kind: 'wait_concurrent';
+} {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    (result as { kind?: unknown }).kind === 'wait_concurrent'
+  );
+}
+
+interface SpawnAttemptBox {
+  sessionId: string | null;
+  workspacePath: string | null;
+}
+
+export function runSpawnExecutionFlow(
+  deps: SpawnExecutionFlowDeps,
+  input: SpawnExecutionFlowInput
+): Promise<StagedRunOutcome> {
+  const attempt: SpawnAttemptBox = { sessionId: null, workspacePath: null };
+  const executionId = input.execution.id;
+  const flow = stagedRun<SpawnExecutionFlowState>(
+    'spawn-execution',
+    (s) => [
+      s.snapshot({
+        name: 'gather-spawn-admission',
+        provides: ['freshTask', 'slotResolution', 'workflowValid', 'isSpawning', 'indexedSession'],
+        reads: ['task', 'workflow', 'execution'],
+        run: (view) => ({
+          freshTask: deps.getFreshTask(view.task.id) ?? view.task,
+          slotResolution: resolveWorkflowNodeSlot(
+            view.workflow,
+            view.execution.workflowNodeId,
+            view.execution.agentName
+          ),
+          workflowValid: validateExecutionAgainstWorkflow(view.execution, view.workflow).valid,
+          isSpawning: deps.isSpawningExecution(view.execution.id),
+          indexedSession: deps.inspectIndexedSession(view.execution.agentSessionId),
+        }),
+      }),
+      s.decide({
+        name: 'admission',
+        reads: ['freshTask', 'slotResolution', 'workflowValid', 'isSpawning', 'indexedSession'],
+        branches: ['reuseLive', 'waitConcurrent', 'rejectSpawn', 'proceedFresh'],
+        run: (view) => {
+          const liveSessionId = view.indexedSession.alive ? view.indexedSession.sessionId : null;
+          const admission = decideSpawnExecutionAdmissionViaPipeline({
+            hasLiveIndexedSession: liveSessionId !== null,
+            isSpawningExecution: view.isSpawning,
+            taskStatus: view.freshTask.status,
+            executionWorkflowValid: view.workflowValid,
+            slotResolvable: view.slotResolution !== null,
+          });
+          return {
+            decision: admission,
+            reuseLive:
+              admission.action === 'reuse_live' ? { sessionId: liveSessionId! } : undefined,
+            waitConcurrent: admission.action === 'wait_concurrent' ? true : undefined,
+            rejectSpawn:
+              admission.action === 'reject_permanent' || admission.action === 'reject_transient'
+                ? true
+                : undefined,
+            proceedFresh: admission.action === 'proceed_fresh' ? true : undefined,
+          };
+        },
+      }),
+      s.effect({
+        name: 'rebind-live-session',
+        when: 'reuseLive',
+        reads: ['execution'],
+        writes: [],
+        run: (view) => {
+          deps.rebindLiveExecution(
+            view.execution,
+            (view.reuseLive as { sessionId: string }).sessionId
+          );
+        },
+      }),
+      s.halt({
+        name: 'return-live-session',
+        when: 'reuseLive',
+        run: (view) => (view.reuseLive as { sessionId: string }).sessionId,
+      }),
+      s.halt({
+        name: 'defer-to-concurrent-spawn',
+        when: 'waitConcurrent',
+        run: () => ({ kind: 'wait_concurrent' }),
+      }),
+      s.halt({
+        name: 'raise-spawn-rejection',
+        when: 'rejectSpawn',
+        reads: ['freshTask', 'execution', 'workflow'],
+        run: (view) => {
+          deps.raiseSpawnRejection(view.freshTask, view.execution, view.workflow);
+        },
+      }),
+      s.effect({
+        name: 'reserve-and-spawn-session',
+        when: 'proceedFresh',
+        reads: [
+          'task',
+          'space',
+          'workflow',
+          'workflowRun',
+          'execution',
+          'slotResolution',
+          'kickoff',
+        ],
+        writes: ['isSpawning'],
+        run: async (view) => {
+          deps.reserveExecution(view.execution.id);
+          const sessionId = deps.resolveSpawnSessionId(view.space, view.task, view.execution);
+          const workspacePath = await deps.resolveWorkspacePath(view.task, view.space);
+          const slotResolution = view.slotResolution!;
+          attempt.workspacePath = workspacePath;
+          attempt.sessionId = await deps.createSpawnedSession({
+            task: view.task,
+            space: view.space,
+            workflow: view.workflow,
+            workflowRun: view.workflowRun,
+            execution: view.execution,
+            node: slotResolution.node,
+            slot: slotResolution.slot,
+            sessionId,
+            workspacePath,
+            kickoff: view.kickoff,
+          });
+        },
+        compensate: () => {
+          if (attempt.sessionId !== null) {
+            deps.cancelSpawnedSession(attempt.sessionId);
+          }
+          deps.releaseExecution(executionId);
+        },
+      }),
+      s.resnapshot({
+        name: 'read-spawn-attempt',
+        when: 'proceedFresh',
+        provides: ['spawnedSessionId', 'workspacePath'],
+        run: () => {
+          if (attempt.sessionId === null || attempt.workspacePath === null) {
+            throw new Error(`Spawn attempt for execution ${executionId} has no spawned session`);
+          }
+          return { spawnedSessionId: attempt.sessionId, workspacePath: attempt.workspacePath };
+        },
+      }),
+      s.effect({
+        name: 'bind-execution-session',
+        when: 'proceedFresh',
+        reads: ['execution', 'spawnedSessionId'],
+        writes: ['execution'],
+        run: (view) => {
+          deps.bindExecutionToSession(view.execution, view.spawnedSessionId);
+        },
+      }),
+      s.resnapshot({
+        name: 'read-bound-execution',
+        when: 'proceedFresh',
+        provides: ['execution'],
+        run: () => {
+          const bound = deps.getNodeExecution(executionId);
+          if (!bound) {
+            throw new Error(`Spawn flow cannot re-read execution ${executionId} after binding`);
+          }
+          return { execution: bound };
+        },
+      }),
+      s.effect({
+        name: 'attach-node-agent',
+        when: 'proceedFresh',
+        reads: ['task', 'space', 'workflowRun', 'execution', 'spawnedSessionId', 'workspacePath'],
+        writes: [],
+        run: async (view) => {
+          await deps.attachNodeAgent({
+            task: view.task,
+            space: view.space,
+            workflowRun: view.workflowRun,
+            execution: view.execution,
+            sessionId: view.spawnedSessionId,
+            workspacePath: view.workspacePath,
+          });
+          deps.registerSpawnCompletionCallback(
+            view.task.id,
+            view.execution.workflowNodeId,
+            view.spawnedSessionId
+          );
+        },
+      }),
+      s.effect({
+        name: 'kickoff-session',
+        when: 'proceedFresh',
+        reads: [
+          'task',
+          'space',
+          'workflow',
+          'workflowRun',
+          'execution',
+          'slotResolution',
+          'spawnedSessionId',
+          'workspacePath',
+          'kickoff',
+        ],
+        writes: [],
+        run: async (view) => {
+          if (!view.kickoff) return;
+          const slotResolution = view.slotResolution!;
+          const message = await deps.buildKickoffMessage({
+            task: view.task,
+            space: view.space,
+            workflow: view.workflow,
+            workflowRun: view.workflowRun,
+            execution: view.execution,
+            node: slotResolution.node,
+            slot: slotResolution.slot,
+            sessionId: view.spawnedSessionId,
+            workspacePath: view.workspacePath,
+          });
+          await deps.injectKickoffMessage(view.spawnedSessionId, message);
+        },
+      }),
+      s.halt({
+        name: 'complete-spawn',
+        when: 'proceedFresh',
+        reads: ['spawnedSessionId'],
+        run: (view) => view.spawnedSessionId,
+      }),
+    ],
+    { input: ['task', 'space', 'workflow', 'workflowRun', 'execution', 'kickoff'] }
+  );
+  return flow(input);
+}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -78,6 +78,11 @@ import {
 import { decideActivationRouting, selectWorkflowNodeForAgent } from './activation-routing';
 import { decideSpawnExecutionAdmission } from './spawn-admission-gates';
 import {
+  isSpawnFlowWaitConcurrent,
+  runSpawnExecutionFlow,
+  type SpawnExecutionFlowDeps,
+} from './spawn-flow';
+import {
   assembleNodeAgentSessionInit,
   buildExecutionBaseSessionId,
   buildSlotOverrides,
@@ -655,35 +660,7 @@ export class TaskAgentManager {
     }
 
     if (admission.action === 'wait_concurrent') {
-      const CONCURRENT_SPAWN_TIMEOUT_MS = 30_000;
-      const deadline = Date.now() + CONCURRENT_SPAWN_TIMEOUT_MS;
-      return new Promise((resolve, reject) => {
-        const interval = setInterval(() => {
-          const fresh = this.config.nodeExecutionRepo.getById(execution.id);
-          if (fresh?.agentSessionId) {
-            clearInterval(interval);
-            resolve(fresh.agentSessionId);
-            return;
-          }
-          if (!this.spawningExecutionIds.has(execution.id)) {
-            clearInterval(interval);
-            reject(
-              new Error(
-                `Concurrent spawn for execution ${execution.id} failed before session was created`
-              )
-            );
-            return;
-          }
-          if (Date.now() >= deadline) {
-            clearInterval(interval);
-            reject(
-              new Error(
-                `Concurrent spawn for execution ${execution.id} timed out after ${CONCURRENT_SPAWN_TIMEOUT_MS}ms`
-              )
-            );
-          }
-        }, 50);
-      });
+      return this.waitForConcurrentSpawnSession(execution);
     }
 
     if (admission.action === 'reject_permanent' || admission.action === 'reject_transient') {
@@ -877,6 +854,311 @@ export class TaskAgentManager {
     } finally {
       this.spawningExecutionIds.delete(execution.id);
     }
+  }
+
+  private waitForConcurrentSpawnSession(execution: NodeExecution): Promise<string> {
+    const CONCURRENT_SPAWN_TIMEOUT_MS = 30_000;
+    const deadline = Date.now() + CONCURRENT_SPAWN_TIMEOUT_MS;
+    return new Promise((resolve, reject) => {
+      const interval = setInterval(() => {
+        const fresh = this.config.nodeExecutionRepo.getById(execution.id);
+        if (fresh?.agentSessionId) {
+          clearInterval(interval);
+          resolve(fresh.agentSessionId);
+          return;
+        }
+        if (!this.spawningExecutionIds.has(execution.id)) {
+          clearInterval(interval);
+          reject(
+            new Error(
+              `Concurrent spawn for execution ${execution.id} failed before session was created`
+            )
+          );
+          return;
+        }
+        if (Date.now() >= deadline) {
+          clearInterval(interval);
+          reject(
+            new Error(
+              `Concurrent spawn for execution ${execution.id} timed out after ${CONCURRENT_SPAWN_TIMEOUT_MS}ms`
+            )
+          );
+        }
+      }, 50);
+    });
+  }
+
+  async spawnWorkflowNodeAgentForExecutionViaFlow(
+    task: SpaceTask,
+    space: Space,
+    workflow: SpaceWorkflow,
+    workflowRun: SpaceWorkflowRun,
+    execution: NodeExecution,
+    options: SpawnTaskAgentOptions = {}
+  ): Promise<string> {
+    const outcome = await runSpawnExecutionFlow(this.buildSpawnExecutionFlowDeps(), {
+      task,
+      space,
+      workflow,
+      workflowRun,
+      execution,
+      kickoff: options.kickoff ?? true,
+    });
+    if (outcome.status === 'error') {
+      throw outcome.error;
+    }
+    if (outcome.status === 'superseded') {
+      throw new Error(
+        `Spawn for execution ${execution.id} superseded at stage ${outcome.stage ?? 'unknown'}`
+      );
+    }
+    const result = outcome.result;
+    if (isSpawnFlowWaitConcurrent(result)) {
+      return this.waitForConcurrentSpawnSession(execution);
+    }
+    this.spawningExecutionIds.delete(execution.id);
+    return result as string;
+  }
+
+  private buildSpawnExecutionFlowDeps(): SpawnExecutionFlowDeps {
+    return {
+      getFreshTask: (taskId) => this.config.taskRepo.getTask(taskId),
+      getNodeExecution: (executionId) => this.config.nodeExecutionRepo.getById(executionId),
+      isSpawningExecution: (executionId) => this.spawningExecutionIds.has(executionId),
+      inspectIndexedSession: (agentSessionId) => {
+        if (agentSessionId && this.agentSessionIndex.has(agentSessionId)) {
+          if (this.isSessionAlive(agentSessionId)) {
+            return { sessionId: agentSessionId, alive: true };
+          }
+          this.agentSessionIndex.delete(agentSessionId);
+        }
+        return { sessionId: agentSessionId, alive: false };
+      },
+      reserveExecution: (executionId) => {
+        this.spawningExecutionIds.add(executionId);
+      },
+      releaseExecution: (executionId) => {
+        this.spawningExecutionIds.delete(executionId);
+      },
+      cancelSpawnedSession: (sessionId) => {
+        this.cancelBySessionId(sessionId);
+      },
+      rebindLiveExecution: (execution, sessionId) => {
+        const startedAt = execution.startedAt ?? Date.now();
+        this.config.nodeExecutionRepo.update(execution.id, {
+          status: 'in_progress',
+          agentSessionId: sessionId,
+          startedAt,
+          completedAt: null,
+        });
+      },
+      raiseSpawnRejection: (freshTask, rejectedExecution, rejectedWorkflow) => {
+        validateTaskAllowsSpawn(freshTask);
+        assertExecutionValidAgainstWorkflow(rejectedExecution, rejectedWorkflow);
+        throw new Error(
+          `No agent slot found for agent name "${rejectedExecution.agentName}" in node "${rejectedExecution.workflowNodeId}"`
+        );
+      },
+      resolveSpawnSessionId: (space, task, execution) =>
+        this.resolveSessionId(buildExecutionBaseSessionId(space.id, task.id, execution.id)),
+      resolveWorkspacePath: async (task, space) => {
+        const workspace = resolveSpawnWorkspace({
+          cachedTaskWorktreePath: this.taskWorktreePaths.get(task.id),
+          hasWorktreeManager: Boolean(this.config.worktreeManager),
+          spaceWorkspacePath: space.workspacePath,
+        });
+        let workspacePath = workspace.workspacePath;
+        if (workspace.createWorktree && this.config.worktreeManager) {
+          try {
+            const result = await this.config.worktreeManager.createTaskWorktree(
+              space.id,
+              task.id,
+              task.title,
+              task.taskNumber
+            );
+            workspacePath = result.path;
+            this.taskWorktreePaths.set(task.id, result.path);
+          } catch (err) {
+            log.warn(
+              `TaskAgentManager: failed to create worktree for workflow task ${task.id}, falling back to space workspace: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+        return workspacePath;
+      },
+      createSpawnedSession: async (request) => {
+        const slotOverrides = buildSlotOverrides(request.slot, {
+          task: request.task,
+          node: request.node,
+          workflow: request.workflow,
+          workflowRun: request.workflowRun,
+        });
+
+        let init = resolveAgentInit({
+          task: request.task,
+          space: request.space,
+          agentManager: this.config.spaceAgentManager,
+          sessionId: request.sessionId,
+          workspacePath: request.workspacePath,
+          workflowRun: request.workflowRun,
+          workflow: request.workflow,
+          slotOverrides,
+          agentId: request.slot.agentId,
+        });
+
+        const customAgent = request.kickoff
+          ? this.config.spaceAgentManager.getById(request.slot.agentId)
+          : null;
+        if (request.kickoff && !customAgent) {
+          throw new PermanentSpawnError(`Agent not found: ${request.slot.agentId}`);
+        }
+
+        const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
+          request.task.id,
+          request.sessionId,
+          request.execution.agentName,
+          request.space.id,
+          request.workflowRun.id,
+          request.workspacePath,
+          request.execution.workflowNodeId
+        );
+
+        init = assembleNodeAgentSessionInit({
+          baseInit: init,
+          title: formatWorkflowNodeSessionTitle(request.task, request.execution.agentName),
+          nodeAgentMcpServer: nodeAgentMcpServer as unknown as McpServerConfig,
+          agentMemoryMcpServers: this.buildAgentMemoryMcpServers(
+            request.space.id,
+            request.sessionId
+          ),
+        });
+
+        const actualSessionId = await this.createSubSession(
+          request.task.id,
+          request.sessionId,
+          init,
+          {
+            agentId: request.slot.agentId,
+            agentName: request.execution.agentName,
+            nodeId: request.execution.workflowNodeId,
+          }
+        );
+
+        const spawned = this.getSubSession(actualSessionId);
+        if (!spawned) {
+          throw new Error(`Spawned node session ${actualSessionId} is not registered in memory`);
+        }
+        return actualSessionId;
+      },
+      bindExecutionToSession: (execution, sessionId) => {
+        const startedAt = Date.now();
+        const updatedExecution = this.config.nodeExecutionRepo.update(execution.id, {
+          status: 'in_progress',
+          agentSessionId: sessionId,
+          startedAt,
+          completedAt: null,
+        });
+        if (
+          !updatedExecution ||
+          updatedExecution.status !== 'in_progress' ||
+          updatedExecution.agentSessionId !== sessionId ||
+          !updatedExecution.startedAt
+        ) {
+          log.error('[Spawn] Execution state mismatch after spawn', {
+            executionId: execution.id,
+            expectedStatus: 'in_progress',
+            actualStatus: updatedExecution?.status ?? null,
+            expectedSessionId: sessionId,
+            actualSessionId: updatedExecution?.agentSessionId ?? null,
+          });
+          this.config.nodeExecutionRepo.update(execution.id, {
+            status: 'blocked',
+            result: 'Execution state corruption after spawn',
+            completedAt: Date.now(),
+          });
+          throw new Error(`Execution state corruption after spawn for ${execution.id}`);
+        }
+      },
+      attachNodeAgent: async (request) => {
+        const spawned = this.getSubSession(request.sessionId);
+        if (!spawned) {
+          throw new Error(`Spawned node session ${request.sessionId} is not registered in memory`);
+        }
+        await this.ensureNodeAgentAttached(spawned, {
+          taskId: request.task.id,
+          subSessionId: request.sessionId,
+          agentName: request.execution.agentName,
+          spaceId: request.space.id,
+          workflowRunId: request.workflowRun.id,
+          workspacePath: request.workspacePath,
+          workflowNodeId: request.execution.workflowNodeId,
+          phase: 'spawn',
+        });
+      },
+      registerSpawnCompletionCallback: (taskId, workflowNodeId, sessionId) => {
+        this.registerCompletionCallback(sessionId, async () => {
+          await this.handleSubSessionComplete(taskId, workflowNodeId, sessionId);
+        });
+      },
+      buildKickoffMessage: async (request) => {
+        const goal = request.task.goalId
+          ? this.config.goalService?.getGoal(request.task.goalId)
+          : null;
+        const linkedGoal = goal?.spaceId === request.task.spaceId ? goal : null;
+
+        const memoryQuery = `${request.task.title}\n${request.task.description}`;
+        const coreMemories = this.config.memoryRepo
+          ? this.config.memoryRepo.listCoreMemories(request.space.id, 10)
+          : [];
+        const relevantMemories = this.config.memoryRepo
+          ? await this.config.memoryRepo.search(request.space.id, memoryQuery, 5)
+          : [];
+        const relevantScopeLessons = this.config.evolutionScopeService
+          ? this.config.evolutionScopeService.selectActiveLessonsForTask({
+              taskId: request.task.id,
+              limit: 3,
+            })
+          : [];
+
+        const customAgent = this.config.spaceAgentManager.getById(request.slot.agentId);
+        const initialMessage = buildCustomAgentTaskMessage({
+          customAgent: customAgent!,
+          task: request.task,
+          workflowRun: request.workflowRun,
+          workflow: request.workflow,
+          space: request.space,
+          sessionId: request.sessionId,
+          workspacePath: request.workspacePath,
+          goal: linkedGoal,
+          relevantScopeLessons,
+          slotOverrides: buildSlotOverrides(request.slot, {
+            task: request.task,
+            node: request.node,
+            workflow: request.workflow,
+            workflowRun: request.workflowRun,
+          }),
+          nodeId: request.execution.workflowNodeId,
+          agentSlotName: request.execution.agentName,
+          coreMemories,
+          relevantMemories,
+        });
+        const runtimeContract = this.buildNodeExecutionRuntimeContract(
+          request.workflow,
+          request.execution,
+          request.space
+        );
+        return runtimeContract ? `${initialMessage}\n\n${runtimeContract}` : initialMessage;
+      },
+      injectKickoffMessage: async (sessionId, message) => {
+        const spawned = this.getSubSession(sessionId);
+        if (!spawned) {
+          throw new Error(`Spawned node session ${sessionId} is not registered in memory`);
+        }
+        await this.withSessionInjectLock(spawned.session.id, () =>
+          this.injectMessageIntoSession(spawned, message)
+        );
+      },
+    };
   }
 
   private sanitizeAgentNameForId(name: string): string {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -78,6 +78,7 @@ import {
 import { decideActivationRouting, selectWorkflowNodeForAgent } from './activation-routing';
 import { decideSpawnExecutionAdmission } from './spawn-admission-gates';
 import {
+  isSpawnFlowReusedSession,
   isSpawnFlowWaitConcurrent,
   runSpawnExecutionFlow,
   type SpawnExecutionFlowDeps,
@@ -915,6 +916,9 @@ export class TaskAgentManager {
     const result = outcome.result;
     if (isSpawnFlowWaitConcurrent(result)) {
       return this.waitForConcurrentSpawnSession(execution);
+    }
+    if (isSpawnFlowReusedSession(result)) {
+      return result.sessionId;
     }
     this.spawningExecutionIds.delete(execution.id);
     return result as string;

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -277,6 +277,19 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     expect(h.order).toEqual([]);
   });
 
+  test('reuse_live clears no reservation: a concurrent peer keeps its in-flight spawn guard', async () => {
+    const h = makeSpawnFlowHarness({
+      execution: makeExecution({ agentSessionId: 'live-session', status: 'idle' }),
+    });
+    seedIndexedSession(h.tam, 'live-session');
+    h.spawningIds().add('exec-1');
+
+    const result = await h.spawn();
+
+    expect(result).toBe('live-session');
+    expect(h.spawningIds().has('exec-1')).toBe(true);
+  });
+
   test('indexed but dead session: evicted from the index and spawned fresh', async () => {
     const h = makeSpawnFlowHarness({
       execution: makeExecution({ agentSessionId: 'zombie-session', status: 'idle' }),

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  NodeExecution,
+  Space,
+  SpaceTask,
+  SpaceWorkflow,
+  SpaceWorkflowRun,
+} from '@hyperneo/shared';
+import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { PermanentSpawnError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+
+const TASK_ID = 'task-1240';
+const RUN_ID = 'run-1240';
+const SPACE_ID = 'space-1240';
+const NODE_ID = 'node-coder';
+const AGENT_NAME = 'coder';
+const AGENT_ID = 'agent-coder';
+const SPAWNED_SESSION_ID = 'spawned-session-1';
+
+function makeExecution(overrides: Partial<NodeExecution> = {}): NodeExecution {
+  return {
+    id: 'exec-1',
+    workflowRunId: RUN_ID,
+    workflowNodeId: NODE_ID,
+    agentName: AGENT_NAME,
+    agentId: AGENT_ID,
+    agentSessionId: null,
+    status: 'pending',
+    result: null,
+    data: null,
+    createdAt: 1,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: 1,
+    lastActivityAt: null,
+    ...overrides,
+  };
+}
+
+function makeTask(status: string): SpaceTask {
+  return {
+    id: TASK_ID,
+    spaceId: SPACE_ID,
+    workflowRunId: RUN_ID,
+    title: 'Compose the spawn flow',
+    description: 'Pin the staged spawn flow at the TaskAgentManager seam',
+    taskNumber: 1240,
+    status,
+  } as unknown as SpaceTask;
+}
+
+function makeWorkflow(
+  nodes: Array<{ id: string; agents: Array<{ agentId: string | null; name: string }> }> = [
+    { id: NODE_ID, agents: [{ agentId: AGENT_ID, name: AGENT_NAME }] },
+  ]
+): SpaceWorkflow {
+  return {
+    id: 'wf-1',
+    spaceId: SPACE_ID,
+    name: 'Coding',
+    nodes,
+    channels: [],
+    startNodeId: nodes[0]?.id ?? NODE_ID,
+    endNodeId: nodes[0]?.id ?? NODE_ID,
+  } as unknown as SpaceWorkflow;
+}
+
+function fakeSession(id: string, processingStatus = 'idle'): AgentSession {
+  return {
+    session: { id },
+    getProcessingState: () => ({ status: processingStatus }),
+  } as unknown as AgentSession;
+}
+
+function fakeCustomAgent() {
+  return {
+    id: AGENT_ID,
+    name: AGENT_NAME,
+    customPrompt: 'do the composed work',
+    model: 'm',
+    tools: [],
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+interface SpawnFlowHarnessOptions {
+  taskStatus?: string;
+  callerTask?: SpaceTask;
+  taskMissing?: boolean;
+  execution?: NodeExecution;
+  workflow?: SpaceWorkflow | null;
+  kickoff?: boolean;
+  worktreeGate?: Promise<{ path: string }>;
+  failEnsure?: boolean;
+}
+
+interface SpawnFlowHarness {
+  tam: TaskAgentManager;
+  updates: Array<{ id: string; patch: Record<string, unknown> }>;
+  order: string[];
+  cancels: string[];
+  setReadback: (row: NodeExecution | null) => void;
+  spawningIds: () => Set<string>;
+  spawn: () => Promise<string>;
+}
+
+function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowHarness {
+  const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const order: string[] = [];
+  const cancels: string[] = [];
+  const row = options.execution ?? makeExecution();
+  const dbRow: NodeExecution = { ...row };
+  const taskStatus = options.taskStatus ?? 'in_progress';
+  let readback: NodeExecution | null | undefined;
+
+  const tam = new TaskAgentManager({
+    db: { getDatabase: () => new BunDatabase(':memory:'), getSession: () => null },
+    sessionManager: { registerSession: () => {}, getSession: () => undefined },
+    internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+    taskRepo: {
+      getTask: (id: string) =>
+        options.taskMissing || id !== TASK_ID ? undefined : makeTask(taskStatus),
+    },
+    nodeExecutionRepo: {
+      getById: (id: string) => (id === row.id ? dbRow : undefined),
+      listByWorkflowRun: () => [row],
+      listByNode: (runId: string, nodeId: string) =>
+        runId === RUN_ID && nodeId === row.workflowNodeId ? [row] : [],
+      update: (id: string, patch: Record<string, unknown>) => {
+        updates.push({ id, patch });
+        if (patch.status === 'in_progress' && patch.agentSessionId === SPAWNED_SESSION_ID) {
+          order.push('execution-bind');
+        }
+        if (id === row.id) Object.assign(dbRow, patch);
+        if (readback !== undefined) return readback;
+        return { ...dbRow };
+      },
+    },
+    spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    spaceAgentManager: {
+      getById: (id: string) => (id !== AGENT_ID ? undefined : fakeCustomAgent()),
+    },
+    ...(options.worktreeGate
+      ? { worktreeManager: { createTaskWorktree: () => options.worktreeGate } }
+      : {}),
+  } as unknown as TaskAgentManagerConfig);
+
+  const internal = tam as unknown as {
+    createSubSession: (...args: unknown[]) => Promise<string>;
+    getSubSession: (id: string) => AgentSession | undefined;
+    ensureNodeAgentAttached: (...args: unknown[]) => Promise<void>;
+    registerCompletionCallback: (...args: unknown[]) => void;
+    injectMessageIntoSession: (...args: unknown[]) => Promise<string>;
+    cancelBySessionId: (id: string) => void;
+    buildNodeAgentMcpServerForSession: (...args: unknown[]) => unknown;
+    spawningExecutionIds: Set<string>;
+  };
+  internal.createSubSession = async () => {
+    order.push('createSubSession');
+    return SPAWNED_SESSION_ID;
+  };
+  internal.getSubSession = (id: string) =>
+    id === SPAWNED_SESSION_ID ? fakeSession(id) : undefined;
+  internal.ensureNodeAgentAttached = async () => {
+    if (options.failEnsure) throw new Error('attach boom');
+    order.push('ensureNodeAgentAttached');
+  };
+  internal.registerCompletionCallback = () => {
+    order.push('registerCompletionCallback');
+  };
+  internal.injectMessageIntoSession = async () => {
+    order.push('kickoff-inject');
+    return 'msg-id';
+  };
+  internal.cancelBySessionId = (id: string) => {
+    cancels.push(id);
+  };
+  internal.buildNodeAgentMcpServerForSession = () => ({ __role: 'node-agent' });
+
+  const task = options.callerTask ?? makeTask(taskStatus);
+  const space = { id: SPACE_ID, workspacePath: '/tmp/ws' } as unknown as Space;
+  const workflowRun = {
+    id: RUN_ID,
+    workflowId: 'wf-1',
+    status: 'in_progress',
+  } as unknown as SpaceWorkflowRun;
+
+  return {
+    tam,
+    updates,
+    order,
+    cancels,
+    setReadback: (value) => {
+      readback = value;
+    },
+    spawningIds: () => internal.spawningExecutionIds,
+    spawn: () =>
+      tam.spawnWorkflowNodeAgentForExecutionViaFlow(
+        task,
+        space,
+        (options.workflow === undefined ? makeWorkflow() : options.workflow) as SpaceWorkflow,
+        workflowRun,
+        row,
+        options.kickoff === undefined ? {} : { kickoff: options.kickoff }
+      ),
+  };
+}
+
+function seedIndexedSession(
+  tam: TaskAgentManager,
+  sessionId: string,
+  processingStatus = 'idle'
+): void {
+  (tam as unknown as { agentSessionIndex: Map<string, AgentSession> }).agentSessionIndex.set(
+    sessionId,
+    fakeSession(sessionId, processingStatus)
+  );
+}
+
+describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parity', () => {
+  test('ordering: createSubSession, execution bind, ensureNodeAgentAttached, completion callback, kickoff inject', async () => {
+    const h = makeSpawnFlowHarness();
+
+    const result = await h.spawn();
+
+    expect(result).toBe(SPAWNED_SESSION_ID);
+    expect(h.order).toEqual([
+      'createSubSession',
+      'execution-bind',
+      'ensureNodeAgentAttached',
+      'registerCompletionCallback',
+      'kickoff-inject',
+    ]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+  });
+
+  test('kickoff inject runs only when options.kickoff allows it', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false });
+
+    await h.spawn();
+
+    expect(h.order).toContain('registerCompletionCallback');
+    expect(h.order).not.toContain('kickoff-inject');
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+  });
+
+  test('indexed live session is reused: rebinds the execution and returns the id without spawning', async () => {
+    const h = makeSpawnFlowHarness({
+      execution: makeExecution({ agentSessionId: 'live-session', status: 'idle' }),
+    });
+    seedIndexedSession(h.tam, 'live-session');
+
+    const result = await h.spawn();
+
+    expect(result).toBe('live-session');
+    expect(h.updates[0]).toEqual({
+      id: 'exec-1',
+      patch: {
+        status: 'in_progress',
+        agentSessionId: 'live-session',
+        startedAt: expect.any(Number),
+        completedAt: null,
+      },
+    });
+    expect(h.order).toEqual([]);
+  });
+
+  test('indexed but dead session: evicted from the index and spawned fresh', async () => {
+    const h = makeSpawnFlowHarness({
+      execution: makeExecution({ agentSessionId: 'zombie-session', status: 'idle' }),
+      kickoff: false,
+    });
+    seedIndexedSession(h.tam, 'zombie-session', 'completed');
+    const index = h.tam as unknown as { agentSessionIndex: Map<string, AgentSession> };
+
+    const result = await h.spawn();
+
+    expect(result).toBe(SPAWNED_SESSION_ID);
+    expect(index.agentSessionIndex.has('zombie-session')).toBe(false);
+    expect(h.order).toContain('createSubSession');
+  });
+
+  test('fresh-task re-read is authoritative: repo archived beats an open caller snapshot', async () => {
+    const h = makeSpawnFlowHarness({ taskStatus: 'archived', callerTask: makeTask('in_progress') });
+
+    await expect(h.spawn()).rejects.toBeInstanceOf(PermanentSpawnError);
+    await expect(h.spawn()).rejects.toThrow('Task task-1240 is archived');
+    expect(h.order).toEqual([]);
+  });
+
+  test('missing repo task falls back to the caller snapshot', async () => {
+    const h = makeSpawnFlowHarness({ taskMissing: true, kickoff: false });
+
+    const result = await h.spawn();
+
+    expect(result).toBe(SPAWNED_SESSION_ID);
+    expect(h.order).toContain('createSubSession');
+  });
+
+  test('slot-resolution failure is a permanent rejection routed through the rejection halt', async () => {
+    const h = makeSpawnFlowHarness({
+      workflow: makeWorkflow([
+        {
+          id: NODE_ID,
+          agents: [
+            { agentId: 'agent-a', name: 'alice' },
+            { agentId: 'agent-b', name: 'bob' },
+          ],
+        },
+      ]),
+    });
+
+    await expect(h.spawn()).rejects.toBeInstanceOf(PermanentSpawnError);
+    await expect(h.spawn()).rejects.toThrow(
+      `Agent slot ${AGENT_NAME} no longer exists on workflow node ${NODE_ID}`
+    );
+    expect(h.order).toEqual([]);
+    expect(h.cancels).toEqual([]);
+  });
+
+  test('readback returning null blocks the execution, cancels the session, and throws corruption', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false });
+    h.setReadback(null);
+
+    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
+
+    expect(h.updates[1]).toEqual({
+      id: 'exec-1',
+      patch: {
+        status: 'blocked',
+        result: 'Execution state corruption after spawn',
+        completedAt: expect.any(Number),
+      },
+    });
+    expect(h.order).not.toContain('ensureNodeAgentAttached');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+  });
+
+  test('a failure after session creation cancels the spawned session, releases the reservation, and rethrows', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false, failEnsure: true });
+
+    await expect(h.spawn()).rejects.toThrow('attach boom');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+  });
+
+  test('an admission failure before session creation cancels nothing', async () => {
+    const h = makeSpawnFlowHarness({ taskStatus: 'archived' });
+
+    await expect(h.spawn()).rejects.toBeInstanceOf(PermanentSpawnError);
+    expect(h.cancels).toEqual([]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+  });
+
+  test('a second call waits on the in-flight peer through the shell wait loop', async () => {
+    const gate = deferred<{ path: string }>();
+    const h = makeSpawnFlowHarness({ kickoff: false, worktreeGate: gate.promise });
+
+    const first = h.spawn();
+    const second = h.spawn();
+    gate.resolve({ path: '/tmp/wt-1240' });
+
+    expect(await second).toBe(SPAWNED_SESSION_ID);
+    expect(await first).toBe(SPAWNED_SESSION_ID);
+    expect(h.order.filter((step) => step === 'createSubSession')).toHaveLength(1);
+    expect(h.updates.some((u) => u.patch.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-admission-decision-pipeline.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-admission-decision-pipeline.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test';
+import type { SpaceTaskStatus } from '@hyperneo/shared';
+import type { SpawnExecutionAdmissionInput } from '../../../../src/lib/space/runtime/spawn-admission-gates';
+import { decideSpawnExecutionAdmission } from '../../../../src/lib/space/runtime/spawn-admission-gates';
+import {
+  applyConcurrentSpawnGate,
+  applyLiveSessionGate,
+  applyProceedGate,
+  applySlotResolutionGate,
+  applyTaskStatusGate,
+  applyWorkflowValidityGate,
+  decideSpawnExecutionAdmissionViaPipeline,
+  type SpawnAdmissionCtx,
+} from '../../../../src/lib/space/runtime/spawn-admission-decision-pipeline';
+
+const BASE: SpawnExecutionAdmissionInput = {
+  hasLiveIndexedSession: false,
+  isSpawningExecution: false,
+  taskStatus: 'in_progress',
+  executionWorkflowValid: true,
+  slotResolvable: true,
+};
+
+function undecided(input: SpawnExecutionAdmissionInput): SpawnAdmissionCtx {
+  return { ...input, decision: null };
+}
+
+describe('spawn admission decisionRun gates', () => {
+  test('non-deciding gates pass the ctx through by reference', () => {
+    const ctx = undecided(BASE);
+    expect(applyLiveSessionGate(ctx)).toBe(ctx);
+    expect(applyConcurrentSpawnGate(ctx)).toBe(ctx);
+    expect(applyTaskStatusGate(ctx)).toBe(ctx);
+    expect(applyWorkflowValidityGate(ctx)).toBe(ctx);
+    expect(applySlotResolutionGate(ctx)).toBe(ctx);
+  });
+
+  test('applyProceedGate always decides proceed_fresh', () => {
+    const ctx = undecided(BASE);
+    expect(applyProceedGate(ctx).decision).toEqual({ action: 'proceed_fresh' });
+  });
+
+  test('applyLiveSessionGate decides reuse_live on a live indexed session', () => {
+    const decision = applyLiveSessionGate(
+      undecided({ ...BASE, hasLiveIndexedSession: true })
+    ).decision;
+    expect(decision).toEqual({ action: 'reuse_live' });
+  });
+
+  test('applyConcurrentSpawnGate decides wait_concurrent on an in-flight spawn', () => {
+    const decision = applyConcurrentSpawnGate(
+      undecided({ ...BASE, isSpawningExecution: true })
+    ).decision;
+    expect(decision).toEqual({ action: 'wait_concurrent' });
+  });
+
+  test('applyTaskStatusGate maps each terminal and rate/usage status to its member', () => {
+    expect(applyTaskStatusGate(undecided({ ...BASE, taskStatus: 'archived' })).decision).toEqual({
+      action: 'reject_permanent',
+      reason: 'task_archived',
+    });
+    expect(applyTaskStatusGate(undecided({ ...BASE, taskStatus: 'cancelled' })).decision).toEqual({
+      action: 'reject_permanent',
+      reason: 'task_cancelled',
+    });
+    expect(
+      applyTaskStatusGate(undecided({ ...BASE, taskStatus: 'rate_limited' })).decision
+    ).toEqual({ action: 'reject_transient', reason: 'task_rate_or_usage_limited' });
+    expect(
+      applyTaskStatusGate(undecided({ ...BASE, taskStatus: 'usage_limited' })).decision
+    ).toEqual({ action: 'reject_transient', reason: 'task_rate_or_usage_limited' });
+    expect(applyTaskStatusGate(undecided({ ...BASE, taskStatus: 'stopped' })).decision).toBeNull();
+  });
+
+  test('applyWorkflowValidityGate and applySlotResolutionGate decide their permanent rejects', () => {
+    expect(
+      applyWorkflowValidityGate(undecided({ ...BASE, executionWorkflowValid: false })).decision
+    ).toEqual({ action: 'reject_permanent', reason: 'workflow_invalid' });
+    expect(applySlotResolutionGate(undecided({ ...BASE, slotResolvable: false })).decision).toEqual(
+      {
+        action: 'reject_permanent',
+        reason: 'slot_unresolvable',
+      }
+    );
+  });
+});
+
+describe('spawn admission decisionRun parity with the pure core', () => {
+  const STATUSES: SpaceTaskStatus[] = [
+    'draft',
+    'open',
+    'in_progress',
+    'review',
+    'approved',
+    'done',
+    'blocked',
+    'cancelled',
+    'archived',
+    'rate_limited',
+    'usage_limited',
+    'stopped',
+  ];
+
+  test('the pipeline matches decideSpawnExecutionAdmission across the full input matrix', () => {
+    for (const hasLiveIndexedSession of [false, true]) {
+      for (const isSpawningExecution of [false, true]) {
+        for (const taskStatus of STATUSES) {
+          for (const executionWorkflowValid of [false, true]) {
+            for (const slotResolvable of [false, true]) {
+              const input: SpawnExecutionAdmissionInput = {
+                hasLiveIndexedSession,
+                isSpawningExecution,
+                taskStatus,
+                executionWorkflowValid,
+                slotResolvable,
+              };
+              expect(decideSpawnExecutionAdmissionViaPipeline(input)).toEqual(
+                decideSpawnExecutionAdmission(input)
+              );
+            }
+          }
+        }
+      }
+    }
+  });
+
+  test('precedence: a live indexed session beats every downstream gate', () => {
+    const decision = decideSpawnExecutionAdmissionViaPipeline({
+      hasLiveIndexedSession: true,
+      isSpawningExecution: true,
+      taskStatus: 'archived',
+      executionWorkflowValid: false,
+      slotResolvable: false,
+    });
+    expect(decision).toEqual({ action: 'reuse_live' });
+  });
+
+  test('precedence: an in-flight concurrent spawn beats the reject gates', () => {
+    const decision = decideSpawnExecutionAdmissionViaPipeline({
+      hasLiveIndexedSession: false,
+      isSpawningExecution: true,
+      taskStatus: 'usage_limited',
+      executionWorkflowValid: false,
+      slotResolvable: false,
+    });
+    expect(decision).toEqual({ action: 'wait_concurrent' });
+  });
+
+  test('precedence: task status beats workflow validity beats slot resolvability', () => {
+    expect(
+      decideSpawnExecutionAdmissionViaPipeline({
+        hasLiveIndexedSession: false,
+        isSpawningExecution: false,
+        taskStatus: 'archived',
+        executionWorkflowValid: false,
+        slotResolvable: false,
+      })
+    ).toEqual({ action: 'reject_permanent', reason: 'task_archived' });
+    expect(
+      decideSpawnExecutionAdmissionViaPipeline({
+        hasLiveIndexedSession: false,
+        isSpawningExecution: false,
+        taskStatus: 'in_progress',
+        executionWorkflowValid: false,
+        slotResolvable: false,
+      })
+    ).toEqual({ action: 'reject_permanent', reason: 'workflow_invalid' });
+  });
+
+  test('the pipeline decides synchronously', () => {
+    let observed: unknown = 'unset';
+    Promise.resolve().then(() => {
+      observed = 'microtask ran first';
+    });
+    const decision = decideSpawnExecutionAdmissionViaPipeline(BASE);
+    expect(decision).toEqual({ action: 'proceed_fresh' });
+    expect(observed).toBe('unset');
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  NodeExecution,
+  Space,
+  SpaceTask,
+  SpaceWorkflow,
+  SpaceWorkflowRun,
+} from '@hyperneo/shared';
+import type { SpawnExecutionFlowDeps } from '../../../../src/lib/space/runtime/spawn-flow';
+import {
+  isSpawnFlowWaitConcurrent,
+  runSpawnExecutionFlow,
+} from '../../../../src/lib/space/runtime/spawn-flow';
+
+const TASK_ID = 'task-1240';
+const RUN_ID = 'run-1240';
+const SPACE_ID = 'space-1240';
+const NODE_ID = 'node-coder';
+const AGENT_NAME = 'coder';
+const AGENT_ID = 'agent-coder';
+const EXECUTION_ID = 'exec-1240';
+const SPAWNED_SESSION_ID = 'spawned-session-1';
+
+function makeExecution(overrides: Partial<NodeExecution> = {}): NodeExecution {
+  return {
+    id: EXECUTION_ID,
+    workflowRunId: RUN_ID,
+    workflowNodeId: NODE_ID,
+    agentName: AGENT_NAME,
+    agentId: AGENT_ID,
+    agentSessionId: null,
+    status: 'pending',
+    result: null,
+    data: null,
+    createdAt: 1,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: 1,
+    lastActivityAt: null,
+    ...overrides,
+  };
+}
+
+function makeTask(status: string): SpaceTask {
+  return {
+    id: TASK_ID,
+    spaceId: SPACE_ID,
+    workflowRunId: RUN_ID,
+    title: 'Compose the spawn flow',
+    description: 'Staged spawn composition over the admission union',
+    taskNumber: 1240,
+    status,
+  } as unknown as SpaceTask;
+}
+
+function makeWorkflow(): SpaceWorkflow {
+  return {
+    id: 'wf-1240',
+    spaceId: SPACE_ID,
+    name: 'Coding',
+    nodes: [{ id: NODE_ID, agents: [{ agentId: AGENT_ID, name: AGENT_NAME }] }],
+    channels: [],
+    startNodeId: NODE_ID,
+    endNodeId: NODE_ID,
+  } as unknown as SpaceWorkflow;
+}
+
+interface FlowFixture {
+  deps: SpawnExecutionFlowDeps;
+  calls: string[];
+  cancels: string[];
+  releases: string[];
+  reservations: string[];
+  rebinds: Array<{ executionId: string; sessionId: string }>;
+  binds: Array<{ executionId: string; sessionId: string }>;
+  attaches: NodeExecution[];
+  kickoffMessages: string[];
+  injected: Array<{ sessionId: string; message: string }>;
+  liveIndexedSessionId: string | null;
+  spawningExecutionIds: Set<string>;
+  workspaceGate: Promise<string> | null;
+  input: {
+    task: SpaceTask;
+    space: Space;
+    workflow: SpaceWorkflow;
+    workflowRun: SpaceWorkflowRun;
+    execution: NodeExecution;
+    kickoff: boolean;
+  };
+  run: (
+    overrides?: Partial<SpawnExecutionFlowDeps>
+  ) => Promise<ReturnType<typeof runSpawnExecutionFlow>>;
+}
+
+function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {}): FlowFixture {
+  const calls: string[] = [];
+  const cancels: string[] = [];
+  const releases: string[] = [];
+  const reservations: string[] = [];
+  const rebinds: Array<{ executionId: string; sessionId: string }> = [];
+  const binds: Array<{ executionId: string; sessionId: string }> = [];
+  const attaches: NodeExecution[] = [];
+  const kickoffMessages: string[] = [];
+  const injected: Array<{ sessionId: string; message: string }> = [];
+  const spawningExecutionIds = new Set<string>();
+  const task = makeTask(options.taskStatus ?? 'in_progress');
+  const execution = makeExecution();
+  const boundExecution = {
+    ...execution,
+    status: 'in_progress' as const,
+    agentSessionId: SPAWNED_SESSION_ID,
+  };
+  let liveIndexedSessionId: string | null = null;
+  let workspaceGate: Promise<string> | null = null;
+
+  const deps: SpawnExecutionFlowDeps = {
+    getFreshTask: () => task,
+    getNodeExecution: () => boundExecution,
+    isSpawningExecution: (executionId) => spawningExecutionIds.has(executionId),
+    inspectIndexedSession: (agentSessionId) => ({ sessionId: agentSessionId, alive: false }),
+    reserveExecution: (executionId) => {
+      calls.push('reserve');
+      reservations.push(executionId);
+      spawningExecutionIds.add(executionId);
+    },
+    releaseExecution: (executionId) => {
+      calls.push('release');
+      releases.push(executionId);
+      spawningExecutionIds.delete(executionId);
+    },
+    cancelSpawnedSession: (sessionId) => {
+      calls.push(`cancel:${sessionId}`);
+      cancels.push(sessionId);
+    },
+    rebindLiveExecution: (row, sessionId) => {
+      calls.push(`rebind:${sessionId}`);
+      rebinds.push({ executionId: row.id, sessionId });
+    },
+    raiseSpawnRejection: () => {
+      calls.push('reject');
+      throw new Error('admission rejected');
+    },
+    resolveSpawnSessionId: () => {
+      calls.push('resolve-session-id');
+      return 'base-session-1';
+    },
+    resolveWorkspacePath: async () => {
+      calls.push('resolve-workspace');
+      return workspaceGate === null ? '/tmp/ws' : await workspaceGate;
+    },
+    createSpawnedSession: async () => {
+      calls.push('create');
+      return SPAWNED_SESSION_ID;
+    },
+    bindExecutionToSession: (row, sessionId) => {
+      calls.push(`bind:${sessionId}`);
+      binds.push({ executionId: row.id, sessionId });
+    },
+    attachNodeAgent: async (request) => {
+      calls.push('attach');
+      attaches.push(request.execution);
+    },
+    registerSpawnCompletionCallback: (taskId, workflowNodeId, sessionId) => {
+      calls.push(`register:${taskId}:${workflowNodeId}:${sessionId}`);
+    },
+    buildKickoffMessage: async () => {
+      calls.push('kickoff-message');
+      kickoffMessages.push('kickoff-msg');
+      return 'kickoff-msg';
+    },
+    injectKickoffMessage: async (sessionId, message) => {
+      calls.push(`inject:${sessionId}`);
+      injected.push({ sessionId, message });
+    },
+  };
+
+  return {
+    deps,
+    calls,
+    cancels,
+    releases,
+    reservations,
+    rebinds,
+    binds,
+    attaches,
+    kickoffMessages,
+    injected,
+    liveIndexedSessionId,
+    spawningExecutionIds,
+    workspaceGate,
+    input: {
+      task,
+      space: { id: SPACE_ID, workspacePath: '/tmp/ws' } as unknown as Space,
+      workflow: makeWorkflow(),
+      workflowRun: {
+        id: RUN_ID,
+        workflowId: 'wf-1240',
+        status: 'in_progress',
+      } as unknown as SpaceWorkflowRun,
+      execution,
+      kickoff: options.kickoff ?? true,
+    },
+    run: (overrides) =>
+      runSpawnExecutionFlow(
+        { ...deps, ...overrides },
+        {
+          task,
+          space: { id: SPACE_ID, workspacePath: '/tmp/ws' } as unknown as Space,
+          workflow: makeWorkflow(),
+          workflowRun: {
+            id: RUN_ID,
+            workflowId: 'wf-1240',
+            status: 'in_progress',
+          } as unknown as SpaceWorkflowRun,
+          execution,
+          kickoff: options.kickoff ?? true,
+        }
+      ),
+  };
+}
+
+describe('spawn flow — proceed_fresh path', () => {
+  test('runs admission, reserve, spawn, bind, attach, register, kickoff, and halts with the session id', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run();
+    expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
+    expect(h.calls).toEqual([
+      'reserve',
+      'resolve-session-id',
+      'resolve-workspace',
+      'create',
+      `bind:${SPAWNED_SESSION_ID}`,
+      'attach',
+      `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
+      'kickoff-message',
+      `inject:${SPAWNED_SESSION_ID}`,
+    ]);
+    expect(h.cancels).toEqual([]);
+    expect(h.releases).toEqual([]);
+    expect(h.reservations).toEqual([EXECUTION_ID]);
+  });
+
+  test('a kickoff-disabled spawn skips the kickoff message and inject but still binds and attaches', async () => {
+    const h = makeFlowFixture({ kickoff: false });
+    const outcome = await h.run();
+    expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
+    expect(h.calls).toEqual([
+      'reserve',
+      'resolve-session-id',
+      'resolve-workspace',
+      'create',
+      `bind:${SPAWNED_SESSION_ID}`,
+      'attach',
+      `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
+    ]);
+  });
+
+  test('the attach stage consumes the re-read bound execution row, not the admission-time snapshot', async () => {
+    const h = makeFlowFixture();
+    await h.run();
+    expect(h.attaches).toHaveLength(1);
+    expect(h.attaches[0]).toBe(h.deps.getNodeExecution(EXECUTION_ID) as NodeExecution);
+    expect(h.attaches[0].status).toBe('in_progress');
+    expect(h.attaches[0].agentSessionId).toBe(SPAWNED_SESSION_ID);
+  });
+
+  test('a missing fresh task falls back to the caller task snapshot', async () => {
+    const h = makeFlowFixture({ taskStatus: 'in_progress' });
+    const outcome = await h.run({ getFreshTask: () => null });
+    expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
+    expect(h.calls).toContain('create');
+  });
+});
+
+describe('spawn flow — alternative admission branches', () => {
+  test('reuse_live rebinds the indexed session and halts with its id', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      inspectIndexedSession: (agentSessionId) => ({
+        sessionId: agentSessionId ?? 'live-1',
+        alive: true,
+      }),
+    });
+    expect(outcome).toEqual({ status: 'completed', result: 'live-1' });
+    expect(h.rebinds).toEqual([{ executionId: EXECUTION_ID, sessionId: 'live-1' }]);
+    expect(h.calls).toEqual(['rebind:live-1']);
+    expect(h.reservations).toEqual([]);
+  });
+
+  test('wait_concurrent halts with the wait marker and runs no effect stage', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      isSpawningExecution: () => true,
+    });
+    expect(outcome).toEqual({ status: 'completed', result: { kind: 'wait_concurrent' } });
+    expect(isSpawnFlowWaitConcurrent(outcome.result)).toBe(true);
+    expect(h.calls).toEqual([]);
+  });
+
+  test('reject branches route through the rejection halt and surface its error', async () => {
+    const h = makeFlowFixture({ taskStatus: 'archived' });
+    const outcome = await h.run();
+    expect(outcome.status).toBe('error');
+    if (outcome.status === 'error') {
+      expect(outcome.stage).toBe('raise-spawn-rejection');
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toBe('admission rejected');
+      expect(outcome.unwind).toEqual([]);
+    }
+    expect(h.calls).toEqual(['reject']);
+    expect(h.cancels).toEqual([]);
+  });
+});
+
+describe('spawn flow — failure unwind (the catch-path cancel compensation)', () => {
+  test('a bind failure after session creation cancels the spawned session and releases the reservation', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      bindExecutionToSession: () => {
+        throw new Error('bind boom');
+      },
+    });
+    expect(outcome.status).toBe('error');
+    if (outcome.status === 'error') {
+      expect(outcome.stage).toBe('bind-execution-session');
+      expect((outcome.error as Error).message).toBe('bind boom');
+      expect(outcome.unwind).toEqual([
+        { stage: 'reserve-and-spawn-session', status: 'compensated' },
+      ]);
+    }
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.calls.indexOf(`cancel:${SPAWNED_SESSION_ID}`)).toBeLessThan(
+      h.calls.indexOf('release')
+    );
+  });
+
+  test('a create failure before the session exists releases the reservation without cancelling', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      createSpawnedSession: async () => {
+        throw new Error('create boom');
+      },
+    });
+    expect(outcome.status).toBe('error');
+    if (outcome.status === 'error') {
+      expect(outcome.stage).toBe('reserve-and-spawn-session');
+      expect((outcome.error as Error).message).toBe('create boom');
+    }
+    expect(h.cancels).toEqual([]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+  });
+
+  test('an attach failure cancels the spawned session and releases the reservation', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      attachNodeAgent: async () => {
+        throw new Error('attach boom');
+      },
+    });
+    expect(outcome.status).toBe('error');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.binds).toHaveLength(1);
+  });
+
+  test('a kickoff inject failure cancels the spawned session and releases the reservation', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      injectKickoffMessage: async () => {
+        throw new Error('inject boom');
+      },
+    });
+    expect(outcome.status).toBe('error');
+    if (outcome.status === 'error') {
+      expect(outcome.stage).toBe('kickoff-session');
+    }
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+  });
+
+  test('the compensation runs even when the spawn reservation was the only committed write', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      resolveWorkspacePath: async () => {
+        throw new Error('worktree boom');
+      },
+    });
+    expect(outcome.status).toBe('error');
+    expect(h.cancels).toEqual([]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.spawningExecutionIds.has(EXECUTION_ID)).toBe(false);
+  });
+});
+
+describe('spawn flow microtask profile', () => {
+  test('the reuse-live branch executes its effect and halt inside the invoke call', async () => {
+    const h = makeFlowFixture();
+    const promise = h.run({
+      inspectIndexedSession: (agentSessionId) => ({
+        sessionId: agentSessionId ?? 'live-1',
+        alive: true,
+      }),
+    });
+    expect(h.calls).toEqual(['rebind:live-1']);
+    await expect(promise).resolves.toEqual({ status: 'completed', result: 'live-1' });
+  });
+
+  test('admission and the reservation commit before the first awaited effect boundary', async () => {
+    const h = makeFlowFixture();
+    let releaseWorkspace: ((path: string) => void) | null = null;
+    const gate = new Promise<string>((resolve) => {
+      releaseWorkspace = resolve;
+    });
+    const promise = h.run({
+      resolveWorkspacePath: async () => {
+        h.calls.push('resolve-workspace');
+        await gate;
+        return '/tmp/ws';
+      },
+    });
+    expect(h.calls).toEqual(['reserve', 'resolve-session-id', 'resolve-workspace']);
+    expect(h.spawningExecutionIds.has(EXECUTION_ID)).toBe(true);
+    expect(h.calls).not.toContain('create');
+    releaseWorkspace!('/tmp/ws');
+    await expect(promise).resolves.toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
+  });
+
+  test('an inter-stage continuation defers past a queued microtask observer', async () => {
+    const h = makeFlowFixture();
+    const order: string[] = [];
+    const promise = runSpawnExecutionFlow(
+      {
+        ...h.deps,
+        resolveWorkspacePath: async () => {
+          order.push('workspace');
+          return '/tmp/ws';
+        },
+        bindExecutionToSession: () => {
+          order.push('bind');
+        },
+      },
+      h.input
+    );
+    queueMicrotask(() => order.push('observer'));
+    await promise;
+    expect(order).toEqual(['workspace', 'observer', 'bind']);
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -8,6 +8,7 @@ import type {
 } from '@hyperneo/shared';
 import type { SpawnExecutionFlowDeps } from '../../../../src/lib/space/runtime/spawn-flow';
 import {
+  isSpawnFlowReusedSession,
   isSpawnFlowWaitConcurrent,
   runSpawnExecutionFlow,
 } from '../../../../src/lib/space/runtime/spawn-flow';
@@ -273,7 +274,7 @@ describe('spawn flow — proceed_fresh path', () => {
 });
 
 describe('spawn flow — alternative admission branches', () => {
-  test('reuse_live rebinds the indexed session and halts with its id', async () => {
+  test('reuse_live rebinds the indexed session and halts with a reused-session result', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run({
       inspectIndexedSession: (agentSessionId) => ({
@@ -281,7 +282,11 @@ describe('spawn flow — alternative admission branches', () => {
         alive: true,
       }),
     });
-    expect(outcome).toEqual({ status: 'completed', result: 'live-1' });
+    expect(outcome).toEqual({
+      status: 'completed',
+      result: { kind: 'reused_session', sessionId: 'live-1' },
+    });
+    expect(isSpawnFlowReusedSession(outcome.result)).toBe(true);
     expect(h.rebinds).toEqual([{ executionId: EXECUTION_ID, sessionId: 'live-1' }]);
     expect(h.calls).toEqual(['rebind:live-1']);
     expect(h.reservations).toEqual([]);
@@ -403,7 +408,10 @@ describe('spawn flow microtask profile', () => {
       }),
     });
     expect(h.calls).toEqual(['rebind:live-1']);
-    await expect(promise).resolves.toEqual({ status: 'completed', result: 'live-1' });
+    await expect(promise).resolves.toEqual({
+      status: 'completed',
+      result: { kind: 'reused_session', sessionId: 'live-1' },
+    });
   });
 
   test('admission and the reservation commit before the first awaited effect boundary', async () => {


### PR DESCRIPTION
Superpipe chain P PR 4/6 (task #1240), additive — the apply is P5. Composes the workflow-node spawn flow over the S2 staged-run combinator: the P2 admission core becomes a decisionRun gate list (parity-pinned against the pure function across the full input matrix), and spawn-flow.ts stages it as snapshot → decide (branch routing via ?dep guards on the decision member, no per-action dispatcher) → reserve/spawn → bind → attach/register → kickoff → halt, with the catch-path session cancel + reservation release as the registered reverse-unwind compensation and microtask pins for the sync decide. TaskAgentManager gains spawnWorkflowNodeAgentForExecutionViaFlow; the concurrent-spawn WAIT loop moves to a shared shell-owned helper (pipeline is never the loop) and the existing method is otherwise untouched — P1 pins stay green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->