### PR TITLE
fix(daemon): keep saveSDKMessage true when post-commit effects fail

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -588,8 +588,13 @@ export class SDKMessageRepository {
         this.scheduleMessageSearchIndex(id);
         if (countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
       })();
-      if (countsTowardsBadge) this.notifySessionsChanged(sessionId);
-      this.deleteSupersededMessageSearchRows(sessionId, message);
+      try {
+        if (countsTowardsBadge) this.notifySessionsChanged(sessionId);
+        this.deleteSupersededMessageSearchRows(sessionId, message);
+      } catch (error) {
+        this.logger.error('[Database] Post-commit side effects failed for SDK message:', error);
+        this.logger.error('[Database] Message type:', message.type, 'Session:', sessionId);
+      }
       return true;
     } catch (error) {
       this.logger.error('[Database] Failed to save SDK message:', error);

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -7,6 +7,7 @@ import type {
   MessageSearchResponse,
 } from '../../../../src/storage/message-search';
 import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
 import { Database } from '../../../../src/storage/sqlite-compat';
 
 describe('SDKMessageRepository', () => {
@@ -381,6 +382,32 @@ describe('SDKMessageRepository', () => {
 
       expect(session1Messages.length).toBe(1);
       expect(session2Messages.length).toBe(1);
+    });
+
+    it('returns false when the insert itself fails', () => {
+      db.exec('DROP TABLE sdk_messages');
+
+      expect(repository.saveSDKMessage('session-1', createUserMessage('never persisted'))).toBe(
+        false
+      );
+    });
+
+    it('returns true for a committed row when post-commit notifications fail', () => {
+      const failingReactiveDb = {
+        resolveTaskIdForSession: () => null,
+        notifyChange: () => {
+          throw new Error('reactive notify failed');
+        },
+      } as unknown as ReactiveDatabase;
+      const repo = new SDKMessageRepository(db as any, failingReactiveDb);
+
+      const result = repo.saveSDKMessage('session-1', createUserMessage('committed'));
+
+      expect(result).toBe(true);
+      const row = db
+        .prepare(`SELECT COUNT(*) AS count FROM sdk_messages WHERE session_id = ?`)
+        .get('session-1') as { count: number };
+      expect(row.count).toBe(1);
     });
   });
 


### PR DESCRIPTION
In saveSDKMessage, an exception in the post-commit notifySessionsChanged/deleteSupersededMessageSearchRows work returned false even though the row was already committed, causing sdk-message-handler to skip the sdkMessages.delta push and downstream sdk.message events for a persisted message. The post-commit work is now guarded so failures log without flipping the return; genuine insert failures still return false. Repository tests pin both paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->