### PR TITLE
feat(space): compose verified-stop flow as stagedRun (superpipe S4 PR 4/6)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -92,6 +92,7 @@ import {
   type StopVerificationDecision,
   type StopVerificationSnapshot,
 } from './stop-verification-gates';
+import { runVerifiedStopFlow, type VerifiedStopFlowDeps } from './verified-stop-flow';
 import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-manager';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
@@ -2318,6 +2319,59 @@ export class TaskAgentManager {
     } finally {
       this.cancellingSessions.delete(sessionId);
     }
+  }
+
+  async stopSessionVerifiedViaFlow(sessionId: string): Promise<VerifiedSessionStop> {
+    this.cancellingSessions.add(sessionId);
+    try {
+      const outcome = await runVerifiedStopFlow(this.buildVerifiedStopFlowDeps(), sessionId);
+      if (outcome.status === 'error') {
+        throw outcome.error;
+      }
+      if (outcome.status === 'superseded') {
+        throw new Error(
+          `TaskAgentManager.stopSessionVerifiedViaFlow: verified stop for session ${sessionId} superseded at stage ${outcome.stage ?? 'unknown'}`
+        );
+      }
+      return outcome.result as VerifiedSessionStop;
+    } finally {
+      this.cancellingSessions.delete(sessionId);
+    }
+  }
+
+  private buildVerifiedStopFlowDeps(): VerifiedStopFlowDeps {
+    return {
+      claimSession: (sessionId) => {
+        const session =
+          this.agentSessionIndex.get(sessionId) ??
+          this.config.sessionManager?.getCachedSession(sessionId) ??
+          null;
+        this.agentSessionIndex.delete(sessionId);
+        return session;
+      },
+      stopSessionStrict: (sessionId, session) =>
+        this.stopSessionPreserveDb(sessionId, session, { strict: true }),
+      readProcessingStatus: (session) => session.getProcessingState().status,
+      isInterruptInProgress: (session) => session.isInterruptInProgress(),
+      awaitProcessExitSettle: (session) =>
+        this.awaitSessionProcessExit(session, VERIFIED_STOP_PROCESS_EXIT_SETTLE_MS),
+      readLivePids: (session) => session.getTrackedAgentRootPidsSplit().live,
+      terminateTrackedProcesses: (session) =>
+        session.terminateTrackedAgentProcesses({
+          forceDelayMs: VERIFIED_STOP_ESCALATION_FORCE_KILL_MS,
+        }),
+      unregisterSession: async (sessionId) => {
+        await this.config.sessionManager?.unregisterSession?.(sessionId);
+      },
+      detachSessionBookkeeping: (sessionId) => this.detachSessionBookkeeping(sessionId),
+      warn: (message, err) => {
+        if (err === undefined) {
+          log.warn(message);
+          return;
+        }
+        log.warn(message, err);
+      },
+    };
   }
 
   private async gatherStopVerificationSnapshot(

--- a/packages/daemon/src/lib/space/runtime/verified-stop-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/verified-stop-flow.ts
@@ -4,6 +4,7 @@ import {
   assembleVerifiedStopResult,
   decideStopVerification,
   isStopDownProcessingStatus,
+  type SessionLivenessSnapshot,
   type StopVerificationDecision,
 } from './stop-verification-gates';
 import { stagedRun, type StagedRunOutcome } from './staged-run';
@@ -29,12 +30,6 @@ interface VerifiedStopFlowState {
   livePids: readonly number[];
 }
 
-interface SessionLivenessGather {
-  processingStatus: AgentProcessingState['status'];
-  interruptInProgress: boolean;
-  livePids: readonly number[];
-}
-
 function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -42,7 +37,7 @@ function describeError(err: unknown): string {
 async function gatherSessionLiveness(
   deps: VerifiedStopFlowDeps,
   session: AgentSession
-): Promise<SessionLivenessGather> {
+): Promise<SessionLivenessSnapshot> {
   const processingStatus = deps.readProcessingStatus(session);
   if (!isStopDownProcessingStatus(processingStatus)) {
     return { processingStatus, interruptInProgress: false, livePids: [] };

--- a/packages/daemon/src/lib/space/runtime/verified-stop-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/verified-stop-flow.ts
@@ -1,0 +1,273 @@
+import type { AgentProcessingState } from '@hyperneo/shared';
+import type { AgentSession } from '../../../lib/agent/agent-session';
+import {
+  assembleVerifiedStopResult,
+  decideStopVerification,
+  isStopDownProcessingStatus,
+  type StopVerificationDecision,
+} from './stop-verification-gates';
+import { stagedRun, type StagedRunOutcome } from './staged-run';
+
+export interface VerifiedStopFlowDeps {
+  claimSession(sessionId: string): AgentSession | null;
+  stopSessionStrict(sessionId: string, session: AgentSession): Promise<void>;
+  readProcessingStatus(session: AgentSession): AgentProcessingState['status'];
+  isInterruptInProgress(session: AgentSession): boolean;
+  awaitProcessExitSettle(session: AgentSession): Promise<void>;
+  readLivePids(session: AgentSession): readonly number[];
+  terminateTrackedProcesses(session: AgentSession): void;
+  unregisterSession(sessionId: string): Promise<void>;
+  detachSessionBookkeeping(sessionId: string): void;
+  warn(message: string, err?: unknown): void;
+}
+
+interface VerifiedStopFlowState {
+  sessionId: string;
+  session: AgentSession | null;
+  processingStatus: AgentProcessingState['status'];
+  interruptInProgress: boolean;
+  livePids: readonly number[];
+}
+
+interface SessionLivenessGather {
+  processingStatus: AgentProcessingState['status'];
+  interruptInProgress: boolean;
+  livePids: readonly number[];
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function gatherSessionLiveness(
+  deps: VerifiedStopFlowDeps,
+  session: AgentSession
+): Promise<SessionLivenessGather> {
+  const processingStatus = deps.readProcessingStatus(session);
+  if (!isStopDownProcessingStatus(processingStatus)) {
+    return { processingStatus, interruptInProgress: false, livePids: [] };
+  }
+  const interruptInProgress = deps.isInterruptInProgress(session);
+  if (interruptInProgress) {
+    return { processingStatus, interruptInProgress, livePids: [] };
+  }
+  await deps.awaitProcessExitSettle(session);
+  return { processingStatus, interruptInProgress, livePids: deps.readLivePids(session) };
+}
+
+export function runVerifiedStopFlow(
+  deps: VerifiedStopFlowDeps,
+  sessionId: string
+): Promise<StagedRunOutcome> {
+  const notes: string[] = [];
+  const flow = stagedRun<VerifiedStopFlowState>(
+    'verified-stop',
+    (s) => [
+      s.snapshot({
+        name: 'claim-session',
+        provides: ['session'],
+        reads: ['sessionId'],
+        run: (view) => ({ session: deps.claimSession(view.sessionId) }),
+      }),
+      s.decide({
+        name: 'session-presence',
+        reads: ['session'],
+        branches: ['missing', 'present'],
+        run: (view) =>
+          view.session === null
+            ? { decision: { action: 'missing' }, missing: true }
+            : { decision: { action: 'interrupt' }, present: true },
+      }),
+      s.effect({
+        name: 'unregister-missing-session',
+        when: 'missing',
+        reads: ['sessionId'],
+        writes: [],
+        run: async (view) => {
+          try {
+            await deps.unregisterSession(view.sessionId);
+          } catch (err) {
+            deps.warn(
+              `TaskAgentManager.stopSessionsVerified: failed to unregister missing session ${view.sessionId}:`,
+              err
+            );
+          }
+        },
+      }),
+      s.halt({
+        name: 'missing-verdict',
+        when: 'missing',
+        reads: ['sessionId'],
+        run: (view) => ({
+          sessionId: view.sessionId,
+          stopped: true,
+          detail: 'no in-memory session; unregistered',
+        }),
+      }),
+      s.effect({
+        name: 'interrupt-session',
+        when: 'present',
+        reads: ['sessionId', 'session'],
+        writes: [],
+        run: async (view) => {
+          try {
+            await deps.stopSessionStrict(view.sessionId, view.session!);
+          } catch (err) {
+            notes.push(`interrupt failed: ${describeError(err)}`);
+          }
+        },
+      }),
+      s.resnapshot({
+        name: 'verify-after-interrupt',
+        when: 'present',
+        provides: ['processingStatus', 'interruptInProgress', 'livePids'],
+        reads: ['session'],
+        run: (view) => gatherSessionLiveness(deps, view.session!),
+      }),
+      s.decide({
+        name: 'verdict-after-first-interrupt',
+        when: 'present',
+        reads: ['processingStatus', 'interruptInProgress', 'livePids'],
+        branches: ['downAfterFirstInterrupt', 'retryInterrupt'],
+        run: (view) => {
+          const decision = decideStopVerification({
+            sessionPresent: true,
+            processingStatus: view.processingStatus,
+            interruptInProgress: view.interruptInProgress,
+            livePids: view.livePids,
+            interruptAttemptsSoFar: 1,
+            escalationDone: false,
+          });
+          if (decision.action === 'down') {
+            return { decision, downAfterFirstInterrupt: true };
+          }
+          if (decision.action === 'retry_interrupt') {
+            return { decision, retryInterrupt: { reason: decision.reason } };
+          }
+          return { decision };
+        },
+      }),
+      s.effect({
+        name: 'retry-interrupt',
+        when: 'retryInterrupt',
+        reads: ['sessionId', 'session'],
+        writes: [],
+        run: async (view) => {
+          const reason = (view.retryInterrupt as { reason: string }).reason;
+          deps.warn(
+            `TaskAgentManager.stopSessionsVerified: session ${view.sessionId} still alive after interrupt (${reason}); retrying once`
+          );
+          try {
+            await deps.stopSessionStrict(view.sessionId, view.session!);
+          } catch (err) {
+            notes.push(`retry interrupt failed: ${describeError(err)}`);
+          }
+        },
+      }),
+      s.resnapshot({
+        name: 'verify-after-retry',
+        when: 'retryInterrupt',
+        provides: ['processingStatus', 'interruptInProgress', 'livePids'],
+        reads: ['session'],
+        run: (view) => gatherSessionLiveness(deps, view.session!),
+      }),
+      s.decide({
+        name: 'verdict-after-retry',
+        when: 'retryInterrupt',
+        reads: ['processingStatus', 'interruptInProgress', 'livePids'],
+        branches: ['downAfterRetry', 'escalateTerminate'],
+        run: (view) => {
+          const decision = decideStopVerification({
+            sessionPresent: true,
+            processingStatus: view.processingStatus,
+            interruptInProgress: view.interruptInProgress,
+            livePids: view.livePids,
+            interruptAttemptsSoFar: 2,
+            escalationDone: false,
+          });
+          if (decision.action === 'down') {
+            return { decision, downAfterRetry: true };
+          }
+          if (decision.action === 'escalate_terminate') {
+            return { decision, escalateTerminate: { reason: decision.reason } };
+          }
+          return { decision };
+        },
+      }),
+      s.effect({
+        name: 'note-stopped-on-retry',
+        when: 'downAfterRetry',
+        reads: [],
+        writes: [],
+        run: () => {
+          notes.push('first interrupt did not land; stopped on retry');
+        },
+      }),
+      s.effect({
+        name: 'terminate-tracked-processes',
+        when: 'escalateTerminate',
+        reads: ['sessionId', 'session'],
+        writes: [],
+        run: (view) => {
+          const reason = (view.escalateTerminate as { reason: string }).reason;
+          deps.warn(
+            `TaskAgentManager.stopSessionsVerified: session ${view.sessionId} survived interrupt retry (${reason}); escalating to tracked process termination`
+          );
+          notes.push(`escalated after verification failure (${reason})`);
+          try {
+            deps.terminateTrackedProcesses(view.session!);
+          } catch (err) {
+            notes.push(`escalation failed: ${describeError(err)}`);
+          }
+        },
+      }),
+      s.resnapshot({
+        name: 'verify-after-escalation',
+        when: 'escalateTerminate',
+        provides: ['processingStatus', 'interruptInProgress', 'livePids'],
+        reads: ['session'],
+        run: (view) => gatherSessionLiveness(deps, view.session!),
+      }),
+      s.decide({
+        name: 'final-verdict',
+        when: 'escalateTerminate',
+        reads: ['processingStatus', 'interruptInProgress', 'livePids'],
+        run: (view) => ({
+          decision: decideStopVerification({
+            sessionPresent: true,
+            processingStatus: view.processingStatus,
+            interruptInProgress: view.interruptInProgress,
+            livePids: view.livePids,
+            interruptAttemptsSoFar: 2,
+            escalationDone: true,
+          }),
+        }),
+      }),
+      s.effect({
+        name: 'detach-and-unregister',
+        reads: ['sessionId'],
+        writes: [],
+        run: async (view) => {
+          deps.detachSessionBookkeeping(view.sessionId);
+          try {
+            await deps.unregisterSession(view.sessionId);
+          } catch (err) {
+            notes.push(`unregister failed: ${describeError(err)}`);
+          }
+        },
+      }),
+      s.halt({
+        name: 'stop-verdict',
+        reads: ['sessionId', 'decision'],
+        run: (view) =>
+          assembleVerifiedStopResult({
+            sessionId: view.sessionId,
+            notes,
+            decision: view.decision as StopVerificationDecision,
+          }),
+      }),
+    ],
+    { input: ['sessionId'] }
+  );
+  return flow({ sessionId });
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -31,6 +31,7 @@ import {
 import type { SQLiteValue } from '../types';
 import {
   decideMessageAdmission,
+  extractReplacementEdges,
   normalizeMessageAdmissionInput,
   type SDKMessageReplacementEdge,
   type SendStatus,

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
@@ -33,6 +33,7 @@ interface FakeSessionOptions {
   processingStateError?: unknown;
   cleanupError?: unknown;
   terminateError?: unknown;
+  processExitedPromise?: Promise<void> | null;
 }
 
 function makeFakeSession(options: FakeSessionOptions = {}): FakeSessionController {
@@ -58,6 +59,7 @@ function makeFakeSession(options: FakeSessionOptions = {}): FakeSessionControlle
   };
   let interruptCalls = 0;
   controller.session = {
+    processExitedPromise: options.processExitedPromise ?? null,
     handleInterrupt: async (interruptOptions?: FakeInterruptOptions) => {
       calls.interruptOptions.push(interruptOptions);
       if (options.interruptGate) await options.interruptGate;
@@ -140,6 +142,10 @@ function internalsOf(manager: TaskAgentManager) {
     sessionListeners: Map<string, () => void>;
     completionCallbacks: Map<string, unknown>;
   };
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
@@ -354,6 +360,37 @@ describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
     releaseInterrupt();
     await promise;
     expect(internals.subSessions.get('task-1')?.has('sess-1')).toBe(false);
+  });
+
+  test('waits for the tracked process exit before checking live pids', async () => {
+    const manager = makeManager(makeSessionManager());
+    let releaseExit: () => void = () => {};
+    const exitGate = new Promise<void>((resolve) => {
+      releaseExit = resolve;
+    });
+    const fake = makeFakeSession({
+      statusSequence: ['processing', 'idle'],
+      livePids: [4242],
+      processExitedPromise: exitGate,
+    });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    let settled = false;
+    const promise = manager.stopSessionVerifiedViaFlow('sess-1').then((result) => {
+      settled = true;
+      return result;
+    });
+    await tick();
+    expect(settled).toBe(false);
+    expect(fake.calls.interrupts).toBe(1);
+    expect(fake.calls.terminations).toBe(0);
+
+    fake.clearPids();
+    releaseExit();
+    const result = await promise;
+    expect(settled).toBe(true);
+    expect(result).toEqual({ sessionId: 'sess-1', stopped: true });
+    expect(fake.calls.terminations).toBe(0);
   });
 
   test('propagates a verification crash and still clears the cancelling guard', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-stop-verified-flow.test.ts
@@ -1,0 +1,382 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+
+interface FakeInterruptOptions {
+  skipDeferredReplay?: boolean;
+  preserveDeliveryJobs?: boolean;
+}
+
+interface FakeSessionCalls {
+  interrupts: number;
+  cleanups: number;
+  terminations: number;
+  terminateOptions: Array<{ forceDelayMs?: number } | undefined>;
+  interruptOptions: Array<FakeInterruptOptions | undefined>;
+}
+
+interface FakeSessionController {
+  calls: FakeSessionCalls;
+  setStatus(status: string): void;
+  clearPids(): void;
+  session: AgentSession;
+}
+
+interface FakeSessionOptions {
+  statusSequence?: string[];
+  interruptErrors?: unknown[];
+  interruptGate?: Promise<void>;
+  livePids?: number[];
+  onTerminate?: (controller: FakeSessionController) => void;
+  interruptInProgress?: boolean;
+  processingStateError?: unknown;
+  cleanupError?: unknown;
+  terminateError?: unknown;
+}
+
+function makeFakeSession(options: FakeSessionOptions = {}): FakeSessionController {
+  const statusSequence = options.statusSequence ?? ['processing', 'idle'];
+  let statusIndex = 0;
+  let livePids = [...(options.livePids ?? [])];
+  const calls: FakeSessionCalls = {
+    interrupts: 0,
+    cleanups: 0,
+    terminations: 0,
+    terminateOptions: [],
+    interruptOptions: [],
+  };
+  const controller: FakeSessionController = {
+    calls,
+    setStatus(status: string) {
+      statusSequence[statusIndex] = status;
+    },
+    clearPids() {
+      livePids = [];
+    },
+    session: null as unknown as AgentSession,
+  };
+  let interruptCalls = 0;
+  controller.session = {
+    handleInterrupt: async (interruptOptions?: FakeInterruptOptions) => {
+      calls.interruptOptions.push(interruptOptions);
+      if (options.interruptGate) await options.interruptGate;
+      interruptCalls++;
+      calls.interrupts++;
+      const err = options.interruptErrors?.[interruptCalls - 1];
+      if (err !== undefined) throw err;
+      if (statusIndex < statusSequence.length - 1) {
+        statusIndex++;
+      }
+    },
+    cleanup: async () => {
+      calls.cleanups++;
+      if (options.cleanupError !== undefined) throw options.cleanupError;
+    },
+    getProcessingState: () => {
+      if (options.processingStateError !== undefined) throw options.processingStateError;
+      return { status: statusSequence[statusIndex] };
+    },
+    isInterruptInProgress: () => options.interruptInProgress === true,
+    getTrackedAgentRootPidsSplit: () => ({ live: [...livePids], exited: [] }),
+    terminateTrackedAgentProcesses: (opts?: { forceDelayMs?: number }) => {
+      calls.terminations++;
+      calls.terminateOptions.push(opts);
+      options.onTerminate?.(controller);
+      if (options.terminateError !== undefined) throw options.terminateError;
+    },
+  } as unknown as AgentSession;
+  return controller;
+}
+
+function makeSessionManager(options: { events?: string[]; failUnregisterFor?: string[] } = {}) {
+  const cached = new Map<string, AgentSession>();
+  const unregisterCalls: string[] = [];
+  return {
+    cached,
+    unregisterCalls,
+    getCachedSession: (sessionId: string) => cached.get(sessionId) ?? null,
+    unregisterSession: async (sessionId: string) => {
+      options.events?.push('unregister');
+      unregisterCalls.push(sessionId);
+      cached.delete(sessionId);
+      if (options.failUnregisterFor?.includes(sessionId)) {
+        throw new Error('unregister rejected');
+      }
+    },
+  };
+}
+
+function makeManager(sessionManager: ReturnType<typeof makeSessionManager>): TaskAgentManager {
+  const db = new BunDatabase(':memory:');
+  return new TaskAgentManager({
+    db: { getDatabase: () => db },
+    internalEventBus: { subscribe: () => () => {} },
+    sessionManager,
+  } as unknown as ConstructorParameters<typeof TaskAgentManager>[0]);
+}
+
+function registerSession(
+  manager: TaskAgentManager,
+  taskId: string,
+  sessionId: string,
+  session: AgentSession
+): void {
+  const internals = internalsOf(manager);
+  let nodeMap = internals.subSessions.get(taskId);
+  if (!nodeMap) {
+    nodeMap = new Map();
+    internals.subSessions.set(taskId, nodeMap);
+  }
+  nodeMap.set(sessionId, session);
+  internals.agentSessionIndex.set(sessionId, session);
+}
+
+function internalsOf(manager: TaskAgentManager) {
+  return manager as unknown as {
+    subSessions: Map<string, Map<string, AgentSession>>;
+    agentSessionIndex: Map<string, AgentSession>;
+    cancellingSessions: Set<string>;
+    sessionListeners: Map<string, () => void>;
+    completionCallbacks: Map<string, unknown>;
+  };
+}
+
+describe('TaskAgentManager.stopSessionVerifiedViaFlow', () => {
+  test('happy path: interrupts once, verifies down, detaches, and unregisters', async () => {
+    const sessionManager = makeSessionManager();
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['processing', 'idle'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(1);
+    expect(fake.calls.cleanups).toBeGreaterThanOrEqual(1);
+    expect(fake.calls.terminations).toBe(0);
+    expect(fake.calls.interruptOptions).toEqual([{ skipDeferredReplay: true }]);
+    expect(result).toEqual({ sessionId: 'sess-1', stopped: true });
+
+    const internals = internalsOf(manager);
+    expect(internals.agentSessionIndex.has('sess-1')).toBe(false);
+    expect(internals.subSessions.get('task-1')?.has('sess-1')).toBe(false);
+    expect(sessionManager.unregisterCalls).toEqual(['sess-1']);
+    expect(internals.cancellingSessions.has('sess-1')).toBe(false);
+  });
+
+  test('a missing session reports stopped and still unregisters', async () => {
+    const sessionManager = makeSessionManager();
+    const manager = makeManager(sessionManager);
+
+    const result = await manager.stopSessionVerifiedViaFlow('ghost-session');
+
+    expect(result).toEqual({
+      sessionId: 'ghost-session',
+      stopped: true,
+      detail: 'no in-memory session; unregistered',
+    });
+    expect(sessionManager.unregisterCalls).toEqual(['ghost-session']);
+  });
+
+  test('a missing session keeps the stopped verdict when its unregister rejects', async () => {
+    const sessionManager = makeSessionManager({ failUnregisterFor: ['ghost'] });
+    const manager = makeManager(sessionManager);
+
+    const result = await manager.stopSessionVerifiedViaFlow('ghost');
+
+    expect(result).toEqual({
+      sessionId: 'ghost',
+      stopped: true,
+      detail: 'no in-memory session; unregistered',
+    });
+  });
+
+  test('retries the interrupt once when the first attempt fails to land', async () => {
+    const sessionManager = makeSessionManager();
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['processing', 'processing', 'idle'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(2);
+    expect(fake.calls.terminations).toBe(0);
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      stopped: true,
+      detail: 'first interrupt did not land; stopped on retry',
+    });
+    expect(sessionManager.unregisterCalls).toEqual(['sess-1']);
+  });
+
+  test('surfaces a strict stop error and recovers when the retry lands', async () => {
+    const manager = makeManager(makeSessionManager());
+    const fake = makeFakeSession({
+      statusSequence: ['processing', 'idle'],
+      interruptErrors: [new Error('boom')],
+    });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(2);
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toContain('interrupt failed: ');
+    expect(result.detail).toContain('boom');
+    expect(result.detail).toContain('stopped on retry');
+  });
+
+  test('escalates with the 2000ms force delay and reports the leak when still alive', async () => {
+    const sessionManager = makeSessionManager();
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['processing'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(2);
+    expect(fake.calls.terminations).toBe(1);
+    expect(fake.calls.terminateOptions[0]?.forceDelayMs).toBe(2000);
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      stopped: false,
+      detail:
+        "escalated after verification failure (processing state 'processing'); " +
+        "still alive: processing state 'processing'",
+    });
+
+    const internals = internalsOf(manager);
+    expect(internals.agentSessionIndex.has('sess-1')).toBe(false);
+    expect(internals.subSessions.get('task-1')?.has('sess-1')).toBe(false);
+    expect(sessionManager.unregisterCalls).toEqual(['sess-1']);
+  });
+
+  test('reports stopped when escalation terminates the surviving process', async () => {
+    const manager = makeManager(makeSessionManager());
+    const fake = makeFakeSession({
+      statusSequence: ['processing'],
+      onTerminate: (controller) => controller.setStatus('idle'),
+    });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.terminations).toBe(1);
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toContain('escalated after verification failure');
+  });
+
+  test('verifies no live SDK process remains and escalates when one lingers', async () => {
+    const manager = makeManager(makeSessionManager());
+    const fake = makeFakeSession({
+      statusSequence: ['processing', 'idle'],
+      livePids: [4242],
+      onTerminate: (controller) => controller.clearPids(),
+    });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(2);
+    expect(fake.calls.terminations).toBe(1);
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toContain('live SDK process pid(s) 4242');
+  });
+
+  test('keeps the stop verdict when the final unregister rejects', async () => {
+    const sessionManager = makeSessionManager({ failUnregisterFor: ['sess-1'] });
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['processing', 'idle'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      stopped: true,
+      detail: 'unregister failed: unregister rejected',
+    });
+  });
+
+  test('detaches the listener and completion callback before unregistering', async () => {
+    const events: string[] = [];
+    const sessionManager = makeSessionManager({ events });
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['processing', 'idle'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+    const internals = internalsOf(manager);
+    internals.sessionListeners.set('sess-1', () => events.push('listener-unsub'));
+    internals.completionCallbacks.set('sess-1', () => {});
+
+    await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(events).toEqual(['listener-unsub', 'unregister']);
+    expect(internals.sessionListeners.has('sess-1')).toBe(false);
+    expect(internals.completionCallbacks.has('sess-1')).toBe(false);
+  });
+
+  test('holds the cancelling guard while the interrupt is in flight and clears it after', async () => {
+    const manager = makeManager(makeSessionManager());
+    let releaseInterrupt: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseInterrupt = resolve;
+    });
+    const fake = makeFakeSession({ statusSequence: ['processing', 'idle'], interruptGate: gate });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const promise = manager.stopSessionVerifiedViaFlow('sess-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(internalsOf(manager).cancellingSessions.has('sess-1')).toBe(true);
+
+    releaseInterrupt();
+    const result = await promise;
+    expect(result).toEqual({ sessionId: 'sess-1', stopped: true });
+    expect(internalsOf(manager).cancellingSessions.has('sess-1')).toBe(false);
+  });
+
+  test('evicts the session from the index synchronously with the flow start', async () => {
+    const manager = makeManager(makeSessionManager());
+    let releaseInterrupt: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseInterrupt = resolve;
+    });
+    const fake = makeFakeSession({ statusSequence: ['processing', 'idle'], interruptGate: gate });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const promise = manager.stopSessionVerifiedViaFlow('sess-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    const internals = internalsOf(manager);
+    expect(internals.agentSessionIndex.has('sess-1')).toBe(false);
+    expect(internals.subSessions.get('task-1')?.has('sess-1')).toBe(true);
+
+    releaseInterrupt();
+    await promise;
+    expect(internals.subSessions.get('task-1')?.has('sess-1')).toBe(false);
+  });
+
+  test('propagates a verification crash and still clears the cancelling guard', async () => {
+    const manager = makeManager(makeSessionManager());
+    const fake = makeFakeSession({ processingStateError: new Error('status blew up') });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    await expect(manager.stopSessionVerifiedViaFlow('sess-1')).rejects.toThrow('status blew up');
+    expect(fake.calls.interrupts).toBe(1);
+    expect(internalsOf(manager).cancellingSessions.has('sess-1')).toBe(false);
+  });
+
+  test('treats an interrupted processing state as down after one interrupt', async () => {
+    const sessionManager = makeSessionManager();
+    const manager = makeManager(sessionManager);
+    const fake = makeFakeSession({ statusSequence: ['interrupted'] });
+    registerSession(manager, 'task-1', 'sess-1', fake.session);
+
+    const result = await manager.stopSessionVerifiedViaFlow('sess-1');
+
+    expect(fake.calls.interrupts).toBe(1);
+    expect(fake.calls.terminations).toBe(0);
+    expect(result).toEqual({ sessionId: 'sess-1', stopped: true });
+    expect(sessionManager.unregisterCalls).toEqual(['sess-1']);
+  });
+});

--- a/packages/daemon/tests/unit/5-space/runtime/verified-stop-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/verified-stop-flow.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentProcessingState } from '@hyperneo/shared';
+import type { AgentSession } from '../../../../src/lib/agent/agent-session';
+import type { StagedRunOutcome } from '../../../../src/lib/space/runtime/staged-run';
+import type { VerifiedStopFlowDeps } from '../../../../src/lib/space/runtime/verified-stop-flow';
+import { runVerifiedStopFlow } from '../../../../src/lib/space/runtime/verified-stop-flow';
+
+const SESSION_ID = 'sess-1';
+
+interface FakeSessionOptions {
+  missing?: boolean;
+  statusSequence?: string[];
+  interruptErrors?: unknown[];
+  interruptGate?: Promise<void>;
+  livePids?: number[];
+  interruptInProgress?: boolean;
+  terminateError?: unknown;
+  onTerminate?: (fixture: FlowFixture) => void;
+  failUnregister?: boolean;
+  processingStatusError?: unknown;
+}
+
+interface FlowCalls {
+  interrupts: number;
+  terminates: number;
+  settles: number;
+  pidReads: number;
+  unregisters: string[];
+  detaches: string[];
+  warns: string[];
+}
+
+interface FlowFixture {
+  calls: FlowCalls;
+  events: string[];
+  setStatus(status: string): void;
+  clearPids(): void;
+  run(): Promise<StagedRunOutcome>;
+}
+
+function makeFlowFixture(options: FakeSessionOptions = {}): FlowFixture {
+  const statusSequence = options.statusSequence ?? ['processing', 'idle'];
+  let statusIndex = 0;
+  let livePids = [...(options.livePids ?? [])];
+  const session = { token: 'session' } as unknown as AgentSession;
+  const calls: FlowCalls = {
+    interrupts: 0,
+    terminates: 0,
+    settles: 0,
+    pidReads: 0,
+    unregisters: [],
+    detaches: [],
+    warns: [],
+  };
+  const events: string[] = [];
+  const fixture: FlowFixture = {
+    calls,
+    events,
+    setStatus(status: string) {
+      statusSequence[statusIndex] = status;
+    },
+    clearPids() {
+      livePids = [];
+    },
+    run: () => runVerifiedStopFlow(deps, SESSION_ID),
+  };
+  const warn = (message: string): void => {
+    const kind = message.includes('retrying once')
+      ? 'warn-retry'
+      : message.includes('escalating to tracked process termination')
+        ? 'warn-escalate'
+        : 'warn-unregister-missing';
+    calls.warns.push(kind);
+    events.push(kind);
+  };
+  const deps: VerifiedStopFlowDeps = {
+    claimSession: () => {
+      events.push('claim');
+      return options.missing === true ? null : session;
+    },
+    stopSessionStrict: async () => {
+      calls.interrupts += 1;
+      events.push(`interrupt-${calls.interrupts}`);
+      if (options.interruptGate) await options.interruptGate;
+      const err = options.interruptErrors?.[calls.interrupts - 1];
+      if (err !== undefined) throw err;
+      if (statusIndex < statusSequence.length - 1) {
+        statusIndex += 1;
+      }
+    },
+    readProcessingStatus: () => {
+      events.push('status-read');
+      if (options.processingStatusError !== undefined) throw options.processingStatusError;
+      return statusSequence[statusIndex] as AgentProcessingState['status'];
+    },
+    isInterruptInProgress: () => {
+      events.push('in-progress-check');
+      return options.interruptInProgress === true;
+    },
+    awaitProcessExitSettle: async () => {
+      calls.settles += 1;
+      events.push('settle');
+    },
+    readLivePids: () => {
+      calls.pidReads += 1;
+      events.push('read-pids');
+      return [...livePids];
+    },
+    terminateTrackedProcesses: () => {
+      calls.terminates += 1;
+      events.push('terminate');
+      options.onTerminate?.(fixture);
+      if (options.terminateError !== undefined) throw options.terminateError;
+    },
+    unregisterSession: async (sessionId: string) => {
+      events.push('unregister');
+      calls.unregisters.push(sessionId);
+      if (options.failUnregister) throw new Error('unregister rejected');
+    },
+    detachSessionBookkeeping: (sessionId: string) => {
+      events.push('detach');
+      calls.detaches.push(sessionId);
+    },
+    warn: (message: string) => warn(message),
+  };
+  return fixture;
+}
+
+describe('runVerifiedStopFlow ladder', () => {
+  test('happy path: one interrupt, down verdict, detach then unregister, no escalation', async () => {
+    const fixture = makeFlowFixture();
+    await expect(fixture.run()).resolves.toEqual({
+      status: 'completed',
+      result: { sessionId: SESSION_ID, stopped: true },
+    });
+    expect(fixture.calls.interrupts).toBe(1);
+    expect(fixture.calls.terminates).toBe(0);
+    expect(fixture.calls.warns).toEqual([]);
+    expect(fixture.calls.detaches).toEqual([SESSION_ID]);
+    expect(fixture.calls.unregisters).toEqual([SESSION_ID]);
+    expect(fixture.events).toEqual([
+      'claim',
+      'interrupt-1',
+      'status-read',
+      'in-progress-check',
+      'settle',
+      'read-pids',
+      'detach',
+      'unregister',
+    ]);
+  });
+
+  test('a missing session skips the ladder, unregisters, and never detaches', async () => {
+    const fixture = makeFlowFixture({ missing: true });
+    await expect(fixture.run()).resolves.toEqual({
+      status: 'completed',
+      result: {
+        sessionId: SESSION_ID,
+        stopped: true,
+        detail: 'no in-memory session; unregistered',
+      },
+    });
+    expect(fixture.calls.interrupts).toBe(0);
+    expect(fixture.calls.detaches).toEqual([]);
+    expect(fixture.calls.unregisters).toEqual([SESSION_ID]);
+    expect(fixture.events).toEqual(['claim', 'unregister']);
+  });
+
+  test('a missing-session unregister failure only warns and keeps the stopped verdict', async () => {
+    const fixture = makeFlowFixture({ missing: true, failUnregister: true });
+    await expect(fixture.run()).resolves.toEqual({
+      status: 'completed',
+      result: {
+        sessionId: SESSION_ID,
+        stopped: true,
+        detail: 'no in-memory session; unregistered',
+      },
+    });
+    expect(fixture.calls.warns).toEqual(['warn-unregister-missing']);
+  });
+
+  test('a failed first verification retries the interrupt once and notes the rescue', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['processing', 'processing', 'idle'] });
+    await expect(fixture.run()).resolves.toEqual({
+      status: 'completed',
+      result: {
+        sessionId: SESSION_ID,
+        stopped: true,
+        detail: 'first interrupt did not land; stopped on retry',
+      },
+    });
+    expect(fixture.calls.interrupts).toBe(2);
+    expect(fixture.calls.terminates).toBe(0);
+    expect(fixture.calls.warns).toEqual(['warn-retry']);
+  });
+
+  test('a strict interrupt failure is noted and recovered when the retry lands', async () => {
+    const fixture = makeFlowFixture({
+      statusSequence: ['processing', 'idle'],
+      interruptErrors: [new Error('boom')],
+    });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    const result = outcome.result as { stopped: boolean; detail?: string };
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toBe(
+      'interrupt failed: boom; first interrupt did not land; stopped on retry'
+    );
+    expect(fixture.calls.interrupts).toBe(2);
+  });
+
+  test('a retry interrupt failure is noted before the escalation note', async () => {
+    const fixture = makeFlowFixture({
+      statusSequence: ['processing'],
+      interruptErrors: [undefined, new Error('retry boom')],
+      onTerminate: (f) => f.setStatus('idle'),
+    });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    const result = outcome.result as { stopped: boolean; detail?: string };
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toBe(
+      "retry interrupt failed: retry boom; escalated after verification failure (processing state 'processing')"
+    );
+    expect(fixture.calls.terminates).toBe(1);
+  });
+
+  test('escalates to tracked termination and reports the leak when still alive', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['processing'] });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    expect(outcome.result).toEqual({
+      sessionId: SESSION_ID,
+      stopped: false,
+      detail:
+        "escalated after verification failure (processing state 'processing'); " +
+        "still alive: processing state 'processing'",
+    });
+    expect(fixture.calls.interrupts).toBe(2);
+    expect(fixture.calls.terminates).toBe(1);
+    expect(fixture.calls.warns).toEqual(['warn-retry', 'warn-escalate']);
+    expect(fixture.calls.detaches).toEqual([SESSION_ID]);
+    expect(fixture.calls.unregisters).toEqual([SESSION_ID]);
+  });
+
+  test('a successful escalation reports stopped with the escalation note', async () => {
+    const fixture = makeFlowFixture({
+      statusSequence: ['processing'],
+      onTerminate: (f) => f.setStatus('idle'),
+    });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    const result = outcome.result as { stopped: boolean; detail?: string };
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toBe(
+      "escalated after verification failure (processing state 'processing')"
+    );
+  });
+
+  test('an escalation failure is noted and the leak verdict stays last', async () => {
+    const fixture = makeFlowFixture({
+      statusSequence: ['processing'],
+      terminateError: new Error('kill boom'),
+    });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    expect(outcome.result).toEqual({
+      sessionId: SESSION_ID,
+      stopped: false,
+      detail:
+        "escalated after verification failure (processing state 'processing'); " +
+        "escalation failed: kill boom; still alive: processing state 'processing'",
+    });
+  });
+
+  test('a lingering live pid escalates and a clean termination reports stopped', async () => {
+    const fixture = makeFlowFixture({
+      statusSequence: ['processing', 'idle'],
+      livePids: [4242],
+      onTerminate: (f) => f.clearPids(),
+    });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    const result = outcome.result as { stopped: boolean; detail?: string };
+    expect(result.stopped).toBe(true);
+    expect(result.detail).toBe(
+      'escalated after verification failure (live SDK process pid(s) 4242)'
+    );
+    expect(fixture.calls.terminates).toBe(1);
+  });
+
+  test('the processing state is checked before the interrupt-in-progress flag', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['processing'], interruptInProgress: true });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    const result = outcome.result as { stopped: boolean; detail?: string };
+    expect(result.stopped).toBe(false);
+    expect(result.detail).toContain("still alive: processing state 'processing'");
+    expect(result.detail).not.toContain('interrupt still in progress');
+    expect(fixture.events).not.toContain('in-progress-check');
+  });
+
+  test('an in-progress interrupt is not down and escalates with its own reason', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['idle'], interruptInProgress: true });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('completed');
+    expect(outcome.result).toEqual({
+      sessionId: SESSION_ID,
+      stopped: false,
+      detail:
+        'escalated after verification failure (interrupt still in progress); ' +
+        'still alive: interrupt still in progress',
+    });
+    expect(fixture.calls.interrupts).toBe(2);
+    expect(fixture.calls.terminates).toBe(1);
+  });
+
+  test('the process-exit settle await runs before the live-pid read', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['processing', 'idle'] });
+    await fixture.run();
+    const settleAt = fixture.events.indexOf('settle');
+    const pidReadAt = fixture.events.indexOf('read-pids');
+    expect(settleAt).toBeGreaterThanOrEqual(0);
+    expect(pidReadAt).toBeGreaterThan(settleAt);
+  });
+
+  test('a settle await is skipped while an interrupt is still in progress', async () => {
+    const fixture = makeFlowFixture({ statusSequence: ['idle'], interruptInProgress: true });
+    await fixture.run();
+    expect(fixture.calls.settles).toBe(0);
+    expect(fixture.calls.pidReads).toBe(0);
+  });
+
+  test('a final unregister failure is noted but keeps the stop verdict', async () => {
+    const fixture = makeFlowFixture({ failUnregister: true });
+    await expect(fixture.run()).resolves.toEqual({
+      status: 'completed',
+      result: {
+        sessionId: SESSION_ID,
+        stopped: true,
+        detail: 'unregister failed: unregister rejected',
+      },
+    });
+    expect(fixture.calls.detaches).toEqual([SESSION_ID]);
+  });
+
+  test('a throwing verification read fails the pass with the stage named', async () => {
+    const fixture = makeFlowFixture({ processingStatusError: new Error('status blew up') });
+    const outcome = await fixture.run();
+    expect(outcome.status).toBe('error');
+    expect(outcome.stage).toBe('verify-after-interrupt');
+    expect((outcome.error as Error).message).toBe('status blew up');
+    expect(outcome.unwind).toEqual([]);
+    expect(fixture.calls.interrupts).toBe(1);
+    expect(fixture.calls.detaches).toEqual([]);
+    expect(fixture.calls.unregisters).toEqual([]);
+  });
+});
+
+describe('runVerifiedStopFlow microtask profile', () => {
+  test('claim, the presence decision, and the interrupt start before the first await boundary', async () => {
+    let releaseInterrupt: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      releaseInterrupt = resolve;
+    });
+    const fixture = makeFlowFixture({ interruptGate: gate });
+    const promise = fixture.run();
+    expect(fixture.events).toEqual(['claim', 'interrupt-1']);
+    releaseInterrupt!();
+    const outcome = await promise;
+    expect(outcome.status).toBe('completed');
+  });
+
+  test('a queued microtask observer runs between the interrupt and its verification', async () => {
+    const order: string[] = [];
+    const deps: VerifiedStopFlowDeps = {
+      claimSession: () => {
+        order.push('claim');
+        return { token: 'session' } as unknown as AgentSession;
+      },
+      stopSessionStrict: async () => {
+        order.push('interrupt');
+      },
+      readProcessingStatus: () => {
+        order.push('status-read');
+        return 'idle' as AgentProcessingState['status'];
+      },
+      isInterruptInProgress: () => false,
+      awaitProcessExitSettle: async () => {
+        order.push('settle');
+      },
+      readLivePids: () => [],
+      terminateTrackedProcesses: () => {
+        order.push('terminate');
+      },
+      unregisterSession: async () => {
+        order.push('unregister');
+      },
+      detachSessionBookkeeping: () => {
+        order.push('detach');
+      },
+      warn: () => {
+        order.push('warn');
+      },
+    };
+    const promise = runVerifiedStopFlow(deps, SESSION_ID);
+    queueMicrotask(() => order.push('observer'));
+    await promise;
+    expect(order).toEqual([
+      'claim',
+      'interrupt',
+      'observer',
+      'status-read',
+      'settle',
+      'detach',
+      'unregister',
+    ]);
+  });
+});


### PR DESCRIPTION
First production consumer of the S2 stagedRun combinator: the verified-stop ladder in task-agent-manager.ts, composed over the S3 stop-verification gates as `verified-stop-flow.ts` — snapshot (claim session) → decide (missing/present) → interrupt effect (stopSessionPreserveDb strict) → resnapshot (inspectSessionDown: processing state, interrupt-in-progress, process-exit settle, live pids) → decide (down/retry) → retry effect → resnapshot → decide (down/escalate) → terminate effect (forceDelayMs 2000) → resnapshot → final verdict → detach+unregister effect → halt (assembleVerifiedStopResult). Per ADR 0004 the shell keeps the Promise.all fan-out in stopSessionsVerified (pipeline is per-session), effects are idempotent-or-escalating with no compensations, outcomes are interpreter-stamped, and declared read/write sets follow the S2 contract.

Additive: `stopSessionVerifiedViaFlow` interprets flow outcomes while `stopSessionVerified` keeps its inline cascade until S PR 5 swaps it, so the S1 pin suite stays green unchanged. New tests pin the flow decision table and the manager shell with detail-string parity to the S1 pins (happy/missing/retry/escalate/leak/notes/precedence/crash, cancellingSessions guard, forceDelayMs 2000).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->