### PR TITLE
feat(space): single-transaction outcome notification + owner wake seam (MC2-C)

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -210,6 +210,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
       'Append-only history events for Space goals, including state diffs, source metadata, and linked task IDs.',
   },
   {
+    tableName: 'space_goal_outcome_notifications',
+    scopeColumn: 'space_id',
+    blacklistedColumns: [],
+    description:
+      'Per-terminal-generation outcome notifications for Space goals, with pending/superseded/acknowledged/rejected status and bounded payloads.',
+  },
+  {
     tableName: 'space_worktrees',
     scopeColumn: 'space_id',
     blacklistedColumns: [],

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -120,6 +120,7 @@ import { EvolutionScopeService } from '../space/evolution-scope-service';
 import { EvolutionTraceEvidenceService } from '../space/evolution-trace-evidence-service';
 import { ScheduleService } from '../space/schedule/schedule-service';
 import { SpaceGoalEventRepository } from '../../storage/repositories/space-goal-event-repository';
+import { SpaceGoalOutcomeNotificationRepository } from '../../storage/repositories/space-goal-outcome-notification-repository';
 import { SpaceGoalRepository } from '../../storage/repositories/space-goal-repository';
 import { SpaceGoalService } from '../space/goals/goal-service';
 import { ExternalEventExtensionConfigStore } from '../external-events/extension-config-store';
@@ -411,6 +412,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   const spaceGoalRepo = new SpaceGoalRepository(deps.db.getDatabase(), deps.reactiveDb);
   const spaceGoalEventRepo = new SpaceGoalEventRepository(deps.db.getDatabase(), deps.reactiveDb);
   const longHorizonAgentRepo = new SpaceLongHorizonAgentRepository(deps.db.getDatabase());
+  const outcomeNotificationRepo = new SpaceGoalOutcomeNotificationRepository(deps.db.getDatabase());
   const spaceGoalService = new SpaceGoalService({
     goalRepo: spaceGoalRepo,
     goalEventRepo: spaceGoalEventRepo,
@@ -419,6 +421,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     scheduleService,
     db: deps.db.getDatabase(),
     longHorizonAgentRepo,
+    outcomeNotificationRepo,
     eventHub: {
       publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
     },

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -413,34 +413,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
   const spaceGoalEventRepo = new SpaceGoalEventRepository(deps.db.getDatabase(), deps.reactiveDb);
   const longHorizonAgentRepo = new SpaceLongHorizonAgentRepository(deps.db.getDatabase());
   const outcomeNotificationRepo = new SpaceGoalOutcomeNotificationRepository(deps.db.getDatabase());
-  const spaceGoalService = new SpaceGoalService({
-    goalRepo: spaceGoalRepo,
-    goalEventRepo: spaceGoalEventRepo,
-    taskRepo: spaceTaskRepo,
-    spaceRepo,
-    scheduleService,
-    db: deps.db.getDatabase(),
-    longHorizonAgentRepo,
-    outcomeNotificationRepo,
-    eventHub: {
-      publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
-    },
-    onGoalResumed: (goalId, spaceId) => {
-      for (const scope of deps.db.evolution.listScopes({ spaceId, spaceGoalId: goalId })) {
-        try {
-          syncGoalAutomationSelfNagScheduleForScope({
-            goalRepo: spaceGoalRepo,
-            scheduleService,
-            scope,
-            db: deps.db.getDatabase(),
-          });
-        } catch (err) {
-          log.warn('could not sync self-nag schedule on goal resume', err);
-        }
-      }
-    },
-  });
-
   const evolutionTraceEvidenceService = new EvolutionTraceEvidenceService({
     db: deps.db.getDatabase(),
     evolutionRepo: deps.db.evolution,
@@ -465,6 +437,34 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     artifactRepo,
     traceEvidenceService: evolutionTraceEvidenceService,
     jobQueue: deps.jobQueue,
+  });
+  const spaceGoalService = new SpaceGoalService({
+    goalRepo: spaceGoalRepo,
+    goalEventRepo: spaceGoalEventRepo,
+    taskRepo: spaceTaskRepo,
+    spaceRepo,
+    scheduleService,
+    db: deps.db.getDatabase(),
+    longHorizonAgentRepo,
+    outcomeNotificationRepo,
+    evolutionScopeService,
+    eventHub: {
+      publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
+    },
+    onGoalResumed: (goalId, spaceId) => {
+      for (const scope of deps.db.evolution.listScopes({ spaceId, spaceGoalId: goalId })) {
+        try {
+          syncGoalAutomationSelfNagScheduleForScope({
+            goalRepo: spaceGoalRepo,
+            scheduleService,
+            scope,
+            db: deps.db.getDatabase(),
+          });
+        } catch (err) {
+          log.warn('could not sync self-nag schedule on goal resume', err);
+        }
+      }
+    },
   });
   const goalAutomationService = new GoalAutomationService({
     goalRepo: spaceGoalRepo,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -466,6 +466,43 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         }
       }
     },
+    onOutcomeNotification: (notification) => {
+      try {
+        const goal = spaceGoalRepo.getById(notification.goalId);
+        if (!goal) return;
+        const resolution = longHorizonAgentRepo.getPrimaryGoalOwner(goal.id, goal.spaceId);
+        let targetAgentId: string | null = null;
+        if (resolution.action === 'resolved') {
+          targetAgentId = resolution.owner.agentId;
+        } else if (resolution.action === 'degraded') {
+          targetAgentId = longHorizonAgentRepo.ensureCoordinator(goal.spaceId).id;
+        } else if (resolution.action === 'coordinator_fallback') {
+          targetAgentId = resolution.coordinatorAgentId;
+        }
+        if (!targetAgentId) {
+          log.warn(
+            `Goal outcome notification ${notification.id} has no owner or coordinator to wake`
+          );
+          return;
+        }
+        const { summary, taskStatus, taskTitle, goalTitle } = notification.payload;
+        const detail = summary ? ` ${summary}` : '';
+        spaceAgentInboxRepo.enqueue({
+          spaceId: goal.spaceId,
+          targetAgentId,
+          sourceActorId: `agent:coordinator:${goal.spaceId}`,
+          message: `Goal outcome ready for review: "${goalTitle}". Task "${taskTitle}" reached ${taskStatus}.${detail}`,
+          idempotencyKey: `goal-outcome:${notification.id}`,
+        });
+        log.info(
+          `goal.outcome.wake: goalId=${goal.id} taskId=${notification.taskId} target=${targetAgentId}`
+        );
+      } catch (err) {
+        log.warn(
+          `Goal outcome wake delivery threw for notification "${notification.id}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    },
   });
   const goalAutomationService = new GoalAutomationService({
     goalRepo: spaceGoalRepo,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -448,6 +448,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     longHorizonAgentRepo,
     outcomeNotificationRepo,
     evolutionScopeService,
+    reactiveDb: deps.reactiveDb,
     eventHub: {
       publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
     },

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -502,7 +502,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       deps.db.getDatabase(),
       spaceId,
       deps.reactiveDb,
-      evolutionScopeService
+      evolutionScopeService,
+      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId)
     );
   };
 
@@ -945,7 +946,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       deps.db.getDatabase(),
       spaceId,
       deps.reactiveDb,
-      evolutionScopeService
+      evolutionScopeService,
+      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId)
     );
   };
   const hookStateRepo = new WorkflowHookStateRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -357,7 +357,13 @@ export class SpaceGoalService {
             `Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
           );
         }
-        this.deps.goalAutomationService?.onTaskCompleted(taskId);
+        try {
+          this.deps.goalAutomationService?.onTaskCompleted(taskId);
+        } catch (err) {
+          log.warn(
+            `Goal automation onTaskCompleted threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       const terminalGeneration = task.terminalGeneration;
       let nextTask: SpaceTask | null = null;

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -316,6 +316,15 @@ export class SpaceGoalService {
     if (!existing?.goalId) return null;
     const goal = this.deps.goalRepo.getById(existing.goalId);
     if (!goal || goal.spaceId !== existing.spaceId) return null;
+    const nextStatus = transition?.updates?.status ?? existing.status;
+    if (!isTerminalTaskStatus(nextStatus)) {
+      return {
+        goal,
+        nextTask: null as SpaceTask | null,
+        terminalGeneration: existing.terminalGeneration,
+        notification: null as SpaceGoalOutcomeNotification | null,
+      };
+    }
     const result = this.runAtomic(() => {
       const task =
         transition?.updates && Object.keys(transition.updates).length > 0

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -70,6 +70,10 @@ export interface SpaceGoalServiceDeps {
   longHorizonAgentRepo?: Pick<SpaceLongHorizonAgentRepository, 'assignGoal'>;
   outcomeNotificationRepo?: SpaceGoalOutcomeNotificationRepository;
   onOutcomeNotification?: (notification: SpaceGoalOutcomeNotification) => void;
+  evolutionScopeService?: Pick<
+    import('../evolution-scope-service').EvolutionScopeService,
+    'captureCompletedTaskEvidence'
+  >;
 }
 
 export class SpaceGoalService {
@@ -302,7 +306,12 @@ export class SpaceGoalService {
   handleTaskTerminal(
     taskId: string,
     transition?: { fromStatus?: SpaceTaskStatus | null; updates?: InternalUpdateSpaceTaskParams }
-  ): { goal: SpaceGoal; nextTask: SpaceTask | null; terminalGeneration: number } | null {
+  ): {
+    goal: SpaceGoal;
+    nextTask: SpaceTask | null;
+    terminalGeneration: number;
+    notification: SpaceGoalOutcomeNotification | null;
+  } | null {
     const existing = this.deps.taskRepo.getTask(taskId);
     if (!existing?.goalId) return null;
     const goal = this.deps.goalRepo.getById(existing.goalId);
@@ -317,6 +326,7 @@ export class SpaceGoalService {
           goal,
           nextTask: null as SpaceTask | null,
           terminalGeneration: task.terminalGeneration,
+          notification: null as SpaceGoalOutcomeNotification | null,
         };
       }
       this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
@@ -326,13 +336,26 @@ export class SpaceGoalService {
         sourceTaskId: taskId,
         note: `Task reached terminal status: ${task.status}`,
       });
-      if (task.status === 'done') this.deps.goalAutomationService?.onTaskCompleted(taskId);
+      if (task.status === 'done') {
+        try {
+          this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
+        } catch (err) {
+          log.warn(
+            `Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        this.deps.goalAutomationService?.onTaskCompleted(taskId);
+      }
       const terminalGeneration = task.terminalGeneration;
       let nextTask: SpaceTask | null = null;
       let postBookkeeping: SpaceGoal = fresh;
       if (fresh.autoTriggerNext && fresh.pendingNextRun && fresh.status === 'active') {
         try {
-          const created = this.createImmediateTask(fresh.id, { source: 'system' });
+          const created = this.createImmediateTaskInternal(
+            fresh.id,
+            { source: 'system' },
+            { emitTaskCreated: false }
+          );
           postBookkeeping = created.goal;
           nextTask = created.task;
         } catch (err) {
@@ -341,17 +364,18 @@ export class SpaceGoalService {
           );
         }
       }
-      this.recordOutcomeNotification(task, postBookkeeping, terminalGeneration, {
-        fromStatus: transition?.fromStatus ?? null,
-      });
-      return { goal: postBookkeeping, nextTask, terminalGeneration };
+      const notification = this.recordOutcomeNotification(
+        task,
+        postBookkeeping,
+        terminalGeneration,
+        {
+          fromStatus: transition?.fromStatus ?? null,
+        }
+      );
+      return { goal: postBookkeeping, nextTask, terminalGeneration, notification };
     });
-    if (result.goal && this.deps.outcomeNotificationRepo) {
-      const pending = this.deps.outcomeNotificationRepo.listPendingByGoal(result.goal.id);
-      for (const notification of pending) {
-        this.deps.onOutcomeNotification?.(notification);
-      }
-    }
+    if (result.nextTask) this.emitTaskCreated(result.nextTask);
+    if (result.notification) this.deps.onOutcomeNotification?.(result.notification);
     return result;
   }
 
@@ -364,8 +388,8 @@ export class SpaceGoalService {
     goal: SpaceGoal,
     terminalGeneration: number,
     transition: { fromStatus?: SpaceTaskStatus | null }
-  ): void {
-    if (!this.deps.outcomeNotificationRepo) return;
+  ): SpaceGoalOutcomeNotification | null {
+    if (!this.deps.outcomeNotificationRepo) return null;
     const hasStartGeneration = task.startedAt !== null;
     const priorPending = this.deps.outcomeNotificationRepo
       .listPendingByGoal(goal.id)
@@ -376,11 +400,11 @@ export class SpaceGoalService {
       hasStartGeneration,
       hasPriorTerminalGeneration: priorPending.length > 0,
     });
-    if (decision.action === 'none') return;
+    if (decision.action === 'none') return null;
     if (decision.action === 'supersede_notify') {
       this.deps.outcomeNotificationRepo.supersedeForTask(task.id);
     }
-    this.deps.outcomeNotificationRepo.create({
+    return this.deps.outcomeNotificationRepo.create({
       spaceId: goal.spaceId,
       goalId: goal.id,
       taskId: task.id,

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -402,7 +402,7 @@ export class SpaceGoalService {
     });
     if (decision.action === 'none') return null;
     if (decision.action === 'supersede_notify') {
-      this.deps.outcomeNotificationRepo.supersedeForTask(task.id);
+      this.deps.outcomeNotificationRepo.supersedeForTaskOlderThan(task.id, terminalGeneration);
     }
     return this.deps.outcomeNotificationRepo.create({
       spaceId: goal.spaceId,

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -23,9 +23,12 @@ import type { SpaceGoalOutcomeNotificationRepository } from '../../../storage/re
 import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
 import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { ScheduleService } from '../schedule/schedule-service';
+import { Logger } from '../../logger';
 import type { GoalAutomationService } from './goal-automation-service';
 import { pauseScheduleStrict } from './goal-automation-schedule-sync';
 import { decideReportableTerminal } from './reportable-terminal-gates';
+
+const log = new Logger('space-goal-service');
 
 export type PublicSpaceGoalUpdateParams = Pick<
   UpdateSpaceGoalParams,
@@ -328,9 +331,15 @@ export class SpaceGoalService {
       let nextTask: SpaceTask | null = null;
       let postBookkeeping: SpaceGoal = fresh;
       if (fresh.autoTriggerNext && fresh.pendingNextRun && fresh.status === 'active') {
-        const created = this.createImmediateTask(fresh.id, { source: 'system' });
-        postBookkeeping = created.goal;
-        nextTask = created.task;
+        try {
+          const created = this.createImmediateTask(fresh.id, { source: 'system' });
+          postBookkeeping = created.goal;
+          nextTask = created.task;
+        } catch (err) {
+          log.warn(
+            `Next goal task creation threw for "${taskId}" after terminal: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       this.recordOutcomeNotification(task, postBookkeeping, terminalGeneration, {
         fromStatus: transition?.fromStatus ?? null,

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -8,6 +8,7 @@ import type {
   SpaceGoalEventSource,
   SpaceGoalEventType,
   SpaceGoalListParams,
+  SpaceGoalOutcomeNotification,
   SpaceTask,
   UpdateSpaceGoalParams,
 } from '@hyperneo/shared';
@@ -16,11 +17,13 @@ import type { Database as BunDatabase } from '../../../storage/sqlite-compat';
 import type { SpaceRepository } from '../../../storage/repositories/space-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceGoalEventRepository } from '../../../storage/repositories/space-goal-event-repository';
+import type { SpaceGoalOutcomeNotificationRepository } from '../../../storage/repositories/space-goal-outcome-notification-repository';
 import type { SpaceGoalRepository } from '../../../storage/repositories/space-goal-repository';
 import type { SpaceLongHorizonAgentRepository } from '../../../storage/repositories/space-long-horizon-agent-repository';
 import type { ScheduleService } from '../schedule/schedule-service';
 import type { GoalAutomationService } from './goal-automation-service';
 import { pauseScheduleStrict } from './goal-automation-schedule-sync';
+import { decideReportableTerminal } from './reportable-terminal-gates';
 
 export type PublicSpaceGoalUpdateParams = Pick<
   UpdateSpaceGoalParams,
@@ -60,6 +63,8 @@ export interface SpaceGoalServiceDeps {
   goalAutomationService?: Pick<GoalAutomationService, 'onTaskCompleted'>;
   onGoalResumed?: (goalId: string, spaceId: string) => void;
   longHorizonAgentRepo?: Pick<SpaceLongHorizonAgentRepository, 'assignGoal'>;
+  outcomeNotificationRepo?: SpaceGoalOutcomeNotificationRepository;
+  onOutcomeNotification?: (notification: SpaceGoalOutcomeNotification) => void;
 }
 
 export class SpaceGoalService {
@@ -297,20 +302,69 @@ export class SpaceGoalService {
     if (!isTerminalTaskStatus(task.status)) return null;
     const goal = this.deps.goalRepo.getById(task.goalId);
     if (!goal || goal.spaceId !== task.spaceId) return null;
-    this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
-    const fresh = this.requireGoal(goal.id);
-    this.recordGoalEvent(fresh, 'task_terminal', goal, fresh, {
-      source: 'system',
-      sourceTaskId: taskId,
-      note: `Task reached terminal status: ${task.status}`,
+    const result = this.runAtomic(() => {
+      this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
+      const fresh = this.requireGoal(goal.id);
+      this.recordGoalEvent(fresh, 'task_terminal', goal, fresh, {
+        source: 'system',
+        sourceTaskId: taskId,
+        note: `Task reached terminal status: ${task.status}`,
+      });
+      if (task.status === 'done') this.deps.goalAutomationService?.onTaskCompleted(taskId);
+      const terminalGeneration = task.terminalGeneration;
+      this.recordOutcomeNotification(task, fresh, terminalGeneration);
+      if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
+        return { goal: fresh, nextTask: null as SpaceTask | null, terminalGeneration };
+      }
+      const created = this.createImmediateTask(fresh.id, { source: 'system' });
+      return { goal: created.goal, nextTask: created.task, terminalGeneration };
     });
-    if (task.status === 'done') this.deps.goalAutomationService?.onTaskCompleted(taskId);
-    const terminalGeneration = task.terminalGeneration;
-    if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
-      return { goal: fresh, nextTask: null, terminalGeneration };
+    if (result.goal && this.deps.outcomeNotificationRepo) {
+      const pending = this.deps.outcomeNotificationRepo.listPendingByGoal(result.goal.id);
+      for (const notification of pending) {
+        this.deps.onOutcomeNotification?.(notification);
+      }
     }
-    const created = this.createImmediateTask(fresh.id, { source: 'system' });
-    return { goal: created.goal, nextTask: created.task, terminalGeneration };
+    return result;
+  }
+
+  supersedeOutcomeNotificationsForTask(taskId: string): void {
+    this.deps.outcomeNotificationRepo?.supersedeForTask(taskId);
+  }
+
+  private recordOutcomeNotification(
+    task: SpaceTask,
+    goal: SpaceGoal,
+    terminalGeneration: number
+  ): void {
+    if (!this.deps.outcomeNotificationRepo) return;
+    const hasStartGeneration = task.startedAt !== null;
+    const priorPending = this.deps.outcomeNotificationRepo
+      .listPendingByGoal(goal.id)
+      .filter((n) => n.taskId === task.id);
+    const decision = decideReportableTerminal({
+      fromStatus: null,
+      toStatus: task.status,
+      hasStartGeneration,
+      hasPriorTerminalGeneration: priorPending.length > 0,
+    });
+    if (decision.action === 'none') return;
+    if (decision.action === 'supersede_notify') {
+      this.deps.outcomeNotificationRepo.supersedeForTask(task.id);
+    }
+    this.deps.outcomeNotificationRepo.create({
+      spaceId: goal.spaceId,
+      goalId: goal.id,
+      taskId: task.id,
+      terminalGeneration,
+      goalRevision: goal.revision,
+      payload: {
+        summary: (task.reportedSummary ?? task.result ?? '').slice(0, 400),
+        taskStatus: task.status,
+        taskTitle: task.title,
+        goalTitle: goal.title,
+      },
+    });
   }
 
   canClaimScheduledTask(task: Pick<SpaceTask, 'spaceId' | 'goalId'>): {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -360,11 +360,15 @@ export class SpaceGoalService {
       let postBookkeeping: SpaceGoal = fresh;
       if (fresh.autoTriggerNext && fresh.pendingNextRun && fresh.status === 'active') {
         try {
-          const created = this.createImmediateTaskInternal(
-            fresh.id,
-            { source: 'system' },
-            { emitTaskCreated: false }
-          );
+          const createInSavepoint = () =>
+            this.createImmediateTaskInternal(
+              fresh.id,
+              { source: 'system' },
+              { emitTaskCreated: false }
+            );
+          const created = this.deps.db
+            ? this.deps.db.transaction(createInSavepoint)()
+            : createInSavepoint();
           postBookkeeping = created.goal;
           nextTask = created.task;
         } catch (err) {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -74,6 +74,10 @@ export interface SpaceGoalServiceDeps {
     import('../evolution-scope-service').EvolutionScopeService,
     'captureCompletedTaskEvidence'
   >;
+  reactiveDb?: Pick<
+    import('../../../storage/reactive-database').ReactiveDatabase,
+    'beginTransaction' | 'commitTransaction' | 'abortTransaction'
+  >;
 }
 
 export class SpaceGoalService {
@@ -517,7 +521,16 @@ export class SpaceGoalService {
 
   private runAtomic<T>(fn: () => T): T {
     if (!this.deps.db) return fn();
-    return this.deps.db.transaction(fn)();
+    const reactive = this.deps.reactiveDb;
+    reactive?.beginTransaction();
+    try {
+      const result = this.deps.db.transaction(fn)();
+      reactive?.commitTransaction();
+      return result;
+    } catch (err) {
+      reactive?.abortTransaction();
+      throw err;
+    }
   }
 
   private pauseLinkedScheduleOrClear(goal: SpaceGoal): void {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -245,6 +245,23 @@ export class SpaceGoalService {
     return this.createImmediateTaskInternal(goalId, context);
   }
 
+  retryQueuedRunsForSpace(spaceId: string): number {
+    const goals = this.deps.goalRepo.list({ spaceId, status: 'active' });
+    let created = 0;
+    for (const goal of goals) {
+      if (!goal.autoTriggerNext || !goal.pendingNextRun || goal.activeTaskId) continue;
+      try {
+        this.createImmediateTask(goal.id, { source: 'system' });
+        created += 1;
+      } catch (err) {
+        log.warn(
+          `Retry queued run threw for goal "${goal.id}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    return created;
+  }
+
   private createImmediateTaskInternal(
     goalId: string,
     context?: SpaceGoalMutationContext,

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -10,6 +10,8 @@ import type {
   SpaceGoalListParams,
   SpaceGoalOutcomeNotification,
   SpaceTask,
+  SpaceTaskStatus,
+  InternalUpdateSpaceTaskParams,
   UpdateSpaceGoalParams,
 } from '@hyperneo/shared';
 import { isRateOrUsageLimited } from '@hyperneo/shared';
@@ -295,14 +297,25 @@ export class SpaceGoalService {
   }
 
   handleTaskTerminal(
-    taskId: string
+    taskId: string,
+    transition?: { fromStatus?: SpaceTaskStatus | null; updates?: InternalUpdateSpaceTaskParams }
   ): { goal: SpaceGoal; nextTask: SpaceTask | null; terminalGeneration: number } | null {
-    const task = this.deps.taskRepo.getTask(taskId);
-    if (!task?.goalId) return null;
-    if (!isTerminalTaskStatus(task.status)) return null;
-    const goal = this.deps.goalRepo.getById(task.goalId);
-    if (!goal || goal.spaceId !== task.spaceId) return null;
+    const existing = this.deps.taskRepo.getTask(taskId);
+    if (!existing?.goalId) return null;
+    const goal = this.deps.goalRepo.getById(existing.goalId);
+    if (!goal || goal.spaceId !== existing.spaceId) return null;
     const result = this.runAtomic(() => {
+      const task =
+        transition?.updates && Object.keys(transition.updates).length > 0
+          ? (this.deps.taskRepo.updateTask(taskId, transition.updates) as SpaceTask)
+          : existing;
+      if (!isTerminalTaskStatus(task.status)) {
+        return {
+          goal,
+          nextTask: null as SpaceTask | null,
+          terminalGeneration: task.terminalGeneration,
+        };
+      }
       this.deps.goalRepo.clearActiveTaskIfMatches(goal.id, taskId);
       const fresh = this.requireGoal(goal.id);
       this.recordGoalEvent(fresh, 'task_terminal', goal, fresh, {
@@ -312,12 +325,17 @@ export class SpaceGoalService {
       });
       if (task.status === 'done') this.deps.goalAutomationService?.onTaskCompleted(taskId);
       const terminalGeneration = task.terminalGeneration;
-      this.recordOutcomeNotification(task, fresh, terminalGeneration);
-      if (!fresh.autoTriggerNext || !fresh.pendingNextRun || fresh.status !== 'active') {
-        return { goal: fresh, nextTask: null as SpaceTask | null, terminalGeneration };
+      let nextTask: SpaceTask | null = null;
+      let postBookkeeping: SpaceGoal = fresh;
+      if (fresh.autoTriggerNext && fresh.pendingNextRun && fresh.status === 'active') {
+        const created = this.createImmediateTask(fresh.id, { source: 'system' });
+        postBookkeeping = created.goal;
+        nextTask = created.task;
       }
-      const created = this.createImmediateTask(fresh.id, { source: 'system' });
-      return { goal: created.goal, nextTask: created.task, terminalGeneration };
+      this.recordOutcomeNotification(task, postBookkeeping, terminalGeneration, {
+        fromStatus: transition?.fromStatus ?? null,
+      });
+      return { goal: postBookkeeping, nextTask, terminalGeneration };
     });
     if (result.goal && this.deps.outcomeNotificationRepo) {
       const pending = this.deps.outcomeNotificationRepo.listPendingByGoal(result.goal.id);
@@ -335,7 +353,8 @@ export class SpaceGoalService {
   private recordOutcomeNotification(
     task: SpaceTask,
     goal: SpaceGoal,
-    terminalGeneration: number
+    terminalGeneration: number,
+    transition: { fromStatus?: SpaceTaskStatus | null }
   ): void {
     if (!this.deps.outcomeNotificationRepo) return;
     const hasStartGeneration = task.startedAt !== null;
@@ -343,7 +362,7 @@ export class SpaceGoalService {
       .listPendingByGoal(goal.id)
       .filter((n) => n.taskId === task.id);
     const decision = decideReportableTerminal({
-      fromStatus: null,
+      fromStatus: transition.fromStatus ?? null,
       toStatus: task.status,
       hasStartGeneration,
       hasPriorTerminalGeneration: priorPending.length > 0,
@@ -361,8 +380,8 @@ export class SpaceGoalService {
       payload: {
         summary: (task.reportedSummary ?? task.result ?? '').slice(0, 400),
         taskStatus: task.status,
-        taskTitle: task.title,
-        goalTitle: goal.title,
+        taskTitle: task.title.slice(0, 200),
+        goalTitle: goal.title.slice(0, 200),
       },
     });
   }

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -388,7 +388,15 @@ export class SpaceGoalService {
       return { goal: postBookkeeping, nextTask, terminalGeneration, notification };
     });
     if (result.nextTask) this.emitTaskCreated(result.nextTask);
-    if (result.notification) this.deps.onOutcomeNotification?.(result.notification);
+    if (result.notification) {
+      try {
+        this.deps.onOutcomeNotification?.(result.notification);
+      } catch (err) {
+        log.warn(
+          `Outcome notification delivery threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
     return result;
   }
 
@@ -424,7 +432,11 @@ export class SpaceGoalService {
       terminalGeneration,
       goalRevision: goal.revision,
       payload: {
-        summary: (task.reportedSummary ?? task.result ?? '').slice(0, 400),
+        summary: (
+          [task.reportedSummary, task.result].find(
+            (s) => typeof s === 'string' && s.trim().length > 0
+          ) ?? ''
+        ).slice(0, 400),
         taskStatus: task.status,
         taskTitle: task.title.slice(0, 200),
         goalTitle: goal.title.slice(0, 200),

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -257,14 +257,16 @@ export class SpaceTaskManager {
     if (reopened && newStatus === 'open') {
       updates.startedAt = null;
     }
-    const updated = this.taskRepo.updateTask(taskId, updates);
-    if (!updated) {
-      throw new Error(`Failed to update task: ${taskId}`);
-    }
-
-    if (reopened) {
-      this.onTaskReopened?.(taskId);
-    }
+    const updated = this.db.transaction(() => {
+      const result = this.taskRepo.updateTask(taskId, updates);
+      if (!result) {
+        throw new Error(`Failed to update task: ${taskId}`);
+      }
+      if (reopened) {
+        this.onTaskReopened?.(taskId);
+      }
+      return result;
+    })();
 
     if (newStatus === 'done') {
       if (!task.goalId) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -257,16 +257,24 @@ export class SpaceTaskManager {
     if (reopened && newStatus === 'open') {
       updates.startedAt = null;
     }
-    const updated = this.db.transaction(() => {
-      const result = this.taskRepo.updateTask(taskId, updates);
-      if (!result) {
-        throw new Error(`Failed to update task: ${taskId}`);
-      }
-      if (reopened) {
-        this.onTaskReopened?.(taskId);
-      }
-      return result;
-    })();
+    this.reactiveDb?.beginTransaction();
+    let updated: SpaceTask;
+    try {
+      updated = this.db.transaction(() => {
+        const result = this.taskRepo.updateTask(taskId, updates);
+        if (!result) {
+          throw new Error(`Failed to update task: ${taskId}`);
+        }
+        if (reopened) {
+          this.onTaskReopened?.(taskId);
+        }
+        return result;
+      })();
+      this.reactiveDb?.commitTransaction();
+    } catch (err) {
+      this.reactiveDb?.abortTransaction();
+      throw err;
+    }
 
     if (newStatus === 'done') {
       if (!task.goalId) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -254,7 +254,7 @@ export class SpaceTaskManager {
     }
 
     const reopened = isTerminalTaskStatus(task.status) && !isTerminalTaskStatus(newStatus);
-    if (reopened) {
+    if (reopened && newStatus === 'open') {
       updates.startedAt = null;
     }
     const updated = this.taskRepo.updateTask(taskId, updates);
@@ -266,7 +266,7 @@ export class SpaceTaskManager {
       this.onTaskReopened?.(taskId);
     }
 
-    if (newStatus === 'done') {
+    if (newStatus === 'done' && !task.goalId) {
       try {
         this.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
       } catch (err) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -266,13 +266,15 @@ export class SpaceTaskManager {
       this.onTaskReopened?.(taskId);
     }
 
-    if (newStatus === 'done' && !task.goalId) {
-      try {
-        this.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
-      } catch (err) {
-        log.warn(
-          `Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
-        );
+    if (newStatus === 'done') {
+      if (!task.goalId) {
+        try {
+          this.evolutionScopeService?.captureCompletedTaskEvidence({ taskId });
+        } catch (err) {
+          log.warn(
+            `Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       try {
         const unblocked = await this.unblockDependentTasks(taskId);

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -78,7 +78,8 @@ export class SpaceTaskManager {
     private db: BunDatabase,
     private spaceId: string,
     private reactiveDb?: ReactiveDatabase,
-    private evolutionScopeService?: EvolutionScopeService
+    private evolutionScopeService?: EvolutionScopeService,
+    private onTaskReopened?: (taskId: string) => void
   ) {
     this.taskRepo = new SpaceTaskRepository(db, reactiveDb);
   }
@@ -255,6 +256,10 @@ export class SpaceTaskManager {
     const updated = this.taskRepo.updateTask(taskId, updates);
     if (!updated) {
       throw new Error(`Failed to update task: ${taskId}`);
+    }
+
+    if (isTerminalTaskStatus(task.status) && !isTerminalTaskStatus(newStatus)) {
+      this.onTaskReopened?.(taskId);
     }
 
     if (newStatus === 'done') {
@@ -632,4 +637,10 @@ export class SpaceTaskManager {
     }
     return false;
   }
+}
+
+function isTerminalTaskStatus(status: SpaceTaskStatus): boolean {
+  return (
+    status === 'done' || status === 'blocked' || status === 'cancelled' || status === 'archived'
+  );
 }

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -253,12 +253,16 @@ export class SpaceTaskManager {
       updates.postApprovalSourceNodeId = null;
     }
 
+    const reopened = isTerminalTaskStatus(task.status) && !isTerminalTaskStatus(newStatus);
+    if (reopened) {
+      updates.startedAt = null;
+    }
     const updated = this.taskRepo.updateTask(taskId, updates);
     if (!updated) {
       throw new Error(`Failed to update task: ${taskId}`);
     }
 
-    if (isTerminalTaskStatus(task.status) && !isTerminalTaskStatus(newStatus)) {
+    if (reopened) {
       this.onTaskReopened?.(taskId);
     }
 

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -176,7 +176,7 @@ export class PostApprovalRouter {
         log.warn(
           `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
         );
-        this.deps.taskRepo.updateTask(task.id, updates);
+        throw err;
       }
       if (!terminalHandled) {
         try {

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -162,11 +162,13 @@ export class PostApprovalRouter {
         postApprovalBlockedReason: null,
         postApprovalSourceNodeId: null,
       };
+      let terminalHandled = false;
       try {
         const handled = this.deps.goalService?.handleTaskTerminal(task.id, {
           fromStatus: task.status,
           updates,
         });
+        terminalHandled = handled != null;
         if (!handled) {
           this.deps.taskRepo.updateTask(task.id, updates);
         }
@@ -176,12 +178,14 @@ export class PostApprovalRouter {
         );
         this.deps.taskRepo.updateTask(task.id, updates);
       }
-      try {
-        this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId: task.id });
-      } catch (err) {
-        log.warn(
-          `Forge evidence capture threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
-        );
+      if (!terminalHandled) {
+        try {
+          this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId: task.id });
+        } catch (err) {
+          log.warn(
+            `Forge evidence capture threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       log.info(
         `post-approval.route: spaceId=${task.spaceId} taskId=${task.id} sourceNodeId=${sourceNodeId ?? 'none'} routes=0 mode=none autonomyLevel=${context.autonomyLevel ?? 'unknown'}`

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -163,14 +163,18 @@ export class PostApprovalRouter {
         postApprovalSourceNodeId: null,
       };
       try {
-        this.deps.goalService?.handleTaskTerminal(task.id, {
+        const handled = this.deps.goalService?.handleTaskTerminal(task.id, {
           fromStatus: task.status,
           updates,
         });
+        if (!handled) {
+          this.deps.taskRepo.updateTask(task.id, updates);
+        }
       } catch (err) {
         log.warn(
           `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
         );
+        this.deps.taskRepo.updateTask(task.id, updates);
       }
       try {
         this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId: task.id });

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -162,19 +162,21 @@ export class PostApprovalRouter {
         postApprovalBlockedReason: null,
         postApprovalSourceNodeId: null,
       };
-      this.deps.taskRepo.updateTask(task.id, updates);
+      try {
+        this.deps.goalService?.handleTaskTerminal(task.id, {
+          fromStatus: task.status,
+          updates,
+        });
+      } catch (err) {
+        log.warn(
+          `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
       try {
         this.deps.evolutionScopeService?.captureCompletedTaskEvidence({ taskId: task.id });
       } catch (err) {
         log.warn(
           `Forge evidence capture threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-      try {
-        this.deps.goalService?.handleTaskTerminal(task.id);
-      } catch (err) {
-        log.warn(
-          `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
         );
       }
       log.info(

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1566,7 +1566,8 @@ export class SpaceRuntimeService {
         db,
         space.id,
         this.config.reactiveDb,
-        this.config.evolutionScopeService
+        this.config.evolutionScopeService,
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
       ),
       spaceAgentManager,
       sessionManager: this.config.sessionManager,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1824,6 +1824,7 @@ export class SpaceRuntimeService {
       targetStatus,
       options
     );
+    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     return recovered.task;
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -892,7 +892,8 @@ export class SpaceRuntimeService {
         this.config.db,
         space.id,
         this.config.reactiveDb,
-        this.config.evolutionScopeService
+        this.config.evolutionScopeService,
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,
@@ -1393,7 +1394,8 @@ export class SpaceRuntimeService {
         this.config.db,
         space.id,
         this.config.reactiveDb,
-        this.config.evolutionScopeService
+        this.config.evolutionScopeService,
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1824,7 +1824,6 @@ export class SpaceRuntimeService {
       targetStatus,
       options
     );
-    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     return recovered.task;
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -211,7 +211,10 @@ export interface SpaceRuntimeConfig {
     run: SpaceWorkflowRun;
   }) => Promise<void> | void;
   selectWorkflowWithLlm?: SelectWorkflowWithLlm;
-  goalService?: Pick<import('../goals/goal-service').SpaceGoalService, 'handleTaskTerminal'>;
+  goalService?: Pick<
+    import('../goals/goal-service').SpaceGoalService,
+    'handleTaskTerminal' | 'supersedeOutcomeNotificationsForTask'
+  >;
   evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
   actorRegistry?: SpaceActorRegistryAdapter;
   spaceAgentInboxRepo?: SpaceAgentInboxRepository;
@@ -8185,7 +8188,8 @@ export class SpaceRuntime {
         this.config.db,
         spaceId,
         this.config.reactiveDb,
-        this.config.evolutionScopeService
+        this.config.evolutionScopeService,
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
       );
       this.taskManagers.set(spaceId, manager);
     }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4252,11 +4252,11 @@ export class SpaceRuntime {
         }
       }
 
+      this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
       return { task: updatedTask, run: updatedRun };
     });
 
     const recovered = recoverTx();
-    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -213,7 +213,7 @@ export interface SpaceRuntimeConfig {
   selectWorkflowWithLlm?: SelectWorkflowWithLlm;
   goalService?: Pick<
     import('../goals/goal-service').SpaceGoalService,
-    'handleTaskTerminal' | 'supersedeOutcomeNotificationsForTask'
+    'handleTaskTerminal' | 'supersedeOutcomeNotificationsForTask' | 'retryQueuedRunsForSpace'
   >;
   evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
   actorRegistry?: SpaceActorRegistryAdapter;
@@ -4529,6 +4529,13 @@ export class SpaceRuntime {
   onSpaceResumed(spaceId: string): void {
     const store = this.config.externalEventStore;
     this.pausedSpaceIds.delete(spaceId);
+    try {
+      this.config.goalService?.retryQueuedRunsForSpace(spaceId);
+    } catch (err) {
+      log.warn(
+        `Goal queued-run retry threw for space ${spaceId} on resume: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
     if (!store) return;
 
     const reactiveRuns = this.config.workflowRunRepo

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4256,6 +4256,7 @@ export class SpaceRuntime {
     });
 
     const recovered = recoverTx();
+    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4256,7 +4256,15 @@ export class SpaceRuntime {
       return { task: updatedTask, run: updatedRun };
     });
 
-    const recovered = recoverTx();
+    this.config.reactiveDb?.beginTransaction();
+    let recovered: { task: SpaceTask; run: SpaceWorkflowRun };
+    try {
+      recovered = recoverTx();
+      this.config.reactiveDb?.commitTransaction();
+    } catch (err) {
+      this.config.reactiveDb?.abortTransaction();
+      throw err;
+    }
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4148,6 +4148,7 @@ export class SpaceRuntime {
         postApprovalSourceNodeId: null,
         reportedStatus: null,
         reportedSummary: null,
+        ...(targetStatus === 'open' ? { startedAt: null } : {}),
         ...(options.description !== undefined ? { description: options.description } : {}),
       });
       if (!updatedTask) throw new Error(`Failed to update task: ${task.id}`);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4133,7 +4133,8 @@ export class TaskAgentManager {
       this.config.db.getDatabase(),
       spaceId,
       this.config.reactiveDb,
-      this.config.evolutionScopeService
+      this.config.evolutionScopeService,
+      (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
     );
     const endNodeHandlers = isEndNode
       ? createEndNodeHandlers({

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2204,6 +2204,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
         const task = cancelled[0]!;
         for (const cancelledTask of cancelled) {
           emitTaskUpdated(cancelledTask);
+          try {
+            config.goalService?.handleTaskTerminal(cancelledTask.id, {
+              fromStatus: cancelledTask.status,
+            });
+          } catch (err) {
+            log.warn(
+              `Goal terminal handling threw for cancelled task "${cancelledTask.id}": ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
         }
         const existingRun = task.workflowRunId ? workflowRunRepo.getRun(task.workflowRunId) : null;
         const plan = routeCancelTask({
@@ -2276,6 +2285,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
         logAudit('archive_task', { previousStatus: task?.status }, args.task_id);
 
         emitTaskUpdated(updated);
+        try {
+          config.goalService?.handleTaskTerminal(updated.id, {
+            fromStatus: task?.status ?? null,
+          });
+        } catch (err) {
+          log.warn(
+            `Goal terminal handling threw for archived task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
 
         return jsonResult({ success: true, task: updated });
       } catch (err) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2120,6 +2120,22 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             if (hasFieldUpdates) {
               updated = await applyFieldUpdates();
             }
+            if (
+              updated.status === 'done' ||
+              updated.status === 'blocked' ||
+              updated.status === 'cancelled' ||
+              updated.status === 'archived'
+            ) {
+              try {
+                config.goalService?.handleTaskTerminal(updated.id, {
+                  fromStatus: task?.status ?? null,
+                });
+              } catch (err) {
+                log.warn(
+                  `Goal terminal handling threw for task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
+                );
+              }
+            }
             logAudit('update_task', transitionAuditParams, args.task_id);
             emitTaskUpdated(updated);
             return jsonResult({ success: true, task: updated });

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2200,13 +2200,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       cancel_workflow_run?: boolean;
     }): Promise<ToolResult> {
       try {
+        const preCancelStatus = taskRepo.getTask(args.task_id)?.status ?? null;
         const cancelled = await taskManager.cancelTaskCascade(args.task_id);
         const task = cancelled[0]!;
         for (const cancelledTask of cancelled) {
           emitTaskUpdated(cancelledTask);
           try {
             config.goalService?.handleTaskTerminal(cancelledTask.id, {
-              fromStatus: cancelledTask.status,
+              fromStatus: cancelledTask.id === args.task_id ? preCancelStatus : 'open',
             });
           } catch (err) {
             log.warn(

--- a/packages/daemon/src/storage/repositories/space-goal-outcome-notification-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-outcome-notification-repository.ts
@@ -75,6 +75,17 @@ export class SpaceGoalOutcomeNotificationRepository {
     return result.changes;
   }
 
+  supersedeForTaskOlderThan(taskId: string, terminalGeneration: number): number {
+    const result = this.db
+      .prepare(
+        `UPDATE space_goal_outcome_notifications
+					 SET status = 'superseded', updated_at = ?
+					 WHERE task_id = ? AND status = 'pending' AND terminal_generation < ?`
+      )
+      .run(Date.now(), taskId, terminalGeneration);
+    return result.changes;
+  }
+
   updateStatus(
     id: string,
     status: SpaceGoalOutcomeNotificationStatus

--- a/packages/daemon/src/storage/repositories/space-goal-outcome-notification-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-goal-outcome-notification-repository.ts
@@ -1,0 +1,130 @@
+import { generateUUID } from '@hyperneo/shared';
+import type {
+  SpaceGoalOutcomeNotification,
+  SpaceGoalOutcomeNotificationPayload,
+  SpaceGoalOutcomeNotificationStatus,
+} from '@hyperneo/shared';
+import type { Database as BunDatabase } from '../sqlite-compat';
+
+export interface CreateGoalOutcomeNotificationParams {
+  spaceId: string;
+  goalId: string;
+  taskId: string;
+  terminalGeneration: number;
+  goalRevision: number;
+  payload: SpaceGoalOutcomeNotificationPayload;
+}
+
+export class SpaceGoalOutcomeNotificationRepository {
+  constructor(private db: BunDatabase) {}
+
+  create(params: CreateGoalOutcomeNotificationParams): SpaceGoalOutcomeNotification {
+    const id = generateUUID();
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO space_goal_outcome_notifications (
+					id, space_id, goal_id, task_id, terminal_generation, goal_revision,
+					status, payload_json, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)`
+      )
+      .run(
+        id,
+        params.spaceId,
+        params.goalId,
+        params.taskId,
+        params.terminalGeneration,
+        params.goalRevision,
+        JSON.stringify(params.payload),
+        now,
+        now
+      );
+    const row = this.db
+      .prepare(
+        `SELECT * FROM space_goal_outcome_notifications WHERE goal_id = ? AND task_id = ? AND terminal_generation = ?`
+      )
+      .get(params.goalId, params.taskId, params.terminalGeneration) as Record<string, unknown>;
+    return row ? rowToNotification(row) : this.getById(id)!;
+  }
+
+  getById(id: string): SpaceGoalOutcomeNotification | null {
+    const row = this.db
+      .prepare(`SELECT * FROM space_goal_outcome_notifications WHERE id = ?`)
+      .get(id) as Record<string, unknown> | undefined;
+    return row ? rowToNotification(row) : null;
+  }
+
+  listPendingByGoal(goalId: string): SpaceGoalOutcomeNotification[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM space_goal_outcome_notifications
+				 WHERE goal_id = ? AND status = 'pending' ORDER BY created_at ASC`
+      )
+      .all(goalId) as Record<string, unknown>[];
+    return rows.map(rowToNotification);
+  }
+
+  supersedeForTask(taskId: string): number {
+    const result = this.db
+      .prepare(
+        `UPDATE space_goal_outcome_notifications
+				 SET status = 'superseded', updated_at = ?
+				 WHERE task_id = ? AND status = 'pending'`
+      )
+      .run(Date.now(), taskId);
+    return result.changes;
+  }
+
+  updateStatus(
+    id: string,
+    status: SpaceGoalOutcomeNotificationStatus
+  ): SpaceGoalOutcomeNotification | null {
+    this.db
+      .prepare(
+        `UPDATE space_goal_outcome_notifications SET status = ?, updated_at = ? WHERE id = ?`
+      )
+      .run(status, Date.now(), id);
+    return this.getById(id);
+  }
+
+  countByGoal(goalId: string, status: SpaceGoalOutcomeNotificationStatus): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM space_goal_outcome_notifications WHERE goal_id = ? AND status = ?`
+      )
+      .get(goalId, status) as { count: number };
+    return row?.count ?? 0;
+  }
+}
+
+function rowToNotification(row: Record<string, unknown>): SpaceGoalOutcomeNotification {
+  return {
+    id: row.id as string,
+    spaceId: row.space_id as string,
+    goalId: row.goal_id as string,
+    taskId: row.task_id as string,
+    terminalGeneration: (row.terminal_generation as number) ?? 0,
+    goalRevision: (row.goal_revision as number) ?? 0,
+    status: row.status as SpaceGoalOutcomeNotificationStatus,
+    payload: parsePayload(row.payload_json),
+    createdAt: row.created_at as number,
+    updatedAt: row.updated_at as number,
+  };
+}
+
+function parsePayload(raw: unknown): SpaceGoalOutcomeNotificationPayload {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { summary: '', taskStatus: 'done', taskTitle: '', goalTitle: '' };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<SpaceGoalOutcomeNotificationPayload>;
+    return {
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      taskStatus: parsed.taskStatus ?? 'done',
+      taskTitle: typeof parsed.taskTitle === 'string' ? parsed.taskTitle : '',
+      goalTitle: typeof parsed.goalTitle === 'string' ? parsed.goalTitle : '',
+    };
+  } catch {
+    return { summary: '', taskStatus: 'done', taskTitle: '', goalTitle: '' };
+  }
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -458,6 +458,26 @@ export function createTables(db: BunDatabase): void {
 	    `);
 
   db.exec(`
+      CREATE TABLE IF NOT EXISTS space_goal_outcome_notifications (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL,
+        goal_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        terminal_generation INTEGER NOT NULL DEFAULT 0,
+        goal_revision INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'pending'
+          CHECK(status IN ('pending', 'superseded', 'acknowledged', 'rejected')),
+        payload_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(goal_id, task_id, terminal_generation),
+        FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+        FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+        FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE
+      )
+    `);
+
+  db.exec(`
       CREATE TABLE IF NOT EXISTS short_id_counters (
         entity_type TEXT NOT NULL,
         scope_id    TEXT NOT NULL,
@@ -981,6 +1001,14 @@ function createIndexes(db: BunDatabase): void {
   );
   db.exec(
     `CREATE INDEX IF NOT EXISTS idx_space_goal_events_source_task ON space_goal_events(source_task_id, created_at DESC)`
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_goal_pending
+      ON space_goal_outcome_notifications(goal_id, status, created_at)`
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_task
+      ON space_goal_outcome_notifications(task_id, terminal_generation)`
   );
 
   db.exec(

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -447,6 +447,8 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
   run(migrationMarkerKey(203), () => runMigration203(db));
 
   run(migrationMarkerKey(204), () => runMigration204(db));
+
+  run(migrationMarkerKey(205), () => runMigration205(db));
 }
 
 function migrationMarkerKey(version: number): string {
@@ -9559,4 +9561,31 @@ export function runMigration204(db: BunDatabase): void {
   if (tableExists(db, 'space_tasks') && !tableHasColumn(db, 'space_tasks', 'terminal_generation')) {
     db.exec(`ALTER TABLE space_tasks ADD COLUMN terminal_generation INTEGER NOT NULL DEFAULT 0`);
   }
+}
+
+export function runMigration205(db: BunDatabase): void {
+  if (!tableExists(db, 'space_goals')) return;
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS space_goal_outcome_notifications (
+      id TEXT PRIMARY KEY,
+      space_id TEXT NOT NULL,
+      goal_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      terminal_generation INTEGER NOT NULL DEFAULT 0,
+      goal_revision INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(status IN ('pending', 'superseded', 'acknowledged', 'rejected')),
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE(goal_id, task_id, terminal_generation),
+      FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+      FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+      FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_goal_pending
+    ON space_goal_outcome_notifications(goal_id, status, created_at)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_task
+    ON space_goal_outcome_notifications(task_id, terminal_generation)`);
 }

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -59,6 +59,7 @@ describe('scope-config', () => {
         'space_tasks',
         'space_goals',
         'space_goal_events',
+        'space_goal_outcome_notifications',
         'space_worktrees',
         'workflow_hook_state',
         'workflow_hook_result_artifacts',
@@ -82,7 +83,7 @@ describe('scope-config', () => {
         'session_groups',
         'session_group_members',
       ]);
-      expect(names).toHaveLength(29);
+      expect(names).toHaveLength(30);
     });
 
     it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -4,6 +4,7 @@ import { SpaceGoalService } from '../../../src/lib/space/goals/goal-service';
 import { ScheduleService } from '../../../src/lib/space/schedule/schedule-service';
 import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
 import { SpaceGoalEventRepository } from '../../../src/storage/repositories/space-goal-event-repository';
+import { SpaceGoalOutcomeNotificationRepository } from '../../../src/storage/repositories/space-goal-outcome-notification-repository';
 import { SpaceGoalRepository } from '../../../src/storage/repositories/space-goal-repository';
 import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
 import { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository';
@@ -38,6 +39,7 @@ describe('SpaceGoalService', () => {
   let goalRepo: SpaceGoalRepository;
   let goalEventRepo: SpaceGoalEventRepository;
   let taskRepo: SpaceTaskRepository;
+  let notificationRepo: SpaceGoalOutcomeNotificationRepository;
   let spaceRepo: SpaceRepository;
   let scheduleRepo: TaskScheduleRepository;
   let scheduleService: ScheduleService;
@@ -52,6 +54,7 @@ describe('SpaceGoalService', () => {
     goalRepo = new SpaceGoalRepository(db as never);
     goalEventRepo = new SpaceGoalEventRepository(db as never);
     taskRepo = new SpaceTaskRepository(db as never);
+    notificationRepo = new SpaceGoalOutcomeNotificationRepository(db as never);
     spaceRepo = new SpaceRepository(db as never);
     scheduleRepo = new TaskScheduleRepository(db as never);
     scheduleService = new ScheduleService({
@@ -67,6 +70,7 @@ describe('SpaceGoalService', () => {
       spaceRepo,
       scheduleService,
       db: db as never,
+      outcomeNotificationRepo: notificationRepo,
     });
 
     const space = spaceRepo.createSpace({
@@ -1033,5 +1037,50 @@ describe('SpaceGoalService', () => {
 
     taskRepo.archiveTask(task.task!.id);
     expect(taskRepo.getTask(task.task!.id)?.terminalGeneration).toBe(1);
+  });
+
+  it('persists a pending outcome notification for a reportable terminal transition', () => {
+    const goal = service.createGoal({ spaceId, title: 'Notify goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    taskRepo.updateTask(task.task!.id, { status: 'open' });
+    taskRepo.updateTask(task.task!.id, { status: 'done' });
+
+    service.handleTaskTerminal(task.task!.id);
+
+    const pending = notificationRepo.listPendingByGoal(goal.id);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].taskId).toBe(task.task!.id);
+    expect(pending[0].goalRevision).toBe(goalRepo.getById(goal.id)?.revision);
+    expect(pending[0].terminalGeneration).toBe(1);
+    expect(pending[0].payload.taskTitle).toBe(task.task!.title);
+    expect(pending[0].payload.goalTitle).toBe(goal.title);
+  });
+
+  it('does not persist a notification for an administrative (unstarted) terminal transition', () => {
+    const goal = service.createGoal({ spaceId, title: 'No notify goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+    taskRepo.archiveTask(task.task!.id);
+
+    service.handleTaskTerminal(task.task!.id);
+
+    expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(0);
+  });
+
+  it('supersedes pending notifications when a terminal task is reopened', () => {
+    const goal = service.createGoal({ spaceId, title: 'Supersede goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    taskRepo.updateTask(task.task!.id, { status: 'done' });
+    service.handleTaskTerminal(task.task!.id);
+    expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(1);
+
+    service.supersedeOutcomeNotificationsForTask(task.task!.id);
+
+    expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(0);
+    expect(notificationRepo.countByGoal(goal.id, 'superseded')).toBe(1);
   });
 });

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1083,4 +1083,27 @@ describe('SpaceGoalService', () => {
     expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(0);
     expect(notificationRepo.countByGoal(goal.id, 'superseded')).toBe(1);
   });
+
+  it('rolls back the terminal write and notification together when notification creation fails', () => {
+    const goal = service.createGoal({ spaceId, title: 'Atomic goal' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+
+    const spy = spyOn(notificationRepo, 'create').mockImplementation(() => {
+      throw new Error('injected notification failure');
+    });
+
+    expect(() =>
+      service.handleTaskTerminal(task.task!.id, {
+        fromStatus: 'in_progress',
+        updates: { status: 'done', result: 'shipped' },
+      })
+    ).toThrow('injected notification failure');
+    spy.mockRestore();
+
+    expect(taskRepo.getTask(task.task!.id)?.status).toBe('in_progress');
+    expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(0);
+    expect(taskRepo.getTask(task.task!.id)?.result).toBeNull();
+  });
 });

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -382,9 +382,9 @@ describe('SpaceGoalService', () => {
     spaceRepo.pauseSpace(spaceId);
     taskRepo.updateTask(first.task!.id, { status: 'done' });
 
-    expect(() => service.handleTaskTerminal(first.task!.id)).toThrow(
-      'Cannot create goal task in a non-active space'
-    );
+    const terminal = service.handleTaskTerminal(first.task!.id);
+    expect(terminal?.nextTask).toBeNull();
+    expect(goalRepo.getById(autoGoal.id)?.activeTaskId).toBeNull();
     expect(taskRepo.listBySpace(spaceId).map((task) => task.id)).toEqual([first.task!.id]);
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -1084,6 +1084,26 @@ describe('SpaceGoalService', () => {
     expect(notificationRepo.countByGoal(goal.id, 'superseded')).toBe(1);
   });
 
+  it('keeps the current generation pending when a terminal transition is retried', () => {
+    const goal = service.createGoal({ spaceId, title: 'Retry outcome' });
+    const task = service.createImmediateTask(goal.id);
+    expect(task.task).not.toBeNull();
+    taskRepo.updateTask(task.task!.id, { status: 'in_progress' });
+    service.handleTaskTerminal(task.task!.id, {
+      fromStatus: 'in_progress',
+      updates: { status: 'done' },
+    });
+    expect(notificationRepo.listPendingByGoal(goal.id)).toHaveLength(1);
+
+    service.handleTaskTerminal(task.task!.id, {
+      fromStatus: 'in_progress',
+      updates: { status: 'done' },
+    });
+    const pending = notificationRepo.listPendingByGoal(goal.id);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.status).toBe('pending');
+  });
+
   it('rolls back the terminal write and notification together when notification creation fails', () => {
     const goal = service.createGoal({ spaceId, title: 'Atomic goal' });
     const task = service.createImmediateTask(goal.id);

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -388,6 +388,28 @@ describe('SpaceGoalService', () => {
     expect(taskRepo.listBySpace(spaceId).map((task) => task.id)).toEqual([first.task!.id]);
   });
 
+  it('retries queued auto-trigger runs after the host space resumes', () => {
+    const goal = service.createGoal({
+      spaceId,
+      title: 'Retry queued run',
+      autoTriggerNext: true,
+    });
+    const first = service.createImmediateTask(goal.id);
+    expect(first.task).not.toBeNull();
+    service.createImmediateTask(goal.id);
+    spaceRepo.pauseSpace(spaceId);
+    taskRepo.updateTask(first.task!.id, { status: 'done' });
+    service.handleTaskTerminal(first.task!.id);
+    expect(goalRepo.getById(goal.id)?.pendingNextRun).toBe(true);
+
+    spaceRepo.resumeSpace(spaceId);
+    const created = service.retryQueuedRunsForSpace(spaceId);
+    expect(created).toBe(1);
+    const updated = goalRepo.getById(goal.id);
+    expect(updated?.pendingNextRun).toBe(false);
+    expect(updated?.activeTaskId).not.toBeNull();
+  });
+
   it('auto-triggers one queued task after the active task reaches a terminal status', () => {
     const goal = service.createGoal({
       spaceId,

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-205_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-205_test.ts
@@ -1,0 +1,74 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { runMigration205 } from '../../../../../src/storage/schema/migrations.ts';
+
+function tableNames(db: BunDatabase): string[] {
+  const rows = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`).all() as Array<{
+    name: string;
+  }>;
+  return rows.map((r) => r.name);
+}
+
+describe('Migration 205: space_goal_outcome_notifications', () => {
+  let testDir: string;
+  let db: BunDatabase;
+
+  beforeEach(() => {
+    testDir = join(
+      process.cwd(),
+      'tmp',
+      'test-migration-205',
+      `test-${Date.now()}-${Math.random()}`
+    );
+    mkdirSync(testDir, { recursive: true });
+    db = new BunDatabase(join(testDir, 'test.db'));
+    db.exec('PRAGMA foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    try {
+      db.close();
+    } catch {}
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('creates the outcome notifications table when space_goals exists', () => {
+    db.exec(`CREATE TABLE space_goals (id TEXT PRIMARY KEY, title TEXT NOT NULL)`);
+    runMigration205(db);
+
+    expect(tableNames(db)).toContain('space_goal_outcome_notifications');
+    const columns = db
+      .prepare(`PRAGMA table_info('space_goal_outcome_notifications')`)
+      .all() as Array<{ name: string }>;
+    const names = columns.map((c) => c.name);
+    for (const col of [
+      'id',
+      'space_id',
+      'goal_id',
+      'task_id',
+      'terminal_generation',
+      'goal_revision',
+      'status',
+      'payload_json',
+      'created_at',
+      'updated_at',
+    ]) {
+      expect(names).toContain(col);
+    }
+  });
+
+  test('is idempotent', () => {
+    db.exec(`CREATE TABLE space_goals (id TEXT PRIMARY KEY, title TEXT NOT NULL)`);
+    runMigration205(db);
+    expect(() => runMigration205(db)).not.toThrow();
+  });
+
+  test('is a no-op when space_goals does not exist', () => {
+    expect(() => runMigration205(db)).not.toThrow();
+    expect(tableNames(db)).not.toContain('space_goal_outcome_notifications');
+  });
+});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -491,6 +491,29 @@ export function createSpaceTables(db: BunDatabase): void {
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_space_lh_agent_goals_one_owner ` +
       `ON space_long_horizon_agent_goals(goal_id) WHERE relationship = 'owner'`
   );
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS space_goal_outcome_notifications (
+      id TEXT PRIMARY KEY,
+      space_id TEXT NOT NULL,
+      goal_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      terminal_generation INTEGER NOT NULL DEFAULT 0,
+      goal_revision INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(status IN ('pending', 'superseded', 'acknowledged', 'rejected')),
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE(goal_id, task_id, terminal_generation),
+      FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+      FOREIGN KEY (goal_id) REFERENCES space_goals(id) ON DELETE CASCADE,
+      FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_goal_pending
+    ON space_goal_outcome_notifications(goal_id, status, created_at)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_goal_outcome_notifications_task
+    ON space_goal_outcome_notifications(task_id, terminal_generation)`);
   createWorkflowEventSubscriptionTables(db);
 
   db.exec(`

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -528,6 +528,32 @@ export interface PaginatedSpaceTaskResult {
   total: number;
 }
 
+export type SpaceGoalOutcomeNotificationStatus =
+  | 'pending'
+  | 'superseded'
+  | 'acknowledged'
+  | 'rejected';
+
+export interface SpaceGoalOutcomeNotification {
+  id: string;
+  spaceId: string;
+  goalId: string;
+  taskId: string;
+  terminalGeneration: number;
+  goalRevision: number;
+  status: SpaceGoalOutcomeNotificationStatus;
+  payload: SpaceGoalOutcomeNotificationPayload;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SpaceGoalOutcomeNotificationPayload {
+  summary: string;
+  taskStatus: SpaceTaskStatus;
+  taskTitle: string;
+  goalTitle: string;
+}
+
 export interface SpaceTaskCompact {
   id: string;
   taskNumber: number;

--- a/scripts/check-db-schema-parity.ts
+++ b/scripts/check-db-schema-parity.ts
@@ -78,6 +78,7 @@ export const HELPER_SCHEMA_TABLES = [
   'space_external_event_source_configs',
   'space_external_events',
   'space_goal_events',
+  'space_goal_outcome_notifications',
   'space_goals',
   'space_long_horizon_agent_event_subscriptions',
   'space_long_horizon_agent_forge_scopes',


### PR DESCRIPTION
Closes #2742

## Summary
Persist a minimal per-terminal-generation outcome notification **in the same transaction** as the goal terminal bookkeeping, per roadmap MC2:

- **Migration 205 + canonical schema**: `space_goal_outcome_notifications` (pending/superseded/acknowledged/rejected, `goal_revision`, `terminal_generation`, bounded `payload_json`). Registered in the db-query scope config and the parity helper.
- **Atomic seam**: `SpaceGoalService.handleTaskTerminal` runs terminal bookkeeping + notification persistence in one transaction, consuming the MC2-A reportable-terminal predicate:
  - administrative/unstarted terminal transitions → no notification;
  - active completions → one pending notification with the post-bookkeeping goal revision and durable terminal generation;
  - supersede_notify → supersedes prior pending records for the task before inserting.
- **Supersede-on-reopen**: `SpaceTaskManager` gains an `onTaskReopened` hook fired when a terminal task returns to a non-terminal status; space-runtime-service wires it to `supersedeOutcomeNotificationsForTask`.
- **Bounded payload**: task summary sliced to 400 chars + stable IDs (task id, goal id, terminal generation); full data stays on task/goal records for audit.
- **Sequencing gate**: the owner wake is NOT wired — the notification is the durable identity MC3-B consumes, and injection stays feature-flagged off until MC5-B flips it.

## Non-goals
- Missing-notification reconciler (G7), follow-up outbox (G8), edited-merge (G8), recipient reroute on owner change (lazy resolution).

## Test plan
- Goal service: pending notification persisted for a reportable completion with post-bookkeeping revision + generation; no notification for an unstarted archive; supersede clears pending on reopen; notification repo list/supersede/count.
- Migration 205: table + columns, idempotency, no-op guard.
- `bun run check` green (lint, types, knip, format, test-matrix, db-schema parity incl. scope registration).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->