### PR TITLE
fix(daemon): align getSupersededMessageUuids with model_refusal_fallback gate

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -382,16 +382,7 @@ export class SDKMessageRepository {
   }
 
   private getSupersededMessageUuids(message: SDKMessage): string[] {
-    const maybeSuperseding = message as SDKMessage & {
-      supersedes?: unknown;
-      retracted_message_uuids?: unknown;
-    };
-    return [
-      ...(Array.isArray(maybeSuperseding.supersedes) ? maybeSuperseding.supersedes : []),
-      ...(Array.isArray(maybeSuperseding.retracted_message_uuids)
-        ? maybeSuperseding.retracted_message_uuids
-        : []),
-    ].filter((uuid): uuid is string => typeof uuid === 'string' && uuid.length > 0);
+    return extractReplacementEdges(message).map((edge) => edge.targetUuid);
   }
 
   private deleteSupersededMessageSearchRows(sessionId: string, message: SDKMessage): void {

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository-helpers.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   computeIsRenderable,
   computeIsTerminal,
   extractParentToolUseId,
+  extractReplacementEdges,
 } from '../../../../src/storage/repositories/sdk-message-repository';
 import type { SDKMessage } from '@hyperneo/shared/sdk';
 
@@ -201,6 +202,47 @@ describe('computeIsTerminal', () => {
 
   test('unknown types are not terminal', () => {
     expect(computeIsTerminal(asMsg({ type: 'partial_assistant' }))).toBe(0);
+  });
+});
+
+describe('extractReplacementEdges', () => {
+  test('records superseded edges regardless of subtype', () => {
+    expect(
+      extractReplacementEdges(
+        asMsg({ type: 'assistant', uuid: 'replacement-1', supersedes: ['old-a'] })
+      )
+    ).toEqual([{ targetUuid: 'old-a', kind: 'superseded' }]);
+  });
+
+  test('records retracted edges only on model_refusal_fallback messages', () => {
+    expect(
+      extractReplacementEdges(
+        asMsg({
+          type: 'system',
+          subtype: 'model_refusal_fallback',
+          uuid: 'fallback-notice',
+          retracted_message_uuids: ['old-b'],
+        })
+      )
+    ).toEqual([{ targetUuid: 'old-b', kind: 'retracted' }]);
+  });
+
+  test('ignores retracted_message_uuids without the fallback subtype', () => {
+    expect(
+      extractReplacementEdges(
+        asMsg({
+          type: 'assistant',
+          uuid: 'ordinary-message',
+          retracted_message_uuids: ['must-stay-visible'],
+        })
+      )
+    ).toEqual([]);
+  });
+
+  test('dedupes within a kind and drops empty and non-string values', () => {
+    expect(
+      extractReplacementEdges(asMsg({ type: 'assistant', supersedes: ['dup', 'dup', '', 42] }))
+    ).toEqual([{ targetUuid: 'dup', kind: 'superseded' }]);
   });
 });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -4471,6 +4471,27 @@ describe('SDKMessageRepository', () => {
       expect(searchAfterFlush({ query: 'refused searchable' }).results).toEqual([]);
     });
 
+    it('removes search rows for retraction arrays outside model refusal fallback messages', () => {
+      createSearchIndex();
+      repository.saveSDKMessage(
+        'session-1',
+        createUserMessage('orphan retraction marker', 'orphan-uuid')
+      );
+
+      expect(searchAfterFlush({ query: 'orphan retraction' }).results).toHaveLength(1);
+      repository.saveSDKMessage('session-1', {
+        type: 'assistant',
+        uuid: 'non-fallback-carrier',
+        retracted_message_uuids: ['orphan-uuid'],
+        message: { role: 'assistant', content: [{ type: 'text', text: 'carrier text' }] },
+      } as unknown as SDKMessage);
+
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM sdk_message_replacements`).get()).toEqual({
+        count: 0,
+      });
+      expect(searchAfterFlush({ query: 'orphan retraction' }).results).toEqual([]);
+    });
+
     it('keeps fallback-retracted messages out during search index rebuild', () => {
       createSearchIndex();
       repository.saveSDKMessage(

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -4471,7 +4471,7 @@ describe('SDKMessageRepository', () => {
       expect(searchAfterFlush({ query: 'refused searchable' }).results).toEqual([]);
     });
 
-    it('removes search rows for retraction arrays outside model refusal fallback messages', () => {
+    it('keeps search rows for retraction arrays outside model refusal fallback messages', () => {
       createSearchIndex();
       repository.saveSDKMessage(
         'session-1',
@@ -4489,7 +4489,7 @@ describe('SDKMessageRepository', () => {
       expect(db.prepare(`SELECT COUNT(*) AS count FROM sdk_message_replacements`).get()).toEqual({
         count: 0,
       });
-      expect(searchAfterFlush({ query: 'orphan retraction' }).results).toEqual([]);
+      expect(searchAfterFlush({ query: 'orphan retraction' }).results).toHaveLength(1);
     });
 
     it('keeps fallback-retracted messages out during search index rebuild', () => {


### PR DESCRIPTION
`extractReplacementEdges` records `retracted` edges only for `model_refusal_fallback` messages, but `getSupersededMessageUuids` merged `supersedes` + `retracted_message_uuids` unguarded — so FTS supersession deletes and the replacement-edge table could diverge for non-refusal carriers of `retracted_message_uuids`. This centralizes the uuid list on `extractReplacementEdges`, pins the gate with pure unit tests, and flips a pinned integration test to assert non-fallback carriers no longer delete search rows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->