### PR TITLE
refactor(daemon): extract parse/inflate layer as pure projections (chain A PR 2/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-projections.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-projections.ts
@@ -1,0 +1,97 @@
+import { sendStatusToDeliveryStatus } from '@hyperneo/shared';
+import type { ChatMessage, MessageOrigin } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+
+export type MalformedSdkRowPolicy = 'synthesize' | 'skip' | 'throw' | 'null';
+
+export function parseSdkMessageRow(raw: string, policy: 'throw' | 'synthesize'): SDKMessage;
+export function parseSdkMessageRow(raw: string, policy: 'skip' | 'null'): SDKMessage | null;
+export function parseSdkMessageRow(raw: string, policy: MalformedSdkRowPolicy): SDKMessage | null;
+export function parseSdkMessageRow(raw: string, policy: MalformedSdkRowPolicy): SDKMessage | null {
+  if (policy === 'throw') return JSON.parse(raw) as SDKMessage;
+  try {
+    return JSON.parse(raw) as SDKMessage;
+  } catch {
+    if (policy === 'synthesize') {
+      return { type: 'unknown', rawContent: raw } as unknown as SDKMessage;
+    }
+    return null;
+  }
+}
+
+export interface PaginationMessageRow {
+  id: string;
+  sdk_message: string;
+  timestamp: string;
+  rowid: unknown;
+  origin: unknown;
+  send_status: unknown;
+}
+
+export function projectTopLevelMessageRow(
+  row: PaginationMessageRow
+): SDKMessage & { timestamp: number } {
+  const sdkMessage = parseSdkMessageRow(row.sdk_message, 'synthesize');
+  const timestamp = new Date(row.timestamp).getTime();
+  const extra: Record<string, unknown> = {
+    id: row.id,
+    timestamp,
+    rowid: typeof row.rowid === 'number' ? row.rowid : Number(row.rowid ?? 0),
+    origin: row.origin != null ? (row.origin as MessageOrigin) : undefined,
+  };
+  if (sdkMessage.type === 'user') {
+    const deliveryStatus = sendStatusToDeliveryStatus(row.send_status as string | null | undefined);
+    if (deliveryStatus) extra.deliveryStatus = deliveryStatus;
+  }
+  return { ...sdkMessage, ...extra } as SDKMessage & { timestamp: number };
+}
+
+export interface SubagentMessageRow {
+  id: string;
+  sdk_message: string;
+  timestamp: string;
+}
+
+export function projectSubagentMessageRow(
+  row: SubagentMessageRow
+): SDKMessage & { timestamp: number } {
+  const sdkMessage = parseSdkMessageRow(row.sdk_message, 'synthesize');
+  return {
+    ...sdkMessage,
+    id: row.id,
+    timestamp: new Date(row.timestamp).getTime(),
+    origin: undefined,
+  } as unknown as SDKMessage & { timestamp: number };
+}
+
+export interface BackgroundTaskMessageRow {
+  id: string;
+  sdk_message: string;
+  timestamp: string;
+  origin: MessageOrigin | null;
+}
+
+export function projectBackgroundTaskMessageRow(
+  row: BackgroundTaskMessageRow
+): ChatMessage & { timestamp: number } {
+  const sdkMessage = parseSdkMessageRow(row.sdk_message, 'synthesize');
+  return {
+    ...sdkMessage,
+    id: row.id,
+    timestamp: new Date(row.timestamp).getTime(),
+    origin: row.origin ?? undefined,
+  } as unknown as ChatMessage & { timestamp: number };
+}
+
+export function inflatePersistedMessage(row: {
+  id: string;
+  sdk_message: string;
+  timestamp: string;
+}): SDKMessage & { dbId: string; timestamp: number } {
+  const message = parseSdkMessageRow(row.sdk_message, 'synthesize');
+  return {
+    ...message,
+    dbId: row.id,
+    timestamp: new Date(row.timestamp).getTime(),
+  } as SDKMessage & { dbId: string; timestamp: number };
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -1,5 +1,5 @@
 import type { Database as BunDatabase } from '../sqlite-compat';
-import { generateUUID, sendStatusToDeliveryStatus } from '@hyperneo/shared';
+import { generateUUID } from '@hyperneo/shared';
 import type {
   MessageContent,
   MessageDeliveryStatus,
@@ -11,6 +11,15 @@ import type { SDKMessage, SDKUserMessage } from '@hyperneo/shared/sdk';
 import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
 import type { ReactiveDatabase } from '../reactive-database';
 import { Logger } from '../../lib/logger';
+import {
+  inflatePersistedMessage,
+  projectBackgroundTaskMessageRow,
+  projectSubagentMessageRow,
+  projectTopLevelMessageRow,
+  type BackgroundTaskMessageRow,
+  type PaginationMessageRow,
+  type SubagentMessageRow,
+} from './sdk-message-projections';
 import {
   buildFtsQuery,
   extractVisibleSearchText,
@@ -764,30 +773,11 @@ export class SDKMessageRepository {
     params.push(limit);
 
     const stmt = this.db.prepare(query);
-    const rows = stmt.all(...params) as Record<string, unknown>[];
+    const rows = stmt.all(...params) as Array<PaginationMessageRow>;
 
     const messages: Array<SDKMessage & { timestamp: number }> = [];
     for (const r of rows) {
-      let sdkMessage: SDKMessage;
-      try {
-        sdkMessage = JSON.parse(r.sdk_message as string) as SDKMessage;
-      } catch {
-        sdkMessage = { type: 'unknown', rawContent: r.sdk_message } as unknown as SDKMessage;
-      }
-      const timestamp = new Date(r.timestamp as string).getTime();
-      const extra: Record<string, unknown> = {
-        id: r.id,
-        timestamp,
-        rowid: typeof r.rowid === 'number' ? r.rowid : Number(r.rowid ?? 0),
-        origin: r.origin != null ? (r.origin as MessageOrigin) : undefined,
-      };
-      if (sdkMessage.type === 'user') {
-        const deliveryStatus = sendStatusToDeliveryStatus(
-          r.send_status as string | null | undefined
-        );
-        if (deliveryStatus) extra.deliveryStatus = deliveryStatus;
-      }
-      messages.push({ ...sdkMessage, ...extra } as SDKMessage & { timestamp: number });
+      messages.push(projectTopLevelMessageRow(r));
       if (messages.length >= limit) break;
     }
 
@@ -821,27 +811,9 @@ export class SDKMessageRepository {
       const subagentParams: SQLiteValue[] = [sessionId, ...Array.from(toolUseIds)];
 
       const subagentStmt = this.db.prepare(subagentQuery);
-      const subagentRows = subagentStmt.all(...subagentParams) as Record<string, unknown>[];
+      const subagentRows = subagentStmt.all(...subagentParams) as Array<SubagentMessageRow>;
 
-      subagentMessages = subagentRows.flatMap((r) => {
-        let sdkMessage: SDKMessage;
-        try {
-          sdkMessage = JSON.parse(r.sdk_message as string) as SDKMessage;
-        } catch {
-          sdkMessage = { type: 'unknown', rawContent: r.sdk_message } as unknown as SDKMessage;
-        }
-        const timestamp = new Date(r.timestamp as string).getTime();
-        return [
-          {
-            ...sdkMessage,
-            id: r.id,
-            timestamp,
-            origin: undefined,
-          } as unknown as SDKMessage & {
-            timestamp: number;
-          },
-        ];
-      });
+      subagentMessages = subagentRows.map((r) => projectSubagentMessageRow(r));
     }
 
     return {
@@ -950,29 +922,14 @@ export class SDKMessageRepository {
          )
          ORDER BY timestamp DESC, rowid DESC`
       )
-      .all(sessionId, BACKGROUND_TASK_METADATA_BATCH_SIZE, sessionId, sessionId) as Array<{
-      id: string;
-      sdk_message: string;
-      timestamp: string;
-      origin: MessageOrigin | null;
-    }>;
+      .all(
+        sessionId,
+        BACKGROUND_TASK_METADATA_BATCH_SIZE,
+        sessionId,
+        sessionId
+      ) as Array<BackgroundTaskMessageRow>;
 
-    return rows
-      .map((row) => {
-        let sdkMessage: SDKMessage;
-        try {
-          sdkMessage = JSON.parse(row.sdk_message) as SDKMessage;
-        } catch {
-          sdkMessage = { type: 'unknown', rawContent: row.sdk_message } as unknown as SDKMessage;
-        }
-        return {
-          ...sdkMessage,
-          id: row.id,
-          timestamp: new Date(row.timestamp).getTime(),
-          origin: row.origin ?? undefined,
-        } as unknown as ChatMessage & { timestamp: number };
-      })
-      .reverse();
+    return rows.map((row) => projectBackgroundTaskMessageRow(row)).reverse();
   }
 
   getSDKMessagesByType(
@@ -1013,7 +970,7 @@ export class SDKMessageRepository {
       sdk_message: string;
       timestamp: string;
     } | null;
-    return row ? this.inflatePersistedMessage(row) : null;
+    return row ? inflatePersistedMessage(row) : null;
   }
 
   getSDKMessageCount(sessionId: string): number {
@@ -1193,7 +1150,7 @@ export class SDKMessageRepository {
       for (const row of rows) {
         messagesByRowId.set(
           row.row_id,
-          this.inflatePersistedMessage(row) as SDKUserMessage & {
+          inflatePersistedMessage(row) as SDKUserMessage & {
             dbId: string;
             timestamp: number;
           }
@@ -1226,7 +1183,7 @@ export class SDKMessageRepository {
       sdk_message: string;
       timestamp: string;
     } | null;
-    return row ? this.inflatePersistedMessage(row) : null;
+    return row ? inflatePersistedMessage(row) : null;
   }
 
   getMessageByStatusAndDbId(
@@ -1245,7 +1202,7 @@ export class SDKMessageRepository {
       sdk_message: string;
       timestamp: string;
     } | null;
-    return row ? this.inflatePersistedMessage(row) : null;
+    return row ? inflatePersistedMessage(row) : null;
   }
 
   getUserMessageIdsByStatus(
@@ -1268,24 +1225,6 @@ export class SDKMessageRepository {
       uuid: row.sdk_uuid ?? undefined,
       timestamp: new Date(row.timestamp).getTime(),
     }));
-  }
-
-  private inflatePersistedMessage(row: {
-    id: string;
-    sdk_message: string;
-    timestamp: string;
-  }): SDKMessage & { dbId: string; timestamp: number } {
-    let message: SDKMessage;
-    try {
-      message = JSON.parse(row.sdk_message) as SDKMessage;
-    } catch {
-      message = { type: 'unknown', rawContent: row.sdk_message } as unknown as SDKMessage;
-    }
-    return {
-      ...message,
-      dbId: row.id,
-      timestamp: new Date(row.timestamp).getTime(),
-    } as SDKMessage & { dbId: string; timestamp: number };
   }
 
   updateMessageStatus(

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
@@ -43,8 +43,8 @@ describe('parseSdkMessageRow — malformed policy table', () => {
 });
 
 describe('projectTopLevelMessageRow', () => {
-  function projectRow(overrides: Partial<Parameters<typeof projectTopLevelMessageRow>[0]>) {
-    return projectTopLevelMessageRow({
+  function topRow(overrides: Partial<Parameters<typeof projectTopLevelMessageRow>[0]> = {}) {
+    return {
       id: 'row-1',
       sdk_message: rawAssistant,
       timestamp: TIMESTAMP,
@@ -52,11 +52,11 @@ describe('projectTopLevelMessageRow', () => {
       origin: 'system',
       send_status: null,
       ...overrides,
-    });
+    };
   }
 
   test('attaches row metadata around the parsed message', () => {
-    const projected = projectRow({});
+    const projected = projectTopLevelMessageRow(topRow());
     expect(projected.type).toBe('assistant');
     expect((projected as { id?: string }).id).toBe('row-1');
     expect(projected.timestamp).toBe(TIMESTAMP_MS);
@@ -65,25 +65,31 @@ describe('projectTopLevelMessageRow', () => {
   });
 
   test('normalizes null origin to an explicit undefined key', () => {
-    const projected = projectRow({ origin: null });
+    const projected = projectTopLevelMessageRow(topRow({ origin: null }));
     expect('origin' in projected).toBe(true);
     expect((projected as { origin?: string }).origin).toBeUndefined();
   });
 
   test('coerces non-number rowid values', () => {
-    expect((projectRow({ rowid: '42' }) as { rowid?: number }).rowid).toBe(42);
-    expect((projectRow({ rowid: null }) as { rowid?: number }).rowid).toBe(0);
+    expect((projectTopLevelMessageRow(topRow({ rowid: '42' })) as { rowid?: number }).rowid).toBe(
+      42
+    );
+    expect((projectTopLevelMessageRow(topRow({ rowid: null })) as { rowid?: number }).rowid).toBe(
+      0
+    );
   });
 
   test('row metadata overrides same-named payload fields', () => {
-    const projected = projectRow({
-      sdk_message: JSON.stringify({
-        type: 'assistant',
-        id: 'payload-id',
-        timestamp: 1,
-        rowid: 99,
-      }),
-    });
+    const projected = projectTopLevelMessageRow(
+      topRow({
+        sdk_message: JSON.stringify({
+          type: 'assistant',
+          id: 'payload-id',
+          timestamp: 1,
+          rowid: 99,
+        }),
+      })
+    );
     expect((projected as { id?: string }).id).toBe('row-1');
     expect(projected.timestamp).toBe(TIMESTAMP_MS);
     expect((projected as { rowid?: number }).rowid).toBe(7);
@@ -91,21 +97,26 @@ describe('projectTopLevelMessageRow', () => {
 
   test('maps send_status to deliveryStatus on user rows only', () => {
     const rawUser = JSON.stringify({ type: 'user', message: { content: 'hi' } });
-    const projectUser = (send_status: unknown) => projectRow({ sdk_message: rawUser, send_status });
+    const projectUser = (send_status: unknown) =>
+      projectTopLevelMessageRow(topRow({ sdk_message: rawUser, send_status }));
 
     expect((projectUser('enqueued') as { deliveryStatus?: string }).deliveryStatus).toBe('queued');
     expect((projectUser('failed') as { deliveryStatus?: string }).deliveryStatus).toBe('failed');
     expect((projectUser(null) as { deliveryStatus?: string }).deliveryStatus).toBe('delivered');
     expect('deliveryStatus' in projectUser('not-a-status')).toBe(false);
-    expect('deliveryStatus' in projectRow({ send_status: 'enqueued' })).toBe(false);
+    expect('deliveryStatus' in projectTopLevelMessageRow(topRow({ send_status: 'enqueued' }))).toBe(
+      false
+    );
   });
 
   test('synthesizes type=unknown for malformed rows while keeping metadata', () => {
-    const projected = projectRow({
-      id: 'bad',
-      sdk_message: RAW_MALFORMED,
-      send_status: 'enqueued',
-    });
+    const projected = projectTopLevelMessageRow(
+      topRow({
+        id: 'bad',
+        sdk_message: RAW_MALFORMED,
+        send_status: 'enqueued',
+      })
+    );
     expect(projected.type).toBe('unknown');
     expect((projected as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
     expect((projected as { id?: string }).id).toBe('bad');

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-projections.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'bun:test';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+import {
+  inflatePersistedMessage,
+  parseSdkMessageRow,
+  projectBackgroundTaskMessageRow,
+  projectSubagentMessageRow,
+  projectTopLevelMessageRow,
+} from '../../../../src/storage/repositories/sdk-message-projections';
+
+const RAW_MALFORMED = '{not-json';
+const TIMESTAMP = '2026-08-11T12:00:00.000Z';
+const TIMESTAMP_MS = new Date(TIMESTAMP).getTime();
+
+const rawAssistant = JSON.stringify({
+  type: 'assistant',
+  message: { content: [{ type: 'text', text: 'hello' }] },
+});
+
+describe('parseSdkMessageRow — malformed policy table', () => {
+  test('parses valid JSON identically under every policy', () => {
+    const expected = JSON.parse(rawAssistant) as SDKMessage;
+    for (const policy of ['synthesize', 'skip', 'throw', 'null'] as const) {
+      expect(parseSdkMessageRow(rawAssistant, policy)).toEqual(expected);
+    }
+  });
+
+  test("policy 'synthesize' keeps the row as type=unknown carrying the raw payload", () => {
+    expect(parseSdkMessageRow(RAW_MALFORMED, 'synthesize')).toEqual({
+      type: 'unknown',
+      rawContent: RAW_MALFORMED,
+    });
+  });
+
+  test("policies 'skip' and 'null' yield null for malformed rows", () => {
+    expect(parseSdkMessageRow(RAW_MALFORMED, 'skip')).toBeNull();
+    expect(parseSdkMessageRow(RAW_MALFORMED, 'null')).toBeNull();
+  });
+
+  test("policy 'throw' propagates the parse failure", () => {
+    expect(() => parseSdkMessageRow(RAW_MALFORMED, 'throw')).toThrow();
+  });
+});
+
+describe('projectTopLevelMessageRow', () => {
+  function projectRow(overrides: Partial<Parameters<typeof projectTopLevelMessageRow>[0]>) {
+    return projectTopLevelMessageRow({
+      id: 'row-1',
+      sdk_message: rawAssistant,
+      timestamp: TIMESTAMP,
+      rowid: 7,
+      origin: 'system',
+      send_status: null,
+      ...overrides,
+    });
+  }
+
+  test('attaches row metadata around the parsed message', () => {
+    const projected = projectRow({});
+    expect(projected.type).toBe('assistant');
+    expect((projected as { id?: string }).id).toBe('row-1');
+    expect(projected.timestamp).toBe(TIMESTAMP_MS);
+    expect((projected as { rowid?: number }).rowid).toBe(7);
+    expect((projected as { origin?: string }).origin).toBe('system');
+  });
+
+  test('normalizes null origin to an explicit undefined key', () => {
+    const projected = projectRow({ origin: null });
+    expect('origin' in projected).toBe(true);
+    expect((projected as { origin?: string }).origin).toBeUndefined();
+  });
+
+  test('coerces non-number rowid values', () => {
+    expect((projectRow({ rowid: '42' }) as { rowid?: number }).rowid).toBe(42);
+    expect((projectRow({ rowid: null }) as { rowid?: number }).rowid).toBe(0);
+  });
+
+  test('row metadata overrides same-named payload fields', () => {
+    const projected = projectRow({
+      sdk_message: JSON.stringify({
+        type: 'assistant',
+        id: 'payload-id',
+        timestamp: 1,
+        rowid: 99,
+      }),
+    });
+    expect((projected as { id?: string }).id).toBe('row-1');
+    expect(projected.timestamp).toBe(TIMESTAMP_MS);
+    expect((projected as { rowid?: number }).rowid).toBe(7);
+  });
+
+  test('maps send_status to deliveryStatus on user rows only', () => {
+    const rawUser = JSON.stringify({ type: 'user', message: { content: 'hi' } });
+    const projectUser = (send_status: unknown) => projectRow({ sdk_message: rawUser, send_status });
+
+    expect((projectUser('enqueued') as { deliveryStatus?: string }).deliveryStatus).toBe('queued');
+    expect((projectUser('failed') as { deliveryStatus?: string }).deliveryStatus).toBe('failed');
+    expect((projectUser(null) as { deliveryStatus?: string }).deliveryStatus).toBe('delivered');
+    expect('deliveryStatus' in projectUser('not-a-status')).toBe(false);
+    expect('deliveryStatus' in projectRow({ send_status: 'enqueued' })).toBe(false);
+  });
+
+  test('synthesizes type=unknown for malformed rows while keeping metadata', () => {
+    const projected = projectRow({
+      id: 'bad',
+      sdk_message: RAW_MALFORMED,
+      send_status: 'enqueued',
+    });
+    expect(projected.type).toBe('unknown');
+    expect((projected as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
+    expect((projected as { id?: string }).id).toBe('bad');
+    expect((projected as { rowid?: number }).rowid).toBe(7);
+    expect('deliveryStatus' in projected).toBe(false);
+  });
+});
+
+describe('projectSubagentMessageRow', () => {
+  test('attaches id, timestamp, and an explicit undefined origin', () => {
+    const projected = projectSubagentMessageRow({
+      id: 'sub-1',
+      sdk_message: rawAssistant,
+      timestamp: TIMESTAMP,
+    });
+    expect(projected.type).toBe('assistant');
+    expect((projected as { id?: string }).id).toBe('sub-1');
+    expect(projected.timestamp).toBe(TIMESTAMP_MS);
+    expect('origin' in projected).toBe(true);
+    expect((projected as { origin?: string }).origin).toBeUndefined();
+    expect('rowid' in projected).toBe(false);
+  });
+
+  test('synthesizes type=unknown for malformed rows', () => {
+    const projected = projectSubagentMessageRow({
+      id: 'sub-bad',
+      sdk_message: RAW_MALFORMED,
+      timestamp: TIMESTAMP,
+    });
+    expect(projected.type).toBe('unknown');
+    expect((projected as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
+  });
+});
+
+describe('projectBackgroundTaskMessageRow', () => {
+  test('attaches id, timestamp, and null-normalized origin', () => {
+    const projected = projectBackgroundTaskMessageRow({
+      id: 'bg-1',
+      sdk_message: JSON.stringify({ type: 'system', subtype: 'task_started' }),
+      timestamp: TIMESTAMP,
+      origin: null,
+    });
+    expect(projected.type).toBe('system');
+    expect((projected as { id?: string }).id).toBe('bg-1');
+    expect(projected.timestamp).toBe(TIMESTAMP_MS);
+    expect((projected as { origin?: string }).origin).toBeUndefined();
+  });
+
+  test('synthesizes type=unknown for malformed rows', () => {
+    const projected = projectBackgroundTaskMessageRow({
+      id: 'bg-bad',
+      sdk_message: RAW_MALFORMED,
+      timestamp: TIMESTAMP,
+      origin: 'system',
+    });
+    expect(projected.type).toBe('unknown');
+    expect((projected as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
+    expect((projected as { origin?: string }).origin).toBe('system');
+  });
+});
+
+describe('inflatePersistedMessage', () => {
+  test('attaches dbId and timestamp', () => {
+    const inflated = inflatePersistedMessage({
+      id: 'db-1',
+      sdk_message: rawAssistant,
+      timestamp: TIMESTAMP,
+    });
+    expect(inflated.type).toBe('assistant');
+    expect(inflated.dbId).toBe('db-1');
+    expect(inflated.timestamp).toBe(TIMESTAMP_MS);
+    expect((inflated as { id?: string }).id).toBeUndefined();
+  });
+
+  test('synthesizes type=unknown for malformed rows while keeping dbId', () => {
+    const inflated = inflatePersistedMessage({
+      id: 'db-bad',
+      sdk_message: RAW_MALFORMED,
+      timestamp: TIMESTAMP,
+    });
+    expect(inflated.type).toBe('unknown');
+    expect((inflated as { rawContent?: string }).rawContent).toBe(RAW_MALFORMED);
+    expect(inflated.dbId).toBe('db-bad');
+  });
+});


### PR DESCRIPTION
Extracts the sdk_messages parse/inflate layer from SDKMessageRepository into a new pure sdk-message-projections.ts module: parseSdkMessageRow with the per-reader malformed policy as a parameter (synthesize/skip/throw/null preserved, not normalized — per the A1 policy table), plus the top-level row-metadata attach, subagent mapping, background-task mapping, and inflatePersistedMessage. SQL stays in the repository; the facade and reactive-proxy surface are untouched, and parity is covered by the pre-existing suites, the A1 pins, and new unit tests for the projections module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->