### PR TITLE
refactor(daemon): extract decideMessageAdmission core (chain B PR 2/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/sdk-message-admission.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-admission.ts
@@ -1,0 +1,169 @@
+import type { HyperNeoActionMessage, MessageOrigin } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+import { isHyperNeoActionMessage } from '@hyperneo/shared/sdk';
+import { HIDDEN_SYSTEM_SUBTYPES } from '@hyperneo/shared/sdk/type-guards';
+
+export type SendStatus = 'deferred' | 'enqueued' | 'submitted' | 'consumed' | 'failed';
+
+export type MessageAdmissionVariant = 'sdk' | 'user' | 'hyperneo_action';
+
+export interface MessageAdmissionOptions {
+  variant: MessageAdmissionVariant;
+  sendStatus: SendStatus | null;
+  origin?: MessageOrigin;
+}
+
+export interface NormalizedMessageAdmissionInput {
+  message: SDKMessage;
+}
+
+export interface MessageAdmissionRecord {
+  isRenderable: 0 | 1;
+  isTerminal: 0 | 1;
+  isConversationAnchor: boolean;
+  countsTowardsBadge: boolean;
+  parentToolUseId: string | null;
+  sdkUuid: string | null;
+  replacementEdges: SDKMessageReplacementEdge[];
+}
+
+const BADGE_HIDDEN_SUBTYPES = new Set<string>([...HIDDEN_SYSTEM_SUBTYPES, 'thinking_tokens']);
+
+function isVisibleBadgeRow(opts: {
+  parentToolUseId: string | null;
+  messageType: string;
+  messageSubtype: string | null;
+  sendStatus: SendStatus | null;
+}): boolean {
+  if (opts.parentToolUseId !== null) return false;
+  if (BADGE_HIDDEN_SUBTYPES.has(opts.messageSubtype ?? '')) return false;
+  if (opts.messageType === 'user') {
+    const status = opts.sendStatus ?? 'consumed';
+    return status === 'consumed' || status === 'failed';
+  }
+  return true;
+}
+
+export function computeIsRenderable(message: SDKMessage): 0 | 1 {
+  const messageType = message.type;
+  const content = (message as { message?: { content?: unknown } }).message?.content;
+  if (!Array.isArray(content)) {
+    return 1;
+  }
+
+  if (messageType === 'user') {
+    const hasToolResult = content.some(
+      (block) =>
+        typeof block === 'object' &&
+        block !== null &&
+        (block as { type?: unknown }).type === 'tool_result'
+    );
+    return hasToolResult ? 0 : 1;
+  }
+
+  if (messageType === 'assistant') {
+    const hasRenderable = content.some((block) => {
+      if (typeof block !== 'object' || block === null) return false;
+      const blockObj = block as { type?: unknown; text?: unknown; thinking?: unknown };
+      if (blockObj.type === 'tool_use') return true;
+      if (blockObj.type === 'text') {
+        const text = typeof blockObj.text === 'string' ? blockObj.text : '';
+        return text.trim().length > 0;
+      }
+      if (blockObj.type === 'thinking') {
+        const thinking = typeof blockObj.thinking === 'string' ? blockObj.thinking : '';
+        return thinking.trim().length > 0;
+      }
+      return false;
+    });
+    return hasRenderable ? 1 : 0;
+  }
+
+  return 1;
+}
+
+export function computeIsTerminal(message: SDKMessage): 0 | 1 {
+  return message.type === 'result' ? 1 : 0;
+}
+
+export function extractParentToolUseId(message: SDKMessage): string | null {
+  const candidate = (message as { parent_tool_use_id?: unknown }).parent_tool_use_id;
+  return typeof candidate === 'string' ? candidate : null;
+}
+
+export function extractSdkUuid(message: SDKMessage): string | null {
+  const candidate = (message as { uuid?: unknown }).uuid;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
+
+export interface SDKMessageReplacementEdge {
+  targetUuid: string;
+  kind: 'superseded' | 'retracted';
+}
+
+export function extractReplacementEdges(message: SDKMessage): SDKMessageReplacementEdge[] {
+  const replacementMessage = message as SDKMessage & {
+    supersedes?: unknown;
+    retracted_message_uuids?: unknown;
+  };
+  const edges: SDKMessageReplacementEdge[] = [];
+  const seen = new Set<string>();
+  const append = (values: unknown, kind: SDKMessageReplacementEdge['kind']) => {
+    if (!Array.isArray(values)) return;
+    for (const value of values) {
+      if (typeof value !== 'string' || value.length === 0) continue;
+      const key = `${kind}\0${value}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      edges.push({ targetUuid: value, kind });
+    }
+  };
+  append(replacementMessage.supersedes, 'superseded');
+  if ('subtype' in replacementMessage && replacementMessage.subtype === 'model_refusal_fallback') {
+    append(replacementMessage.retracted_message_uuids, 'retracted');
+  }
+  return edges;
+}
+
+export function normalizeMessageAdmissionInput(
+  message: SDKMessage | HyperNeoActionMessage
+): NormalizedMessageAdmissionInput {
+  if (isHyperNeoActionMessage(message)) {
+    return {
+      message: {
+        type: 'hyperneo_action',
+        subtype: message.action,
+        uuid: message.uuid,
+      } as unknown as SDKMessage,
+    };
+  }
+  return { message };
+}
+
+export function decideMessageAdmission(
+  input: NormalizedMessageAdmissionInput,
+  options: MessageAdmissionOptions
+): MessageAdmissionRecord {
+  const { message } = input;
+  const { variant, sendStatus } = options;
+  const messageType = message.type;
+  const messageSubtype = 'subtype' in message ? (message.subtype as string) : null;
+  const isRenderable = computeIsRenderable(message);
+  const anchorStatusAllowed =
+    variant !== 'user' || sendStatus === 'consumed' || sendStatus === 'failed';
+  const parentToolUseId = extractParentToolUseId(message);
+  return {
+    isRenderable,
+    isTerminal: computeIsTerminal(message),
+    isConversationAnchor: isRenderable === 1 && messageType === 'user' && anchorStatusAllowed,
+    countsTowardsBadge: isVisibleBadgeRow({
+      parentToolUseId,
+      messageType,
+      messageSubtype,
+      sendStatus,
+    }),
+    parentToolUseId,
+    sdkUuid: extractSdkUuid(message),
+    replacementEdges: extractReplacementEdges(message),
+  };
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -20,8 +20,21 @@ import {
   type MessageSearchResult,
 } from '../message-search';
 import type { SQLiteValue } from '../types';
+import {
+  decideMessageAdmission,
+  normalizeMessageAdmissionInput,
+  type SDKMessageReplacementEdge,
+  type SendStatus,
+} from './sdk-message-admission';
 
-export type SendStatus = 'deferred' | 'enqueued' | 'submitted' | 'consumed' | 'failed';
+export {
+  computeIsRenderable,
+  computeIsTerminal,
+  extractParentToolUseId,
+  extractSdkUuid,
+  extractReplacementEdges,
+} from './sdk-message-admission';
+export type { SDKMessageReplacementEdge, SendStatus } from './sdk-message-admission';
 
 const MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const ROOM_SESSION_PREFIXES = ['room:chat:', 'planner:', 'coder:', 'leader:', 'general:'];
@@ -60,109 +73,11 @@ const EXCLUDED_FROM_LAST_MESSAGE_SQL_LIST = toSqlStringList([
   'model_refusal_fallback',
 ]);
 
-const BADGE_HIDDEN_SUBTYPES = new Set<string>([...HIDDEN_SYSTEM_SUBTYPES, 'thinking_tokens']);
-
-function isVisibleBadgeRow(opts: {
-  parentToolUseId: string | null;
-  messageType: string;
-  messageSubtype: string | null;
-  sendStatus: SendStatus | null;
-}): boolean {
-  if (opts.parentToolUseId !== null) return false;
-  if (BADGE_HIDDEN_SUBTYPES.has(opts.messageSubtype ?? '')) return false;
-  if (opts.messageType === 'user') {
-    const status = opts.sendStatus ?? 'consumed';
-    return status === 'consumed' || status === 'failed';
-  }
-  return true;
-}
-
 function isOlderThanMessageSearchTtl(value: string | number | null | undefined): boolean {
   if (value === null || value === undefined) return false;
   const timestamp = typeof value === 'number' ? value : Date.parse(value);
   if (!Number.isFinite(timestamp)) return false;
   return timestamp < Date.now() - MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS;
-}
-
-export function computeIsRenderable(message: SDKMessage): 0 | 1 {
-  const messageType = message.type;
-  const content = (message as { message?: { content?: unknown } }).message?.content;
-  if (!Array.isArray(content)) {
-    return 1;
-  }
-
-  if (messageType === 'user') {
-    const hasToolResult = content.some(
-      (block) =>
-        typeof block === 'object' &&
-        block !== null &&
-        (block as { type?: unknown }).type === 'tool_result'
-    );
-    return hasToolResult ? 0 : 1;
-  }
-
-  if (messageType === 'assistant') {
-    const hasRenderable = content.some((block) => {
-      if (typeof block !== 'object' || block === null) return false;
-      const blockObj = block as { type?: unknown; text?: unknown; thinking?: unknown };
-      if (blockObj.type === 'tool_use') return true;
-      if (blockObj.type === 'text') {
-        const text = typeof blockObj.text === 'string' ? blockObj.text : '';
-        return text.trim().length > 0;
-      }
-      if (blockObj.type === 'thinking') {
-        const thinking = typeof blockObj.thinking === 'string' ? blockObj.thinking : '';
-        return thinking.trim().length > 0;
-      }
-      return false;
-    });
-    return hasRenderable ? 1 : 0;
-  }
-
-  return 1;
-}
-
-export function computeIsTerminal(message: SDKMessage): 0 | 1 {
-  return message.type === 'result' ? 1 : 0;
-}
-
-export function extractParentToolUseId(message: SDKMessage): string | null {
-  const candidate = (message as { parent_tool_use_id?: unknown }).parent_tool_use_id;
-  return typeof candidate === 'string' ? candidate : null;
-}
-
-export function extractSdkUuid(message: SDKMessage): string | null {
-  const candidate = (message as { uuid?: unknown }).uuid;
-  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
-}
-
-export interface SDKMessageReplacementEdge {
-  targetUuid: string;
-  kind: 'superseded' | 'retracted';
-}
-
-export function extractReplacementEdges(message: SDKMessage): SDKMessageReplacementEdge[] {
-  const replacementMessage = message as SDKMessage & {
-    supersedes?: unknown;
-    retracted_message_uuids?: unknown;
-  };
-  const edges: SDKMessageReplacementEdge[] = [];
-  const seen = new Set<string>();
-  const append = (values: unknown, kind: SDKMessageReplacementEdge['kind']) => {
-    if (!Array.isArray(values)) return;
-    for (const value of values) {
-      if (typeof value !== 'string' || value.length === 0) continue;
-      const key = `${kind}\0${value}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      edges.push({ targetUuid: value, kind });
-    }
-  };
-  append(replacementMessage.supersedes, 'superseded');
-  if ('subtype' in replacementMessage && replacementMessage.subtype === 'model_refusal_fallback') {
-    append(replacementMessage.retracted_message_uuids, 'retracted');
-  }
-  return edges;
 }
 
 export class SDKMessageRepository {
@@ -219,9 +134,8 @@ export class SDKMessageRepository {
     sourceMessageId: string,
     sessionId: string,
     taskId: string | null,
-    message: SDKMessage
+    edges: SDKMessageReplacementEdge[]
   ): void {
-    const edges = extractReplacementEdges(message);
     if (edges.length === 0) return;
     const insert = this.db.prepare(
       `INSERT OR IGNORE INTO sdk_message_replacements (
@@ -533,20 +447,15 @@ export class SDKMessageRepository {
   saveSDKMessage(sessionId: string, message: SDKMessage, origin?: MessageOrigin): boolean {
     try {
       const id = generateUUID();
+      const admission = decideMessageAdmission(normalizeMessageAdmissionInput(message), {
+        variant: 'sdk',
+        sendStatus: null,
+        origin,
+      });
       const messageType = message.type;
       const messageSubtype = 'subtype' in message ? (message.subtype as string) : null;
       const timestamp = new Date().toISOString();
       const taskId = this.resolveTaskIdForSession(sessionId);
-      const isRenderable = computeIsRenderable(message);
-      const isTerminal = computeIsTerminal(message);
-      const isConversationAnchor = isRenderable === 1 && messageType === 'user';
-      const parentToolUseId = extractParentToolUseId(message);
-      const countsTowardsBadge = isVisibleBadgeRow({
-        parentToolUseId,
-        messageType,
-        messageSubtype,
-        sendStatus: null,
-      });
 
       const stmt = this.db.prepare(
         `INSERT INTO sdk_messages (
@@ -560,7 +469,7 @@ export class SDKMessageRepository {
         const conversationTurnIndex = this.resolveConversationTurnIndex(
           taskId,
           sessionId,
-          isConversationAnchor
+          admission.isConversationAnchor
         );
         const values = [
           id,
@@ -570,13 +479,13 @@ export class SDKMessageRepository {
           JSON.stringify(message),
           timestamp,
           origin ?? null,
-          isRenderable,
-          isTerminal,
-          parentToolUseId,
+          admission.isRenderable,
+          admission.isTerminal,
+          admission.parentToolUseId,
           taskId,
         ];
-        stmt.run(...values, conversationTurnIndex, extractSdkUuid(message));
-        if (isTerminal && this.tableHasColumn('sdk_messages', 'consumed_seq')) {
+        stmt.run(...values, conversationTurnIndex, admission.sdkUuid);
+        if (admission.isTerminal && this.tableHasColumn('sdk_messages', 'consumed_seq')) {
           const resultSeq = this.nextConsumedSeq();
           if (resultSeq !== null) {
             this.db
@@ -584,12 +493,12 @@ export class SDKMessageRepository {
               .run(resultSeq, id);
           }
         }
-        this.saveReplacementEdges(id, sessionId, taskId, message);
+        this.saveReplacementEdges(id, sessionId, taskId, admission.replacementEdges);
         this.scheduleMessageSearchIndex(id);
-        if (countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+        if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
       })();
       try {
-        if (countsTowardsBadge) this.notifySessionsChanged(sessionId);
+        if (admission.countsTowardsBadge) this.notifySessionsChanged(sessionId);
         this.deleteSupersededMessageSearchRows(sessionId, message);
       } catch (error) {
         this.logger.error('[Database] Post-commit side effects failed for SDK message:', error);
@@ -1090,23 +999,15 @@ export class SDKMessageRepository {
     origin?: MessageOrigin
   ): { id: string; countsTowardsBadge: boolean } {
     const id = generateUUID();
+    const admission = decideMessageAdmission(normalizeMessageAdmissionInput(message), {
+      variant: 'user',
+      sendStatus,
+      origin,
+    });
     const messageType = message.type;
     const messageSubtype = 'subtype' in message ? (message.subtype as string) : null;
     const timestamp = new Date().toISOString();
     const taskId = this.resolveTaskIdForSession(sessionId);
-    const isRenderable = computeIsRenderable(message);
-    const isTerminal = computeIsTerminal(message);
-    const isConversationAnchor =
-      isRenderable === 1 &&
-      messageType === 'user' &&
-      (sendStatus === 'consumed' || sendStatus === 'failed');
-    const parentToolUseId = extractParentToolUseId(message);
-    const countsTowardsBadge = isVisibleBadgeRow({
-      parentToolUseId,
-      messageType,
-      messageSubtype,
-      sendStatus,
-    });
 
     const stmt = this.db.prepare(
       `INSERT INTO sdk_messages (
@@ -1119,7 +1020,7 @@ export class SDKMessageRepository {
     const conversationTurnIndex = this.resolveConversationTurnIndex(
       taskId,
       sessionId,
-      isConversationAnchor
+      admission.isConversationAnchor
     );
     const values = [
       id,
@@ -1130,16 +1031,16 @@ export class SDKMessageRepository {
       timestamp,
       sendStatus,
       origin ?? null,
-      isRenderable,
-      isTerminal,
-      parentToolUseId,
+      admission.isRenderable,
+      admission.isTerminal,
+      admission.parentToolUseId,
       taskId,
     ];
-    stmt.run(...values, conversationTurnIndex, extractSdkUuid(message));
-    this.saveReplacementEdges(id, sessionId, taskId, message);
+    stmt.run(...values, conversationTurnIndex, admission.sdkUuid);
+    this.saveReplacementEdges(id, sessionId, taskId, admission.replacementEdges);
     this.scheduleMessageSearchIndex(id);
-    if (countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
-    return { id, countsTowardsBadge };
+    if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+    return { id, countsTowardsBadge: admission.countsTowardsBadge };
   }
 
   runPostSaveSideEffects(sessionId: string, id: string, countsTowardsBadge: boolean): void {
@@ -2014,14 +1915,16 @@ export class SDKMessageRepository {
   saveHyperNeoActionMessage(sessionId: string, message: HyperNeoActionMessage): string {
     const id = generateUUID();
     const timestamp = new Date(message.timestamp).toISOString();
-    const taskId = this.resolveTaskIdForSession(sessionId);
-    const conversationTurnIndex = this.resolveConversationTurnIndex(taskId, sessionId, false);
-    const countsTowardsBadge = isVisibleBadgeRow({
-      parentToolUseId: null,
-      messageType: 'hyperneo_action',
-      messageSubtype: message.action,
+    const admission = decideMessageAdmission(normalizeMessageAdmissionInput(message), {
+      variant: 'hyperneo_action',
       sendStatus: null,
     });
+    const taskId = this.resolveTaskIdForSession(sessionId);
+    const conversationTurnIndex = this.resolveConversationTurnIndex(
+      taskId,
+      sessionId,
+      admission.isConversationAnchor
+    );
 
     const values = [
       id,
@@ -2041,10 +1944,10 @@ export class SDKMessageRepository {
     );
 
     this.db.transaction(() => {
-      insertStmt.run(...values, conversationTurnIndex, message.uuid);
-      if (countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
+      insertStmt.run(...values, conversationTurnIndex, admission.sdkUuid);
+      if (admission.countsTowardsBadge) this.bumpVisibleMessageCount(sessionId, 1);
     })();
-    if (countsTowardsBadge) this.notifySessionsChanged(sessionId);
+    if (admission.countsTowardsBadge) this.notifySessionsChanged(sessionId);
     this.scheduleMessageSearchIndex(id);
     return id;
   }

--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-admission.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-admission.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'bun:test';
+import type { HyperNeoActionMessage } from '@hyperneo/shared';
+import type { SDKMessage } from '@hyperneo/shared/sdk';
+import {
+  decideMessageAdmission,
+  normalizeMessageAdmissionInput,
+  type SendStatus,
+} from '../../../../src/storage/repositories/sdk-message-admission';
+
+const asMsg = (payload: Record<string, unknown>): SDKMessage => payload as unknown as SDKMessage;
+
+function userMessage(uuid: string, extra: Record<string, unknown> = {}): SDKMessage {
+  return asMsg({
+    type: 'user',
+    uuid,
+    message: { role: 'user', content: [{ type: 'text', text: `text-${uuid}` }] },
+    ...extra,
+  });
+}
+
+function toolResultUserMessage(uuid: string): SDKMessage {
+  return asMsg({
+    type: 'user',
+    uuid,
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'toolu-1', content: 'result' }],
+    },
+  });
+}
+
+function assistantMessage(uuid: string, extra: Record<string, unknown> = {}): SDKMessage {
+  return asMsg({
+    type: 'assistant',
+    uuid,
+    message: { role: 'assistant', content: [{ type: 'text', text: `text-${uuid}` }] },
+    ...extra,
+  });
+}
+
+function resultMessage(uuid: string): SDKMessage {
+  return asMsg({ type: 'result', subtype: 'success', uuid, is_error: false, result: 'done' });
+}
+
+function actionMessage(uuid: string): HyperNeoActionMessage {
+  return {
+    type: 'hyperneo_action',
+    uuid,
+    session_id: 'sess-action',
+    action: 'sdk_resume_choice',
+    resolved: false,
+    timestamp: Date.parse('2026-02-03T04:05:06.000Z'),
+  };
+}
+
+describe('decideMessageAdmission (chain B2)', () => {
+  describe('sdk variant: anchor is not send-status gated', () => {
+    test('renderable user message admits as anchor with badge, uuid, and replacement edges', () => {
+      const record = decideMessageAdmission(
+        normalizeMessageAdmissionInput(userMessage('u-1', { supersedes: ['edge-a'] })),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(record).toEqual({
+        isRenderable: 1,
+        isTerminal: 0,
+        isConversationAnchor: true,
+        countsTowardsBadge: true,
+        parentToolUseId: null,
+        sdkUuid: 'u-1',
+        replacementEdges: [{ targetUuid: 'edge-a', kind: 'superseded' }],
+      });
+    });
+
+    test('a non-renderable user tool-result message does not anchor but still counts toward the badge', () => {
+      const record = decideMessageAdmission(
+        normalizeMessageAdmissionInput(toolResultUserMessage('u-tool')),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(record.isRenderable).toBe(0);
+      expect(record.isConversationAnchor).toBe(false);
+      expect(record.countsTowardsBadge).toBe(true);
+    });
+
+    test('a terminal result message is admitted as terminal without anchoring', () => {
+      const record = decideMessageAdmission(normalizeMessageAdmissionInput(resultMessage('r-1')), {
+        variant: 'sdk',
+        sendStatus: null,
+      });
+      expect(record.isTerminal).toBe(1);
+      expect(record.isConversationAnchor).toBe(false);
+      expect(record.countsTowardsBadge).toBe(true);
+    });
+
+    test('a subagent row carries its parent tool use id and never counts toward the badge', () => {
+      const record = decideMessageAdmission(
+        normalizeMessageAdmissionInput(assistantMessage('a-sub', { parent_tool_use_id: 'tu_1' })),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(record.parentToolUseId).toBe('tu_1');
+      expect(record.countsTowardsBadge).toBe(false);
+    });
+
+    test('a badge-hidden subtype never counts toward the badge', () => {
+      const record = decideMessageAdmission(
+        normalizeMessageAdmissionInput(asMsg({ type: 'system', subtype: 'task_started' })),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(record.countsTowardsBadge).toBe(false);
+      expect(record.isConversationAnchor).toBe(false);
+    });
+
+    test('retracted edges are admitted only under the model_refusal_fallback subtype', () => {
+      const refusal = decideMessageAdmission(
+        normalizeMessageAdmissionInput(
+          userMessage('u-refusal', {
+            subtype: 'model_refusal_fallback',
+            supersedes: ['sup-1'],
+            retracted_message_uuids: ['ret-1'],
+          })
+        ),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(refusal.replacementEdges).toEqual([
+        { targetUuid: 'sup-1', kind: 'superseded' },
+        { targetUuid: 'ret-1', kind: 'retracted' },
+      ]);
+
+      const plain = decideMessageAdmission(
+        normalizeMessageAdmissionInput(
+          userMessage('u-plain', { retracted_message_uuids: ['ret-2'] })
+        ),
+        { variant: 'sdk', sendStatus: null }
+      );
+      expect(plain.replacementEdges).toEqual([]);
+    });
+  });
+
+  describe('user variant: anchor is gated on consumed or failed send status', () => {
+    const STATUSES: SendStatus[] = ['deferred', 'enqueued', 'submitted', 'consumed', 'failed'];
+
+    test.each(STATUSES)('sendStatus %s', (sendStatus) => {
+      const record = decideMessageAdmission(normalizeMessageAdmissionInput(userMessage('u-2')), {
+        variant: 'user',
+        sendStatus,
+      });
+      const settled = sendStatus === 'consumed' || sendStatus === 'failed';
+      expect(record.isConversationAnchor).toBe(settled);
+      expect(record.countsTowardsBadge).toBe(settled);
+      expect(record.isRenderable).toBe(1);
+      expect(record.sdkUuid).toBe('u-2');
+    });
+
+    test('the same message anchors on the sdk variant while deferred does not anchor on the user variant', () => {
+      const input = normalizeMessageAdmissionInput(userMessage('u-contrast'));
+      const sdkRecord = decideMessageAdmission(input, { variant: 'sdk', sendStatus: null });
+      const deferredRecord = decideMessageAdmission(input, {
+        variant: 'user',
+        sendStatus: 'deferred',
+      });
+      expect(sdkRecord.isConversationAnchor).toBe(true);
+      expect(deferredRecord.isConversationAnchor).toBe(false);
+    });
+  });
+
+  describe('hyperneo_action variant: fixed-shape admission via the normalizer', () => {
+    test('never anchors, counts toward the badge, and carries no edges', () => {
+      const record = decideMessageAdmission(
+        normalizeMessageAdmissionInput(actionMessage('act-1')),
+        {
+          variant: 'hyperneo_action',
+          sendStatus: null,
+        }
+      );
+      expect(record).toEqual({
+        isRenderable: 1,
+        isTerminal: 0,
+        isConversationAnchor: false,
+        countsTowardsBadge: true,
+        parentToolUseId: null,
+        sdkUuid: 'act-1',
+        replacementEdges: [],
+      });
+    });
+  });
+
+  describe('normalizeMessageAdmissionInput', () => {
+    test('passes an SDKMessage through unchanged', () => {
+      const message = userMessage('u-pass');
+      expect(normalizeMessageAdmissionInput(message)).toEqual({ message });
+    });
+
+    test('maps the disjoint HyperNeoActionMessage onto the shared carrier', () => {
+      expect(normalizeMessageAdmissionInput(actionMessage('act-2'))).toEqual({
+        message: {
+          type: 'hyperneo_action',
+          subtype: 'sdk_resume_choice',
+          uuid: 'act-2',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Extracts the save-path admission decision into a pure `decideMessageAdmission(normalizedInput, {variant, sendStatus, origin})` core in `sdk-message-admission.ts` beside the repository, returning one admission record (isRenderable, isTerminal, isConversationAnchor, countsTowardsBadge, parentToolUseId, sdkUuid, replacementEdges). The module also introduces the shared normalized input: `normalizeMessageAdmissionInput` passes SDK messages through and maps the disjoint `HyperNeoActionMessage` onto the same carrier, so all three save sites consume one core.

The two pinned divergences stay encoded as variant parameters: only the `user` variant applies the anchor send-status gate, and `consumed_seq` allocation at insert remains terminal-only on the SDK path. Placement is unchanged — the SDK variant computes the record before its transaction, the user variant inside the composed transaction, and the repository's public helper surface is preserved via re-exports. Focused unit tests cover the three variants and the normalizer; B1 drift pins guard parity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->