### PR TITLE
test(daemon): count PRAGMA table_xinfo in schema-introspection guard

### DIFF
--- a/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/sdk-message-repository.test.ts
@@ -5303,7 +5303,12 @@ describe('SDKMessageRepository', () => {
           prepare: (sql: string, ...args: unknown[]) => unknown;
         }
       ).prepare = (sql: string, ...args: unknown[]) => {
-        if (sql.includes('sqlite_master') || sql.includes('PRAGMA table_info')) count++;
+        if (
+          sql.includes('sqlite_master') ||
+          sql.includes('PRAGMA table_info') ||
+          sql.includes('PRAGMA table_xinfo')
+        )
+          count++;
         return originalPrepare(sql, ...args);
       };
       return {


### PR DESCRIPTION
The schema-introspection counter in the sdk-message-repository test matched `sqlite_master`/`PRAGMA table_info`, but `tableColumns()` issues `PRAGMA table_xinfo` — so only tableExistsCache was pinned and a regression to per-save column introspection would have stayed green. The counter now also matches `table_xinfo`, so the zero-introspection assertion on steady-state saves covers both caches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->