### PR TITLE
refactor(space): interpret spawn seam through casExecutionStatus + reserveSpawnForTick (superpipe P5 PR 5/6)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -244,9 +244,10 @@ export class PostApprovalRouter {
       }));
     } catch (err) {
       if (isSpawnSupersededError(err)) {
-        const reason = `post-approval spawn for task ${task.id} superseded at ${err.stage ?? 'unknown'} — a concurrent writer moved the guarded row; retrying on a later tick`;
+        const reason = `post-approval spawn for task ${task.id} superseded at ${err.stage ?? 'unknown'} — a concurrent writer moved the guarded row; the dispatch stays recorded as blocked for retry`;
         log.warn(`PostApprovalRouter.route: ${reason}`);
         clearPendingCompletionState(this.deps.taskRepo, task.id);
+        this.deps.taskRepo.updateTask(task.id, { postApprovalBlockedReason: reason });
         return { mode: 'skipped', reason };
       }
       throw err;

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -12,6 +12,7 @@ import {
   type PostApprovalTemplateContext,
 } from '../workflows/post-approval-template';
 import { Logger } from '../../logger';
+import { isSpawnSupersededError } from './workflow-node-execution-validation';
 import { POST_APPROVAL_TASK_AGENT_TARGET } from '../workflows/post-approval-validator';
 
 const log = new Logger('post-approval-router');
@@ -233,12 +234,24 @@ export class PostApprovalRouter {
 
     const startedAt = Date.now();
     const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
-    const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
-      task,
-      workflow,
-      targetAgent: route.targetAgent!,
-      kickoffMessage,
-    });
+    let spawnedSessionId: string;
+    try {
+      ({ sessionId: spawnedSessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
+        task,
+        workflow,
+        targetAgent: route.targetAgent!,
+        kickoffMessage,
+      }));
+    } catch (err) {
+      if (isSpawnSupersededError(err)) {
+        const reason = `post-approval spawn for task ${task.id} superseded at ${err.stage ?? 'unknown'} — a concurrent writer moved the guarded row; retrying on a later tick`;
+        log.warn(`PostApprovalRouter.route: ${reason}`);
+        clearPendingCompletionState(this.deps.taskRepo, task.id);
+        return { mode: 'skipped', reason };
+      }
+      throw err;
+    }
+    const sessionId = spawnedSessionId;
 
     this.deps.taskRepo.updateTask(task.id, {
       pendingCheckpointType: null,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6507,13 +6507,20 @@ export class SpaceRuntime {
         return;
       }
       if (canonicalTask.status === 'open') {
-        const nowTs = Date.now();
-        await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
-          status: 'in_progress',
-          startedAt: canonicalTask.startedAt ?? nowTs,
-          completedAt: null,
-          pendingCheckpointType: null,
-        });
+        const trailingTask = this.config.taskRepo.getTask(canonicalTask.id);
+        if (trailingTask?.status === 'open') {
+          const nowTs = Date.now();
+          await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
+            status: 'in_progress',
+            startedAt: canonicalTask.startedAt ?? nowTs,
+            completedAt: null,
+            pendingCheckpointType: null,
+          });
+        } else {
+          log.info(
+            `SpaceRuntime: skipping trailing open→in_progress for task ${canonicalTask.id} — status moved concurrently to ${trailingTask?.status ?? 'missing'} during the spawn pass`
+          );
+        }
       }
     }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -6507,18 +6507,17 @@ export class SpaceRuntime {
         return;
       }
       if (canonicalTask.status === 'open') {
-        const trailingTask = this.config.taskRepo.getTask(canonicalTask.id);
-        if (trailingTask?.status === 'open') {
+        const outcome = this.config.taskRepo.casStatus(canonicalTask.id, ['open'], 'in_progress');
+        if (outcome === 'won') {
           const nowTs = Date.now();
           await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
-            status: 'in_progress',
             startedAt: canonicalTask.startedAt ?? nowTs,
             completedAt: null,
             pendingCheckpointType: null,
           });
         } else {
           log.info(
-            `SpaceRuntime: skipping trailing open→in_progress for task ${canonicalTask.id} — status moved concurrently to ${trailingTask?.status ?? 'missing'} during the spawn pass`
+            `SpaceRuntime: skipping trailing open→in_progress for task ${canonicalTask.id} — status moved concurrently during the spawn pass`
           );
         }
       }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -136,6 +136,7 @@ import {
   formatMissingAgentReference,
   isMissingWorkflowAgentError,
   isPermanentSpawnError,
+  isSpawnSupersededError,
   isTransientSpawnError,
   MissingWorkflowAgentError,
 } from './workflow-node-execution-validation';
@@ -3927,6 +3928,7 @@ export class SpaceRuntime {
 
       const justRehydrated = !this.rehydrated;
       if (!this.rehydrated) {
+        this.config.taskRepo.clearAllSpawnReservations();
         await this.rehydrateExecutors();
         await this.recoverStalledRuns();
         this.rehydrated = true;
@@ -6441,6 +6443,12 @@ export class SpaceRuntime {
             });
           }
         } catch (err) {
+          if (isSpawnSupersededError(err)) {
+            log.info(
+              `SpaceRuntime: spawn for execution ${execution.id} superseded at ${err.stage ?? 'unknown'} — concurrent writer moved a guarded row; skipping for this tick`
+            );
+            continue;
+          }
           if (this.cancelExecutionForPermanentSpawnError(execution, err)) {
             permanentSpawnFailureReason = err instanceof Error ? err.message : String(err);
             continue;
@@ -6790,6 +6798,12 @@ export class SpaceRuntime {
             }
           }
         } catch (err) {
+          if (isSpawnSupersededError(err)) {
+            log.info(
+              `SpaceRuntime: queued handoff spawn for target ${targetAgentName} superseded at ${err.stage ?? 'unknown'} — concurrent writer moved a guarded row; skipping for this pass`
+            );
+            continue;
+          }
           const errMsg = err instanceof Error ? err.message : String(err);
           if (isPermanentSpawnError(err)) {
             log.warn(

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -72,6 +72,7 @@ export interface SpawnExecutionFlowDeps {
   resolveWorkspacePath(task: SpaceTask, space: Space): Promise<string>;
   createSpawnedSession(request: SpawnSessionRequest): Promise<string>;
   bindExecutionToSession(execution: NodeExecution, sessionId: string): 'won' | 'superseded';
+  flushPendingMessagesForTarget(workflowRunId: string, agentName: string, sessionId: string): void;
   attachNodeAgent(request: AttachNodeAgentRequest): Promise<void>;
   registerSpawnCompletionCallback(taskId: string, workflowNodeId: string, sessionId: string): void;
   buildKickoffMessage(request: KickoffMessageRequest): Promise<string>;
@@ -293,6 +294,19 @@ export function runSpawnExecutionFlow(
         writes: [],
         run: (view) => {
           deps.releaseTaskSpawn(view.task.id);
+        },
+      }),
+      s.effect({
+        name: 'flush-pending-messages',
+        when: 'proceedFresh',
+        reads: ['workflowRun', 'execution', 'spawnedSessionId'],
+        writes: [],
+        run: (view) => {
+          deps.flushPendingMessagesForTarget(
+            view.workflowRun.id,
+            view.execution.agentName,
+            view.spawnedSessionId
+          );
         },
       }),
       s.effect({

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -287,6 +287,15 @@ export function runSpawnExecutionFlow(
         },
       }),
       s.effect({
+        name: 'release-task-spawn',
+        when: 'proceedFresh',
+        reads: ['task'],
+        writes: [],
+        run: (view) => {
+          deps.releaseTaskSpawn(view.task.id);
+        },
+      }),
+      s.effect({
         name: 'attach-node-agent',
         when: 'proceedFresh',
         reads: ['task', 'space', 'workflowRun', 'execution', 'spawnedSessionId', 'workspacePath'],
@@ -337,15 +346,6 @@ export function runSpawnExecutionFlow(
             workspacePath: view.workspacePath,
           });
           await deps.injectKickoffMessage(view.spawnedSessionId, message);
-        },
-      }),
-      s.effect({
-        name: 'release-task-spawn',
-        when: 'proceedFresh',
-        reads: ['task'],
-        writes: [],
-        run: (view) => {
-          deps.releaseTaskSpawn(view.task.id);
         },
       }),
       s.halt({

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -297,19 +297,6 @@ export function runSpawnExecutionFlow(
         },
       }),
       s.effect({
-        name: 'flush-pending-messages',
-        when: 'proceedFresh',
-        reads: ['workflowRun', 'execution', 'spawnedSessionId'],
-        writes: [],
-        run: (view) => {
-          deps.flushPendingMessagesForTarget(
-            view.workflowRun.id,
-            view.execution.agentName,
-            view.spawnedSessionId
-          );
-        },
-      }),
-      s.effect({
         name: 'attach-node-agent',
         when: 'proceedFresh',
         reads: ['task', 'space', 'workflowRun', 'execution', 'spawnedSessionId', 'workspacePath'],
@@ -360,6 +347,19 @@ export function runSpawnExecutionFlow(
             workspacePath: view.workspacePath,
           });
           await deps.injectKickoffMessage(view.spawnedSessionId, message);
+        },
+      }),
+      s.effect({
+        name: 'flush-pending-messages',
+        when: 'proceedFresh',
+        reads: ['workflowRun', 'execution', 'spawnedSessionId'],
+        writes: [],
+        run: (view) => {
+          deps.flushPendingMessagesForTarget(
+            view.workflowRun.id,
+            view.execution.agentName,
+            view.spawnedSessionId
+          );
         },
       }),
       s.halt({

--- a/packages/daemon/src/lib/space/runtime/spawn-flow.ts
+++ b/packages/daemon/src/lib/space/runtime/spawn-flow.ts
@@ -59,8 +59,10 @@ export interface SpawnExecutionFlowDeps {
   inspectIndexedSession(agentSessionId: string | null): IndexedSessionInspection;
   reserveExecution(executionId: string): void;
   releaseExecution(executionId: string): void;
+  reserveTaskSpawn(taskId: string): 'won' | 'superseded';
+  releaseTaskSpawn(taskId: string): void;
   cancelSpawnedSession(sessionId: string): void;
-  rebindLiveExecution(execution: NodeExecution, sessionId: string): void;
+  rebindLiveExecution(execution: NodeExecution, sessionId: string): 'won' | 'superseded';
   raiseSpawnRejection(
     freshTask: SpaceTask,
     execution: NodeExecution,
@@ -69,7 +71,7 @@ export interface SpawnExecutionFlowDeps {
   resolveSpawnSessionId(space: Space, task: SpaceTask, execution: NodeExecution): string;
   resolveWorkspacePath(task: SpaceTask, space: Space): Promise<string>;
   createSpawnedSession(request: SpawnSessionRequest): Promise<string>;
-  bindExecutionToSession(execution: NodeExecution, sessionId: string): void;
+  bindExecutionToSession(execution: NodeExecution, sessionId: string): 'won' | 'superseded';
   attachNodeAgent(request: AttachNodeAgentRequest): Promise<void>;
   registerSpawnCompletionCallback(taskId: string, workflowNodeId: string, sessionId: string): void;
   buildKickoffMessage(request: KickoffMessageRequest): Promise<string>;
@@ -177,12 +179,11 @@ export function runSpawnExecutionFlow(
         when: 'reuseLive',
         reads: ['execution'],
         writes: [],
-        run: (view) => {
+        run: (view) =>
           deps.rebindLiveExecution(
             view.execution,
             (view.reuseLive as { sessionId: string }).sessionId
-          );
-        },
+          ),
       }),
       s.halt({
         name: 'return-live-session',
@@ -203,6 +204,17 @@ export function runSpawnExecutionFlow(
         reads: ['freshTask', 'execution', 'workflow'],
         run: (view) => {
           deps.raiseSpawnRejection(view.freshTask, view.execution, view.workflow);
+        },
+      }),
+      s.effect({
+        name: 'reserve-task-spawn',
+        when: 'proceedFresh',
+        reads: ['task'],
+        writes: [],
+        run: (view) => deps.reserveTaskSpawn(view.task.id),
+        compensate: (view, result) => {
+          if (result === 'superseded') return;
+          deps.releaseTaskSpawn(view.task.id);
         },
       }),
       s.effect({
@@ -260,9 +272,7 @@ export function runSpawnExecutionFlow(
         when: 'proceedFresh',
         reads: ['execution', 'spawnedSessionId'],
         writes: ['execution'],
-        run: (view) => {
-          deps.bindExecutionToSession(view.execution, view.spawnedSessionId);
-        },
+        run: (view) => deps.bindExecutionToSession(view.execution, view.spawnedSessionId),
       }),
       s.resnapshot({
         name: 'read-bound-execution',
@@ -327,6 +337,15 @@ export function runSpawnExecutionFlow(
             workspacePath: view.workspacePath,
           });
           await deps.injectKickoffMessage(view.spawnedSessionId, message);
+        },
+      }),
+      s.effect({
+        name: 'release-task-spawn',
+        when: 'proceedFresh',
+        reads: ['task'],
+        writes: [],
+        run: (view) => {
+          deps.releaseTaskSpawn(view.task.id);
         },
       }),
       s.halt({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -682,11 +682,26 @@ export class TaskAgentManager {
     }
     return new Promise<string>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
+      let settled = false;
+      let waiter:
+        | ((outcome: { status: 'resolved'; sessionId: string } | { status: 'failed' }) => void)
+        | undefined;
       const settle = (finish: () => void) => {
+        if (settled) return;
+        settled = true;
         if (timer !== undefined) clearTimeout(timer);
         finish();
       };
+      const removeWaiter = () => {
+        if (!waiter) return;
+        const current = this.concurrentSpawnWaiters.get(execution.id);
+        if (!current) return;
+        const index = current.indexOf(waiter);
+        if (index >= 0) current.splice(index, 1);
+        if (current.length === 0) this.concurrentSpawnWaiters.delete(execution.id);
+      };
       timer = setTimeout(() => {
+        removeWaiter();
         settle(() => {
           reject(
             new Error(
@@ -695,20 +710,26 @@ export class TaskAgentManager {
           );
         });
       }, CONCURRENT_SPAWN_TIMEOUT_MS);
-      const waiters = this.concurrentSpawnWaiters.get(execution.id) ?? [];
-      waiters.push((outcome) => {
+      waiter = (outcome) => {
         settle(() => {
           if (outcome.status === 'resolved') {
             resolve(outcome.sessionId);
-          } else {
-            reject(
-              new Error(
-                `Concurrent spawn for execution ${execution.id} failed before session was created`
-              )
-            );
+            return;
           }
+          const bound = this.config.nodeExecutionRepo.getById(execution.id)?.agentSessionId;
+          if (bound) {
+            resolve(bound);
+            return;
+          }
+          reject(
+            new Error(
+              `Concurrent spawn for execution ${execution.id} failed before session was created`
+            )
+          );
         });
-      });
+      };
+      const waiters = this.concurrentSpawnWaiters.get(execution.id) ?? [];
+      waiters.push(waiter);
       this.concurrentSpawnWaiters.set(execution.id, waiters);
     });
   }
@@ -724,6 +745,7 @@ export class TaskAgentManager {
   }
 
   private buildSpawnExecutionFlowDeps(): SpawnExecutionFlowDeps {
+    const spawnState = { reservationHeld: false };
     return {
       getFreshTask: (taskId) => this.config.taskRepo.getTask(taskId),
       getNodeExecution: (executionId) => this.config.nodeExecutionRepo.getById(executionId),
@@ -743,9 +765,17 @@ export class TaskAgentManager {
       releaseExecution: (executionId) => {
         this.spawningExecutionIds.delete(executionId);
       },
-      reserveTaskSpawn: (taskId) =>
-        this.config.taskRepo.reserveSpawnForTick(taskId, SPAWN_RESERVABLE_TASK_STATUSES),
+      reserveTaskSpawn: (taskId) => {
+        const outcome = this.config.taskRepo.reserveSpawnForTick(
+          taskId,
+          SPAWN_RESERVABLE_TASK_STATUSES
+        );
+        if (outcome === 'won') spawnState.reservationHeld = true;
+        return outcome;
+      },
       releaseTaskSpawn: (taskId) => {
+        if (!spawnState.reservationHeld) return;
+        spawnState.reservationHeld = false;
         this.config.taskRepo.releaseSpawnReservation(taskId);
       },
       cancelSpawnedSession: (sessionId) => {
@@ -863,9 +893,14 @@ export class TaskAgentManager {
         return actualSessionId;
       },
       bindExecutionToSession: (execution, sessionId) => {
-        return this.config.nodeExecutionRepo.casExecutionStatus(
+        const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(execution.status)
+          ? execution.status === 'in_progress'
+            ? (['in_progress'] as const)
+            : ([execution.status, 'in_progress'] as const)
+          : ([] as const);
+        const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
           execution.id,
-          SPAWN_BINDABLE_EXECUTION_STATUSES,
+          expected,
           'in_progress',
           {
             agentSessionId: sessionId,
@@ -873,6 +908,13 @@ export class TaskAgentManager {
             completedAt: null,
           }
         );
+        if (outcome === 'won') {
+          this.settleConcurrentSpawnWaiters(execution.id, {
+            status: 'resolved',
+            sessionId,
+          });
+        }
+        return outcome;
       },
       attachNodeAgent: async (request) => {
         const spawned = this.getSubSession(request.sessionId);
@@ -1012,6 +1054,9 @@ export class TaskAgentManager {
                   }
                 );
                 if (outcome === 'superseded') {
+                  if (!match.agentSessionId) {
+                    throw new SpawnSupersededError(match.id, 'reuse-target-bind');
+                  }
                   log.info(
                     `TaskAgentManager: skipped rebinding execution ${match.id} to reused session ${existingSessionId} — status moved concurrently`
                   );
@@ -2552,6 +2597,9 @@ export class TaskAgentManager {
 
   async cleanupAll(): Promise<void> {
     clearAllRetryableHookActionTimers();
+    for (const executionId of [...this.concurrentSpawnWaiters.keys()]) {
+      this.settleConcurrentSpawnWaiters(executionId, { status: 'failed' });
+    }
     if (this.taskArchiveListenerUnsub) {
       this.taskArchiveListenerUnsub();
       this.taskArchiveListenerUnsub = null;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1042,6 +1042,7 @@ export class TaskAgentManager {
                       'idle',
                       {
                         agentSessionId: null,
+                        completedAt: Date.now(),
                       }
                     );
                   }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -72,11 +72,13 @@ import { jsonResult } from '../tools/tool-result';
 import {
   assertExecutionValidAgainstWorkflow,
   PermanentSpawnError,
-  validateExecutionAgainstWorkflow,
+  SPAWN_BINDABLE_EXECUTION_STATUSES,
+  SPAWN_RESERVABLE_TASK_STATUSES,
+  SpawnSupersededError,
+  isSpawnSupersededError,
   validateTaskAllowsSpawn,
 } from './workflow-node-execution-validation';
 import { decideActivationRouting, selectWorkflowNodeForAgent } from './activation-routing';
-import { decideSpawnExecutionAdmission } from './spawn-admission-gates';
 import {
   isSpawnFlowReusedSession,
   isSpawnFlowWaitConcurrent,
@@ -89,7 +91,6 @@ import {
   buildSlotOverrides,
   findAvailableSessionId,
   resolveSpawnWorkspace,
-  resolveWorkflowNodeSlot,
 } from './spawn-slot-resolution';
 import {
   assembleVerifiedStopResult,
@@ -329,6 +330,10 @@ export class TaskAgentManager {
   private readonly rehydrateInFlight = new Map<string, Promise<AgentSession | null>>();
 
   private spawningExecutionIds = new Set<string>();
+  private concurrentSpawnWaiters = new Map<
+    string,
+    Array<(outcome: { status: 'resolved'; sessionId: string } | { status: 'failed' }) => void>
+  >();
 
   private completionCallbacks: CompletionCallbackMap = new Map();
 
@@ -631,279 +636,6 @@ export class TaskAgentManager {
     execution: NodeExecution,
     options: SpawnTaskAgentOptions = {}
   ): Promise<string> {
-    const indexedSessionId = execution.agentSessionId;
-    let hasLiveIndexedSession = false;
-    if (indexedSessionId && this.agentSessionIndex.has(indexedSessionId)) {
-      if (this.isSessionAlive(indexedSessionId)) {
-        hasLiveIndexedSession = true;
-      } else {
-        this.agentSessionIndex.delete(indexedSessionId);
-      }
-    }
-
-    const freshTask = this.config.taskRepo.getTask(task.id) ?? task;
-    const slotResolution = resolveWorkflowNodeSlot(
-      workflow,
-      execution.workflowNodeId,
-      execution.agentName
-    );
-    const admission = decideSpawnExecutionAdmission({
-      hasLiveIndexedSession,
-      isSpawningExecution: this.spawningExecutionIds.has(execution.id),
-      taskStatus: freshTask.status,
-      executionWorkflowValid: validateExecutionAgainstWorkflow(execution, workflow).valid,
-      slotResolvable: slotResolution !== null,
-    });
-
-    if (admission.action === 'reuse_live') {
-      const sessionId = indexedSessionId!;
-      const startedAt = execution.startedAt ?? Date.now();
-      this.config.nodeExecutionRepo.update(execution.id, {
-        status: 'in_progress',
-        agentSessionId: sessionId,
-        startedAt,
-        completedAt: null,
-      });
-      return sessionId;
-    }
-
-    if (admission.action === 'wait_concurrent') {
-      return this.waitForConcurrentSpawnSession(execution);
-    }
-
-    if (admission.action === 'reject_permanent' || admission.action === 'reject_transient') {
-      validateTaskAllowsSpawn(freshTask);
-      assertExecutionValidAgainstWorkflow(execution, workflow);
-      throw new Error(
-        `No agent slot found for agent name "${execution.agentName}" in node "${execution.workflowNodeId}"`
-      );
-    }
-
-    const { node, slot } = slotResolution!;
-
-    this.spawningExecutionIds.add(execution.id);
-    let spawnedSessionId: string | null = null;
-
-    try {
-      const taskId = task.id;
-      const sessionId = this.resolveSessionId(
-        buildExecutionBaseSessionId(space.id, taskId, execution.id)
-      );
-
-      const workspace = resolveSpawnWorkspace({
-        cachedTaskWorktreePath: this.taskWorktreePaths.get(taskId),
-        hasWorktreeManager: Boolean(this.config.worktreeManager),
-        spaceWorkspacePath: space.workspacePath,
-      });
-      let workspacePath = workspace.workspacePath;
-      if (workspace.createWorktree && this.config.worktreeManager) {
-        try {
-          const result = await this.config.worktreeManager.createTaskWorktree(
-            space.id,
-            taskId,
-            task.title,
-            task.taskNumber
-          );
-          workspacePath = result.path;
-          this.taskWorktreePaths.set(taskId, result.path);
-        } catch (err) {
-          log.warn(
-            `TaskAgentManager: failed to create worktree for workflow task ${taskId}, falling back to space workspace: ${err instanceof Error ? err.message : String(err)}`
-          );
-        }
-      }
-
-      const slotOverrides = buildSlotOverrides(slot, {
-        task,
-        node,
-        workflow,
-        workflowRun,
-      });
-
-      let init = resolveAgentInit({
-        task,
-        space,
-        agentManager: this.config.spaceAgentManager,
-        sessionId,
-        workspacePath,
-        workflowRun,
-        workflow,
-        slotOverrides,
-        agentId: slot.agentId,
-      });
-
-      const shouldKickoff = options.kickoff ?? true;
-      const customAgent = shouldKickoff
-        ? this.config.spaceAgentManager.getById(slot.agentId)
-        : null;
-      if (shouldKickoff && !customAgent) {
-        throw new PermanentSpawnError(`Agent not found: ${slot.agentId}`);
-      }
-
-      const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
-        taskId,
-        sessionId,
-        execution.agentName,
-        space.id,
-        workflowRun.id,
-        workspacePath,
-        execution.workflowNodeId
-      );
-
-      init = assembleNodeAgentSessionInit({
-        baseInit: init,
-        title: formatWorkflowNodeSessionTitle(task, execution.agentName),
-        nodeAgentMcpServer: nodeAgentMcpServer as unknown as McpServerConfig,
-        agentMemoryMcpServers: this.buildAgentMemoryMcpServers(space.id, sessionId),
-      });
-
-      const actualSessionId = await this.createSubSession(taskId, sessionId, init, {
-        agentId: slot.agentId,
-        agentName: execution.agentName,
-        nodeId: execution.workflowNodeId,
-      });
-      spawnedSessionId = actualSessionId;
-
-      const spawned = this.getSubSession(actualSessionId);
-      if (!spawned) {
-        throw new Error(`Spawned node session ${actualSessionId} is not registered in memory`);
-      }
-
-      const startedAt = Date.now();
-      const updatedExecution = this.config.nodeExecutionRepo.update(execution.id, {
-        status: 'in_progress',
-        agentSessionId: actualSessionId,
-        startedAt,
-        completedAt: null,
-      });
-      if (
-        !updatedExecution ||
-        updatedExecution.status !== 'in_progress' ||
-        updatedExecution.agentSessionId !== actualSessionId ||
-        !updatedExecution.startedAt
-      ) {
-        log.error('[Spawn] Execution state mismatch after spawn', {
-          executionId: execution.id,
-          expectedStatus: 'in_progress',
-          actualStatus: updatedExecution?.status ?? null,
-          expectedSessionId: actualSessionId,
-          actualSessionId: updatedExecution?.agentSessionId ?? null,
-        });
-        this.config.nodeExecutionRepo.update(execution.id, {
-          status: 'blocked',
-          result: 'Execution state corruption after spawn',
-          completedAt: Date.now(),
-        });
-        throw new Error(`Execution state corruption after spawn for ${execution.id}`);
-      }
-
-      await this.ensureNodeAgentAttached(spawned, {
-        taskId,
-        subSessionId: actualSessionId,
-        agentName: execution.agentName,
-        spaceId: space.id,
-        workflowRunId: workflowRun.id,
-        workspacePath,
-        workflowNodeId: execution.workflowNodeId,
-        phase: 'spawn',
-      });
-
-      this.registerCompletionCallback(actualSessionId, async () => {
-        await this.handleSubSessionComplete(taskId, execution.workflowNodeId, actualSessionId);
-      });
-
-      if (shouldKickoff) {
-        const goal = task.goalId ? this.config.goalService?.getGoal(task.goalId) : null;
-        const linkedGoal = goal?.spaceId === task.spaceId ? goal : null;
-
-        const memoryQuery = `${task.title}\n${task.description}`;
-        const coreMemories = this.config.memoryRepo
-          ? this.config.memoryRepo.listCoreMemories(space.id, 10)
-          : [];
-        const relevantMemories = this.config.memoryRepo
-          ? await this.config.memoryRepo.search(space.id, memoryQuery, 5)
-          : [];
-        const relevantScopeLessons = this.config.evolutionScopeService
-          ? this.config.evolutionScopeService.selectActiveLessonsForTask({
-              taskId: task.id,
-              limit: 3,
-            })
-          : [];
-        const initialMessage = buildCustomAgentTaskMessage({
-          customAgent: customAgent!,
-          task,
-          workflowRun,
-          workflow,
-          space,
-          sessionId: actualSessionId,
-          workspacePath,
-          goal: linkedGoal,
-          relevantScopeLessons,
-          slotOverrides,
-          nodeId: execution.workflowNodeId,
-          agentSlotName: execution.agentName,
-          coreMemories,
-          relevantMemories,
-        });
-        const runtimeContract = this.buildNodeExecutionRuntimeContract(workflow, execution, space);
-        const kickoffMessage = runtimeContract
-          ? `${initialMessage}\n\n${runtimeContract}`
-          : initialMessage;
-        await this.withSessionInjectLock(spawned.session.id, () =>
-          this.injectMessageIntoSession(spawned, kickoffMessage)
-        );
-      }
-      return actualSessionId;
-    } catch (err) {
-      if (spawnedSessionId) {
-        this.cancelBySessionId(spawnedSessionId);
-      }
-      throw err;
-    } finally {
-      this.spawningExecutionIds.delete(execution.id);
-    }
-  }
-
-  private waitForConcurrentSpawnSession(execution: NodeExecution): Promise<string> {
-    const CONCURRENT_SPAWN_TIMEOUT_MS = 30_000;
-    const deadline = Date.now() + CONCURRENT_SPAWN_TIMEOUT_MS;
-    return new Promise((resolve, reject) => {
-      const interval = setInterval(() => {
-        const fresh = this.config.nodeExecutionRepo.getById(execution.id);
-        if (fresh?.agentSessionId) {
-          clearInterval(interval);
-          resolve(fresh.agentSessionId);
-          return;
-        }
-        if (!this.spawningExecutionIds.has(execution.id)) {
-          clearInterval(interval);
-          reject(
-            new Error(
-              `Concurrent spawn for execution ${execution.id} failed before session was created`
-            )
-          );
-          return;
-        }
-        if (Date.now() >= deadline) {
-          clearInterval(interval);
-          reject(
-            new Error(
-              `Concurrent spawn for execution ${execution.id} timed out after ${CONCURRENT_SPAWN_TIMEOUT_MS}ms`
-            )
-          );
-        }
-      }, 50);
-    });
-  }
-
-  async spawnWorkflowNodeAgentForExecutionViaFlow(
-    task: SpaceTask,
-    space: Space,
-    workflow: SpaceWorkflow,
-    workflowRun: SpaceWorkflowRun,
-    execution: NodeExecution,
-    options: SpawnTaskAgentOptions = {}
-  ): Promise<string> {
     const outcome = await runSpawnExecutionFlow(this.buildSpawnExecutionFlowDeps(), {
       task,
       space,
@@ -913,12 +645,12 @@ export class TaskAgentManager {
       kickoff: options.kickoff ?? true,
     });
     if (outcome.status === 'error') {
+      this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
       throw outcome.error;
     }
     if (outcome.status === 'superseded') {
-      throw new Error(
-        `Spawn for execution ${execution.id} superseded at stage ${outcome.stage ?? 'unknown'}`
-      );
+      this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
+      throw new SpawnSupersededError(execution.id, outcome.stage ?? null);
     }
     const result = outcome.result;
     if (isSpawnFlowWaitConcurrent(result)) {
@@ -928,7 +660,67 @@ export class TaskAgentManager {
       return result.sessionId;
     }
     this.spawningExecutionIds.delete(execution.id);
+    this.settleConcurrentSpawnWaiters(execution.id, {
+      status: 'resolved',
+      sessionId: result as string,
+    });
     return result as string;
+  }
+
+  private waitForConcurrentSpawnSession(execution: NodeExecution): Promise<string> {
+    const CONCURRENT_SPAWN_TIMEOUT_MS = 30_000;
+    const fresh = this.config.nodeExecutionRepo.getById(execution.id);
+    if (fresh?.agentSessionId) {
+      return Promise.resolve(fresh.agentSessionId);
+    }
+    if (!this.spawningExecutionIds.has(execution.id)) {
+      return Promise.reject(
+        new Error(
+          `Concurrent spawn for execution ${execution.id} failed before session was created`
+        )
+      );
+    }
+    return new Promise<string>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (finish: () => void) => {
+        if (timer !== undefined) clearTimeout(timer);
+        finish();
+      };
+      timer = setTimeout(() => {
+        settle(() => {
+          reject(
+            new Error(
+              `Concurrent spawn for execution ${execution.id} timed out after ${CONCURRENT_SPAWN_TIMEOUT_MS}ms`
+            )
+          );
+        });
+      }, CONCURRENT_SPAWN_TIMEOUT_MS);
+      const waiters = this.concurrentSpawnWaiters.get(execution.id) ?? [];
+      waiters.push((outcome) => {
+        settle(() => {
+          if (outcome.status === 'resolved') {
+            resolve(outcome.sessionId);
+          } else {
+            reject(
+              new Error(
+                `Concurrent spawn for execution ${execution.id} failed before session was created`
+              )
+            );
+          }
+        });
+      });
+      this.concurrentSpawnWaiters.set(execution.id, waiters);
+    });
+  }
+
+  private settleConcurrentSpawnWaiters(
+    executionId: string,
+    outcome: { status: 'resolved'; sessionId: string } | { status: 'failed' }
+  ): void {
+    const waiters = this.concurrentSpawnWaiters.get(executionId);
+    if (!waiters) return;
+    this.concurrentSpawnWaiters.delete(executionId);
+    for (const waiter of waiters) waiter(outcome);
   }
 
   private buildSpawnExecutionFlowDeps(): SpawnExecutionFlowDeps {
@@ -951,17 +743,26 @@ export class TaskAgentManager {
       releaseExecution: (executionId) => {
         this.spawningExecutionIds.delete(executionId);
       },
+      reserveTaskSpawn: (taskId) =>
+        this.config.taskRepo.reserveSpawnForTick(taskId, SPAWN_RESERVABLE_TASK_STATUSES),
+      releaseTaskSpawn: (taskId) => {
+        this.config.taskRepo.releaseSpawnReservation(taskId);
+      },
       cancelSpawnedSession: (sessionId) => {
         this.cancelBySessionId(sessionId);
       },
       rebindLiveExecution: (execution, sessionId) => {
         const startedAt = execution.startedAt ?? Date.now();
-        this.config.nodeExecutionRepo.update(execution.id, {
-          status: 'in_progress',
-          agentSessionId: sessionId,
-          startedAt,
-          completedAt: null,
-        });
+        return this.config.nodeExecutionRepo.casExecutionStatus(
+          execution.id,
+          SPAWN_BINDABLE_EXECUTION_STATUSES,
+          'in_progress',
+          {
+            agentSessionId: sessionId,
+            startedAt,
+            completedAt: null,
+          }
+        );
       },
       raiseSpawnRejection: (freshTask, rejectedExecution, rejectedWorkflow) => {
         validateTaskAllowsSpawn(freshTask);
@@ -1062,33 +863,16 @@ export class TaskAgentManager {
         return actualSessionId;
       },
       bindExecutionToSession: (execution, sessionId) => {
-        const startedAt = Date.now();
-        const updatedExecution = this.config.nodeExecutionRepo.update(execution.id, {
-          status: 'in_progress',
-          agentSessionId: sessionId,
-          startedAt,
-          completedAt: null,
-        });
-        if (
-          !updatedExecution ||
-          updatedExecution.status !== 'in_progress' ||
-          updatedExecution.agentSessionId !== sessionId ||
-          !updatedExecution.startedAt
-        ) {
-          log.error('[Spawn] Execution state mismatch after spawn', {
-            executionId: execution.id,
-            expectedStatus: 'in_progress',
-            actualStatus: updatedExecution?.status ?? null,
-            expectedSessionId: sessionId,
-            actualSessionId: updatedExecution?.agentSessionId ?? null,
-          });
-          this.config.nodeExecutionRepo.update(execution.id, {
-            status: 'blocked',
-            result: 'Execution state corruption after spawn',
-            completedAt: Date.now(),
-          });
-          throw new Error(`Execution state corruption after spawn for ${execution.id}`);
-        }
+        return this.config.nodeExecutionRepo.casExecutionStatus(
+          execution.id,
+          SPAWN_BINDABLE_EXECUTION_STATUSES,
+          'in_progress',
+          {
+            agentSessionId: sessionId,
+            startedAt: Date.now(),
+            completedAt: null,
+          }
+        );
       },
       attachNodeAgent: async (request) => {
         const spawned = this.getSubSession(request.sessionId);
@@ -1217,12 +1001,21 @@ export class TaskAgentManager {
                     e.agentName === memberInfo.agentName && e.agentSessionId === existingSessionId
                 );
               if (match) {
-                this.config.nodeExecutionRepo.update(match.id, {
-                  status: 'in_progress',
-                  agentSessionId: existingSessionId,
-                  startedAt: match.startedAt ?? Date.now(),
-                  completedAt: null,
-                });
+                const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
+                  match.id,
+                  SPAWN_BINDABLE_EXECUTION_STATUSES,
+                  'in_progress',
+                  {
+                    agentSessionId: existingSessionId,
+                    startedAt: match.startedAt ?? Date.now(),
+                    completedAt: null,
+                  }
+                );
+                if (outcome === 'superseded') {
+                  log.info(
+                    `TaskAgentManager: skipped rebinding execution ${match.id} to reused session ${existingSessionId} — status moved concurrently`
+                  );
+                }
               }
               if (memberInfo.nodeId) {
                 const staleCoOwners = this.config.nodeExecutionRepo
@@ -1238,10 +1031,20 @@ export class TaskAgentManager {
                     stale.status === 'cancelled' ||
                     stale.status === 'waiting_rebind' ||
                     stale.status === 'pending';
-                  this.config.nodeExecutionRepo.update(stale.id, {
-                    agentSessionId: null,
-                    ...(!mustPreserve ? { status: 'idle' as const } : {}),
-                  });
+                  if (mustPreserve) {
+                    this.config.nodeExecutionRepo.update(stale.id, {
+                      agentSessionId: null,
+                    });
+                  } else {
+                    this.config.nodeExecutionRepo.casExecutionStatus(
+                      stale.id,
+                      [stale.status],
+                      'idle',
+                      {
+                        agentSessionId: null,
+                      }
+                    );
+                  }
                 }
               }
             }
@@ -1349,12 +1152,21 @@ export class TaskAgentManager {
         );
         const match = nodeExecs.find((e) => e.agentName === memberInfo.agentName);
         if (match && !match.agentSessionId) {
-          this.config.nodeExecutionRepo.update(match.id, {
-            status: 'in_progress',
-            agentSessionId: sessionId,
-            startedAt: match.startedAt ?? Date.now(),
-            completedAt: null,
-          });
+          const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
+            match.id,
+            SPAWN_BINDABLE_EXECUTION_STATUSES,
+            'in_progress',
+            {
+              agentSessionId: sessionId,
+              startedAt: match.startedAt ?? Date.now(),
+              completedAt: null,
+            }
+          );
+          if (outcome === 'superseded') {
+            log.info(
+              `TaskAgentManager: skipped binding new session ${sessionId} to execution ${match.id} — status moved concurrently`
+            );
+          }
         } else if (match && match.agentSessionId) {
           log.warn(
             `TaskAgentManager: NodeExecution ${match.id} already has agentSessionId ${match.agentSessionId}; skipping update for new session ${sessionId}`
@@ -2193,9 +2005,17 @@ export class TaskAgentManager {
       if (existing.agentSessionId) {
         this.agentSessionIndex.delete(existing.agentSessionId);
       }
-      this.config.nodeExecutionRepo.update(existing.id, {
-        status: 'pending',
-      });
+      const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
+        existing.id,
+        [existing.status],
+        'pending'
+      );
+      if (outcome === 'superseded') {
+        log.info(
+          `TaskAgentManager.activateTargetSessionsForMessage: execution ${existing.id} moved concurrently (${existing.status} no longer current); skipping activation for this call`
+        );
+        return [];
+      }
     }
 
     const gateRoute = decideActivationRouting({
@@ -2257,6 +2077,14 @@ export class TaskAgentManager {
     let sessionId: string | null;
     try {
       sessionId = await Promise.race([spawnPromise, timeoutPromise]);
+    } catch (err) {
+      if (isSpawnSupersededError(err)) {
+        log.info(
+          `TaskAgentManager.activateTargetSessionsForMessage: spawn of agent "${agentName}" for run ${workflowRunId} superseded; skipping activation for this call`
+        );
+        return [];
+      }
+      throw err;
     } finally {
       clearTimeout(timeoutTimer);
     }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2597,7 +2597,7 @@ export class TaskAgentManager {
 
   async cleanupAll(): Promise<void> {
     clearAllRetryableHookActionTimers();
-    for (const executionId of [...this.concurrentSpawnWaiters.keys()]) {
+    for (const executionId of this.concurrentSpawnWaiters.keys()) {
       this.settleConcurrentSpawnWaiters(executionId, { status: 'failed' });
     }
     if (this.taskArchiveListenerUnsub) {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -5,7 +5,6 @@ import type {
   SpaceWorkflow,
   SpaceWorkflowRun,
   NodeExecution,
-  NodeExecutionStatus,
   MessageHub,
   McpServerConfig,
   MessageContent,
@@ -55,8 +54,7 @@ export interface SubSessionMemberInfo {
   agentName?: string;
   nodeId?: string;
   deferFreshExecutionBind?: boolean;
-  executionBindObservedStatus?: NodeExecutionStatus;
-  onSessionReused?: (sessionId: string) => void;
+  freshSessionOnly?: boolean;
 }
 
 export interface VerifiedSessionStop {
@@ -640,7 +638,8 @@ export class TaskAgentManager {
     execution: NodeExecution,
     options: SpawnTaskAgentOptions = {}
   ): Promise<string> {
-    const outcome = await runSpawnExecutionFlow(this.buildSpawnExecutionFlowDeps(), {
+    const spawnState = { reservationHeld: false, reservedExecution: false };
+    const outcome = await runSpawnExecutionFlow(this.buildSpawnExecutionFlowDeps(spawnState), {
       task,
       space,
       workflow,
@@ -649,11 +648,15 @@ export class TaskAgentManager {
       kickoff: options.kickoff ?? true,
     });
     if (outcome.status === 'error') {
-      this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
+      if (spawnState.reservedExecution) {
+        this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
+      }
       throw outcome.error;
     }
     if (outcome.status === 'superseded') {
-      this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
+      if (spawnState.reservedExecution) {
+        this.settleConcurrentSpawnWaiters(execution.id, { status: 'failed' });
+      }
       throw new SpawnSupersededError(execution.id, outcome.stage ?? null);
     }
     const result = outcome.result;
@@ -748,8 +751,10 @@ export class TaskAgentManager {
     for (const waiter of waiters) waiter(outcome);
   }
 
-  private buildSpawnExecutionFlowDeps(): SpawnExecutionFlowDeps {
-    const spawnState = { reservationHeld: false, reusedSessionIds: new Set<string>() };
+  private buildSpawnExecutionFlowDeps(spawnState: {
+    reservationHeld: boolean;
+    reservedExecution: boolean;
+  }): SpawnExecutionFlowDeps {
     return {
       getFreshTask: (taskId) => this.config.taskRepo.getTask(taskId),
       getNodeExecution: (executionId) => this.config.nodeExecutionRepo.getById(executionId),
@@ -764,6 +769,7 @@ export class TaskAgentManager {
         return { sessionId: agentSessionId, alive: false };
       },
       reserveExecution: (executionId) => {
+        spawnState.reservedExecution = true;
         this.spawningExecutionIds.add(executionId);
       },
       releaseExecution: (executionId) => {
@@ -783,12 +789,6 @@ export class TaskAgentManager {
         this.config.taskRepo.releaseSpawnReservation(taskId);
       },
       cancelSpawnedSession: (sessionId) => {
-        if (spawnState.reusedSessionIds.has(sessionId)) {
-          log.info(
-            `TaskAgentManager: spawn compensation skipped cancel for reused session ${sessionId} — it remains owned by its prior node`
-          );
-          return;
-        }
         this.cancelBySessionId(sessionId);
       },
       rebindLiveExecution: (execution, sessionId) => {
@@ -897,10 +897,7 @@ export class TaskAgentManager {
             agentName: request.execution.agentName,
             nodeId: request.execution.workflowNodeId,
             deferFreshExecutionBind: true,
-            executionBindObservedStatus: request.execution.status,
-            onSessionReused: (sessionId) => {
-              spawnState.reusedSessionIds.add(sessionId);
-            },
+            freshSessionOnly: true,
           }
         );
 
@@ -912,9 +909,7 @@ export class TaskAgentManager {
       },
       bindExecutionToSession: (execution, sessionId) => {
         const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(execution.status)
-          ? execution.status === 'in_progress'
-            ? (['in_progress'] as const)
-            : ([execution.status, 'in_progress'] as const)
+          ? ([execution.status] as const)
           : ([] as const);
         const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
           execution.id,
@@ -924,7 +919,8 @@ export class TaskAgentManager {
             agentSessionId: sessionId,
             startedAt: Date.now(),
             completedAt: null,
-          }
+          },
+          { expectAgentSessionId: execution.agentSessionId ?? null }
         );
         if (outcome === 'won') {
           this.settleConcurrentSpawnWaiters(execution.id, {
@@ -1048,7 +1044,7 @@ export class TaskAgentManager {
           .listByWorkflowRun(parentTask.workflowRunId)
           .filter((e) => e.agentName === memberInfo.agentName && e.agentSessionId)
           .at(-1);
-        if (prevExec?.agentSessionId) {
+        if (prevExec?.agentSessionId && !memberInfo.freshSessionOnly) {
           const existing =
             this.agentSessionIndex.get(prevExec.agentSessionId) ??
             (await this.rehydrateSubSession(prevExec.agentSessionId));
@@ -1057,8 +1053,6 @@ export class TaskAgentManager {
             log.info(
               `TaskAgentManager: reusing session ${existingSessionId} for agent "${memberInfo.agentName}" (task ${taskId}); skipping new session ${sessionId}`
             );
-
-            memberInfo.onSessionReused?.(existingSessionId);
 
             if (memberInfo.nodeId) {
               const nodeExecs = this.config.nodeExecutionRepo.listByNode(
@@ -1072,9 +1066,8 @@ export class TaskAgentManager {
                     e.agentName === memberInfo.agentName && e.agentSessionId === existingSessionId
                 );
               if (match) {
-                const observed = memberInfo.executionBindObservedStatus ?? match.status;
-                const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(observed)
-                  ? ([observed] as const)
+                const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(match.status)
+                  ? ([match.status] as const)
                   : ([] as const);
                 const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
                   match.id,
@@ -1177,16 +1170,18 @@ export class TaskAgentManager {
               await this.mcpSelfHeal(target, missing);
             };
 
-            const runId = parentTask.workflowRunId;
-            void this.flushPendingMessagesForTarget(
-              runId,
-              memberInfo.agentName,
-              existingSessionId
-            ).catch((err) => {
-              log.warn(
-                `TaskAgentManager: flushPendingMessagesForTarget failed for ${memberInfo.agentName} (session ${existingSessionId}): ${err instanceof Error ? err.message : String(err)}`
-              );
-            });
+            if (!memberInfo.deferFreshExecutionBind) {
+              const runId = parentTask.workflowRunId;
+              void this.flushPendingMessagesForTarget(
+                runId,
+                memberInfo.agentName,
+                existingSessionId
+              ).catch((err) => {
+                log.warn(
+                  `TaskAgentManager: flushPendingMessagesForTarget failed for ${memberInfo.agentName} (session ${existingSessionId}): ${err instanceof Error ? err.message : String(err)}`
+                );
+              });
+            }
 
             return existingSessionId;
           }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1210,9 +1210,10 @@ export class TaskAgentManager {
             }
           );
           if (outcome === 'superseded') {
-            log.info(
-              `TaskAgentManager: skipped binding new session ${sessionId} to execution ${match.id} — status moved concurrently`
-            );
+            this.subSessions.get(taskId)?.delete(sessionId);
+            this.agentSessionIndex.delete(sessionId);
+            void this.config.sessionManager.unregisterSession(sessionId).catch(() => {});
+            throw new SpawnSupersededError(match.id, 'fresh-create-bind');
           }
         } else if (match && match.agentSessionId) {
           log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -53,6 +53,7 @@ export interface SubSessionMemberInfo {
   agentId?: string;
   agentName?: string;
   nodeId?: string;
+  deferExecutionBind?: boolean;
 }
 
 export interface VerifiedSessionStop {
@@ -882,6 +883,7 @@ export class TaskAgentManager {
             agentId: request.slot.agentId,
             agentName: request.execution.agentName,
             nodeId: request.execution.workflowNodeId,
+            deferExecutionBind: true,
           }
         );
 
@@ -893,9 +895,7 @@ export class TaskAgentManager {
       },
       bindExecutionToSession: (execution, sessionId) => {
         const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(execution.status)
-          ? execution.status === 'in_progress'
-            ? (['in_progress'] as const)
-            : ([execution.status, 'in_progress'] as const)
+          ? ([execution.status] as const)
           : ([] as const);
         const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
           execution.id,
@@ -1041,10 +1041,10 @@ export class TaskAgentManager {
                   (e) =>
                     e.agentName === memberInfo.agentName && e.agentSessionId === existingSessionId
                 );
-              if (match) {
+              if (match && !memberInfo.deferExecutionBind) {
                 const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
                   match.id,
-                  SPAWN_BINDABLE_EXECUTION_STATUSES,
+                  [match.status],
                   'in_progress',
                   {
                     agentSessionId: existingSessionId,
@@ -1198,10 +1198,10 @@ export class TaskAgentManager {
           memberInfo.nodeId
         );
         const match = nodeExecs.find((e) => e.agentName === memberInfo.agentName);
-        if (match && !match.agentSessionId) {
+        if (match && !match.agentSessionId && !memberInfo.deferExecutionBind) {
           const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
             match.id,
-            SPAWN_BINDABLE_EXECUTION_STATUSES,
+            [match.status],
             'in_progress',
             {
               agentSessionId: sessionId,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -5,6 +5,7 @@ import type {
   SpaceWorkflow,
   SpaceWorkflowRun,
   NodeExecution,
+  NodeExecutionStatus,
   MessageHub,
   McpServerConfig,
   MessageContent,
@@ -53,7 +54,9 @@ export interface SubSessionMemberInfo {
   agentId?: string;
   agentName?: string;
   nodeId?: string;
-  deferExecutionBind?: boolean;
+  deferFreshExecutionBind?: boolean;
+  executionBindObservedStatus?: NodeExecutionStatus;
+  onSessionReused?: (sessionId: string) => void;
 }
 
 export interface VerifiedSessionStop {
@@ -745,7 +748,7 @@ export class TaskAgentManager {
   }
 
   private buildSpawnExecutionFlowDeps(): SpawnExecutionFlowDeps {
-    const spawnState = { reservationHeld: false };
+    const spawnState = { reservationHeld: false, reusedSessionIds: new Set<string>() };
     return {
       getFreshTask: (taskId) => this.config.taskRepo.getTask(taskId),
       getNodeExecution: (executionId) => this.config.nodeExecutionRepo.getById(executionId),
@@ -779,13 +782,22 @@ export class TaskAgentManager {
         this.config.taskRepo.releaseSpawnReservation(taskId);
       },
       cancelSpawnedSession: (sessionId) => {
+        if (spawnState.reusedSessionIds.has(sessionId)) {
+          log.info(
+            `TaskAgentManager: spawn compensation skipped cancel for reused session ${sessionId} — it remains owned by its prior node`
+          );
+          return;
+        }
         this.cancelBySessionId(sessionId);
       },
       rebindLiveExecution: (execution, sessionId) => {
         const startedAt = execution.startedAt ?? Date.now();
+        const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(execution.status)
+          ? ([execution.status] as const)
+          : ([] as const);
         return this.config.nodeExecutionRepo.casExecutionStatus(
           execution.id,
-          SPAWN_BINDABLE_EXECUTION_STATUSES,
+          expected,
           'in_progress',
           {
             agentSessionId: sessionId,
@@ -883,7 +895,11 @@ export class TaskAgentManager {
             agentId: request.slot.agentId,
             agentName: request.execution.agentName,
             nodeId: request.execution.workflowNodeId,
-            deferExecutionBind: true,
+            deferFreshExecutionBind: true,
+            executionBindObservedStatus: request.execution.status,
+            onSessionReused: (sessionId) => {
+              spawnState.reusedSessionIds.add(sessionId);
+            },
           }
         );
 
@@ -895,7 +911,9 @@ export class TaskAgentManager {
       },
       bindExecutionToSession: (execution, sessionId) => {
         const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(execution.status)
-          ? ([execution.status] as const)
+          ? execution.status === 'in_progress'
+            ? (['in_progress'] as const)
+            : ([execution.status, 'in_progress'] as const)
           : ([] as const);
         const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
           execution.id,
@@ -914,6 +932,15 @@ export class TaskAgentManager {
           });
         }
         return outcome;
+      },
+      flushPendingMessagesForTarget: (workflowRunId, agentName, sessionId) => {
+        void this.flushPendingMessagesForTarget(workflowRunId, agentName, sessionId).catch(
+          (err) => {
+            log.warn(
+              `TaskAgentManager: flushPendingMessagesForTarget failed for ${agentName} (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        );
       },
       attachNodeAgent: async (request) => {
         const spawned = this.getSubSession(request.sessionId);
@@ -1030,6 +1057,8 @@ export class TaskAgentManager {
               `TaskAgentManager: reusing session ${existingSessionId} for agent "${memberInfo.agentName}" (task ${taskId}); skipping new session ${sessionId}`
             );
 
+            memberInfo.onSessionReused?.(existingSessionId);
+
             if (memberInfo.nodeId) {
               const nodeExecs = this.config.nodeExecutionRepo.listByNode(
                 parentTask.workflowRunId,
@@ -1041,10 +1070,14 @@ export class TaskAgentManager {
                   (e) =>
                     e.agentName === memberInfo.agentName && e.agentSessionId === existingSessionId
                 );
-              if (match && !memberInfo.deferExecutionBind) {
+              if (match) {
+                const observed = memberInfo.executionBindObservedStatus ?? match.status;
+                const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(observed)
+                  ? ([observed] as const)
+                  : ([] as const);
                 const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
                   match.id,
-                  [match.status],
+                  expected,
                   'in_progress',
                   {
                     agentSessionId: existingSessionId,
@@ -1198,10 +1231,13 @@ export class TaskAgentManager {
           memberInfo.nodeId
         );
         const match = nodeExecs.find((e) => e.agentName === memberInfo.agentName);
-        if (match && !match.agentSessionId && !memberInfo.deferExecutionBind) {
+        if (match && !match.agentSessionId && !memberInfo.deferFreshExecutionBind) {
+          const expected = SPAWN_BINDABLE_EXECUTION_STATUSES.includes(match.status)
+            ? ([match.status] as const)
+            : ([] as const);
           const outcome = this.config.nodeExecutionRepo.casExecutionStatus(
             match.id,
-            [match.status],
+            expected,
             'in_progress',
             {
               agentSessionId: sessionId,
@@ -1212,14 +1248,24 @@ export class TaskAgentManager {
           if (outcome === 'superseded') {
             this.subSessions.get(taskId)?.delete(sessionId);
             this.agentSessionIndex.delete(sessionId);
-            void this.config.sessionManager.unregisterSession(sessionId).catch(() => {});
+            this.cancelBySessionId(sessionId);
+            try {
+              this.config.db
+                .getDatabase()
+                .prepare('DELETE FROM sessions WHERE id = ?')
+                .run(sessionId);
+            } catch (err) {
+              log.warn(
+                `TaskAgentManager: failed to delete never-streamed session row ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
             throw new SpawnSupersededError(match.id, 'fresh-create-bind');
           }
         } else if (match && match.agentSessionId) {
           log.warn(
             `TaskAgentManager: NodeExecution ${match.id} already has agentSessionId ${match.agentSessionId}; skipping update for new session ${sessionId}`
           );
-        } else {
+        } else if (!memberInfo.deferFreshExecutionBind) {
           log.warn(
             `TaskAgentManager: no matching NodeExecution found for (run=${parentTask.workflowRunId}, node=${memberInfo.nodeId}, agent=${memberInfo.agentName})`
           );
@@ -1233,7 +1279,7 @@ export class TaskAgentManager {
 
     await subSession.startStreamingQuery();
 
-    if (memberInfo?.agentName) {
+    if (memberInfo?.agentName && !memberInfo.deferFreshExecutionBind) {
       const parentTask = this.config.taskRepo.getTask(taskId);
       const runId = parentTask?.workflowRunId;
       if (runId) {

--- a/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
@@ -1,9 +1,32 @@
-import type { NodeExecution, SpaceTask, SpaceWorkflow, WorkflowNode } from '@hyperneo/shared';
+import type {
+  NodeExecution,
+  NodeExecutionStatus,
+  SpaceTask,
+  SpaceTaskStatus,
+  SpaceWorkflow,
+  WorkflowNode,
+} from '@hyperneo/shared';
 import { isRateOrUsageLimited, resolveNodeAgents } from '@hyperneo/shared';
 
 export type ExecutionWorkflowValidationResult =
   | { valid: true }
   | { valid: false; reason: string; permanent: true };
+
+export const SPAWN_BINDABLE_EXECUTION_STATUSES: readonly NodeExecutionStatus[] = [
+  'pending',
+  'in_progress',
+  'idle',
+  'waiting_rebind',
+];
+
+export const SPAWN_RESERVABLE_TASK_STATUSES: readonly SpaceTaskStatus[] = [
+  'draft',
+  'open',
+  'in_progress',
+  'review',
+  'approved',
+  'blocked',
+];
 
 export class PermanentSpawnError extends Error {
   readonly permanent = true;
@@ -27,6 +50,24 @@ export class TransientSpawnError extends Error {
 
 export function isTransientSpawnError(err: unknown): err is TransientSpawnError {
   return err instanceof TransientSpawnError;
+}
+
+export class SpawnSupersededError extends Error {
+  readonly executionId: string;
+  readonly stage: string | null;
+
+  constructor(executionId: string, stage: string | null) {
+    super(
+      `Spawn for execution ${executionId} superseded at stage ${stage ?? 'unknown'} — a concurrent writer moved the guarded row first; skipping for this call`
+    );
+    this.name = 'SpawnSupersededError';
+    this.executionId = executionId;
+    this.stage = stage;
+  }
+}
+
+export function isSpawnSupersededError(err: unknown): err is SpawnSupersededError {
+  return err instanceof SpawnSupersededError;
 }
 
 export interface MissingNodeAgentReference {

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -202,15 +202,38 @@ export class NodeExecutionRepository {
   casExecutionStatus(
     id: string,
     expected: NodeExecutionStatus | readonly NodeExecutionStatus[],
-    next: NodeExecutionStatus
+    next: NodeExecutionStatus,
+    payload: {
+      agentSessionId?: string | null;
+      startedAt?: number | null;
+      completedAt?: number | null;
+    } = {}
   ): 'won' | 'superseded' {
     const expectedStatuses = Array.isArray(expected) ? [...expected] : [expected];
     if (expectedStatuses.length === 0) return 'superseded';
     const placeholders = expectedStatuses.map(() => '?').join(', ');
+    const sets = ['status = ?', 'updated_at = ?'];
+    const values: SQLiteValue[] = [next, Date.now()];
+    if (payload.agentSessionId !== undefined) {
+      sets.push('agent_session_id = ?');
+      values.push(payload.agentSessionId);
+    }
+    if (payload.startedAt !== undefined) {
+      sets.push('started_at = ?');
+      values.push(payload.startedAt);
+    }
+    if (payload.completedAt !== undefined) {
+      sets.push('completed_at = ?');
+      values.push(payload.completedAt);
+    }
     const result = this.db
-      .prepare(`UPDATE node_executions SET status = ? WHERE id = ? AND status IN (${placeholders})`)
-      .run(next, id, ...expectedStatuses);
-    return result.changes > 0 ? 'won' : 'superseded';
+      .prepare(
+        `UPDATE node_executions SET ${sets.join(', ')} WHERE id = ? AND status IN (${placeholders})`
+      )
+      .run(...values, id, ...expectedStatuses);
+    if (result.changes === 0) return 'superseded';
+    this.notify();
+    return 'won';
   }
 
   updateSessionId(id: string, agentSessionId: string | null): NodeExecution | null {

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -207,7 +207,8 @@ export class NodeExecutionRepository {
       agentSessionId?: string | null;
       startedAt?: number | null;
       completedAt?: number | null;
-    } = {}
+    } = {},
+    guards: { expectAgentSessionId?: string | null } = {}
   ): 'won' | 'superseded' {
     const expectedStatuses = Array.isArray(expected) ? [...expected] : [expected];
     if (expectedStatuses.length === 0) return 'superseded';
@@ -226,11 +227,18 @@ export class NodeExecutionRepository {
       sets.push('completed_at = ?');
       values.push(payload.completedAt);
     }
+    let predicate = `id = ? AND status IN (${placeholders})`;
+    if (guards.expectAgentSessionId !== undefined) {
+      predicate += ' AND agent_session_id IS ?';
+    }
     const result = this.db
-      .prepare(
-        `UPDATE node_executions SET ${sets.join(', ')} WHERE id = ? AND status IN (${placeholders})`
-      )
-      .run(...values, id, ...expectedStatuses);
+      .prepare(`UPDATE node_executions SET ${sets.join(', ')} WHERE ${predicate}`)
+      .run(
+        ...values,
+        id,
+        ...expectedStatuses,
+        ...(guards.expectAgentSessionId !== undefined ? [guards.expectAgentSessionId] : [])
+      );
     if (result.changes === 0) return 'superseded';
     this.notify();
     return 'won';

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -31,6 +31,7 @@ import {
 import type { SQLiteValue } from '../types';
 import {
   decideMessageAdmission,
+  extractReplacementEdges,
   normalizeMessageAdmissionInput,
   type SDKMessageReplacementEdge,
   type SendStatus,

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -715,6 +715,10 @@ export class SpaceTaskRepository {
       .run(taskId);
   }
 
+  clearAllSpawnReservations(): void {
+    this.db.prepare(`UPDATE space_tasks SET spawn_reservation_token = NULL`).run();
+  }
+
   archiveTask(id: string): SpaceTask | null {
     const now = Date.now();
     const stmt = this.db.prepare(

--- a/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
@@ -491,6 +491,44 @@ describe('NodeExecutionRepository', () => {
       expect(after.agentSessionId).toBe('session-old');
       expect(after.startedAt).toBeNull();
     });
+
+    it('guards on the expected agent session binding, NULL-safe (PR #2770 review)', () => {
+      const exec = createExecution();
+
+      expect(
+        repo.casExecutionStatus(
+          exec.id,
+          'pending',
+          'in_progress',
+          { agentSessionId: 'a' },
+          { expectAgentSessionId: null }
+        )
+      ).toBe('won');
+      expect(repo.getById(exec.id)!.agentSessionId).toBe('a');
+
+      repo.updateStatus(exec.id, 'pending');
+      expect(
+        repo.casExecutionStatus(
+          exec.id,
+          'pending',
+          'in_progress',
+          { agentSessionId: 'b' },
+          { expectAgentSessionId: 'other-session' }
+        )
+      ).toBe('superseded');
+      expect(repo.getById(exec.id)!.agentSessionId).toBe('a');
+
+      expect(
+        repo.casExecutionStatus(
+          exec.id,
+          'pending',
+          'in_progress',
+          { agentSessionId: 'c' },
+          { expectAgentSessionId: 'a' }
+        )
+      ).toBe('won');
+      expect(repo.getById(exec.id)!.agentSessionId).toBe('c');
+    });
   });
 
   describe('updateSessionId', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
@@ -432,7 +432,7 @@ describe('NodeExecutionRepository', () => {
       expect(repo.getById(other.id)).toEqual(otherBefore);
     });
 
-    it('stamps no timestamps and emits no reactive notification', () => {
+    it('stamps updated_at and emits a reactive notification only on a win', () => {
       const calls: Array<{ table: string; scope?: unknown }> = [];
       const reactiveDb = {
         notifyChange: (table: string, scope?: unknown) => calls.push({ table, scope }),
@@ -442,13 +442,54 @@ describe('NodeExecutionRepository', () => {
         reactiveDb as unknown as Parameters<typeof NodeExecutionRepository.prototype.constructor>[1]
       );
       const exec = createExecution();
+      repo.updateStatus(exec.id, 'in_progress');
 
-      expect(reactiveRepo.casExecutionStatus(exec.id, 'pending', 'blocked')).toBe('won');
+      expect(reactiveRepo.casExecutionStatus(exec.id, 'pending', 'blocked')).toBe('superseded');
+      expect(calls).toEqual([]);
+
+      expect(reactiveRepo.casExecutionStatus(exec.id, 'in_progress', 'blocked')).toBe('won');
 
       const after = repo.getById(exec.id)!;
-      expect(after.startedAt).toBeNull();
+      expect(after.status).toBe('blocked');
+      expect(after.updatedAt).toBeGreaterThanOrEqual(after.createdAt);
+      expect(calls).toEqual([{ table: 'node_executions', scope: undefined }]);
+    });
+
+    it('applies the bind payload atomically with the winning status transition', () => {
+      const exec = createExecution();
+      const before = repo.getById(exec.id)!;
+      expect(before.startedAt).toBeNull();
+
+      const outcome = repo.casExecutionStatus(exec.id, 'pending', 'in_progress', {
+        agentSessionId: 'session-1',
+        startedAt: 1234,
+        completedAt: null,
+      });
+
+      expect(outcome).toBe('won');
+      const after = repo.getById(exec.id)!;
+      expect(after.status).toBe('in_progress');
+      expect(after.agentSessionId).toBe('session-1');
+      expect(after.startedAt).toBe(1234);
       expect(after.completedAt).toBeNull();
-      expect(calls).toEqual([]);
+    });
+
+    it('applies no payload when the CAS loses', () => {
+      const exec = createExecution();
+      repo.update(exec.id, { agentSessionId: 'session-old' });
+      repo.updateStatus(exec.id, 'cancelled');
+
+      const outcome = repo.casExecutionStatus(exec.id, 'pending', 'in_progress', {
+        agentSessionId: 'session-1',
+        startedAt: 1234,
+        completedAt: null,
+      });
+
+      expect(outcome).toBe('superseded');
+      const after = repo.getById(exec.id)!;
+      expect(after.status).toBe('cancelled');
+      expect(after.agentSessionId).toBe('session-old');
+      expect(after.startedAt).toBeNull();
     });
   });
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -827,6 +827,21 @@ describe('SpaceTaskRepository', () => {
       expect(after?.status).toBe('in_progress');
       expect(notifiedTables).toEqual([]);
     });
+
+    it('clearAllSpawnReservations drops every held token so a fresh process can reserve again', () => {
+      const held = repo.createTask({ spaceId, title: 'Held', description: '' });
+      const running = repo.createTask({ spaceId, title: 'Running', description: '' });
+      repo.updateTask(held.id, { status: 'in_progress' });
+      repo.updateTask(running.id, { status: 'in_progress' });
+      expect(repo.reserveSpawnForTick(held.id, runningStatuses)).toBe('won');
+      expect(repo.reserveSpawnForTick(running.id, runningStatuses)).toBe('won');
+      expect(repo.reserveSpawnForTick(held.id, runningStatuses)).toBe('superseded');
+
+      repo.clearAllSpawnReservations();
+
+      expect(repo.reserveSpawnForTick(held.id, runningStatuses)).toBe('won');
+      expect(repo.reserveSpawnForTick(running.id, runningStatuses)).toBe('won');
+    });
   });
 
   describe('getTaskBySessionId', () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -80,6 +80,27 @@ function reviewerExec(sessionId: string = REVIEWER_SESSION_ID) {
   };
 }
 
+function recordingCas(
+  updates: Array<{ id: string; payload: Record<string, unknown> }>,
+  rows: Array<Record<string, unknown>>
+): (
+  id: string,
+  expected: readonly string[],
+  next: string,
+  payload?: Record<string, unknown>
+) => 'won' | 'superseded' {
+  return (id, expected, next, payload) => {
+    updates.push({
+      id,
+      payload: { status: next, ...payload, __cas: expected },
+    });
+    const row = rows.find((candidate) => candidate.id === id);
+    if (!row || !expected.includes(String(row.status))) return 'superseded';
+    row.status = next;
+    return 'won';
+  };
+}
+
 function makeManager(rows: unknown[] = [reviewerExec()]): TaskAgentManager {
   return new TaskAgentManager({
     db: { getDatabase: () => new BunDatabase(':memory:') },
@@ -92,6 +113,10 @@ function makeManager(rows: unknown[] = [reviewerExec()]): TaskAgentManager {
       listByWorkflowRun: () => rows,
       listByNode: () => rows,
       update: () => rows[0],
+      casExecutionStatus: recordingCas(
+        [],
+        rows.map((row) => row as Record<string, unknown>)
+      ),
     },
     spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
   } as unknown as TaskAgentManagerConfig);
@@ -269,6 +294,11 @@ describe('spawnPostApprovalSubSession — reuse-if-exists else create', () => {
           updates.push({ id, payload });
           return null;
         },
+        casExecutionStatus: recordingCas(updates, [
+          staleCoOwner,
+          pendingCoOwner,
+          targetExec,
+        ] as Array<Record<string, unknown>>),
       },
       spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
     } as unknown as TaskAgentManagerConfig);
@@ -425,6 +455,7 @@ function makeRecordingManager(
         updates.push({ id, payload });
         return null;
       },
+      casExecutionStatus: recordingCas(updates, rows),
     },
     spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
   } as unknown as TaskAgentManagerConfig);
@@ -497,7 +528,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(fromInitSpy).not.toHaveBeenCalled();
   });
 
-  test('reuse path rebinds the node execution with an unconditional in_progress write (BEFORE picture)', async () => {
+  test('reuse path rebinds the node execution through a bindable-status CAS (AFTER picture, superpipe P5)', async () => {
     const { tam, updates } = makeRecordingManager([makeExecutionRow()]);
     seedLiveSession(tam);
     stubMcpReinjection(tam);
@@ -519,6 +550,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
         agentSessionId: REVIEWER_SESSION_ID,
         startedAt: 1,
         completedAt: null,
+        __cas: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
       },
     });
   });
@@ -595,11 +627,15 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     });
     expect(updates.find((u) => u.id === 'exec-active')).toEqual({
       id: 'exec-active',
-      payload: { agentSessionId: null, status: 'idle' },
+      payload: {
+        status: 'idle',
+        agentSessionId: null,
+        __cas: ['in_progress'],
+      },
     });
   });
 
-  test('fresh create binds the new session to the matching pending execution (unconditional write)', async () => {
+  test('fresh create binds the new session to the matching pending execution through the bindable-status CAS', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-pending',
       agentSessionId: null,
@@ -623,6 +659,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
         agentSessionId: 'fresh-id',
         startedAt: expect.any(Number),
         completedAt: null,
+        __cas: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
       },
     });
   });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -838,6 +838,54 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(boundPriorOwner.status).toBe('in_progress');
   });
 
+  test('a deferred reuse skips the inner flush — the flow flushes once after the outer bind (PR #2770 review)', async () => {
+    const priorBound = makeExecutionRow({
+      id: 'exec-prior-flush',
+      workflowNodeId: 'node-prior',
+      status: 'in_progress',
+    });
+    const flushed: Array<{ runId: string; agentName: string; sessionId: string }> = [];
+    const tam = new TaskAgentManager({
+      db: { getDatabase: () => new BunDatabase(':memory:') },
+      sessionManager: { registerSession: () => {}, getCachedSession: () => undefined },
+      internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+      taskRepo: {
+        getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'T' }),
+      },
+      nodeExecutionRepo: {
+        listByWorkflowRun: () => [priorBound],
+        listByNode: () => [],
+        listByAgentSessionId: () => [priorBound],
+        update: () => null,
+        casExecutionStatus: () => 'won',
+      },
+      spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    } as unknown as TaskAgentManagerConfig);
+    (
+      tam as unknown as {
+        flushPendingMessagesForTarget: (
+          runId: string,
+          agentName: string,
+          sessionId: string
+        ) => Promise<void>;
+      }
+    ).flushPendingMessagesForTarget = async (runId, agentName, sessionId) => {
+      flushed.push({ runId, agentName, sessionId });
+    };
+    seedLiveSession(tam);
+    stubReusePathHelpers(tam);
+
+    const actual = await tam.createSubSession(TASK_ID, 'deferred-reuse-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: 'node-other',
+      deferFreshExecutionBind: true,
+    });
+
+    expect(actual).toBe(REVIEWER_SESSION_ID);
+    expect(flushed).toEqual([]);
+  });
+
   test('deferFreshExecutionBind leaves the fresh target row to the guarded outer bind: no inner write, session still created (PR #2770 review)', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-deferred',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -904,7 +904,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(flushed).toEqual([]);
   });
 
-  test('deferFreshExecutionBind leaves the fresh target row to the guarded outer bind: no inner write, session still created (PR #2770 review)', async () => {
+  test('deferFreshExecutionBind leaves the fresh target row to the guarded outer bind and drains nothing pre-commit (PR #2770 review)', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-deferred',
       agentSessionId: null,
@@ -912,6 +912,18 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
       startedAt: null,
     });
     const { tam, updates } = makeRecordingManager([pendingExec]);
+    const flushed: Array<{ runId: string; agentName: string; sessionId: string }> = [];
+    (
+      tam as unknown as {
+        flushPendingMessagesForTarget: (
+          runId: string,
+          agentName: string,
+          sessionId: string
+        ) => Promise<void>;
+      }
+    ).flushPendingMessagesForTarget = async (runId, agentName, sessionId) => {
+      flushed.push({ runId, agentName, sessionId });
+    };
 
     const actual = await tam.createSubSession(TASK_ID, 'deferred-id', minimalInit(), {
       agentId: 'agent-reviewer',
@@ -925,6 +937,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(updates.find((u) => u.id === 'exec-deferred')).toBeUndefined();
     expect(pendingExec.status).toBe('pending');
     expect(pendingExec.agentSessionId).toBeNull();
+    expect(flushed).toEqual([]);
   });
 
   test('fresh create binds the new session to the matching pending execution through the bindable-status CAS', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -550,7 +550,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
         agentSessionId: REVIEWER_SESSION_ID,
         startedAt: 1,
         completedAt: null,
-        __cas: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+        __cas: ['in_progress'],
       },
     });
   });
@@ -730,6 +730,29 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(pendingExec.agentSessionId).toBeNull();
   });
 
+  test('deferExecutionBind leaves the target row to the guarded outer bind: no inner write, session still created (PR #2770 review)', async () => {
+    const pendingExec = makeExecutionRow({
+      id: 'exec-deferred',
+      agentSessionId: null,
+      status: 'pending',
+      startedAt: null,
+    });
+    const { tam, updates } = makeRecordingManager([pendingExec]);
+
+    const actual = await tam.createSubSession(TASK_ID, 'deferred-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+      deferExecutionBind: true,
+    });
+
+    expect(actual).toBe('deferred-id');
+    expect(fromInitSpy).toHaveBeenCalledTimes(1);
+    expect(updates.find((u) => u.id === 'exec-deferred')).toBeUndefined();
+    expect(pendingExec.status).toBe('pending');
+    expect(pendingExec.agentSessionId).toBeNull();
+  });
+
   test('fresh create binds the new session to the matching pending execution through the bindable-status CAS', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-pending',
@@ -754,7 +777,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
         agentSessionId: 'fresh-id',
         startedAt: expect.any(Number),
         completedAt: null,
-        __cas: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+        __cas: ['pending'],
       },
     });
   });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -838,6 +838,24 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(boundPriorOwner.status).toBe('in_progress');
   });
 
+  test('freshSessionOnly is honored: a seeded prior live session is NOT reused — a fresh session is created (PR #2770 review)', async () => {
+    const { tam, updates } = makeRecordingManager([makeExecutionRow()]);
+    seedLiveSession(tam);
+    stubReusePathHelpers(tam);
+
+    const actual = await tam.createSubSession(TASK_ID, 'fresh-only-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: 'node-prior',
+      freshSessionOnly: true,
+    });
+
+    expect(actual).toBe('fresh-only-id');
+    expect(actual).not.toBe(REVIEWER_SESSION_ID);
+    expect(fromInitSpy).toHaveBeenCalledTimes(1);
+    expect(updates.find((u) => u.payload?.agentSessionId === REVIEWER_SESSION_ID)).toBeUndefined();
+  });
+
   test('a deferred reuse skips the inner flush — the flow flushes once after the outer bind (PR #2770 review)', async () => {
     const priorBound = makeExecutionRow({
       id: 'exec-prior-flush',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -636,6 +636,52 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     });
   });
 
+  test('a sessionless reuse target whose bind CAS loses aborts the reuse before any ownership transfer (PR #2770 review)', async () => {
+    const sessionlessTarget = makeExecutionRow({
+      id: 'exec-target-sessionless',
+      agentSessionId: null,
+      status: 'pending',
+      startedAt: null,
+    });
+    const boundElsewhere = makeExecutionRow({
+      id: 'exec-prior-owner',
+      workflowNodeId: 'node-prior',
+      status: 'in_progress',
+    });
+    const updates: Array<{ id: string; payload: Record<string, unknown> }> = [];
+    const tam = new TaskAgentManager({
+      db: { getDatabase: () => new BunDatabase(':memory:') },
+      sessionManager: { registerSession: () => {} },
+      internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+      taskRepo: {
+        getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'T' }),
+      },
+      nodeExecutionRepo: {
+        listByWorkflowRun: () => [sessionlessTarget, boundElsewhere],
+        listByNode: (_runId: string, nodeId: string) =>
+          nodeId === REVIEWER_NODE_ID ? [sessionlessTarget] : [],
+        listByAgentSessionId: () => [],
+        update: (id: string, payload: Record<string, unknown>) => {
+          updates.push({ id, payload });
+          return null;
+        },
+        casExecutionStatus: () => 'superseded',
+      },
+      spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    } as unknown as TaskAgentManagerConfig);
+    seedLiveSession(tam);
+    stubMcpReinjection(tam);
+
+    const spawnPromise = tam.createSubSession(TASK_ID, 'proposed-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+    });
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage reuse-target-bind');
+    expect(updates).toEqual([]);
+  });
+
   test('fresh create binds the new session to the matching pending execution through the bindable-status CAS', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-pending',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -682,6 +682,54 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(updates).toEqual([]);
   });
 
+  test('a fresh create whose bind CAS loses aborts before streaming: session unregistered, nothing left bound (PR #2770 review)', async () => {
+    const pendingExec = makeExecutionRow({
+      id: 'exec-fresh-lost',
+      agentSessionId: null,
+      status: 'pending',
+      startedAt: null,
+    });
+    const unregistered: string[] = [];
+    const tam = new TaskAgentManager({
+      db: { getDatabase: () => new BunDatabase(':memory:') },
+      sessionManager: {
+        registerSession: () => {},
+        unregisterSession: async (id: string) => {
+          unregistered.push(id);
+        },
+      },
+      internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+      taskRepo: {
+        getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'T' }),
+      },
+      nodeExecutionRepo: {
+        listByWorkflowRun: () => [pendingExec],
+        listByNode: () => [pendingExec],
+        listByAgentSessionId: () => [],
+        update: () => null,
+        casExecutionStatus: () => 'superseded',
+      },
+      spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    } as unknown as TaskAgentManagerConfig);
+
+    const spawnPromise = tam.createSubSession(TASK_ID, 'fresh-lost-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+    });
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage fresh-create-bind');
+    const internal = tam as unknown as {
+      subSessions: Map<string, Map<string, AgentSessionType>>;
+      agentSessionIndex: Map<string, AgentSessionType>;
+    };
+    expect(internal.subSessions.get(TASK_ID)?.size ?? 0).toBe(0);
+    expect(internal.agentSessionIndex.size).toBe(0);
+    expect(unregistered).toEqual(['fresh-lost-id']);
+    expect(pendingExec.status).toBe('pending');
+    expect(pendingExec.agentSessionId).toBeNull();
+  });
+
   test('fresh create binds the new session to the matching pending execution through the bindable-status CAS', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-pending',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -694,6 +694,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
       db: { getDatabase: () => new BunDatabase(':memory:') },
       sessionManager: {
         registerSession: () => {},
+        getCachedSession: () => undefined,
         unregisterSession: async (id: string) => {
           unregistered.push(id);
         },
@@ -730,7 +731,114 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
     expect(pendingExec.agentSessionId).toBeNull();
   });
 
-  test('deferExecutionBind leaves the target row to the guarded outer bind: no inner write, session still created (PR #2770 review)', async () => {
+  test('a cancelled fresh target observed by a direct caller supersedes into the abort — no resurrection (PR #2770 review)', async () => {
+    const cancelledExec = makeExecutionRow({
+      id: 'exec-cancelled-observed',
+      agentSessionId: null,
+      status: 'cancelled',
+      startedAt: null,
+    });
+    const casCalls: Array<{ expected: string[]; next: string }> = [];
+    const tam = new TaskAgentManager({
+      db: { getDatabase: () => new BunDatabase(':memory:') },
+      sessionManager: {
+        registerSession: () => {},
+        getCachedSession: () => undefined,
+        unregisterSession: async () => {},
+      },
+      internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+      taskRepo: {
+        getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'T' }),
+      },
+      nodeExecutionRepo: {
+        listByWorkflowRun: () => [cancelledExec],
+        listByNode: () => [cancelledExec],
+        listByAgentSessionId: () => [],
+        update: () => null,
+        casExecutionStatus: (
+          _id: string,
+          expected: readonly string[],
+          next: string
+        ): 'won' | 'superseded' => {
+          casCalls.push({ expected: [...expected], next });
+          return expected.includes(cancelledExec.status) ? 'won' : 'superseded';
+        },
+      },
+      spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    } as unknown as TaskAgentManagerConfig);
+
+    const spawnPromise = tam.createSubSession(TASK_ID, 'cancelled-target-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+    });
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage fresh-create-bind');
+    expect(casCalls).toEqual([{ expected: [], next: 'in_progress' }]);
+    expect(cancelledExec.status).toBe('cancelled');
+  });
+
+  test('a cancelled reuse target observed by a direct caller supersedes into the abort before any transfer (PR #2770 review)', async () => {
+    const cancelledTarget = makeExecutionRow({
+      id: 'exec-cancelled-reuse',
+      agentSessionId: null,
+      status: 'cancelled',
+      startedAt: null,
+    });
+    const boundPriorOwner = makeExecutionRow({
+      id: 'exec-prior-owner-cancel',
+      workflowNodeId: 'node-prior',
+      status: 'in_progress',
+    });
+    const updates: Array<{ id: string; payload: Record<string, unknown> }> = [];
+    const casCalls: Array<{ expected: string[]; next: string }> = [];
+    const tam = new TaskAgentManager({
+      db: { getDatabase: () => new BunDatabase(':memory:') },
+      sessionManager: {
+        registerSession: () => {},
+        getCachedSession: () => undefined,
+        unregisterSession: async () => {},
+      },
+      internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+      taskRepo: {
+        getTask: () => ({ id: TASK_ID, spaceId: SPACE_ID, workflowRunId: RUN_ID, title: 'T' }),
+      },
+      nodeExecutionRepo: {
+        listByWorkflowRun: () => [cancelledTarget, boundPriorOwner],
+        listByNode: (_runId: string, nodeId: string) =>
+          nodeId === REVIEWER_NODE_ID ? [cancelledTarget] : [],
+        listByAgentSessionId: () => [boundPriorOwner],
+        update: (id: string, payload: Record<string, unknown>) => {
+          updates.push({ id, payload });
+          return null;
+        },
+        casExecutionStatus: (
+          _id: string,
+          expected: readonly string[],
+          next: string
+        ): 'won' | 'superseded' => {
+          casCalls.push({ expected: [...expected], next });
+          return 'superseded';
+        },
+      },
+      spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    } as unknown as TaskAgentManagerConfig);
+    seedLiveSession(tam);
+    stubReusePathHelpers(tam);
+
+    const spawnPromise = tam.createSubSession(TASK_ID, 'cancelled-reuse-id', minimalInit(), {
+      agentId: 'agent-reviewer',
+      agentName: REVIEWER_AGENT,
+      nodeId: REVIEWER_NODE_ID,
+    });
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage reuse-target-bind');
+    expect(casCalls).toEqual([{ expected: [], next: 'in_progress' }]);
+    expect(updates).toEqual([]);
+    expect(boundPriorOwner.status).toBe('in_progress');
+  });
+
+  test('deferFreshExecutionBind leaves the fresh target row to the guarded outer bind: no inner write, session still created (PR #2770 review)', async () => {
     const pendingExec = makeExecutionRow({
       id: 'exec-deferred',
       agentSessionId: null,
@@ -743,7 +851,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
       agentId: 'agent-reviewer',
       agentName: REVIEWER_AGENT,
       nodeId: REVIEWER_NODE_ID,
-      deferExecutionBind: true,
+      deferFreshExecutionBind: true,
     });
 
     expect(actual).toBe('deferred-id');

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-post-approval-fresh-session.test.ts
@@ -630,6 +630,7 @@ describe('createSubSession — reuse hard-constraint binding details (spawn seam
       payload: {
         status: 'idle',
         agentSessionId: null,
+        completedAt: expect.any(Number),
         __cas: ['in_progress'],
       },
     });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -121,6 +121,7 @@ export interface SpawnAdmissionCasCall {
     startedAt?: number | null;
     completedAt?: number | null;
   };
+  guards?: { expectAgentSessionId?: string | null };
 }
 
 interface SpawnHarness {
@@ -183,10 +184,11 @@ function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
         id: string,
         expected: readonly string[] | string,
         next: string,
-        payload?: SpawnAdmissionCasCall['payload']
+        payload?: SpawnAdmissionCasCall['payload'],
+        guards?: { expectAgentSessionId?: string | null }
       ): 'won' | 'superseded' => {
         const expectedList = Array.isArray(expected) ? [...expected] : [expected];
-        casCalls.push({ id, expected: expectedList, next, payload });
+        casCalls.push({ id, expected: expectedList, next, payload, guards });
         if (next === 'in_progress' && payload?.agentSessionId === 'live-session') {
           return options.rebindCasOutcome ?? 'won';
         }
@@ -623,6 +625,7 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
         startedAt: expect.any(Number),
         completedAt: null,
       },
+      guards: { expectAgentSessionId: null },
     });
   });
 
@@ -714,6 +717,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
         startedAt: expect.any(Number),
         completedAt: null,
       },
+      guards: { expectAgentSessionId: null },
     });
   });
 });
@@ -770,10 +774,11 @@ function makeActivateHarness(
         id: string,
         expected: readonly string[] | string,
         next: string,
-        payload?: SpawnAdmissionCasCall['payload']
+        payload?: SpawnAdmissionCasCall['payload'],
+        guards?: { expectAgentSessionId?: string | null }
       ): 'won' | 'superseded' => {
         const expectedList = Array.isArray(expected) ? [...expected] : [expected];
-        casCalls.push({ id, expected: expectedList, next, payload });
+        casCalls.push({ id, expected: expectedList, next, payload, guards });
         if (next === 'pending' && options.resetCasOutcome) {
           return options.resetCasOutcome;
         }

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -108,25 +108,43 @@ interface SpawnHarnessOptions {
   worktreeGate?: Promise<{ path: string }>;
   missingAgent?: boolean;
   failEnsure?: boolean;
+  bindCasOutcome?: 'won' | 'superseded';
+  rebindCasOutcome?: 'won' | 'superseded';
+}
+
+export interface SpawnAdmissionCasCall {
+  id: string;
+  expected: string[];
+  next: string;
+  payload?: {
+    agentSessionId?: string | null;
+    startedAt?: number | null;
+    completedAt?: number | null;
+  };
 }
 
 interface SpawnHarness {
   tam: TaskAgentManager;
   updates: Array<{ id: string; patch: Record<string, unknown> }>;
+  casCalls: SpawnAdmissionCasCall[];
   order: string[];
   cancels: string[];
-  setReadback: (row: NodeExecution | null) => void;
+  reservations: string[];
+  reservationReleases: string[];
   spawn: () => Promise<string>;
 }
 
 function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
   const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const casCalls: SpawnAdmissionCasCall[] = [];
   const order: string[] = [];
   const cancels: string[] = [];
+  const reservations: string[] = [];
+  const reservationReleases: string[] = [];
   const row = options.execution ?? makeExecution();
   const dbRow: NodeExecution = { ...row };
   const taskStatus = options.taskStatus ?? 'in_progress';
-  let readback: NodeExecution | null | undefined;
+  const heldReservations = new Set<string>();
 
   const tam = new TaskAgentManager({
     db: { getDatabase: () => new BunDatabase(':memory:'), getSession: () => null },
@@ -135,6 +153,17 @@ function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
     taskRepo: {
       getTask: (id: string) =>
         options.taskMissing || id !== TASK_ID ? undefined : makeTask(taskStatus),
+      reserveSpawnForTick: (taskId: string, allowed: readonly string[]): 'won' | 'superseded' => {
+        reservations.push(taskId);
+        if (heldReservations.has(taskId)) return 'superseded';
+        if (!allowed.includes(taskStatus)) return 'superseded';
+        heldReservations.add(taskId);
+        return 'won';
+      },
+      releaseSpawnReservation: (taskId: string) => {
+        reservationReleases.push(taskId);
+        heldReservations.delete(taskId);
+      },
     },
     nodeExecutionRepo: {
       getById: (id: string) => (id === row.id ? dbRow : undefined),
@@ -147,8 +176,31 @@ function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
           order.push('execution-bind');
         }
         if (id === row.id) Object.assign(dbRow, patch);
-        if (readback !== undefined) return readback;
         return { ...dbRow };
+      },
+      casExecutionStatus: (
+        id: string,
+        expected: readonly string[] | string,
+        next: string,
+        payload?: SpawnAdmissionCasCall['payload']
+      ): 'won' | 'superseded' => {
+        const expectedList = Array.isArray(expected) ? [...expected] : [expected];
+        casCalls.push({ id, expected: expectedList, next, payload });
+        if (next === 'in_progress' && payload?.agentSessionId === 'live-session') {
+          return options.rebindCasOutcome ?? 'won';
+        }
+        if (options.bindCasOutcome && next === 'in_progress' && payload?.agentSessionId) {
+          return options.bindCasOutcome;
+        }
+        if (id !== row.id || !expectedList.includes(dbRow.status)) return 'superseded';
+        dbRow.status = next as NodeExecution['status'];
+        if (payload?.agentSessionId !== undefined) dbRow.agentSessionId = payload.agentSessionId;
+        if (payload?.startedAt !== undefined) dbRow.startedAt = payload.startedAt;
+        if (payload?.completedAt !== undefined) dbRow.completedAt = payload.completedAt;
+        if (next === 'in_progress' && payload?.agentSessionId === SPAWNED_SESSION_ID) {
+          order.push('execution-bind');
+        }
+        return 'won';
       },
     },
     spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
@@ -203,11 +255,11 @@ function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
   return {
     tam,
     updates,
+    casCalls,
     order,
     cancels,
-    setReadback: (value) => {
-      readback = value;
-    },
+    reservations,
+    reservationReleases,
     spawn: () =>
       tam.spawnWorkflowNodeAgentForExecution(
         task,
@@ -232,7 +284,7 @@ function seedIndexedSession(
 }
 
 describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
-  test('indexed live session is reused: rebinds the execution to in_progress and returns the id', async () => {
+  test('indexed live session is reused: rebinds the execution to in_progress via CAS and returns the id', async () => {
     const h = makeSpawnHarness({
       execution: makeExecution({
         agentSessionId: 'live-session',
@@ -246,11 +298,13 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     const result = await h.spawn();
 
     expect(result).toBe('live-session');
-    expect(h.updates).toHaveLength(1);
-    expect(h.updates[0]).toEqual({
+    expect(h.updates).toEqual([]);
+    expect(h.casCalls).toHaveLength(1);
+    expect(h.casCalls[0]).toEqual({
       id: 'exec-1',
-      patch: {
-        status: 'in_progress',
+      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      next: 'in_progress',
+      payload: {
         agentSessionId: 'live-session',
         startedAt: 1234,
         completedAt: null,
@@ -259,7 +313,7 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     expect(h.order).toEqual([]);
   });
 
-  test('live-session reuse precedes task validation: an archived task still rebinds (BEFORE picture)', async () => {
+  test('live-session reuse precedes task validation: an archived task still rebinds', async () => {
     const h = makeSpawnHarness({
       taskStatus: 'archived',
       execution: makeExecution({
@@ -273,15 +327,11 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     const result = await h.spawn();
 
     expect(result).toBe('live-session');
-    expect(h.updates).toHaveLength(1);
-    expect(h.updates[0]).toEqual({
-      id: 'exec-1',
-      patch: {
-        status: 'in_progress',
-        agentSessionId: 'live-session',
-        startedAt: 1234,
-        completedAt: null,
-      },
+    expect(h.casCalls).toHaveLength(1);
+    expect(h.casCalls[0]?.payload).toEqual({
+      agentSessionId: 'live-session',
+      startedAt: 1234,
+      completedAt: null,
     });
     expect(h.order).toEqual([]);
   });
@@ -294,7 +344,7 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
 
     await h.spawn();
 
-    expect(typeof h.updates[0]?.patch.startedAt).toBe('number');
+    expect(typeof h.casCalls[0]?.payload?.startedAt).toBe('number');
   });
 
   test('indexed but dead session: evicted from the index and spawned fresh', async () => {
@@ -386,14 +436,16 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     expect(h.order).toEqual([]);
   });
 
-  test('PARKED stopped task passes spawn admission (mid-tick-park race this chain closes in P5)', async () => {
+  test('PARKED stopped task fails the spawn reservation: no spawn, no execution write (AFTER picture, superpipe P5)', async () => {
     const h = makeSpawnHarness({ taskStatus: 'stopped', kickoff: false });
 
-    const result = await h.spawn();
+    await expect(h.spawn()).rejects.toThrow('superseded at stage reserve-task-spawn');
 
-    expect(result).toBe(SPAWNED_SESSION_ID);
-    expect(h.order).toContain('createSubSession');
-    expect(h.updates.some((u) => u.patch.status === 'in_progress')).toBe(true);
+    expect(h.order).toEqual([]);
+    expect(h.casCalls).toEqual([]);
+    expect(h.updates).toEqual([]);
+    expect(h.cancels).toEqual([]);
+    expect(h.reservationReleases).toEqual([]);
   });
 
   test('null workflow (definition vanished) is a permanent rejection', async () => {
@@ -485,7 +537,7 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent-spawn waiter', () =>
     expect(await second).toBe(SPAWNED_SESSION_ID);
     expect(await first).toBe(SPAWNED_SESSION_ID);
     expect(h.order.filter((step) => step === 'createSubSession')).toHaveLength(1);
-    expect(h.updates.some((u) => u.patch.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
+    expect(h.casCalls.some((c) => c.payload?.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
   });
 
   test('rejects when the in-flight peer fails before creating a session', async () => {
@@ -494,10 +546,16 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent-spawn waiter', () =>
 
     const first = h.spawn();
     const second = h.spawn();
+    const secondMessage = second.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
     gate.resolve({ path: '/tmp/wt-1237' });
 
     await expect(first).rejects.toThrow('Agent not found: agent-coder (task: task-1237)');
-    await expect(second).rejects.toThrow('failed before session was created');
+    expect(await secondMessage).toBe(
+      'Concurrent spawn for execution exec-1 failed before session was created'
+    );
     expect(h.cancels).toEqual([]);
     expect(h.order.filter((step) => step === 'createSubSession')).toHaveLength(0);
   });
@@ -507,16 +565,12 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent-spawn waiter', () =>
     const h = makeSpawnHarness({ kickoff: false, worktreeGate: gate.promise });
 
     const first = h.spawn();
-    const realNow = Date.now();
-    let clockOffset = 0;
-    const nowSpy = spyOn(Date, 'now').mockImplementation(() => realNow + clockOffset);
+    const restoreTimers = fireActivationTimeoutImmediately();
     try {
       const second = h.spawn();
-      clockOffset = 60_000;
       await expect(second).rejects.toThrow('timed out after 30000ms');
     } finally {
-      clockOffset = 0;
-      nowSpy.mockRestore();
+      restoreTimers();
       gate.resolve({ path: '/tmp/wt-1237' });
     }
     await expect(first).resolves.toBe(SPAWNED_SESSION_ID);
@@ -525,7 +579,7 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent-spawn waiter', () =>
 });
 
 describe('spawnWorkflowNodeAgentForExecution — post-create execution binding', () => {
-  test('ordering: createSubSession, execution bind, ensureNodeAgentAttached, completion callback, kickoff inject', async () => {
+  test('ordering: createSubSession, CAS execution bind, ensureNodeAgentAttached, completion callback, kickoff inject', async () => {
     const h = makeSpawnHarness();
 
     await h.spawn();
@@ -548,52 +602,36 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
     expect(h.order).not.toContain('kickoff-inject');
   });
 
-  test('readback returning null blocks the execution and throws corruption', async () => {
+  test('the bind carries the bindable-status precondition and the full bind payload (AFTER picture)', async () => {
     const h = makeSpawnHarness({ kickoff: false });
-    h.setReadback(null);
 
-    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
+    await h.spawn();
 
-    expect(h.updates[1]).toEqual({
+    const bind = h.casCalls.find(
+      (c) => c.payload?.agentSessionId === SPAWNED_SESSION_ID && c.next === 'in_progress'
+    );
+    expect(bind).toEqual({
       id: 'exec-1',
-      patch: {
-        status: 'blocked',
-        result: 'Execution state corruption after spawn',
-        completedAt: expect.any(Number),
+      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      next: 'in_progress',
+      payload: {
+        agentSessionId: SPAWNED_SESSION_ID,
+        startedAt: expect.any(Number),
+        completedAt: null,
       },
     });
+  });
+
+  test('a concurrent execution write that fails the bind CAS skips for this call: the spawned session is cancelled and the execution is not resurrected (AFTER picture)', async () => {
+    const h = makeSpawnHarness({ kickoff: false, bindCasOutcome: 'superseded' });
+    const spawnPromise = h.spawn();
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
+
+    expect(h.updates).toEqual([]);
     expect(h.order).not.toContain('ensureNodeAgentAttached');
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
-  });
-
-  test('readback with a mismatched status blocks the execution and throws corruption', async () => {
-    const h = makeSpawnHarness({ kickoff: false });
-    h.setReadback(
-      makeExecution({ status: 'pending', agentSessionId: SPAWNED_SESSION_ID, startedAt: 5 })
-    );
-
-    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
-    expect(h.updates[1]?.patch.status).toBe('blocked');
-  });
-
-  test('readback bound to a different session blocks the execution and throws corruption', async () => {
-    const h = makeSpawnHarness({ kickoff: false });
-    h.setReadback(
-      makeExecution({ status: 'in_progress', agentSessionId: 'other-session', startedAt: 5 })
-    );
-
-    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
-    expect(h.updates[1]?.patch.result).toBe('Execution state corruption after spawn');
-  });
-
-  test('readback without startedAt blocks the execution and throws corruption', async () => {
-    const h = makeSpawnHarness({ kickoff: false });
-    h.setReadback(
-      makeExecution({ status: 'in_progress', agentSessionId: SPAWNED_SESSION_ID, startedAt: null })
-    );
-
-    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
-    expect(h.updates[1]?.patch.status).toBe('blocked');
+    expect(h.reservationReleases).toEqual([TASK_ID]);
   });
 
   test('a failure after session creation cancels the spawned session and rethrows', async () => {
@@ -611,41 +649,44 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
   });
 });
 
-describe('spawnWorkflowNodeAgentForExecution — racy tolerated writes (BEFORE picture, ADR 0004 Phase 0)', () => {
-  test('live-session rebind writes in_progress with no precondition: a concurrent DB flip is clobbered', async () => {
+describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER picture, ADR 0004 Phase 0)', () => {
+  test('live-session rebind a CAS loses to a concurrent cancel: the cancelled row is not clobbered and the call skips', async () => {
     const h = makeSpawnHarness({
       execution: makeExecution({
         agentSessionId: 'live-session',
         status: 'in_progress',
         startedAt: 42,
       }),
+      rebindCasOutcome: 'superseded',
     });
     seedIndexedSession(h.tam, 'live-session');
-    h.setReadback(makeExecution({ agentSessionId: 'live-session', status: 'cancelled' }));
 
-    const result = await h.spawn();
+    const spawnPromise = h.spawn();
 
-    expect(result).toBe('live-session');
-    expect(h.updates[0]?.patch).toEqual({
-      status: 'in_progress',
+    await expect(spawnPromise).rejects.toThrow('superseded at stage rebind-live-session');
+    expect(h.casCalls[0]?.expected).toEqual(['pending', 'in_progress', 'idle', 'waiting_rebind']);
+    expect(h.casCalls[0]?.payload).toEqual({
       agentSessionId: 'live-session',
       startedAt: 42,
       completedAt: null,
     });
+    expect(h.updates).toEqual([]);
+    expect(h.reservations).toEqual([]);
   });
 
-  test('post-create bind carries no status precondition: exactly the in_progress bind payload', async () => {
+  test('post-create bind carries the bindable-status precondition: exactly the in_progress bind payload', async () => {
     const h = makeSpawnHarness({ kickoff: false });
 
     await h.spawn();
 
-    const bind = h.updates.find(
-      (u) => u.patch.agentSessionId === SPAWNED_SESSION_ID && u.patch.status === 'in_progress'
+    const bind = h.casCalls.find(
+      (c) => c.payload?.agentSessionId === SPAWNED_SESSION_ID && c.next === 'in_progress'
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      patch: {
-        status: 'in_progress',
+      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      next: 'in_progress',
+      payload: {
         agentSessionId: SPAWNED_SESSION_ID,
         startedAt: expect.any(Number),
         completedAt: null,
@@ -657,6 +698,7 @@ describe('spawnWorkflowNodeAgentForExecution — racy tolerated writes (BEFORE p
 interface ActivateHarness {
   tam: TaskAgentManager;
   updates: Array<{ id: string; patch: Record<string, unknown> }>;
+  casCalls: SpawnAdmissionCasCall[];
   order: string[];
   activate: (options?: {
     workflowNodeId?: string;
@@ -669,11 +711,14 @@ function makeActivateHarness(
     indexSession?: { id: string; processingStatus: string };
     workflow?: SpaceWorkflow;
     spawn?: () => Promise<string>;
+    resetCasOutcome?: 'won' | 'superseded';
   } = {}
 ): ActivateHarness {
   const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const casCalls: SpawnAdmissionCasCall[] = [];
   const order: string[] = [];
   const rows = options.executions ?? [makeExecution()];
+  const rowStatuses = new Map(rows.map((row) => [row.id, row.status]));
 
   const tam = new TaskAgentManager({
     db: { getDatabase: () => new BunDatabase(':memory:') },
@@ -697,6 +742,21 @@ function makeActivateHarness(
       update: (id: string, patch: Record<string, unknown>) => {
         updates.push({ id, patch });
         return { ...makeExecution(), ...patch };
+      },
+      casExecutionStatus: (
+        id: string,
+        expected: readonly string[] | string,
+        next: string,
+        payload?: SpawnAdmissionCasCall['payload']
+      ): 'won' | 'superseded' => {
+        const expectedList = Array.isArray(expected) ? [...expected] : [expected];
+        casCalls.push({ id, expected: expectedList, next, payload });
+        if (next === 'pending' && options.resetCasOutcome) {
+          return options.resetCasOutcome;
+        }
+        if (!expectedList.includes(rowStatuses.get(id) ?? 'pending')) return 'superseded';
+        rowStatuses.set(id, next as NodeExecution['status']);
+        return 'won';
       },
     },
     spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
@@ -724,6 +784,7 @@ function makeActivateHarness(
   return {
     tam,
     updates,
+    casCalls,
     order,
     activate: (activateOptions) =>
       tam.activateTargetSessionsForMessage(TASK_ID, RUN_ID, AGENT_NAME, activateOptions),
@@ -772,7 +833,7 @@ describe('activateTargetSessionsForMessage — admission', () => {
     expect(h.updates).toEqual([]);
   });
 
-  test('a dead session resets the execution to pending (status only) and spawns fresh', async () => {
+  test('a dead session resets the execution to pending via CAS and spawns fresh', async () => {
     const h = makeActivateHarness({
       executions: [makeExecution({ status: 'in_progress', agentSessionId: 'dead-session' })],
       indexSession: { id: 'dead-session', processingStatus: 'completed' },
@@ -784,7 +845,8 @@ describe('activateTargetSessionsForMessage — admission', () => {
       const result = await h.activate();
 
       expect(result).toEqual([{ agentName: AGENT_NAME, sessionId: 'new-session' }]);
-      expect(h.updates).toEqual([{ id: 'exec-1', patch: { status: 'pending' } }]);
+      expect(h.updates).toEqual([]);
+      expect(h.casCalls).toEqual([{ id: 'exec-1', expected: ['in_progress'], next: 'pending' }]);
       expect(index.agentSessionIndex.has('dead-session')).toBe(false);
       expect(h.order).toEqual(['activation', 'spawn']);
     } finally {
@@ -792,16 +854,19 @@ describe('activateTargetSessionsForMessage — admission', () => {
     }
   });
 
-  test('dead-session reset is an unconditional status-only write (BEFORE picture, ADR 0004 Phase 0)', async () => {
+  test('dead-session reset is CAS-guarded from the just-read status: a concurrent move skips activation for this call (AFTER picture, ADR 0004 Phase 0)', async () => {
     const h = makeActivateHarness({
       executions: [makeExecution({ status: 'in_progress', agentSessionId: 'dead-session' })],
+      resetCasOutcome: 'superseded',
     });
     const restoreTimers = fireActivationTimeoutImmediately();
 
     try {
-      await h.activate();
+      const result = await h.activate();
 
-      expect(h.updates).toEqual([{ id: 'exec-1', patch: { status: 'pending' } }]);
+      expect(result).toEqual([]);
+      expect(h.casCalls).toEqual([{ id: 'exec-1', expected: ['in_progress'], next: 'pending' }]);
+      expect(h.order).toEqual([]);
     } finally {
       restoreTimers();
     }

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -306,7 +306,7 @@ describe('spawnWorkflowNodeAgentForExecution — admission table', () => {
     expect(h.casCalls).toHaveLength(1);
     expect(h.casCalls[0]).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      expected: ['idle'],
       next: 'in_progress',
       payload: {
         agentSessionId: 'live-session',
@@ -616,7 +616,7 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending'],
+      expected: ['pending', 'in_progress'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,
@@ -687,7 +687,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
     const spawnPromise = h.spawn();
 
     await expect(spawnPromise).rejects.toThrow('superseded at stage rebind-live-session');
-    expect(h.casCalls[0]?.expected).toEqual(['pending', 'in_progress', 'idle', 'waiting_rebind']);
+    expect(h.casCalls[0]?.expected).toEqual(['in_progress']);
     expect(h.casCalls[0]?.payload).toEqual({
       agentSessionId: 'live-session',
       startedAt: 42,
@@ -707,7 +707,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending'],
+      expected: ['pending', 'in_progress'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -616,7 +616,7 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress'],
+      expected: ['pending'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,
@@ -707,7 +707,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress'],
+      expected: ['pending'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-admission.test.ts
@@ -131,6 +131,7 @@ interface SpawnHarness {
   cancels: string[];
   reservations: string[];
   reservationReleases: string[];
+  flipExecutionStatus: (status: string) => void;
   spawn: () => Promise<string>;
 }
 
@@ -260,6 +261,9 @@ function makeSpawnHarness(options: SpawnHarnessOptions = {}): SpawnHarness {
     cancels,
     reservations,
     reservationReleases,
+    flipExecutionStatus: (status: string) => {
+      dbRow.status = status as NodeExecution['status'];
+    },
     spawn: () =>
       tam.spawnWorkflowNodeAgentForExecution(
         task,
@@ -602,7 +606,7 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
     expect(h.order).not.toContain('kickoff-inject');
   });
 
-  test('the bind carries the bindable-status precondition and the full bind payload (AFTER picture)', async () => {
+  test('the bind carries the observed-status precondition and the full bind payload (AFTER picture)', async () => {
     const h = makeSpawnHarness({ kickoff: false });
 
     await h.spawn();
@@ -612,7 +616,7 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      expected: ['pending', 'in_progress'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,
@@ -620,6 +624,25 @@ describe('spawnWorkflowNodeAgentForExecution — post-create execution binding',
         completedAt: null,
       },
     });
+  });
+
+  test('a mid-spawn quiesce to idle (observed pending) fails the bind CAS: no resurrection of the quiesced row (PR #2770 review)', async () => {
+    const h = makeSpawnHarness({ kickoff: false });
+    const internal = h.tam as unknown as {
+      createSubSession: (...args: unknown[]) => Promise<string>;
+    };
+    const originalCreate = internal.createSubSession.bind(internal);
+    internal.createSubSession = async (...args: unknown[]) => {
+      const sessionId = await originalCreate(...args);
+      h.flipExecutionStatus('idle');
+      return sessionId;
+    };
+
+    const spawnPromise = h.spawn();
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.order).not.toContain('ensureNodeAgentAttached');
   });
 
   test('a concurrent execution write that fails the bind CAS skips for this call: the spawned session is cancelled and the execution is not resurrected (AFTER picture)', async () => {
@@ -674,7 +697,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
     expect(h.reservations).toEqual([]);
   });
 
-  test('post-create bind carries the bindable-status precondition: exactly the in_progress bind payload', async () => {
+  test('post-create bind carries the observed-status precondition: exactly the in_progress bind payload', async () => {
     const h = makeSpawnHarness({ kickoff: false });
 
     await h.spawn();
@@ -684,7 +707,7 @@ describe('spawnWorkflowNodeAgentForExecution — CAS-guarded spawn writes (AFTER
     );
     expect(bind).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      expected: ['pending', 'in_progress'],
       next: 'in_progress',
       payload: {
         agentSessionId: SPAWNED_SESSION_ID,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
@@ -257,6 +257,31 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent park/cancel during s
     process.off('unhandledRejection', onUnhandled);
   });
 
+  test('a mid-spawn quiesce to idle is not laundered by an inner pre-bind: the flow path defers to the observed-status outer bind (PR #2770 review)', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+    const h = makeRealRepoHarness();
+    const execution = makeExecutionRow(h.execRepo, h.runId);
+    const spawnPromise = h.spawn(execution);
+    const spawnMessage = spawnPromise.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    h.execRepo.updateStatus(execution.id, 'idle');
+    h.releaseWorkspaceGate({ path: '/tmp/wt-1241' });
+
+    expect(await spawnMessage).toContain('superseded at stage bind-execution-session');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    const row = h.execRepo.getById(execution.id);
+    expect(row?.status).toBe('idle');
+    expect(row?.agentSessionId).toBeNull();
+    expect(h.order).not.toContain('ensureNodeAgentAttached');
+    expect(unhandled).toEqual([]);
+    process.off('unhandledRejection', onUnhandled);
+  });
+
   test('a spawned execution binds through CAS and the task reservation is released on success', async () => {
     const h = makeRealRepoHarness();
     const execution = makeExecutionRow(h.execRepo, h.runId);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  NodeExecution,
+  Space,
+  SpaceTask,
+  SpaceWorkflow,
+  SpaceWorkflowRun,
+} from '@hyperneo/shared';
+import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
+import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
+import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
+import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+const TASK_ID = 'task-1241';
+const RUN_ID = 'run-1241';
+const SPACE_ID = 'space-1241';
+const NODE_ID = 'node-coder';
+const AGENT_NAME = 'coder';
+const AGENT_ID = 'agent-coder';
+const SPAWNED_SESSION_ID = 'spawned-session-real-1';
+
+function makeExecutionRow(execRepo: NodeExecutionRepository, runId: string): NodeExecution {
+  return execRepo.create({
+    workflowRunId: runId,
+    workflowNodeId: NODE_ID,
+    agentName: AGENT_NAME,
+    agentId: AGENT_ID,
+    status: 'pending',
+  });
+}
+
+function makeWorkflow(): SpaceWorkflow {
+  return {
+    id: 'wf-1',
+    spaceId: SPACE_ID,
+    name: 'Coding',
+    nodes: [
+      { id: NODE_ID, agents: [{ agentId: AGENT_ID, name: AGENT_NAME }] },
+      { id: 'node-reviewer', agents: [{ agentId: AGENT_ID, name: 'reviewer' }] },
+    ],
+    channels: [],
+    startNodeId: NODE_ID,
+    endNodeId: NODE_ID,
+  } as unknown as SpaceWorkflow;
+}
+
+function fakeSession(id: string): AgentSession {
+  return {
+    session: { id },
+    getProcessingState: () => ({ status: 'idle' }),
+  } as unknown as AgentSession;
+}
+
+function fakeCustomAgent() {
+  return { id: AGENT_ID, name: AGENT_NAME, customPrompt: 'work', model: 'm', tools: [] };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+interface RealRepoHarness {
+  tam: TaskAgentManager;
+  execRepo: NodeExecutionRepository;
+  taskRepo: SpaceTaskRepository;
+  runId: string;
+  cancels: string[];
+  order: string[];
+  workspaceGate: Promise<{ path: string }>;
+  releaseWorkspaceGate: (value: { path: string }) => void;
+  spawn: (execution: NodeExecution) => Promise<string>;
+}
+
+function makeRealRepoHarness(options: { taskStatus?: string } = {}): RealRepoHarness {
+  const db = new BunDatabase(':memory:');
+  createSpaceTables(db);
+  const spaceRow = new SpaceRepository(db).createSpace({
+    workspacePath: '/tmp/ws-1241',
+    slug: 'spawn-cas',
+    name: 'Spawn CAS',
+  } as never);
+  const spaceId = spaceRow.id;
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+  ).run('wf-1241', spaceId, 'Coding', now, now);
+  const runRow = new SpaceWorkflowRunRepository(db).createRun({
+    spaceId,
+    workflowId: 'wf-1241',
+    title: 'Run #1',
+  });
+  db.prepare(
+    `INSERT INTO space_agents (id, space_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
+  ).run(AGENT_ID, spaceId, 'Coder', now, now);
+  const execRepo = new NodeExecutionRepository(db);
+  const taskRepo = new SpaceTaskRepository(db);
+  const cancels: string[] = [];
+  const order: string[] = [];
+  const workspaceGate = deferred<{ path: string }>();
+
+  taskRepo.createTaskWithId(TASK_ID, {
+    spaceId,
+    workflowRunId: runRow.id,
+    title: 'After-picture spawn CAS',
+    description: '',
+    status: options.taskStatus ?? 'in_progress',
+  } as never);
+
+  const tam = new TaskAgentManager({
+    db: { getDatabase: () => db, getSession: () => null },
+    sessionManager: { registerSession: () => {}, getSession: () => undefined },
+    internalEventBus: new InternalEventBus<DaemonInternalEventMap>(),
+    taskRepo,
+    nodeExecutionRepo: execRepo,
+    spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
+    spaceAgentManager: {
+      getById: (id: string) => (id !== AGENT_ID ? undefined : fakeCustomAgent()),
+    },
+    worktreeManager: { createTaskWorktree: () => workspaceGate.promise },
+  } as unknown as TaskAgentManagerConfig);
+
+  const internal = tam as unknown as {
+    createSubSession: (...args: unknown[]) => Promise<string>;
+    getSubSession: (id: string) => AgentSession | undefined;
+    ensureNodeAgentAttached: (...args: unknown[]) => Promise<void>;
+    registerCompletionCallback: (...args: unknown[]) => void;
+    injectMessageIntoSession: (...args: unknown[]) => Promise<string>;
+    cancelBySessionId: (id: string) => void;
+    buildNodeAgentMcpServerForSession: (...args: unknown[]) => unknown;
+  };
+  internal.createSubSession = async () => {
+    order.push('createSubSession');
+    return SPAWNED_SESSION_ID;
+  };
+  internal.getSubSession = (id: string) =>
+    id === SPAWNED_SESSION_ID ? fakeSession(id) : undefined;
+  internal.ensureNodeAgentAttached = async () => {
+    order.push('ensureNodeAgentAttached');
+  };
+  internal.registerCompletionCallback = () => {};
+  internal.injectMessageIntoSession = async () => 'msg-id';
+  internal.cancelBySessionId = (id: string) => {
+    cancels.push(id);
+  };
+  internal.buildNodeAgentMcpServerForSession = () => ({ __role: 'node-agent' });
+
+  const task = {
+    id: TASK_ID,
+    spaceId: SPACE_ID,
+    workflowRunId: RUN_ID,
+    title: 'After-picture spawn CAS',
+    description: '',
+    status: options.taskStatus ?? 'in_progress',
+  } as unknown as SpaceTask;
+  const space = { id: SPACE_ID, workspacePath: '/tmp/ws' } as unknown as Space;
+  const workflowRun = {
+    id: RUN_ID,
+    workflowId: 'wf-1',
+    status: 'in_progress',
+  } as unknown as SpaceWorkflowRun;
+
+  return {
+    tam,
+    execRepo,
+    taskRepo,
+    runId: runRow.id,
+    cancels,
+    order,
+    workspaceGate: workspaceGate.promise,
+    releaseWorkspaceGate: workspaceGate.resolve,
+    spawn: (execution) =>
+      tam.spawnWorkflowNodeAgentForExecution(task, space, makeWorkflow(), workflowRun, execution, {
+        kickoff: false,
+      }),
+  };
+}
+
+describe('spawnWorkflowNodeAgentForExecution — concurrent park/cancel during spawn (AFTER picture, superpipe P5)', () => {
+  test('a mid-spawn-loop park (task → stopped) supersedes the next execution reservation: the remainder does not spawn, no unhandled rejection', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+    const h = makeRealRepoHarness();
+    const first = makeExecutionRow(h.execRepo, h.runId);
+    const remainder = h.execRepo.create({
+      workflowRunId: h.runId,
+      workflowNodeId: 'node-reviewer',
+      agentName: 'reviewer',
+      agentId: AGENT_ID,
+      status: 'pending',
+    });
+    const firstSpawn = h.spawn(first);
+    const firstSpawnMessage = firstSpawn.then(
+      (id) => `resolved:${id}`,
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    h.taskRepo.updateTask(TASK_ID, { status: 'stopped' });
+    const remainderSpawn = h.spawn(remainder);
+    const remainderMessage = remainderSpawn.then(
+      (id) => `resolved:${id}`,
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+    h.releaseWorkspaceGate({ path: '/tmp/wt-1241' });
+
+    expect(await remainderMessage).toContain('superseded at stage reserve-task-spawn');
+    expect(h.execRepo.getById(remainder.id)?.status).toBe('pending');
+    expect(h.execRepo.getById(remainder.id)?.agentSessionId).toBeNull();
+    expect(await firstSpawnMessage).toBe(`resolved:${SPAWNED_SESSION_ID}`);
+    expect(h.execRepo.getById(first.id)?.status).toBe('in_progress');
+    const task = h.taskRepo.getTask(TASK_ID);
+    expect(task?.status).toBe('stopped');
+    expect(unhandled).toEqual([]);
+    process.off('unhandledRejection', onUnhandled);
+  });
+
+  test('a mid-spawn execution cancel loses nothing: the bind CAS supersedes, the spawned session is compensated, and the cancelled row is not resurrected', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+    const h = makeRealRepoHarness();
+    const execution = makeExecutionRow(h.execRepo, h.runId);
+    const spawnPromise = h.spawn(execution);
+    const spawnMessage = spawnPromise.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    h.execRepo.update(execution.id, {
+      status: 'cancelled',
+      result: 'cancelled concurrently',
+      completedAt: Date.now(),
+    });
+    h.releaseWorkspaceGate({ path: '/tmp/wt-1241' });
+
+    expect(await spawnMessage).toContain('superseded at stage bind-execution-session');
+    expect(h.order).toEqual(['createSubSession']);
+    expect(h.order).not.toContain('ensureNodeAgentAttached');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    const row = h.execRepo.getById(execution.id);
+    expect(row?.status).toBe('cancelled');
+    expect(row?.result).toBe('cancelled concurrently');
+    expect(row?.agentSessionId).toBeNull();
+    expect(h.taskRepo.getTask(TASK_ID)?.status).toBe('in_progress');
+    expect(unhandled).toEqual([]);
+    process.off('unhandledRejection', onUnhandled);
+  });
+
+  test('a spawned execution binds through CAS and the task reservation is released on success', async () => {
+    const h = makeRealRepoHarness();
+    const execution = makeExecutionRow(h.execRepo, h.runId);
+    const spawnPromise = h.spawn(execution);
+
+    h.releaseWorkspaceGate({ path: '/tmp/wt-1241' });
+
+    await expect(spawnPromise).resolves.toBe(SPAWNED_SESSION_ID);
+    const row = h.execRepo.getById(execution.id);
+    expect(row?.status).toBe('in_progress');
+    expect(row?.agentSessionId).toBe(SPAWNED_SESSION_ID);
+    expect(row?.startedAt).not.toBeNull();
+    const task = h.taskRepo.getTask(TASK_ID);
+    expect(task).not.toBeNull();
+    expect(h.taskRepo.reserveSpawnForTick(TASK_ID, ['in_progress', 'open'])).toBe('won');
+  });
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-cas.test.ts
@@ -273,4 +273,45 @@ describe('spawnWorkflowNodeAgentForExecution — concurrent park/cancel during s
     expect(task).not.toBeNull();
     expect(h.taskRepo.reserveSpawnForTick(TASK_ID, ['in_progress', 'open'])).toBe('won');
   });
+
+  test('an attach stall releases the task reservation before slow post-bind work: a sibling execution still spawns (PR #2770 review)', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.on('unhandledRejection', onUnhandled);
+    const attachGate = deferred<void>();
+    const h = makeRealRepoHarness();
+    h.tam as unknown as { ensureNodeAgentAttached: (...args: unknown[]) => Promise<void> };
+    const internal = h.tam as unknown as {
+      ensureNodeAgentAttached: (...args: unknown[]) => Promise<void>;
+    };
+    const originalAttach = internal.ensureNodeAgentAttached.bind(internal);
+    let attachCalls = 0;
+    internal.ensureNodeAgentAttached = async (...args: unknown[]) => {
+      attachCalls += 1;
+      if (attachCalls === 1) await attachGate.promise;
+      await originalAttach(...args);
+    };
+    const first = makeExecutionRow(h.execRepo, h.runId);
+    const sibling = h.execRepo.create({
+      workflowRunId: h.runId,
+      workflowNodeId: 'node-reviewer',
+      agentName: 'reviewer',
+      agentId: AGENT_ID,
+      status: 'pending',
+    });
+
+    const firstSpawn = h.spawn(first);
+    h.releaseWorkspaceGate({ path: '/tmp/wt-1241' });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const siblingSpawn = h.spawn(sibling);
+
+    await expect(siblingSpawn).resolves.toBe(SPAWNED_SESSION_ID);
+    expect(h.execRepo.getById(sibling.id)?.status).toBe('in_progress');
+    expect(h.execRepo.getById(first.id)?.status).toBe('in_progress');
+
+    attachGate.resolve();
+    await expect(firstSpawn).resolves.toBe(SPAWNED_SESSION_ID);
+    expect(unhandled).toEqual([]);
+    process.off('unhandledRejection', onUnhandled);
+  });
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -118,6 +118,7 @@ interface SpawnFlowHarnessOptions {
   kickoffGate?: Promise<void>;
   failEnsure?: boolean;
   bindCasOutcome?: 'won' | 'superseded';
+  sessionReused?: boolean;
 }
 
 interface SpawnFlowHarness {
@@ -214,8 +215,12 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
     buildNodeAgentMcpServerForSession: (...args: unknown[]) => unknown;
     spawningExecutionIds: Set<string>;
   };
-  internal.createSubSession = async () => {
+  internal.createSubSession = async (...args: unknown[]) => {
     order.push('createSubSession');
+    if (options.sessionReused) {
+      const memberInfo = args[3] as { onSessionReused?: (id: string) => void } | undefined;
+      memberInfo?.onSessionReused?.(SPAWNED_SESSION_ID);
+    }
     return SPAWNED_SESSION_ID;
   };
   internal.getSubSession = (id: string) =>
@@ -332,7 +337,7 @@ describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () =
     expect(result).toBe('live-session');
     expect(h.casCalls[0]).toEqual({
       id: 'exec-1',
-      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      expected: ['idle'],
       next: 'in_progress',
       payload: {
         agentSessionId: 'live-session',
@@ -429,6 +434,20 @@ describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () =
 
     await expect(h.spawn()).rejects.toThrow('attach boom');
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservationReleases).toEqual([TASK_ID]);
+  });
+
+  test('a reused session is never cancelled by spawn compensation — it stays owned by its prior node (PR #2770 review)', async () => {
+    const h = makeSpawnFlowHarness({
+      kickoff: false,
+      bindCasOutcome: 'superseded',
+      sessionReused: true,
+    });
+    const spawnPromise = h.spawn();
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
+    expect(h.cancels).toEqual([]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
     expect(h.reservationReleases).toEqual([TASK_ID]);
   });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import type {
   NodeExecution,
   Space,
@@ -115,6 +115,7 @@ interface SpawnFlowHarnessOptions {
   workflow?: SpaceWorkflow | null;
   kickoff?: boolean;
   worktreeGate?: Promise<{ path: string }>;
+  kickoffGate?: Promise<void>;
   failEnsure?: boolean;
   bindCasOutcome?: 'won' | 'superseded';
 }
@@ -227,6 +228,7 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
     order.push('registerCompletionCallback');
   };
   internal.injectMessageIntoSession = async () => {
+    if (options.kickoffGate) await options.kickoffGate;
     order.push('kickoff-inject');
     return 'msg-id';
   };
@@ -273,6 +275,21 @@ function seedIndexedSession(
     sessionId,
     fakeSession(sessionId, processingStatus)
   );
+}
+
+function fireLongTimersImmediately(): () => void {
+  const originalSetTimeout = globalThis.setTimeout;
+  const spy = spyOn(globalThis, 'setTimeout').mockImplementation(((
+    callback: () => void,
+    delay?: number
+  ) => {
+    const effective = typeof delay === 'number' ? delay : 0;
+    if (effective >= 30_000) {
+      return originalSetTimeout(callback, 0);
+    }
+    return originalSetTimeout(callback, effective);
+  }) as unknown as typeof setTimeout);
+  return () => spy.mockRestore();
 }
 
 describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () => {
@@ -449,5 +466,73 @@ describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () =
     expect(await first).toBe(SPAWNED_SESSION_ID);
     expect(h.order.filter((step) => step === 'createSubSession')).toHaveLength(1);
     expect(h.casCalls.some((c) => c.payload?.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
+  });
+
+  test('waiters settle at the winning bind, not after kickoff: a slow attach/kickoff cannot time out a waiting peer (PR #2770 review)', async () => {
+    const gate = deferred<{ path: string }>();
+    const kickoffGate = deferred<void>();
+    const h = makeSpawnFlowHarness({
+      worktreeGate: gate.promise,
+      kickoffGate: kickoffGate.promise,
+    });
+
+    const first = h.spawn();
+    const second = h.spawn();
+    gate.resolve({ path: '/tmp/wt-1240' });
+
+    expect(await second).toBe(SPAWNED_SESSION_ID);
+    expect(h.order).toContain('execution-bind');
+    expect(h.order).not.toContain('kickoff-inject');
+    expect(
+      (h.tam as unknown as { concurrentSpawnWaiters: Map<string, unknown[]> })
+        .concurrentSpawnWaiters.size
+    ).toBe(0);
+
+    kickoffGate.resolve();
+    expect(await first).toBe(SPAWNED_SESSION_ID);
+    expect(h.order).toContain('kickoff-inject');
+  });
+
+  test('a timed-out waiter removes itself from the waiter map (PR #2770 review)', async () => {
+    const restoreTimers = fireLongTimersImmediately();
+    const h = makeSpawnFlowHarness({ kickoff: false });
+    h.spawningIds().add('exec-1');
+    const waiters = (h.tam as unknown as { concurrentSpawnWaiters: Map<string, unknown[]> })
+      .concurrentSpawnWaiters;
+
+    const waitPromise = (
+      h.tam as unknown as {
+        waitForConcurrentSpawnSession: (execution: NodeExecution) => Promise<string>;
+      }
+    ).waitForConcurrentSpawnSession(makeExecution());
+    const message = waitPromise.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    expect(await message).toBe('Concurrent spawn for execution exec-1 timed out after 30000ms');
+    expect(waiters.size).toBe(0);
+    restoreTimers();
+  });
+
+  test('cleanupAll settles pending waiters as failed (PR #2770 review)', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false });
+    h.spawningIds().add('exec-1');
+
+    const waitPromise = (
+      h.tam as unknown as {
+        waitForConcurrentSpawnSession: (execution: NodeExecution) => Promise<string>;
+      }
+    ).waitForConcurrentSpawnSession(makeExecution());
+    const message = waitPromise.then(
+      () => 'resolved',
+      (err: unknown) => (err instanceof Error ? err.message : String(err))
+    );
+
+    await h.tam.cleanupAll();
+
+    expect(await message).toBe(
+      'Concurrent spawn for execution exec-1 failed before session was created'
+    );
   });
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -105,6 +105,7 @@ export interface CasCall {
     startedAt?: number | null;
     completedAt?: number | null;
   };
+  guards?: { expectAgentSessionId?: string | null };
 }
 
 interface SpawnFlowHarnessOptions {
@@ -118,7 +119,6 @@ interface SpawnFlowHarnessOptions {
   kickoffGate?: Promise<void>;
   failEnsure?: boolean;
   bindCasOutcome?: 'won' | 'superseded';
-  sessionReused?: boolean;
 }
 
 interface SpawnFlowHarness {
@@ -130,6 +130,7 @@ interface SpawnFlowHarness {
   reservations: string[];
   reservationReleases: string[];
   spawningIds: () => Set<string>;
+  setExecutionSessionId: (sessionId: string | null) => void;
   spawn: () => Promise<string>;
 }
 
@@ -178,12 +179,19 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
         id: string,
         expected: readonly string[] | string,
         next: string,
-        payload?: CasCall['payload']
+        payload?: CasCall['payload'],
+        guards?: { expectAgentSessionId?: string | null }
       ): 'won' | 'superseded' => {
         const expectedList = Array.isArray(expected) ? [...expected] : [expected];
-        casCalls.push({ id, expected: expectedList, next, payload });
+        casCalls.push({ id, expected: expectedList, next, payload, guards });
         if (options.bindCasOutcome && next === 'in_progress' && payload?.agentSessionId) {
           return options.bindCasOutcome;
+        }
+        if (
+          guards?.expectAgentSessionId !== undefined &&
+          dbRow.agentSessionId !== guards.expectAgentSessionId
+        ) {
+          return 'superseded';
         }
         if (id !== row.id || !expectedList.includes(dbRow.status)) return 'superseded';
         dbRow.status = next as NodeExecution['status'];
@@ -215,12 +223,8 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
     buildNodeAgentMcpServerForSession: (...args: unknown[]) => unknown;
     spawningExecutionIds: Set<string>;
   };
-  internal.createSubSession = async (...args: unknown[]) => {
+  internal.createSubSession = async () => {
     order.push('createSubSession');
-    if (options.sessionReused) {
-      const memberInfo = args[3] as { onSessionReused?: (id: string) => void } | undefined;
-      memberInfo?.onSessionReused?.(SPAWNED_SESSION_ID);
-    }
     return SPAWNED_SESSION_ID;
   };
   internal.getSubSession = (id: string) =>
@@ -259,6 +263,9 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
     reservations,
     reservationReleases,
     spawningIds: () => internal.spawningExecutionIds,
+    setExecutionSessionId: (sessionId) => {
+      dbRow.agentSessionId = sessionId;
+    },
     spawn: () =>
       tam.spawnWorkflowNodeAgentForExecution(
         task,
@@ -427,6 +434,28 @@ describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () =
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
     expect(h.reservationReleases).toEqual([TASK_ID]);
+  });
+
+  test('a foreign session binding landing mid-spawn fails the bind identity guard: no overwrite, session compensated, foreign binding survives (PR #2770 review)', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false });
+    const internal = h.tam as unknown as {
+      createSubSession: (...args: unknown[]) => Promise<string>;
+    };
+    const originalCreate = internal.createSubSession.bind(internal);
+    internal.createSubSession = async (...args: unknown[]) => {
+      const sessionId = await originalCreate(...args);
+      h.setExecutionSessionId('foreign-direct-session');
+      return sessionId;
+    };
+
+    const spawnPromise = h.spawn();
+
+    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.order).not.toContain('ensureNodeAgentAttached');
+    expect(h.casCalls.some((c) => c.payload?.agentSessionId === 'foreign-direct-session')).toBe(
+      false
+    );
   });
 
   test('a failure after session creation cancels the spawned session, releases the reservation, and rethrows', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -11,6 +11,7 @@ import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-
 import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
 import type { TaskAgentManagerConfig } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { SpawnSupersededError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import { PermanentSpawnError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
 
@@ -95,6 +96,17 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   return { promise, resolve };
 }
 
+export interface CasCall {
+  id: string;
+  expected: string[];
+  next: string;
+  payload?: {
+    agentSessionId?: string | null;
+    startedAt?: number | null;
+    completedAt?: number | null;
+  };
+}
+
 interface SpawnFlowHarnessOptions {
   taskStatus?: string;
   callerTask?: SpaceTask;
@@ -104,26 +116,32 @@ interface SpawnFlowHarnessOptions {
   kickoff?: boolean;
   worktreeGate?: Promise<{ path: string }>;
   failEnsure?: boolean;
+  bindCasOutcome?: 'won' | 'superseded';
 }
 
 interface SpawnFlowHarness {
   tam: TaskAgentManager;
   updates: Array<{ id: string; patch: Record<string, unknown> }>;
+  casCalls: CasCall[];
   order: string[];
   cancels: string[];
-  setReadback: (row: NodeExecution | null) => void;
+  reservations: string[];
+  reservationReleases: string[];
   spawningIds: () => Set<string>;
   spawn: () => Promise<string>;
 }
 
 function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowHarness {
   const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const casCalls: CasCall[] = [];
   const order: string[] = [];
   const cancels: string[] = [];
+  const reservations: string[] = [];
+  const reservationReleases: string[] = [];
   const row = options.execution ?? makeExecution();
   const dbRow: NodeExecution = { ...row };
   const taskStatus = options.taskStatus ?? 'in_progress';
-  let readback: NodeExecution | null | undefined;
+  const heldReservations = new Set<string>();
 
   const tam = new TaskAgentManager({
     db: { getDatabase: () => new BunDatabase(':memory:'), getSession: () => null },
@@ -132,6 +150,17 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
     taskRepo: {
       getTask: (id: string) =>
         options.taskMissing || id !== TASK_ID ? undefined : makeTask(taskStatus),
+      reserveSpawnForTick: (taskId: string, allowed: readonly string[]): 'won' | 'superseded' => {
+        reservations.push(taskId);
+        if (heldReservations.has(taskId)) return 'superseded';
+        if (!allowed.includes(taskStatus)) return 'superseded';
+        heldReservations.add(taskId);
+        return 'won';
+      },
+      releaseSpawnReservation: (taskId: string) => {
+        reservationReleases.push(taskId);
+        heldReservations.delete(taskId);
+      },
     },
     nodeExecutionRepo: {
       getById: (id: string) => (id === row.id ? dbRow : undefined),
@@ -140,12 +169,29 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
         runId === RUN_ID && nodeId === row.workflowNodeId ? [row] : [],
       update: (id: string, patch: Record<string, unknown>) => {
         updates.push({ id, patch });
-        if (patch.status === 'in_progress' && patch.agentSessionId === SPAWNED_SESSION_ID) {
+        if (id === row.id) Object.assign(dbRow, patch);
+        return { ...dbRow };
+      },
+      casExecutionStatus: (
+        id: string,
+        expected: readonly string[] | string,
+        next: string,
+        payload?: CasCall['payload']
+      ): 'won' | 'superseded' => {
+        const expectedList = Array.isArray(expected) ? [...expected] : [expected];
+        casCalls.push({ id, expected: expectedList, next, payload });
+        if (options.bindCasOutcome && next === 'in_progress' && payload?.agentSessionId) {
+          return options.bindCasOutcome;
+        }
+        if (id !== row.id || !expectedList.includes(dbRow.status)) return 'superseded';
+        dbRow.status = next as NodeExecution['status'];
+        if (payload?.agentSessionId !== undefined) dbRow.agentSessionId = payload.agentSessionId;
+        if (payload?.startedAt !== undefined) dbRow.startedAt = payload.startedAt;
+        if (payload?.completedAt !== undefined) dbRow.completedAt = payload.completedAt;
+        if (next === 'in_progress' && payload?.agentSessionId === SPAWNED_SESSION_ID) {
           order.push('execution-bind');
         }
-        if (id === row.id) Object.assign(dbRow, patch);
-        if (readback !== undefined) return readback;
-        return { ...dbRow };
+        return 'won';
       },
     },
     spaceManager: { getSpace: async () => ({ id: SPACE_ID, workspacePath: '/tmp/ws' }) },
@@ -200,14 +246,14 @@ function makeSpawnFlowHarness(options: SpawnFlowHarnessOptions = {}): SpawnFlowH
   return {
     tam,
     updates,
+    casCalls,
     order,
     cancels,
-    setReadback: (value) => {
-      readback = value;
-    },
+    reservations,
+    reservationReleases,
     spawningIds: () => internal.spawningExecutionIds,
     spawn: () =>
-      tam.spawnWorkflowNodeAgentForExecutionViaFlow(
+      tam.spawnWorkflowNodeAgentForExecution(
         task,
         space,
         (options.workflow === undefined ? makeWorkflow() : options.workflow) as SpaceWorkflow,
@@ -229,8 +275,8 @@ function seedIndexedSession(
   );
 }
 
-describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parity', () => {
-  test('ordering: createSubSession, execution bind, ensureNodeAgentAttached, completion callback, kickoff inject', async () => {
+describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () => {
+  test('ordering: createSubSession, CAS bind, ensureNodeAgentAttached, completion callback, kickoff inject, reservation released', async () => {
     const h = makeSpawnFlowHarness();
 
     const result = await h.spawn();
@@ -244,6 +290,8 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
       'kickoff-inject',
     ]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservations).toEqual([TASK_ID]);
+    expect(h.reservationReleases).toEqual([TASK_ID]);
   });
 
   test('kickoff inject runs only when options.kickoff allows it', async () => {
@@ -256,7 +304,7 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     expect(h.spawningIds().has('exec-1')).toBe(false);
   });
 
-  test('indexed live session is reused: rebinds the execution and returns the id without spawning', async () => {
+  test('indexed live session is reused: rebinds the execution via CAS and returns the id without spawning or reserving', async () => {
     const h = makeSpawnFlowHarness({
       execution: makeExecution({ agentSessionId: 'live-session', status: 'idle' }),
     });
@@ -265,16 +313,18 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     const result = await h.spawn();
 
     expect(result).toBe('live-session');
-    expect(h.updates[0]).toEqual({
+    expect(h.casCalls[0]).toEqual({
       id: 'exec-1',
-      patch: {
-        status: 'in_progress',
+      expected: ['pending', 'in_progress', 'idle', 'waiting_rebind'],
+      next: 'in_progress',
+      payload: {
         agentSessionId: 'live-session',
         startedAt: expect.any(Number),
         completedAt: null,
       },
     });
     expect(h.order).toEqual([]);
+    expect(h.reservations).toEqual([]);
   });
 
   test('reuse_live clears no reservation: a concurrent peer keeps its in-flight spawn guard', async () => {
@@ -343,23 +393,18 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     expect(h.cancels).toEqual([]);
   });
 
-  test('readback returning null blocks the execution, cancels the session, and throws corruption', async () => {
-    const h = makeSpawnFlowHarness({ kickoff: false });
-    h.setReadback(null);
+  test('a bind the CAS loses (concurrent writer) skips for this call: no blocked write, spawned session compensated, no resurrection (AFTER picture)', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false, bindCasOutcome: 'superseded' });
+    const spawnPromise = h.spawn();
 
-    await expect(h.spawn()).rejects.toThrow('Execution state corruption after spawn for exec-1');
+    await expect(spawnPromise).rejects.toBeInstanceOf(SpawnSupersededError);
+    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
 
-    expect(h.updates[1]).toEqual({
-      id: 'exec-1',
-      patch: {
-        status: 'blocked',
-        result: 'Execution state corruption after spawn',
-        completedAt: expect.any(Number),
-      },
-    });
+    expect(h.updates).toEqual([]);
     expect(h.order).not.toContain('ensureNodeAgentAttached');
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservationReleases).toEqual([TASK_ID]);
   });
 
   test('a failure after session creation cancels the spawned session, releases the reservation, and rethrows', async () => {
@@ -368,17 +413,31 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     await expect(h.spawn()).rejects.toThrow('attach boom');
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservationReleases).toEqual([TASK_ID]);
   });
 
-  test('an admission failure before session creation cancels nothing', async () => {
+  test('an admission failure before session creation cancels nothing and reserves nothing', async () => {
     const h = makeSpawnFlowHarness({ taskStatus: 'archived' });
 
     await expect(h.spawn()).rejects.toBeInstanceOf(PermanentSpawnError);
     expect(h.cancels).toEqual([]);
     expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservations).toEqual([]);
   });
 
-  test('a second call waits on the in-flight peer through the shell wait loop', async () => {
+  test('a parked (stopped) task fails the spawn reservation into superseded instead of spawning (AFTER picture)', async () => {
+    const h = makeSpawnFlowHarness({ taskStatus: 'stopped', kickoff: false });
+
+    await expect(h.spawn()).rejects.toBeInstanceOf(SpawnSupersededError);
+    await expect(h.spawn()).rejects.toThrow('superseded at stage reserve-task-spawn');
+    expect(h.order).toEqual([]);
+    expect(h.casCalls).toEqual([]);
+    expect(h.cancels).toEqual([]);
+    expect(h.spawningIds().has('exec-1')).toBe(false);
+    expect(h.reservationReleases).toEqual([]);
+  });
+
+  test('a second call waits on the in-flight peer through the promise handoff', async () => {
     const gate = deferred<{ path: string }>();
     const h = makeSpawnFlowHarness({ kickoff: false, worktreeGate: gate.promise });
 
@@ -389,6 +448,6 @@ describe('spawnWorkflowNodeAgentForExecutionViaFlow — staged composition parit
     expect(await second).toBe(SPAWNED_SESSION_ID);
     expect(await first).toBe(SPAWNED_SESSION_ID);
     expect(h.order.filter((step) => step === 'createSubSession')).toHaveLength(1);
-    expect(h.updates.some((u) => u.patch.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
+    expect(h.casCalls.some((c) => c.payload?.agentSessionId === SPAWNED_SESSION_ID)).toBe(true);
   });
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-spawn-flow.test.ts
@@ -438,18 +438,49 @@ describe('spawnWorkflowNodeAgentForExecution — staged spawn interpreter', () =
     expect(h.reservationReleases).toEqual([TASK_ID]);
   });
 
-  test('a reused session is never cancelled by spawn compensation — it stays owned by its prior node (PR #2770 review)', async () => {
-    const h = makeSpawnFlowHarness({
-      kickoff: false,
-      bindCasOutcome: 'superseded',
-      sessionReused: true,
-    });
-    const spawnPromise = h.spawn();
+  test('the staged flow never transfers a reused session — it always spawns fresh (PR #2770 final-round descope)', async () => {
+    const seenMemberInfo: Array<Record<string, unknown>> = [];
+    const h = makeSpawnFlowHarness({ kickoff: false });
+    const tam = h.tam as unknown as {
+      createSubSession: (...args: unknown[]) => Promise<string>;
+    };
+    const original = tam.createSubSession.bind(tam);
+    tam.createSubSession = async (...args: unknown[]) => {
+      seenMemberInfo.push(args[3] as Record<string, unknown>);
+      return original(...args);
+    };
 
-    await expect(spawnPromise).rejects.toThrow('superseded at stage bind-execution-session');
-    expect(h.cancels).toEqual([]);
-    expect(h.spawningIds().has('exec-1')).toBe(false);
-    expect(h.reservationReleases).toEqual([TASK_ID]);
+    await h.spawn();
+
+    expect(seenMemberInfo).toHaveLength(1);
+    expect(seenMemberInfo[0]?.freshSessionOnly).toBe(true);
+    expect(seenMemberInfo[0]?.deferFreshExecutionBind).toBe(true);
+  });
+
+  test('a task-reservation loser does not fail the winning spawn waiters (PR #2770 review)', async () => {
+    const h = makeSpawnFlowHarness({ kickoff: false, taskStatus: 'stopped' });
+    h.spawningIds().add('exec-1');
+    const waitPromise = (
+      h.tam as unknown as {
+        waitForConcurrentSpawnSession: (execution: NodeExecution) => Promise<string>;
+      }
+    ).waitForConcurrentSpawnSession(makeExecution());
+    const settled = waitPromise.then(
+      () => 'settled',
+      (err: unknown) => `rejected:${err instanceof Error ? err.message : String(err)}`
+    );
+    h.spawningIds().delete('exec-1');
+
+    const loser = h.spawn();
+
+    await expect(loser).rejects.toThrow('superseded at stage reserve-task-spawn');
+    expect(
+      (h.tam as unknown as { concurrentSpawnWaiters: Map<string, unknown[]> })
+        .concurrentSpawnWaiters.size
+    ).toBe(1);
+    expect(
+      await Promise.race([settled, new Promise((r) => setTimeout(() => r('pending'), 50))])
+    ).toBe('pending');
   });
 
   test('an admission failure before session creation cancels nothing and reserves nothing', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -187,6 +187,7 @@ describe('PostApprovalRouter.route', () => {
       expect(result.reason).toContain('superseded');
     }
     expect(taskRepo.getTask(task.id)?.status).toBe('approved');
+    expect(taskRepo.getTask(task.id)?.postApprovalBlockedReason).toContain('superseded');
   });
 
   test('targetAgent pointing at node agent → spawn sub-session + stamp', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from '../../../../src/storage/sqlite-compat';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpawnSupersededError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import {
   PostApprovalRouter,
   isPostApprovalRoutingEnabled,
@@ -152,6 +153,40 @@ describe('PostApprovalRouter.route', () => {
     const final = taskRepo.getTask(task.id);
     expect(final?.status).toBe('done');
     expect(delegates.spawned).toHaveLength(0);
+  });
+
+  test('a superseded spawn maps to a benign skipped route — task stays approved for a later tick (PR #2770 review)', async () => {
+    const task = makeApprovedTask(taskRepo);
+    const delegates = makeDelegates();
+    const throwingSpawner = {
+      spawnPostApprovalSubSession: () => {
+        throw new SpawnSupersededError('exec-post-approval', 'fresh-create-bind');
+      },
+    };
+    const router = new PostApprovalRouter({
+      taskRepo,
+      spawner: throwingSpawner,
+      livenessProbe: delegates.liveness,
+    });
+
+    const workflow = stubWorkflow({
+      postApproval: {
+        targetAgent: 'deployer',
+        instructions: 'Deploy {{task_title}} now.',
+      },
+    });
+
+    const result = await router.route(task, workflow, {
+      approvalSource: 'agent',
+      task_title: task.title,
+      spaceId: SPACE_ID,
+    });
+
+    expect(result.mode).toBe('skipped');
+    if (result.mode === 'skipped') {
+      expect(result.reason).toContain('superseded');
+    }
+    expect(taskRepo.getTask(task.id)?.status).toBe('approved');
   });
 
   test('targetAgent pointing at node agent → spawn sub-session + stamp', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -14,6 +14,7 @@ import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.t
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import { MAX_BLOCKED_RUN_RETRIES } from '../../../../src/lib/space/runtime/constants.ts';
+import { SpawnSupersededError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import { InternalEventBus } from '../../../../src/lib/internal-event-bus.ts';
 import type { DaemonInternalEventMap } from '../../../../src/lib/internal-event-bus.ts';
 import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
@@ -2548,6 +2549,67 @@ describe('SpaceRuntime — tick loop correctness', () => {
       const updated = taskRepo.getTask(tasks[0].id)!;
       expect(updated.status).toBe('in_progress');
       expect(updated.taskAgentSessionId).toBeTruthy();
+    });
+
+    test('a superseded spawn skips for this tick without cancelling, blocking, or retrying (superpipe P5)', async () => {
+      const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+        spawnWorkflowNodeAgentForExecution: async (_task, _space, _workflow, _run, execution) => {
+          const exec = execution as { id: string; agentName: string };
+          if (exec.agentName === 'Planner') {
+            throw new SpawnSupersededError(exec.id, 'reserve-task-spawn');
+          }
+          const sessionId = `session:${exec.agentName}:new`;
+          nodeExecutionRepo.update(exec.id, {
+            status: 'in_progress',
+            agentSessionId: sessionId,
+            startedAt: Date.now(),
+            completedAt: null,
+          });
+          return sessionId;
+        },
+      });
+      const rt = new SpaceRuntime(buildConfig(tam));
+
+      const workflow = workflowManager.createWorkflow({
+        spaceId: SPACE_ID,
+        name: `Superseded spawn ${Date.now()}`,
+        description: 'Test',
+        nodes: [
+          {
+            id: STEP_A,
+            name: 'Build',
+            agents: [
+              { agentId: AGENT_PLANNER, name: 'Planner' },
+              { agentId: AGENT_CODER, name: 'Coder' },
+            ],
+          },
+          {
+            id: STEP_B,
+            name: 'Done',
+            agents: [{ agentId: AGENT_PLANNER, name: 'Finisher' }],
+          },
+        ],
+        transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+        startNodeId: STEP_A,
+        endNodeId: STEP_B,
+        rules: [],
+        tags: [],
+        completionAutonomyLevel: 3,
+      });
+      const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      await rt.executeTick();
+
+      const executions = nodeExecutionRepo.listByWorkflowRun(tasks[0].workflowRunId!);
+      const planner = executions.find((exec) => exec.agentName === 'Planner');
+      const coder = executions.find((exec) => exec.agentName === 'Coder');
+      expect(planner?.status).toBe('pending');
+      expect(planner?.agentSessionId).toBeNull();
+      expect(coder?.status).toBe('in_progress');
+      expect(coder?.agentSessionId).toBe('session:Coder:new');
+
+      const run = workflowRunRepo.getRun(tasks[0].workflowRunId!);
+      expect(run?.status).toBe('in_progress');
+      expect(taskRepo.getTask(tasks[0].id)!.status).toBe('in_progress');
     });
   });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -2611,6 +2611,57 @@ describe('SpaceRuntime — tick loop correctness', () => {
       expect(run?.status).toBe('in_progress');
       expect(taskRepo.getTask(tasks[0].id)!.status).toBe('in_progress');
     });
+
+    test('a park landing mid-spawn-pass is not undone by the trailing open→in_progress update (PR #2770 review)', async () => {
+      let parked = false;
+      const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
+        spawnWorkflowNodeAgentForExecution: async (_task, _space, _workflow, _run, execution) => {
+          const exec = execution as { id: string; agentName: string };
+          if (!parked) {
+            parked = true;
+            taskRepo.updateTask(
+              taskRepo.listByWorkflowRun(workflowRunRepo.listBySpace(SPACE_ID)[0].id)[0].id,
+              { status: 'stopped' }
+            );
+          }
+          throw new SpawnSupersededError(exec.id, 'reserve-task-spawn');
+        },
+      });
+      const rt = new SpaceRuntime(buildConfig(tam));
+
+      const workflow = workflowManager.createWorkflow({
+        spaceId: SPACE_ID,
+        name: `Park mid-spawn ${Date.now()}`,
+        description: 'Test',
+        nodes: [
+          {
+            id: STEP_A,
+            name: 'Build',
+            agents: [
+              { agentId: AGENT_PLANNER, name: 'Planner' },
+              { agentId: AGENT_CODER, name: 'Coder' },
+            ],
+          },
+          {
+            id: STEP_B,
+            name: 'Done',
+            agents: [{ agentId: AGENT_PLANNER, name: 'Finisher' }],
+          },
+        ],
+        transitions: [{ from: STEP_A, to: STEP_B, condition: { type: 'always' }, order: 0 }],
+        startNodeId: STEP_A,
+        endNodeId: STEP_B,
+        rules: [],
+        tags: [],
+        completionAutonomyLevel: 3,
+      });
+      const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+      await rt.executeTick();
+
+      expect(taskRepo.getTask(tasks[0].id)!.status).toBe('stopped');
+      const executions = nodeExecutionRepo.listByWorkflowRun(tasks[0].workflowRunId!);
+      expect(executions.every((exec) => exec.status === 'pending')).toBe(true);
+    });
   });
 
   describe('rehydration does not duplicate executors from startWorkflowRun', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -143,8 +143,9 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
     },
     releaseTaskSpawn: (taskId) => {
       calls.push(`release-task:${taskId}`);
-      taskReservationReleases.push(taskId);
+      if (!heldTaskReservations.has(taskId)) return;
       heldTaskReservations.delete(taskId);
+      taskReservationReleases.push(taskId);
     },
     cancelSpawnedSession: (sessionId) => {
       calls.push(`cancel:${sessionId}`);
@@ -242,7 +243,7 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
 }
 
 describe('spawn flow — proceed_fresh path', () => {
-  test('runs admission, task reservation, reserve, spawn, bind, attach, register, kickoff, release, and halts with the session id', async () => {
+  test('runs admission, task reservation, reserve, spawn, bind, early reservation release, attach, register, kickoff, and halts with the session id', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run();
     expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
@@ -253,11 +254,11 @@ describe('spawn flow — proceed_fresh path', () => {
       'resolve-workspace',
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
+      `release-task:${TASK_ID}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
       'kickoff-message',
       `inject:${SPAWNED_SESSION_ID}`,
-      `release-task:${TASK_ID}`,
     ]);
     expect(h.cancels).toEqual([]);
     expect(h.releases).toEqual([]);
@@ -277,9 +278,9 @@ describe('spawn flow — proceed_fresh path', () => {
       'resolve-workspace',
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
+      `release-task:${TASK_ID}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
-      `release-task:${TASK_ID}`,
     ]);
   });
 

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -177,6 +177,9 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
       binds.push({ executionId: row.id, sessionId });
       return 'won';
     },
+    flushPendingMessagesForTarget: (workflowRunId, agentName) => {
+      calls.push(`flush-pending:${workflowRunId}:${agentName}`);
+    },
     attachNodeAgent: async (request) => {
       calls.push('attach');
       attaches.push(request.execution);
@@ -255,6 +258,7 @@ describe('spawn flow — proceed_fresh path', () => {
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
       `release-task:${TASK_ID}`,
+      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
       'kickoff-message',
@@ -279,6 +283,7 @@ describe('spawn flow — proceed_fresh path', () => {
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
       `release-task:${TASK_ID}`,
+      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
     ]);

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -72,6 +72,8 @@ interface FlowFixture {
   cancels: string[];
   releases: string[];
   reservations: string[];
+  taskReservations: string[];
+  taskReservationReleases: string[];
   rebinds: Array<{ executionId: string; sessionId: string }>;
   binds: Array<{ executionId: string; sessionId: string }>;
   attaches: NodeExecution[];
@@ -98,6 +100,8 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
   const cancels: string[] = [];
   const releases: string[] = [];
   const reservations: string[] = [];
+  const taskReservations: string[] = [];
+  const taskReservationReleases: string[] = [];
   const rebinds: Array<{ executionId: string; sessionId: string }> = [];
   const binds: Array<{ executionId: string; sessionId: string }> = [];
   const attaches: NodeExecution[] = [];
@@ -113,6 +117,7 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
   };
   let liveIndexedSessionId: string | null = null;
   let workspaceGate: Promise<string> | null = null;
+  const heldTaskReservations = new Set<string>();
 
   const deps: SpawnExecutionFlowDeps = {
     getFreshTask: () => task,
@@ -129,6 +134,18 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
       releases.push(executionId);
       spawningExecutionIds.delete(executionId);
     },
+    reserveTaskSpawn: (taskId) => {
+      calls.push(`reserve-task:${taskId}`);
+      taskReservations.push(taskId);
+      if (heldTaskReservations.has(taskId)) return 'superseded';
+      heldTaskReservations.add(taskId);
+      return 'won';
+    },
+    releaseTaskSpawn: (taskId) => {
+      calls.push(`release-task:${taskId}`);
+      taskReservationReleases.push(taskId);
+      heldTaskReservations.delete(taskId);
+    },
     cancelSpawnedSession: (sessionId) => {
       calls.push(`cancel:${sessionId}`);
       cancels.push(sessionId);
@@ -136,6 +153,7 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
     rebindLiveExecution: (row, sessionId) => {
       calls.push(`rebind:${sessionId}`);
       rebinds.push({ executionId: row.id, sessionId });
+      return 'won';
     },
     raiseSpawnRejection: () => {
       calls.push('reject');
@@ -156,6 +174,7 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
     bindExecutionToSession: (row, sessionId) => {
       calls.push(`bind:${sessionId}`);
       binds.push({ executionId: row.id, sessionId });
+      return 'won';
     },
     attachNodeAgent: async (request) => {
       calls.push('attach');
@@ -181,6 +200,8 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
     cancels,
     releases,
     reservations,
+    taskReservations,
+    taskReservationReleases,
     rebinds,
     binds,
     attaches,
@@ -221,11 +242,12 @@ function makeFlowFixture(options: { taskStatus?: string; kickoff?: boolean } = {
 }
 
 describe('spawn flow — proceed_fresh path', () => {
-  test('runs admission, reserve, spawn, bind, attach, register, kickoff, and halts with the session id', async () => {
+  test('runs admission, task reservation, reserve, spawn, bind, attach, register, kickoff, release, and halts with the session id', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run();
     expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
     expect(h.calls).toEqual([
+      `reserve-task:${TASK_ID}`,
       'reserve',
       'resolve-session-id',
       'resolve-workspace',
@@ -235,10 +257,13 @@ describe('spawn flow — proceed_fresh path', () => {
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
       'kickoff-message',
       `inject:${SPAWNED_SESSION_ID}`,
+      `release-task:${TASK_ID}`,
     ]);
     expect(h.cancels).toEqual([]);
     expect(h.releases).toEqual([]);
     expect(h.reservations).toEqual([EXECUTION_ID]);
+    expect(h.taskReservations).toEqual([TASK_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
   });
 
   test('a kickoff-disabled spawn skips the kickoff message and inject but still binds and attaches', async () => {
@@ -246,6 +271,7 @@ describe('spawn flow — proceed_fresh path', () => {
     const outcome = await h.run();
     expect(outcome).toEqual({ status: 'completed', result: SPAWNED_SESSION_ID });
     expect(h.calls).toEqual([
+      `reserve-task:${TASK_ID}`,
       'reserve',
       'resolve-session-id',
       'resolve-workspace',
@@ -253,6 +279,7 @@ describe('spawn flow — proceed_fresh path', () => {
       `bind:${SPAWNED_SESSION_ID}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
+      `release-task:${TASK_ID}`,
     ]);
   });
 
@@ -318,7 +345,7 @@ describe('spawn flow — alternative admission branches', () => {
 });
 
 describe('spawn flow — failure unwind (the catch-path cancel compensation)', () => {
-  test('a bind failure after session creation cancels the spawned session and releases the reservation', async () => {
+  test('a bind failure after session creation cancels the spawned session and releases both reservations', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run({
       bindExecutionToSession: () => {
@@ -331,16 +358,18 @@ describe('spawn flow — failure unwind (the catch-path cancel compensation)', (
       expect((outcome.error as Error).message).toBe('bind boom');
       expect(outcome.unwind).toEqual([
         { stage: 'reserve-and-spawn-session', status: 'compensated' },
+        { stage: 'reserve-task-spawn', status: 'compensated' },
       ]);
     }
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
     expect(h.calls.indexOf(`cancel:${SPAWNED_SESSION_ID}`)).toBeLessThan(
       h.calls.indexOf('release')
     );
   });
 
-  test('a create failure before the session exists releases the reservation without cancelling', async () => {
+  test('a create failure before the session exists releases both reservations without cancelling', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run({
       createSpawnedSession: async () => {
@@ -354,9 +383,10 @@ describe('spawn flow — failure unwind (the catch-path cancel compensation)', (
     }
     expect(h.cancels).toEqual([]);
     expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
   });
 
-  test('an attach failure cancels the spawned session and releases the reservation', async () => {
+  test('an attach failure cancels the spawned session and releases both reservations', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run({
       attachNodeAgent: async () => {
@@ -366,10 +396,11 @@ describe('spawn flow — failure unwind (the catch-path cancel compensation)', (
     expect(outcome.status).toBe('error');
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
     expect(h.binds).toHaveLength(1);
   });
 
-  test('a kickoff inject failure cancels the spawned session and releases the reservation', async () => {
+  test('a kickoff inject failure cancels the spawned session and releases both reservations', async () => {
     const h = makeFlowFixture();
     const outcome = await h.run({
       injectKickoffMessage: async () => {
@@ -382,6 +413,7 @@ describe('spawn flow — failure unwind (the catch-path cancel compensation)', (
     }
     expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
     expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
   });
 
   test('the compensation runs even when the spawn reservation was the only committed write', async () => {
@@ -395,6 +427,72 @@ describe('spawn flow — failure unwind (the catch-path cancel compensation)', (
     expect(h.cancels).toEqual([]);
     expect(h.releases).toEqual([EXECUTION_ID]);
     expect(h.spawningExecutionIds.has(EXECUTION_ID)).toBe(false);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
+  });
+});
+
+describe('spawn flow — superseded CAS outcomes (ADR 0004 Phase 0 condition 3)', () => {
+  test('a lost task-spawn reservation supersedes before any spawn work and releases nothing', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      reserveTaskSpawn: (taskId) => {
+        h.deps.reserveTaskSpawn(taskId);
+        return 'superseded' as const;
+      },
+    });
+    expect(outcome).toEqual({
+      status: 'superseded',
+      stage: 'reserve-task-spawn',
+      unwind: [{ stage: 'reserve-task-spawn', status: 'compensated' }],
+    });
+    expect(h.calls).toEqual([`reserve-task:${TASK_ID}`]);
+    expect(h.cancels).toEqual([]);
+    expect(h.reservations).toEqual([]);
+    expect(h.taskReservationReleases).toEqual([]);
+    expect(h.spawningExecutionIds.has(EXECUTION_ID)).toBe(false);
+  });
+
+  test('a lost bind CAS supersedes after the spawn, cancelling the spawned session and releasing both reservations', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      bindExecutionToSession: () => 'superseded',
+    });
+    expect(outcome.status).toBe('superseded');
+    if (outcome.status === 'superseded') {
+      expect(outcome.stage).toBe('bind-execution-session');
+      expect(outcome.unwind).toEqual([
+        { stage: 'reserve-and-spawn-session', status: 'compensated' },
+        { stage: 'reserve-task-spawn', status: 'compensated' },
+      ]);
+    }
+    expect(h.cancels).toEqual([SPAWNED_SESSION_ID]);
+    expect(h.releases).toEqual([EXECUTION_ID]);
+    expect(h.taskReservationReleases).toEqual([TASK_ID]);
+    expect(h.attaches).toEqual([]);
+    expect(h.injected).toEqual([]);
+    expect(h.taskReservationReleases).not.toContain(undefined);
+  });
+
+  test('a lost rebind CAS supersedes the reuse_live branch with nothing to compensate', async () => {
+    const h = makeFlowFixture();
+    const outcome = await h.run({
+      inspectIndexedSession: (agentSessionId) => ({
+        sessionId: agentSessionId ?? 'live-1',
+        alive: true,
+      }),
+      rebindLiveExecution: (row, sessionId) => {
+        h.deps.rebindLiveExecution(row, sessionId);
+        return 'superseded' as const;
+      },
+    });
+    expect(outcome).toEqual({
+      status: 'superseded',
+      stage: 'rebind-live-session',
+      unwind: [],
+    });
+    expect(h.calls).toEqual(['rebind:live-1']);
+    expect(h.cancels).toEqual([]);
+    expect(h.reservations).toEqual([]);
   });
 });
 
@@ -427,7 +525,12 @@ describe('spawn flow microtask profile', () => {
         return '/tmp/ws';
       },
     });
-    expect(h.calls).toEqual(['reserve', 'resolve-session-id', 'resolve-workspace']);
+    expect(h.calls).toEqual([
+      `reserve-task:${TASK_ID}`,
+      'reserve',
+      'resolve-session-id',
+      'resolve-workspace',
+    ]);
     expect(h.spawningExecutionIds.has(EXECUTION_ID)).toBe(true);
     expect(h.calls).not.toContain('create');
     releaseWorkspace!('/tmp/ws');
@@ -446,6 +549,7 @@ describe('spawn flow microtask profile', () => {
         },
         bindExecutionToSession: () => {
           order.push('bind');
+          return 'won' as const;
         },
       },
       h.input

--- a/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/spawn-flow.test.ts
@@ -258,11 +258,11 @@ describe('spawn flow — proceed_fresh path', () => {
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
       `release-task:${TASK_ID}`,
-      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
       'kickoff-message',
       `inject:${SPAWNED_SESSION_ID}`,
+      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
     ]);
     expect(h.cancels).toEqual([]);
     expect(h.releases).toEqual([]);
@@ -283,9 +283,9 @@ describe('spawn flow — proceed_fresh path', () => {
       'create',
       `bind:${SPAWNED_SESSION_ID}`,
       `release-task:${TASK_ID}`,
-      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
       'attach',
       `register:${TASK_ID}:${NODE_ID}:${SPAWNED_SESSION_ID}`,
+      `flush-pending:${RUN_ID}:${AGENT_NAME}`,
     ]);
   });
 

--- a/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-activation-routing.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-agent-manager-activation-routing.test.ts
@@ -57,6 +57,18 @@ function makeManager(input: {
       update: (id: string, params: unknown) => {
         updates.push({ id, params });
       },
+      casExecutionStatus: (
+        id: string,
+        expected: readonly string[],
+        next: string
+      ): 'won' | 'superseded' => {
+        updates.push({ id, params: { status: next, __cas: [...expected] } });
+        if (!execution || id !== execution.id || !expected.includes(execution.status)) {
+          return 'superseded';
+        }
+        execution.status = next as typeof execution.status;
+        return 'won';
+      },
     },
   } as unknown as ConstructorParameters<typeof TaskAgentManager>[0]);
   const internals = manager as unknown as Record<string, unknown>;
@@ -93,7 +105,9 @@ describe('TaskAgentManager.activateTargetSessionsForMessage activation routing',
       { workflowNodeId: NODE_ID }
     );
     expect(result).toEqual([]);
-    expect(harness.updates).toEqual([{ id: EXEC_ID, params: { status: 'pending' } }]);
+    expect(harness.updates).toEqual([
+      { id: EXEC_ID, params: { status: 'pending', __cas: ['in_progress'] } },
+    ]);
     expect(harness.activationCalls()).toBe(0);
     expect(harness.spawnCalls()).toBe(0);
   });
@@ -130,7 +144,9 @@ describe('TaskAgentManager.activateTargetSessionsForMessage activation routing',
       { workflowNodeId: NODE_ID }
     );
     expect(result).toEqual([{ agentName: AGENT_NAME, sessionId: LIVE_SESSION_ID }]);
-    expect(harness.updates).toEqual([{ id: EXEC_ID, params: { status: 'pending' } }]);
+    expect(harness.updates).toEqual([
+      { id: EXEC_ID, params: { status: 'pending', __cas: ['blocked'] } },
+    ]);
     expect(harness.activationCalls()).toBe(1);
     expect(harness.spawnCalls()).toBe(1);
   });


### PR DESCRIPTION
First production consumer of the Phase 0 primitives: `spawnWorkflowNodeAgentForExecution` is now the P4 staged interpreter. Every execution-status write at the spawn seam (the six P1-pinned sites plus the bind/rebind) goes through `casExecutionStatus` — extended to carry the bind payload atomically and to stamp `updated_at` + reactive notification on a win — so the readback "corruption check" is replaced by the CAS outcome and a concurrent legitimate writer supersedes instead of being misflagged and blocked. The spawn pass reserves the task via `reserveSpawnForTick`/`releaseSpawnReservation` (released on success, compensated on unwind, stale tokens cleared at first-tick rehydration), so a mid-spawn-loop park fails the next reservation instead of spawning the remainder onto a parked task; `spawningExecutionIds` semantics are unchanged. The 50ms DB-polling concurrent-spawn waiter is now an explicit promise handoff with the same three outcome classes, and a `SpawnSupersededError` is skipped (not classified) by the tick spawn loop, queued-handoff repair, and the activation path.

Behavior change is pinned both ways: the P1 before-picture tests are rewritten as after-picture pins (parked task → superseded at `reserve-task-spawn`, concurrent cancel → bind CAS supersedes with the spawned session compensated and no resurrection, no unhandled rejection), and a new real-repo suite pins the mid-spawn-loop park and cancel races end to end.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->