### PR TITLE
refactor(daemon): extract message-search admission as decisionRun (chain C PR 2/5)

### DIFF
--- a/packages/daemon/src/storage/repositories/message-search-admission.ts
+++ b/packages/daemon/src/storage/repositories/message-search-admission.ts
@@ -1,0 +1,150 @@
+import { decisionRun } from '../../lib/space/runtime/decision-pipeline';
+
+const MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const ROOM_SESSION_PREFIXES = ['room:chat:', 'planner:', 'coder:', 'leader:', 'general:'];
+const ROOM_SESSION_TYPES = new Set(['room_chat', 'planner', 'coder', 'leader', 'general']);
+const TERMINAL_SPACE_TASK_STATUSES = new Set(['done', 'cancelled', 'completed']);
+const SEARCHABLE_MESSAGE_TYPES = new Set(['system', 'user', 'assistant']);
+
+export function isOlderThanMessageSearchTtl(
+  value: string | number | null | undefined,
+  now: number
+): boolean {
+  if (value === null || value === undefined) return false;
+  const timestamp = typeof value === 'number' ? value : Date.parse(value);
+  if (!Number.isFinite(timestamp)) return false;
+  return timestamp < now - MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS;
+}
+
+export interface MessageSearchEligibilityRow {
+  session_id: string;
+  session_status: string | null;
+  session_type: string | null;
+  session_last_active_at: string | null;
+  session_room_id: string | null;
+  task_status: string | null;
+  task_completed_at: number | null;
+  task_updated_at: number | null;
+}
+
+export function isMessageSearchIndexEligible(
+  row: MessageSearchEligibilityRow,
+  now: number
+): boolean {
+  if (ROOM_SESSION_PREFIXES.some((prefix) => row.session_id.startsWith(prefix))) {
+    return false;
+  }
+
+  if (row.session_status === 'archived') return false;
+  if (
+    row.session_status === 'ended' &&
+    isOlderThanMessageSearchTtl(row.session_last_active_at, now)
+  ) {
+    return false;
+  }
+
+  if (row.session_type && ROOM_SESSION_TYPES.has(row.session_type)) return false;
+  if (row.session_room_id) return false;
+
+  const isSpaceSession =
+    row.session_id.startsWith('space:') ||
+    row.session_type === 'space_chat' ||
+    row.session_type === 'space_task_agent';
+  const isNormalSession =
+    !row.session_id.includes(':') && (!row.session_type || row.session_type === 'worker');
+  if (!isSpaceSession && !isNormalSession) return false;
+
+  if (row.task_status === 'archived') return false;
+  if (
+    row.task_status &&
+    TERMINAL_SPACE_TASK_STATUSES.has(row.task_status) &&
+    isOlderThanMessageSearchTtl(row.task_completed_at ?? row.task_updated_at, now)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export type MessageSearchSkipReason =
+  | 'superseded'
+  | 'non_searchable_type'
+  | 'ineligible'
+  | 'empty_body'
+  | 'user_status_not_searchable';
+
+export type MessageSearchAdmissionDecision =
+  | { action: 'skip'; reason: MessageSearchSkipReason }
+  | { action: 'index' };
+
+export type MessageSearchAdmissionFact = boolean | (() => boolean);
+
+export interface MessageSearchAdmissionCtx {
+  messageType: string;
+  body: string;
+  now: number;
+  eligibility: MessageSearchEligibilityRow;
+  isSuperseded: MessageSearchAdmissionFact;
+  isSearchableUserStatus: MessageSearchAdmissionFact;
+  decision: MessageSearchAdmissionDecision | null;
+}
+
+export type MessageSearchAdmissionInput = Omit<MessageSearchAdmissionCtx, 'decision'>;
+
+function decided(
+  ctx: MessageSearchAdmissionCtx,
+  decision: MessageSearchAdmissionDecision
+): MessageSearchAdmissionCtx {
+  return { ...ctx, decision };
+}
+
+function readAdmissionFact(value: MessageSearchAdmissionFact): boolean {
+  return typeof value === 'function' ? value() : value;
+}
+
+export function applySupersededGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return readAdmissionFact(ctx.isSuperseded)
+    ? decided(ctx, { action: 'skip', reason: 'superseded' })
+    : ctx;
+}
+
+export function applySearchableTypeGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return SEARCHABLE_MESSAGE_TYPES.has(ctx.messageType)
+    ? ctx
+    : decided(ctx, { action: 'skip', reason: 'non_searchable_type' });
+}
+
+export function applyEligibilityGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return isMessageSearchIndexEligible(ctx.eligibility, ctx.now)
+    ? ctx
+    : decided(ctx, { action: 'skip', reason: 'ineligible' });
+}
+
+export function applyBodyNonemptyGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return ctx.body.length > 0 ? ctx : decided(ctx, { action: 'skip', reason: 'empty_body' });
+}
+
+export function applyUserStatusGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return ctx.messageType === 'user' && !readAdmissionFact(ctx.isSearchableUserStatus)
+    ? decided(ctx, { action: 'skip', reason: 'user_status_not_searchable' })
+    : ctx;
+}
+
+export function applyIndexGate(ctx: MessageSearchAdmissionCtx): MessageSearchAdmissionCtx {
+  return decided(ctx, { action: 'index' });
+}
+
+const messageSearchAdmissionRun = decisionRun('message-search-admission', [
+  applySupersededGate,
+  applySearchableTypeGate,
+  applyEligibilityGate,
+  applyBodyNonemptyGate,
+  applyUserStatusGate,
+  applyIndexGate,
+]);
+
+export function decideMessageSearchAdmission(
+  input: MessageSearchAdmissionInput
+): MessageSearchAdmissionDecision {
+  return messageSearchAdmissionRun(input).decision ?? { action: 'index' };
+}

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -20,14 +20,10 @@ import {
   type MessageSearchResult,
 } from '../message-search';
 import type { SQLiteValue } from '../types';
+import { decideMessageSearchAdmission } from './message-search-admission';
 
 export type SendStatus = 'deferred' | 'enqueued' | 'submitted' | 'consumed' | 'failed';
 
-const MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const ROOM_SESSION_PREFIXES = ['room:chat:', 'planner:', 'coder:', 'leader:', 'general:'];
-const ROOM_SESSION_TYPES = new Set(['room_chat', 'planner', 'coder', 'leader', 'general']);
-const TERMINAL_SPACE_TASK_STATUSES = new Set(['done', 'cancelled', 'completed']);
-const SEARCHABLE_MESSAGE_TYPES = new Set(['system', 'user', 'assistant']);
 const RENDERABLE_TEXT_MESSAGE_BATCH_SIZE = 50;
 const RENDERABLE_TEXT_MESSAGE_MAX_SCAN = 250;
 const STATUS_MESSAGE_HYDRATION_BATCH_SIZE = 900;
@@ -75,13 +71,6 @@ function isVisibleBadgeRow(opts: {
     return status === 'consumed' || status === 'failed';
   }
   return true;
-}
-
-function isOlderThanMessageSearchTtl(value: string | number | null | undefined): boolean {
-  if (value === null || value === undefined) return false;
-  const timestamp = typeof value === 'number' ? value : Date.parse(value);
-  if (!Number.isFinite(timestamp)) return false;
-  return timestamp < Date.now() - MESSAGE_SEARCH_TERMINAL_SESSION_TTL_MS;
 }
 
 export function computeIsRenderable(message: SDKMessage): 0 | 1 {
@@ -233,7 +222,7 @@ export class SDKMessageRepository {
     }
   }
 
-  private upsertMessageSearchRow(rowId: string): void {
+  private upsertMessageSearchRow(rowId: string, now: number): void {
     if (!this.hasMessageSearchIndex()) return;
     const hasSessions = this.tableExists('sessions');
     const hasSpaceTasks = this.tableExists('space_tasks');
@@ -294,23 +283,26 @@ export class SDKMessageRepository {
       | undefined;
     if (!row) return;
 
-    let parsed: SDKMessage | null = null;
+    let parsedMessage: SDKMessage | null = null;
     try {
-      parsed = JSON.parse(row.sdk_message) as SDKMessage;
+      parsedMessage = JSON.parse(row.sdk_message) as SDKMessage;
     } catch {
       return;
     }
-    const body = extractVisibleSearchText(parsed);
+    const message = parsedMessage;
+    const body = extractVisibleSearchText(message);
     this.db
       .prepare(`DELETE FROM message_search_content WHERE kind = 'message' AND source_id = ?`)
       .run(row.id);
-    if (this.isMessageSuperseded(row.id, row.session_id, parsed)) return;
-    if (!SEARCHABLE_MESSAGE_TYPES.has(row.message_type)) return;
-    if (!this.isMessageSearchIndexEligible(row)) return;
-    if (!body) return;
-    if (row.message_type === 'user' && !this.isSearchableUserMessageStatus(row.id)) {
-      return;
-    }
+    const admission = decideMessageSearchAdmission({
+      messageType: row.message_type,
+      body,
+      now,
+      eligibility: row,
+      isSuperseded: () => this.isMessageSuperseded(row.id, row.session_id, message),
+      isSearchableUserStatus: () => this.isSearchableUserMessageStatus(row.id),
+    });
+    if (admission.action !== 'index') return;
     this.db
       .prepare(
         `INSERT INTO message_search_content (
@@ -320,7 +312,7 @@ export class SDKMessageRepository {
       )
       .run(
         row.id,
-        (parsed as { uuid?: string }).uuid ?? row.id,
+        (message as { uuid?: string }).uuid ?? row.id,
         row.session_id,
         row.task_id,
         row.space_id,
@@ -330,48 +322,6 @@ export class SDKMessageRepository {
         body,
         parseSearchTimestamp(row.timestamp)
       );
-  }
-
-  private isMessageSearchIndexEligible(row: {
-    session_id: string;
-    session_status: string | null;
-    session_type: string | null;
-    session_last_active_at: string | null;
-    session_room_id: string | null;
-    task_status: string | null;
-    task_completed_at: number | null;
-    task_updated_at: number | null;
-  }): boolean {
-    if (ROOM_SESSION_PREFIXES.some((prefix) => row.session_id.startsWith(prefix))) {
-      return false;
-    }
-
-    if (row.session_status === 'archived') return false;
-    if (row.session_status === 'ended' && isOlderThanMessageSearchTtl(row.session_last_active_at)) {
-      return false;
-    }
-
-    if (row.session_type && ROOM_SESSION_TYPES.has(row.session_type)) return false;
-    if (row.session_room_id) return false;
-
-    const isSpaceSession =
-      row.session_id.startsWith('space:') ||
-      row.session_type === 'space_chat' ||
-      row.session_type === 'space_task_agent';
-    const isNormalSession =
-      !row.session_id.includes(':') && (!row.session_type || row.session_type === 'worker');
-    if (!isSpaceSession && !isNormalSession) return false;
-
-    if (row.task_status === 'archived') return false;
-    if (
-      row.task_status &&
-      TERMINAL_SPACE_TASK_STATUSES.has(row.task_status) &&
-      isOlderThanMessageSearchTtl(row.task_completed_at ?? row.task_updated_at)
-    ) {
-      return false;
-    }
-
-    return true;
   }
 
   private deleteMessageSearchRow(rowId: string): void {
@@ -404,7 +354,7 @@ export class SDKMessageRepository {
   private scheduleMessageSearchIndex(messageId: string): void {
     if (!this.hasMessageSearchIndex()) return;
     if (!this.tableExists('message_search_pending')) {
-      this.upsertMessageSearchRow(messageId);
+      this.upsertMessageSearchRow(messageId, Date.now());
       return;
     }
     this.db
@@ -429,7 +379,7 @@ export class SDKMessageRepository {
     for (const { message_id } of pending) {
       try {
         this.db.transaction(() => {
-          this.upsertMessageSearchRow(message_id);
+          this.upsertMessageSearchRow(message_id, Date.now());
           deletePendingStmt.run(message_id);
         })();
       } catch (err) {

--- a/packages/daemon/tests/unit/4-space-storage/storage/message-search-admission.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/message-search-admission.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decideMessageSearchAdmission,
+  isMessageSearchIndexEligible,
+  isOlderThanMessageSearchTtl,
+  type MessageSearchAdmissionInput,
+  type MessageSearchEligibilityRow,
+} from '../../../../src/storage/repositories/message-search-admission';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TTL_MS = 30 * DAY_MS;
+const NOW = 1_700_000_000_000;
+
+function eligibleRow(
+  overrides: Partial<MessageSearchEligibilityRow> = {}
+): MessageSearchEligibilityRow {
+  return {
+    session_id: 'session-1',
+    session_status: 'active',
+    session_type: null,
+    session_last_active_at: null,
+    session_room_id: null,
+    task_status: null,
+    task_completed_at: null,
+    task_updated_at: null,
+    ...overrides,
+  };
+}
+
+function admittingInput(
+  overrides: Partial<MessageSearchAdmissionInput> = {}
+): MessageSearchAdmissionInput {
+  return {
+    messageType: 'user',
+    body: 'searchable body',
+    now: NOW,
+    eligibility: eligibleRow(),
+    isSuperseded: false,
+    isSearchableUserStatus: true,
+    ...overrides,
+  };
+}
+
+describe('decideMessageSearchAdmission', () => {
+  test('indexes when every gate passes', () => {
+    expect(decideMessageSearchAdmission(admittingInput())).toEqual({ action: 'index' });
+  });
+
+  test('superseded wins over every later gate', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        messageType: 'result',
+        body: '',
+        eligibility: eligibleRow({ session_id: 'room:chat:room-1', session_status: 'archived' }),
+        isSuperseded: true,
+        isSearchableUserStatus: false,
+      })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'superseded' });
+  });
+
+  test('searchable-type wins over eligibility, body, and user-status', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        messageType: 'result',
+        body: '',
+        eligibility: eligibleRow({ session_status: 'archived' }),
+        isSearchableUserStatus: false,
+      })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'non_searchable_type' });
+  });
+
+  test('eligibility wins over body and user-status', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        body: '',
+        eligibility: eligibleRow({ session_status: 'archived' }),
+        isSearchableUserStatus: false,
+      })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'ineligible' });
+  });
+
+  test('body-nonempty wins over user-status', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({ body: '', isSearchableUserStatus: false })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'empty_body' });
+  });
+
+  test('user-status decides last for user rows', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({ isSearchableUserStatus: false })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'user_status_not_searchable' });
+  });
+
+  test('consults the superseded fact first and the user-status fact last', () => {
+    const calls: string[] = [];
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        isSuperseded: () => {
+          calls.push('superseded');
+          return false;
+        },
+        isSearchableUserStatus: () => {
+          calls.push('user-status');
+          return true;
+        },
+      })
+    );
+    expect(decision).toEqual({ action: 'index' });
+    expect(calls).toEqual(['superseded', 'user-status']);
+  });
+
+  test('does not consult the user-status fact when an earlier gate skips', () => {
+    const calls: string[] = [];
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        messageType: 'result',
+        isSuperseded: false,
+        isSearchableUserStatus: () => {
+          calls.push('user-status');
+          return false;
+        },
+      })
+    );
+    expect(decision).toEqual({ action: 'skip', reason: 'non_searchable_type' });
+    expect(calls).toEqual([]);
+  });
+
+  test('skips the user-status fact entirely for non-user rows that pass earlier gates', () => {
+    const decision = decideMessageSearchAdmission(
+      admittingInput({
+        messageType: 'assistant',
+        isSearchableUserStatus: () => {
+          throw new Error('user-status fact must not be consulted for assistant rows');
+        },
+      })
+    );
+    expect(decision).toEqual({ action: 'index' });
+  });
+
+  test('evaluates ended-session retention against the injected now', () => {
+    const oldActiveAt = new Date(NOW - TTL_MS - DAY_MS).toISOString();
+    const endedRow = eligibleRow({
+      session_status: 'ended',
+      session_last_active_at: oldActiveAt,
+    });
+
+    expect(decideMessageSearchAdmission(admittingInput({ eligibility: endedRow }))).toEqual({
+      action: 'skip',
+      reason: 'ineligible',
+    });
+
+    expect(
+      decideMessageSearchAdmission(admittingInput({ eligibility: endedRow, now: NOW - 2 * DAY_MS }))
+    ).toEqual({ action: 'index' });
+  });
+});
+
+describe('isOlderThanMessageSearchTtl', () => {
+  test('keeps a value exactly at the cutoff', () => {
+    expect(isOlderThanMessageSearchTtl(NOW - TTL_MS, NOW)).toBe(false);
+  });
+
+  test('rejects a value one millisecond past the cutoff', () => {
+    expect(isOlderThanMessageSearchTtl(NOW - TTL_MS - 1, NOW)).toBe(true);
+  });
+
+  test('parses ISO strings and numeric timestamps identically', () => {
+    const timestamp = NOW - TTL_MS - DAY_MS;
+    expect(isOlderThanMessageSearchTtl(new Date(timestamp).toISOString(), NOW)).toBe(true);
+    expect(isOlderThanMessageSearchTtl(timestamp, NOW)).toBe(true);
+  });
+
+  test('keeps null, undefined, and unparseable values', () => {
+    expect(isOlderThanMessageSearchTtl(null, NOW)).toBe(false);
+    expect(isOlderThanMessageSearchTtl(undefined, NOW)).toBe(false);
+    expect(isOlderThanMessageSearchTtl('not-a-date', NOW)).toBe(false);
+  });
+
+  test('uses the injected now, not the wall clock', () => {
+    const timestamp = Date.now() - TTL_MS - DAY_MS;
+    expect(isOlderThanMessageSearchTtl(timestamp, timestamp + TTL_MS)).toBe(false);
+    expect(isOlderThanMessageSearchTtl(timestamp, timestamp + TTL_MS + 1)).toBe(true);
+  });
+});
+
+describe('isMessageSearchIndexEligible', () => {
+  test('admits a plain session with no policy signals', () => {
+    expect(isMessageSearchIndexEligible(eligibleRow(), NOW)).toBe(true);
+  });
+
+  test('rejects room-prefixed session ids before any status check', () => {
+    expect(isMessageSearchIndexEligible(eligibleRow({ session_id: 'room:chat:room-1' }), NOW)).toBe(
+      false
+    );
+  });
+
+  test('rejects terminal space tasks past the injected cutoff via updated_at fallback', () => {
+    const row = eligibleRow({
+      session_id: 'space:space-1:task:task-1:exec:exec-1',
+      task_status: 'done',
+      task_completed_at: null,
+      task_updated_at: NOW - TTL_MS - DAY_MS,
+    });
+    expect(isMessageSearchIndexEligible(row, NOW)).toBe(false);
+    expect(isMessageSearchIndexEligible(row, NOW - 2 * DAY_MS)).toBe(true);
+  });
+});


### PR DESCRIPTION
Extracts the FTS upsert admission gates from sdk-message-repository into message-search-admission.ts as a decisionRun pipeline with first-skip-wins precedence (superseded → searchable-type → eligibility → body-nonempty → user-status). Body gathering stays ahead of the delete/decision boundary so a malformed payload still throws inside the flush transaction and retains the pending row for retry, and isOlderThanMessageSearchTtl now takes an injected now supplied by every admission shell (flush loop and the synchronous no-pending-table fallback). Adds unit tests pinning gate order, lazy fact evaluation, and the TTL cutoff boundary; C1's repository-level pins cover parity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->