### PR TITLE
test(daemon): pin rate-limit-watchdog trip/reset decision table

### DIFF
--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -1426,4 +1426,222 @@ describe('RateLimitWatchdog', () => {
       expect(() => watchdog.retryNow()).not.toThrow();
     });
   });
+
+  describe('decision table pins', () => {
+    it('billing-terminal outranks a usable hinted reset: surfaces without any cooldown', async () => {
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const result = await watchdog.scheduleRetry(
+        "403 You've reached your usage limit for this billing cycle",
+        { uuid: 'm1', content: 'x' },
+        {
+          billingTerminal: true,
+          kind: 'usage_limit',
+          resetAtMs: Date.now() + 2 * 60 * 60 * 1000,
+        }
+      );
+      expect(result).toBe(false);
+      expect(stateManager.setRateLimitCooldown).not.toHaveBeenCalled();
+      expect(notifyPause).not.toHaveBeenCalled();
+      expect(watchdog.isPending()).toBe(false);
+    });
+
+    it('billing-terminal surfaces after a non-empty chain is exhausted (all entries unavailable)', async () => {
+      const A: FallbackModelEntry = { provider: 'minimax', model: 'abab6.5' };
+      const { deps, notifyPause, switchAndRetry } = createMockDeps({
+        chain: [A],
+        available: () => false,
+      });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const result = await watchdog.scheduleRetry(
+        '402 insufficient credits',
+        { uuid: 'm1', content: 'x' },
+        { billingTerminal: true, kind: 'usage_limit' }
+      );
+      expect(result).toBe(false);
+      expect(switchAndRetry).not.toHaveBeenCalled();
+      expect(stateManager.setRateLimitCooldown).not.toHaveBeenCalled();
+      expect(notifyPause).not.toHaveBeenCalled();
+    });
+
+    it('a hinted reset beyond the 7-day horizon is ignored; the ladder arms but the hinted kind labels the pause', async () => {
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const result = await watchdog.scheduleRetry(
+        '429',
+        { uuid: 'm1', content: 'x' },
+        { resetAtMs: Date.now() + 8 * 24 * 60 * 60 * 1000, kind: 'usage_limit' }
+      );
+      expect(result).toBe(true);
+      expect(watchdog.getState().retryCount).toBe(1);
+      expect(notifyPause.mock.calls[0][0]).toMatchObject({ kind: 'usage_limit' });
+      watchdog.cancel();
+    });
+
+    it('ladder pause kind falls back to message classification when the hint carries no kind', async () => {
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const result = await watchdog.scheduleRetry(
+        'quota exceeded for today',
+        { uuid: 'm1', content: 'x' },
+        { resetAtMs: Date.now() - 1000 }
+      );
+      expect(result).toBe(true);
+      expect(watchdog.getState().retryCount).toBe(1);
+      expect(notifyPause.mock.calls[0][0]).toMatchObject({ kind: 'usage_limit' });
+      watchdog.cancel();
+    });
+
+    it('the ladder delay steps with the episode retry count (10min step, then 30min step)', async () => {
+      const { deps } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 5 });
+      const msg = { uuid: 'm1', content: 'x' };
+      const beforeFirst = Date.now();
+      await watchdog.scheduleRetry('429', msg);
+      const beforeSecond = Date.now();
+      await watchdog.scheduleRetry('429', msg);
+      const writes = (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls;
+      expect(writes[0][0].retryAt - beforeFirst).toBeGreaterThan(8 * 60 * 1000);
+      expect(writes[0][0].retryAt - beforeFirst).toBeLessThan(12 * 60 * 1000);
+      expect(writes[1][0].retryAt - beforeSecond).toBeGreaterThan(24 * 60 * 1000);
+      expect(writes[1][0].retryAt - beforeSecond).toBeLessThan(36 * 60 * 1000);
+      watchdog.cancel();
+    });
+
+    it('ignores an LLM-refined reset in the past and keeps the ladder cooldown', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() - 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+
+      expect(
+        (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
+      ).toHaveLength(1);
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      watchdog.cancel();
+    });
+
+    it('ignores an LLM-refined reset beyond the 7-day horizon and keeps the ladder cooldown', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 8 * 24 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+
+      expect(
+        (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls
+      ).toHaveLength(1);
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      watchdog.cancel();
+    });
+
+    it('normalizes an epoch-seconds LLM reset and re-arms at reset plus buffer', async () => {
+      const resetSec = Math.floor((Date.now() + 2 * 60 * 60 * 1000) / 1000);
+      const classify = mock(async () => ({
+        resetAtMs: resetSec,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+
+      const calls = (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls;
+      expect(calls[1][0].retryAt).toBe(resetSec * 1000 + RESET_BUFFER_MS);
+      watchdog.cancel();
+    });
+
+    it('a kind-only LLM assessment (no reset) neither re-arms nor relabels the pause', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: null,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry('throttled by waf', { uuid: 'm1', content: 'x' });
+      await flush();
+      await flush();
+
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      expect(notifyPause.mock.calls[0][0]).toMatchObject({ kind: 'rate_limit' });
+      expect(watchdog.getState().limitKind).toBe('rate_limit');
+      watchdog.cancel();
+    });
+
+    it('skips LLM refinement when a usable hinted reset scheduled the cooldown', async () => {
+      const classify = mock(async () => ({
+        resetAtMs: Date.now() + 3 * 60 * 60 * 1000,
+        kind: 'usage_limit' as const,
+        notALimit: false,
+      }));
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      deps.classifyUnknownLimit = classify;
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+
+      await watchdog.scheduleRetry(
+        'throttled by waf',
+        { uuid: 'm1', content: 'x' },
+        { resetAtMs: Date.now() + 2 * 60 * 60 * 1000, kind: 'usage_limit' }
+      );
+      await flush();
+      await flush();
+
+      expect(classify).not.toHaveBeenCalled();
+      expect(notifyPause).toHaveBeenCalledTimes(1);
+      watchdog.cancel();
+    });
+
+    it('isManualRecoveryPause is true after startup retries are exhausted', async () => {
+      const { deps } = createMockDeps({ chain: [] });
+      const retryCallback = mock(async () => false);
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps);
+      watchdog.setRetryCallback(retryCallback);
+      expect(watchdog.isManualRecoveryPause()).toBe(false);
+
+      await watchdog.scheduleRetry('429', { uuid: 'm1', content: 'hi' });
+      for (let i = 0; i < 4; i++) {
+        watchdog.retryNow();
+        await flush();
+      }
+
+      expect(watchdog.isManualRecoveryPause()).toBe(true);
+      expect(watchdog.isRecoveryPending()).toBe(true);
+    });
+
+    it('reset clears the paused limit kind alongside the episode', async () => {
+      const { deps } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps);
+      await watchdog.scheduleRetry(
+        '429',
+        { uuid: 'm1', content: 'x' },
+        { resetAtMs: Date.now() + 60 * 60 * 1000, kind: 'usage_limit' }
+      );
+      expect(watchdog.getState().limitKind).toBe('usage_limit');
+      watchdog.reset();
+      expect(watchdog.getState().limitKind).toBeNull();
+      expect(watchdog.getState().retryCount).toBe(0);
+    });
+  });
 });

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -1529,6 +1529,10 @@ describe('RateLimitWatchdog', () => {
       watchdog.cancel();
     });
 
+    it('the reset-horizon policy value itself is exactly seven days', () => {
+      expect(MAX_RESET_HORIZON_MS).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+
     it('ladder pause kind falls back to message classification when the hint carries no kind', async () => {
       const { deps, notifyPause } = createMockDeps({ chain: [] });
       const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { FallbackModelEntry } from '@hyperneo/shared';
-import { BACKOFF_LADDER_MS, RESET_BUFFER_MS } from '../../../../src/lib/agent/fallback-recovery';
+import {
+  BACKOFF_LADDER_MS,
+  MAX_RESET_HORIZON_MS,
+  RESET_BUFFER_MS,
+} from '../../../../src/lib/agent/fallback-recovery';
 import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
 import {
   RateLimitWatchdog,
@@ -1098,6 +1102,28 @@ describe('RateLimitWatchdog', () => {
       expect(watchdog.getState().retryCount).toBe(1);
       watchdog.clearPendingCooldown();
     });
+
+    it('a new user turn re-arms the fallback chain (tried entries cleared)', async () => {
+      const A: FallbackModelEntry = { provider: 'glm', model: 'glm-a' };
+      const { deps, switchAndRetry, setModel } = createMockDeps({
+        current: { provider: 'anthropic', model: 'sonnet' },
+        chain: [A],
+        switchSucceeds: false,
+      });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      await watchdog.scheduleRetry('429', { uuid: 'm1', content: 'hi' });
+      await flush();
+      await flush();
+      expect(switchAndRetry).toHaveBeenCalledTimes(1);
+      expect(switchAndRetry.mock.calls[0][1]).toEqual(A);
+
+      setModel('anthropic', 'sonnet');
+      await watchdog.scheduleRetry('429', { uuid: 'm2', content: 'hey' });
+      await flush();
+      expect(switchAndRetry).toHaveBeenCalledTimes(2);
+      expect(switchAndRetry.mock.calls[1][1]).toEqual(A);
+      watchdog.cancel();
+    });
   });
 
   describe('cancel / retryNow / reset / destroy', () => {
@@ -1467,14 +1493,39 @@ describe('RateLimitWatchdog', () => {
     it('a hinted reset beyond the 7-day horizon is ignored; the ladder arms but the hinted kind labels the pause', async () => {
       const { deps, notifyPause } = createMockDeps({ chain: [] });
       const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const before = Date.now();
       const result = await watchdog.scheduleRetry(
         '429',
         { uuid: 'm1', content: 'x' },
-        { resetAtMs: Date.now() + 8 * 24 * 60 * 60 * 1000, kind: 'usage_limit' }
+        { resetAtMs: Date.now() + MAX_RESET_HORIZON_MS + 60 * 1000, kind: 'usage_limit' }
       );
       expect(result).toBe(true);
       expect(watchdog.getState().retryCount).toBe(1);
-      expect(notifyPause.mock.calls[0][0]).toMatchObject({ kind: 'usage_limit' });
+      expect(notifyPause.mock.calls[0][0]).toMatchObject({
+        kind: 'usage_limit',
+        reason: 'backoff-ladder',
+      });
+      const write = (stateManager.setRateLimitCooldown as ReturnType<typeof mock>).mock.calls[0][0];
+      expect(write.retryAt - before).toBeGreaterThan(8 * 60 * 1000);
+      expect(write.retryAt - before).toBeLessThan(12 * 60 * 1000);
+      watchdog.cancel();
+    });
+
+    it('a hinted reset just inside the 7-day horizon still free-waits', async () => {
+      const resetAt = Date.now() + MAX_RESET_HORIZON_MS - 60 * 1000;
+      const { deps, notifyPause } = createMockDeps({ chain: [] });
+      const watchdog = new RateLimitWatchdog('s', stateManager, deps, { maxAutoRetries: 3 });
+      const result = await watchdog.scheduleRetry(
+        '429',
+        { uuid: 'm1', content: 'x' },
+        { resetAtMs: resetAt, kind: 'usage_limit' }
+      );
+      expect(result).toBe(true);
+      expect(watchdog.getState().retryCount).toBe(0);
+      expect(notifyPause.mock.calls[0][0]).toMatchObject({
+        kind: 'usage_limit',
+        reason: 'parsed-reset',
+      });
       watchdog.cancel();
     });
 
@@ -1531,7 +1582,7 @@ describe('RateLimitWatchdog', () => {
 
     it('ignores an LLM-refined reset beyond the 7-day horizon and keeps the ladder cooldown', async () => {
       const classify = mock(async () => ({
-        resetAtMs: Date.now() + 8 * 24 * 60 * 60 * 1000,
+        resetAtMs: Date.now() + MAX_RESET_HORIZON_MS + 60 * 1000,
         kind: 'usage_limit' as const,
         notALimit: false,
       }));

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog.test.ts
@@ -1563,6 +1563,10 @@ describe('RateLimitWatchdog', () => {
       watchdog.cancel();
     });
 
+    it('the ladder policy values themselves are 10 then 30 minutes', () => {
+      expect(BACKOFF_LADDER_MS.slice(0, 2)).toEqual([10 * 60 * 1000, 30 * 60 * 1000]);
+    });
+
     it('ignores an LLM-refined reset in the past and keeps the ladder cooldown', async () => {
       const classify = mock(async () => ({
         resetAtMs: Date.now() - 60 * 1000,


### PR DESCRIPTION
Policy-core pilot PR 1/2 (test-only, zero prod change): characterization tests pinning the current rate-limit-watchdog decision table ahead of extracting its pure trip/reset core. Pins trip precedence (billing-terminal outranks a usable reset hint and surfaces after an exhausted chain), the 7-day reset-horizon boundary, ladder stepping and kind fallback, LLM-refinement input gates (past/horizon/epoch-seconds/kind-only, hinted-reset skip), and the manual-recovery-pause/reset stand-down arms.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->