### PR TITLE
fix(space): transaction crash-safety hardening for goal outcomes (MC2-C 2/4)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -504,7 +504,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       spaceId,
       deps.reactiveDb,
       evolutionScopeService,
-      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId)
+      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId),
+      (taskId, fromStatus) => spaceGoalService.handleTaskTerminal(taskId, { fromStatus })
     );
   };
 
@@ -948,7 +949,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       spaceId,
       deps.reactiveDb,
       evolutionScopeService,
-      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId)
+      (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId),
+      (taskId, fromStatus) => spaceGoalService.handleTaskTerminal(taskId, { fromStatus })
     );
   };
   const hookStateRepo = new WorkflowHookStateRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -505,7 +505,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       deps.reactiveDb,
       evolutionScopeService,
       (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId),
-      (taskId, fromStatus) => spaceGoalService.handleTaskTerminal(taskId, { fromStatus })
+      (taskId, fromStatus) =>
+        spaceGoalService.handleTaskTerminal(taskId, { fromStatus, deferPostCommitEffects: true })
     );
   };
 
@@ -684,8 +685,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     spaceWorkflowManager,
     spaceTaskManagerFactory,
     deps.internalEventBus,
-    spaceRuntimeService,
-    spaceGoalService
+    spaceRuntimeService
   );
 
   setupTaskScheduleHandlers(deps.messageHub, {
@@ -950,7 +950,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
       deps.reactiveDb,
       evolutionScopeService,
       (taskId) => spaceGoalService.supersedeOutcomeNotificationsForTask(taskId),
-      (taskId, fromStatus) => spaceGoalService.handleTaskTerminal(taskId, { fromStatus })
+      (taskId, fromStatus) =>
+        spaceGoalService.handleTaskTerminal(taskId, { fromStatus, deferPostCommitEffects: true })
     );
   };
   const hookStateRepo = new WorkflowHookStateRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -448,6 +448,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     longHorizonAgentRepo,
     outcomeNotificationRepo,
     evolutionScopeService,
+    reactiveDb: deps.reactiveDb,
     eventHub: {
       publish: (event, data) => deps.internalEventBus.publish(event as never, data as never),
     },

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -484,20 +484,6 @@ export function setupSpaceTaskHandlers(
               });
             }
           } else {
-            const {
-              status: _s,
-              result: _r,
-              approvalReason: _ar,
-              cancelReason: _cr,
-              ...otherFields
-            } = updateParams;
-            if (Object.keys(otherFields).length > 0) {
-              await ensureWorkflowOverridesStillUnlocked(otherFields);
-              await taskManager.updateTask(taskId, otherFields, {
-                onCascadedTasks: emitCascadedTasks,
-              });
-            }
-
             const mappedReason =
               updateParams.status === 'cancelled'
                 ? (updateParams.cancelReason ?? updateParams.approvalReason ?? undefined)
@@ -526,6 +512,20 @@ export function setupSpaceTaskHandlers(
                 },
                 { onCascadedTasks: emitCascadedTasks }
               );
+            }
+
+            const {
+              status: _s,
+              result: _r,
+              approvalReason: _ar,
+              cancelReason: _cr,
+              ...otherFields
+            } = updateParams;
+            if (Object.keys(otherFields).length > 0) {
+              await ensureWorkflowOverridesStillUnlocked(otherFields);
+              task = await taskManager.updateTask(taskId, otherFields, {
+                onCascadedTasks: emitCascadedTasks,
+              });
             }
           }
         }

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -11,12 +11,6 @@ import {
   type UpdateSpaceTaskParams,
 } from '@hyperneo/shared';
 
-const TERMINAL_TASK_STATUSES = new Set<SpaceTaskStatus>([
-  'done',
-  'blocked',
-  'cancelled',
-  'archived',
-]);
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
 import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -24,7 +18,6 @@ import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { mapPostApprovalDispatchWarning } from '../space/runtime/post-approval-router';
-import type { SpaceGoalService } from '../space/goals/goal-service';
 import { arraysEqual } from '../utils/array-utils';
 
 const log = new Logger('space-task-handlers');
@@ -91,8 +84,7 @@ export function setupSpaceTaskHandlers(
   workflowManager: SpaceWorkflowManager,
   taskManagerFactory: SpaceTaskManagerFactory,
   internalEventBus: InternalEventBus<DaemonInternalEventMap>,
-  spaceRuntimeService?: SpaceRuntimeService,
-  spaceGoalService?: Pick<SpaceGoalService, 'handleTaskTerminal'>
+  spaceRuntimeService?: SpaceRuntimeService
 ): void {
   messageHub.onRequest('spaceTask.create', async (data) => {
     const params = data as CreateSpaceTaskParams & { draft?: boolean; goalId?: unknown };
@@ -302,7 +294,6 @@ export function setupSpaceTaskHandlers(
 
     let task: SpaceTask;
     let emitTaskUpdated = true;
-    let handleGoalTerminal = true;
     const emitCascadedTasks = async (cascadedTasks: SpaceTask[]) => {
       if (!emitTaskUpdated) return;
       for (const cascadedTask of cascadedTasks) {
@@ -469,7 +460,6 @@ export function setupSpaceTaskHandlers(
               updateParams
             );
             emitTaskUpdated = false;
-            handleGoalTerminal = false;
           } else if (parkingStoppedWorkflowTask) {
             if (!spaceRuntimeService) {
               throw new Error(
@@ -494,6 +484,20 @@ export function setupSpaceTaskHandlers(
               });
             }
           } else {
+            const {
+              status: _s,
+              result: _r,
+              approvalReason: _ar,
+              cancelReason: _cr,
+              ...otherFields
+            } = updateParams;
+            if (Object.keys(otherFields).length > 0) {
+              await ensureWorkflowOverridesStillUnlocked(otherFields);
+              await taskManager.updateTask(taskId, otherFields, {
+                onCascadedTasks: emitCascadedTasks,
+              });
+            }
+
             const mappedReason =
               updateParams.status === 'cancelled'
                 ? (updateParams.cancelReason ?? updateParams.approvalReason ?? undefined)
@@ -523,20 +527,6 @@ export function setupSpaceTaskHandlers(
                 { onCascadedTasks: emitCascadedTasks }
               );
             }
-
-            const {
-              status: _s,
-              result: _r,
-              approvalReason: _ar,
-              cancelReason: _cr,
-              ...otherFields
-            } = updateParams;
-            if (Object.keys(otherFields).length > 0) {
-              await ensureWorkflowOverridesStillUnlocked(otherFields);
-              task = await taskManager.updateTask(taskId, otherFields, {
-                onCascadedTasks: emitCascadedTasks,
-              });
-            }
           }
         }
       } else {
@@ -545,7 +535,6 @@ export function setupSpaceTaskHandlers(
         task = dependencyUpdate.task;
         if (dependencyUpdate.handledByRuntime) {
           emitTaskUpdated = false;
-          handleGoalTerminal = false;
         }
       }
     } else {
@@ -558,19 +547,6 @@ export function setupSpaceTaskHandlers(
       task = dependencyUpdate.task;
       if (dependencyUpdate.handledByRuntime) {
         emitTaskUpdated = false;
-        handleGoalTerminal = false;
-      }
-    }
-
-    if (handleGoalTerminal && spaceGoalService && TERMINAL_TASK_STATUSES.has(task.status)) {
-      try {
-        spaceGoalService.handleTaskTerminal(task.id, {
-          fromStatus: currentTaskForOverrides.status,
-        });
-      } catch (err) {
-        log.warn(
-          `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
-        );
       }
     }
 

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -370,7 +370,13 @@ export class SpaceGoalService {
             `Forge evidence capture threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
           );
         }
-        this.deps.goalAutomationService?.onTaskCompleted(taskId);
+        try {
+          this.deps.goalAutomationService?.onTaskCompleted(taskId);
+        } catch (err) {
+          log.warn(
+            `Goal automation onTaskCompleted threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
       let nextTask: SpaceTask | null = null;
       let postBookkeeping: SpaceGoal = fresh;

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -372,11 +372,15 @@ export class SpaceGoalService {
       let postBookkeeping: SpaceGoal = fresh;
       if (fresh.autoTriggerNext && fresh.pendingNextRun && fresh.status === 'active') {
         try {
-          const created = this.createImmediateTaskInternal(
-            fresh.id,
-            { source: 'system' },
-            { emitTaskCreated: false }
-          );
+          const createInSavepoint = () =>
+            this.createImmediateTaskInternal(
+              fresh.id,
+              { source: 'system' },
+              { emitTaskCreated: false }
+            );
+          const created = this.deps.db
+            ? this.deps.db.transaction(createInSavepoint)()
+            : createInSavepoint();
           postBookkeeping = created.goal;
           nextTask = created.task;
         } catch (err) {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -74,6 +74,10 @@ export interface SpaceGoalServiceDeps {
     import('../evolution-scope-service').EvolutionScopeService,
     'captureCompletedTaskEvidence'
   >;
+  reactiveDb?: Pick<
+    import('../../../storage/reactive-database').ReactiveDatabase,
+    'beginTransaction' | 'commitTransaction' | 'abortTransaction'
+  >;
 }
 
 export class SpaceGoalService {
@@ -529,7 +533,16 @@ export class SpaceGoalService {
 
   private runAtomic<T>(fn: () => T): T {
     if (!this.deps.db) return fn();
-    return this.deps.db.transaction(fn)();
+    const reactive = this.deps.reactiveDb;
+    reactive?.beginTransaction();
+    try {
+      const result = this.deps.db.transaction(fn)();
+      reactive?.commitTransaction();
+      return result;
+    } catch (err) {
+      reactive?.abortTransaction();
+      throw err;
+    }
   }
 
   private pauseLinkedScheduleOrClear(goal: SpaceGoal): void {

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -400,7 +400,15 @@ export class SpaceGoalService {
       return { goal: postBookkeeping, nextTask, terminalGeneration, notification };
     });
     if (result.nextTask) this.emitTaskCreated(result.nextTask);
-    if (result.notification) this.deps.onOutcomeNotification?.(result.notification);
+    if (result.notification) {
+      try {
+        this.deps.onOutcomeNotification?.(result.notification);
+      } catch (err) {
+        log.warn(
+          `Outcome notification delivery threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
     return result;
   }
 
@@ -436,7 +444,11 @@ export class SpaceGoalService {
       terminalGeneration,
       goalRevision: goal.revision,
       payload: {
-        summary: (task.reportedSummary ?? task.result ?? '').slice(0, 400),
+        summary: (
+          [task.reportedSummary, task.result].find(
+            (s) => typeof s === 'string' && s.trim().length > 0
+          ) ?? ''
+        ).slice(0, 400),
         taskStatus: task.status,
         taskTitle: task.title.slice(0, 200),
         goalTitle: goal.title.slice(0, 200),

--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -309,7 +309,11 @@ export class SpaceGoalService {
 
   handleTaskTerminal(
     taskId: string,
-    transition?: { fromStatus?: SpaceTaskStatus | null; updates?: InternalUpdateSpaceTaskParams }
+    transition?: {
+      fromStatus?: SpaceTaskStatus | null;
+      updates?: InternalUpdateSpaceTaskParams;
+      deferPostCommitEffects?: boolean;
+    }
   ): {
     goal: SpaceGoal;
     nextTask: SpaceTask | null;
@@ -409,15 +413,22 @@ export class SpaceGoalService {
       );
       return { goal: postBookkeeping, nextTask, terminalGeneration, notification };
     });
-    if (result.nextTask) this.emitTaskCreated(result.nextTask);
-    if (result.notification) {
-      try {
-        this.deps.onOutcomeNotification?.(result.notification);
-      } catch (err) {
-        log.warn(
-          `Outcome notification delivery threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
-        );
+    const deliverPostCommit = (): void => {
+      if (result.nextTask) this.emitTaskCreated(result.nextTask);
+      if (result.notification) {
+        try {
+          this.deps.onOutcomeNotification?.(result.notification);
+        } catch (err) {
+          log.warn(
+            `Outcome notification delivery threw for task "${taskId}": ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
       }
+    };
+    if (transition?.deferPostCommitEffects) {
+      setImmediate(deliverPostCommit);
+    } else {
+      deliverPostCommit();
     }
     return result;
   }

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -257,16 +257,24 @@ export class SpaceTaskManager {
     if (reopened && newStatus === 'open') {
       updates.startedAt = null;
     }
-    const updated = this.db.transaction(() => {
-      const result = this.taskRepo.updateTask(taskId, updates);
-      if (!result) {
-        throw new Error(`Failed to update task: ${taskId}`);
-      }
-      if (reopened) {
-        this.onTaskReopened?.(taskId);
-      }
-      return result;
-    })();
+    this.reactiveDb?.beginTransaction();
+    let updated: SpaceTask;
+    try {
+      updated = this.db.transaction(() => {
+        const result = this.taskRepo.updateTask(taskId, updates);
+        if (!result) {
+          throw new Error(`Failed to update task: ${taskId}`);
+        }
+        if (reopened) {
+          this.onTaskReopened?.(taskId);
+        }
+        return result;
+      })();
+      this.reactiveDb?.commitTransaction();
+    } catch (err) {
+      this.reactiveDb?.abortTransaction();
+      throw err;
+    }
 
     if (newStatus === 'done') {
       if (!task.goalId) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -79,7 +79,8 @@ export class SpaceTaskManager {
     private spaceId: string,
     private reactiveDb?: ReactiveDatabase,
     private evolutionScopeService?: EvolutionScopeService,
-    private onTaskReopened?: (taskId: string) => void
+    private onTaskReopened?: (taskId: string) => void,
+    private onTerminalTransition?: (taskId: string, fromStatus: SpaceTaskStatus) => void
   ) {
     this.taskRepo = new SpaceTaskRepository(db, reactiveDb);
   }
@@ -267,6 +268,9 @@ export class SpaceTaskManager {
         }
         if (reopened) {
           this.onTaskReopened?.(taskId);
+        }
+        if (isTerminalTaskStatus(newStatus)) {
+          this.onTerminalTransition?.(taskId, task.status);
         }
         return result;
       })();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -893,7 +893,8 @@ export class SpaceRuntimeService {
         space.id,
         this.config.reactiveDb,
         this.config.evolutionScopeService,
-        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
+        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,
@@ -1395,7 +1396,8 @@ export class SpaceRuntimeService {
         space.id,
         this.config.reactiveDb,
         this.config.evolutionScopeService,
-        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
+        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,
@@ -1567,7 +1569,8 @@ export class SpaceRuntimeService {
         space.id,
         this.config.reactiveDb,
         this.config.evolutionScopeService,
-        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
+        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
       ),
       spaceAgentManager,
       sessionManager: this.config.sessionManager,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -894,7 +894,11 @@ export class SpaceRuntimeService {
         this.config.reactiveDb,
         this.config.evolutionScopeService,
         (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
-        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
+        (taskId, fromStatus) =>
+          this.config.goalService?.handleTaskTerminal(taskId, {
+            fromStatus,
+            deferPostCommitEffects: true,
+          })
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,
@@ -1397,7 +1401,11 @@ export class SpaceRuntimeService {
         this.config.reactiveDb,
         this.config.evolutionScopeService,
         (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
-        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
+        (taskId, fromStatus) =>
+          this.config.goalService?.handleTaskTerminal(taskId, {
+            fromStatus,
+            deferPostCommitEffects: true,
+          })
       ),
       spaceAgentManager: this.config.spaceAgentManager,
       sessionManager: this.config.sessionManager,
@@ -1570,7 +1578,11 @@ export class SpaceRuntimeService {
         this.config.reactiveDb,
         this.config.evolutionScopeService,
         (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
-        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
+        (taskId, fromStatus) =>
+          this.config.goalService?.handleTaskTerminal(taskId, {
+            fromStatus,
+            deferPostCommitEffects: true,
+          })
       ),
       spaceAgentManager,
       sessionManager: this.config.sessionManager,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -1824,7 +1824,6 @@ export class SpaceRuntimeService {
       targetStatus,
       options
     );
-    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     return recovered.task;
   }
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4270,6 +4270,7 @@ export class SpaceRuntime {
     });
 
     const recovered = recoverTx();
+    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3579,6 +3579,20 @@ export class SpaceRuntime {
     if (updated) {
       let emitUpdated = true;
 
+      const isTerminal = (status: SpaceTaskStatus): boolean =>
+        status === 'done' ||
+        status === 'blocked' ||
+        status === 'cancelled' ||
+        status === 'archived';
+      if (
+        previous &&
+        params.status !== undefined &&
+        isTerminal(previous.status) &&
+        !isTerminal(params.status)
+      ) {
+        this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
+      }
+
       if (params.status === 'blocked') {
         const reason = params.result ?? updated.result ?? 'Task blocked';
         if (params.blockReason === 'dependency_added') {
@@ -8320,7 +8334,8 @@ export class SpaceRuntime {
         spaceId,
         this.config.reactiveDb,
         this.config.evolutionScopeService,
-        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
+        (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
+        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
       );
       this.taskManagers.set(spaceId, manager);
     }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4162,6 +4162,7 @@ export class SpaceRuntime {
         postApprovalSourceNodeId: null,
         reportedStatus: null,
         reportedSummary: null,
+        ...(targetStatus === 'open' ? { startedAt: null } : {}),
         ...(options.description !== undefined ? { description: options.description } : {}),
       });
       if (!updatedTask) throw new Error(`Failed to update task: ${task.id}`);

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3575,23 +3575,22 @@ export class SpaceRuntime {
     if (previous && params.status !== undefined && params.status !== previous.status) {
       assertValidSpaceTaskTransition(previous.status, params.status);
     }
-    let updated = this.config.taskRepo.updateTask(taskId, params);
+    const isTerminal = (status: SpaceTaskStatus): boolean =>
+      status === 'done' || status === 'blocked' || status === 'cancelled' || status === 'archived';
+    const reopensFromTerminal =
+      previous &&
+      params.status !== undefined &&
+      isTerminal(previous.status) &&
+      !isTerminal(params.status);
+    let updated = reopensFromTerminal
+      ? this.config.db.transaction(() => {
+          const result = this.config.taskRepo.updateTask(taskId, params);
+          this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
+          return result;
+        })()
+      : this.config.taskRepo.updateTask(taskId, params);
     if (updated) {
       let emitUpdated = true;
-
-      const isTerminal = (status: SpaceTaskStatus): boolean =>
-        status === 'done' ||
-        status === 'blocked' ||
-        status === 'cancelled' ||
-        status === 'archived';
-      if (
-        previous &&
-        params.status !== undefined &&
-        isTerminal(previous.status) &&
-        !isTerminal(params.status)
-      ) {
-        this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
-      }
 
       if (params.status === 'blocked') {
         const reason = params.result ?? updated.result ?? 'Task blocked';
@@ -8335,7 +8334,11 @@ export class SpaceRuntime {
         this.config.reactiveDb,
         this.config.evolutionScopeService,
         (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
-        (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
+        (taskId, fromStatus) =>
+          this.config.goalService?.handleTaskTerminal(taskId, {
+            fromStatus,
+            deferPostCommitEffects: true,
+          })
       );
       this.taskManagers.set(spaceId, manager);
     }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4270,7 +4270,15 @@ export class SpaceRuntime {
       return { task: updatedTask, run: updatedRun };
     });
 
-    const recovered = recoverTx();
+    this.config.reactiveDb?.beginTransaction();
+    let recovered: { task: SpaceTask; run: SpaceWorkflowRun };
+    try {
+      recovered = recoverTx();
+      this.config.reactiveDb?.commitTransaction();
+    } catch (err) {
+      this.config.reactiveDb?.abortTransaction();
+      throw err;
+    }
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3582,13 +3582,23 @@ export class SpaceRuntime {
       params.status !== undefined &&
       isTerminal(previous.status) &&
       !isTerminal(params.status);
-    let updated = reopensFromTerminal
-      ? this.config.db.transaction(() => {
+    let updated: SpaceTask | null;
+    if (reopensFromTerminal) {
+      this.config.reactiveDb?.beginTransaction();
+      try {
+        updated = this.config.db.transaction(() => {
           const result = this.config.taskRepo.updateTask(taskId, params);
           this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
           return result;
-        })()
-      : this.config.taskRepo.updateTask(taskId, params);
+        })();
+        this.config.reactiveDb?.commitTransaction();
+      } catch (err) {
+        this.config.reactiveDb?.abortTransaction();
+        throw err;
+      }
+    } else {
+      updated = this.config.taskRepo.updateTask(taskId, params);
+    }
     if (updated) {
       let emitUpdated = true;
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -4266,11 +4266,11 @@ export class SpaceRuntime {
         }
       }
 
+      this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
       return { task: updatedTask, run: updatedRun };
     });
 
     const recovered = recoverTx();
-    this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId);
     await this.ensureExecutorRegistered(recovered.run);
     const recoveredWorkflow = this.config.spaceWorkflowManager.getWorkflowForRun(recovered.run);
     if (recoveredWorkflow) {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4188,7 +4188,8 @@ export class TaskAgentManager {
       spaceId,
       this.config.reactiveDb,
       this.config.evolutionScopeService,
-      (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId)
+      (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
+      (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
     );
     const endNodeHandlers = isEndNode
       ? createEndNodeHandlers({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -4189,7 +4189,11 @@ export class TaskAgentManager {
       this.config.reactiveDb,
       this.config.evolutionScopeService,
       (taskId) => this.config.goalService?.supersedeOutcomeNotificationsForTask(taskId),
-      (taskId, fromStatus) => this.config.goalService?.handleTaskTerminal(taskId, { fromStatus })
+      (taskId, fromStatus) =>
+        this.config.goalService?.handleTaskTerminal(taskId, {
+          fromStatus,
+          deferPostCommitEffects: true,
+        })
     );
     const endNodeHandlers = isEndNode
       ? createEndNodeHandlers({

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -192,6 +192,14 @@ export function createMarkCompleteHandler(
       const reportedSummary = normalizeMeaningfulTaskResult(task.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(task.result);
       const result = artifactSummary ?? existingResult ?? reportedSummary ?? 'Task completed.';
+      const updated = await taskManager.setTaskStatus(taskId, 'done', {
+        approvalSource: task.approvalSource ?? 'agent',
+        result,
+        reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
+        onCascadedTasks: async (cascadedTasks) => {
+          for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
+        },
+      });
       if (goalUpdate) {
         goalService?.updateGoal(
           goalUpdate.goalId,
@@ -204,14 +212,6 @@ export function createMarkCompleteHandler(
           { source: 'workflow_node_agent', sourceTaskId: taskId }
         );
       }
-      const updated = await taskManager.setTaskStatus(taskId, 'done', {
-        approvalSource: task.approvalSource ?? 'agent',
-        result,
-        reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
-        onCascadedTasks: async (cascadedTasks) => {
-          for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
-        },
-      });
       emitTaskUpdated(updated);
       log.info(
         `post-approval.complete: spaceId=${spaceId} taskId=${taskId} outcome=done mode=${task.postApprovalSessionId ? 'spawn' : 'inline'}`

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -115,17 +115,6 @@ export function createMarkCompleteHandler(
     assertPrMerged,
   } = deps;
 
-  const handleGoalTerminal = (task: SpaceTask, fromStatus: SpaceTask['status']): void => {
-    if (!goalService) return;
-    try {
-      goalService.handleTaskTerminal(task.id, { fromStatus });
-    } catch (err) {
-      log.warn(
-        `Goal terminal handling threw for task "${task.id}": ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  };
-
   const emitTaskUpdated = (task: SpaceTask): void => {
     if (!internalEventBus) return;
     void internalEventBus
@@ -203,14 +192,6 @@ export function createMarkCompleteHandler(
       const reportedSummary = normalizeMeaningfulTaskResult(task.reportedSummary);
       const existingResult = normalizeMeaningfulTaskResult(task.result);
       const result = artifactSummary ?? existingResult ?? reportedSummary ?? 'Task completed.';
-      const updated = await taskManager.setTaskStatus(taskId, 'done', {
-        approvalSource: task.approvalSource ?? 'agent',
-        result,
-        reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
-        onCascadedTasks: async (cascadedTasks) => {
-          for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
-        },
-      });
       if (goalUpdate) {
         goalService?.updateGoal(
           goalUpdate.goalId,
@@ -223,7 +204,14 @@ export function createMarkCompleteHandler(
           { source: 'workflow_node_agent', sourceTaskId: taskId }
         );
       }
-      handleGoalTerminal(updated, task.status);
+      const updated = await taskManager.setTaskStatus(taskId, 'done', {
+        approvalSource: task.approvalSource ?? 'agent',
+        result,
+        reportedSummary: artifactSummary ?? reportedSummary ?? undefined,
+        onCascadedTasks: async (cascadedTasks) => {
+          for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
+        },
+      });
       emitTaskUpdated(updated);
       log.info(
         `post-approval.complete: spaceId=${spaceId} taskId=${taskId} outcome=done mode=${task.postApprovalSessionId ? 'spawn' : 'inline'}`

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2112,14 +2112,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             return jsonResult({ success: true, task: stopped });
           }
           case 'set_status': {
-            let updated = await taskManager.setTaskStatus(args.task_id, args.status!, {
+            if (hasFieldUpdates) {
+              await applyFieldUpdates();
+            }
+            const updated = await taskManager.setTaskStatus(args.task_id, args.status!, {
               onCascadedTasks: async (cascadedTasks) => {
                 for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
               },
             });
-            if (hasFieldUpdates) {
-              updated = await applyFieldUpdates();
-            }
             logAudit('update_task', transitionAuditParams, args.task_id);
             emitTaskUpdated(updated);
             return jsonResult({ success: true, task: updated });

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2120,22 +2120,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             if (hasFieldUpdates) {
               updated = await applyFieldUpdates();
             }
-            if (
-              updated.status === 'done' ||
-              updated.status === 'blocked' ||
-              updated.status === 'cancelled' ||
-              updated.status === 'archived'
-            ) {
-              try {
-                config.goalService?.handleTaskTerminal(updated.id, {
-                  fromStatus: task?.status ?? null,
-                });
-              } catch (err) {
-                log.warn(
-                  `Goal terminal handling threw for task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
-                );
-              }
-            }
             logAudit('update_task', transitionAuditParams, args.task_id);
             emitTaskUpdated(updated);
             return jsonResult({ success: true, task: updated });
@@ -2216,20 +2200,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
       cancel_workflow_run?: boolean;
     }): Promise<ToolResult> {
       try {
-        const preCancelStatus = taskRepo.getTask(args.task_id)?.status ?? null;
         const cancelled = await taskManager.cancelTaskCascade(args.task_id);
         const task = cancelled[0]!;
         for (const cancelledTask of cancelled) {
           emitTaskUpdated(cancelledTask);
-          try {
-            config.goalService?.handleTaskTerminal(cancelledTask.id, {
-              fromStatus: cancelledTask.id === args.task_id ? preCancelStatus : 'open',
-            });
-          } catch (err) {
-            log.warn(
-              `Goal terminal handling threw for cancelled task "${cancelledTask.id}": ${err instanceof Error ? err.message : String(err)}`
-            );
-          }
         }
         const existingRun = task.workflowRunId ? workflowRunRepo.getRun(task.workflowRunId) : null;
         const plan = routeCancelTask({
@@ -2302,15 +2276,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
         logAudit('archive_task', { previousStatus: task?.status }, args.task_id);
 
         emitTaskUpdated(updated);
-        try {
-          config.goalService?.handleTaskTerminal(updated.id, {
-            fromStatus: task?.status ?? null,
-          });
-        } catch (err) {
-          log.warn(
-            `Goal terminal handling threw for archived task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
-          );
-        }
 
         return jsonResult({ success: true, task: updated });
       } catch (err) {
@@ -2931,14 +2896,6 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
           },
         });
-
-        try {
-          config.goalService?.handleTaskTerminal(updated.id);
-        } catch (err) {
-          log.warn(
-            `Goal terminal handling threw for task "${updated.id}": ${err instanceof Error ? err.message : String(err)}`
-          );
-        }
 
         logAudit(
           'approve_task',

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -2112,14 +2112,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
             return jsonResult({ success: true, task: stopped });
           }
           case 'set_status': {
-            if (hasFieldUpdates) {
-              await applyFieldUpdates();
-            }
-            const updated = await taskManager.setTaskStatus(args.task_id, args.status!, {
+            let updated = await taskManager.setTaskStatus(args.task_id, args.status!, {
               onCascadedTasks: async (cascadedTasks) => {
                 for (const cascadedTask of cascadedTasks) emitTaskUpdated(cascadedTask);
               },
             });
+            if (hasFieldUpdates) {
+              updated = await applyFieldUpdates();
+            }
             logAudit('update_task', transitionAuditParams, args.task_id);
             emitTaskUpdated(updated);
             return jsonResult({ success: true, task: updated });


### PR DESCRIPTION
## Summary
Second of 4 stacked PRs (base: space/mc2c1-notification-persistence). Makes the notification transactions truly atomic under rollback/crash.

- `runAtomic` brackets the raw transaction with the reactive database begin/commit/abort hooks so rolled-back terminal writes don't emit phantom change events.
- Savepoint isolation for auto-triggered next-task creation: a post-mutation failure rolls back only the created task, not the terminal record.
- Emit `space.task.created` only after the terminal transaction commits.
- Atomic reopen supersede + reactive buffering in the task-manager reopen transaction.
- Workflow recovery: supersede outcomes inside the recovery transaction, reset `startedAt` on `open` recovery, and buffer recovery reactive changes.
- Isolated automation/delivery callbacks so they cannot roll back the committed outcome.

## Test plan
- Goal-service rollback + retry tests.
- Space-task-manager status-transition + recovery tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->