### PR TITLE
fix(space): retry queued goal auto-trigger runs on space resume (MC2-C 3/4)

### DIFF
--- a/packages/daemon/src/lib/space/goals/goal-service.ts
+++ b/packages/daemon/src/lib/space/goals/goal-service.ts
@@ -245,6 +245,23 @@ export class SpaceGoalService {
     return this.createImmediateTaskInternal(goalId, context);
   }
 
+  retryQueuedRunsForSpace(spaceId: string): number {
+    const goals = this.deps.goalRepo.list({ spaceId, status: 'active' });
+    let created = 0;
+    for (const goal of goals) {
+      if (!goal.autoTriggerNext || !goal.pendingNextRun || goal.activeTaskId) continue;
+      try {
+        this.createImmediateTask(goal.id, { source: 'system' });
+        created += 1;
+      } catch (err) {
+        log.warn(
+          `Retry queued run threw for goal "${goal.id}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    return created;
+  }
+
   private createImmediateTaskInternal(
     goalId: string,
     context?: SpaceGoalMutationContext,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -216,7 +216,7 @@ export interface SpaceRuntimeConfig {
   selectWorkflowWithLlm?: SelectWorkflowWithLlm;
   goalService?: Pick<
     import('../goals/goal-service').SpaceGoalService,
-    'handleTaskTerminal' | 'supersedeOutcomeNotificationsForTask'
+    'handleTaskTerminal' | 'supersedeOutcomeNotificationsForTask' | 'retryQueuedRunsForSpace'
   >;
   evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
   actorRegistry?: SpaceActorRegistryAdapter;
@@ -4566,6 +4566,13 @@ export class SpaceRuntime {
   onSpaceResumed(spaceId: string): void {
     const store = this.config.externalEventStore;
     this.pausedSpaceIds.delete(spaceId);
+    try {
+      this.config.goalService?.retryQueuedRunsForSpace(spaceId);
+    } catch (err) {
+      log.warn(
+        `Goal queued-run retry threw for space ${spaceId} on resume: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
     if (!store) return;
 
     const reactiveRuns = this.config.workflowRunRepo

--- a/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/space-goal-service.test.ts
@@ -388,6 +388,28 @@ describe('SpaceGoalService', () => {
     expect(taskRepo.listBySpace(spaceId).map((task) => task.id)).toEqual([first.task!.id]);
   });
 
+  it('retries queued auto-trigger runs after the host space resumes', () => {
+    const goal = service.createGoal({
+      spaceId,
+      title: 'Retry queued run',
+      autoTriggerNext: true,
+    });
+    const first = service.createImmediateTask(goal.id);
+    expect(first.task).not.toBeNull();
+    service.createImmediateTask(goal.id);
+    spaceRepo.pauseSpace(spaceId);
+    taskRepo.updateTask(first.task!.id, { status: 'done' });
+    service.handleTaskTerminal(first.task!.id);
+    expect(goalRepo.getById(goal.id)?.pendingNextRun).toBe(true);
+
+    spaceRepo.resumeSpace(spaceId);
+    const created = service.retryQueuedRunsForSpace(spaceId);
+    expect(created).toBe(1);
+    const updated = goalRepo.getById(goal.id);
+    expect(updated?.pendingNextRun).toBe(false);
+    expect(updated?.activeTaskId).not.toBeNull();
+  });
+
   it('auto-triggers one queued task after the active task reaches a terminal status', () => {
     const goal = service.createGoal({
       spaceId,


### PR DESCRIPTION
## Summary
Third of 4 stacked PRs (base: space/mc2c2-crash-safety). Closes the post-terminal lifecycle gap.

- When automatic next-task creation fails (e.g. host space paused), the goal keeps `pendingNextRun` true but nothing re-consumed it.
- Add `retryQueuedRunsForSpace` on the goal service and invoke it from the runtime's `onSpaceResumed`, so an `autoTriggerNext` goal no longer silently stalls after the space resumes.

## Test plan
- Goal-service test: queued run is retried after the host space resumes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->