### PR TITLE
feat(space): wake the goal owner on reportable terminal outcomes (MC2-C 4/4)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -1,5 +1,6 @@
 import type { MessageHub } from '@hyperneo/shared';
 import { generateUUID } from '@hyperneo/shared';
+import type { SpaceGoalOutcomeNotification } from '@hyperneo/shared';
 import type { SDKUserMessage } from '@hyperneo/shared/sdk';
 import type { UUID } from 'crypto';
 import type { DaemonInternalEventMap, InternalEventBus } from '../internal-event-bus';
@@ -438,6 +439,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     traceEvidenceService: evolutionTraceEvidenceService,
     jobQueue: deps.jobQueue,
   });
+  let deliverOutcomeWake: (notification: SpaceGoalOutcomeNotification) => void = () => {};
   const spaceGoalService = new SpaceGoalService({
     goalRepo: spaceGoalRepo,
     goalEventRepo: spaceGoalEventRepo,
@@ -468,35 +470,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     },
     onOutcomeNotification: (notification) => {
       try {
-        const goal = spaceGoalRepo.getById(notification.goalId);
-        if (!goal) return;
-        const resolution = longHorizonAgentRepo.getPrimaryGoalOwner(goal.id, goal.spaceId);
-        let targetAgentId: string | null = null;
-        if (resolution.action === 'resolved') {
-          targetAgentId = resolution.owner.agentId;
-        } else if (resolution.action === 'degraded') {
-          targetAgentId = longHorizonAgentRepo.ensureCoordinator(goal.spaceId).id;
-        } else if (resolution.action === 'coordinator_fallback') {
-          targetAgentId = resolution.coordinatorAgentId;
-        }
-        if (!targetAgentId) {
-          log.warn(
-            `Goal outcome notification ${notification.id} has no owner or coordinator to wake`
-          );
-          return;
-        }
-        const { summary, taskStatus, taskTitle, goalTitle } = notification.payload;
-        const detail = summary ? ` ${summary}` : '';
-        spaceAgentInboxRepo.enqueue({
-          spaceId: goal.spaceId,
-          targetAgentId,
-          sourceActorId: `agent:coordinator:${goal.spaceId}`,
-          message: `Goal outcome ready for review: "${goalTitle}". Task "${taskTitle}" reached ${taskStatus}.${detail}`,
-          idempotencyKey: `goal-outcome:${notification.id}`,
-        });
-        log.info(
-          `goal.outcome.wake: goalId=${goal.id} taskId=${notification.taskId} target=${targetAgentId}`
-        );
+        deliverOutcomeWake(notification);
       } catch (err) {
         log.warn(
           `Goal outcome wake delivery threw for notification "${notification.id}": ${err instanceof Error ? err.message : String(err)}`
@@ -685,7 +659,15 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
     evolutionScopeService,
     evolutionEpisodeService,
     artifactProfile,
+    outcomeNotificationRepo,
   });
+  deliverOutcomeWake = (notification) => {
+    void spaceRuntimeService.deliverGoalOutcomeWake(notification).catch((err) => {
+      log.warn(
+        `Goal outcome wake delivery failed for notification "${notification.id}": ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+  };
 
   deps.spaceManager.onSpaceResumedRegister((spaceId) => {
     try {

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -466,6 +466,43 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
         }
       }
     },
+    onOutcomeNotification: (notification) => {
+      try {
+        const goal = spaceGoalRepo.getById(notification.goalId);
+        if (!goal) return;
+        const resolution = longHorizonAgentRepo.getPrimaryGoalOwner(goal.id, goal.spaceId);
+        let targetAgentId: string | null = null;
+        if (resolution.action === 'resolved') {
+          targetAgentId = resolution.owner.agentId;
+        } else if (resolution.action === 'degraded') {
+          targetAgentId = longHorizonAgentRepo.ensureCoordinator(goal.spaceId).id;
+        } else if (resolution.action === 'coordinator_fallback') {
+          targetAgentId = resolution.coordinatorAgentId;
+        }
+        if (!targetAgentId) {
+          log.warn(
+            `Goal outcome notification ${notification.id} has no owner or coordinator to wake`
+          );
+          return;
+        }
+        const { summary, taskStatus, taskTitle, goalTitle } = notification.payload;
+        const detail = summary ? ` ${summary}` : '';
+        spaceAgentInboxRepo.enqueue({
+          spaceId: goal.spaceId,
+          targetAgentId,
+          sourceActorId: `agent:coordinator:${goal.spaceId}`,
+          message: `Goal outcome ready for review: "${goalTitle}". Task "${taskTitle}" reached ${taskStatus}.${detail}`,
+          idempotencyKey: `goal-outcome:${notification.id}`,
+        });
+        log.info(
+          `goal.outcome.wake: goalId=${goal.id} taskId=${notification.taskId} target=${targetAgentId}`
+        );
+      } catch (err) {
+        log.warn(
+          `Goal outcome wake delivery threw for notification "${notification.id}": ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    },
   });
   const goalAutomationService = new GoalAutomationService({
     goalRepo: spaceGoalRepo,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -5,12 +5,14 @@ import type {
   Session,
   Space,
   SpaceWorkerAgent,
+  SpaceGoalOutcomeNotification,
   SpaceLongHorizonAgent,
   SpaceTask,
   SpaceWorkflowRun,
   UpdateSpaceTaskParams,
 } from '@hyperneo/shared';
-import { isRateOrUsageLimited, isScopedBashToolEntry } from '@hyperneo/shared';
+import type { SpaceGoalOutcomeNotificationRepository } from '../../../storage/repositories/space-goal-outcome-notification-repository';
+import { generateUUID, isRateOrUsageLimited, isScopedBashToolEntry } from '@hyperneo/shared';
 import type { MessageRecord, ActorRef } from '../../../../../messaging/src/types';
 import { canonicalAgentHandle, SpaceActorRegistryAdapter } from '../actor-registry';
 import { SpaceMessageResolver } from '../messaging-adapter';
@@ -139,6 +141,7 @@ export interface SpaceRuntimeServiceConfig {
   goalService?: import('../goals/goal-service').SpaceGoalService;
   evolutionScopeService?: import('../evolution-scope-service').EvolutionScopeService;
   evolutionEpisodeService?: import('../evolution-episode-service').EvolutionEpisodeService;
+  outcomeNotificationRepo?: SpaceGoalOutcomeNotificationRepository;
 }
 
 export class SpaceRuntimeService {
@@ -320,6 +323,53 @@ export class SpaceRuntimeService {
       message.idempotencyKey ?? message.messageId
     );
     return session.getSessionData().id;
+  }
+
+  async deliverGoalOutcomeWake(notification: SpaceGoalOutcomeNotification): Promise<void> {
+    if (this.config.outcomeNotificationRepo?.getById(notification.id)?.status !== 'pending') {
+      return;
+    }
+    const goal = this.config.goalService?.getGoal(notification.goalId);
+    if (!goal || goal.spaceId !== notification.spaceId) return;
+    const resolution = this.config.longHorizonAgentRepo?.getPrimaryGoalOwner(goal.id, goal.spaceId);
+    let targetAgentId: string | null = null;
+    if (resolution?.action === 'resolved') {
+      targetAgentId = resolution.owner.agentId;
+    } else if (resolution?.action === 'coordinator_fallback') {
+      targetAgentId = resolution.coordinatorAgentId;
+    } else if (resolution?.action === 'degraded') {
+      targetAgentId = this.config.longHorizonAgentRepo?.ensureCoordinator(goal.spaceId).id ?? null;
+    }
+    if (!targetAgentId) {
+      log.warn(
+        `Goal outcome wake has no owner or coordinator for notification "${notification.id}"`
+      );
+      return;
+    }
+    const agent = this.config.longHorizonAgentRepo?.getById(targetAgentId);
+    if (!agent) return;
+    const actor: ActorRef = {
+      actorId: `agent:${encodeActorIdComponent(agent.id)}`,
+      kind: 'agent',
+      spaceId: goal.spaceId,
+      handle: `@${agent.handle}`,
+      roles: ['space-agent', 'coordinator'],
+      status: 'inactive',
+    };
+    const { summary, taskStatus, taskTitle, goalTitle } = notification.payload;
+    const detail = summary ? ` ${summary}` : '';
+    const message: MessageRecord = {
+      messageId: generateUUID(),
+      spaceId: goal.spaceId,
+      senderActorId: `agent:coordinator:${goal.spaceId}`,
+      targets: [actor.actorId],
+      body: `Goal outcome ready for review: "${goalTitle}". Task "${taskTitle}" reached ${taskStatus}.${detail}`,
+      kind: 'message',
+      taskId: notification.taskId,
+      idempotencyKey: `goal-outcome:${notification.id}`,
+      createdAt: Date.now(),
+    };
+    await this.queueLongTermAgentMessage(actor, message);
   }
 
   private async queueLongTermAgentMessage(


### PR DESCRIPTION
## Summary
Fourth of 4 stacked PRs (base: space/mc2c3-goal-lifecycle). Wires the durable owner-wake delivery.

- `onOutcomeNotification` seam now enqueues a bounded wake to the durable agent inbox.
- Resolves the primary owner via the owner-resolution core at delivery time, falling back visibly to the coordinator when no usable owner exists.

## Test plan
- CI on the full stacked head.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->