### PR TITLE
feat(daemon): redact secrets in ACP command approval displays

### DIFF
--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -1,11 +1,275 @@
 import { createHash } from 'node:crypto';
-import { getAcpCommandIdentity } from '@hyperneo/shared/acp';
+import { parseAcpCommandWithSpans } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
-/* @public - consumed by ACP provider sync in a later stack PR */
+const SECRET_ARG_NAME_PATTERN =
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)$/i;
+
+const SECRET_HEADER_NAME_PATTERN =
+  /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
+
+const SHELL_COMMAND_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
+const CURL_COMMAND_NAMES = new Set(['curl']);
+const ENV_COMMAND_NAMES = new Set(['env', 'export']);
+const SHELL_OPERATORS = new Set(['&&', '||', ';', '|', '&', '(', ')']);
+
+function commandBaseName(command: string): string {
+  return (command.split('/').pop() ?? command).toLowerCase();
+}
+
+function isSecretArgName(name: string): boolean {
+  return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
+}
+
+function isSecretHeaderValue(value: string): boolean {
+  const headerName = value.split(':', 1)[0]?.trim() ?? '';
+  return SECRET_HEADER_NAME_PATTERN.test(headerName);
+}
+
+function isHeaderArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^H$/i.test(stripped) || /^header$/i.test(stripped);
+}
+
+function isUserArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^u$/i.test(stripped) || /^user$/i.test(stripped);
+}
+
+function isSecretEnvAssignment(arg: string): boolean {
+  const equalsIndex = arg.indexOf('=');
+  if (equalsIndex <= 0) return false;
+  return isSecretArgName(arg.slice(0, equalsIndex));
+}
+
+export function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function displayQuote(token: string): string {
+  if (!/\s/.test(token)) return token;
+  if (/[$`&|;<>()*?]/.test(token)) return token;
+  return shellQuote(token);
+}
+
+const URL_USERINFO_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*:\/\/[^:/@\s]+:)([^@/\s]+)(@.+)$/;
+
+function redactUrlUserinfo(value: string): string {
+  const match = URL_USERINFO_PATTERN.exec(value);
+  return match ? `${match[1]}[redacted]${match[3]}` : value;
+}
+
+const SCRIPT_SENSITIVITY_PATTERN =
+  /(^|\s)--?[^\s'"]*(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)|(^|\s)-[hu]\b/i;
+
+function redactShellCommand(script: string, depth: number): string {
+  if (depth <= 0) {
+    return SCRIPT_SENSITIVITY_PATTERN.test(script) ? '[redacted script]' : script;
+  }
+  try {
+    const parsed = parseAcpCommandWithSpans(script);
+    const tokens = [parsed.command, ...parsed.args];
+    const redactedArgs = redactCommandSecrets(parsed.command, parsed.args, depth - 1, {
+      shellScript: true,
+    });
+    const redactedCommand = isSecretEnvAssignment(parsed.command)
+      ? `${parsed.command.slice(0, parsed.command.indexOf('='))}=[redacted]`
+      : parsed.command;
+    const redactedTokens = [redactedCommand, ...redactedArgs];
+    let result = script;
+    let changed = false;
+    for (let index = redactedTokens.length - 1; index >= 0; index--) {
+      if (redactedTokens[index] === tokens[index]) continue;
+      const span = parsed.rawSpans[index];
+      if (!span) {
+        changed = false;
+        break;
+      }
+      const rawText = result.slice(span.start, span.end);
+      const at = rawText.indexOf(tokens[index]);
+      if (at >= 0) {
+        result =
+          result.slice(0, span.start) +
+          rawText.slice(0, at) +
+          redactedTokens[index] +
+          rawText.slice(at + tokens[index].length) +
+          result.slice(span.end);
+      } else {
+        result = result.slice(0, span.start) + redactedTokens[index] + result.slice(span.end);
+      }
+      changed = true;
+    }
+    if (changed) return result;
+    if (redactedTokens.some((token, index) => token !== tokens[index])) {
+      return redactedTokens.map(displayQuote).join(' ');
+    }
+    return script;
+  } catch {
+    return script;
+  }
+}
+
+export function redactCommandSecrets(
+  command: string,
+  args: string[],
+  depth = 3,
+  options: { shellScript?: boolean } = {}
+): string[] {
+  const isEnv = ENV_COMMAND_NAMES.has(commandBaseName(command));
+  const assignmentsAllowed = isEnv || options.shellScript === true;
+  let inLeadingAssignments =
+    options.shellScript === true ? command.indexOf('=') > 0 || isEnv : true;
+  let currentCommand = command;
+  let awaitingCommandWord = options.shellScript === true || isEnv;
+  let endOfOptions = false;
+  const redacted: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (options.shellScript === true && (SHELL_OPERATORS.has(arg) || /[;&|]$/.test(arg))) {
+      inLeadingAssignments = true;
+      endOfOptions = false;
+      awaitingCommandWord = true;
+      const word = arg.replace(/[;&|]+$/, '');
+      if (word && !SHELL_OPERATORS.has(word)) currentCommand = word;
+      redacted.push(arg);
+      continue;
+    }
+    if (arg === '--') {
+      endOfOptions = true;
+      redacted.push(arg);
+      continue;
+    }
+    if (endOfOptions) {
+      redacted.push(redactUrlUserinfo(arg));
+      continue;
+    }
+    if (!arg.startsWith('-')) {
+      const looksLikeUrl = /^[a-z][a-z0-9+.-]*:/i.test(arg);
+      if (options.shellScript === true && !looksLikeUrl && /[;&|]/.test(arg)) {
+        inLeadingAssignments = true;
+        endOfOptions = false;
+        awaitingCommandWord = true;
+        redacted.push(
+          arg.replace(/(^|[;&|])([A-Za-z_][\w-]*)=([^;&|\s]*)/g, (whole, pre, name) =>
+            isSecretEnvAssignment(`${name}=`) ? `${pre}${name}=[redacted]` : whole
+          )
+        );
+        continue;
+      }
+      const isAssignmentShaped = arg.indexOf('=') > 0;
+      if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
+        redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
+      } else {
+        if (!isAssignmentShaped) {
+          inLeadingAssignments = false;
+          if (awaitingCommandWord) {
+            currentCommand = arg;
+            awaitingCommandWord = false;
+          }
+        }
+        redacted.push(redactUrlUserinfo(arg));
+      }
+      continue;
+    }
+    const tokenCommandName = commandBaseName(currentCommand);
+    const tokenCurl = CURL_COMMAND_NAMES.has(tokenCommandName);
+    const tokenShell = SHELL_COMMAND_NAMES.has(tokenCommandName);
+    if (tokenCurl && /^-[a-z]*$/i.test(arg)) {
+      const letters = arg.slice(1).toLowerCase();
+      const valueFlag = letters.charAt(letters.length - 1);
+      const next = args[index + 1];
+      if (
+        (valueFlag === 'h' || valueFlag === 'u') &&
+        next !== undefined &&
+        !next.startsWith('--')
+      ) {
+        if (valueFlag === 'u' || isSecretHeaderValue(next)) {
+          redacted.push(arg, '[redacted]');
+          index++;
+          continue;
+        }
+      }
+      redacted.push(arg);
+      continue;
+    }
+    if (tokenCurl && /^-[a-z]*[hu]/i.test(arg)) {
+      const lowered = arg.toLowerCase();
+      let carrierIndex = -1;
+      for (let scan = 1; scan < lowered.length; scan++) {
+        const ch = lowered[scan];
+        if (ch === 'h' || ch === 'u') {
+          carrierIndex = scan;
+          break;
+        }
+        if (!/[a-z]/i.test(ch)) break;
+      }
+      if (carrierIndex > 0) {
+        const value = arg.slice(carrierIndex + 1);
+        const secret = lowered[carrierIndex] === 'u' || isSecretHeaderValue(value);
+        if (secret && value) {
+          redacted.push(`${arg.slice(0, carrierIndex + 1)}[redacted]`);
+          continue;
+        }
+      }
+    }
+    if (tokenShell && /^-[a-z]*c[a-z]*$/i.test(arg)) {
+      const next = args[index + 1];
+      if (next !== undefined) {
+        redacted.push(arg, redactShellCommand(next, depth));
+        index++;
+        continue;
+      }
+    }
+    if (tokenShell && /^-[a-z]*c/i.test(arg)) {
+      const cIndex = arg.toLowerCase().lastIndexOf('c');
+      const attachedScript = arg.slice(cIndex + 1);
+      if (attachedScript && !/[a-zA-Z]/.test(attachedScript)) {
+        redacted.push(`${arg.slice(0, cIndex + 1)}${redactShellCommand(attachedScript, depth)}`);
+        continue;
+      }
+    }
+    const equalsIndex = arg.indexOf('=');
+    if (equalsIndex >= 0) {
+      const name = arg.slice(0, equalsIndex);
+      const value = arg.slice(equalsIndex + 1);
+      if (isSecretArgName(name)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (tokenCurl && isHeaderArgName(name) && isSecretHeaderValue(value)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (tokenCurl && isUserArgName(name)) {
+        redacted.push(`${name}=[redacted]`);
+      } else {
+        const redactedValue = redactUrlUserinfo(value);
+        redacted.push(redactedValue === value ? arg : `${name}=${redactedValue}`);
+      }
+      continue;
+    }
+    const next = args[index + 1];
+    if (isSecretArgName(arg) && next !== undefined && !next.startsWith('--')) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (tokenCurl && isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (tokenCurl && isUserArgName(arg) && next !== undefined && !next.startsWith('--')) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}
+
 export function getAcpCommandIdentityDigest(commandLine: string): string {
-  return createHash('sha256').update(getAcpCommandIdentity(commandLine)).digest('hex');
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
+  const identity = JSON.stringify([command, ...redactCommandSecrets(command, args)]);
+  return createHash('sha256').update(identity).digest('hex');
 }
 
 const ACP_SAFE_ENV_KEYS = [

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import {
   buildAcpSafeEnv,
   getAcpCommandIdentity,
+  getAcpCommandIdentityDigest,
   parseAcpCommand,
+  redactCommandSecrets,
 } from '../../../../src/lib/acp/acp-command';
 
 describe('buildAcpSafeEnv', () => {
@@ -80,5 +82,324 @@ describe('getAcpCommandIdentity', () => {
     expect(getAcpCommandIdentity('devin   acp "model one"')).toBe(
       getAcpCommandIdentity("devin acp 'model one'")
     );
+  });
+});
+
+describe('getAcpCommandIdentityDigest', () => {
+  test('excludes secret-shaped argument values from the digest', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --token topsecret')).toBe(
+      getAcpCommandIdentityDigest('devin acp --token othersecret')
+    );
+    expect(getAcpCommandIdentityDigest('agent --api-key=k1 --stdio')).toBe(
+      getAcpCommandIdentityDigest('agent --api-key=k2 --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('agent --password p1 run')).toBe(
+      getAcpCommandIdentityDigest('agent --password p2 run')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --auth-token=a')).toBe(
+      getAcpCommandIdentityDigest('devin acp --auth-token=b')
+    );
+    expect(getAcpCommandIdentityDigest('agent --token -abc')).toBe(
+      getAcpCommandIdentityDigest('agent --token -xyz')
+    );
+    expect(
+      getAcpCommandIdentityDigest('curl -H "Authorization: Bearer topsecret" https://api')
+    ).toBe(getAcpCommandIdentityDigest('curl -H "Authorization: Bearer othersafe" https://api'));
+    expect(getAcpCommandIdentityDigest('curl -H "Cookie: session=topsecret" https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -H "Cookie: session=other" https://a')
+    );
+    expect(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'Authorization: Bearer topsecret\' https://a"')
+    ).toBe(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'Authorization: Bearer othersafe\' https://a"')
+    );
+    expect(getAcpCommandIdentityDigest("curl -H'Authorization: Bearer topsecret' https://a")).toBe(
+      getAcpCommandIdentityDigest("curl -H'Authorization: Bearer othersafe' https://a")
+    );
+    expect(getAcpCommandIdentityDigest('curl -u admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -u admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -uadmin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -uadmin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
+  });
+
+  test('keeps non-credential header values visible in the digest', () => {
+    expect(getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: DELETE" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: PUT" /a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -H "Accept: application/json" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "Accept: text/plain" /a')
+    );
+    expect(getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: DELETE\' /a"')).not.toBe(
+      getAcpCommandIdentityDigest('sh -c "curl -H \'X-Method: PUT\' /a"')
+    );
+    expect(getAcpCommandIdentityDigest("curl -H'X-Method: DELETE' /a")).not.toBe(
+      getAcpCommandIdentityDigest("curl -H'X-Method: PUT' /a")
+    );
+  });
+
+  test('redacts userinfo credentials embedded in positional URLs', () => {
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:topsecret@db/app')).toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:othersafe@db/app')
+    );
+    expect(getAcpCommandIdentityDigest('curl https://alice:topsecret@example.test/a')).toBe(
+      getAcpCommandIdentityDigest('curl https://alice:othersafe@example.test/a')
+    );
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-a/app')).not.toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-b/app')
+    );
+  });
+
+  test('gates tool-specific user options on their executables', () => {
+    expect(getAcpCommandIdentityDigest('python3 -u agent-a.py')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -u agent-b.py')
+    );
+    expect(getAcpCommandIdentityDigest('pip install --user package-a')).not.toBe(
+      getAcpCommandIdentityDigest('pip install --user package-b')
+    );
+    expect(getAcpCommandIdentityDigest('python3 -c \'print("one")\'')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -c \'print("two")\'')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user=admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user=admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('env API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
+      getAcpCommandIdentityDigest('env MODE=slow agent')
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'API_TOKEN=topsecret curl https://a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'API_TOKEN=othersafe curl https://a'")
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'export API_TOKEN=topsecret'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'export API_TOKEN=othersafe'")
+    );
+  });
+
+  test('does not swallow the next flag after a valueless secret flag', () => {
+    expect(getAcpCommandIdentityDigest('agent --token --verbose one')).not.toBe(
+      getAcpCommandIdentityDigest('agent --token --verbose two')
+    );
+    expect(getAcpCommandIdentityDigest('agent --token --verbose')).not.toBe(
+      getAcpCommandIdentityDigest('agent --verbose --token')
+    );
+  });
+
+  test('still distinguishes commands that differ outside secret arguments', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('other-acp --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --model one')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --model two')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --token a --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --token a --verbose')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --max-tokens 4096')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --max-tokens 8192')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --password-policy strict')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --password-policy relaxed')
+    );
+  });
+
+  test('limits nested header redaction to header-taking commands', () => {
+    expect(getAcpCommandIdentityDigest(`bash -c "tool -H x file-a"`)).not.toBe(
+      getAcpCommandIdentityDigest(`bash -c "tool -H x file-b"`)
+    );
+    expect(
+      getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer topsecret' /a"`)
+    ).toBe(getAcpCommandIdentityDigest(`bash -c "curl -H 'Authorization: Bearer othersafe' /a"`));
+  });
+
+  test('keeps curl ownership across positional arguments', () => {
+    expect(
+      getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer a"')
+    ).toBe(getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer b"'));
+    expect(getAcpCommandIdentityDigest('curl https://example.test -u alice:topsecret')).toBe(
+      getAcpCommandIdentityDigest('curl https://example.test -u alice:othersafe')
+    );
+  });
+
+  test('follows the command launched by env wrappers', () => {
+    expect(getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token topsecret'")).toBe(
+      getAcpCommandIdentityDigest("env MODE=prod bash -c 'curl --token othersafe'")
+    );
+  });
+
+  test('redacts credentials behind clustered curl flags', () => {
+    expect(getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer topsecret' /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer othersafe' /a`)
+    );
+    expect(getAcpCommandIdentityDigest(`curl -sU alice:topsecret /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sU alice:othersafe /a`)
+    );
+  });
+
+  test('redacts userinfo inside option values', () => {
+    expect(getAcpCommandIdentityDigest('curl --url=https://alice:topsecret@h/a')).toBe(
+      getAcpCommandIdentityDigest('curl --url=https://alice:othersafe@h/a')
+    );
+  });
+});
+
+describe('redactCommandSecrets', () => {
+  test('preserves token boundaries when redisplaying shell command arguments', () => {
+    expect(redactCommandSecrets('sh', ['-c', `rm -- "important file" --token topsecret`])).toEqual([
+      '-c',
+      `rm -- "important file" --token topsecret`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `rm "important file" --token topsecret`])).toEqual([
+      '-c',
+      `rm "important file" --token [redacted]`,
+    ]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `curl -H 'Authorization: Bearer topsecret' https://a`])
+    ).toEqual(['-c', `curl -H '[redacted]' https://a`]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo "safe; rm -rf /" && curl --token topsecret`])
+    ).toEqual(['-c', `echo "safe; rm -rf /" && curl --token [redacted]`]);
+    expect(redactCommandSecrets('sh', ['-c', `API_TOKEN=topsecret curl https://a`])).toEqual([
+      '-c',
+      `API_TOKEN=[redacted] curl https://a`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `pip install --user package-a`])).toEqual([
+      '-c',
+      `pip install --user package-a`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `echo topsecret && curl --token topsecret`])).toEqual([
+      '-c',
+      `echo topsecret && curl --token [redacted]`,
+    ]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo 'Bearer x' && curl -H 'Authorization: Bearer x'`])
+    ).toEqual(['-c', `echo 'Bearer x' && curl -H '[redacted]'`]);
+    expect(
+      redactCommandSecrets('sh', ['-c', `echo "--token topsecret" && curl --token topsecret`])
+    ).toEqual(['-c', `echo "--token topsecret" && curl --token [redacted]`]);
+  });
+
+  test('stops treating assignments as environment after the command word', () => {
+    expect(getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=one'"`)).not.toBe(
+      getAcpCommandIdentityDigest(`sh -c "rm -- 'API_TOKEN=two'"`)
+    );
+    expect(redactCommandSecrets('sh', ['-c', `rm -- 'API_TOKEN=one'`])).toEqual([
+      '-c',
+      `rm -- 'API_TOKEN=one'`,
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', `MODE=prod rm -- 'API_TOKEN=one'`])).toEqual([
+      '-c',
+      `MODE=prod rm -- 'API_TOKEN=one'`,
+    ]);
+    expect(getAcpCommandIdentityDigest('env FOO=1 cmd data=one')).not.toBe(
+      getAcpCommandIdentityDigest('env FOO=1 cmd data=two')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=topsecret'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'export MODE=prod API_TOKEN=othersafe'")
+    );
+    expect(
+      getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=topsecret curl https://b'`)
+    ).toBe(
+      getAcpCommandIdentityDigest(`sh -c 'curl https://a && API_TOKEN=othersafe curl https://b'`)
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=topsecret curl /a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'echo ok; API_TOKEN=othersafe curl /a'")
+    );
+    expect(getAcpCommandIdentityDigest("sh -c 'echo ok;API_TOKEN=topsecret curl /a'")).toBe(
+      getAcpCommandIdentityDigest("sh -c 'echo ok;API_TOKEN=othersafe curl /a'")
+    );
+  });
+
+  test('redacts credentials behind clustered and attached curl flags', () => {
+    expect(redactCommandSecrets('curl', ['-sH', 'Authorization: Bearer topsecret', '/a'])).toEqual([
+      '-sH',
+      '[redacted]',
+      '/a',
+    ]);
+  });
+
+  test('treats tokens after -- as positional data', () => {
+    expect(getAcpCommandIdentityDigest(`rm -- --password file-a`)).not.toBe(
+      getAcpCommandIdentityDigest(`rm -- --password file-b`)
+    );
+    expect(redactCommandSecrets('rm', ['--', '--password', 'file-a'])).toEqual([
+      '--',
+      '--password',
+      'file-a',
+    ]);
+  });
+
+  test('keeps the quote wrapper around redacted url tokens', () => {
+    expect(redactCommandSecrets('sh', ['-c', `curl 'https://u:p@h/a?x=1&y=2'`])).toEqual([
+      '-c',
+      `curl 'https://u:[redacted]@h/a?x=1&y=2'`,
+    ]);
+  });
+
+  test('recurses combined shell flags with c before other letters', () => {
+    expect(getAcpCommandIdentityDigest(`bash -cl 'curl --token topsecret'`)).toBe(
+      getAcpCommandIdentityDigest(`bash -cl 'curl --token othersafe'`)
+    );
+    expect(redactCommandSecrets('bash', ['-cl', `curl --token topsecret`])).toEqual([
+      '-cl',
+      `curl --token [redacted]`,
+    ]);
+  });
+
+  test('conservatively redacts scripts past the recursion cutoff', () => {
+    let nested = 'curl --token topsecret';
+    for (let i = 0; i < 4; i++) {
+      nested = `sh -c ${JSON.stringify(nested)}`;
+    }
+    const display = redactCommandSecrets('sh', ['-c', nested]);
+    expect(display.join(' ')).toContain('[redacted script]');
+    const sensitive = `sh -c ${JSON.stringify(`sh -c ${JSON.stringify('curl --token topsecret')}`)}`;
+    expect(getAcpCommandIdentityDigest(sensitive)).toBe(
+      getAcpCommandIdentityDigest(sensitive.replace('topsecret', 'othersafe'))
+    );
+    const benign = redactCommandSecrets('sh', ['-c', `sh -c 'echo plain'`]);
+    expect(benign.join(' ')).not.toContain('[redacted');
+  });
+
+  test('redacts leading assignments inside shell scripts', () => {
+    expect(
+      getAcpCommandIdentityDigest("sh -c 'MODE=prod API_TOKEN=topsecret curl https://a'")
+    ).toBe(getAcpCommandIdentityDigest("sh -c 'MODE=prod API_TOKEN=othersafe curl https://a'"));
+    expect(
+      redactCommandSecrets('sh', ['-lc', `MODE=prod API_TOKEN=topsecret curl https://a`])
+    ).toEqual(['-lc', `MODE=prod API_TOKEN=[redacted] curl https://a`]);
+    expect(getAcpCommandIdentityDigest('bash -xc "curl --token topsecret"')).toBe(
+      getAcpCommandIdentityDigest('bash -xc "curl --token othersafe"')
+    );
+    expect(redactCommandSecrets('bash', ['-lc', `curl --token topsecret`])).toEqual([
+      '-lc',
+      `curl --token [redacted]`,
+    ]);
+    expect(redactCommandSecrets('bash', ['-xc', `curl --token topsecret`])).toEqual([
+      '-xc',
+      `curl --token [redacted]`,
+    ]);
+  });
+
+  test('redisplays shell scripts verbatim when nothing was redacted', () => {
+    expect(redactCommandSecrets('sh', ['-c', 'echo "safe; rm -rf /"'])).toEqual([
+      '-c',
+      'echo "safe; rm -rf /"',
+    ]);
+    expect(redactCommandSecrets('sh', ['-c', "echo 'a b' && echo c"])).toEqual([
+      '-c',
+      "echo 'a b' && echo c",
+    ]);
   });
 });

--- a/packages/shared/src/acp/acp-command.ts
+++ b/packages/shared/src/acp/acp-command.ts
@@ -1,62 +1,110 @@
+export interface AcpCommandTokenSpan {
+  start: number;
+  end: number;
+}
+
+export interface ParsedAcpCommandWithSpans {
+  command: string;
+  args: string[];
+  rawSpans: AcpCommandTokenSpan[];
+}
+
 export function getAcpCommandIdentity(commandLine: string): string {
   const { command, args } = parseAcpCommand(commandLine);
   return JSON.stringify([command, ...args]);
 }
 
 export function parseAcpCommand(commandLine: string): { command: string; args: string[] } {
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
+  return { command, args };
+}
+
+export function parseAcpCommandWithSpans(commandLine: string): ParsedAcpCommandWithSpans {
   const tokens: string[] = [];
+  const rawSpans: AcpCommandTokenSpan[] = [];
   let current = '';
   let quote: 'single' | 'double' | null = null;
   let escaping = false;
   let tokenStarted = false;
+  let rawStart = 0;
+  let rawEnd = 0;
 
   const trimmedCommand = commandLine.trim();
+  const base = commandLine.length - commandLine.trimStart().length;
+
+  const pushToken = () => {
+    tokens.push(current);
+    rawSpans.push({ start: rawStart, end: rawEnd });
+    current = '';
+    tokenStarted = false;
+  };
+
   for (let index = 0; index < trimmedCommand.length; index++) {
-    const char = trimmedCommand[index];
     if (escaping) {
-      current += char;
+      current += trimmedCommand[index];
+      rawEnd = base + index + 1;
       escaping = false;
       tokenStarted = true;
       continue;
     }
 
+    const char = trimmedCommand[index];
     if (char === '\\') {
       const next = trimmedCommand[index + 1];
       if (
         next !== undefined &&
         (/\s/.test(next) || next === "'" || next === '"' || next === '\\')
       ) {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
+        rawEnd = base + index + 1;
         escaping = true;
       } else {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
         current += char;
-        tokenStarted = true;
+        rawEnd = base + index + 1;
       }
       continue;
     }
 
     if (char === "'" && quote !== 'double') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'single' ? null : 'single';
-      tokenStarted = true;
       continue;
     }
 
     if (char === '"' && quote !== 'single') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'double' ? null : 'double';
-      tokenStarted = true;
       continue;
     }
 
     if (/\s/.test(char) && !quote) {
       if (tokenStarted) {
-        tokens.push(current);
-        current = '';
-        tokenStarted = false;
+        pushToken();
       }
       continue;
     }
 
+    if (!tokenStarted) {
+      tokenStarted = true;
+      rawStart = base + index;
+    }
     current += char;
-    tokenStarted = true;
+    rawEnd = base + index + 1;
   }
 
   if (escaping) {
@@ -66,10 +114,10 @@ export function parseAcpCommand(commandLine: string): { command: string; args: s
   if (quote) {
     throw new Error('Invalid ACP command: unmatched quote');
   }
-  if (tokenStarted) tokens.push(current);
+  if (tokenStarted) pushToken();
   if (!tokens[0]) {
     throw new Error('Invalid ACP command: command is empty');
   }
 
-  return { command: tokens[0], args: tokens.slice(1) };
+  return { command: tokens[0], args: tokens.slice(1), rawSpans };
 }


### PR DESCRIPTION
Extracted from #2711 (ACP split 8/10, first of five slices). Reference ref: `space/acp-split-8-10-feat-daemon-wire-acp-runtime-query-runner`.

## What this adds

- `parseAcpCommandWithSpans` (shared `acp-command.ts`): the existing tokenizer now also records each token's raw span in the original line, so callers can rewrite a token in place while preserving the author's quoting. `parseAcpCommand` is now a thin wrapper over it — no behavior change.
- `redactCommandSecrets` + `shellQuote` (daemon `acp-command.ts`): redacts secret-shaped argument names (`--token`, `-p`, `--api-key`, …), header values (`Authorization: …`, curl `-H`/`--header`), curl `-u`/`--user`, leading and inline env assignments, URL userinfo (`https://user:pass@host`), and nested shell scripts (recursively, depth-bounded, span-anchored so quoting survives).
- `getAcpCommandIdentityDigest` now hashes the **redacted** identity, so rotating a credential value no longer starts a fresh ACP conversation — only a real command change does.
- New `acp-command.test.ts` (26 tests) pinning the redactor and the redaction-aware digest.

## What this does NOT add (later slices)

- No call sites in the query runner yet — the terminal-approval display that consumes `redactCommandSecrets`/`shellQuote` lands in the host-callbacks slice. All exports are exercised by tests, so knip stays green.

## Scope freeze

Redaction coverage is exactly what #2711 converged on after review. Further secret-vector hardening belongs in follow-up issues, not this stack.

## Verification

- `bun test packages/daemon/tests/unit/lib/acp/acp-command.test.ts` — 26/26 pass
- knip, `tsc --build --noEmit`, biome format — clean
- Full local ACP suites match the clean-dev baseline exactly (28 pre-existing sandbox-only failures, none new)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->