### PR TITLE
refactor(daemon): extract rate-limit-watchdog trip/reset core as pure gates

### DIFF
--- a/packages/daemon/src/lib/agent/rate-limit-watchdog-gates.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog-gates.ts
@@ -1,0 +1,80 @@
+import { type CooldownDecision, computeCooldown, MAX_RESET_HORIZON_MS } from './fallback-recovery';
+import { cooldownFromReset, type LimitRetryHint, normalizeEpochMs } from './limit-error-classifier';
+import type { LlmLimitAssessment } from './limit-error-llm-classifier';
+
+export type RateLimitWatchdogStatus = 'idle' | 'cooldown' | 'fallback-pending';
+
+export type RateLimitTripDecision =
+  | { action: 'surface-billing' }
+  | { action: 'give-up' }
+  | { action: 'cooldown'; decision: CooldownDecision; charge: boolean };
+
+export function decideRateLimitTrip(input: {
+  hint: LimitRetryHint | null;
+  errorMessage: string;
+  retryCount: number;
+  maxAutoRetries: number;
+  now: number;
+}): RateLimitTripDecision {
+  if (input.hint?.billingTerminal) {
+    return { action: 'surface-billing' };
+  }
+  const hintedReset = input.hint?.resetAtMs ?? null;
+  const usableHintedReset =
+    hintedReset !== null &&
+    hintedReset > input.now &&
+    hintedReset <= input.now + MAX_RESET_HORIZON_MS
+      ? hintedReset
+      : null;
+  const decision =
+    usableHintedReset !== null
+      ? cooldownFromReset(usableHintedReset, input.now)
+      : computeCooldown(input.errorMessage, input.retryCount, input.now);
+  if (!decision.freeWait && input.retryCount >= input.maxAutoRetries) {
+    return { action: 'give-up' };
+  }
+  return { action: 'cooldown', decision, charge: !decision.freeWait };
+}
+
+export function refinedResetAtMs(
+  assessment: LlmLimitAssessment | null,
+  now: number
+): number | null {
+  if (!assessment || assessment.notALimit) return null;
+  const raw = assessment.resetAtMs;
+  const resetMs = typeof raw === 'number' && Number.isFinite(raw) ? normalizeEpochMs(raw) : null;
+  if (resetMs === null || resetMs <= now || resetMs > now + MAX_RESET_HORIZON_MS) return null;
+  return resetMs;
+}
+
+export function resolveWatchdogStatus(input: {
+  fallbackPending: boolean;
+  cooldownActive: boolean;
+}): RateLimitWatchdogStatus {
+  if (input.fallbackPending) return 'fallback-pending';
+  return input.cooldownActive ? 'cooldown' : 'idle';
+}
+
+export function canRetryNow(input: {
+  fallbackPending: boolean;
+  cooldownActive: boolean;
+  startupExhausted: boolean;
+}): boolean {
+  if (input.fallbackPending) return false;
+  return input.cooldownActive || input.startupExhausted;
+}
+
+export function manualRecoveryPause(input: {
+  cooldownActive: boolean;
+  fallbackPending: boolean;
+  retryCallbackInFlight: boolean;
+  startupExhausted: boolean;
+  billingPauseSurfaced: boolean;
+}): boolean {
+  return (
+    !input.cooldownActive &&
+    !input.fallbackPending &&
+    !input.retryCallbackInFlight &&
+    (input.startupExhausted || input.billingPauseSurfaced)
+  );
+}

--- a/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
+++ b/packages/daemon/src/lib/agent/rate-limit-watchdog.ts
@@ -6,12 +6,19 @@ import {
   classifyLimitKind,
   computeCooldown,
   entryKey,
-  MAX_RESET_HORIZON_MS,
   selectNextFallback,
 } from './fallback-recovery';
-import { cooldownFromReset, normalizeEpochMs, type LimitRetryHint } from './limit-error-classifier';
+import { cooldownFromReset, type LimitRetryHint } from './limit-error-classifier';
 import type { LlmLimitAssessment } from './limit-error-llm-classifier';
 import type { ProcessingStateManager } from './processing-state-manager';
+import {
+  canRetryNow,
+  decideRateLimitTrip,
+  manualRecoveryPause,
+  type RateLimitWatchdogStatus,
+  refinedResetAtMs,
+  resolveWatchdogStatus,
+} from './rate-limit-watchdog-gates';
 
 export interface RateLimitWatchdogConfig {
   cooldownMs: number;
@@ -25,8 +32,6 @@ const DEFAULT_CONFIG: RateLimitWatchdogConfig = {
 
 const STARTUP_RETRY_DELAY_MS = 60 * 1000;
 const MAX_STARTUP_RETRIES = 3;
-
-export type RateLimitWatchdogStatus = 'idle' | 'cooldown' | 'fallback-pending';
 
 export interface RateLimitWatchdogState {
   status: RateLimitWatchdogStatus;
@@ -113,11 +118,10 @@ export class RateLimitWatchdog {
     const retryAt = this.cooldownTimer !== null ? Date.now() + this.getRemainingMs() : null;
 
     return {
-      status: this.fallbackPending
-        ? 'fallback-pending'
-        : this.cooldownTimer !== null
-          ? 'cooldown'
-          : 'idle',
+      status: resolveWatchdogStatus({
+        fallbackPending: this.fallbackPending,
+        cooldownActive: this.cooldownTimer !== null,
+      }),
       retryCount: this.retryCount,
       maxRetries: this.config.maxAutoRetries,
       retryAt,
@@ -204,33 +208,28 @@ export class RateLimitWatchdog {
       );
     }
 
-    if (this.lastHint?.billingTerminal) {
+    const trip = decideRateLimitTrip({
+      hint: this.lastHint,
+      errorMessage,
+      retryCount: this.retryCount,
+      maxAutoRetries: this.config.maxAutoRetries,
+      now: Date.now(),
+    });
+    if (trip.action === 'surface-billing') {
       this.logger.warn(
         `Billing-cycle limit with no available fallback; surfacing instead of cooling down. ` +
           `Error: ${errorMessage}`
       );
       return false;
     }
-
-    const now = Date.now();
-    const hintedReset = this.lastHint?.resetAtMs ?? null;
-    const usableHintedReset =
-      hintedReset !== null && hintedReset > now && hintedReset <= now + MAX_RESET_HORIZON_MS
-        ? hintedReset
-        : null;
-    const decision =
-      usableHintedReset !== null
-        ? cooldownFromReset(usableHintedReset, now)
-        : computeCooldown(errorMessage, this.retryCount, now);
-
-    if (!decision.freeWait && this.retryCount >= this.config.maxAutoRetries) {
+    if (trip.action === 'give-up') {
       this.logger.warn(
         `Max auto-retries (${this.config.maxAutoRetries}) exceeded for 429 error. Giving up. ` +
           `Error: ${errorMessage}`
       );
       return false;
     }
-    if (!decision.freeWait) {
+    if (trip.charge) {
       this.retryCount++;
     }
 
@@ -241,15 +240,15 @@ export class RateLimitWatchdog {
       return true;
     }
 
-    const armed = await this.scheduleCooldown(errorMessage, decision, entryGeneration);
+    const armed = await this.scheduleCooldown(errorMessage, trip.decision, entryGeneration);
 
     if (
       armed &&
-      decision.reason === 'backoff-ladder' &&
+      trip.decision.reason === 'backoff-ladder' &&
       this.deps.classifyUnknownLimit &&
       entryGeneration === this.generation
     ) {
-      this.fireLlmRefinement(errorMessage, entryGeneration, !decision.freeWait);
+      this.fireLlmRefinement(errorMessage, entryGeneration, trip.charge);
     }
     return true;
   }
@@ -265,13 +264,10 @@ export class RateLimitWatchdog {
     void classify(errorMessage)
       .then(async (result) => {
         if (entryGeneration !== this.generation || this.cooldownTimer !== timerAtFire) return;
-        if (!result || result.notALimit) return;
-        const resetMs =
-          typeof result.resetAtMs === 'number' && Number.isFinite(result.resetAtMs)
-            ? normalizeEpochMs(result.resetAtMs)
-            : null;
+        if (!result) return;
         const now = Date.now();
-        if (resetMs === null || resetMs <= now || resetMs > now + MAX_RESET_HORIZON_MS) return;
+        const resetMs = refinedResetAtMs(result, now);
+        if (resetMs === null) return;
         this.logger.info(
           `LLM limit refinement: retry at ${new Date(resetMs).toISOString()} ` +
             `(was backoff ladder) for error: ${errorMessage}`
@@ -614,10 +610,13 @@ export class RateLimitWatchdog {
   }
 
   retryNow(): boolean {
-    if (this.fallbackPending) {
-      return false;
-    }
-    if (this.cooldownTimer === null && !this.startupExhausted) {
+    if (
+      !canRetryNow({
+        fallbackPending: this.fallbackPending,
+        cooldownActive: this.cooldownTimer !== null,
+        startupExhausted: this.startupExhausted,
+      })
+    ) {
       return false;
     }
 
@@ -677,12 +676,13 @@ export class RateLimitWatchdog {
   }
 
   isManualRecoveryPause(): boolean {
-    return (
-      this.cooldownTimer === null &&
-      !this.fallbackPending &&
-      !this.retryCallbackInFlight &&
-      (this.startupExhausted || this.billingPauseSurfaced)
-    );
+    return manualRecoveryPause({
+      cooldownActive: this.cooldownTimer !== null,
+      fallbackPending: this.fallbackPending,
+      retryCallbackInFlight: this.retryCallbackInFlight,
+      startupExhausted: this.startupExhausted,
+      billingPauseSurfaced: this.billingPauseSurfaced,
+    });
   }
 
   isRateLimitBannerCancelled(): boolean {

--- a/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog-gates.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rate-limit-watchdog-gates.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'bun:test';
+import { RESET_BUFFER_MS } from '../../../../src/lib/agent/fallback-recovery';
+import {
+  canRetryNow,
+  decideRateLimitTrip,
+  manualRecoveryPause,
+  type RateLimitTripDecision,
+  refinedResetAtMs,
+  resolveWatchdogStatus,
+} from '../../../../src/lib/agent/rate-limit-watchdog-gates';
+
+const NOW = 1_700_000_000_000;
+
+function asCooldownTrip(
+  trip: RateLimitTripDecision
+): Extract<RateLimitTripDecision, { action: 'cooldown' }> {
+  if (trip.action !== 'cooldown') throw new Error(`expected cooldown decision, got ${trip.action}`);
+  return trip;
+}
+
+describe('rate-limit-watchdog-gates', () => {
+  describe('decideRateLimitTrip', () => {
+    it('billing-terminal outranks a usable hinted reset', () => {
+      const trip = decideRateLimitTrip({
+        hint: { billingTerminal: true, kind: 'usage_limit', resetAtMs: NOW + 60 * 60 * 1000 },
+        errorMessage: '429',
+        retryCount: 0,
+        maxAutoRetries: 3,
+        now: NOW,
+      });
+      expect(trip).toEqual({ action: 'surface-billing' });
+    });
+
+    it('a usable hinted reset arms a free-wait cooldown at reset plus buffer without charging', () => {
+      const reset = NOW + 2 * 60 * 60 * 1000;
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: { resetAtMs: reset, kind: 'usage_limit' },
+          errorMessage: '429',
+          retryCount: 2,
+          maxAutoRetries: 3,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(false);
+      expect(trip.decision.reason).toBe('parsed-reset');
+      expect(trip.decision.freeWait).toBe(true);
+      expect(trip.decision.retryAtMs).toBe(reset + RESET_BUFFER_MS);
+    });
+
+    it('a stale hinted reset falls back to the ladder and charges the budget', () => {
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: { resetAtMs: NOW - 1000, kind: 'usage_limit' },
+          errorMessage: '429',
+          retryCount: 0,
+          maxAutoRetries: 3,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(true);
+      expect(trip.decision.reason).toBe('backoff-ladder');
+      expect(trip.decision.freeWait).toBe(false);
+    });
+
+    it('a hinted reset beyond the 7-day horizon falls back to the ladder', () => {
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: { resetAtMs: NOW + 8 * 24 * 60 * 60 * 1000, kind: 'usage_limit' },
+          errorMessage: '429',
+          retryCount: 0,
+          maxAutoRetries: 3,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(true);
+      expect(trip.decision.reason).toBe('backoff-ladder');
+    });
+
+    it('a message-parsed reset arms a free wait even without a hint', () => {
+      const reset = NOW + 60 * 60 * 1000;
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: null,
+          errorMessage: `resets ${new Date(reset).toISOString()}`,
+          retryCount: 5,
+          maxAutoRetries: 0,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(false);
+      expect(trip.decision.reason).toBe('parsed-reset');
+      expect(trip.decision.retryAtMs).toBe(reset + RESET_BUFFER_MS);
+    });
+
+    it('gives up when the ladder is required and the retry budget is spent', () => {
+      const trip = decideRateLimitTrip({
+        hint: null,
+        errorMessage: '429',
+        retryCount: 2,
+        maxAutoRetries: 2,
+        now: NOW,
+      });
+      expect(trip).toEqual({ action: 'give-up' });
+    });
+
+    it('a free wait bypasses a spent retry budget', () => {
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: { resetAtMs: NOW + 60 * 60 * 1000, kind: 'usage_limit' },
+          errorMessage: '429',
+          retryCount: 2,
+          maxAutoRetries: 0,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(false);
+    });
+
+    it('arms the ladder under budget with one step left', () => {
+      const trip = asCooldownTrip(
+        decideRateLimitTrip({
+          hint: null,
+          errorMessage: '429',
+          retryCount: 1,
+          maxAutoRetries: 2,
+          now: NOW,
+        })
+      );
+      expect(trip.charge).toBe(true);
+      expect(trip.decision.reason).toBe('backoff-ladder');
+    });
+  });
+
+  describe('refinedResetAtMs', () => {
+    it('rejects null assessments, not-a-limit verdicts, and missing resets', () => {
+      expect(refinedResetAtMs(null, NOW)).toBeNull();
+      expect(
+        refinedResetAtMs({ resetAtMs: NOW + 60 * 1000, kind: null, notALimit: true }, NOW)
+      ).toBeNull();
+      expect(
+        refinedResetAtMs({ resetAtMs: null, kind: 'usage_limit', notALimit: false }, NOW)
+      ).toBeNull();
+    });
+
+    it('rejects resets in the past and beyond the horizon', () => {
+      expect(
+        refinedResetAtMs({ resetAtMs: NOW - 1, kind: null, notALimit: false }, NOW)
+      ).toBeNull();
+      expect(
+        refinedResetAtMs(
+          { resetAtMs: NOW + 8 * 24 * 60 * 60 * 1000, kind: null, notALimit: false },
+          NOW
+        )
+      ).toBeNull();
+    });
+
+    it('normalizes epoch-seconds resets', () => {
+      const sec = Math.floor((NOW + 2 * 60 * 60 * 1000) / 1000);
+      expect(refinedResetAtMs({ resetAtMs: sec, kind: 'usage_limit', notALimit: false }, NOW)).toBe(
+        sec * 1000
+      );
+    });
+
+    it('passes epoch-milliseconds resets through unchanged', () => {
+      const ms = NOW + 2 * 60 * 60 * 1000;
+      expect(refinedResetAtMs({ resetAtMs: ms, kind: 'rate_limit', notALimit: false }, NOW)).toBe(
+        ms
+      );
+    });
+  });
+
+  describe('resolveWatchdogStatus', () => {
+    it('prefers fallback-pending over cooldown over idle', () => {
+      expect(resolveWatchdogStatus({ fallbackPending: true, cooldownActive: true })).toBe(
+        'fallback-pending'
+      );
+      expect(resolveWatchdogStatus({ fallbackPending: true, cooldownActive: false })).toBe(
+        'fallback-pending'
+      );
+      expect(resolveWatchdogStatus({ fallbackPending: false, cooldownActive: true })).toBe(
+        'cooldown'
+      );
+      expect(resolveWatchdogStatus({ fallbackPending: false, cooldownActive: false })).toBe('idle');
+    });
+  });
+
+  describe('canRetryNow', () => {
+    it('admits only with a live cooldown timer or an exhausted startup budget, never mid-fallback', () => {
+      expect(
+        canRetryNow({ fallbackPending: true, cooldownActive: true, startupExhausted: true })
+      ).toBe(false);
+      expect(
+        canRetryNow({ fallbackPending: false, cooldownActive: false, startupExhausted: false })
+      ).toBe(false);
+      expect(
+        canRetryNow({ fallbackPending: false, cooldownActive: true, startupExhausted: false })
+      ).toBe(true);
+      expect(
+        canRetryNow({ fallbackPending: false, cooldownActive: false, startupExhausted: true })
+      ).toBe(true);
+    });
+  });
+
+  describe('manualRecoveryPause', () => {
+    it('pauses manually only when quiet and startup-exhausted or billing-surfaced', () => {
+      const base = {
+        cooldownActive: false,
+        fallbackPending: false,
+        retryCallbackInFlight: false,
+        startupExhausted: false,
+        billingPauseSurfaced: false,
+      };
+      expect(manualRecoveryPause(base)).toBe(false);
+      expect(manualRecoveryPause({ ...base, startupExhausted: true })).toBe(true);
+      expect(manualRecoveryPause({ ...base, billingPauseSurfaced: true })).toBe(true);
+      expect(manualRecoveryPause({ ...base, startupExhausted: true, cooldownActive: true })).toBe(
+        false
+      );
+      expect(manualRecoveryPause({ ...base, startupExhausted: true, fallbackPending: true })).toBe(
+        false
+      );
+      expect(
+        manualRecoveryPause({ ...base, startupExhausted: true, retryCallbackInFlight: true })
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Policy-core pilot PR 2/2 for the rate-limit watchdog (task #1218): moves the pure trip/reset decision logic out of the class into rate-limit-watchdog-gates.ts, following the message-ownership-gates precedent — plain pure functions, no decisionRun (simpler per ADR 0004's admission-gates sanction). decideRateLimitTrip (billing-terminal → retry budget → cooldown+charge), refinedResetAtMs (LLM reset normalize + horizon gate), resolveWatchdogStatus, canRetryNow, and manualRecoveryPause; the class keeps timers, state writes, notify callbacks, SDK deps, and generation/ownership checks, reading snapshots and interpreting the returned decisions. Zero behavior change: the PR-1 characterization pins pass unchanged, plus a new gates unit suite (15 tests) covering the decision table directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->