### PR TITLE
feat(daemon): redact secrets in ACP command approval displays

### DIFF
--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -1,11 +1,202 @@
 import { createHash } from 'node:crypto';
-import { getAcpCommandIdentity } from '@hyperneo/shared/acp';
+import { parseAcpCommandWithSpans } from '@hyperneo/shared/acp';
 
 export { getAcpCommandIdentity, parseAcpCommand } from '@hyperneo/shared/acp';
 
-/* @public - consumed by ACP provider sync in a later stack PR */
+const SECRET_ARG_NAME_PATTERN =
+  /(?:^|[-_])(?:token|secret|password|passphrase|credential|api[-_]?key|bearer)$/i;
+
+const SECRET_HEADER_NAME_PATTERN =
+  /(?:^|[-_])(?:authorization|auth|cookie|session|token|secret|password|credential|api[-_]?key|bearer)$/i;
+
+const CURL_COMMAND_NAMES = new Set(['curl']);
+const CURL_VALUE_TAKING_SHORT = new Set([
+  'a',
+  'b',
+  'c',
+  'd',
+  'e',
+  'f',
+  'k',
+  'm',
+  'o',
+  'p',
+  'q',
+  'r',
+  't',
+  'w',
+  'x',
+  'y',
+  'z',
+]);
+const ENV_COMMAND_NAMES = new Set(['env', 'export']);
+
+function commandBaseName(command: string): string {
+  const base = command.split(/[\\/]/).pop() ?? command;
+  return base.replace(/\.exe$/i, '').toLowerCase();
+}
+
+function isSecretArgName(name: string): boolean {
+  return SECRET_ARG_NAME_PATTERN.test(name.replace(/^-+/, ''));
+}
+
+function isSecretHeaderValue(value: string): boolean {
+  const headerName = value.split(':', 1)[0]?.trim() ?? '';
+  return SECRET_HEADER_NAME_PATTERN.test(headerName);
+}
+
+function isHeaderArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^H$/i.test(stripped) || /^header$/i.test(stripped);
+}
+
+function isUserArgName(name: string): boolean {
+  const stripped = name.replace(/^-+/, '');
+  return /^u$/i.test(stripped) || /^user$/i.test(stripped) || /^proxy-user$/i.test(stripped);
+}
+
+function isSecretEnvAssignment(arg: string): boolean {
+  const equalsIndex = arg.indexOf('=');
+  if (equalsIndex <= 0) return false;
+  return isSecretArgName(arg.slice(0, equalsIndex));
+}
+
+export function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:@%+=,-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+const URL_USERINFO_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*:\/\/[^:/@\s]*:)([^@/\s]+)(@.+)$/;
+
+function redactUrlUserinfo(value: string): string {
+  const match = URL_USERINFO_PATTERN.exec(value);
+  return match ? `${match[1]}[redacted]${match[3]}` : value;
+}
+
+export function redactCommandSecrets(command: string, args: string[]): string[] {
+  const isEnv = ENV_COMMAND_NAMES.has(commandBaseName(command));
+  const assignmentsAllowed = isEnv;
+  let inLeadingAssignments = true;
+  let currentCommand = command;
+  let awaitingCommandWord = isEnv;
+  let endOfOptions = false;
+  const redacted: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--') {
+      endOfOptions = true;
+      redacted.push(arg);
+      continue;
+    }
+    if (endOfOptions) {
+      redacted.push(redactUrlUserinfo(arg));
+      continue;
+    }
+    if (!arg.startsWith('-')) {
+      const looksLikeUrl = /^[a-z][a-z0-9+.-]*:/i.test(arg);
+      const isAssignmentShaped = arg.indexOf('=') > 0;
+      if (inLeadingAssignments && assignmentsAllowed && isSecretEnvAssignment(arg)) {
+        redacted.push(`${arg.slice(0, arg.indexOf('='))}=[redacted]`);
+      } else {
+        if (!isAssignmentShaped) {
+          inLeadingAssignments = false;
+          if (awaitingCommandWord) {
+            currentCommand = arg;
+            awaitingCommandWord = false;
+          }
+        }
+        if (isAssignmentShaped && !looksLikeUrl) {
+          const at = arg.indexOf('=');
+          const value = arg.slice(at + 1);
+          const redactedValue = redactUrlUserinfo(value);
+          redacted.push(redactedValue === value ? arg : `${arg.slice(0, at + 1)}${redactedValue}`);
+        } else {
+          redacted.push(redactUrlUserinfo(arg));
+        }
+      }
+      continue;
+    }
+    const tokenCommandName = commandBaseName(currentCommand);
+    const tokenCurl = CURL_COMMAND_NAMES.has(tokenCommandName);
+    if (tokenCurl && /^-[a-z]*$/i.test(arg)) {
+      const letters = arg.slice(1).toLowerCase();
+      const valueFlag = letters.charAt(letters.length - 1);
+      const next = args[index + 1];
+      if (
+        (valueFlag === 'h' || valueFlag === 'u') &&
+        next !== undefined &&
+        (valueFlag === 'u' || !next.startsWith('--'))
+      ) {
+        if (valueFlag === 'u' || isSecretHeaderValue(next)) {
+          redacted.push(arg, '[redacted]');
+          index++;
+          continue;
+        }
+      }
+      redacted.push(arg);
+      continue;
+    }
+    if (tokenCurl && /^-[a-z]*[hu]/i.test(arg)) {
+      const lowered = arg.toLowerCase();
+      let carrierIndex = -1;
+      for (let scan = 1; scan < lowered.length; scan++) {
+        const ch = lowered[scan];
+        if (ch === 'h' || ch === 'u') {
+          carrierIndex = scan;
+          break;
+        }
+        if (!/[a-z]/i.test(ch)) break;
+        if (CURL_VALUE_TAKING_SHORT.has(ch)) break;
+      }
+      if (carrierIndex > 0) {
+        const value = arg.slice(carrierIndex + 1);
+        const secret = lowered[carrierIndex] === 'u' || isSecretHeaderValue(value);
+        if (secret && value) {
+          redacted.push(`${arg.slice(0, carrierIndex + 1)}[redacted]`);
+          continue;
+        }
+      }
+    }
+    const equalsIndex = arg.indexOf('=');
+    if (equalsIndex >= 0) {
+      const name = arg.slice(0, equalsIndex);
+      const value = arg.slice(equalsIndex + 1);
+      if (isSecretArgName(name)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (tokenCurl && isHeaderArgName(name) && isSecretHeaderValue(value)) {
+        redacted.push(`${name}=[redacted]`);
+      } else if (tokenCurl && isUserArgName(name)) {
+        redacted.push(`${name}=[redacted]`);
+      } else {
+        const redactedValue = redactUrlUserinfo(value);
+        redacted.push(redactedValue === value ? arg : `${name}=${redactedValue}`);
+      }
+      continue;
+    }
+    const next = args[index + 1];
+    if (isSecretArgName(arg) && next !== undefined && !next.startsWith('--')) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (tokenCurl && isHeaderArgName(arg) && next !== undefined && isSecretHeaderValue(next)) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    if (tokenCurl && isUserArgName(arg) && next !== undefined) {
+      redacted.push(arg, '[redacted]');
+      index++;
+      continue;
+    }
+    redacted.push(arg);
+  }
+  return redacted;
+}
+
 export function getAcpCommandIdentityDigest(commandLine: string): string {
-  return createHash('sha256').update(getAcpCommandIdentity(commandLine)).digest('hex');
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
+  const identity = JSON.stringify([command, ...redactCommandSecrets(command, args)]);
+  return createHash('sha256').update(identity).digest('hex');
 }
 
 const ACP_SAFE_ENV_KEYS = [

--- a/packages/daemon/src/lib/acp/acp-command.ts
+++ b/packages/daemon/src/lib/acp/acp-command.ts
@@ -120,8 +120,18 @@ export function redactCommandSecrets(command: string, args: string[]): string[] 
     if (tokenCurl && /^-[a-z]*$/i.test(arg)) {
       const letters = arg.slice(1).toLowerCase();
       const valueFlag = letters.charAt(letters.length - 1);
+      let clusterCarriesValue = false;
+      for (let scan = 0; scan < letters.length - 1; scan++) {
+        const ch = letters[scan];
+        if (ch === 'h' || ch === 'u') break;
+        if (CURL_VALUE_TAKING_SHORT.has(ch)) {
+          clusterCarriesValue = true;
+          break;
+        }
+      }
       const next = args[index + 1];
       if (
+        !clusterCarriesValue &&
         (valueFlag === 'h' || valueFlag === 'u') &&
         next !== undefined &&
         (valueFlag === 'u' || !next.startsWith('--'))

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'bun:test';
 import {
   buildAcpSafeEnv,
   getAcpCommandIdentity,
+  getAcpCommandIdentityDigest,
   parseAcpCommand,
+  redactCommandSecrets,
+  shellQuote,
 } from '../../../../src/lib/acp/acp-command';
 
 describe('buildAcpSafeEnv', () => {
@@ -79,6 +82,230 @@ describe('getAcpCommandIdentity', () => {
   test('normalizes equivalent command identities', () => {
     expect(getAcpCommandIdentity('devin   acp "model one"')).toBe(
       getAcpCommandIdentity("devin acp 'model one'")
+    );
+  });
+});
+
+describe('getAcpCommandIdentityDigest', () => {
+  test('excludes secret-shaped argument values from the digest', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --token topsecret')).toBe(
+      getAcpCommandIdentityDigest('devin acp --token othersecret')
+    );
+    expect(getAcpCommandIdentityDigest('agent --api-key=k1 --stdio')).toBe(
+      getAcpCommandIdentityDigest('agent --api-key=k2 --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('agent --password p1 run')).toBe(
+      getAcpCommandIdentityDigest('agent --password p2 run')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --auth-token=a')).toBe(
+      getAcpCommandIdentityDigest('devin acp --auth-token=b')
+    );
+    expect(getAcpCommandIdentityDigest('agent --token -abc')).toBe(
+      getAcpCommandIdentityDigest('agent --token -xyz')
+    );
+    expect(
+      getAcpCommandIdentityDigest('curl -H "Authorization: Bearer topsecret" https://api')
+    ).toBe(getAcpCommandIdentityDigest('curl -H "Authorization: Bearer othersafe" https://api'));
+    expect(getAcpCommandIdentityDigest('curl -H "Cookie: session=topsecret" https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -H "Cookie: session=other" https://a')
+    );
+    expect(getAcpCommandIdentityDigest("curl -H'Authorization: Bearer topsecret' https://a")).toBe(
+      getAcpCommandIdentityDigest("curl -H'Authorization: Bearer othersafe' https://a")
+    );
+    expect(getAcpCommandIdentityDigest('curl -u admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -u admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -uadmin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl -uadmin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
+  });
+
+  test('keeps non-credential header values visible in the digest', () => {
+    expect(getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: DELETE" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "X-HTTP-Method-Override: PUT" /a')
+    );
+    expect(getAcpCommandIdentityDigest('curl -H "Accept: application/json" /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -H "Accept: text/plain" /a')
+    );
+    expect(getAcpCommandIdentityDigest("curl -H'X-Method: DELETE' /a")).not.toBe(
+      getAcpCommandIdentityDigest("curl -H'X-Method: PUT' /a")
+    );
+  });
+
+  test('redacts userinfo credentials embedded in positional URLs', () => {
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:topsecret@db/app')).toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:othersafe@db/app')
+    );
+    expect(getAcpCommandIdentityDigest('curl https://alice:topsecret@example.test/a')).toBe(
+      getAcpCommandIdentityDigest('curl https://alice:othersafe@example.test/a')
+    );
+    expect(getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-a/app')).not.toBe(
+      getAcpCommandIdentityDigest('psql postgresql://alice:pw@db-b/app')
+    );
+  });
+
+  test('gates tool-specific user options on their executables', () => {
+    expect(getAcpCommandIdentityDigest('python3 -u agent-a.py')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -u agent-b.py')
+    );
+    expect(getAcpCommandIdentityDigest('pip install --user package-a')).not.toBe(
+      getAcpCommandIdentityDigest('pip install --user package-b')
+    );
+    expect(getAcpCommandIdentityDigest('python3 -c \'print("one")\'')).not.toBe(
+      getAcpCommandIdentityDigest('python3 -c \'print("two")\'')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('curl --user=admin:topsecret https://a')).toBe(
+      getAcpCommandIdentityDigest('curl --user=admin:othersafe https://a')
+    );
+    expect(getAcpCommandIdentityDigest('env API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env API_TOKEN=othersafe agent')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=fast agent')).not.toBe(
+      getAcpCommandIdentityDigest('env MODE=slow agent')
+    );
+  });
+
+  test('does not swallow the next flag after a valueless secret flag', () => {
+    expect(getAcpCommandIdentityDigest('agent --token --verbose one')).not.toBe(
+      getAcpCommandIdentityDigest('agent --token --verbose two')
+    );
+    expect(getAcpCommandIdentityDigest('agent --token --verbose')).not.toBe(
+      getAcpCommandIdentityDigest('agent --verbose --token')
+    );
+  });
+
+  test('still distinguishes commands that differ outside secret arguments', () => {
+    expect(getAcpCommandIdentityDigest('devin acp --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('other-acp --stdio')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --model one')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --model two')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --token a --stdio')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --token a --verbose')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --max-tokens 4096')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --max-tokens 8192')
+    );
+    expect(getAcpCommandIdentityDigest('devin acp --password-policy strict')).not.toBe(
+      getAcpCommandIdentityDigest('devin acp --password-policy relaxed')
+    );
+  });
+
+  test('keeps curl ownership across positional arguments', () => {
+    expect(
+      getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer a"')
+    ).toBe(getAcpCommandIdentityDigest('curl https://example.test -H "Authorization: Bearer b"'));
+    expect(getAcpCommandIdentityDigest('curl https://example.test -u alice:topsecret')).toBe(
+      getAcpCommandIdentityDigest('curl https://example.test -u alice:othersafe')
+    );
+  });
+
+  test('redacts credentials behind clustered curl flags', () => {
+    expect(getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer topsecret' /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sH 'Authorization: Bearer othersafe' /a`)
+    );
+    expect(getAcpCommandIdentityDigest(`curl -sU alice:topsecret /a`)).toBe(
+      getAcpCommandIdentityDigest(`curl -sU alice:othersafe /a`)
+    );
+  });
+
+  test('redacts userinfo inside option values', () => {
+    expect(getAcpCommandIdentityDigest('curl --url=https://alice:topsecret@h/a')).toBe(
+      getAcpCommandIdentityDigest('curl --url=https://alice:othersafe@h/a')
+    );
+  });
+});
+
+describe('shellQuote', () => {
+  test('passes safe tokens through and quotes the rest with single quotes', () => {
+    expect(shellQuote('/usr/local/bin/curl')).toBe('/usr/local/bin/curl');
+    expect(shellQuote('two words')).toBe("'two words'");
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+});
+
+describe('redactCommandSecrets', () => {
+  test('redacts credentials behind clustered and attached curl flags', () => {
+    expect(redactCommandSecrets('curl', ['-sH', 'Authorization: Bearer topsecret', '/a'])).toEqual([
+      '-sH',
+      '[redacted]',
+      '/a',
+    ]);
+  });
+
+  test('does not treat curl data values as credential flags', () => {
+    expect(redactCommandSecrets('curl', ['-duser=delete-all', '/a'])).toEqual([
+      '-duser=delete-all',
+      '/a',
+    ]);
+    expect(getAcpCommandIdentityDigest('curl -duser=delete-all /a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -duser=other /a')
+    );
+  });
+
+  test('redacts curl proxy-user credentials', () => {
+    expect(
+      redactCommandSecrets('curl', ['--proxy-user', 'alice:topsecret', 'https://api'])
+    ).toEqual(['--proxy-user', '[redacted]', 'https://api']);
+    expect(getAcpCommandIdentityDigest('curl --proxy-user alice:topsecret https://api')).toBe(
+      getAcpCommandIdentityDigest('curl --proxy-user other:safe https://api')
+    );
+  });
+
+  test('consumes dash-prefixed curl user values', () => {
+    expect(redactCommandSecrets('curl', ['-u', '--topsecret:', 'https://api'])).toEqual([
+      '-u',
+      '[redacted]',
+      'https://api',
+    ]);
+  });
+
+  test('redacts url passwords with empty usernames', () => {
+    expect(redactCommandSecrets('curl', ['https://:topsecret@example.test/a'])).toEqual([
+      'https://:[redacted]@example.test/a',
+    ]);
+  });
+
+  test('normalizes windows executable names', () => {
+    expect(
+      redactCommandSecrets('C:\\Windows\\System32\\curl.exe', [
+        '-H',
+        'Authorization: Bearer topsecret',
+        'https://api',
+      ])
+    ).toEqual(['-H', '[redacted]', 'https://api']);
+  });
+
+  test('redacts url userinfo inside environment assignments', () => {
+    expect(
+      redactCommandSecrets('env', ['DATABASE_URL=postgresql://alice:topsecret@db/app', 'agent'])
+    ).toEqual(['DATABASE_URL=postgresql://alice:[redacted]@db/app', 'agent']);
+  });
+
+  test('treats tokens after -- as positional data', () => {
+    expect(getAcpCommandIdentityDigest(`rm -- --password file-a`)).not.toBe(
+      getAcpCommandIdentityDigest(`rm -- --password file-b`)
+    );
+    expect(redactCommandSecrets('rm', ['--', '--password', 'file-a'])).toEqual([
+      '--',
+      '--password',
+      'file-a',
+    ]);
+  });
+
+  test('stops treating assignments as environment after the command word', () => {
+    expect(getAcpCommandIdentityDigest('env FOO=1 cmd data=one')).not.toBe(
+      getAcpCommandIdentityDigest('env FOO=1 cmd data=two')
+    );
+    expect(getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=topsecret agent')).toBe(
+      getAcpCommandIdentityDigest('env MODE=prod API_TOKEN=othersafe agent')
     );
   });
 });

--- a/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
+++ b/packages/daemon/tests/unit/lib/acp/acp-command.test.ts
@@ -240,6 +240,17 @@ describe('redactCommandSecrets', () => {
     ]);
   });
 
+  test('does not treat curl data clusters as trailing user flags', () => {
+    expect(redactCommandSecrets('curl', ['-du', 'https://a'])).toEqual(['-du', 'https://a']);
+    expect(getAcpCommandIdentityDigest('curl -du https://a')).not.toBe(
+      getAcpCommandIdentityDigest('curl -du https://b')
+    );
+    expect(redactCommandSecrets('curl', ['-su', 'alice:topsecret'])).toEqual([
+      '-su',
+      '[redacted]',
+    ]);
+  });
+
   test('does not treat curl data values as credential flags', () => {
     expect(redactCommandSecrets('curl', ['-duser=delete-all', '/a'])).toEqual([
       '-duser=delete-all',

--- a/packages/shared/src/acp/acp-command.ts
+++ b/packages/shared/src/acp/acp-command.ts
@@ -1,62 +1,110 @@
+export interface AcpCommandTokenSpan {
+  start: number;
+  end: number;
+}
+
+export interface ParsedAcpCommandWithSpans {
+  command: string;
+  args: string[];
+  rawSpans: AcpCommandTokenSpan[];
+}
+
 export function getAcpCommandIdentity(commandLine: string): string {
   const { command, args } = parseAcpCommand(commandLine);
   return JSON.stringify([command, ...args]);
 }
 
 export function parseAcpCommand(commandLine: string): { command: string; args: string[] } {
+  const { command, args } = parseAcpCommandWithSpans(commandLine);
+  return { command, args };
+}
+
+export function parseAcpCommandWithSpans(commandLine: string): ParsedAcpCommandWithSpans {
   const tokens: string[] = [];
+  const rawSpans: AcpCommandTokenSpan[] = [];
   let current = '';
   let quote: 'single' | 'double' | null = null;
   let escaping = false;
   let tokenStarted = false;
+  let rawStart = 0;
+  let rawEnd = 0;
 
   const trimmedCommand = commandLine.trim();
+  const base = commandLine.length - commandLine.trimStart().length;
+
+  const pushToken = () => {
+    tokens.push(current);
+    rawSpans.push({ start: rawStart, end: rawEnd });
+    current = '';
+    tokenStarted = false;
+  };
+
   for (let index = 0; index < trimmedCommand.length; index++) {
-    const char = trimmedCommand[index];
     if (escaping) {
-      current += char;
+      current += trimmedCommand[index];
+      rawEnd = base + index + 1;
       escaping = false;
       tokenStarted = true;
       continue;
     }
 
+    const char = trimmedCommand[index];
     if (char === '\\') {
       const next = trimmedCommand[index + 1];
       if (
         next !== undefined &&
         (/\s/.test(next) || next === "'" || next === '"' || next === '\\')
       ) {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
+        rawEnd = base + index + 1;
         escaping = true;
       } else {
+        if (!tokenStarted) {
+          tokenStarted = true;
+          rawStart = base + index;
+        }
         current += char;
-        tokenStarted = true;
+        rawEnd = base + index + 1;
       }
       continue;
     }
 
     if (char === "'" && quote !== 'double') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'single' ? null : 'single';
-      tokenStarted = true;
       continue;
     }
 
     if (char === '"' && quote !== 'single') {
+      if (!tokenStarted) {
+        tokenStarted = true;
+        rawStart = base + index;
+      }
+      rawEnd = base + index + 1;
       quote = quote === 'double' ? null : 'double';
-      tokenStarted = true;
       continue;
     }
 
     if (/\s/.test(char) && !quote) {
       if (tokenStarted) {
-        tokens.push(current);
-        current = '';
-        tokenStarted = false;
+        pushToken();
       }
       continue;
     }
 
+    if (!tokenStarted) {
+      tokenStarted = true;
+      rawStart = base + index;
+    }
     current += char;
-    tokenStarted = true;
+    rawEnd = base + index + 1;
   }
 
   if (escaping) {
@@ -66,10 +114,10 @@ export function parseAcpCommand(commandLine: string): { command: string; args: s
   if (quote) {
     throw new Error('Invalid ACP command: unmatched quote');
   }
-  if (tokenStarted) tokens.push(current);
+  if (tokenStarted) pushToken();
   if (!tokens[0]) {
     throw new Error('Invalid ACP command: command is empty');
   }
 
-  return { command: tokens[0], args: tokens.slice(1) };
+  return { command: tokens[0], args: tokens.slice(1), rawSpans };
 }


### PR DESCRIPTION
Extracted from #2711 (ACP split 8/10). Supersedes #2778, which carried this plus shell-script nesting in one slice — split after round-1 review showed the two halves draw independent findings.

## What this adds

- `parseAcpCommandWithSpans` (shared `acp-command.ts`): the existing tokenizer now also records each token's raw span in the original line, so a later slice can rewrite tokens in place while preserving the author's quoting. `parseAcpCommand` becomes a thin wrapper — no behavior change.
- `redactCommandSecrets` (daemon `acp-command.ts`, flat scope — the top-level command only): redacts secret-shaped argument names (`--token`, `-p`, `--api-key`, …), header values (`Authorization: …`, curl `-H`/`--header`), curl user options (`-u`, `--user`, `--proxy-user`, clustered flags with value-taking-option awareness), URL userinfo (including empty-username forms), env-wrapper assignments, and `NAME=value` right-hand URL userinfo. Windows executable names (`C:\…\curl.exe`) normalize before command-specific matching.
- `shellQuote` for redisplaying tokens safely.
- `getAcpCommandIdentityDigest` now hashes the **redacted** identity, so rotating a credential value no longer starts a fresh ACP conversation — only a real command change does.
- 25 tests pinning the flat redactor and redaction-aware digest.

## Deliberately not here (next slice)

- Shell-script nesting: `sh -c` recursion, command tracking across operators, span-anchored in-place rewrite, recursion cutoff, newline handling. No call sites in the query runner yet (those land with host-callback wiring).

## Review context carried from #2778 round 1

This slice absorbs six of the ten findings verbatim: Windows name normalization, env-assignment URL userinfo, curl `-d` data values, `--proxy-user`, dash-prefixed `-u` values, empty-username URLs.

## Verification

- `bun test packages/daemon/tests/unit/lib/acp/acp-command.test.ts` — 25/25
- knip, `tsc --build --noEmit`, oxlint, biome — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lsm/hyperneo/pull/2781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->